### PR TITLE
@hapi/joi: accept generic schema types in ObjectSchemas

### DIFF
--- a/types/hapi__joi/hapi__joi-tests.ts
+++ b/types/hapi__joi/hapi__joi-tests.ts
@@ -1099,3 +1099,42 @@ schema = Joi.symbol().map(new Map<string, symbol>());
 schema = Joi.symbol().map({
     key: Symbol('asd'),
 });
+
+// --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+// Test generic types
+
+interface User {
+    name: string;
+    family?: string;
+    age: number;
+}
+
+const userSchemaObject = Joi.object<User>({
+    name: Joi.string().required(),
+    family: Joi.string(),
+});
+
+let userSchema = Joi.object<User>().keys({
+    name: Joi.string().required(),
+    family: Joi.string(),
+});
+
+userSchema = userSchema.append({
+    age: Joi.number(),
+});
+
+userSchema = userSchema.append({
+    height: Joi.number(), // $ExpectError
+});
+
+const userSchemaError = Joi.object<User>().keys({
+    name: Joi.string().required(),
+    family: Joi.string(),
+    height: Joi.number(), // $ExpectError
+});
+
+const userSchemaObjectError = Joi.object<User>({
+    name: Joi.string().required(),
+    family: Joi.string(),
+    height: Joi.number(), // $ExpectError
+});

--- a/types/hapi__joi/index.d.ts
+++ b/types/hapi__joi/index.d.ts
@@ -660,9 +660,9 @@ declare namespace Joi {
 
     type SchemaLike = string | number | boolean | object | null | Schema | SchemaMap;
 
-    interface SchemaMap {
-        [key: string]: SchemaLike | SchemaLike[];
-    }
+    type SchemaMap<TSchema = any> = {
+        [key in keyof TSchema]?: SchemaLike | SchemaLike[];
+    };
 
     type Schema = AnySchema
         | ArraySchema
@@ -1502,7 +1502,7 @@ declare namespace Joi {
         matches: SchemaLike | Reference;
     }
 
-    interface ObjectSchema extends AnySchema {
+    interface ObjectSchema<TSchema = any> extends AnySchema {
         /**
          * Defines an all-or-nothing relationship between keys where if one of the peers is present, all of them are required as well.
          *
@@ -1513,7 +1513,7 @@ declare namespace Joi {
         /**
          * Appends the allowed object keys. If schema is null, undefined, or {}, no changes will be applied.
          */
-        append(schema?: SchemaMap): this;
+        append(schema?: SchemaMap<TSchema>): this;
 
         /**
          * Verifies an assertion where.
@@ -1532,7 +1532,7 @@ declare namespace Joi {
         /**
          * Sets or extends the allowed object keys.
          */
-        keys(schema?: SchemaMap): this;
+        keys(schema?: SchemaMap<TSchema>): this;
 
         /**
          * Specifies the exact number of keys in the object.
@@ -1919,7 +1919,7 @@ declare namespace Joi {
         /**
          * Generates a schema object that matches an object data type (as well as JSON strings that have been parsed into objects).
          */
-        object(schema?: SchemaMap): ObjectSchema;
+        object<TSchema = any>(schema?: SchemaMap<TSchema>): ObjectSchema<TSchema>;
 
         /**
          * Generates a schema object that matches a string data type. Note that empty strings are not allowed by default and must be enabled with allow('').


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

We define types for our GraphQL query resolver arguments using typescript and perform more complex validation using Joi. The main issue was that when we changed the shape of our arguments Joi validators does not complain at all.  
This adds support to optionally specify `ObjectSchema` shape via typescript generics. So if you provide a generic object type to `Joi.object()` (checkout tests) you cannot specify keys outside that shape.  
Hopefully we'll support more complex scenarios in future PRs.  
I was very careful not to break any existing workflow and only add a little bit of typescript sugar.
