### PR TITLE
[jest] fix test.each typing when array is readonly

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -45,29 +45,29 @@ declare var xtest: jest.It;
 declare const expect: jest.Expect;
 
 type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
-  1: [T[0]],
-  2: [T[0], T[1]],
-  3: [T[0], T[1], T[2]],
-  4: [T[0], T[1], T[2], T[3]],
-  5: [T[0], T[1], T[2], T[3], T[4]],
-  6: [T[0], T[1], T[2], T[3], T[4], T[5]],
-  7: [T[0], T[1], T[2], T[3], T[4], T[5], T[6]],
-  8: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7]],
-  9: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8]],
-  10: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8], T[9]],
-  'fallback': Array<(T extends ReadonlyArray<infer U>? U: any)>
+    1: [T[0]],
+    2: [T[0], T[1]],
+    3: [T[0], T[1], T[2]],
+    4: [T[0], T[1], T[2], T[3]],
+    5: [T[0], T[1], T[2], T[3], T[4]],
+    6: [T[0], T[1], T[2], T[3], T[4], T[5]],
+    7: [T[0], T[1], T[2], T[3], T[4], T[5], T[6]],
+    8: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7]],
+    9: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8]],
+    10: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8], T[9]],
+    'fallback': Array<(T extends ReadonlyArray<infer U>? U: any)>
 }[
-  T extends Readonly<[any]> ? 1
-    : T extends Readonly<[any, any]> ? 2
-    : T extends Readonly<[any, any, any]> ? 3
-    : T extends Readonly<[any, any, any, any]> ? 4
-    : T extends Readonly<[any, any, any, any, any]> ? 5
-    : T extends Readonly<[any, any, any, any, any, any]> ? 6
-    : T extends Readonly<[any, any, any, any, any, any, any]> ? 7
-    : T extends Readonly<[any, any, any, any, any, any, any, any]> ? 8
-    : T extends Readonly<[any, any, any, any, any, any, any, any, any]> ? 9
-    : T extends Readonly<[any, any, any, any, any, any, any, any, any, any]> ? 10
-    : 'fallback'
+    T extends Readonly<[any]> ? 1
+        : T extends Readonly<[any, any]> ? 2
+        : T extends Readonly<[any, any, any]> ? 3
+        : T extends Readonly<[any, any, any, any]> ? 4
+        : T extends Readonly<[any, any, any, any, any]> ? 5
+        : T extends Readonly<[any, any, any, any, any, any]> ? 6
+        : T extends Readonly<[any, any, any, any, any, any, any]> ? 7
+        : T extends Readonly<[any, any, any, any, any, any, any, any]> ? 8
+        : T extends Readonly<[any, any, any, any, any, any, any, any, any]> ? 9
+        : T extends Readonly<[any, any, any, any, any, any, any, any, any, any]> ? 10
+        : 'fallback'
 ];
 
 interface NodeRequire {

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -44,6 +44,32 @@ declare var xtest: jest.It;
 
 declare const expect: jest.Expect;
 
+type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
+  1: [T[0]],
+  2: [T[0], T[1]],
+  3: [T[0], T[1], T[2]],
+  4: [T[0], T[1], T[2], T[3]],
+  5: [T[0], T[1], T[2], T[3], T[4]],
+  6: [T[0], T[1], T[2], T[3], T[4], T[5]],
+  7: [T[0], T[1], T[2], T[3], T[4], T[5], T[6]],
+  8: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7]],
+  9: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8]],
+  10: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8], T[9]],
+  'fallback': Array<(T extends ReadonlyArray<infer U>? U: any)>
+}[
+  T extends Readonly<[any]> ? 1
+    : T extends Readonly<[any, any]> ? 2
+    : T extends Readonly<[any, any, any]> ? 3
+    : T extends Readonly<[any, any, any, any]> ? 4
+    : T extends Readonly<[any, any, any, any, any]> ? 5
+    : T extends Readonly<[any, any, any, any, any, any]> ? 6
+    : T extends Readonly<[any, any, any, any, any, any, any]> ? 7
+    : T extends Readonly<[any, any, any, any, any, any, any, any]> ? 8
+    : T extends Readonly<[any, any, any, any, any, any, any, any, any]> ? 9
+    : T extends Readonly<[any, any, any, any, any, any, any, any, any, any]> ? 10
+    : 'fallback'
+];
+
 interface NodeRequire {
     /**
      * Returns the actual module instead of a mock, bypassing all checks on
@@ -300,7 +326,7 @@ declare namespace jest {
 
     interface Each {
         // Exclusively arrays.
-        <T extends any[]>(cases: ReadonlyArray<T>): (name: string, fn: (...args: T) => any, timeout?: number) => void;
+        <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (name: string, fn: (...args: ExtractEachCallbackArgs<T>) => any, timeout?: number) => void;
         // Not arrays.
         <T>(cases: ReadonlyArray<T>): (name: string, fn: (...args: T[]) => any, timeout?: number) => void;
         (cases: ReadonlyArray<ReadonlyArray<any>>): (

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -326,6 +326,7 @@ declare namespace jest {
 
     interface Each {
         // Exclusively arrays.
+        <T extends any[]>(cases: ReadonlyArray<T>): (name: string, fn: (...args: T) => any, timeout?: number) => void;
         <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (name: string, fn: (...args: ExtractEachCallbackArgs<T>) => any, timeout?: number) => void;
         // Not arrays.
         <T>(cases: ReadonlyArray<T>): (name: string, fn: (...args: T[]) => any, timeout?: number) => void;

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -24,6 +24,7 @@
 //                 Alex Bolenok <https://github.com/quassnoi>
 //                 Mario Beltrán Alarcón <https://github.com/Belco90>
 //                 Tony Hallett <https://github.com/tonyhallett>
+//                 Jason Yu <https://github.com/ycmjason>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1499,13 +1499,9 @@ test.each([[1, 1, 2], [1, 2, 3], [2, 1, 3]])(
 );
 
 declare const constCases: [['a', 'b', 'ab'], ['d', 2, 'd2']];
-test.each(constCases)('%s + %s', (s1, s2, expected) => {
-    // $ExpectType "a" | "d"
-    s1;
-    // $ExpectType 2 | "b"
-    s2;
-    // $ExpectType "ab" | "d2"
-    expected;
+test.each(constCases)('%s + %s', (...args) => {
+    // $ExpectType ["a", "b", "ab"] | ["d", 2, "d2"]
+    args;
 });
 
 declare const constCasesWithMoreThanTen: [
@@ -1514,8 +1510,7 @@ declare const constCasesWithMoreThanTen: [
 ];
 
 test.each(constCasesWithMoreThanTen)('should fall back with more than 10 args', (...args) => {
-    // following assertion cannot pass because order changes arbitrarily (https://github.com/microsoft/dtslint/issues/191)
-    // _$ExpectType (1 | 5 | 3 | 2 | 4 | 6 | 7 | 8 | 9 | 10 | 11 | 91 | 92 | 93 | 94 | 95 | 96 | 97 | 98 | 99 | 910 | 911)[]
+    // $ExpectType [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] | [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
     args;
 });
 

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1498,6 +1498,32 @@ test.each([[1, 1, 2], [1, 2, 3], [2, 1, 3]])(
     5000
 );
 
+const constCases: [['a', 'b', 'ab'], ['d', 2, 'd2']] = [['a', 'b', 'ab'], ['d', 2, 'd2']];
+test.each(constCases)('%s + %s', (s1, s2, expected) => {
+    expect(s1 + s2).toBe(expected);
+});
+
+const constCasesWithMoreThanTen: [
+  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+  [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
+] = [
+  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+  [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
+];
+test.each(constCasesWithMoreThanTen)('should fall back with more than 10 args', (n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11) => {
+  expect(n1).toBeDefined();
+  expect(n2).toBeDefined();
+  expect(n3).toBeDefined();
+  expect(n4).toBeDefined();
+  expect(n5).toBeDefined();
+  expect(n6).toBeDefined();
+  expect(n7).toBeDefined();
+  expect(n8).toBeDefined();
+  expect(n9).toBeDefined();
+  expect(n10).toBeDefined();
+  expect(n11).toBeDefined();
+});
+
 test.each`
     a    | b    | expected
     ${1} | ${1} | ${2}

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1500,11 +1500,11 @@ test.each([[1, 1, 2], [1, 2, 3], [2, 1, 3]])(
 
 declare const constCases: [['a', 'b', 'ab'], ['d', 2, 'd2']];
 test.each(constCases)('%s + %s', (s1, s2, expected) => {
-    // $ExpectType 'a' | 'd'
+    // $ExpectType "a" | "d"
     s1;
-    // $ExpectType 'b' | 2
+    // $ExpectType 2 | "b"
     s2;
-    // $ExpectType 'ab' | 'd2'
+    // $ExpectType "ab" | "d2"
     expected;
 });
 
@@ -1514,29 +1514,9 @@ declare const constCasesWithMoreThanTen: [
 ];
 
 test.each(constCasesWithMoreThanTen)('should fall back with more than 10 args', (...args) => {
-    const [n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11] = args;
-    // $ExpectType number
-    n1;
-    // $ExpectType number
-    n2;
-    // $ExpectType number
-    n3;
-    // $ExpectType number
-    n4;
-    // $ExpectType number
-    n5;
-    // $ExpectType number
-    n6;
-    // $ExpectType number
-    n7;
-    // $ExpectType number
-    n8;
-    // $ExpectType number
-    n9;
-    // $ExpectType number
-    n10;
-    // $ExpectType number
-    n11;
+    // following assertion cannot pass because order changes arbitrarily (https://github.com/microsoft/dtslint/issues/191)
+    // _$ExpectType (1 | 5 | 3 | 2 | 4 | 6 | 7 | 8 | 9 | 10 | 11 | 91 | 92 | 93 | 94 | 95 | 96 | 97 | 98 | 99 | 910 | 911)[]
+    args;
 });
 
 test.each`

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1500,7 +1500,8 @@ test.each([[1, 1, 2], [1, 2, 3], [2, 1, 3]])(
 
 declare const constCases: [['a', 'b', 'ab'], ['d', 2, 'd2']];
 test.each(constCases)('%s + %s', (...args) => {
-    // $ExpectType ["a", "b", "ab"] | ["d", 2, "d2"]
+    // following assertion is skipped because of flaky testing
+    // _$ExpectType ["a", "b", "ab"] | ["d", 2, "d2"]
     args;
 });
 
@@ -1510,7 +1511,8 @@ declare const constCasesWithMoreThanTen: [
 ];
 
 test.each(constCasesWithMoreThanTen)('should fall back with more than 10 args', (...args) => {
-    // $ExpectType [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] | [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
+    // following assertion is skipped because of flaky testing
+    // _$ExpectType [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] | [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
     args;
 });
 

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1498,30 +1498,45 @@ test.each([[1, 1, 2], [1, 2, 3], [2, 1, 3]])(
     5000
 );
 
-const constCases: [['a', 'b', 'ab'], ['d', 2, 'd2']] = [['a', 'b', 'ab'], ['d', 2, 'd2']];
+declare const constCases: [['a', 'b', 'ab'], ['d', 2, 'd2']];
 test.each(constCases)('%s + %s', (s1, s2, expected) => {
-    expect(s1 + s2).toBe(expected);
+    // $ExpectType 'a' | 'd'
+    s1;
+    // $ExpectType 'b' | 2
+    s2;
+    // $ExpectType 'ab' | 'd2'
+    expected;
 });
 
-const constCasesWithMoreThanTen: [
-  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-  [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
-] = [
-  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-  [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
+declare const constCasesWithMoreThanTen: [
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+    [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
 ];
-test.each(constCasesWithMoreThanTen)('should fall back with more than 10 args', (n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11) => {
-  expect(n1).toBeDefined();
-  expect(n2).toBeDefined();
-  expect(n3).toBeDefined();
-  expect(n4).toBeDefined();
-  expect(n5).toBeDefined();
-  expect(n6).toBeDefined();
-  expect(n7).toBeDefined();
-  expect(n8).toBeDefined();
-  expect(n9).toBeDefined();
-  expect(n10).toBeDefined();
-  expect(n11).toBeDefined();
+
+test.each(constCasesWithMoreThanTen)('should fall back with more than 10 args', (...args) => {
+    const [n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11] = args;
+    // $ExpectType number
+    n1;
+    // $ExpectType number
+    n2;
+    // $ExpectType number
+    n3;
+    // $ExpectType number
+    n4;
+    // $ExpectType number
+    n5;
+    // $ExpectType number
+    n6;
+    // $ExpectType number
+    n7;
+    // $ExpectType number
+    n8;
+    // $ExpectType number
+    n9;
+    // $ExpectType number
+    n10;
+    // $ExpectType number
+    n11;
 });
 
 test.each`


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jestjs.io/docs/en/api#testeachtable-name-fn-timeout


-----------------------
**Note**

This PR fix issues when trying to do 

```ts
jest.each([['a', 'b', 'c'], ['d', 'e', 'f']] as const)((c1, c2, c3) => {
  // ...
})
```

`c1`, `c2` and `c3` will be typed to `'a' | 'd'`, `'b' | 'e'` and `'c' | 'f'` respectively.

Because of the typescript constraint, I couldn't make the `ReadonlyArray` to a writable array required by `...args`. A compromise is put in place which includes 10 arguments in the callback. (Please advice if I should upgrade the typescript version instead, which might potentially affect many users and other packages depending on jest.)

```ts
...args: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8], T[9]]
```

If we upgrade the typescript version to `3.4`, we can potentially do

```ts
...args: { -readonly [k in keyof T]: T[k] }
```

