### PR TITLE
Add typings for `emoji-strip`

### DIFF
--- a/types/emoji-strip/emoji-strip-tests.ts
+++ b/types/emoji-strip/emoji-strip-tests.ts
@@ -1,0 +1,3 @@
+import emojiStrip from 'emoji-strip';
+
+emojiStrip('Smile emoji: 😀');

--- a/types/emoji-strip/emoji-strip-tests.ts
+++ b/types/emoji-strip/emoji-strip-tests.ts
@@ -1,3 +1,3 @@
-import emojiStrip from 'emoji-strip';
+import emojiStrip = require('emoji-strip');
 
 const text: string = emojiStrip('Smile emoji: 😀');

--- a/types/emoji-strip/emoji-strip-tests.ts
+++ b/types/emoji-strip/emoji-strip-tests.ts
@@ -1,3 +1,3 @@
 import emojiStrip from 'emoji-strip';
 
-emojiStrip('Smile emoji: 😀');
+const text: string = emojiStrip('Smile emoji: 😀');

--- a/types/emoji-strip/index.d.ts
+++ b/types/emoji-strip/index.d.ts
@@ -2,15 +2,14 @@
 // Project: https://github.com/nizaroni/emoji-strip
 // Definitions by: Gary King <https://github.com/garyking>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
 
-declare module 'emoji-strip' {
-    /**
-     * Strip emojis from text.
-     *
-     * @param text The text from which to strip the emojis.
-     * @returns The text, with emojis removed.
-     */
-    function emojiStrip(text: string): string;
+/**
+ * Strip emojis from text.
+ *
+ * @param text The text from which to strip the emojis.
+ * @returns The text, with emojis removed.
+ */
+declare function emojiStrip(text: string): string;
 
-    export default emojiStrip;
-}
+export = emojiStrip;

--- a/types/emoji-strip/index.d.ts
+++ b/types/emoji-strip/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for emoji-strip 1.0
+// Project: https://github.com/khalifenizar/emoji-strip
+// Definitions by: Gary King <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*~ If this module is a UMD module that exposes a global variable 'myLib' when
+ *~ loaded outside a module loader environment, declare that global here.
+ *~ Otherwise, delete this declaration.
+ */
+export as namespace myLib;
+
+/*~ If this module has methods, declare them as functions like so.
+ */
+export function myMethod(a: string): string;
+export function myOtherMethod(a: number): number;
+
+/*~ You can declare types that are available via importing the module */
+export interface someType {
+    name: string;
+    length: number;
+    extras?: string[];
+}
+
+/*~ You can declare properties of the module using const, let, or var */
+export const myField: number;
+
+/*~ If there are types, properties, or methods inside dotted names
+ *~ of the module, declare them inside a 'namespace'.
+ */
+export namespace subProp {
+    /*~ For example, given this definition, someone could write:
+     *~   import { subProp } from 'yourModule';
+     *~   subProp.foo();
+     *~ or
+     *~   import * as yourMod from 'yourModule';
+     *~   yourMod.subProp.foo();
+     */
+    function foo(): void;
+}

--- a/types/emoji-strip/index.d.ts
+++ b/types/emoji-strip/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for emoji-strip 1.0.1
+// Type definitions for emoji-strip 1.0
 // Project: https://github.com/nizaroni/emoji-strip
 // Definitions by: Gary King <https://github.com/garyking>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/emoji-strip/index.d.ts
+++ b/types/emoji-strip/index.d.ts
@@ -1,39 +1,16 @@
-// Type definitions for emoji-strip 1.0
-// Project: https://github.com/khalifenizar/emoji-strip
-// Definitions by: Gary King <https://github.com/DefinitelyTyped>
+// Type definitions for emoji-strip 1.0.1
+// Project: https://github.com/nizaroni/emoji-strip
+// Definitions by: Gary King <https://github.com/garyking>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/*~ If this module is a UMD module that exposes a global variable 'myLib' when
- *~ loaded outside a module loader environment, declare that global here.
- *~ Otherwise, delete this declaration.
- */
-export as namespace myLib;
-
-/*~ If this module has methods, declare them as functions like so.
- */
-export function myMethod(a: string): string;
-export function myOtherMethod(a: number): number;
-
-/*~ You can declare types that are available via importing the module */
-export interface someType {
-    name: string;
-    length: number;
-    extras?: string[];
-}
-
-/*~ You can declare properties of the module using const, let, or var */
-export const myField: number;
-
-/*~ If there are types, properties, or methods inside dotted names
- *~ of the module, declare them inside a 'namespace'.
- */
-export namespace subProp {
-    /*~ For example, given this definition, someone could write:
-     *~   import { subProp } from 'yourModule';
-     *~   subProp.foo();
-     *~ or
-     *~   import * as yourMod from 'yourModule';
-     *~   yourMod.subProp.foo();
+declare module 'emoji-strip' {
+    /**
+     * Strip emojis from text.
+     *
+     * @param text The text from which to strip the emojis.
+     * @returns The text, with emojis removed.
      */
-    function foo(): void;
+    function emojiStrip(text: string): string;
+
+    export default emojiStrip;
 }

--- a/types/emoji-strip/tsconfig.json
+++ b/types/emoji-strip/tsconfig.json
@@ -14,7 +14,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",

--- a/types/emoji-strip/tsconfig.json
+++ b/types/emoji-strip/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "emoji-strip-tests.ts"
+    ]
+}

--- a/types/emoji-strip/tslint.json
+++ b/types/emoji-strip/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.