### PR TITLE
[@types/chai] fix comment of function 'isAtMost'

### DIFF
--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -535,7 +535,7 @@ declare namespace Chai {
         isBelow(valueToCheck: number, valueToBeBelow: number, message?: string): void;
 
         /**
-         * Asserts valueToCheck is greater than or equal to (>=) valueToBeAtMost.
+         * Asserts valueToCheck is less than or equal to (<=) valueToBeAtMost.
          *
          * @param valueToCheck   Actual value.
          * @param valueToBeAtMost   Minimum Potential expected value.


### PR DESCRIPTION
comment of 'isAtMost' was copied from 'isAtLeast' and does not reflect the behaviour of the function. See https://github.com/chaijs/chai/blob/master/chai.js#L4481

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chaijs/chai/blob/master/chai.js#L4481
