### PR TITLE
[@types/stoppable] Generic Server

### DIFF
--- a/types/stoppable/index.d.ts
+++ b/types/stoppable/index.d.ts
@@ -2,17 +2,19 @@
 // Project: https://github.com/hunterloftis/stoppable
 // Definitions by: Eric Byers <https://github.com/EricByers>
 //                 John Plusjé <https://github.com/jplusje>
+//                 Ilia Baryshnikov <https://github.com/qwelias>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-import { Server } from 'http';
+import { Server as NetServer } from 'net';
+import { Server as HttpServer } from 'http';
+
+declare function stoppable <S extends NetServer>(server: S, grace?: number): stoppable.StoppableServer<S>;
 
 declare namespace stoppable {
-  interface StoppableServer extends Server {
+  type StoppableServer<S = HttpServer> = S & {
     stop(callback?: (e: Error, gracefully: boolean) => void): void;
   }
 }
-
-declare function stoppable(server: Server, grace?: number): stoppable.StoppableServer;
 
 export = stoppable;

--- a/types/stoppable/index.d.ts
+++ b/types/stoppable/index.d.ts
@@ -13,9 +13,9 @@ import { Server as HttpServer } from 'http';
 declare function stoppable <S extends NetServer>(server: S, grace?: number): stoppable.StoppableServer<S>;
 
 declare namespace stoppable {
-  type StoppableServer<S = HttpServer> = S & {
-    stop(callback?: (e: Error, gracefully: boolean) => void): void;
-  }
+    type StoppableServer<S = HttpServer> = S & {
+        stop(callback?: (e: Error, gracefully: boolean) => void): void;
+    };
 }
 
 export = stoppable;

--- a/types/stoppable/index.d.ts
+++ b/types/stoppable/index.d.ts
@@ -4,6 +4,7 @@
 //                 John Plusjé <https://github.com/jplusje>
 //                 Ilia Baryshnikov <https://github.com/qwelias>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 import { Server as NetServer } from 'net';

--- a/types/stoppable/stoppable-tests.ts
+++ b/types/stoppable/stoppable-tests.ts
@@ -1,12 +1,16 @@
 import * as http from 'http';
-import stoppable = require('stoppable');
+import * as net from 'net';
+import * as stoppable from 'stoppable';
 
-const server: stoppable.StoppableServer = stoppable(http.createServer());
-server.stop();
+const server0: stoppable.StoppableServer<net.Server> = stoppable(net.createServer());
+server0.stop();
+
+const server1: stoppable.StoppableServer = stoppable(http.createServer());
+server1.stop();
 
 const server2: stoppable.StoppableServer = stoppable(http.createServer(), 10000);
 server2.stop();
 
 const server3: stoppable.StoppableServer = stoppable(http.createServer());
-server.stop((err, gracefully) => {});
-server.close();
+server3.stop((err, gracefully) => {});
+server3.close();


### PR DESCRIPTION
There's more that just `http.Server`, `net.Server` is the base **Server**, these changes allow you to use the lib with any sort of server, which extends `net.Server`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/http.html#http_class_http_server and https://nodejs.org/api/net.html#net_class_net_server
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
