### PR TITLE
[react-input-mask] exporting interface which was was not exported before

### DIFF
--- a/types/react-input-mask/index.d.ts
+++ b/types/react-input-mask/index.d.ts
@@ -25,7 +25,7 @@ export interface MaskOptions {
   permanents: number[];
 }
 
-interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
   /**
    * Mask string. Format characters are:
    * * `9`: `0-9`


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.) 
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://powerapps.microsoft.com/en-us/blog/use-of-react-and-office-ui-fabric-react-in-the-powerapps-component-framework-is-now-available-for-public-preview/ to use `react-input-mask` component I it's required to create component manually, like following:
```
ReactDOM.render(
  React.createElement(
    ReactInputMask,
    this.props
  ),
  this.theContainer
);
``` 
Thus `this.props` needs to be typed object. But since respective interface was not exported, correctly create such object was impossible. Only option would be create a copy of `Props` interface. Exporting original `Props` interface fixed that issue.

