### PR TITLE
Updated passport-google-oauth2 to include missing function signature

### DIFF
--- a/types/passport-google-oauth2/index.d.ts
+++ b/types/passport-google-oauth2/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for passport-google-oauth2 0.1
 // Project: https://github.com/mstade/passport-google-oauth2
 // Definitions by: Elliot Blackburn <https://github.com/bluehatbrit>
+//                 Mike Francis <https://github.com/mikefrancis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -29,6 +30,21 @@ export interface VerifyOptions {
 
 export type VerifyCallback = (error: any, user?: any, options?: VerifyOptions) => void;
 
+export type VerifyFunctionWithRequestAndParams = (
+  req: Request,
+  accessToken: string,
+  refreshToken: string,
+  params: {
+    access_token: string;
+    expires_in: number;
+    scope: string;
+    token_type: 'Bearer';
+    id_token: string;
+  },
+  profile: any,
+  done: VerifyCallback,
+) => void;
+
 export type VerifyFunctionWithRequest = (
     req: Request,
     accessToken: string,
@@ -43,6 +59,7 @@ export class Strategy implements Strategy {
   name: string;
   authenticate: (req: Request, options?: object) => void;
 
+  constructor(options: StrategyOptionsWithRequest, verify: VerifyFunctionWithRequestAndParams);
   constructor(options: StrategyOptionsWithRequest, verify: VerifyFunctionWithRequest);
   constructor(options: StrategyOptions, verify: VerifyFunction);
   constructor(verify: VerifyFunction);

--- a/types/passport-google-oauth2/index.d.ts
+++ b/types/passport-google-oauth2/index.d.ts
@@ -59,8 +59,7 @@ export class Strategy implements Strategy {
   name: string;
   authenticate: (req: Request, options?: object) => void;
 
-  constructor(options: StrategyOptionsWithRequest, verify: VerifyFunctionWithRequestAndParams);
-  constructor(options: StrategyOptionsWithRequest, verify: VerifyFunctionWithRequest);
+  constructor(options: StrategyOptionsWithRequest, verify: VerifyFunctionWithRequest | VerifyFunctionWithRequestAndParams);
   constructor(options: StrategyOptions, verify: VerifyFunction);
   constructor(verify: VerifyFunction);
 }


### PR DESCRIPTION
There is a missing type for a function signature which is not documented in the current typings:

https://github.com/jaredhanson/passport-oauth2/blob/master/lib/strategy.js#L193

This PR adds in the missing type so that the `params` is available in the callback function as mentioned in https://github.com/jaredhanson/passport-google-oauth2/issues/28

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.