### PR TITLE
Fix node tty.d.ts WriteStream.cursorTo function signature

### DIFF
--- a/types/node/test/tty.ts
+++ b/types/node/test/tty.ts
@@ -14,6 +14,7 @@ ws.clearLine(0);
 ws.clearLine(1);
 ws.clearScreenDown();
 ws.cursorTo(42, 42);
+ws.cursorTo(42);
 ws.addListener('resize', () => {
 });
 ws.getColorDepth();

--- a/types/node/test/tty.ts
+++ b/types/node/test/tty.ts
@@ -15,6 +15,7 @@ ws.clearLine(1);
 ws.clearScreenDown();
 ws.cursorTo(42, 42);
 ws.cursorTo(42);
+ws.cursorTo(42, () => { });
 ws.addListener('resize', () => {
 });
 ws.getColorDepth();

--- a/types/node/tty.d.ts
+++ b/types/node/tty.d.ts
@@ -46,6 +46,7 @@ declare module "tty" {
          * Moves this WriteStream's cursor to the specified position.
          */
         cursorTo(x: number, y?: number, callback?: () => void): boolean;
+        cursorTo(x: number, callback: () => void): boolean;
         /**
          * Moves this WriteStream's cursor relative to its current position.
          */

--- a/types/node/tty.d.ts
+++ b/types/node/tty.d.ts
@@ -1,7 +1,6 @@
 declare module "tty" {
     import * as net from "net";
 
-
     function isatty(fd: number): boolean;
     class ReadStream extends net.Socket {
         constructor(fd: number, options?: net.SocketConstructorOpts);

--- a/types/node/tty.d.ts
+++ b/types/node/tty.d.ts
@@ -45,7 +45,7 @@ declare module "tty" {
         /**
          * Moves this WriteStream's cursor to the specified position.
          */
-        cursorTo(x: number, y: number, callback?: () => void): boolean;
+        cursorTo(x: number, y?: number, callback?: () => void): boolean;
         /**
          * Moves this WriteStream's cursor relative to its current position.
          */

--- a/types/node/tty.d.ts
+++ b/types/node/tty.d.ts
@@ -1,6 +1,7 @@
 declare module "tty" {
     import * as net from "net";
 
+
     function isatty(fd: number): boolean;
     class ReadStream extends net.Socket {
         constructor(fd: number, options?: net.SocketConstructorOpts);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://nodejs.org/api/tty.html#tty_writestream_cursorto_x_y_callback](https://nodejs.org/api/tty.html#tty_writestream_cursorto_x_y_callback)
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

