### PR TITLE
semantic-release: add missing type definitions

### DIFF
--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -14,13 +14,56 @@ declare namespace SemanticRelease {
 	 * Each option will take precedence over options configured in the
 	 * configuration file and shareable configurations.
 	 */
-	type Options = Partial<GlobalConfig>;
+	interface Options {
+		/**
+		 * The branch on which releases should happen.
+		 */
+		branch?: string;
+
+		/**
+		 * The Git repository URL, in any supported format.
+		 */
+		repositoryUrl?: string;
+
+		/**
+		 * The Git tag format used by semantic-release to identify releases.
+		 */
+		tagFormat?: string;
+
+		/**
+		 * Specifies the list of plugins to use. Plugins will run in series, in
+		 * the order specified.
+		 *
+		 * If this option is not specified, then semantic-release will use a
+		 * default list of plugins.
+		 *
+		 * Configuration options for each plugin can be defined by wrapping the
+		 * name and an options object in an array.
+		 */
+		plugins?: ReadonlyArray<PluginSpec>;
+
+		/**
+		 * Dry-run mode, skip publishing, print next version and release notes.
+		 */
+		dryRun?: boolean;
+
+		/**
+		 * Set to false to skip Continuous Integration environment verifications.
+		 * This allows for making releases from a local machine.
+		 */
+		ci?: boolean;
+
+		/**
+		 * Any other options supported by plugins.
+		 */
+		[name: string]: any;
+	}
 
 	/**
 	 * semantic-release options, after normalization and defaults have been
 	 * applied.
 	 */
-	interface GlobalConfig {
+	interface GlobalConfig extends Options {
 		/**
 		 * The branch on which releases should happen.
 		 */
@@ -47,22 +90,6 @@ declare namespace SemanticRelease {
 		 * name and an options object in an array.
 		 */
 		plugins: ReadonlyArray<PluginSpec>;
-
-		/**
-		 * Dry-run mode, skip publishing, print next version and release notes.
-		 */
-		dryRun?: boolean;
-
-		/**
-		 * Set to false to skip Continuous Integration environment verifications.
-		 * This allows for making releases from a local machine.
-		 */
-		ci?: boolean;
-
-		/**
-		 * Any other options supported by plugins.
-		 */
-		[name: string]: any;
 	}
 
 	/**

--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -6,197 +6,353 @@
 
 /// <reference types="node" />
 
-declare module SemanticRelease {
-	/** semantic-release options.
-	 * 
+declare namespace SemanticRelease {
+	/**
+	 * semantic-release options.
+	 *
 	 * Can be used to set any core option or plugin options.
 	 * Each option will take precedence over options configured in the
-	 * configuration file and shareable configurations. */
-	export type Options = Partial<GlobalConfig>;
+	 * configuration file and shareable configurations.
+	 */
+	type Options = Partial<GlobalConfig>;
 
-	/** semantic-release options, after normalization and defaults have been
-	 * applied. */
-	export interface GlobalConfig {
-		/** The branch on which releases should happen. */
+	/**
+	 * semantic-release options, after normalization and defaults have been
+	 * applied.
+	 */
+	interface GlobalConfig {
+		/**
+		 * The branch on which releases should happen.
+		 */
 		branch: string;
-		/** The Git repository URL, in any supported format. */
+
+		/**
+		 * The Git repository URL, in any supported format.
+		 */
 		repositoryUrl: string;
-		/** The Git tag format used by semantic-release to identify releases. */
+
+		/**
+		 * The Git tag format used by semantic-release to identify releases.
+		 */
 		tagFormat: string;
-		/** Specifies the list of plugins to use. Plugins will run in series, in
+
+		/**
+		 * Specifies the list of plugins to use. Plugins will run in series, in
 		 * the order specified.
-		 * 
+		 *
 		 * If this option is not specified, then semantic-release will use a
 		 * default list of plugins.
-		 * 
+		 *
 		 * Configuration options for each plugin can be defined by wrapping the
-		 * name and an options object in an array. */
+		 * name and an options object in an array.
+		 */
 		plugins: ReadonlyArray<PluginSpec>;
-		/** Dry-run mode, skip publishing, print next version and release notes. */
+
+		/**
+		 * Dry-run mode, skip publishing, print next version and release notes.
+		 */
 		dryRun?: boolean;
-		/** Set to false to skip Continuous Integration environment verifications.
-		 * This allows for making releases from a local machine. */
+
+		/**
+		 * Set to false to skip Continuous Integration environment verifications.
+		 * This allows for making releases from a local machine.
+		 */
 		ci?: boolean;
-		/** Any other options supported by plugins. */
+
+		/**
+		 * Any other options supported by plugins.
+		 */
 		[name: string]: any;
 	}
 
-	/** Specifies a plugin to use.
-	 * 
+	/**
+	 * Specifies a plugin to use.
+	 *
 	 * The plugin is specified by its module name.
-	 * 
+	 *
 	 * To pass options to a plugin, specify an array containing the plugin module
-	 * name and an options object. */
-	export type PluginSpec = string | [string, any];
+	 * name and an options object.
+	 */
+	type PluginSpec = string | [string, any];
 
 	/** semantic-release configuration specific for API usage. */
-	export interface Config {
-		/** The current working directory to use. It should be configured to
+	interface Config {
+		/**
+		 * The current working directory to use. It should be configured to
 		 * the root of the Git repository to release from.
-		 * 
+		 *
 		 * It allows to run semantic-release from a specific path without
 		 * having to change the local process cwd with process.chdir().
-		 * 
-		 * @default process.cwd */
+		 *
+		 * @default process.cwd
+		 */
 		cwd?: string;
-		/** The environment variables to use.
-		 * 
+
+		/**
+		 * The environment variables to use.
+		 *
 		 * It allows to run semantic-release with specific environment
 		 * variables without having to modify the local process.env.
-		 * 
-		 * @default process.env */
+		 *
+		 * @default process.env
+		 */
 		env?: { [name: string]: string };
-		/** The writable stream used to log information.
-		 * 
+
+		/**
+		 * The writable stream used to log information.
+		 *
 		 * It allows to configure semantic-release to write logs to a specific
 		 * stream rather than the local process.stdout.
-		 * 
-		 * @default process.stdout */
+		 *
+		 * @default process.stdout
+		 */
 		stdout?: NodeJS.WriteStream;
-		/** The writable stream used to log errors.
-		 * 
+
+		/**
+		 * The writable stream used to log errors.
+		 *
 		 * It allows to configure semantic-release to write errors to a
 		 * specific stream rather than the local process.stderr.
-		 * 
-		 * @default process.stderr */
+		 *
+		 * @default process.stderr
+		 */
 		stderr?: NodeJS.WriteStream;
 	}
 
-	export interface LastRelease {
-		/** The version name of the release */
+	interface LastRelease {
+		/**
+		 * The version name of the release.
+		 */
 		version: string;
-		/** The Git tag of the release. */
+
+		/**
+		 * The Git tag of the release.
+		 */
 		gitTag: string;
-		/** The Git checksum of the last commit of the release. */
+
+		/**
+		 * The Git checksum of the last commit of the release.
+		 */
 		gitHead: string;
 	}
 
-	export interface NextRelease extends LastRelease {
-		/** The semver type of the release. */
+	interface NextRelease extends LastRelease {
+		/**
+		 * The semver type of the release.
+		 */
 		type: "patch" | "minor" | "major";
-		/** The release notes of the next release. */
+
+		/**
+		 * The release notes of the next release.
+		 */
 		notes: string;
 	}
 
-	export interface Context {
-		/** The semantic release configuration itself. */
+	interface Context {
+		/**
+		 * The semantic release configuration itself.
+		 */
 		options?: GlobalConfig;
-		/** The previous release details. */
+
+		/**
+		 * The previous release details.
+		 */
 		lastRelease?: LastRelease;
-		/** The next release details. */
+
+		/**
+		 * The next release details.
+		 */
 		nextRelease?: NextRelease;
-		/** The shared logger instance of semantic release. */
+
+		/**
+		 * The shared logger instance of semantic release.
+		 */
 		logger: {
 			log: (message: string, ...vars: any[]) => void,
 			error: (message: string, ...vars: any[]) => void,
 		};
-		/** Environment variables. */
+
+		/**
+		 * Environment variables.
+		 */
 		env: {
 			[key: string]: string;
 		};
 	}
 
-	export interface Commit {
-		/** The commit abbreviated and full hash. */
+	interface Commit {
+		/**
+		 * The commit abbreviated and full hash.
+		 */
 		commit: {
-			/** The commit hash. */
+			/**
+			 * The commit hash.
+			 */
 			long: string;
-			/** The commit abbreviated hash. */
+
+			/**
+			 * The commit abbreviated hash.
+			 */
 			short: string;
 		};
-		/** The commit abbreviated and full tree hash. */
+
+		/**
+		 * The commit abbreviated and full tree hash.
+		 */
 		tree: {
-			/** The commit tree hash. */
+			/**
+			 * The commit tree hash.
+			 */
 			long: string;
-			/** The commit abbreviated tree hash. */
+
+			/**
+			 * The commit abbreviated tree hash.
+			 */
 			short: string;
 		};
-		/** The commit author information. */
+
+		/**
+		 * The commit author information.
+		 */
 		author: {
-			/** The commit author name. */
+			/**
+			 * The commit author name.
+			 */
 			name: string;
-			/** The commit author email. */
+
+			/**
+			 * The commit author email.
+			 */
 			email: string;
-			/** The commit author date. */
+
+			/**
+			 * The commit author date.
+			 */
 			short: string;
 		};
-		/** The committer information. */
+
+		/**
+		 * The committer information.
+		 */
 		committer: {
-			/** The committer name. */
+			/**
+			 * The committer name.
+			 */
 			name: string;
-			/** The committer email. */
+
+			/**
+			 * The committer email.
+			 */
 			email: string;
-			/** The committer date. */
+
+			/**
+			 * The committer date.
+			 */
 			short: string;
 		};
-		/** The commit subject. */
+
+		/**
+		 * The commit subject.
+		 */
 		subject: string;
-		/** The commit body. */
+
+		/**
+		 * The commit body.
+		 */
 		body: string;
-		/** The commit full message (subject and body). */
+
+		/**
+		 * The commit full message (subject and body).
+		 */
 		message: string;
-		/** The commit hash. */
+
+		/**
+		 * The commit hash.
+		 */
 		hash: string;
-		/** The committer date. */
+
+		/**
+		 * The committer date.
+		 */
 		committerDate: string;
 	}
 
-	/** Details of a release published by a publish plugin. */
-	export interface Release {
-		/** The release name, only if set by the corresponding publish plugin. */
+	/**
+	 * Details of a release published by a publish plugin.
+	 */
+	interface Release {
+		/**
+		 * The release name, only if set by the corresponding publish plugin.
+		 */
 		name?: string;
-		/** The release URL, only if set by the corresponding publish plugin. */
+
+		/**
+		 * The release URL, only if set by the corresponding publish plugin.
+		 */
 		url?: string;
-		/** The semver type of the release. */
+
+		/**
+		 * The semver type of the release.
+		 */
 		type: "patch" | "minor" | "major";
-		/** The version of the release. */
+
+		/**
+		 * The version of the release.
+		 */
 		version: string;
-		/** The sha of the last commit being part of the release. */
+
+		/**
+		 * The sha of the last commit being part of the release.
+		 */
 		gitHead: string;
-		/** The Git tag associated with the release. */
+
+		/**
+		 * The Git tag associated with the release.
+		 */
 		gitTag: string;
-		/** The release notes for the release. */
+
+		/**
+		 * The release notes for the release.
+		 */
 		notes: string;
-		/** The name of the plugin that published the release. */
+
+		/**
+		 * The name of the plugin that published the release.
+		 */
 		pluginName: string;
 	}
 
-	/** An object with details of the release if a release was published, or
-	 * false if no release was published. */
-	export type Result = false | {
-		/** Information related to the last release found. */
+	/**
+	 * An object with details of the release if a release was published, or
+	 * false if no release was published.
+	 */
+	type Result = false | {
+		/**
+		 * Information related to the last release found.
+		 */
 		lastRelease: LastRelease;
-		/** The list of commits included in the new release. */
+
+		/**
+		 * The list of commits included in the new release.
+		 */
 		commits: Commit[];
-		/** Information related to the newly published release. */
+
+		/**
+		 * Information related to the newly published release.
+		 */
 		nextRelease: NextRelease;
-		/** The list of releases published, one release per publish plugin. */
+
+		/**
+		 * The list of releases published, one release per publish plugin.
+		 */
 		releases: Release[];
-	}
+	};
 }
 
-/** Run semantic-release and returns a Promise that resolves to a Result
- * object. */
+/**
+ * Run semantic-release and returns a Promise that resolves to a Result
+ * object.
+ */
 declare function SemanticRelease(options: SemanticRelease.Options,
 	environment?: SemanticRelease.Config): Promise<SemanticRelease.Result>;
 

--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -15,7 +15,24 @@ export interface GlobalConfig {
 	repositoryUrl: string;
 	/** The Git tag format used by semantic-release to identify releases. */
 	tagFormat: string;
+	/** Specifies the list of plugins to use. Plugins will run in series, in
+	 * the order specified.
+	 * 
+	 * If this option is not specified, then semantic-release will use a
+	 * default list of plugins.
+	 * 
+	 * Configuration options for each plugin can be defined by wrapping the
+	 * name and an options object in an array. */
+	plugins: ReadonlyArray<PluginSpec>;
 }
+
+/** Specifies a plugin to use.
+ * 
+ * The plugin is specified by its module name.
+ * 
+ * To pass options to a plugin, specify an array containing the plugin module
+ * name and an options object. */
+export type PluginSpec = string | [string, any];
 
 export interface LastRelease {
 	/** The version name of the release */

--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for semantic-release 15.13
 // Project: https://github.com/semantic-release/semantic-release#readme
 // Definitions by: Leonardo Gatica <https://github.com/lgaticaq>
+//                 Daniel Cassidy <https://github.com/djcsdy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -7,8 +7,6 @@
  * The semantic release configuration itself.
  */
 export interface GlobalConfig {
-	/** The full prepare step configuration. */
-	prepare?: any;
 	/** The branch on which releases should happen. */
 	branch: string;
 	/** The Git repository URL, in any supported format. */
@@ -29,6 +27,8 @@ export interface GlobalConfig {
 	/** Set to false to skip Continuous Integration environment verifications.
 	 * This allows for making releases from a local machine. */
 	ci?: boolean;
+	/** Any other options supported by plugins. */
+	[name: string]: any;
 }
 
 /** Specifies a plugin to use.

--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -24,6 +24,11 @@ export interface GlobalConfig {
 	 * Configuration options for each plugin can be defined by wrapping the
 	 * name and an options object in an array. */
 	plugins: ReadonlyArray<PluginSpec>;
+	/** Dry-run mode, skip publishing, print next version and release notes. */
+	dryRun?: boolean;
+	/** Set to false to skip Continuous Integration environment verifications.
+	 * This allows for making releases from a local machine. */
+	ci?: boolean;
 }
 
 /** Specifies a plugin to use.

--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -43,4 +43,8 @@ export interface Context {
 		log: (message: string, ...vars: any[]) => void,
 		error: (message: string, ...vars: any[]) => void,
 	};
+	/** Environment variables. */
+	env: {
+		[key: string]: string;
+	};
 }

--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -3,70 +3,200 @@
 // Definitions by: Leonardo Gatica <https://github.com/lgaticaq>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/**
- * The semantic release configuration itself.
- */
-export interface GlobalConfig {
-	/** The branch on which releases should happen. */
-	branch: string;
-	/** The Git repository URL, in any supported format. */
-	repositoryUrl: string;
-	/** The Git tag format used by semantic-release to identify releases. */
-	tagFormat: string;
-	/** Specifies the list of plugins to use. Plugins will run in series, in
-	 * the order specified.
+/// <reference types="node" />
+
+declare module SemanticRelease {
+	/** semantic-release options.
 	 * 
-	 * If this option is not specified, then semantic-release will use a
-	 * default list of plugins.
+	 * Can be used to set any core option or plugin options.
+	 * Each option will take precedence over options configured in the
+	 * configuration file and shareable configurations. */
+	export type Options = Partial<GlobalConfig>;
+
+	/** semantic-release options, after normalization and defaults have been
+	 * applied. */
+	export interface GlobalConfig {
+		/** The branch on which releases should happen. */
+		branch: string;
+		/** The Git repository URL, in any supported format. */
+		repositoryUrl: string;
+		/** The Git tag format used by semantic-release to identify releases. */
+		tagFormat: string;
+		/** Specifies the list of plugins to use. Plugins will run in series, in
+		 * the order specified.
+		 * 
+		 * If this option is not specified, then semantic-release will use a
+		 * default list of plugins.
+		 * 
+		 * Configuration options for each plugin can be defined by wrapping the
+		 * name and an options object in an array. */
+		plugins: ReadonlyArray<PluginSpec>;
+		/** Dry-run mode, skip publishing, print next version and release notes. */
+		dryRun?: boolean;
+		/** Set to false to skip Continuous Integration environment verifications.
+		 * This allows for making releases from a local machine. */
+		ci?: boolean;
+		/** Any other options supported by plugins. */
+		[name: string]: any;
+	}
+
+	/** Specifies a plugin to use.
 	 * 
-	 * Configuration options for each plugin can be defined by wrapping the
-	 * name and an options object in an array. */
-	plugins: ReadonlyArray<PluginSpec>;
-	/** Dry-run mode, skip publishing, print next version and release notes. */
-	dryRun?: boolean;
-	/** Set to false to skip Continuous Integration environment verifications.
-	 * This allows for making releases from a local machine. */
-	ci?: boolean;
-	/** Any other options supported by plugins. */
-	[name: string]: any;
+	 * The plugin is specified by its module name.
+	 * 
+	 * To pass options to a plugin, specify an array containing the plugin module
+	 * name and an options object. */
+	export type PluginSpec = string | [string, any];
+
+	/** semantic-release configuration specific for API usage. */
+	export interface Config {
+		/** The current working directory to use. It should be configured to
+		 * the root of the Git repository to release from.
+		 * 
+		 * It allows to run semantic-release from a specific path without
+		 * having to change the local process cwd with process.chdir().
+		 * 
+		 * @default process.cwd */
+		cwd?: string;
+		/** The environment variables to use.
+		 * 
+		 * It allows to run semantic-release with specific environment
+		 * variables without having to modify the local process.env.
+		 * 
+		 * @default process.env */
+		env?: { [name: string]: string };
+		/** The writable stream used to log information.
+		 * 
+		 * It allows to configure semantic-release to write logs to a specific
+		 * stream rather than the local process.stdout.
+		 * 
+		 * @default process.stdout */
+		stdout?: NodeJS.WriteStream;
+		/** The writable stream used to log errors.
+		 * 
+		 * It allows to configure semantic-release to write errors to a
+		 * specific stream rather than the local process.stderr.
+		 * 
+		 * @default process.stderr */
+		stderr?: NodeJS.WriteStream;
+	}
+
+	export interface LastRelease {
+		/** The version name of the release */
+		version: string;
+		/** The Git tag of the release. */
+		gitTag: string;
+		/** The Git checksum of the last commit of the release. */
+		gitHead: string;
+	}
+
+	export interface NextRelease extends LastRelease {
+		/** The semver type of the release. */
+		type: "patch" | "minor" | "major";
+		/** The release notes of the next release. */
+		notes: string;
+	}
+
+	export interface Context {
+		/** The semantic release configuration itself. */
+		options?: GlobalConfig;
+		/** The previous release details. */
+		lastRelease?: LastRelease;
+		/** The next release details. */
+		nextRelease?: NextRelease;
+		/** The shared logger instance of semantic release. */
+		logger: {
+			log: (message: string, ...vars: any[]) => void,
+			error: (message: string, ...vars: any[]) => void,
+		};
+		/** Environment variables. */
+		env: {
+			[key: string]: string;
+		};
+	}
+
+	export interface Commit {
+		/** The commit abbreviated and full hash. */
+		commit: {
+			/** The commit hash. */
+			long: string;
+			/** The commit abbreviated hash. */
+			short: string;
+		};
+		/** The commit abbreviated and full tree hash. */
+		tree: {
+			/** The commit tree hash. */
+			long: string;
+			/** The commit abbreviated tree hash. */
+			short: string;
+		};
+		/** The commit author information. */
+		author: {
+			/** The commit author name. */
+			name: string;
+			/** The commit author email. */
+			email: string;
+			/** The commit author date. */
+			short: string;
+		};
+		/** The committer information. */
+		committer: {
+			/** The committer name. */
+			name: string;
+			/** The committer email. */
+			email: string;
+			/** The committer date. */
+			short: string;
+		};
+		/** The commit subject. */
+		subject: string;
+		/** The commit body. */
+		body: string;
+		/** The commit full message (subject and body). */
+		message: string;
+		/** The commit hash. */
+		hash: string;
+		/** The committer date. */
+		committerDate: string;
+	}
+
+	/** Details of a release published by a publish plugin. */
+	export interface Release {
+		/** The release name, only if set by the corresponding publish plugin. */
+		name?: string;
+		/** The release URL, only if set by the corresponding publish plugin. */
+		url?: string;
+		/** The semver type of the release. */
+		type: "patch" | "minor" | "major";
+		/** The version of the release. */
+		version: string;
+		/** The sha of the last commit being part of the release. */
+		gitHead: string;
+		/** The Git tag associated with the release. */
+		gitTag: string;
+		/** The release notes for the release. */
+		notes: string;
+		/** The name of the plugin that published the release. */
+		pluginName: string;
+	}
+
+	/** An object with details of the release if a release was published, or
+	 * false if no release was published. */
+	export type Result = false | {
+		/** Information related to the last release found. */
+		lastRelease: LastRelease;
+		/** The list of commits included in the new release. */
+		commits: Commit[];
+		/** Information related to the newly published release. */
+		nextRelease: NextRelease;
+		/** The list of releases published, one release per publish plugin. */
+		releases: Release[];
+	}
 }
 
-/** Specifies a plugin to use.
- * 
- * The plugin is specified by its module name.
- * 
- * To pass options to a plugin, specify an array containing the plugin module
- * name and an options object. */
-export type PluginSpec = string | [string, any];
+/** Run semantic-release and returns a Promise that resolves to a Result
+ * object. */
+declare function SemanticRelease(options: SemanticRelease.Options,
+	environment?: SemanticRelease.Config): Promise<SemanticRelease.Result>;
 
-export interface LastRelease {
-	/** The version name of the release */
-	version: string;
-	/** The Git tag of the release. */
-	gitTag: string;
-	/** The Git checksum of the last commit of the release. */
-	gitHead: string;
-}
-
-export interface NextRelease extends LastRelease {
-	/** The release notes of the next release. */
-	notes: string;
-}
-
-export interface Context {
-	/** The semantic release configuration itself. */
-	options?: GlobalConfig;
-	/** The previous release details. */
-	lastRelease?: LastRelease;
-	/** The next release details. */
-	nextRelease?: NextRelease;
-	/** The shared logger instance of semantic release. */
-	logger: {
-		log: (message: string, ...vars: any[]) => void,
-		error: (message: string, ...vars: any[]) => void,
-	};
-	/** Environment variables. */
-	env: {
-		[key: string]: string;
-	};
-}
+export = SemanticRelease;

--- a/types/semantic-release/semantic-release-tests.ts
+++ b/types/semantic-release/semantic-release-tests.ts
@@ -11,6 +11,22 @@ function publish(pluginConfig: any, context: lib.Context) {
     context.logger.log(`New version ${version}`);
 }
 
+const config: lib.GlobalConfig = {
+    branch: "master",
+    repositoryUrl: "https://github.com/semantic-release/semantic-release.git",
+    // Lint check disabled for the following line because this is the actual
+    // format used by semantic-release. This is not a broken template string.
+    tagFormat: "v${version}", // tslint:disable-line: no-invalid-template-strings
+    plugins: ["@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",
+        "@semantic-release/npm",
+        "@semantic-release/github",
+        ["@qiwi/semantic-release-gh-pages-plugin", {
+            msg: "updated",
+            branch: "docs"
+        }]]
+};
+
 const context = {
     nextRelease: {
         version: '1.0.0',

--- a/types/semantic-release/semantic-release-tests.ts
+++ b/types/semantic-release/semantic-release-tests.ts
@@ -1,5 +1,11 @@
 import * as lib from 'semantic-release';
 
+function verify(pluginConfig: any, context: lib.Context) {
+    if (!("AWS_ACCESS_KEY_ID" in context.env)) {
+        throw new Error("AWS_ACCESS_KEY_ID not set");
+    }
+}
+
 function publish(pluginConfig: any, context: lib.Context) {
     const version = context.nextRelease && context.nextRelease.version;
     context.logger.log(`New version ${version}`);
@@ -12,6 +18,12 @@ const context = {
         gitHead: 'f1eed296d2ffe184fb15f52b1c5ad778f5c87645',
         notes: 'New release'
     },
-    logger: console
+    logger: console,
+    env: {
+        AWS_ACCESS_KEY_ID: "12345",
+        SHELL: "/bin/bash",
+        PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    }
 };
+verify({}, context);
 publish({}, context);

--- a/types/semantic-release/semantic-release-tests.ts
+++ b/types/semantic-release/semantic-release-tests.ts
@@ -65,4 +65,54 @@ const config: lib.Config = {
     stderr: process.stderr
 };
 
-semanticRelease(options, config);
+const result: Promise<lib.Result> = semanticRelease(options, config);
+
+const result2: lib.Result = {
+    lastRelease: {
+        version: "1.1.0",
+        gitTag: "v1.1.0",
+        gitHead: "ce5e4bb0624ffaf1deec298b6c79962efec7dd3b"
+    },
+    commits: [{
+        commit: {
+            long: "a018aff59995a17c0564fa3fd0cb96223f4d4096",
+            short: "a018aff"
+        },
+        tree: {
+            long: "c8d47c8f9026337f780299eddcd6bbf69aec5db6",
+            short: "c8d47c8"
+        },
+        author: {
+            name: "Lillian Devold",
+            email: "lillian.devold@example.org",
+            short: "2019-10-22"
+        },
+        committer: {
+            name: "Lillian Devold",
+            email: "lillian.devold@example.org",
+            short: "2019-10-22"
+        },
+        subject: "fix: encode text to HTML",
+        body: "This closes a potential script injection vector.",
+        message: "fix: encode text to HTML\n\nThis closes a potential script injection vector.",
+        hash: "a018aff59995a17c0564fa3fd0cb96223f4d4096",
+        committerDate: "2019-10-22"
+    }],
+    nextRelease: {
+        type: "minor",
+        version: "1.2.0",
+        gitTag: "v1.2.0",
+        gitHead: "a018aff59995a17c0564fa3fd0cb96223f4d4096",
+        notes: ""
+    },
+    releases: [{
+        name: "example-lib",
+        url: "https://www.npmjs.com/package/example-lib",
+        type: "minor",
+        version: "1.2.0",
+        gitHead: "a018aff59995a17c0564fa3fd0cb96223f4d4096",
+        gitTag: "v1.2.0",
+        notes: "",
+        pluginName: "@semantic"
+    }]
+};

--- a/types/semantic-release/semantic-release-tests.ts
+++ b/types/semantic-release/semantic-release-tests.ts
@@ -24,7 +24,9 @@ const config: lib.GlobalConfig = {
         ["@qiwi/semantic-release-gh-pages-plugin", {
             msg: "updated",
             branch: "docs"
-        }]]
+        }]],
+    dryRun: false,
+    ci: true
 };
 
 const context = {

--- a/types/semantic-release/semantic-release-tests.ts
+++ b/types/semantic-release/semantic-release-tests.ts
@@ -1,4 +1,5 @@
 import * as lib from 'semantic-release';
+import semanticRelease = require('semantic-release');
 
 function verify(pluginConfig: any, context: lib.Context) {
     if (!("AWS_ACCESS_KEY_ID" in context.env)) {
@@ -11,7 +12,7 @@ function publish(pluginConfig: any, context: lib.Context) {
     context.logger.log(`New version ${version}`);
 }
 
-const config: lib.GlobalConfig = {
+const options: lib.GlobalConfig = {
     branch: "master",
     repositoryUrl: "https://github.com/semantic-release/semantic-release.git",
     // Lint check disabled for the following line because this is the actual
@@ -35,8 +36,9 @@ const config: lib.GlobalConfig = {
     ]
 };
 
-const context = {
+const context: lib.Context = {
     nextRelease: {
+        type: "major",
         version: '1.0.0',
         gitTag: '1.0.0',
         gitHead: 'f1eed296d2ffe184fb15f52b1c5ad778f5c87645',
@@ -51,3 +53,16 @@ const context = {
 };
 verify({}, context);
 publish({}, context);
+
+const config: lib.Config = {
+    cwd: "/home/example/code/semantic-release",
+    env: {
+        AWS_ACCESS_KEY_ID: "12345",
+        SHELL: "/bin/bash",
+        PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    },
+    stdout: process.stdout,
+    stderr: process.stderr
+};
+
+semanticRelease(options, config);

--- a/types/semantic-release/semantic-release-tests.ts
+++ b/types/semantic-release/semantic-release-tests.ts
@@ -26,7 +26,13 @@ const config: lib.GlobalConfig = {
             branch: "docs"
         }]],
     dryRun: false,
-    ci: true
+    ci: true,
+    // Example of extended options supported by plugins.
+    assets: [
+        {
+            path: "app.zip"
+        }
+    ]
 };
 
 const context = {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://semantic-release.gitbook.io/semantic-release/usage/configuration>, <https://semantic-release.gitbook.io/semantic-release/usage/plugins>, <https://semantic-release.gitbook.io/semantic-release/developer-guide/js-api>, <https://semantic-release.gitbook.io/semantic-release/developer-guide/plugin>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.