### PR TITLE
Added typings for kafka-node-avro

### DIFF
--- a/types/kafka-node-avro/index.d.ts
+++ b/types/kafka-node-avro/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for kafka-node-avro 4.0
+// Project: https://github.com/narcisoguillen/kafka-node-avro#readme
+// Definitions by: Gediminas Katilevicius <https://github.com/alfamegaxq>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+export interface SchemaSettings {
+    /** Kafka schema registry url */
+    registry: string;
+}
+
+export interface KafkaSettings {
+    /** Kafka broker host name */
+    kafkaHost: string;
+}
+
+export interface Settings {
+    /** Kafka broker settings */
+    kafka: KafkaSettings;
+    /** Kafka schema registry settings */
+    schema: SchemaSettings;
+}
+
+export interface SendOptions {
+    /** Kafka topic name to publish message */
+    topic: string;
+    /** Message key */
+    key: string;
+    /**
+     * Object to send to kafka.
+     * It will be automatically Avro encoded if schema registry finds a valid schema for topic
+     */
+    messages: object;
+}
+
+export interface Kafka {
+    /** Publishes message to Kafka */
+    send: (options: SendOptions) => Promise<{}>;
+}
+
+/**
+ * Initialize Kafka client
+ */
+export function init(settings: Settings): Promise<Kafka>;

--- a/types/kafka-node-avro/kafka-node-avro-tests.ts
+++ b/types/kafka-node-avro/kafka-node-avro-tests.ts
@@ -1,0 +1,21 @@
+import * as KafkaAvro from 'kafka-node-avro';
+
+KafkaAvro.init({
+    kafka: {
+        kafkaHost: 'kafka:9092',
+    },
+    schema: {
+        registry: 'http://schema-registry:8081',
+    },
+}).then((client: KafkaAvro.Kafka) => {
+    client
+        .send({
+            topic: 'kafka-topic',
+            key: 'message-key',
+            messages: {
+                name: 'John',
+                lastName: 'Doe',
+                age: 53,
+            },
+        });
+});

--- a/types/kafka-node-avro/tsconfig.json
+++ b/types/kafka-node-avro/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "kafka-node-avro-tests.ts"
+    ]
+}

--- a/types/kafka-node-avro/tslint.json
+++ b/types/kafka-node-avro/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

