### PR TITLE
[Azure-Kusto-Node] Add UserCodeInfo to withAadDeviceAuthentication method

### DIFF
--- a/types/azure-kusto-data/azure-kusto-data-tests.ts
+++ b/types/azure-kusto-data/azure-kusto-data-tests.ts
@@ -16,8 +16,8 @@ KustoConnectionStringBuilder.withAadManagedIdentities(connectionString, 'msi_end
 KustoConnectionStringBuilder.withAadUserPasswordAuthentication(connectionString, 'username', 'password');
 KustoConnectionStringBuilder.withAadUserPasswordAuthentication(connectionString, 'username', 'password', 'authorityId');
 KustoConnectionStringBuilder.withAadDeviceAuthentication(connectionString, 'authId');
-KustoConnectionStringBuilder.withAadDeviceAuthentication(connectionString, 'authId', (tokenResponse: any) => {
-    console.log(`Open ${tokenResponse.verificationUrl} and use ${tokenResponse.userCode } code to authorize.`);
+KustoConnectionStringBuilder.withAadDeviceAuthentication(connectionString, 'authId', tokenResponse => {
+    console.log(`Open ${tokenResponse.verificationUrl} and use ${tokenResponse.userCode} code to authorize.`);
 });
 
 const client2 = new Client("http://cluster.region.kusto.windows.net");

--- a/types/azure-kusto-data/index.d.ts
+++ b/types/azure-kusto-data/index.d.ts
@@ -4,6 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
+import { UserCodeInfo } from "adal-node";
+
 export class Client {
     constructor(kcsb: string | KustoConnectionStringBuilder);
     connectionString: KustoConnectionStringBuilder;
@@ -40,7 +42,7 @@ export class KustoConnectionStringBuilder {
     authorityId: string;
     static withAadApplicationCertificateAuthentication(connectionString: string, aadAppId: string, certificate: string, thumbprint: string, authorityId: string): KustoConnectionStringBuilder;
     static withAadApplicationKeyAuthentication(connectionString: string, aadAppId: string, appKey: string, authorityId: string): KustoConnectionStringBuilder;
-    static withAadDeviceAuthentication(connectionString: string, authorityId: string, authCallback?: any): KustoConnectionStringBuilder;
+    static withAadDeviceAuthentication(connectionString: string, authorityId: string, authCallback?: (tokenReponse: UserCodeInfo) => void): KustoConnectionStringBuilder;
     static withAadUserPasswordAuthentication(connectionString: string, userId: string, password: string, authorityId?: any): KustoConnectionStringBuilder;
     static withAadManagedIdentities(connectionString: string, msiEndpoint?: string, clientId?: string): KustoConnectionStringBuilder;
 }

--- a/types/azure-kusto-data/index.d.ts
+++ b/types/azure-kusto-data/index.d.ts
@@ -4,6 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
+/// <reference types="node" />
 import { UserCodeInfo } from "adal-node";
 
 export class Client {

--- a/types/azure-kusto-data/package.json
+++ b/types/azure-kusto-data/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "adal-node": "^0.1.28"
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Azure/azure-kusto-node/blob/409055242e9509f66fbd46c37dc888d55afe0380/azure-kusto-data/source/security.js#L87
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.