### PR TITLE
[countries-and-timezones] Fix type for getAllCountries and getAllTimezones

### DIFF
--- a/types/countries-and-timezones/countries-and-timezones-tests.ts
+++ b/types/countries-and-timezones/countries-and-timezones-tests.ts
@@ -1,8 +1,8 @@
 import * as lib from 'countries-and-timezones';
 
-lib.getCountry('IT');
-lib.getTimezone('Europe/Warsaw');
-lib.getAllCountries();
-lib.getAllTimezones();
-lib.getCountryForTimezone('Europe/London');
-lib.getTimezonesForCountry('GB');
+const country = lib.getCountry('IT');
+const timezone = lib.getTimezone('Europe/Warsaw');
+const countries = lib.getAllCountries();
+const timezones = lib.getAllTimezones();
+lib.getCountryForTimezone(timezones[timezone.name].name);
+lib.getTimezonesForCountry(countries[country.id].id);

--- a/types/countries-and-timezones/index.d.ts
+++ b/types/countries-and-timezones/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/manuelmhtr/countries-and-timezones#readme
 // Definitions by: David Bird <https://github.com/zero51>
 //                 Piotr Okoński <https://github.com/pokonski>
+//                 Kanitkorn Sujautra <https://github.com/lukyth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Country {
@@ -22,7 +23,7 @@ export interface Timezone {
 
 export function getCountry(id: string): Country;
 export function getTimezone(name: string): Timezone;
-export function getAllCountries(): Country[];
-export function getAllTimezones(): Timezone[];
+export function getAllCountries(): { [id: string]: Country };
+export function getAllTimezones(): { [name: string]: Timezone };
 export function getCountryForTimezone(name: string): Country;
 export function getTimezonesForCountry(id: string): Timezone[];


### PR DESCRIPTION
According to the source code below, `getAllCountries` and `getAllTimezones` should return an object instead array.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `getAllCountries` - https://github.com/manuelmhtr/countries-and-timezones/blob/e1f79ee5f56f316b57d3f783b320e7c726467e9d/src/index.js#L13
  - `getAllTimezones` - https://github.com/manuelmhtr/countries-and-timezones/blob/e1f79ee5f56f316b57d3f783b320e7c726467e9d/src/index.js#L18
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
