### PR TITLE
[styled-components] Make `Omit` a distributive conditional type to support union prop types

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -346,7 +346,7 @@ export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<
 >;
 
 // Helper type operators
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type Omit<T, K extends keyof T> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
 type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, "theme"> & {
     theme?: T;
 };

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1052,8 +1052,7 @@ function unionTest() {
         font-size: ${props => props.kind === 'book' ? 16 : 14}
     `;
 
-    // undesired, fix was reverted because of https://github.com/Microsoft/TypeScript/issues/30663
-    <StyledReadable kind="book" author="Hejlsberg" />; // $ExpectError
+    <StyledReadable kind="book" author="Hejlsberg" />;
     <StyledReadable kind="magazine" author="Hejlsberg" />; // $ExpectError
 }
 


### PR DESCRIPTION
# Description

Fixes #39300 

`Omit` is used in [`@types/styled-components`’s `StyledComponentProps`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/855f629b5cdd572683a0dd271583d2ba1c415432/types/styled-components/index.d.ts#L70), and because it is not defined as a [distributive conditional type](https://www.typescriptlang.org/docs/handbook/advanced-types.html#distributive-conditional-types), `StyledComponentProps` is unable to handle React component props which have a union type.

# Related

[`@emotion/styled`’s `Omit` helper](https://github.com/emotion-js/emotion/blob/dfab765ac1d215d8beaa9bf1e03c8f0bd8a60361/packages/styled-base/types/helper.d.ts#L10) is used similarly, and it’s defined as a distributive conditional type.