### PR TITLE
[@types/node] Add netbsd to type of platforms

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -704,7 +704,8 @@ declare namespace NodeJS {
         | 'openbsd'
         | 'sunos'
         | 'win32'
-        | 'cygwin';
+        | 'cygwin'
+        | 'netbsd';
 
     type Signals =
         "SIGABRT" | "SIGALRM" | "SIGBUS" | "SIGCHLD" | "SIGCONT" | "SIGFPE" | "SIGHUP" | "SIGILL" | "SIGINT" | "SIGIO" |


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
  The following compiles.
  ```typescript
  import './types/node';
  console.log(process.platform == 'netbsd');
  ```
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint node` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/issues/32396
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Sorry, no reference URL, but on NetBSD, `node` says so.

```console
$ node -e 'console.log(process.platform)'
netbsd
```

NOTE: I did not update `v6/base.d.ts`, `v7/base.d.ts`, `v8/base.d.ts`, `v9/base.d.ts`, `v10/globals.d.ts`, `v11/globals.d.ts`, should I?
I just want to solve https://github.com/microsoft/TypeScript/issues/32396.
EDIT: Added the above URL, and checked `Provide a URL...`