### PR TITLE
Highland - added split() and splitBy()

### DIFF
--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -273,6 +273,10 @@ barStream = fooStream.scan(bar, (memo: Bar, x: Foo) => {
 
 fooStream = fooStream.stopOnError((e: Error) => {});
 
+fooStream = fooStream.split();
+
+fooStream = fooStream.splitBy(str);
+
 fooStream = fooStream.take(num);
 
 fooStream.tap((x: Foo) => {});

--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -19,6 +19,7 @@ var anyArr: any[];
 var strArr: string[];
 var numArr: string[];
 var funcArr: Function[];
+var regExp = /a/
 
 var readable: NodeJS.ReadableStream;
 var readwritable: NodeJS.ReadWriteStream;
@@ -276,6 +277,8 @@ fooStream = fooStream.stopOnError((e: Error) => {});
 fooStream = fooStream.split();
 
 fooStream = fooStream.splitBy(str);
+
+fooStream = fooStream.splitBy(regExp)
 
 fooStream = fooStream.take(num);
 

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -911,7 +911,7 @@ declare namespace Highland {
 		 * @param {String|RegExp} sep - String | RegExp - the separator to split on
 		 * @api public
 		 */
-        splitBy(sep: string): Stream<R>;
+		splitBy(sep: string | RegExp): Stream<R>;
 		/**
 		 * Creates a new Stream with the first `n` values from the source.
 		 *

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -889,9 +889,9 @@ declare namespace Highland {
 		 * @param {Function} f - the function to handle an error
 		 * @api public
 		 */
-    stopOnError(f: (err: Error) => void): Stream<R>;
-    
-    /**
+		stopOnError(f: (err: Error) => void): Stream<R>;
+		
+		/**
 		 * [splitBy](splitBy) over newlines.
 		 *
 		 * @id split

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -5,6 +5,7 @@
 //                 William Yu <https://github.com/iwllyu>
 //                 Alvis HT Tang <https://github.com/alvis>
 //                 Jack Wearden <https://github.com/notbobthebuilder>
+//                 Joakim Hasselgren <https://github.com/jhasselgren>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -888,8 +889,28 @@ declare namespace Highland {
 		 * @param {Function} f - the function to handle an error
 		 * @api public
 		 */
-		stopOnError(f: (err: Error) => void): Stream<R>;
-
+    stopOnError(f: (err: Error) => void): Stream<R>;
+    
+    /**
+		 * [splitBy](splitBy) over newlines.
+		 *
+		 * @id split
+		 * @section Streams
+		 * @name Stream.split(s)
+		 * @api public
+		 */
+    split(): Stream<R>;
+      
+    /**
+		 * Splits the source Stream by a separator and emits the pieces in between, much like splitting a string.
+		 *
+		 * @id splitBy
+		 * @section Streams
+		 * @name Stream.splitBy(sep)
+		 * @param {String|RegExp} sep - String | RegExp - the separator to split on
+		 * @api public
+		 */
+    splitBy(sep: string): Stream<R>;
 		/**
 		 * Creates a new Stream with the first `n` values from the source.
 		 *

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -899,6 +899,7 @@ declare namespace Highland {
 		 * @name Stream.split(s)
 		 * @api public
 		 */
+
     split(): Stream<R>;
       
     /**
@@ -910,7 +911,7 @@ declare namespace Highland {
 		 * @param {String|RegExp} sep - String | RegExp - the separator to split on
 		 * @api public
 		 */
-    splitBy(sep: string): Stream<R>;
+        splitBy(sep: string): Stream<R>;
 		/**
 		 * Creates a new Stream with the first `n` values from the source.
 		 *
@@ -920,6 +921,7 @@ declare namespace Highland {
 		 * @param {Number} n - integer representing number of values to read from source
 		 * @api public
 		 */
+
 		take(n: number): Stream<R>;
 
 		/**


### PR DESCRIPTION
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://highlandjs.org/#splitBy
- [ x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
