### PR TITLE
Add options param to fsPromises.rmdir

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2124,7 +2124,7 @@ declare module "fs" {
          * Asynchronous rmdir(2) - delete a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function rmdir(path: PathLike): Promise<void>;
+        function rmdir(path: PathLike, options?: RmDirAsyncOptions): Promise<void>;
 
         /**
          * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -297,3 +297,8 @@ async function testPromisify() {
     });
     const bytesWritten = fs.writevSync(1, [Buffer.from('123')]);
 }
+
+(async () => {
+    await fs.promises.rmdir('/path/to/dir');
+    await fs.promises.rmdir('/path/to/dir', { recursive: true });
+})();

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -302,6 +302,5 @@ async function testPromisify() {
     try {
         await fs.promises.rmdir('some/test/path');
         await fs.promises.rmdir('some/test/path', { recursive: true });
-    }
-    catch (e) {}
+    } catch (e) {}
 })();

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -299,6 +299,9 @@ async function testPromisify() {
 }
 
 (async () => {
-    await fs.promises.rmdir('/path/to/dir');
-    await fs.promises.rmdir('/path/to/dir', { recursive: true });
+    try {
+        await fs.promises.rmdir('some/test/path');
+        await fs.promises.rmdir('some/test/path', { recursive: true });
+    }
+    catch (e) {}
 })();


### PR DESCRIPTION
Fixes #39103

Most of #39103 has been fixed by #39116, but the `fspromises` version was not updated.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/fs.html#fs_fspromises_rmdir_path_options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.