### PR TITLE
[Google.Visualization] Add Missing Properties to LineChartOptions

### DIFF
--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -645,6 +645,19 @@ declare namespace google {
             draw(data: DataTable | DataView, options: LineChartOptions): void;
         }
 
+        // https://developers.google.com/chart/interactive/docs/gallery/trendlines
+        export interface LineChartTrendlineOptions {
+            type?: 'linear' | 'exponential' | 'polynomial';
+            degree?: number;
+            color?: string;
+            lineWidth?: number;
+            opacity?: number;
+            pointsVisible?: boolean;
+            labelInLegend?: string;
+            visibleInLegend?: boolean;
+            showR2?: boolean
+        }
+        
         // https://developers.google.com/chart/interactive/docs/gallery/linechart#Configuration_Options
         export interface LineChartOptions {
             aggregationTarget?: string;
@@ -674,7 +687,7 @@ declare namespace google {
             selectionMode?: string // single / multiple
             series?: any;
             domainAxis?: { type: string };
-            trendlines?: { [key: number]: any; };
+            trendlines?: { [key: number]: LineChartTrendlineOptions; };
             pointShape?: string | 'circle' | 'triangle' | 'square' | 'diamond' | 'star' | 'polygon';
             intervals?: { style: string };
             interval?: any;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -661,6 +661,7 @@ declare namespace google {
             color?: string;
             lineWidth?: number;
             opacity?: number;
+            pointSize?: number;
             pointsVisible?: boolean;
             labelInLegend?: string;
             visibleInLegend?: boolean;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -674,7 +674,7 @@ declare namespace google {
             series?: any;
             domainAxis?: { type: string };
             trendlines?: any;
-            pointShape?: any;
+            pointShape?: string;
             intervals?: { style: string };
             interval?: any;
             theme?: string;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -84,7 +84,7 @@ declare namespace google {
             static count(values: number[]): number;
             
             // https://developers.google.com/chart/interactive/docs/reference#join
-            static join(dataA: DataTable | DataView, dataB: DataTable | DataView, joinMethod: string, keys: number[][], columnsA: number[], columnsB: number[]): DataTable;
+            static join(dataA: DataTable | DataView, dataB: DataTable | DataView, joinMethod: 'full' | 'inner' | 'left' | 'right', keys: number[][], columnsA: number[], columnsB: number[]): DataTable;
         }
         //#endregion
         

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -707,7 +707,7 @@ declare namespace google {
             selectionMode?: string // single / multiple
             series?: any;
             domainAxis?: { type: string };
-            trendlines?: { [key: number]: LineChartTrendlineOptions; };
+            trendlines?: Record<number, LineChartTrendlineOptions>;
             pointShape?: string | 'circle' | 'triangle' | 'square' | 'diamond' | 'star' | 'polygon';
             intervals?: { style: string };
             interval?: any;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -73,6 +73,14 @@ declare namespace google {
         
         //#region data
         // https://developers.google.com/chart/interactive/docs/reference#google_visualization_data_group
+        export interface GroupKeyOptions {
+            column: number;
+            type: string;
+            modifier?: (value: any) => any;
+            label?: string;
+            id?: any;
+        }
+
         export interface GroupColumnOptions {
             column: number;
             aggregation: (values: any[]) => any;
@@ -83,8 +91,7 @@ declare namespace google {
         
         export class data {
             // https://developers.google.com/chart/interactive/docs/reference#group
-            static group(data: DataTable, keys: any[], columns?: GroupColumnOptions[]): DataTable;
-            static group(data: DataView, keys: any[], columns?: GroupColumnOptions[]): DataTable;
+            static group(data: DataTable | DataView, keys: (number | GroupKeyOptions)[], columns?: GroupColumnOptions[]): DataTable;
             
             static sum(values: number[] | string[] | Date[]): number;
             static avg(values: number[] | string[] | Date[]): number;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -72,10 +72,19 @@ declare namespace google {
         //#endregion
         
         //#region data
+        // https://developers.google.com/chart/interactive/docs/reference#google_visualization_data_group
+        export interface GroupColumnOptions {
+            column: number;
+            aggregation: (values: any[]) => any;
+            type: string;
+            label?: string;
+            id?: any;
+        }
+        
         export class data {
             // https://developers.google.com/chart/interactive/docs/reference#group
-            static group(data: DataTable, keys: any[], columns: any[]): DataTable;
-            static group(data: DataView, keys: any[], columns: any[]): DataTable;
+            static group(data: DataTable, keys: any[], columns?: GroupColumnOptions[]): DataTable;
+            static group(data: DataView, keys: any[], columns?: GroupColumnOptions[]): DataTable;
             
             static sum(values: number[] | string[] | Date[]): number;
             static avg(values: number[] | string[] | Date[]): number;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -279,7 +279,8 @@ declare namespace google {
             getTableColumnIndex(viewColumnIndex: number): number;
             getTableRowIndex(viewRowIndex: number): number;
             getViewColumnIndex(tableColumnIndex: number): number;
-            getViewColumns(): any[];
+            getViewColumns(): number[];
+            getViewColumns(): ColumnSpec[];
             getViewRowIndex(tableRowIndex: number): number;
             getViewRows(): number[];
 

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://developers.google.com/chart/
 // Definitions by: Dan Ludwig <https://github.com/danludwig>, Gregory Moore <https://github.com/gmoore-sjcorg>, Dan Manastireanu <https://github.com/danmana>, Michael Cheng <https://github.com/mlcheng>, Ivan Bisultanov <https://github.com/IvanBisultanov>, Gleb Mazovetskiy <https://github.com/glebm>, Shrujal Shah <https://github.com/shrujalshah28>, David <https://github.com/dckorben>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.9
 
 declare namespace google {
 

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://developers.google.com/chart/
 // Definitions by: Dan Ludwig <https://github.com/danludwig>, Gregory Moore <https://github.com/gmoore-sjcorg>, Dan Manastireanu <https://github.com/danmana>, Michael Cheng <https://github.com/mlcheng>, Ivan Bisultanov <https://github.com/IvanBisultanov>, Gleb Mazovetskiy <https://github.com/glebm>, Shrujal Shah <https://github.com/shrujalshah28>, David <https://github.com/dckorben>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 declare namespace google {
 

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -90,15 +90,18 @@ declare namespace google {
         }
         
         export class data {
-            // https://developers.google.com/chart/interactive/docs/reference#group
-            static group(data: DataTable | DataView, keys: (number | GroupKeyOptions)[], columns?: GroupColumnOptions[]): DataTable;
+            // https://developers.google.com/chart/interactive/docs/reference#data_modifier_functions
+            static month(value: Date): number;
             
+            // https://developers.google.com/chart/interactive/docs/reference#group
             static sum(values: number[] | string[] | Date[]): number;
             static avg(values: number[] | string[] | Date[]): number;
             static min(values: number[] | string[] | Date[]): number | string | Date;
             static max(values: number[] | string[] | Date[]): number | string | Date;
             static count(values: any[]): number;
-            
+
+            static group(data: DataTable | DataView, keys: (number | GroupKeyOptions)[], columns?: GroupColumnOptions[]): DataTable;
+                        
             // https://developers.google.com/chart/interactive/docs/reference#join
             static join(dataA: DataTable | DataView, dataB: DataTable | DataView, joinMethod: 'full' | 'inner' | 'left' | 'right', keys: number[][], columnsA: number[], columnsB: number[]): DataTable;
         }

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -675,7 +675,7 @@ declare namespace google {
             series?: any;
             domainAxis?: { type: string };
             trendlines?: { [key: number]: any; };
-            pointShape?: string;
+            pointShape?: string | 'circle' | 'triangle' | 'square' | 'diamond' | 'star' | 'polygon';
             intervals?: { style: string };
             interval?: any;
             theme?: string;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -673,7 +673,7 @@ declare namespace google {
             selectionMode?: string // single / multiple
             series?: any;
             domainAxis?: { type: string };
-            trendlines?: any;
+            trendlines?: { [key: number]: any; };
             pointShape?: string;
             intervals?: { style: string };
             interval?: any;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -77,11 +77,11 @@ declare namespace google {
             static group(data: DataTable, keys: any[], columns: any[]): DataTable;
             static group(data: DataView, keys: any[], columns: any[]): DataTable;
             
-            static sum(values: number[]): number;
-            static avg(values: number[]): number;
-            static min(values: number[]): number;
-            static max(values: number[]): number;
-            static count(values: number[]): number;
+            static sum(values: number[] | string[] | Date[]): number;
+            static avg(values: number[] | string[] | Date[]): number;
+            static min(values: number[] | string[] | Date[]): number | string | Date;
+            static max(values: number[] | string[] | Date[]): number | string | Date;
+            static count(values: any[]): number;
             
             // https://developers.google.com/chart/interactive/docs/reference#join
             static join(dataA: DataTable | DataView, dataB: DataTable | DataView, joinMethod: 'full' | 'inner' | 'left' | 'right', keys: number[][], columnsA: number[], columnsB: number[]): DataTable;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -18,8 +18,7 @@ declare namespace google {
     // https://developers.google.com/chart/interactive/docs/reference
     namespace visualization {
 
-        export function dataTableToCsv(data: DataTable): string;
-        export function dataTableToCsv(data: DataView): string;
+        export function dataTableToCsv(data: DataTable | DataView): string;
         
         export interface ChartSpecs {
             chartType: string;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://developers.google.com/chart/
 // Definitions by: Dan Ludwig <https://github.com/danludwig>, Gregory Moore <https://github.com/gmoore-sjcorg>, Dan Manastireanu <https://github.com/danmana>, Michael Cheng <https://github.com/mlcheng>, Ivan Bisultanov <https://github.com/IvanBisultanov>, Gleb Mazovetskiy <https://github.com/glebm>, Shrujal Shah <https://github.com/shrujalshah28>, David <https://github.com/dckorben>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
 
 declare namespace google {
 
@@ -708,7 +707,7 @@ declare namespace google {
             selectionMode?: string // single / multiple
             series?: any;
             domainAxis?: { type: string };
-            trendlines?: Record<number, LineChartTrendlineOptions>;
+            trendlines?: { [key: number]: LineChartTrendlineOptions; };
             pointShape?: string | 'circle' | 'triangle' | 'square' | 'diamond' | 'star' | 'polygon';
             intervals?: { style: string };
             interval?: any;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Google Visualisation Apis
 // Project: https://developers.google.com/chart/
-// Definitions by: Dan Ludwig <https://github.com/danludwig>, Gregory Moore <https://github.com/gmoore-sjcorg>, Dan Manastireanu <https://github.com/danmana>, Michael Cheng <https://github.com/mlcheng>, Ivan Bisultanov <https://github.com/IvanBisultanov>, Gleb Mazovetskiy <https://github.com/glebm>, Shrujal Shah <https://github.com/shrujalshah28>
+// Definitions by: Dan Ludwig <https://github.com/danludwig>, Gregory Moore <https://github.com/gmoore-sjcorg>, Dan Manastireanu <https://github.com/danmana>, Michael Cheng <https://github.com/mlcheng>, Ivan Bisultanov <https://github.com/IvanBisultanov>, Gleb Mazovetskiy <https://github.com/glebm>, Shrujal Shah <https://github.com/shrujalshah28>, David <https://github.com/dckorben>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace google {

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -654,6 +654,11 @@ declare namespace google {
             reverseCategories?: boolean;
             selectionMode?: string // single / multiple
             series?: any;
+            domainAxis?: { type: string };
+            trendlines?: any;
+            pointShape?: any;
+            intervals?: { style: string };
+            interval?: any;
             theme?: string;
             title?: string;
             titlePosition?: string;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -41,7 +41,6 @@ declare namespace google {
         }
 
         //#region ChartWrapper
-
         // https://developers.google.com/chart/interactive/docs/reference#chartwrapperobject
         export class ChartWrapper {
             constructor(spec?: ChartSpecs);
@@ -70,10 +69,25 @@ declare namespace google {
             setOptions(options: Object): void;
             setView(view_spec: string): void;
         }
-
         //#endregion
+        
+        //#region data
+        export class data {
+            static group(data: DataTable, keys: any[], columns: any[]): DataTable;
+            static group(data: DataView, keys: any[], columns: any[]): DataTable;
+            
+            static join(dataA: DataTable | DataView, dataB: DataTable | DataView, joinMethod: string, keys: number[][], columnsA: number[], columnsB: number[]): DataTable;
+            static join(dataA: DataTable | DataView, dataB: DataTable | DataView, joinMethod: string, keys: number[][], columnsA: number[], columnsB: number[]): DataTable;
+            
+            static sum(values: number[]): number;
+            static avg(values: number[]): number;
+            static min(values: number[]): number;
+            static max(values: number[]): number;
+            static count(values: number[]): number;
+        }
+        //#endregion
+        
         //#region DataTable
-
         // https://developers.google.com/chart/interactive/docs/reference#DataTable
         export class DataTable {
             constructor(data?: any, version?: any);

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -18,6 +18,9 @@ declare namespace google {
     // https://developers.google.com/chart/interactive/docs/reference
     namespace visualization {
 
+        export function dataTableToCsv(data: DataTable): string;
+        export function dataTableToCsv(data: DataView): string;
+        
         export interface ChartSpecs {
             chartType: string;
             container?: HTMLElement;
@@ -98,7 +101,7 @@ declare namespace google {
             getProperty(rowIndex: number, columnIndex: number, name: string): any;
             getProperties(rowIndex: number, columnIndex: number): Properties;
             getRowProperties(rowIndex: number): Properties;
-            getRowProperty(rowIndex: number, name: string): Properties;
+            getRowProperty(rowIndex: number, name: string): any;
             getSortedRows(sortColumn: number): number[];
             getSortedRows(sortColumn: SortByColumn): number[];
             getSortedRows(sortColumns: number[]): number[];
@@ -261,7 +264,7 @@ declare namespace google {
             getTableColumnIndex(viewColumnIndex: number): number;
             getTableRowIndex(viewRowIndex: number): number;
             getViewColumnIndex(tableColumnIndex: number): number;
-            getViewColumns(): number[];
+            getViewColumns(): any[];
             getViewRowIndex(tableRowIndex: number): number;
             getViewRows(): number[];
 
@@ -280,8 +283,8 @@ declare namespace google {
         }
 
         export interface ColumnSpec {
-            calc: (dataTable: DataTable, row: number) => any;
-            type: string;
+            calc?: (dataTable: DataTable, row: number) => any;
+            type?: string;
             label?: string;
             id?: string;
             sourceColumn?: number;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -73,17 +73,18 @@ declare namespace google {
         
         //#region data
         export class data {
+            // https://developers.google.com/chart/interactive/docs/reference#group
             static group(data: DataTable, keys: any[], columns: any[]): DataTable;
             static group(data: DataView, keys: any[], columns: any[]): DataTable;
-            
-            static join(dataA: DataTable | DataView, dataB: DataTable | DataView, joinMethod: string, keys: number[][], columnsA: number[], columnsB: number[]): DataTable;
-            static join(dataA: DataTable | DataView, dataB: DataTable | DataView, joinMethod: string, keys: number[][], columnsA: number[], columnsB: number[]): DataTable;
             
             static sum(values: number[]): number;
             static avg(values: number[]): number;
             static min(values: number[]): number;
             static max(values: number[]): number;
             static count(values: number[]): number;
+            
+            // https://developers.google.com/chart/interactive/docs/reference#join
+            static join(dataA: DataTable | DataView, dataB: DataTable | DataView, joinMethod: string, keys: number[][], columnsA: number[], columnsB: number[]): DataTable;
         }
         //#endregion
         


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/chart/interactive/docs/gallery/linechart#overview

General Notes:
Added missing "data" class which carries manipulations grouping and joining DataTable/DataView.
Fixed several inconsistencies with the documentation around DataTable.
Relaxed several return types which are inaccurately restrictive per documentation.


