### PR TITLE
Add SVGOverlay, introduced in react-leaflet 2.5

### DIFF
--- a/types/react-leaflet/index.d.ts
+++ b/types/react-leaflet/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for react-leaflet 2.4
+// Type definitions for react-leaflet 2.5
 // Project: https://github.com/PaulLeCam/react-leaflet
 // Definitions by: Dave Leaver <https://github.com/danzel>
 //                 David Schneider <https://github.com/davschne>
 //                 Yui T. <https://github.com/yuit>
 //                 Jeroen Claassens <https://github.com/favna>
+//                 Tom Fenech <https://github.com/fenech>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -279,6 +280,14 @@ export interface ImageOverlayProps extends MapLayerProps, Leaflet.ImageOverlayOp
     zIndex?: number;
 }
 export class ImageOverlay<P extends ImageOverlayProps = ImageOverlayProps, E extends Leaflet.ImageOverlay = Leaflet.ImageOverlay> extends MapLayer<P, E> {
+    createLeafletElement(props: P): E;
+    updateLeafletElement(fromProps: P, toProps: P): void;
+}
+
+export interface SVGOverlayProps extends Leaflet.ImageOverlayOptions, MapComponentProps {
+    children?: Children;
+}
+export class SVGOverlay<P extends SVGOverlayProps = SVGOverlayProps, E extends Leaflet.SVGOverlay = Leaflet.SVGOverlay> extends MapComponent<P, E> {
     createLeafletElement(props: P): E;
     updateLeafletElement(fromProps: P, toProps: P): void;
 }

--- a/types/react-leaflet/react-leaflet-tests.tsx
+++ b/types/react-leaflet/react-leaflet-tests.tsx
@@ -25,6 +25,7 @@ import {
     PopupProps,
     Rectangle,
     TileLayer,
+    SVGOverlay,
     Tooltip,
     WMSTileLayer,
     ZoomControl,
@@ -503,6 +504,23 @@ export class SimpleExample extends Component<undefined, SimpleExampleState> {
             </Map>
         );
     }
+}
+
+// svg-overlay.js
+export default class SVGOverlayExample extends Component {
+  render() {
+    return (
+      <Map center={[51.505, -0.09]} zoom={13}>
+        <SVGOverlay bounds={[[51.49, -0.08], [51.5, -0.06]]}>
+          <rect x="0" y="0" width="100%" height="100%" fill="blue" />
+          <circle r="5" cx="10" cy="10" fill="red" />
+          <text x="50%" y="50%" fill="white">
+            text
+          </text>
+        </SVGOverlay>
+      </Map>
+    );
+  }
 }
 
 // tooltip.js


### PR DESCRIPTION
Add definitions for SVG Overlay component, which was added in react-leaflet v2.5.0
https://github.com/PaulLeCam/react-leaflet/releases/tag/v2.5.0

---
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.