### PR TITLE
[office-js, office-js-preview] ExcelApi 1.10 and ExcelApi Online move to release

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -18612,6 +18612,9 @@ declare namespace Excel {
         constructor(url?: string | Session);
         readonly workbook: Workbook;
         readonly application: Application;
+        /**
+        * [Api set: ExcelApi 1.5]
+        */
         readonly runtime: Runtime;
     }
     interface RunOptions extends OfficeExtension.RunOptions<Session> {
@@ -18648,18 +18651,6 @@ declare namespace Excel {
     function run<T>(options: Excel.RunOptions, batch: (context: Excel.RequestContext) => Promise<T>): Promise<T>;
     /**
      * Executes a batch script that performs actions on the Excel object model, using the RequestContext of a previously-created object. When the promise is resolved, any tracked objects that were automatically allocated during execution will be released.
-     *
-     * @remarks
-     *
-     * In addition to this signature, the method also has the following signatures:
-     *
-     * `run<T>(object: OfficeExtension.ClientObject, batch: (context: Excel.RequestContext) => Promise<T>): Promise<T>;`
-     *
-     * `run<T>(objects: OfficeExtension.ClientObject[], batch: (context: Excel.RequestContext) => Promise<T>): Promise<T>;`
-     *
-     * `run<T>(options: Excel.RunOptions, batch: (context: Excel.RequestContext) => Promise<T>): Promise<T>;`
-     *
-     * `run<T>(batch: (context: Excel.RequestContext) => Promise<T>): Promise<T>;`
      *
      * @param context - A previously-created object. The batch will use the same RequestContext as the passed-in object, which means that any changes applied to the object will be picked up by "context.sync()".
      * @param batch - A function that takes in a RequestContext and returns a promise (typically, just the result of "context.sync()"). The context parameter facilitates requests to the Excel application. Since the Office add-in and the Excel application run in two different processes, the RequestContext is required to get access to the Excel object model from the add-in.
@@ -19179,40 +19170,35 @@ declare namespace Excel {
      *
      * Provides information about the row-sorted event and its related worksheet.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     interface WorksheetRowSortedEventArgs {
         /**
          *
          * Gets the range address that represents the sorted areas of a specific worksheet. Only rows changed as a result of the sort operation are returned.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         address: string;
         /**
          *
          * Gets the source of the event. See Excel.EventSource for details.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         source: Excel.EventSource | "Local" | "Remote";
         /**
          *
          * Gets the type of the event. See Excel.EventType for details.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         type: "WorksheetRowSorted";
         /**
          *
          * Gets the id of the worksheet where the sorting happened.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         worksheetId: string;
     }
@@ -19220,40 +19206,35 @@ declare namespace Excel {
      *
      * Provides information about the column-sorted event and its related worksheet.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     interface WorksheetColumnSortedEventArgs {
         /**
          *
          * Gets the range address that represents the sorted areas of a specific worksheet. Only columns changed as a result of the sort operation are returned.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         address: string;
         /**
          *
          * Gets the source of the event. See Excel.EventSource for details.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         source: Excel.EventSource | "Local" | "Remote";
         /**
          *
          * Gets the type of the event. See Excel.EventType for details.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         type: "WorksheetColumnSorted";
         /**
          *
          * Gets the id of the worksheet where the sorting happened.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         worksheetId: string;
     }
@@ -19290,48 +19271,42 @@ declare namespace Excel {
      *
      * Provides information about the left-clicked/tapped event and its related worksheet.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     interface WorksheetSingleClickedEventArgs {
         /**
          *
          * Gets the address that represents the cell which was left-clicked/tapped for a specific worksheet.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         address: string;
         /**
          *
-         * The distance, in points, from the left-clicked/tapped point to the left (or right for RTL) gridline edge of the left-clicked/tapped cell.
+         * The distance, in points, from the left-clicked/tapped point to the left (or right for right-to-left languages) gridline edge of the left-clicked/tapped cell.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         offsetX: number;
         /**
          *
          * The distance, in points, from the left-clicked/tapped point to the top gridline edge of the left-clicked/tapped cell.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         offsetY: number;
         /**
          *
          * Gets the type of the event.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         type: "WorksheetSingleClicked";
         /**
          *
          * Gets the id of the worksheet in which the cell was left-clicked/tapped.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         worksheetId: string;
     }
@@ -19575,6 +19550,14 @@ declare namespace Excel {
     interface WorksheetCalculatedEventArgs {
         /**
          *
+         * The address of the ranges that completed calculation.
+            If multiple ranges completed calculation, the string is a comma-separated list of those range addresses.
+         *
+         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         */
+        address: string;
+        /**
+         *
          * Gets the type of the event. See Excel.EventType for details.
          *
          * [Api set: ExcelApi 1.8]
@@ -19582,7 +19565,7 @@ declare namespace Excel {
         type: "WorksheetCalculated";
         /**
          *
-         * Gets the id of the worksheet that is calculated.
+         * Gets the id of the worksheet in which the calculation occurred.
          *
          * [Api set: ExcelApi 1.8]
          */
@@ -19793,6 +19776,14 @@ declare namespace Excel {
         context: RequestContext;
         /**
          *
+         * Provides information based on current system culture settings. This includes the culture names, number formatting, and other culturally dependent settings.
+         *
+         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * @beta
+         */
+        readonly cultureInfo: Excel.CultureInfo;
+        /**
+         *
          * Returns the Iterative Calculation settings.
             In Excel on Windows and Mac, the settings will apply to the Excel Application.
             In Excel on the web and other platforms, the settings will apply to the active workbook.
@@ -19821,6 +19812,31 @@ declare namespace Excel {
          * [Api set: ExcelApi 1.9]
          */
         readonly calculationState: Excel.CalculationState | "Done" | "Calculating" | "Pending";
+        /**
+         *
+         * Gets the string used as the decimal separator for numeric values. This is based on Excel's local settings.
+         *
+         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * @beta
+         */
+        readonly decimalSeparator: string;
+        /**
+         *
+         * Gets the string used to separate groups of digits to the left of the decimal for numeric values. This is based on Excel's local settings.
+         *
+         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * @beta
+         */
+        readonly thousandsSeparator: string;
+        /**
+         *
+         * Specifies whether the system separators of Microsoft Excel are enabled.
+            System separators include the decimal separator and thousands separator.
+         *
+         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * @beta
+         */
+        readonly useSystemSeparators: boolean;
         /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
          *
          * @remarks
@@ -19993,8 +20009,7 @@ declare namespace Excel {
          *
          * Represents a collection of Comments associated with the workbook. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly comments: Excel.CommentCollection;
         /**
@@ -20029,8 +20044,7 @@ declare namespace Excel {
          *
          * Represents a collection of PivotTableStyles associated with the workbook. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly pivotTableStyles: Excel.PivotTableStyleCollection;
         /**
@@ -20065,16 +20079,14 @@ declare namespace Excel {
          *
          * Represents a collection of SlicerStyles associated with the workbook. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly slicerStyles: Excel.SlicerStyleCollection;
         /**
          *
          * Represents a collection of Slicers associated with the workbook. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly slicers: Excel.SlicerCollection;
         /**
@@ -20088,8 +20100,7 @@ declare namespace Excel {
          *
          * Represents a collection of TableStyles associated with the workbook. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly tableStyles: Excel.TableStyleCollection;
         /**
@@ -20103,8 +20114,7 @@ declare namespace Excel {
          *
          * Represents a collection of TimelineStyles associated with the workbook. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly timelineStyles: Excel.TimelineStyleCollection;
         /**
@@ -20239,16 +20249,14 @@ declare namespace Excel {
          *
          * Gets the currently active slicer in the workbook. If there is no active slicer, an `ItemNotFound` exception is thrown.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         getActiveSlicer(): Excel.Slicer;
         /**
          *
          * Gets the currently active slicer in the workbook. If there is no active slicer, a null object is returned.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         getActiveSlicerOrNullObject(): Excel.Slicer;
         /**
@@ -20456,7 +20464,7 @@ declare namespace Excel {
         readonly autoFilter: Excel.AutoFilter;
         /**
          *
-         * Returns collection of charts that are part of the worksheet. Read-only.
+         * Returns a collection of charts that are part of the worksheet. Read-only.
          *
          * [Api set: ExcelApi 1.1]
          */
@@ -20465,8 +20473,7 @@ declare namespace Excel {
          *
          * Returns a collection of all the Comments objects on the worksheet. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly comments: Excel.CommentCollection;
         /**
@@ -20520,10 +20527,9 @@ declare namespace Excel {
         readonly shapes: Excel.ShapeCollection;
         /**
          *
-         * Returns collection of slicers that are part of the worksheet. Read-only.
+         * Returns a collection of slicers that are part of the worksheet. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly slicers: Excel.SlicerCollection;
         /**
@@ -20648,7 +20654,7 @@ declare namespace Excel {
         calculate(markAllDirty: boolean): void;
         /**
          *
-         * Copies a worksheet and places it at the specified position. 
+         * Copies a worksheet and places it at the specified position.
          *
          * [Api set: ExcelApi 1.7]
          *
@@ -20659,7 +20665,7 @@ declare namespace Excel {
         copy(positionType?: Excel.WorksheetPositionType, relativeTo?: Excel.Worksheet): Excel.Worksheet;
         /**
          *
-         * Copies a worksheet and places it at the specified position. 
+         * Copies a worksheet and places it at the specified position.
          *
          * [Api set: ExcelApi 1.7]
          *
@@ -20811,8 +20817,7 @@ declare namespace Excel {
             The acceptable argument range is between 0 and 8.
             A value of 0 does not change the current display. A value greater than the current number of levels displays all the levels.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param rowLevels The number of row levels of an outline to display.
          * @param columnLevels The number of column levels of an outline to display.
@@ -20870,10 +20875,9 @@ declare namespace Excel {
          *
          * Occurs when one or more columns have been sorted. This happens as the result of a left-to-right sort operation.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * [Api set: ExcelApi 1.10]
          *
          * @eventproperty
-         * @beta
          */
         readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;
         /**
@@ -20918,10 +20922,9 @@ declare namespace Excel {
          *
          * Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * [Api set: ExcelApi 1.10]
          *
          * @eventproperty
-         * @beta
          */
         readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;
         /**
@@ -20935,16 +20938,15 @@ declare namespace Excel {
         readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;
         /**
          *
-         * Occurs when left-clicked/tapped operation happens in the worksheet. This event will not be fired when clicking in the following cases:
-         * 
+         * Occurs when a left-clicked/tapped action happens in the worksheet. This event will not be fired when clicking in the following cases:
+
                     - The user drags the mouse for multi-selection.
-           
+
                     - The user selects a cell in the mode when cell arguments are selected for formula references.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * [Api set: ExcelApi 1.10]
          *
          * @eventproperty
-         * @beta
          */
         readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;
         /**
@@ -21110,10 +21112,9 @@ declare namespace Excel {
          *
          * Occurs when one or more columns have been sorted. This happens as the result of a left-to-right sort operation.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * [Api set: ExcelApi 1.10]
          *
          * @eventproperty
-         * @beta
          */
         readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;
         /**
@@ -21167,10 +21168,9 @@ declare namespace Excel {
          *
          * Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * [Api set: ExcelApi 1.10]
          *
          * @eventproperty
-         * @beta
          */
         readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;
         /**
@@ -21185,15 +21185,12 @@ declare namespace Excel {
         /**
          *
          * Occurs when left-clicked/tapped operation happens in the worksheet collection. This event will not be fired when clicking in the following cases:
-         * 
                     - The user drags the mouse for multi-selection.
-
                     - The user selects a cell in the mode when cell arguments are selected for formula references.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * [Api set: ExcelApi 1.10]
          *
          * @eventproperty
-         * @beta
          */
         readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;
         /**
@@ -21569,8 +21566,7 @@ declare namespace Excel {
          *
          * Returns the distance in points, for 100% zoom, from top edge of the range to bottom edge of the range. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly height: number;
         /**
@@ -21605,8 +21601,7 @@ declare namespace Excel {
          *
          * Returns the distance in points, for 100% zoom, from left edge of the worksheet to left edge of the range. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly left: number;
         /**
@@ -21686,8 +21681,7 @@ declare namespace Excel {
          *
          * Returns the distance in points, for 100% zoom, from top edge of the worksheet to top edge of the range. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly top: number;
         /**
@@ -21709,8 +21703,7 @@ declare namespace Excel {
          *
          * Returns the distance in points, for 100% zoom, from left edge of the range to right edge of the range. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly width: number;
         /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
@@ -21730,26 +21723,28 @@ declare namespace Excel {
         /**
          *
          * Fills range from the current range to the destination range using the specified AutoFill logic.
-            The destination range can be null, or can extend the source either horizontally or vertically.
-            Discontiguous ranges are not supported.
-            For more information, read {@link https://support.office.com/article/video-use-autofill-and-flash-fill-2e79a709-c814-4b27-8bc2-c4dc84d49464 | Use AutoFill and Flash Fill}.
+             The destination range can be null, or can extend the source either horizontally or vertically.
+             Discontiguous ranges are not supported.
+            
+             For more information, read {@link https://support.office.com/article/video-use-autofill-and-flash-fill-2e79a709-c814-4b27-8bc2-c4dc84d49464 | Use AutoFill and Flash Fill}.
          *
-         * [Api set: ExcelApi 1.9, ExcelApi BETA (PREVIEW ONLY) for null `destinationRange`]
+         * [Api set: ExcelApi 1.9, ExcelApi Preview for null `destinationRange`]
          *
-         * @param destinationRange The destination range to autofill. If the destination range is null, data is filled out based on the surrounding cells (which is the behavior when double-clicking the UI’s range fill handle). 
+         * @param destinationRange The destination range to autofill. If the destination range is null, data is filled out based on the surrounding cells (which is the behavior when double-clicking the UI’s range fill handle).
          * @param autoFillType The type of autofill. Specifies how the destination range is to be filled, based on the contents of the current range. Default is "FillDefault".
          */
         autoFill(destinationRange?: Range | string, autoFillType?: Excel.AutoFillType): void;
         /**
          *
          * Fills range from the current range to the destination range using the specified AutoFill logic.
-            The destination range can be null, or can extend the source either horizontally or vertically.
-            Discontiguous ranges are not supported.
-            For more information, read {@link https://support.office.com/article/video-use-autofill-and-flash-fill-2e79a709-c814-4b27-8bc2-c4dc84d49464 | Use AutoFill and Flash Fill}.
+             The destination range can be null, or can extend the source either horizontally or vertically.
+             Discontiguous ranges are not supported.
+            
+             For more information, read {@link https://support.office.com/article/video-use-autofill-and-flash-fill-2e79a709-c814-4b27-8bc2-c4dc84d49464 | Use AutoFill and Flash Fill}.
          *
-         * [Api set: ExcelApi 1.9, ExcelApi BETA (PREVIEW ONLY) for null `destinationRange`]
+         * [Api set: ExcelApi 1.9, ExcelApi Preview for null `destinationRange`]
          *
-         * @param destinationRange The destination range to autofill. If the destination range is null, data is filled out based on the surrounding cells (which is the behavior when double-clicking the UI’s range fill handle). 
+         * @param destinationRange The destination range to autofill. If the destination range is null, data is filled out based on the surrounding cells (which is the behavior when double-clicking the UI’s range fill handle).
          * @param autoFillType The type of autofill. Specifies how the destination range is to be filled, based on the contents of the current range. Default is "FillDefault".
          */
         autoFill(destinationRange?: Range | string, autoFillType?: "FillDefault" | "FillCopy" | "FillSeries" | "FillFormats" | "FillValues" | "FillDays" | "FillWeekdays" | "FillMonths" | "FillYears" | "LinearTrend" | "GrowthTrend" | "FlashFill"): void;
@@ -22187,8 +22182,7 @@ declare namespace Excel {
          *
          * Groups columns and rows for an outline.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param groupOption Specifies how the range can be grouped by rows or columns.
             An `InvalidArgument` error is thrown when the group option differs from the range's
@@ -22200,7 +22194,7 @@ declare namespace Excel {
          *
          * Groups columns and rows for an outline.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * [Api set: ExcelApi 1.10]
          *
          * @param groupOption Specifies how the range can be grouped by rows or columns.
             An `InvalidArgument` error is thrown when the group option differs from the range's
@@ -22212,8 +22206,7 @@ declare namespace Excel {
          *
          * Hide details of the row or column group.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param groupOption Specifies whether to hide details of grouped rows or grouped columns.
          */
@@ -22222,7 +22215,7 @@ declare namespace Excel {
          *
          * Hide details of the row or column group.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * [Api set: ExcelApi 1.10]
          *
          * @param groupOption Specifies whether to hide details of grouped rows or grouped columns.
          */
@@ -22254,6 +22247,17 @@ declare namespace Excel {
          * @param across Optional. Set true to merge cells in each row of the specified range as separate merged cells. The default value is false.
          */
         merge(across?: boolean): void;
+        /**
+         *
+         * Moves cell values, formatting, and formulas from current range to the destination range, replacing the old information in those cells.
+            The destination range will be expanded automatically if it is smaller than the current range. Any cells in the destination range that are outside of the original range's area are not changed.
+         *
+         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * @beta
+         *
+         * @param destinationRange destinationRange Specifies the range to where the information in this range will be moved.
+         */
+        moveTo(destinationRange: Range | string): void;
         /**
          *
          * Removes duplicate values from the range specified by the columns.
@@ -22329,8 +22333,7 @@ declare namespace Excel {
          *
          * Show details of the row or column group.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param groupOption Specifies whether to show details of grouped rows or grouped columns.
          */
@@ -22339,7 +22342,7 @@ declare namespace Excel {
          *
          * Show details of the row or column group.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * [Api set: ExcelApi 1.10]
          *
          * @param groupOption Specifies whether to show details of grouped rows or grouped columns.
          */
@@ -22348,8 +22351,7 @@ declare namespace Excel {
          *
          * Ungroups columns and rows for an outline.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param groupOption Specifies how the range can be ungrouped by rows or columns.
          */
@@ -22358,7 +22360,7 @@ declare namespace Excel {
          *
          * Ungroups columns and rows for an outline.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * [Api set: ExcelApi 1.10]
          *
          * @param groupOption Specifies how the range can be ungrouped by rows or columns.
          */
@@ -24418,7 +24420,7 @@ declare namespace Excel {
         showTotals: boolean;
         /**
          *
-         * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleStyleDark1" through "TableStyleStyleDark11". A custom user-defined style present in the workbook can also be specified.
+         * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleDark1" through "TableStyleDark11". A custom user-defined style present in the workbook can also be specified.
          *
          * [Api set: ExcelApi 1.1]
          */
@@ -26430,7 +26432,7 @@ declare namespace Excel {
         showAxisFieldButtons: boolean;
         /**
          *
-         * Specifies whether or not to display the legend field buttons on a PivotChart
+         * Specifies whether or not to display the legend field buttons on a PivotChart.
          *
          * [Api set: ExcelApi 1.9]
          */
@@ -26444,7 +26446,7 @@ declare namespace Excel {
         showReportFilterFieldButtons: boolean;
         /**
          *
-         * Specifies whether or not to display the show value field buttons on a PivotChart
+         * Specifies whether or not to display the show value field buttons on a PivotChart.
          *
          * [Api set: ExcelApi 1.9]
          */
@@ -31102,6 +31104,112 @@ declare namespace Excel {
     }
     /**
      *
+     * Provides information based on current system culture settings. This includes the culture names, number formatting, and other culturally dependent settings.
+     *
+     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+     * @beta
+     */
+    class CultureInfo extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /**
+         *
+         * Defines the culturally appropriate format of displaying numbers. This is based on current system culture settings.
+         *
+         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * @beta
+         */
+        readonly numberFormatInfo: Excel.NumberFormatInfo;
+        /**
+         *
+         * Gets the culture name in the format languagecode2-country/regioncode2 (e.g. "zh-cn" or "en-us"). This is based on current system settings.
+         *
+         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * @beta
+         */
+        readonly name: string;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.CultureInfoLoadOptions): Excel.CultureInfo;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.CultureInfo;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: {
+            select?: string;
+            expand?: string;
+        }): Excel.CultureInfo;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original Excel.CultureInfo object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.CultureInfoData`) that contains shallow copies of any loaded child properties from the original object.
+        */
+        toJSON(): Excel.Interfaces.CultureInfoData;
+    }
+    /**
+     *
+     * Defines the culturally appropriate format of displaying numbers. This is based on current system culture settings.
+     *
+     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+     * @beta
+     */
+    class NumberFormatInfo extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /**
+         *
+         * Gets the string used as the decimal separator for numeric values. This is based on current system settings.
+         *
+         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * @beta
+         */
+        readonly numberDecimalSeparator: string;
+        /**
+         *
+         * Gets the string used to separate groups of digits to the left of the decimal for numeric values. This is based on current system settings.
+         *
+         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * @beta
+         */
+        readonly numberGroupSeparator: string;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.NumberFormatInfoLoadOptions): Excel.NumberFormatInfo;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.NumberFormatInfo;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: {
+            select?: string;
+            expand?: string;
+        }): Excel.NumberFormatInfo;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original Excel.NumberFormatInfo object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.NumberFormatInfoData`) that contains shallow copies of any loaded child properties from the original object.
+        */
+        toJSON(): Excel.Interfaces.NumberFormatInfoData;
+    }
+    /**
+     *
      * Represents a cell icon.
      *
      * [Api set: ExcelApi 1.2]
@@ -31594,8 +31702,7 @@ declare namespace Excel {
          *
          * Specifies whether the field list can be shown in the UI.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         enableFieldList: boolean;
         /**
@@ -35345,8 +35452,7 @@ declare namespace Excel {
      *
      * Represents a collection of TableStyles.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class TableStyleCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -35357,8 +35463,7 @@ declare namespace Excel {
          *
          * Creates a blank TableStyle with the specified name.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param name The unique name for the new TableStyle. Will throw an invalid argument exception if the name is already in use.
          * @param makeUniqueName Optional, defaults to false. If true, will append numbers to the name in order to make it unique, if needed.
@@ -35369,16 +35474,14 @@ declare namespace Excel {
          *
          * Gets the number of table styles in the collection.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         getCount(): OfficeExtension.ClientResult<number>;
         /**
          *
          * Gets the default TableStyle for the parent object's scope.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          * @returns The TableStyle object that is the current default TableStyle.
          */
         getDefault(): Excel.TableStyle;
@@ -35386,8 +35489,7 @@ declare namespace Excel {
          *
          * Gets a TableStyle by name.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param name Name of the TableStyle to be retrieved.
          * @returns The TableStyle object whose name matches the input.
@@ -35397,8 +35499,7 @@ declare namespace Excel {
          *
          * Gets a TableStyle by name. If the TableStyle does not exist, will return a null object.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param name Name of the TableStyle to be retrieved.
          * @returns The TableStyle object whose name matches the input.
@@ -35408,8 +35509,7 @@ declare namespace Excel {
          *
          * Sets the default TableStyle for use in the parent object's scope.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param newDefaultStyle The TableStyle object or name of the TableStyle object that should be the new default.
          */
@@ -35442,8 +35542,7 @@ declare namespace Excel {
      *
      * Represents a TableStyle, which defines the style elements by region of the Table.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class TableStyle extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -35452,16 +35551,14 @@ declare namespace Excel {
          *
          * Gets the name of the TableStyle.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         name: string;
         /**
          *
          * Specifies whether this TableStyle object is read-only. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly readOnly: boolean;
         /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
@@ -35482,16 +35579,14 @@ declare namespace Excel {
          *
          * Deletes the TableStyle.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         delete(): void;
         /**
          *
          * Creates a duplicate of this TableStyle with copies of all the style elements.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          * @returns The new TableStyle object that has been duplicated from this TableStyle.
          */
         duplicate(): Excel.TableStyle;
@@ -35526,8 +35621,7 @@ declare namespace Excel {
      *
      * Represents a collection of PivotTable styles.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class PivotTableStyleCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -35538,8 +35632,7 @@ declare namespace Excel {
          *
          * Creates a blank PivotTableStyle with the specified name.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param name The unique name for the new PivotTableStyle. Will throw an invalid argument exception if the name is already in use.
          * @param makeUniqueName Optional, defaults to false. If true, will append numbers to the name in order to make it unique, if needed.
@@ -35550,16 +35643,14 @@ declare namespace Excel {
          *
          * Gets the number of PivotTable styles in the collection.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         getCount(): OfficeExtension.ClientResult<number>;
         /**
          *
          * Gets the default PivotTableStyle for the parent object's scope.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          * @returns The PivotTableStyle object that is the current default PivotTableStyle.
          */
         getDefault(): Excel.PivotTableStyle;
@@ -35567,8 +35658,7 @@ declare namespace Excel {
          *
          * Gets a PivotTableStyle by name.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param name Name of the PivotTableStyle to be retrieved.
          * @returns The PivotTableStyle object whose name matches the input.
@@ -35578,8 +35668,7 @@ declare namespace Excel {
          *
          * Gets a PivotTableStyle by name. If the PivotTableStyle does not exist, will return a null object.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param name Name of the PivotTableStyle to be retrieved.
          * @returns The PivotTableStyle object whose name matches the input.
@@ -35589,8 +35678,7 @@ declare namespace Excel {
          *
          * Sets the default PivotTableStyle for use in the parent object's scope.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param newDefaultStyle The PivotTableStyle object or name of the PivotTableStyle object that should be the new default.
          */
@@ -35623,8 +35711,7 @@ declare namespace Excel {
      *
      * Represents a PivotTable Style, which defines style elements by PivotTable region.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class PivotTableStyle extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -35633,16 +35720,14 @@ declare namespace Excel {
          *
          * Gets the name of the PivotTableStyle.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         name: string;
         /**
          *
          * Specifies whether this PivotTableStyle object is read-only. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly readOnly: boolean;
         /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
@@ -35663,16 +35748,14 @@ declare namespace Excel {
          *
          * Deletes the PivotTableStyle.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         delete(): void;
         /**
          *
          * Creates a duplicate of this PivotTableStyle with copies of all the style elements.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          * @returns The new PivotTableStyle object that has been duplicated from this PivotTableStyle.
          */
         duplicate(): Excel.PivotTableStyle;
@@ -35707,8 +35790,7 @@ declare namespace Excel {
      *
      * Represents a collection of SlicerStyle objects.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class SlicerStyleCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -35719,8 +35801,7 @@ declare namespace Excel {
          *
          * Creates a blank SlicerStyle with the specified name.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param name The unique name for the new SlicerStyle. Will throw an invalid argument exception if the name is already in use.
          * @param makeUniqueName Optional, defaults to false. If true, will append numbers to the name in order to make it unique, if needed.
@@ -35731,16 +35812,14 @@ declare namespace Excel {
          *
          * Gets the number of slicer styles in the collection.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         getCount(): OfficeExtension.ClientResult<number>;
         /**
          *
          * Gets the default SlicerStyle for the parent object's scope.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          * @returns The SlicerStyle object that is the current default SlicerStyle.
          */
         getDefault(): Excel.SlicerStyle;
@@ -35748,8 +35827,7 @@ declare namespace Excel {
          *
          * Gets a SlicerStyle by name.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param name Name of the SlicerStyle to be retrieved.
          * @returns The SlicerStyle object whose name matches the input.
@@ -35759,8 +35837,7 @@ declare namespace Excel {
          *
          * Gets a SlicerStyle by name. If the SlicerStyle does not exist, will return a null object.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param name Name of the SlicerStyle to be retrieved.
          * @returns The SlicerStyle object whose name matches the input.
@@ -35770,8 +35847,7 @@ declare namespace Excel {
          *
          * Sets the default SlicerStyle for use in the parent object's scope.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param newDefaultStyle The SlicerStyle object or name of the SlicerStyle object that should be the new default.
          */
@@ -35804,8 +35880,7 @@ declare namespace Excel {
      *
      * Represents a Slicer Style, which defines style elements by region of the slicer.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class SlicerStyle extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -35814,16 +35889,14 @@ declare namespace Excel {
          *
          * Gets the name of the SlicerStyle.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         name: string;
         /**
          *
          * Specifies whether this SlicerStyle object is read-only. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly readOnly: boolean;
         /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
@@ -35844,16 +35917,14 @@ declare namespace Excel {
          *
          * Deletes the SlicerStyle.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         delete(): void;
         /**
          *
          * Creates a duplicate of this SlicerStyle with copies of all the style elements.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          * @returns The new SlicerStyle object that has been duplicated from this SlicerStyle.
          */
         duplicate(): Excel.SlicerStyle;
@@ -35888,8 +35959,7 @@ declare namespace Excel {
      *
      * Represents a collection of TimelineStyles.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class TimelineStyleCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -35900,8 +35970,7 @@ declare namespace Excel {
          *
          * Creates a blank TimelineStyle with the specified name.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param name The unique name for the new TimelineStyle. Will throw an invalid argument exception if the name is already in use.
          * @param makeUniqueName Optional, defaults to false. If true, will append numbers to the name in order to make it unique, if needed.
@@ -35912,16 +35981,14 @@ declare namespace Excel {
          *
          * Gets the number of timeline styles in the collection.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         getCount(): OfficeExtension.ClientResult<number>;
         /**
          *
          * Gets the default TimelineStyle for the parent object's scope.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          * @returns The TimelineStyle object that is the current default TimelineStyle.
          */
         getDefault(): Excel.TimelineStyle;
@@ -35929,8 +35996,7 @@ declare namespace Excel {
          *
          * Gets a TimelineStyle by name.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param name Name of the TimelineStyle to be retrieved.
          * @returns The TimelineStyle object whose name matches the input.
@@ -35940,8 +36006,7 @@ declare namespace Excel {
          *
          * Gets a TimelineStyle by name. If the TimelineStyle does not exist, will return a null object.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param name Name of the TimelineStyle to be retrieved.
          * @returns The TimelineStyle object whose name matches the input.
@@ -35951,8 +36016,7 @@ declare namespace Excel {
          *
          * Sets the default TimelineStyle for use in the parent object's scope.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param newDefaultStyle The TimelineStyle object or name of the TimelineStyle object that should be the new default.
          */
@@ -35985,8 +36049,7 @@ declare namespace Excel {
      *
      * Represents a Timeline style, which defines style elements by region in the Timeline.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class TimelineStyle extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -35995,16 +36058,14 @@ declare namespace Excel {
          *
          * Gets the name of the TimelineStyle.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         name: string;
         /**
          *
          * Specifies whether this TimelineStyle object is read-only. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly readOnly: boolean;
         /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
@@ -36025,16 +36086,14 @@ declare namespace Excel {
          *
          * Deletes the TableStyle.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         delete(): void;
         /**
          *
          * Creates a duplicate of this TimelineStyle with copies of all the style elements.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          * @returns The new TimelineStyle object that has been duplicated from this TimelineStyle.
          */
         duplicate(): Excel.TimelineStyle;
@@ -36849,8 +36908,7 @@ declare namespace Excel {
      *
      * Represents the content contained within a comment or comment reply. Rich content incudes the text string and any other objects contained within the comment body, such as mentions.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     interface CommentRichContent {
         /**
@@ -36858,7 +36916,6 @@ declare namespace Excel {
          * An array containing all the entities (e.g. people) mentioned within the comment.
          *
          * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
          */
         mentions?: Excel.CommentMention[];
         richContent: string;
@@ -36867,8 +36924,7 @@ declare namespace Excel {
      *
      * Represents a collection of comment objects that are part of the workbook.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class CommentCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -36879,11 +36935,10 @@ declare namespace Excel {
          *
          * Creates a new comment with the given content on the given cell. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param cellAddress The cell to which the comment is added. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
-         * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions. [Api set: ExcelApi BETA (PREVIEW ONLY) for string, ExcelApi Preview for CommentRichContent object]
+         * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions. [Api set: ExcelApi 1.10 for string, ExcelApi Preview for CommentRichContent object]
          * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.plain`.
          */
         add(cellAddress: Range | string, content: CommentRichContent | string, contentType?: Excel.ContentType): Excel.Comment;
@@ -36891,11 +36946,10 @@ declare namespace Excel {
          *
          * Creates a new comment with the given content on the given cell. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param cellAddress The cell to which the comment is added. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
-         * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions. [Api set: ExcelApi BETA (PREVIEW ONLY) for string, ExcelApi Preview for CommentRichContent object]
+         * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions. [Api set: ExcelApi 1.10 for string, ExcelApi Preview for CommentRichContent object]
          * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.plain`.
          */
         add(cellAddress: Range | string, content: CommentRichContent | string, contentType?: "Plain" | "Mention"): Excel.Comment;
@@ -36903,16 +36957,14 @@ declare namespace Excel {
          *
          * Gets the number of comments in the collection.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         getCount(): OfficeExtension.ClientResult<number>;
         /**
          *
          * Gets a comment from the collection based on its ID. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param commentId The identifier for the comment.
          */
@@ -36921,8 +36973,7 @@ declare namespace Excel {
          *
          * Gets a comment from the collection based on its position.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param index Index value of the object to be retrieved. Zero-indexed.
          */
@@ -36931,8 +36982,7 @@ declare namespace Excel {
          *
          * Gets the comment from the specified cell.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param cellAddress The cell which the comment is on. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
          */
@@ -36941,8 +36991,7 @@ declare namespace Excel {
          *
          * Gets the comment to which the given reply is connected.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param replyId The identifier of comment reply.
          */
@@ -36975,8 +37024,7 @@ declare namespace Excel {
      *
      * Represents a comment in the workbook.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class Comment extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -36985,48 +37033,42 @@ declare namespace Excel {
          *
          * Represents a collection of reply objects associated with the comment. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly replies: Excel.CommentReplyCollection;
         /**
          *
          * Gets the email of the comment's author.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly authorEmail: string;
         /**
          *
          * Gets the name of the comment's author.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly authorName: string;
         /**
          *
          * Gets or sets the comment's content. The string is plain text.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         content: string;
         /**
          *
          * Gets the creation time of the comment. Returns null if the comment was converted from a note, since the comment does not have a creation date.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly creationDate: Date;
         /**
          *
          * Represents the comment identifier. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly id: string;
         /**
@@ -37071,16 +37113,14 @@ declare namespace Excel {
          *
          * Deletes the comment and all the connected replies.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         delete(): void;
         /**
          *
          * Gets the cell where this comment is located.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         getLocation(): Excel.Range;
         /**
@@ -37124,8 +37164,7 @@ declare namespace Excel {
      *
      * Represents a collection of comment reply objects that are part of the comment.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class CommentReplyCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -37136,10 +37175,9 @@ declare namespace Excel {
          *
          * Creates a comment reply for comment.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
-         * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions). [Api set: ExcelApi BETA (PREVIEW ONLY) for string, ExcelApi Preview for CommentRichContent object]
+         * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions). [Api set: ExcelApi 1.10 for string, ExcelApi Preview for CommentRichContent object]
          * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.plain`.
          */
         add(content: CommentRichContent | string, contentType?: Excel.ContentType): Excel.CommentReply;
@@ -37147,10 +37185,9 @@ declare namespace Excel {
          *
          * Creates a comment reply for comment.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
-         * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions). [Api set: ExcelApi BETA (PREVIEW ONLY) for string, ExcelApi Preview for CommentRichContent object]
+         * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions). [Api set: ExcelApi 1.10 for string, ExcelApi Preview for CommentRichContent object]
          * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.plain`.
          */
         add(content: CommentRichContent | string, contentType?: "Plain" | "Mention"): Excel.CommentReply;
@@ -37158,16 +37195,14 @@ declare namespace Excel {
          *
          * Gets the number of comment replies in the collection.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         getCount(): OfficeExtension.ClientResult<number>;
         /**
          *
          * Returns a comment reply identified by its ID. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param commentReplyId The identifier for the comment reply.
          */
@@ -37176,8 +37211,7 @@ declare namespace Excel {
          *
          * Gets a comment reply based on its position in the collection.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param index The index value of the comment reply to be retrieved. The collection uses zero-based indexing.
          */
@@ -37210,8 +37244,7 @@ declare namespace Excel {
      *
      * Represents a comment reply in the workbook.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class CommentReply extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -37220,40 +37253,35 @@ declare namespace Excel {
          *
          * Gets the email of the comment reply's author.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly authorEmail: string;
         /**
          *
          * Gets the name of the comment reply's author.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly authorName: string;
         /**
          *
          * Gets or sets the comment reply's content. The string is plain text.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         content: string;
         /**
          *
          * Gets the creation time of the comment reply.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly creationDate: Date;
         /**
          *
          * Represents the comment reply identifier. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly id: string;
         /**
@@ -37298,24 +37326,21 @@ declare namespace Excel {
          *
          * Deletes the comment reply.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         delete(): void;
         /**
          *
          * Gets the cell where this comment reply is located.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         getLocation(): Excel.Range;
         /**
          *
          * Gets the parent comment of this reply.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         getParentComment(): Excel.Comment;
         /**
@@ -37638,8 +37663,7 @@ declare namespace Excel {
          *
          * Represents how the object is attached to the cells below it.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         placement: Excel.Placement | "TwoCell" | "OneCell" | "Absolute";
         /**
@@ -37705,8 +37729,7 @@ declare namespace Excel {
          * Copies and pastes a Shape object.
             The pasted shape is copied to the same pixel location as this shape.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param destinationSheet The sheet to which the shape object will be pasted. The default value is the copied Shape's worksheet.
          */
@@ -38788,8 +38811,7 @@ declare namespace Excel {
      *
      * Represents a slicer object in the workbook.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class Slicer extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -38798,24 +38820,21 @@ declare namespace Excel {
          *
          * Represents the collection of SlicerItems that are part of the slicer. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly slicerItems: Excel.SlicerItemCollection;
         /**
          *
          * Represents the worksheet containing the slicer. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly worksheet: Excel.Worksheet;
         /**
          *
          * Represents the caption of slicer.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         caption: string;
         /**
@@ -38823,24 +38842,21 @@ declare namespace Excel {
          * Represents the height, in points, of the slicer.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         height: number;
         /**
          *
          * Represents the unique id of slicer. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly id: string;
         /**
          *
          * True if all filters currently applied on the slicer are cleared.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly isFilterCleared: boolean;
         /**
@@ -38848,16 +38864,14 @@ declare namespace Excel {
          * Represents the distance, in points, from the left side of the slicer to the left of the worksheet.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         left: number;
         /**
          *
          * Represents the name of slicer.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         name: string;
         /**
@@ -38872,16 +38886,14 @@ declare namespace Excel {
          *
          * Represents the sort order of the items in the slicer. Possible values are: "DataSourceOrder", "Ascending", "Descending".
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         sortBy: Excel.SlicerSortType | "DataSourceOrder" | "Ascending" | "Descending";
         /**
          *
          * Constant value that represents the Slicer style. Possible values are: "SlicerStyleLight1" through "SlicerStyleLight6", "TableStyleOther1" through "TableStyleOther2", "SlicerStyleDark1" through "SlicerStyleDark6". A custom user-defined style present in the workbook can also be specified.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         style: string;
         /**
@@ -38889,8 +38901,7 @@ declare namespace Excel {
          * Represents the distance, in points, from the top edge of the slicer to the top of the worksheet.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         top: number;
         /**
@@ -38898,8 +38909,7 @@ declare namespace Excel {
          * Represents the width, in points, of the slicer.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         width: number;
         /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
@@ -38920,24 +38930,21 @@ declare namespace Excel {
          *
          * Clears all the filters currently applied on the slicer.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         clearFilters(): void;
         /**
          *
          * Deletes the slicer.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         delete(): void;
         /**
          *
          * Returns an array of selected items' keys. Read-only.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         getSelectedItems(): OfficeExtension.ClientResult<string[]>;
         /**
@@ -38945,8 +38952,7 @@ declare namespace Excel {
          * Selects slicer items based on their keys. The previous selections are cleared.
             All items will be selected by default if the array is empty.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param items Optional. The specified slicer item names to be selected.
          */
@@ -38982,8 +38988,7 @@ declare namespace Excel {
      *
      * Represents a collection of all the slicer objects on the workbook or a worksheet.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class SlicerCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -38994,8 +38999,7 @@ declare namespace Excel {
          *
          * Adds a new slicer to the workbook.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param slicerSource The data source that the new slicer will be based on. It can be a PivotTable object, a Table object or a string. When a PivotTable object is passed, the data source is the source of the PivotTable object. When a Table object is passed, the data source is the Table object. When a string is passed, it is interpreted as the name/id of a PivotTable/Table.
          * @param sourceField The field in the data source to filter by. It can be a PivotField object, a TableColumn object, the id of a PivotField or the id/name of TableColumn.
@@ -39007,16 +39011,14 @@ declare namespace Excel {
          *
          * Returns the number of slicers in the collection.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         getCount(): OfficeExtension.ClientResult<number>;
         /**
          *
          * Gets a slicer object using its name or id.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param key The name or id of the slicer.
          */
@@ -39025,8 +39027,7 @@ declare namespace Excel {
          *
          * Gets a slicer based on its position in the collection.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param index Index value of the object to be retrieved. Zero-indexed.
          */
@@ -39035,8 +39036,7 @@ declare namespace Excel {
          *
          * Gets a slicer using its name or id. If the slicer does not exist, will return a null object.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param key Name or Id of the slicer to be retrieved.
          */
@@ -39069,8 +39069,7 @@ declare namespace Excel {
      *
      * Represents a slicer item in a slicer.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class SlicerItem extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -39079,8 +39078,7 @@ declare namespace Excel {
          *
          * True if the slicer item has data.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly hasData: boolean;
         /**
@@ -39089,24 +39087,21 @@ declare namespace Excel {
             Setting this value will not clear other SlicerItems' selected state.
             By default, if the slicer item is the only one selected, when it is deselected, all items will be selected.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         isSelected: boolean;
         /**
          *
          * Represents the unique value representing the slicer item.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly key: string;
         /**
          *
          * Represents the title displayed in the UI.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         readonly name: string;
         /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
@@ -39154,8 +39149,7 @@ declare namespace Excel {
      *
      * Represents a collection of all the slicer item objects on the slicer.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     class SlicerItemCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
@@ -39166,16 +39160,14 @@ declare namespace Excel {
          *
          * Returns the number of slicer items in the slicer.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         getCount(): OfficeExtension.ClientResult<number>;
         /**
          *
          * Gets a slicer item object using its key or name.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param key The key or name of the slicer item.
          */
@@ -39184,8 +39176,7 @@ declare namespace Excel {
          *
          * Gets a slicer item based on its position in the collection.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param index Index value of the object to be retrieved. Zero-indexed.
          */
@@ -39194,8 +39185,7 @@ declare namespace Excel {
          *
          * Gets a slicer item using its key or name. If the slicer item does not exist, will return a null object.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          *
          * @param key Key or name of the slicer to be retrieved.
          */
@@ -41379,8 +41369,7 @@ declare namespace Excel {
         flashFill = "FlashFill"
     }
     /**
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     enum GroupOption {
         /**
@@ -41609,8 +41598,7 @@ declare namespace Excel {
         curve = "Curve"
     }
     /**
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     enum ContentType {
         /**
@@ -41993,8 +41981,7 @@ declare namespace Excel {
      *
      * Specifies the slicer sort behavior for Slicer.sortBy API.
      *
-     * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-     * @beta
+     * [Api set: ExcelApi 1.10]
      */
     enum SlicerSortType {
         /**
@@ -46321,7 +46308,7 @@ declare namespace Excel {
             showTotals?: boolean;
             /**
              *
-             * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleStyleDark1" through "TableStyleStyleDark11". A custom user-defined style present in the workbook can also be specified.
+             * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleDark1" through "TableStyleDark11". A custom user-defined style present in the workbook can also be specified.
              *
              * [Api set: ExcelApi 1.1]
              */
@@ -46868,7 +46855,7 @@ declare namespace Excel {
             showAxisFieldButtons?: boolean;
             /**
              *
-             * Specifies whether or not to display the legend field buttons on a PivotChart
+             * Specifies whether or not to display the legend field buttons on a PivotChart.
              *
              * [Api set: ExcelApi 1.9]
              */
@@ -46882,7 +46869,7 @@ declare namespace Excel {
             showReportFilterFieldButtons?: boolean;
             /**
              *
-             * Specifies whether or not to display the show value field buttons on a PivotChart
+             * Specifies whether or not to display the show value field buttons on a PivotChart.
              *
              * [Api set: ExcelApi 1.9]
              */
@@ -48690,8 +48677,7 @@ declare namespace Excel {
              *
              * Specifies whether the field list can be shown in the UI.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             enableFieldList?: boolean;
             /**
@@ -49683,8 +49669,7 @@ declare namespace Excel {
              *
              * Gets the name of the TableStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: string;
         }
@@ -49698,8 +49683,7 @@ declare namespace Excel {
              *
              * Gets the name of the PivotTableStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: string;
         }
@@ -49713,8 +49697,7 @@ declare namespace Excel {
              *
              * Gets the name of the SlicerStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: string;
         }
@@ -49728,8 +49711,7 @@ declare namespace Excel {
              *
              * Gets the name of the TimelineStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: string;
         }
@@ -49998,8 +49980,7 @@ declare namespace Excel {
              *
              * Gets or sets the comment's content. The string is plain text.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             content?: string;
             /**
@@ -50021,8 +50002,7 @@ declare namespace Excel {
              *
              * Gets or sets the comment reply's content. The string is plain text.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             content?: string;
         }
@@ -50101,8 +50081,7 @@ declare namespace Excel {
              *
              * Represents how the object is attached to the cells below it.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             placement?: Excel.Placement | "TwoCell" | "OneCell" | "Absolute";
             /**
@@ -50402,16 +50381,14 @@ declare namespace Excel {
             *
             * Represents the worksheet containing the slicer.
             *
-            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-            * @beta
+            * [Api set: ExcelApi 1.10]
             */
             worksheet?: Excel.Interfaces.WorksheetUpdateData;
             /**
              *
              * Represents the caption of slicer.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             caption?: string;
             /**
@@ -50419,8 +50396,7 @@ declare namespace Excel {
              * Represents the height, in points, of the slicer.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             height?: number;
             /**
@@ -50428,16 +50404,14 @@ declare namespace Excel {
              * Represents the distance, in points, from the left side of the slicer to the left of the worksheet.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             left?: number;
             /**
              *
              * Represents the name of slicer.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: string;
             /**
@@ -50452,16 +50426,14 @@ declare namespace Excel {
              *
              * Represents the sort order of the items in the slicer. Possible values are: "DataSourceOrder", "Ascending", "Descending".
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             sortBy?: Excel.SlicerSortType | "DataSourceOrder" | "Ascending" | "Descending";
             /**
              *
              * Constant value that represents the Slicer style. Possible values are: "SlicerStyleLight1" through "SlicerStyleLight6", "TableStyleOther1" through "TableStyleOther2", "SlicerStyleDark1" through "SlicerStyleDark6". A custom user-defined style present in the workbook can also be specified.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             style?: string;
             /**
@@ -50469,8 +50441,7 @@ declare namespace Excel {
              * Represents the distance, in points, from the top edge of the slicer to the top of the worksheet.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             top?: number;
             /**
@@ -50478,8 +50449,7 @@ declare namespace Excel {
              * Represents the width, in points, of the slicer.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             width?: number;
         }
@@ -50495,8 +50465,7 @@ declare namespace Excel {
             Setting this value will not clear other SlicerItems' selected state.
             By default, if the slicer item is the only one selected, when it is deselected, all items will be selected.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             isSelected?: boolean;
         }
@@ -50516,6 +50485,14 @@ declare namespace Excel {
         }
         /** An interface describing the data returned by calling `application.toJSON()`. */
         interface ApplicationData {
+            /**
+            *
+            * Provides information based on current system culture settings. This includes the culture names, number formatting, and other culturally dependent settings.
+            *
+            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+            * @beta
+            */
+            cultureInfo?: Excel.Interfaces.CultureInfoData;
             /**
             *
             * Returns the Iterative Calculation settings.
@@ -50546,6 +50523,31 @@ declare namespace Excel {
              * [Api set: ExcelApi 1.9]
              */
             calculationState?: Excel.CalculationState | "Done" | "Calculating" | "Pending";
+            /**
+             *
+             * Gets the string used as the decimal separator for numeric values. This is based on Excel's local settings.
+             *
+             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+             * @beta
+             */
+            decimalSeparator?: string;
+            /**
+             *
+             * Gets the string used to separate groups of digits to the left of the decimal for numeric values. This is based on Excel's local settings.
+             *
+             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+             * @beta
+             */
+            thousandsSeparator?: string;
+            /**
+             *
+             * Specifies whether the system separators of Microsoft Excel are enabled.
+            System separators include the decimal separator and thousands separator.
+             *
+             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+             * @beta
+             */
+            useSystemSeparators?: boolean;
         }
         /** An interface describing the data returned by calling `iterativeCalculation.toJSON()`. */
         interface IterativeCalculationData {
@@ -50584,8 +50586,7 @@ declare namespace Excel {
             *
             * Represents a collection of Comments associated with the workbook. Read-only.
             *
-            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-            * @beta
+            * [Api set: ExcelApi 1.10]
             */
             comments?: Excel.Interfaces.CommentData[];
             /**
@@ -50606,8 +50607,7 @@ declare namespace Excel {
             *
             * Represents a collection of PivotTableStyles associated with the workbook. Read-only.
             *
-            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-            * @beta
+            * [Api set: ExcelApi 1.10]
             */
             pivotTableStyles?: Excel.Interfaces.PivotTableStyleData[];
             /**
@@ -50642,16 +50642,14 @@ declare namespace Excel {
             *
             * Represents a collection of SlicerStyles associated with the workbook. Read-only.
             *
-            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-            * @beta
+            * [Api set: ExcelApi 1.10]
             */
             slicerStyles?: Excel.Interfaces.SlicerStyleData[];
             /**
             *
             * Represents a collection of Slicers associated with the workbook. Read-only.
             *
-            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-            * @beta
+            * [Api set: ExcelApi 1.10]
             */
             slicers?: Excel.Interfaces.SlicerData[];
             /**
@@ -50665,8 +50663,7 @@ declare namespace Excel {
             *
             * Represents a collection of TableStyles associated with the workbook. Read-only.
             *
-            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-            * @beta
+            * [Api set: ExcelApi 1.10]
             */
             tableStyles?: Excel.Interfaces.TableStyleData[];
             /**
@@ -50680,8 +50677,7 @@ declare namespace Excel {
             *
             * Represents a collection of TimelineStyles associated with the workbook. Read-only.
             *
-            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-            * @beta
+            * [Api set: ExcelApi 1.10]
             */
             timelineStyles?: Excel.Interfaces.TimelineStyleData[];
             /**
@@ -50783,7 +50779,7 @@ declare namespace Excel {
             autoFilter?: Excel.Interfaces.AutoFilterData;
             /**
             *
-            * Returns collection of charts that are part of the worksheet. Read-only.
+            * Returns a collection of charts that are part of the worksheet. Read-only.
             *
             * [Api set: ExcelApi 1.1]
             */
@@ -50792,8 +50788,7 @@ declare namespace Excel {
             *
             * Returns a collection of all the Comments objects on the worksheet. Read-only.
             *
-            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-            * @beta
+            * [Api set: ExcelApi 1.10]
             */
             comments?: Excel.Interfaces.CommentData[];
             /**
@@ -50840,10 +50835,9 @@ declare namespace Excel {
             shapes?: Excel.Interfaces.ShapeData[];
             /**
             *
-            * Returns collection of slicers that are part of the worksheet. Read-only.
+            * Returns a collection of slicers that are part of the worksheet. Read-only.
             *
-            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-            * @beta
+            * [Api set: ExcelApi 1.10]
             */
             slicers?: Excel.Interfaces.SlicerData[];
             /**
@@ -51061,8 +51055,7 @@ declare namespace Excel {
              *
              * Returns the distance in points, for 100% zoom, from top edge of the range to bottom edge of the range. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             height?: number;
             /**
@@ -51097,8 +51090,7 @@ declare namespace Excel {
              *
              * Returns the distance in points, for 100% zoom, from left edge of the worksheet to left edge of the range. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             left?: number;
             /**
@@ -51178,8 +51170,7 @@ declare namespace Excel {
              *
              * Returns the distance in points, for 100% zoom, from top edge of the worksheet to top edge of the range. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             top?: number;
             /**
@@ -51201,8 +51192,7 @@ declare namespace Excel {
              *
              * Returns the distance in points, for 100% zoom, from left edge of the range to right edge of the range. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             width?: number;
         }
@@ -51611,7 +51601,7 @@ declare namespace Excel {
             showTotals?: boolean;
             /**
              *
-             * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleStyleDark1" through "TableStyleStyleDark11". A custom user-defined style present in the workbook can also be specified.
+             * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleDark1" through "TableStyleDark11". A custom user-defined style present in the workbook can also be specified.
              *
              * [Api set: ExcelApi 1.1]
              */
@@ -52232,7 +52222,7 @@ declare namespace Excel {
             showAxisFieldButtons?: boolean;
             /**
              *
-             * Specifies whether or not to display the legend field buttons on a PivotChart
+             * Specifies whether or not to display the legend field buttons on a PivotChart.
              *
              * [Api set: ExcelApi 1.9]
              */
@@ -52246,7 +52236,7 @@ declare namespace Excel {
             showReportFilterFieldButtons?: boolean;
             /**
              *
-             * Specifies whether or not to display the show value field buttons on a PivotChart
+             * Specifies whether or not to display the show value field buttons on a PivotChart.
              *
              * [Api set: ExcelApi 1.9]
              */
@@ -54224,6 +54214,44 @@ declare namespace Excel {
              */
             isDataFiltered?: boolean;
         }
+        /** An interface describing the data returned by calling `cultureInfo.toJSON()`. */
+        interface CultureInfoData {
+            /**
+            *
+            * Defines the culturally appropriate format of displaying numbers. This is based on current system culture settings.
+            *
+            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+            * @beta
+            */
+            numberFormatInfo?: Excel.Interfaces.NumberFormatInfoData;
+            /**
+             *
+             * Gets the culture name in the format languagecode2-country/regioncode2 (e.g. "zh-cn" or "en-us"). This is based on current system settings.
+             *
+             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+             * @beta
+             */
+            name?: string;
+        }
+        /** An interface describing the data returned by calling `numberFormatInfo.toJSON()`. */
+        interface NumberFormatInfoData {
+            /**
+             *
+             * Gets the string used as the decimal separator for numeric values. This is based on current system settings.
+             *
+             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+             * @beta
+             */
+            numberDecimalSeparator?: string;
+            /**
+             *
+             * Gets the string used to separate groups of digits to the left of the decimal for numeric values. This is based on current system settings.
+             *
+             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+             * @beta
+             */
+            numberGroupSeparator?: string;
+        }
         /** An interface describing the data returned by calling `customXmlPartScopedCollection.toJSON()`. */
         interface CustomXmlPartScopedCollectionData {
             items?: Excel.Interfaces.CustomXmlPartData[];
@@ -54332,8 +54360,7 @@ declare namespace Excel {
              *
              * Specifies whether the field list can be shown in the UI.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             enableFieldList?: boolean;
             /**
@@ -55444,16 +55471,14 @@ declare namespace Excel {
              *
              * Gets the name of the TableStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: string;
             /**
              *
              * Specifies whether this TableStyle object is read-only. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             readOnly?: boolean;
         }
@@ -55467,16 +55492,14 @@ declare namespace Excel {
              *
              * Gets the name of the PivotTableStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: string;
             /**
              *
              * Specifies whether this PivotTableStyle object is read-only. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             readOnly?: boolean;
         }
@@ -55490,16 +55513,14 @@ declare namespace Excel {
              *
              * Gets the name of the SlicerStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: string;
             /**
              *
              * Specifies whether this SlicerStyle object is read-only. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             readOnly?: boolean;
         }
@@ -55513,16 +55534,14 @@ declare namespace Excel {
              *
              * Gets the name of the TimelineStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: string;
             /**
              *
              * Specifies whether this TimelineStyle object is read-only. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             readOnly?: boolean;
         }
@@ -55808,48 +55827,42 @@ declare namespace Excel {
             *
             * Represents a collection of reply objects associated with the comment. Read-only.
             *
-            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-            * @beta
+            * [Api set: ExcelApi 1.10]
             */
             replies?: Excel.Interfaces.CommentReplyData[];
             /**
              *
              * Gets the email of the comment's author.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             authorEmail?: string;
             /**
              *
              * Gets the name of the comment's author.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             authorName?: string;
             /**
              *
              * Gets or sets the comment's content. The string is plain text.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             content?: string;
             /**
              *
              * Gets the creation time of the comment. Returns null if the comment was converted from a note, since the comment does not have a creation date.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             creationDate?: Date;
             /**
              *
              * Represents the comment identifier. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             id?: string;
             /**
@@ -55887,40 +55900,35 @@ declare namespace Excel {
              *
              * Gets the email of the comment reply's author.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             authorEmail?: string;
             /**
              *
              * Gets the name of the comment reply's author.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             authorName?: string;
             /**
              *
              * Gets or sets the comment reply's content. The string is plain text.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             content?: string;
             /**
              *
              * Gets the creation time of the comment reply.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             creationDate?: Date;
             /**
              *
              * Represents the comment reply identifier. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             id?: string;
             /**
@@ -56044,8 +56052,7 @@ declare namespace Excel {
              *
              * Represents how the object is attached to the cells below it.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             placement?: Excel.Placement | "TwoCell" | "OneCell" | "Absolute";
             /**
@@ -56452,24 +56459,21 @@ declare namespace Excel {
             *
             * Represents the collection of SlicerItems that are part of the slicer. Read-only.
             *
-            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-            * @beta
+            * [Api set: ExcelApi 1.10]
             */
             slicerItems?: Excel.Interfaces.SlicerItemData[];
             /**
             *
             * Represents the worksheet containing the slicer. Read-only.
             *
-            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-            * @beta
+            * [Api set: ExcelApi 1.10]
             */
             worksheet?: Excel.Interfaces.WorksheetData;
             /**
              *
              * Represents the caption of slicer.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             caption?: string;
             /**
@@ -56477,24 +56481,21 @@ declare namespace Excel {
              * Represents the height, in points, of the slicer.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             height?: number;
             /**
              *
              * Represents the unique id of slicer. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             id?: string;
             /**
              *
              * True if all filters currently applied on the slicer are cleared.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             isFilterCleared?: boolean;
             /**
@@ -56502,16 +56503,14 @@ declare namespace Excel {
              * Represents the distance, in points, from the left side of the slicer to the left of the worksheet.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             left?: number;
             /**
              *
              * Represents the name of slicer.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: string;
             /**
@@ -56526,16 +56525,14 @@ declare namespace Excel {
              *
              * Represents the sort order of the items in the slicer. Possible values are: "DataSourceOrder", "Ascending", "Descending".
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             sortBy?: Excel.SlicerSortType | "DataSourceOrder" | "Ascending" | "Descending";
             /**
              *
              * Constant value that represents the Slicer style. Possible values are: "SlicerStyleLight1" through "SlicerStyleLight6", "TableStyleOther1" through "TableStyleOther2", "SlicerStyleDark1" through "SlicerStyleDark6". A custom user-defined style present in the workbook can also be specified.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             style?: string;
             /**
@@ -56543,8 +56540,7 @@ declare namespace Excel {
              * Represents the distance, in points, from the top edge of the slicer to the top of the worksheet.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             top?: number;
             /**
@@ -56552,8 +56548,7 @@ declare namespace Excel {
              * Represents the width, in points, of the slicer.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             width?: number;
         }
@@ -56567,8 +56562,7 @@ declare namespace Excel {
              *
              * True if the slicer item has data.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             hasData?: boolean;
             /**
@@ -56577,24 +56571,21 @@ declare namespace Excel {
             Setting this value will not clear other SlicerItems' selected state.
             By default, if the slicer item is the only one selected, when it is deselected, all items will be selected.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             isSelected?: boolean;
             /**
              *
              * Represents the unique value representing the slicer item.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             key?: string;
             /**
              *
              * Represents the title displayed in the UI.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: string;
         }
@@ -56651,6 +56642,14 @@ declare namespace Excel {
             $all?: boolean;
             /**
             *
+            * Provides information based on current system culture settings. This includes the culture names, number formatting, and other culturally dependent settings.
+            *
+            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+            * @beta
+            */
+            cultureInfo?: Excel.Interfaces.CultureInfoLoadOptions;
+            /**
+            *
             * Returns the Iterative Calculation settings.
             In Excel on Windows and Mac, the settings will apply to the Excel Application.
             In Excel on the web and other platforms, the settings will apply to the active workbook.
@@ -56679,6 +56678,31 @@ declare namespace Excel {
              * [Api set: ExcelApi 1.9]
              */
             calculationState?: boolean;
+            /**
+             *
+             * Gets the string used as the decimal separator for numeric values. This is based on Excel's local settings.
+             *
+             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+             * @beta
+             */
+            decimalSeparator?: boolean;
+            /**
+             *
+             * Gets the string used to separate groups of digits to the left of the decimal for numeric values. This is based on Excel's local settings.
+             *
+             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+             * @beta
+             */
+            thousandsSeparator?: boolean;
+            /**
+             *
+             * Specifies whether the system separators of Microsoft Excel are enabled.
+            System separators include the decimal separator and thousands separator.
+             *
+             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+             * @beta
+             */
+            useSystemSeparators?: boolean;
         }
         /**
          *
@@ -56868,7 +56892,7 @@ declare namespace Excel {
             autoFilter?: Excel.Interfaces.AutoFilterLoadOptions;
             /**
             *
-            * Returns collection of charts that are part of the worksheet.
+            * Returns a collection of charts that are part of the worksheet.
             *
             * [Api set: ExcelApi 1.1]
             */
@@ -56991,7 +57015,7 @@ declare namespace Excel {
             autoFilter?: Excel.Interfaces.AutoFilterLoadOptions;
             /**
             *
-            * For EACH ITEM in the collection: Returns collection of charts that are part of the worksheet.
+            * For EACH ITEM in the collection: Returns a collection of charts that are part of the worksheet.
             *
             * [Api set: ExcelApi 1.1]
             */
@@ -57234,8 +57258,7 @@ declare namespace Excel {
              *
              * Returns the distance in points, for 100% zoom, from top edge of the range to bottom edge of the range. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             height?: boolean;
             /**
@@ -57270,8 +57293,7 @@ declare namespace Excel {
              *
              * Returns the distance in points, for 100% zoom, from left edge of the worksheet to left edge of the range. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             left?: boolean;
             /**
@@ -57351,8 +57373,7 @@ declare namespace Excel {
              *
              * Returns the distance in points, for 100% zoom, from top edge of the worksheet to top edge of the range. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             top?: boolean;
             /**
@@ -57374,8 +57395,7 @@ declare namespace Excel {
              *
              * Returns the distance in points, for 100% zoom, from left edge of the range to right edge of the range. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             width?: boolean;
         }
@@ -58054,7 +58074,7 @@ declare namespace Excel {
             showTotals?: boolean;
             /**
              *
-             * For EACH ITEM in the collection: Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleStyleDark1" through "TableStyleStyleDark11". A custom user-defined style present in the workbook can also be specified.
+             * For EACH ITEM in the collection: Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleDark1" through "TableStyleDark11". A custom user-defined style present in the workbook can also be specified.
              *
              * [Api set: ExcelApi 1.1]
              */
@@ -58178,7 +58198,7 @@ declare namespace Excel {
             showTotals?: boolean;
             /**
              *
-             * For EACH ITEM in the collection: Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleStyleDark1" through "TableStyleStyleDark11". A custom user-defined style present in the workbook can also be specified.
+             * For EACH ITEM in the collection: Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleDark1" through "TableStyleDark11". A custom user-defined style present in the workbook can also be specified.
              *
              * [Api set: ExcelApi 1.1]
              */
@@ -58303,7 +58323,7 @@ declare namespace Excel {
             showTotals?: boolean;
             /**
              *
-             * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleStyleDark1" through "TableStyleStyleDark11". A custom user-defined style present in the workbook can also be specified.
+             * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleDark1" through "TableStyleDark11". A custom user-defined style present in the workbook can also be specified.
              *
              * [Api set: ExcelApi 1.1]
              */
@@ -59331,7 +59351,7 @@ declare namespace Excel {
             showAxisFieldButtons?: boolean;
             /**
              *
-             * Specifies whether or not to display the legend field buttons on a PivotChart
+             * Specifies whether or not to display the legend field buttons on a PivotChart.
              *
              * [Api set: ExcelApi 1.9]
              */
@@ -59345,7 +59365,7 @@ declare namespace Excel {
             showReportFilterFieldButtons?: boolean;
             /**
              *
-             * Specifies whether or not to display the show value field buttons on a PivotChart
+             * Specifies whether or not to display the show value field buttons on a PivotChart.
              *
              * [Api set: ExcelApi 1.9]
              */
@@ -62192,6 +62212,64 @@ declare namespace Excel {
         }
         /**
          *
+         * Provides information based on current system culture settings. This includes the culture names, number formatting, and other culturally dependent settings.
+         *
+         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * @beta
+         */
+        interface CultureInfoLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+            *
+            * Defines the culturally appropriate format of displaying numbers. This is based on current system culture settings.
+            *
+            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+            * @beta
+            */
+            numberFormatInfo?: Excel.Interfaces.NumberFormatInfoLoadOptions;
+            /**
+             *
+             * Gets the culture name in the format languagecode2-country/regioncode2 (e.g. "zh-cn" or "en-us"). This is based on current system settings.
+             *
+             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+             * @beta
+             */
+            name?: boolean;
+        }
+        /**
+         *
+         * Defines the culturally appropriate format of displaying numbers. This is based on current system culture settings.
+         *
+         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * @beta
+         */
+        interface NumberFormatInfoLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * Gets the string used as the decimal separator for numeric values. This is based on current system settings.
+             *
+             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+             * @beta
+             */
+            numberDecimalSeparator?: boolean;
+            /**
+             *
+             * Gets the string used to separate groups of digits to the left of the decimal for numeric values. This is based on current system settings.
+             *
+             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+             * @beta
+             */
+            numberGroupSeparator?: boolean;
+        }
+        /**
+         *
          * A scoped collection of custom XML parts.
             A scoped collection is the result of some operation, e.g. filtering by namespace.
             A scoped collection cannot be scoped any further.
@@ -62401,8 +62479,7 @@ declare namespace Excel {
              *
              * Specifies whether the field list can be shown in the UI.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             enableFieldList?: boolean;
             /**
@@ -64300,8 +64377,7 @@ declare namespace Excel {
          *
          * Represents a collection of TableStyles.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface TableStyleCollectionLoadOptions {
             /**
@@ -64312,16 +64388,14 @@ declare namespace Excel {
              *
              * For EACH ITEM in the collection: Gets the name of the TableStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Specifies whether this TableStyle object is read-only. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             readOnly?: boolean;
         }
@@ -64329,8 +64403,7 @@ declare namespace Excel {
          *
          * Represents a TableStyle, which defines the style elements by region of the Table.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface TableStyleLoadOptions {
             /**
@@ -64341,16 +64414,14 @@ declare namespace Excel {
              *
              * Gets the name of the TableStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: boolean;
             /**
              *
              * Specifies whether this TableStyle object is read-only. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             readOnly?: boolean;
         }
@@ -64358,8 +64429,7 @@ declare namespace Excel {
          *
          * Represents a collection of PivotTable styles.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface PivotTableStyleCollectionLoadOptions {
             /**
@@ -64370,16 +64440,14 @@ declare namespace Excel {
              *
              * For EACH ITEM in the collection: Gets the name of the PivotTableStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Specifies whether this PivotTableStyle object is read-only. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             readOnly?: boolean;
         }
@@ -64387,8 +64455,7 @@ declare namespace Excel {
          *
          * Represents a PivotTable Style, which defines style elements by PivotTable region.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface PivotTableStyleLoadOptions {
             /**
@@ -64399,16 +64466,14 @@ declare namespace Excel {
              *
              * Gets the name of the PivotTableStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: boolean;
             /**
              *
              * Specifies whether this PivotTableStyle object is read-only. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             readOnly?: boolean;
         }
@@ -64416,8 +64481,7 @@ declare namespace Excel {
          *
          * Represents a collection of SlicerStyle objects.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface SlicerStyleCollectionLoadOptions {
             /**
@@ -64428,16 +64492,14 @@ declare namespace Excel {
              *
              * For EACH ITEM in the collection: Gets the name of the SlicerStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Specifies whether this SlicerStyle object is read-only. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             readOnly?: boolean;
         }
@@ -64445,8 +64507,7 @@ declare namespace Excel {
          *
          * Represents a Slicer Style, which defines style elements by region of the slicer.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface SlicerStyleLoadOptions {
             /**
@@ -64457,16 +64518,14 @@ declare namespace Excel {
              *
              * Gets the name of the SlicerStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: boolean;
             /**
              *
              * Specifies whether this SlicerStyle object is read-only. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             readOnly?: boolean;
         }
@@ -64474,8 +64533,7 @@ declare namespace Excel {
          *
          * Represents a collection of TimelineStyles.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface TimelineStyleCollectionLoadOptions {
             /**
@@ -64486,16 +64544,14 @@ declare namespace Excel {
              *
              * For EACH ITEM in the collection: Gets the name of the TimelineStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Specifies whether this TimelineStyle object is read-only. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             readOnly?: boolean;
         }
@@ -64503,8 +64559,7 @@ declare namespace Excel {
          *
          * Represents a Timeline style, which defines style elements by region in the Timeline.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface TimelineStyleLoadOptions {
             /**
@@ -64515,16 +64570,14 @@ declare namespace Excel {
              *
              * Gets the name of the TimelineStyle.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: boolean;
             /**
              *
              * Specifies whether this TimelineStyle object is read-only. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             readOnly?: boolean;
         }
@@ -64951,8 +65004,7 @@ declare namespace Excel {
              *
              * For EACH ITEM in the collection: Returns the distance in points, for 100% zoom, from top edge of the range to bottom edge of the range. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             height?: boolean;
             /**
@@ -64987,8 +65039,7 @@ declare namespace Excel {
              *
              * For EACH ITEM in the collection: Returns the distance in points, for 100% zoom, from left edge of the worksheet to left edge of the range. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             left?: boolean;
             /**
@@ -65068,8 +65119,7 @@ declare namespace Excel {
              *
              * For EACH ITEM in the collection: Returns the distance in points, for 100% zoom, from top edge of the worksheet to top edge of the range. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             top?: boolean;
             /**
@@ -65091,8 +65141,7 @@ declare namespace Excel {
              *
              * For EACH ITEM in the collection: Returns the distance in points, for 100% zoom, from left edge of the range to right edge of the range. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             width?: boolean;
         }
@@ -65100,8 +65149,7 @@ declare namespace Excel {
          *
          * Represents a collection of comment objects that are part of the workbook.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface CommentCollectionLoadOptions {
             /**
@@ -65112,40 +65160,35 @@ declare namespace Excel {
              *
              * For EACH ITEM in the collection: Gets the email of the comment's author.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             authorEmail?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Gets the name of the comment's author.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             authorName?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Gets or sets the comment's content. The string is plain text.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             content?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Gets the creation time of the comment. Returns null if the comment was converted from a note, since the comment does not have a creation date.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             creationDate?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Represents the comment identifier. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             id?: boolean;
             /**
@@ -65177,8 +65220,7 @@ declare namespace Excel {
          *
          * Represents a comment in the workbook.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface CommentLoadOptions {
             /**
@@ -65189,40 +65231,35 @@ declare namespace Excel {
              *
              * Gets the email of the comment's author.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             authorEmail?: boolean;
             /**
              *
              * Gets the name of the comment's author.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             authorName?: boolean;
             /**
              *
              * Gets or sets the comment's content. The string is plain text.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             content?: boolean;
             /**
              *
              * Gets the creation time of the comment. Returns null if the comment was converted from a note, since the comment does not have a creation date.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             creationDate?: boolean;
             /**
              *
              * Represents the comment identifier. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             id?: boolean;
             /**
@@ -65254,8 +65291,7 @@ declare namespace Excel {
          *
          * Represents a collection of comment reply objects that are part of the comment.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface CommentReplyCollectionLoadOptions {
             /**
@@ -65266,40 +65302,35 @@ declare namespace Excel {
              *
              * For EACH ITEM in the collection: Gets the email of the comment reply's author.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             authorEmail?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Gets the name of the comment reply's author.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             authorName?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Gets or sets the comment reply's content. The string is plain text.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             content?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Gets the creation time of the comment reply.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             creationDate?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Represents the comment reply identifier. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             id?: boolean;
             /**
@@ -65331,8 +65362,7 @@ declare namespace Excel {
          *
          * Represents a comment reply in the workbook.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface CommentReplyLoadOptions {
             /**
@@ -65343,40 +65373,35 @@ declare namespace Excel {
              *
              * Gets the email of the comment reply's author.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             authorEmail?: boolean;
             /**
              *
              * Gets the name of the comment reply's author.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             authorName?: boolean;
             /**
              *
              * Gets or sets the comment reply's content. The string is plain text.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             content?: boolean;
             /**
              *
              * Gets the creation time of the comment reply.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             creationDate?: boolean;
             /**
              *
              * Represents the comment reply identifier. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             id?: boolean;
             /**
@@ -65547,8 +65572,7 @@ declare namespace Excel {
              *
              * For EACH ITEM in the collection: Represents how the object is attached to the cells below it.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             placement?: boolean;
             /**
@@ -65740,8 +65764,7 @@ declare namespace Excel {
              *
              * Represents how the object is attached to the cells below it.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             placement?: boolean;
             /**
@@ -66017,8 +66040,7 @@ declare namespace Excel {
              *
              * For EACH ITEM in the collection: Represents how the object is attached to the cells below it.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             placement?: boolean;
             /**
@@ -66457,8 +66479,7 @@ declare namespace Excel {
          *
          * Represents a slicer object in the workbook.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface SlicerLoadOptions {
             /**
@@ -66469,16 +66490,14 @@ declare namespace Excel {
             *
             * Represents the worksheet containing the slicer.
             *
-            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-            * @beta
+            * [Api set: ExcelApi 1.10]
             */
             worksheet?: Excel.Interfaces.WorksheetLoadOptions;
             /**
              *
              * Represents the caption of slicer.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             caption?: boolean;
             /**
@@ -66486,24 +66505,21 @@ declare namespace Excel {
              * Represents the height, in points, of the slicer.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             height?: boolean;
             /**
              *
              * Represents the unique id of slicer. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             id?: boolean;
             /**
              *
              * True if all filters currently applied on the slicer are cleared.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             isFilterCleared?: boolean;
             /**
@@ -66511,16 +66527,14 @@ declare namespace Excel {
              * Represents the distance, in points, from the left side of the slicer to the left of the worksheet.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             left?: boolean;
             /**
              *
              * Represents the name of slicer.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: boolean;
             /**
@@ -66535,16 +66549,14 @@ declare namespace Excel {
              *
              * Represents the sort order of the items in the slicer. Possible values are: "DataSourceOrder", "Ascending", "Descending".
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             sortBy?: boolean;
             /**
              *
              * Constant value that represents the Slicer style. Possible values are: "SlicerStyleLight1" through "SlicerStyleLight6", "TableStyleOther1" through "TableStyleOther2", "SlicerStyleDark1" through "SlicerStyleDark6". A custom user-defined style present in the workbook can also be specified.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             style?: boolean;
             /**
@@ -66552,8 +66564,7 @@ declare namespace Excel {
              * Represents the distance, in points, from the top edge of the slicer to the top of the worksheet.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             top?: boolean;
             /**
@@ -66561,8 +66572,7 @@ declare namespace Excel {
              * Represents the width, in points, of the slicer.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             width?: boolean;
         }
@@ -66570,8 +66580,7 @@ declare namespace Excel {
          *
          * Represents a collection of all the slicer objects on the workbook or a worksheet.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface SlicerCollectionLoadOptions {
             /**
@@ -66582,16 +66591,14 @@ declare namespace Excel {
             *
             * For EACH ITEM in the collection: Represents the worksheet containing the slicer.
             *
-            * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-            * @beta
+            * [Api set: ExcelApi 1.10]
             */
             worksheet?: Excel.Interfaces.WorksheetLoadOptions;
             /**
              *
              * For EACH ITEM in the collection: Represents the caption of slicer.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             caption?: boolean;
             /**
@@ -66599,24 +66606,21 @@ declare namespace Excel {
              * For EACH ITEM in the collection: Represents the height, in points, of the slicer.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             height?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Represents the unique id of slicer. Read-only.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             id?: boolean;
             /**
              *
              * For EACH ITEM in the collection: True if all filters currently applied on the slicer are cleared.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             isFilterCleared?: boolean;
             /**
@@ -66624,16 +66628,14 @@ declare namespace Excel {
              * For EACH ITEM in the collection: Represents the distance, in points, from the left side of the slicer to the left of the worksheet.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             left?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Represents the name of slicer.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: boolean;
             /**
@@ -66648,16 +66650,14 @@ declare namespace Excel {
              *
              * For EACH ITEM in the collection: Represents the sort order of the items in the slicer. Possible values are: "DataSourceOrder", "Ascending", "Descending".
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             sortBy?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Constant value that represents the Slicer style. Possible values are: "SlicerStyleLight1" through "SlicerStyleLight6", "TableStyleOther1" through "TableStyleOther2", "SlicerStyleDark1" through "SlicerStyleDark6". A custom user-defined style present in the workbook can also be specified.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             style?: boolean;
             /**
@@ -66665,8 +66665,7 @@ declare namespace Excel {
              * For EACH ITEM in the collection: Represents the distance, in points, from the top edge of the slicer to the top of the worksheet.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             top?: boolean;
             /**
@@ -66674,8 +66673,7 @@ declare namespace Excel {
              * For EACH ITEM in the collection: Represents the width, in points, of the slicer.
             Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             width?: boolean;
         }
@@ -66683,8 +66681,7 @@ declare namespace Excel {
          *
          * Represents a slicer item in a slicer.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface SlicerItemLoadOptions {
             /**
@@ -66695,8 +66692,7 @@ declare namespace Excel {
              *
              * True if the slicer item has data.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             hasData?: boolean;
             /**
@@ -66705,24 +66701,21 @@ declare namespace Excel {
             Setting this value will not clear other SlicerItems' selected state.
             By default, if the slicer item is the only one selected, when it is deselected, all items will be selected.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             isSelected?: boolean;
             /**
              *
              * Represents the unique value representing the slicer item.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             key?: boolean;
             /**
              *
              * Represents the title displayed in the UI.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: boolean;
         }
@@ -66730,8 +66723,7 @@ declare namespace Excel {
          *
          * Represents a collection of all the slicer item objects on the slicer.
          *
-         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-         * @beta
+         * [Api set: ExcelApi 1.10]
          */
         interface SlicerItemCollectionLoadOptions {
             /**
@@ -66742,8 +66734,7 @@ declare namespace Excel {
              *
              * For EACH ITEM in the collection: True if the slicer item has data.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             hasData?: boolean;
             /**
@@ -66752,24 +66743,21 @@ declare namespace Excel {
             Setting this value will not clear other SlicerItems' selected state.
             By default, if the slicer item is the only one selected, when it is deselected, all items will be selected.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             isSelected?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Represents the unique value representing the slicer item.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             key?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Represents the title displayed in the UI.
              *
-             * [Api set: ExcelApi BETA (PREVIEW ONLY)]
-             * @beta
+             * [Api set: ExcelApi 1.10]
              */
             name?: boolean;
         }

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -16367,6 +16367,9 @@ declare namespace Excel {
         constructor(url?: string | Session);
         readonly workbook: Workbook;
         readonly application: Application;
+        /**
+        * [Api set: ExcelApi 1.5]
+        */
         readonly runtime: Runtime;
     }
     interface RunOptions extends OfficeExtension.RunOptions<Session> {
@@ -16403,18 +16406,6 @@ declare namespace Excel {
     function run<T>(options: Excel.RunOptions, batch: (context: Excel.RequestContext) => Promise<T>): Promise<T>;
     /**
      * Executes a batch script that performs actions on the Excel object model, using the RequestContext of a previously-created object. When the promise is resolved, any tracked objects that were automatically allocated during execution will be released.
-     *
-     * @remarks
-     *
-     * In addition to this signature, the method also has the following signatures:
-     *
-     * `run<T>(object: OfficeExtension.ClientObject, batch: (context: Excel.RequestContext) => Promise<T>): Promise<T>;`
-     *
-     * `run<T>(objects: OfficeExtension.ClientObject[], batch: (context: Excel.RequestContext) => Promise<T>): Promise<T>;`
-     *
-     * `run<T>(options: Excel.RunOptions, batch: (context: Excel.RequestContext) => Promise<T>): Promise<T>;`
-     *
-     * `run<T>(batch: (context: Excel.RequestContext) => Promise<T>): Promise<T>;`
      *
      * @param context - A previously-created object. The batch will use the same RequestContext as the passed-in object, which means that any changes applied to the object will be picked up by "context.sync()".
      * @param batch - A function that takes in a RequestContext and returns a promise (typically, just the result of "context.sync()"). The context parameter facilitates requests to the Excel application. Since the Office add-in and the Excel application run in two different processes, the RequestContext is required to get access to the Excel object model from the add-in.
@@ -16792,6 +16783,78 @@ declare namespace Excel {
     }
     /**
      *
+     * Provides information about the row-sorted event and its related worksheet.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    interface WorksheetRowSortedEventArgs {
+        /**
+         *
+         * Gets the range address that represents the sorted areas of a specific worksheet. Only rows changed as a result of the sort operation are returned.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        address: string;
+        /**
+         *
+         * Gets the source of the event. See Excel.EventSource for details.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        source: Excel.EventSource | "Local" | "Remote";
+        /**
+         *
+         * Gets the type of the event. See Excel.EventType for details.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        type: "WorksheetRowSorted";
+        /**
+         *
+         * Gets the id of the worksheet where the sorting happened.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        worksheetId: string;
+    }
+    /**
+     *
+     * Provides information about the column-sorted event and its related worksheet.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    interface WorksheetColumnSortedEventArgs {
+        /**
+         *
+         * Gets the range address that represents the sorted areas of a specific worksheet. Only columns changed as a result of the sort operation are returned.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        address: string;
+        /**
+         *
+         * Gets the source of the event. See Excel.EventSource for details.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        source: Excel.EventSource | "Local" | "Remote";
+        /**
+         *
+         * Gets the type of the event. See Excel.EventType for details.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        type: "WorksheetColumnSorted";
+        /**
+         *
+         * Gets the id of the worksheet where the sorting happened.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        worksheetId: string;
+    }
+    /**
+     *
      * Provides information about the worksheet that raised the SelectionChanged event.
      *
      * [Api set: ExcelApi 1.7]
@@ -16816,6 +16879,49 @@ declare namespace Excel {
          * Gets the id of the worksheet in which the selection changed.
          *
          * [Api set: ExcelApi 1.7]
+         */
+        worksheetId: string;
+    }
+    /**
+     *
+     * Provides information about the left-clicked/tapped event and its related worksheet.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    interface WorksheetSingleClickedEventArgs {
+        /**
+         *
+         * Gets the address that represents the cell which was left-clicked/tapped for a specific worksheet.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        address: string;
+        /**
+         *
+         * The distance, in points, from the left-clicked/tapped point to the left (or right for right-to-left languages) gridline edge of the left-clicked/tapped cell.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        offsetX: number;
+        /**
+         *
+         * The distance, in points, from the left-clicked/tapped point to the top gridline edge of the left-clicked/tapped cell.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        offsetY: number;
+        /**
+         *
+         * Gets the type of the event.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        type: "WorksheetSingleClicked";
+        /**
+         *
+         * Gets the id of the worksheet in which the cell was left-clicked/tapped.
+         *
+         * [Api set: ExcelApi 1.10]
          */
         worksheetId: string;
     }
@@ -17066,7 +17172,7 @@ declare namespace Excel {
         type: "WorksheetCalculated";
         /**
          *
-         * Gets the id of the worksheet that is calculated.
+         * Gets the id of the worksheet in which the calculation occurred.
          *
          * [Api set: ExcelApi 1.8]
          */
@@ -17475,6 +17581,13 @@ declare namespace Excel {
         readonly bindings: Excel.BindingCollection;
         /**
          *
+         * Represents a collection of Comments associated with the workbook. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly comments: Excel.CommentCollection;
+        /**
+         *
          * Represents the collection of custom XML parts contained by this workbook. Read-only.
          *
          * [Api set: ExcelApi 1.5]
@@ -17501,6 +17614,13 @@ declare namespace Excel {
          * [Api set: ExcelApi 1.1]
          */
         readonly names: Excel.NamedItemCollection;
+        /**
+         *
+         * Represents a collection of PivotTableStyles associated with the workbook. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly pivotTableStyles: Excel.PivotTableStyleCollection;
         /**
          *
          * Represents a collection of PivotTables associated with the workbook. Read-only.
@@ -17531,6 +17651,20 @@ declare namespace Excel {
         readonly settings: Excel.SettingCollection;
         /**
          *
+         * Represents a collection of SlicerStyles associated with the workbook. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly slicerStyles: Excel.SlicerStyleCollection;
+        /**
+         *
+         * Represents a collection of Slicers associated with the workbook. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly slicers: Excel.SlicerCollection;
+        /**
+         *
          * Represents a collection of styles associated with the workbook. Read-only.
          *
          * [Api set: ExcelApi 1.7]
@@ -17538,11 +17672,25 @@ declare namespace Excel {
         readonly styles: Excel.StyleCollection;
         /**
          *
+         * Represents a collection of TableStyles associated with the workbook. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly tableStyles: Excel.TableStyleCollection;
+        /**
+         *
          * Represents a collection of tables associated with the workbook. Read-only.
          *
          * [Api set: ExcelApi 1.1]
          */
         readonly tables: Excel.TableCollection;
+        /**
+         *
+         * Represents a collection of TimelineStyles associated with the workbook. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly timelineStyles: Excel.TimelineStyleCollection;
         /**
          *
          * Represents a collection of worksheets associated with the workbook. Read-only.
@@ -17644,6 +17792,20 @@ declare namespace Excel {
          * [Api set: ExcelApi 1.9]
          */
         getActiveChartOrNullObject(): Excel.Chart;
+        /**
+         *
+         * Gets the currently active slicer in the workbook. If there is no active slicer, an `ItemNotFound` exception is thrown.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        getActiveSlicer(): Excel.Slicer;
+        /**
+         *
+         * Gets the currently active slicer in the workbook. If there is no active slicer, a null object is returned.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        getActiveSlicerOrNullObject(): Excel.Slicer;
         /**
          *
          * True if the workbook is being edited by multiple users (co-authoring).
@@ -17821,11 +17983,18 @@ declare namespace Excel {
         readonly autoFilter: Excel.AutoFilter;
         /**
          *
-         * Returns collection of charts that are part of the worksheet. Read-only.
+         * Returns a collection of charts that are part of the worksheet. Read-only.
          *
          * [Api set: ExcelApi 1.1]
          */
         readonly charts: Excel.ChartCollection;
+        /**
+         *
+         * Returns a collection of all the Comments objects on the worksheet. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly comments: Excel.CommentCollection;
         /**
          *
          * Gets an object that can be used to manipulate frozen panes on the worksheet. Read-only.
@@ -17875,6 +18044,13 @@ declare namespace Excel {
          * [Api set: ExcelApi 1.9]
          */
         readonly shapes: Excel.ShapeCollection;
+        /**
+         *
+         * Returns a collection of slicers that are part of the worksheet. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly slicers: Excel.SlicerCollection;
         /**
          *
          * Collection of tables that are part of the worksheet. Read-only.
@@ -17997,8 +18173,8 @@ declare namespace Excel {
         calculate(markAllDirty: boolean): void;
         /**
          *
-         * Copies a worksheet and places it at the specified position. 
-         * 
+         * Copies a worksheet and places it at the specified position.
+         *
          * [Api set: ExcelApi 1.7]
          *
          * @param positionType The location in the workbook to place the newly created worksheet. The default value is "None", which inserts the worksheet at the beginning of the worksheet.
@@ -18008,8 +18184,8 @@ declare namespace Excel {
         copy(positionType?: Excel.WorksheetPositionType, relativeTo?: Excel.Worksheet): Excel.Worksheet;
         /**
          *
-         * Copies a worksheet and places it at the specified position. 
-         * 
+         * Copies a worksheet and places it at the specified position.
+         *
          * [Api set: ExcelApi 1.7]
          *
          * @param positionType The location in the workbook to place the newly created worksheet. The default value is "None", which inserts the worksheet at the beginning of the worksheet.
@@ -18153,6 +18329,20 @@ declare namespace Excel {
          */
         replaceAll(text: string, replacement: string, criteria: Excel.ReplaceCriteria): OfficeExtension.ClientResult<number>;
         /**
+         *
+         * Shows row or column groups by their outline levels.
+            Outlines group and summarize a list of data in the worksheet.
+            The `rowLevels` and `columnLevels` parameters specify how many levels of the outline will be displayed.
+            The acceptable argument range is between 0 and 8.
+            A value of 0 does not change the current display. A value greater than the current number of levels displays all the levels.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param rowLevels The number of row levels of an outline to display.
+         * @param columnLevels The number of column levels of an outline to display.
+         */
+        showOutlineLevels(rowLevels: number, columnLevels: number): void;
+        /**
          * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
          *
          * @param options Provides options for which properties of the object to load.
@@ -18202,6 +18392,15 @@ declare namespace Excel {
         readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;
         /**
          *
+         * Occurs when one or more columns have been sorted. This happens as the result of a left-to-right sort operation.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @eventproperty
+         */
+        readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;
+        /**
+         *
          * Occurs when the worksheet is deactivated.
          *
          * [Api set: ExcelApi 1.7]
@@ -18220,6 +18419,15 @@ declare namespace Excel {
         readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;
         /**
          *
+         * Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @eventproperty
+         */
+        readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;
+        /**
+         *
          * Occurs when the selection changes on a specific worksheet.
          *
          * [Api set: ExcelApi 1.7]
@@ -18227,6 +18435,19 @@ declare namespace Excel {
          * @eventproperty
          */
         readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;
+        /**
+         *
+         * Occurs when a left-clicked/tapped action happens in the worksheet. This event will not be fired when clicking in the following cases:
+
+                    - The user drags the mouse for multi-selection.
+
+                    - The user selects a cell in the mode when cell arguments are selected for formula references.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @eventproperty
+         */
+        readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;
         /**
         * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
         * Whereas the original Excel.Worksheet object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.WorksheetData`) that contains shallow copies of any loaded child properties from the original object.
@@ -18361,6 +18582,15 @@ declare namespace Excel {
         readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;
         /**
          *
+         * Occurs when one or more columns have been sorted. This happens as the result of a left-to-right sort operation.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @eventproperty
+         */
+        readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;
+        /**
+         *
          * Occurs when any worksheet in the workbook is deactivated.
          *
          * [Api set: ExcelApi 1.7]
@@ -18388,6 +18618,15 @@ declare namespace Excel {
         readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;
         /**
          *
+         * Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @eventproperty
+         */
+        readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;
+        /**
+         *
          * Occurs when the selection changes on any worksheet.
          *
          * [Api set: ExcelApi 1.9]
@@ -18395,6 +18634,17 @@ declare namespace Excel {
          * @eventproperty
          */
         readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;
+        /**
+         *
+         * Occurs when left-clicked/tapped operation happens in the worksheet collection. This event will not be fired when clicking in the following cases:
+                    - The user drags the mouse for multi-selection.
+                    - The user selects a cell in the mode when cell arguments are selected for formula references.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @eventproperty
+         */
+        readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;
         /**
         * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
         * Whereas the original `Excel.WorksheetCollection` object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.WorksheetCollectionData`) that contains an "items" array with shallow copies of any loaded properties from the collection's items.
@@ -18756,6 +19006,13 @@ declare namespace Excel {
         formulasR1C1: any[][];
         /**
          *
+         * Returns the distance in points, for 100% zoom, from top edge of the range to bottom edge of the range. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly height: number;
+        /**
+         *
          * Represents if all cells of the current range are hidden. Read-only.
          *
          * [Api set: ExcelApi 1.2]
@@ -18782,6 +19039,13 @@ declare namespace Excel {
          * [Api set: ExcelApi 1.7]
          */
         readonly isEntireRow: boolean;
+        /**
+         *
+         * Returns the distance in points, for 100% zoom, from left edge of the worksheet to left edge of the range. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly left: number;
         /**
          *
          * Represents the data type state of each cell. Read-only.
@@ -18847,6 +19111,13 @@ declare namespace Excel {
         readonly text: string[][];
         /**
          *
+         * Returns the distance in points, for 100% zoom, from top edge of the worksheet to top edge of the range. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly top: number;
+        /**
+         *
          * Represents the type of data of each cell. Read-only.
          *
          * [Api set: ExcelApi 1.1]
@@ -18860,6 +19131,13 @@ declare namespace Excel {
          * [Api set: ExcelApi 1.1]
          */
         values: any[][];
+        /**
+         *
+         * Returns the distance in points, for 100% zoom, from left edge of the range to right edge of the range. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly width: number;
         /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
          *
          * @remarks
@@ -18877,24 +19155,28 @@ declare namespace Excel {
         /**
          *
          * Fills range from the current range to the destination range using the specified AutoFill logic.
-            The destination range can be null, or can extend the source either horizontally or vertically. If the destination range is null, data is filled out based on the surrounding cells (which is the behavior when double-clicking the UI’s range fill handle).
-            For more information, read {@link https://support.office.com/article/video-use-autofill-and-flash-fill-2e79a709-c814-4b27-8bc2-c4dc84d49464 | Use AutoFill and Flash Fill}.
+             The destination range can be null, or can extend the source either horizontally or vertically.
+             Discontiguous ranges are not supported.
+            
+             For more information, read {@link https://support.office.com/article/video-use-autofill-and-flash-fill-2e79a709-c814-4b27-8bc2-c4dc84d49464 | Use AutoFill and Flash Fill}.
          *
          * [Api set: ExcelApi 1.9, ExcelApi Preview for null `destinationRange`]
          *
-         * @param destinationRange The destination range to autofill. Discontiguous ranges are not supported.
+         * @param destinationRange The destination range to autofill. If the destination range is null, data is filled out based on the surrounding cells (which is the behavior when double-clicking the UI’s range fill handle).
          * @param autoFillType The type of autofill. Specifies how the destination range is to be filled, based on the contents of the current range. Default is "FillDefault".
          */
         autoFill(destinationRange?: Range | string, autoFillType?: Excel.AutoFillType): void;
         /**
          *
          * Fills range from the current range to the destination range using the specified AutoFill logic.
-            The destination range can be null, or can extend the source either horizontally or vertically. If the destination range is null, data is filled out based on the surrounding cells (which is the behavior when double-clicking the UI’s range fill handle).
-            For more information, read {@link https://support.office.com/article/video-use-autofill-and-flash-fill-2e79a709-c814-4b27-8bc2-c4dc84d49464 | Use AutoFill and Flash Fill}.
+             The destination range can be null, or can extend the source either horizontally or vertically.
+             Discontiguous ranges are not supported.
+            
+             For more information, read {@link https://support.office.com/article/video-use-autofill-and-flash-fill-2e79a709-c814-4b27-8bc2-c4dc84d49464 | Use AutoFill and Flash Fill}.
          *
          * [Api set: ExcelApi 1.9, ExcelApi Preview for null `destinationRange`]
          *
-         * @param destinationRange The destination range to autofill. Discontiguous ranges are not supported.
+         * @param destinationRange The destination range to autofill. If the destination range is null, data is filled out based on the surrounding cells (which is the behavior when double-clicking the UI’s range fill handle).
          * @param autoFillType The type of autofill. Specifies how the destination range is to be filled, based on the contents of the current range. Default is "FillDefault".
          */
         autoFill(destinationRange?: Range | string, autoFillType?: "FillDefault" | "FillCopy" | "FillSeries" | "FillFormats" | "FillValues" | "FillDays" | "FillWeekdays" | "FillMonths" | "FillYears" | "LinearTrend" | "GrowthTrend" | "FlashFill"): void;
@@ -19296,6 +19578,48 @@ declare namespace Excel {
         getVisibleView(): Excel.RangeView;
         /**
          *
+         * Groups columns and rows for an outline.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param groupOption Specifies how the range can be grouped by rows or columns.
+            An `InvalidArgument` error is thrown when the group option differs from the range's
+            `isEntireRow` or `isEntireColumn` property (i.e., `range.isEntireRow` is true and `groupOption` is "ByColumns"
+            or `range.isEntireColumn` is true and `groupOption` is "ByRows").
+         */
+        group(groupOption: Excel.GroupOption): void;
+        /**
+         *
+         * Groups columns and rows for an outline.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param groupOption Specifies how the range can be grouped by rows or columns.
+            An `InvalidArgument` error is thrown when the group option differs from the range's
+            `isEntireRow` or `isEntireColumn` property (i.e., `range.isEntireRow` is true and `groupOption` is "ByColumns"
+            or `range.isEntireColumn` is true and `groupOption` is "ByRows").
+         */
+        group(groupOption: "ByRows" | "ByColumns"): void;
+        /**
+         *
+         * Hide details of the row or column group.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param groupOption Specifies whether to hide details of grouped rows or grouped columns.
+         */
+        hideGroupDetails(groupOption: Excel.GroupOption): void;
+        /**
+         *
+         * Hide details of the row or column group.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param groupOption Specifies whether to hide details of grouped rows or grouped columns.
+         */
+        hideGroupDetails(groupOption: "ByRows" | "ByColumns"): void;
+        /**
+         *
          * Inserts a cell or a range of cells into the worksheet in place of this range, and shifts the other cells to make space. Returns a new Range object at the now blank space.
          *
          * [Api set: ExcelApi 1.1]
@@ -19392,6 +19716,42 @@ declare namespace Excel {
          * [Api set: ExcelApi 1.7]
          */
         showCard(): void;
+        /**
+         *
+         * Show details of the row or column group.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param groupOption Specifies whether to show details of grouped rows or grouped columns.
+         */
+        showGroupDetails(groupOption: Excel.GroupOption): void;
+        /**
+         *
+         * Show details of the row or column group.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param groupOption Specifies whether to show details of grouped rows or grouped columns.
+         */
+        showGroupDetails(groupOption: "ByRows" | "ByColumns"): void;
+        /**
+         *
+         * Ungroups columns and rows for an outline.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param groupOption Specifies how the range can be ungrouped by rows or columns.
+         */
+        ungroup(groupOption: Excel.GroupOption): void;
+        /**
+         *
+         * Ungroups columns and rows for an outline.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param groupOption Specifies how the range can be ungrouped by rows or columns.
+         */
+        ungroup(groupOption: "ByRows" | "ByColumns"): void;
         /**
          *
          * Unmerge the range cells into separate cells.
@@ -21437,7 +21797,7 @@ declare namespace Excel {
         showTotals: boolean;
         /**
          *
-         * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleStyleDark1" through "TableStyleStyleDark11". A custom user-defined style present in the workbook can also be specified.
+         * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleDark1" through "TableStyleDark11". A custom user-defined style present in the workbook can also be specified.
          *
          * [Api set: ExcelApi 1.1]
          */
@@ -23419,7 +23779,7 @@ declare namespace Excel {
         showAxisFieldButtons: boolean;
         /**
          *
-         * Specifies whether or not to display the legend field buttons on a PivotChart
+         * Specifies whether or not to display the legend field buttons on a PivotChart.
          *
          * [Api set: ExcelApi 1.9]
          */
@@ -23433,7 +23793,7 @@ declare namespace Excel {
         showReportFilterFieldButtons: boolean;
         /**
          *
-         * Specifies whether or not to display the show value field buttons on a PivotChart
+         * Specifies whether or not to display the show value field buttons on a PivotChart.
          *
          * [Api set: ExcelApi 1.9]
          */
@@ -28562,6 +28922,13 @@ declare namespace Excel {
         autoFormat: boolean;
         /**
          *
+         * Specifies whether the field list can be shown in the UI.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        enableFieldList: boolean;
+        /**
+         *
          * This property indicates the PivotLayoutType of all fields on the PivotTable. If fields have different states, this will be null.
          *
          * [Api set: ExcelApi 1.8]
@@ -32292,6 +32659,682 @@ declare namespace Excel {
     }
     /**
      *
+     * Represents a collection of TableStyles.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class TableStyleCollection extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /** Gets the loaded child items in this collection. */
+        readonly items: Excel.TableStyle[];
+        /**
+         *
+         * Creates a blank TableStyle with the specified name.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param name The unique name for the new TableStyle. Will throw an invalid argument exception if the name is already in use.
+         * @param makeUniqueName Optional, defaults to false. If true, will append numbers to the name in order to make it unique, if needed.
+         * @returns The newly created TableStyle.
+         */
+        add(name: string, makeUniqueName?: boolean): Excel.TableStyle;
+        /**
+         *
+         * Gets the number of table styles in the collection.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        getCount(): OfficeExtension.ClientResult<number>;
+        /**
+         *
+         * Gets the default TableStyle for the parent object's scope.
+         *
+         * [Api set: ExcelApi 1.10]
+         * @returns The TableStyle object that is the current default TableStyle.
+         */
+        getDefault(): Excel.TableStyle;
+        /**
+         *
+         * Gets a TableStyle by name.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param name Name of the TableStyle to be retrieved.
+         * @returns The TableStyle object whose name matches the input.
+         */
+        getItem(name: string): Excel.TableStyle;
+        /**
+         *
+         * Gets a TableStyle by name. If the TableStyle does not exist, will return a null object.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param name Name of the TableStyle to be retrieved.
+         * @returns The TableStyle object whose name matches the input.
+         */
+        getItemOrNullObject(name: string): Excel.TableStyle;
+        /**
+         *
+         * Sets the default TableStyle for use in the parent object's scope.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param newDefaultStyle The TableStyle object or name of the TableStyle object that should be the new default.
+         */
+        setDefault(newDefaultStyle: TableStyle | string): void;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.TableStyleCollectionLoadOptions & Excel.Interfaces.CollectionLoadOptions): Excel.TableStyleCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.TableStyleCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: OfficeExtension.LoadOption): Excel.TableStyleCollection;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original `Excel.TableStyleCollection` object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.TableStyleCollectionData`) that contains an "items" array with shallow copies of any loaded properties from the collection's items.
+        */
+        toJSON(): Excel.Interfaces.TableStyleCollectionData;
+    }
+    /**
+     *
+     * Represents a TableStyle, which defines the style elements by region of the Table.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class TableStyle extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /**
+         *
+         * Gets the name of the TableStyle.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        name: string;
+        /**
+         *
+         * Specifies whether this TableStyle object is read-only. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly readOnly: boolean;
+        /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
+         *
+         * @remarks
+         *
+         * This method has the following additional signature:
+         *
+         * `set(properties: Excel.TableStyle): void`
+         *
+         * @param properties A JavaScript object with properties that are structured isomorphically to the properties of the object on which the method is called.
+         * @param options Provides an option to suppress errors if the properties object tries to set any read-only properties.
+         */
+        set(properties: Interfaces.TableStyleUpdateData, options?: OfficeExtension.UpdateOptions): void;
+        /** Sets multiple properties on the object at the same time, based on an existing loaded object. */
+        set(properties: Excel.TableStyle): void;
+        /**
+         *
+         * Deletes the TableStyle.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        delete(): void;
+        /**
+         *
+         * Creates a duplicate of this TableStyle with copies of all the style elements.
+         *
+         * [Api set: ExcelApi 1.10]
+         * @returns The new TableStyle object that has been duplicated from this TableStyle.
+         */
+        duplicate(): Excel.TableStyle;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.TableStyleLoadOptions): Excel.TableStyle;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.TableStyle;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: {
+            select?: string;
+            expand?: string;
+        }): Excel.TableStyle;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original Excel.TableStyle object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.TableStyleData`) that contains shallow copies of any loaded child properties from the original object.
+        */
+        toJSON(): Excel.Interfaces.TableStyleData;
+    }
+    /**
+     *
+     * Represents a collection of PivotTable styles.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class PivotTableStyleCollection extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /** Gets the loaded child items in this collection. */
+        readonly items: Excel.PivotTableStyle[];
+        /**
+         *
+         * Creates a blank PivotTableStyle with the specified name.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param name The unique name for the new PivotTableStyle. Will throw an invalid argument exception if the name is already in use.
+         * @param makeUniqueName Optional, defaults to false. If true, will append numbers to the name in order to make it unique, if needed.
+         * @returns The newly created PivotTableStyle.
+         */
+        add(name: string, makeUniqueName?: boolean): Excel.PivotTableStyle;
+        /**
+         *
+         * Gets the number of PivotTable styles in the collection.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        getCount(): OfficeExtension.ClientResult<number>;
+        /**
+         *
+         * Gets the default PivotTableStyle for the parent object's scope.
+         *
+         * [Api set: ExcelApi 1.10]
+         * @returns The PivotTableStyle object that is the current default PivotTableStyle.
+         */
+        getDefault(): Excel.PivotTableStyle;
+        /**
+         *
+         * Gets a PivotTableStyle by name.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param name Name of the PivotTableStyle to be retrieved.
+         * @returns The PivotTableStyle object whose name matches the input.
+         */
+        getItem(name: string): Excel.PivotTableStyle;
+        /**
+         *
+         * Gets a PivotTableStyle by name. If the PivotTableStyle does not exist, will return a null object.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param name Name of the PivotTableStyle to be retrieved.
+         * @returns The PivotTableStyle object whose name matches the input.
+         */
+        getItemOrNullObject(name: string): Excel.PivotTableStyle;
+        /**
+         *
+         * Sets the default PivotTableStyle for use in the parent object's scope.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param newDefaultStyle The PivotTableStyle object or name of the PivotTableStyle object that should be the new default.
+         */
+        setDefault(newDefaultStyle: PivotTableStyle | string): void;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.PivotTableStyleCollectionLoadOptions & Excel.Interfaces.CollectionLoadOptions): Excel.PivotTableStyleCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.PivotTableStyleCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: OfficeExtension.LoadOption): Excel.PivotTableStyleCollection;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original `Excel.PivotTableStyleCollection` object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.PivotTableStyleCollectionData`) that contains an "items" array with shallow copies of any loaded properties from the collection's items.
+        */
+        toJSON(): Excel.Interfaces.PivotTableStyleCollectionData;
+    }
+    /**
+     *
+     * Represents a PivotTable Style, which defines style elements by PivotTable region.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class PivotTableStyle extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /**
+         *
+         * Gets the name of the PivotTableStyle.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        name: string;
+        /**
+         *
+         * Specifies whether this PivotTableStyle object is read-only. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly readOnly: boolean;
+        /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
+         *
+         * @remarks
+         *
+         * This method has the following additional signature:
+         *
+         * `set(properties: Excel.PivotTableStyle): void`
+         *
+         * @param properties A JavaScript object with properties that are structured isomorphically to the properties of the object on which the method is called.
+         * @param options Provides an option to suppress errors if the properties object tries to set any read-only properties.
+         */
+        set(properties: Interfaces.PivotTableStyleUpdateData, options?: OfficeExtension.UpdateOptions): void;
+        /** Sets multiple properties on the object at the same time, based on an existing loaded object. */
+        set(properties: Excel.PivotTableStyle): void;
+        /**
+         *
+         * Deletes the PivotTableStyle.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        delete(): void;
+        /**
+         *
+         * Creates a duplicate of this PivotTableStyle with copies of all the style elements.
+         *
+         * [Api set: ExcelApi 1.10]
+         * @returns The new PivotTableStyle object that has been duplicated from this PivotTableStyle.
+         */
+        duplicate(): Excel.PivotTableStyle;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.PivotTableStyleLoadOptions): Excel.PivotTableStyle;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.PivotTableStyle;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: {
+            select?: string;
+            expand?: string;
+        }): Excel.PivotTableStyle;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original Excel.PivotTableStyle object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.PivotTableStyleData`) that contains shallow copies of any loaded child properties from the original object.
+        */
+        toJSON(): Excel.Interfaces.PivotTableStyleData;
+    }
+    /**
+     *
+     * Represents a collection of SlicerStyle objects.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class SlicerStyleCollection extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /** Gets the loaded child items in this collection. */
+        readonly items: Excel.SlicerStyle[];
+        /**
+         *
+         * Creates a blank SlicerStyle with the specified name.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param name The unique name for the new SlicerStyle. Will throw an invalid argument exception if the name is already in use.
+         * @param makeUniqueName Optional, defaults to false. If true, will append numbers to the name in order to make it unique, if needed.
+         * @returns The newly created SlicerStyle.
+         */
+        add(name: string, makeUniqueName?: boolean): Excel.SlicerStyle;
+        /**
+         *
+         * Gets the number of slicer styles in the collection.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        getCount(): OfficeExtension.ClientResult<number>;
+        /**
+         *
+         * Gets the default SlicerStyle for the parent object's scope.
+         *
+         * [Api set: ExcelApi 1.10]
+         * @returns The SlicerStyle object that is the current default SlicerStyle.
+         */
+        getDefault(): Excel.SlicerStyle;
+        /**
+         *
+         * Gets a SlicerStyle by name.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param name Name of the SlicerStyle to be retrieved.
+         * @returns The SlicerStyle object whose name matches the input.
+         */
+        getItem(name: string): Excel.SlicerStyle;
+        /**
+         *
+         * Gets a SlicerStyle by name. If the SlicerStyle does not exist, will return a null object.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param name Name of the SlicerStyle to be retrieved.
+         * @returns The SlicerStyle object whose name matches the input.
+         */
+        getItemOrNullObject(name: string): Excel.SlicerStyle;
+        /**
+         *
+         * Sets the default SlicerStyle for use in the parent object's scope.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param newDefaultStyle The SlicerStyle object or name of the SlicerStyle object that should be the new default.
+         */
+        setDefault(newDefaultStyle: SlicerStyle | string): void;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.SlicerStyleCollectionLoadOptions & Excel.Interfaces.CollectionLoadOptions): Excel.SlicerStyleCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.SlicerStyleCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: OfficeExtension.LoadOption): Excel.SlicerStyleCollection;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original `Excel.SlicerStyleCollection` object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.SlicerStyleCollectionData`) that contains an "items" array with shallow copies of any loaded properties from the collection's items.
+        */
+        toJSON(): Excel.Interfaces.SlicerStyleCollectionData;
+    }
+    /**
+     *
+     * Represents a Slicer Style, which defines style elements by region of the slicer.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class SlicerStyle extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /**
+         *
+         * Gets the name of the SlicerStyle.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        name: string;
+        /**
+         *
+         * Specifies whether this SlicerStyle object is read-only. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly readOnly: boolean;
+        /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
+         *
+         * @remarks
+         *
+         * This method has the following additional signature:
+         *
+         * `set(properties: Excel.SlicerStyle): void`
+         *
+         * @param properties A JavaScript object with properties that are structured isomorphically to the properties of the object on which the method is called.
+         * @param options Provides an option to suppress errors if the properties object tries to set any read-only properties.
+         */
+        set(properties: Interfaces.SlicerStyleUpdateData, options?: OfficeExtension.UpdateOptions): void;
+        /** Sets multiple properties on the object at the same time, based on an existing loaded object. */
+        set(properties: Excel.SlicerStyle): void;
+        /**
+         *
+         * Deletes the SlicerStyle.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        delete(): void;
+        /**
+         *
+         * Creates a duplicate of this SlicerStyle with copies of all the style elements.
+         *
+         * [Api set: ExcelApi 1.10]
+         * @returns The new SlicerStyle object that has been duplicated from this SlicerStyle.
+         */
+        duplicate(): Excel.SlicerStyle;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.SlicerStyleLoadOptions): Excel.SlicerStyle;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.SlicerStyle;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: {
+            select?: string;
+            expand?: string;
+        }): Excel.SlicerStyle;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original Excel.SlicerStyle object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.SlicerStyleData`) that contains shallow copies of any loaded child properties from the original object.
+        */
+        toJSON(): Excel.Interfaces.SlicerStyleData;
+    }
+    /**
+     *
+     * Represents a collection of TimelineStyles.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class TimelineStyleCollection extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /** Gets the loaded child items in this collection. */
+        readonly items: Excel.TimelineStyle[];
+        /**
+         *
+         * Creates a blank TimelineStyle with the specified name.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param name The unique name for the new TimelineStyle. Will throw an invalid argument exception if the name is already in use.
+         * @param makeUniqueName Optional, defaults to false. If true, will append numbers to the name in order to make it unique, if needed.
+         * @returns The newly created TimelineStyle.
+         */
+        add(name: string, makeUniqueName?: boolean): Excel.TimelineStyle;
+        /**
+         *
+         * Gets the number of timeline styles in the collection.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        getCount(): OfficeExtension.ClientResult<number>;
+        /**
+         *
+         * Gets the default TimelineStyle for the parent object's scope.
+         *
+         * [Api set: ExcelApi 1.10]
+         * @returns The TimelineStyle object that is the current default TimelineStyle.
+         */
+        getDefault(): Excel.TimelineStyle;
+        /**
+         *
+         * Gets a TimelineStyle by name.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param name Name of the TimelineStyle to be retrieved.
+         * @returns The TimelineStyle object whose name matches the input.
+         */
+        getItem(name: string): Excel.TimelineStyle;
+        /**
+         *
+         * Gets a TimelineStyle by name. If the TimelineStyle does not exist, will return a null object.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param name Name of the TimelineStyle to be retrieved.
+         * @returns The TimelineStyle object whose name matches the input.
+         */
+        getItemOrNullObject(name: string): Excel.TimelineStyle;
+        /**
+         *
+         * Sets the default TimelineStyle for use in the parent object's scope.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param newDefaultStyle The TimelineStyle object or name of the TimelineStyle object that should be the new default.
+         */
+        setDefault(newDefaultStyle: TimelineStyle | string): void;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.TimelineStyleCollectionLoadOptions & Excel.Interfaces.CollectionLoadOptions): Excel.TimelineStyleCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.TimelineStyleCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: OfficeExtension.LoadOption): Excel.TimelineStyleCollection;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original `Excel.TimelineStyleCollection` object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.TimelineStyleCollectionData`) that contains an "items" array with shallow copies of any loaded properties from the collection's items.
+        */
+        toJSON(): Excel.Interfaces.TimelineStyleCollectionData;
+    }
+    /**
+     *
+     * Represents a Timeline style, which defines style elements by region in the Timeline.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class TimelineStyle extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /**
+         *
+         * Gets the name of the TimelineStyle.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        name: string;
+        /**
+         *
+         * Specifies whether this TimelineStyle object is read-only. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly readOnly: boolean;
+        /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
+         *
+         * @remarks
+         *
+         * This method has the following additional signature:
+         *
+         * `set(properties: Excel.TimelineStyle): void`
+         *
+         * @param properties A JavaScript object with properties that are structured isomorphically to the properties of the object on which the method is called.
+         * @param options Provides an option to suppress errors if the properties object tries to set any read-only properties.
+         */
+        set(properties: Interfaces.TimelineStyleUpdateData, options?: OfficeExtension.UpdateOptions): void;
+        /** Sets multiple properties on the object at the same time, based on an existing loaded object. */
+        set(properties: Excel.TimelineStyle): void;
+        /**
+         *
+         * Deletes the TableStyle.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        delete(): void;
+        /**
+         *
+         * Creates a duplicate of this TimelineStyle with copies of all the style elements.
+         *
+         * [Api set: ExcelApi 1.10]
+         * @returns The new TimelineStyle object that has been duplicated from this TimelineStyle.
+         */
+        duplicate(): Excel.TimelineStyle;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.TimelineStyleLoadOptions): Excel.TimelineStyle;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.TimelineStyle;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: {
+            select?: string;
+            expand?: string;
+        }): Excel.TimelineStyle;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original Excel.TimelineStyle object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.TimelineStyleData`) that contains shallow copies of any loaded child properties from the original object.
+        */
+        toJSON(): Excel.Interfaces.TimelineStyleData;
+    }
+    /**
+     *
      * Represents layout and print settings that are not dependent any printer-specific implementation. These settings include margins, orientation, page numbering, title rows, and print area.
      *
      * [Api set: ExcelApi 1.9]
@@ -33039,6 +34082,406 @@ declare namespace Excel {
     }
     /**
      *
+     * Represents the content contained within a comment or comment reply. Rich content incudes the text string and any other objects contained within the comment body, such as mentions.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    interface CommentRichContent {
+    }
+    /**
+     *
+     * Represents a collection of comment objects that are part of the workbook.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class CommentCollection extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /** Gets the loaded child items in this collection. */
+        readonly items: Excel.Comment[];
+        /**
+         *
+         * Creates a new comment with the given content on the given cell. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param cellAddress The cell to which the comment is added. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
+         * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions. [Api set: ExcelApi 1.10 for string, ExcelApi Preview for CommentRichContent object]
+         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.plain`.
+         */
+        add(cellAddress: Range | string, content: CommentRichContent | string, contentType?: Excel.ContentType): Excel.Comment;
+        /**
+         *
+         * Creates a new comment with the given content on the given cell. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param cellAddress The cell to which the comment is added. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
+         * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions. [Api set: ExcelApi 1.10 for string, ExcelApi Preview for CommentRichContent object]
+         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.plain`.
+         */
+        add(cellAddress: Range | string, content: CommentRichContent | string, contentType?: "Plain" | "Mention"): Excel.Comment;
+        /**
+         *
+         * Gets the number of comments in the collection.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        getCount(): OfficeExtension.ClientResult<number>;
+        /**
+         *
+         * Gets a comment from the collection based on its ID. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param commentId The identifier for the comment.
+         */
+        getItem(commentId: string): Excel.Comment;
+        /**
+         *
+         * Gets a comment from the collection based on its position.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param index Index value of the object to be retrieved. Zero-indexed.
+         */
+        getItemAt(index: number): Excel.Comment;
+        /**
+         *
+         * Gets the comment from the specified cell.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param cellAddress The cell which the comment is on. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
+         */
+        getItemByCell(cellAddress: Range | string): Excel.Comment;
+        /**
+         *
+         * Gets the comment to which the given reply is connected.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param replyId The identifier of comment reply.
+         */
+        getItemByReplyId(replyId: string): Excel.Comment;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.CommentCollectionLoadOptions & Excel.Interfaces.CollectionLoadOptions): Excel.CommentCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.CommentCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: OfficeExtension.LoadOption): Excel.CommentCollection;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original `Excel.CommentCollection` object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.CommentCollectionData`) that contains an "items" array with shallow copies of any loaded properties from the collection's items.
+        */
+        toJSON(): Excel.Interfaces.CommentCollectionData;
+    }
+    /**
+     *
+     * Represents a comment in the workbook.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class Comment extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /**
+         *
+         * Represents a collection of reply objects associated with the comment. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly replies: Excel.CommentReplyCollection;
+        /**
+         *
+         * Gets the email of the comment's author.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly authorEmail: string;
+        /**
+         *
+         * Gets the name of the comment's author.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly authorName: string;
+        /**
+         *
+         * Gets or sets the comment's content. The string is plain text.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        content: string;
+        /**
+         *
+         * Gets the creation time of the comment. Returns null if the comment was converted from a note, since the comment does not have a creation date.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly creationDate: Date;
+        /**
+         *
+         * Represents the comment identifier. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly id: string;
+        /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
+         *
+         * @remarks
+         *
+         * This method has the following additional signature:
+         *
+         * `set(properties: Excel.Comment): void`
+         *
+         * @param properties A JavaScript object with properties that are structured isomorphically to the properties of the object on which the method is called.
+         * @param options Provides an option to suppress errors if the properties object tries to set any read-only properties.
+         */
+        set(properties: Interfaces.CommentUpdateData, options?: OfficeExtension.UpdateOptions): void;
+        /** Sets multiple properties on the object at the same time, based on an existing loaded object. */
+        set(properties: Excel.Comment): void;
+        /**
+         *
+         * Deletes the comment and all the connected replies.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        delete(): void;
+        /**
+         *
+         * Gets the cell where this comment is located.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        getLocation(): Excel.Range;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.CommentLoadOptions): Excel.Comment;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.Comment;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: {
+            select?: string;
+            expand?: string;
+        }): Excel.Comment;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original Excel.Comment object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.CommentData`) that contains shallow copies of any loaded child properties from the original object.
+        */
+        toJSON(): Excel.Interfaces.CommentData;
+    }
+    /**
+     *
+     * Represents a collection of comment reply objects that are part of the comment.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class CommentReplyCollection extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /** Gets the loaded child items in this collection. */
+        readonly items: Excel.CommentReply[];
+        /**
+         *
+         * Creates a comment reply for comment.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions). [Api set: ExcelApi 1.10 for string, ExcelApi Preview for CommentRichContent object]
+         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.plain`.
+         */
+        add(content: CommentRichContent | string, contentType?: Excel.ContentType): Excel.CommentReply;
+        /**
+         *
+         * Creates a comment reply for comment.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions). [Api set: ExcelApi 1.10 for string, ExcelApi Preview for CommentRichContent object]
+         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.plain`.
+         */
+        add(content: CommentRichContent | string, contentType?: "Plain" | "Mention"): Excel.CommentReply;
+        /**
+         *
+         * Gets the number of comment replies in the collection.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        getCount(): OfficeExtension.ClientResult<number>;
+        /**
+         *
+         * Returns a comment reply identified by its ID. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param commentReplyId The identifier for the comment reply.
+         */
+        getItem(commentReplyId: string): Excel.CommentReply;
+        /**
+         *
+         * Gets a comment reply based on its position in the collection.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param index The index value of the comment reply to be retrieved. The collection uses zero-based indexing.
+         */
+        getItemAt(index: number): Excel.CommentReply;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.CommentReplyCollectionLoadOptions & Excel.Interfaces.CollectionLoadOptions): Excel.CommentReplyCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.CommentReplyCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: OfficeExtension.LoadOption): Excel.CommentReplyCollection;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original `Excel.CommentReplyCollection` object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.CommentReplyCollectionData`) that contains an "items" array with shallow copies of any loaded properties from the collection's items.
+        */
+        toJSON(): Excel.Interfaces.CommentReplyCollectionData;
+    }
+    /**
+     *
+     * Represents a comment reply in the workbook.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class CommentReply extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /**
+         *
+         * Gets the email of the comment reply's author.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly authorEmail: string;
+        /**
+         *
+         * Gets the name of the comment reply's author.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly authorName: string;
+        /**
+         *
+         * Gets or sets the comment reply's content. The string is plain text.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        content: string;
+        /**
+         *
+         * Gets the creation time of the comment reply.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly creationDate: Date;
+        /**
+         *
+         * Represents the comment reply identifier. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly id: string;
+        /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
+         *
+         * @remarks
+         *
+         * This method has the following additional signature:
+         *
+         * `set(properties: Excel.CommentReply): void`
+         *
+         * @param properties A JavaScript object with properties that are structured isomorphically to the properties of the object on which the method is called.
+         * @param options Provides an option to suppress errors if the properties object tries to set any read-only properties.
+         */
+        set(properties: Interfaces.CommentReplyUpdateData, options?: OfficeExtension.UpdateOptions): void;
+        /** Sets multiple properties on the object at the same time, based on an existing loaded object. */
+        set(properties: Excel.CommentReply): void;
+        /**
+         *
+         * Deletes the comment reply.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        delete(): void;
+        /**
+         *
+         * Gets the cell where this comment reply is located.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        getLocation(): Excel.Range;
+        /**
+         *
+         * Gets the parent comment of this reply.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        getParentComment(): Excel.Comment;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.CommentReplyLoadOptions): Excel.CommentReply;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.CommentReply;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: {
+            select?: string;
+            expand?: string;
+        }): Excel.CommentReply;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original Excel.CommentReply object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.CommentReplyData`) that contains shallow copies of any loaded child properties from the original object.
+        */
+        toJSON(): Excel.Interfaces.CommentReplyData;
+    }
+    /**
+     *
      * Represents a collection of all the shapes in the worksheet.
      *
      * [Api set: ExcelApi 1.9]
@@ -33308,6 +34751,13 @@ declare namespace Excel {
         name: string;
         /**
          *
+         * Represents how the object is attached to the cells below it.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        placement: Excel.Placement | "TwoCell" | "OneCell" | "Absolute";
+        /**
+         *
          * Represents the rotation, in degrees, of the shape.
          *
          * [Api set: ExcelApi 1.9]
@@ -33364,6 +34814,16 @@ declare namespace Excel {
         set(properties: Interfaces.ShapeUpdateData, options?: OfficeExtension.UpdateOptions): void;
         /** Sets multiple properties on the object at the same time, based on an existing loaded object. */
         set(properties: Excel.Shape): void;
+        /**
+         *
+         * Copies and pastes a Shape object.
+            The pasted shape is copied to the same pixel location as this shape.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param destinationSheet The sheet to which the shape object will be pasted. The default value is the copied Shape's worksheet.
+         */
+        copyTo(destinationSheet?: Worksheet | string): Excel.Shape;
         /**
          *
          * Removes the shape from the worksheet.
@@ -34436,6 +35896,405 @@ declare namespace Excel {
         * Whereas the original Excel.ShapeFont object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.ShapeFontData`) that contains shallow copies of any loaded child properties from the original object.
         */
         toJSON(): Excel.Interfaces.ShapeFontData;
+    }
+    /**
+     *
+     * Represents a slicer object in the workbook.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class Slicer extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /**
+         *
+         * Represents the collection of SlicerItems that are part of the slicer. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly slicerItems: Excel.SlicerItemCollection;
+        /**
+         *
+         * Represents the worksheet containing the slicer. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly worksheet: Excel.Worksheet;
+        /**
+         *
+         * Represents the caption of slicer.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        caption: string;
+        /**
+         *
+         * Represents the height, in points, of the slicer.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        height: number;
+        /**
+         *
+         * Represents the unique id of slicer. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly id: string;
+        /**
+         *
+         * True if all filters currently applied on the slicer are cleared.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly isFilterCleared: boolean;
+        /**
+         *
+         * Represents the distance, in points, from the left side of the slicer to the left of the worksheet.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        left: number;
+        /**
+         *
+         * Represents the name of slicer.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        name: string;
+        /**
+         *
+         * Represents the sort order of the items in the slicer. Possible values are: "DataSourceOrder", "Ascending", "Descending".
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        sortBy: Excel.SlicerSortType | "DataSourceOrder" | "Ascending" | "Descending";
+        /**
+         *
+         * Constant value that represents the Slicer style. Possible values are: "SlicerStyleLight1" through "SlicerStyleLight6", "TableStyleOther1" through "TableStyleOther2", "SlicerStyleDark1" through "SlicerStyleDark6". A custom user-defined style present in the workbook can also be specified.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        style: string;
+        /**
+         *
+         * Represents the distance, in points, from the top edge of the slicer to the top of the worksheet.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        top: number;
+        /**
+         *
+         * Represents the width, in points, of the slicer.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        width: number;
+        /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
+         *
+         * @remarks
+         *
+         * This method has the following additional signature:
+         *
+         * `set(properties: Excel.Slicer): void`
+         *
+         * @param properties A JavaScript object with properties that are structured isomorphically to the properties of the object on which the method is called.
+         * @param options Provides an option to suppress errors if the properties object tries to set any read-only properties.
+         */
+        set(properties: Interfaces.SlicerUpdateData, options?: OfficeExtension.UpdateOptions): void;
+        /** Sets multiple properties on the object at the same time, based on an existing loaded object. */
+        set(properties: Excel.Slicer): void;
+        /**
+         *
+         * Clears all the filters currently applied on the slicer.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        clearFilters(): void;
+        /**
+         *
+         * Deletes the slicer.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        delete(): void;
+        /**
+         *
+         * Returns an array of selected items' keys. Read-only.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        getSelectedItems(): OfficeExtension.ClientResult<string[]>;
+        /**
+         *
+         * Selects slicer items based on their keys. The previous selections are cleared.
+            All items will be selected by default if the array is empty.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param items Optional. The specified slicer item names to be selected.
+         */
+        selectItems(items?: string[]): void;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.SlicerLoadOptions): Excel.Slicer;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.Slicer;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: {
+            select?: string;
+            expand?: string;
+        }): Excel.Slicer;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original Excel.Slicer object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.SlicerData`) that contains shallow copies of any loaded child properties from the original object.
+        */
+        toJSON(): Excel.Interfaces.SlicerData;
+    }
+    /**
+     *
+     * Represents a collection of all the slicer objects on the workbook or a worksheet.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class SlicerCollection extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /** Gets the loaded child items in this collection. */
+        readonly items: Excel.Slicer[];
+        /**
+         *
+         * Adds a new slicer to the workbook.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param slicerSource The data source that the new slicer will be based on. It can be a PivotTable object, a Table object or a string. When a PivotTable object is passed, the data source is the source of the PivotTable object. When a Table object is passed, the data source is the Table object. When a string is passed, it is interpreted as the name/id of a PivotTable/Table.
+         * @param sourceField The field in the data source to filter by. It can be a PivotField object, a TableColumn object, the id of a PivotField or the id/name of TableColumn.
+         * @param slicerDestination Optional. The worksheet where the new slicer will be created in. It can be a Worksheet object or the name/id of a worksheet. This parameter can be omitted if the slicer collection is retrieved from worksheet.
+         * @returns The new slicer.
+         */
+        add(slicerSource: string | PivotTable | Table, sourceField: string | PivotField | number | TableColumn, slicerDestination?: string | Worksheet): Excel.Slicer;
+        /**
+         *
+         * Returns the number of slicers in the collection.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        getCount(): OfficeExtension.ClientResult<number>;
+        /**
+         *
+         * Gets a slicer object using its name or id.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param key The name or id of the slicer.
+         */
+        getItem(key: string): Excel.Slicer;
+        /**
+         *
+         * Gets a slicer based on its position in the collection.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param index Index value of the object to be retrieved. Zero-indexed.
+         */
+        getItemAt(index: number): Excel.Slicer;
+        /**
+         *
+         * Gets a slicer using its name or id. If the slicer does not exist, will return a null object.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param key Name or Id of the slicer to be retrieved.
+         */
+        getItemOrNullObject(key: string): Excel.Slicer;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.SlicerCollectionLoadOptions & Excel.Interfaces.CollectionLoadOptions): Excel.SlicerCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.SlicerCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: OfficeExtension.LoadOption): Excel.SlicerCollection;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original `Excel.SlicerCollection` object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.SlicerCollectionData`) that contains an "items" array with shallow copies of any loaded properties from the collection's items.
+        */
+        toJSON(): Excel.Interfaces.SlicerCollectionData;
+    }
+    /**
+     *
+     * Represents a slicer item in a slicer.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class SlicerItem extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /**
+         *
+         * True if the slicer item has data.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly hasData: boolean;
+        /**
+         *
+         * True if the slicer item is selected.
+            Setting this value will not clear other SlicerItems' selected state.
+            By default, if the slicer item is the only one selected, when it is deselected, all items will be selected.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        isSelected: boolean;
+        /**
+         *
+         * Represents the unique value representing the slicer item.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly key: string;
+        /**
+         *
+         * Represents the title displayed in the UI.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        readonly name: string;
+        /** Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate properties, or another API object of the same type.
+         *
+         * @remarks
+         *
+         * This method has the following additional signature:
+         *
+         * `set(properties: Excel.SlicerItem): void`
+         *
+         * @param properties A JavaScript object with properties that are structured isomorphically to the properties of the object on which the method is called.
+         * @param options Provides an option to suppress errors if the properties object tries to set any read-only properties.
+         */
+        set(properties: Interfaces.SlicerItemUpdateData, options?: OfficeExtension.UpdateOptions): void;
+        /** Sets multiple properties on the object at the same time, based on an existing loaded object. */
+        set(properties: Excel.SlicerItem): void;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.SlicerItemLoadOptions): Excel.SlicerItem;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.SlicerItem;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: {
+            select?: string;
+            expand?: string;
+        }): Excel.SlicerItem;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original Excel.SlicerItem object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.SlicerItemData`) that contains shallow copies of any loaded child properties from the original object.
+        */
+        toJSON(): Excel.Interfaces.SlicerItemData;
+    }
+    /**
+     *
+     * Represents a collection of all the slicer item objects on the slicer.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    class SlicerItemCollection extends OfficeExtension.ClientObject {
+        /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
+        context: RequestContext;
+        /** Gets the loaded child items in this collection. */
+        readonly items: Excel.SlicerItem[];
+        /**
+         *
+         * Returns the number of slicer items in the slicer.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        getCount(): OfficeExtension.ClientResult<number>;
+        /**
+         *
+         * Gets a slicer item object using its key or name.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param key The key or name of the slicer item.
+         */
+        getItem(key: string): Excel.SlicerItem;
+        /**
+         *
+         * Gets a slicer item based on its position in the collection.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param index Index value of the object to be retrieved. Zero-indexed.
+         */
+        getItemAt(index: number): Excel.SlicerItem;
+        /**
+         *
+         * Gets a slicer item using its key or name. If the slicer item does not exist, will return a null object.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param key Key or name of the slicer to be retrieved.
+         */
+        getItemOrNullObject(key: string): Excel.SlicerItem;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param options Provides options for which properties of the object to load.
+         */
+        load(options?: Excel.Interfaces.SlicerItemCollectionLoadOptions & Excel.Interfaces.CollectionLoadOptions): Excel.SlicerItemCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNames A comma-delimited string or an array of strings that specify the properties to load.
+         */
+        load(propertyNames?: string | string[]): Excel.SlicerItemCollection;
+        /**
+         * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
+         *
+         * @param propertyNamesAndPaths `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
+         */
+        load(propertyNamesAndPaths?: OfficeExtension.LoadOption): Excel.SlicerItemCollection;
+        /**
+        * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
+        * Whereas the original `Excel.SlicerItemCollection` object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.SlicerItemCollectionData`) that contains an "items" array with shallow copies of any loaded properties from the collection's items.
+        */
+        toJSON(): Excel.Interfaces.SlicerItemCollectionData;
     }
     /**
      * [Api set: ExcelApi 1.7]
@@ -36557,6 +38416,23 @@ declare namespace Excel {
         flashFill = "FlashFill"
     }
     /**
+     * [Api set: ExcelApi 1.10]
+     */
+    enum GroupOption {
+        /**
+         *
+         * Group by rows.
+         *
+         */
+        byRows = "ByRows",
+        /**
+         *
+         * Group by columns.
+         *
+         */
+        byColumns = "ByColumns"
+    }
+    /**
      * [Api set: ExcelApi 1.9]
      */
     enum RangeCopyType {
@@ -36767,6 +38643,23 @@ declare namespace Excel {
         straight = "Straight",
         elbow = "Elbow",
         curve = "Curve"
+    }
+    /**
+     * [Api set: ExcelApi 1.10]
+     */
+    enum ContentType {
+        /**
+         *
+         * Indicates plain format type of the comment content.
+         *
+         */
+        plain = "Plain",
+        /**
+         *
+         * Comment content containing mentions.
+         *
+         */
+        mention = "Mention"
     }
     /**
      * [Api set: ExcelApi 1.9]
@@ -37130,6 +39023,32 @@ declare namespace Excel {
          *
          */
         prompt = "Prompt"
+    }
+    /**
+     *
+     * Specifies the slicer sort behavior for Slicer.sortBy API.
+     *
+     * [Api set: ExcelApi 1.10]
+     */
+    enum SlicerSortType {
+        /**
+         *
+         * Sort slicer items in the order provided by the data source.
+         *
+         */
+        dataSourceOrder = "DataSourceOrder",
+        /**
+         *
+         * Sort slicer items in ascending order by item captions.
+         *
+         */
+        ascending = "Ascending",
+        /**
+         *
+         * Sort slicer items in descending order by item captions.
+         *
+         */
+        descending = "Descending"
     }
     /**
      * [Api set: ExcelApi 1.9]
@@ -41428,7 +43347,7 @@ declare namespace Excel {
             showTotals?: boolean;
             /**
              *
-             * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleStyleDark1" through "TableStyleStyleDark11". A custom user-defined style present in the workbook can also be specified.
+             * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleDark1" through "TableStyleDark11". A custom user-defined style present in the workbook can also be specified.
              *
              * [Api set: ExcelApi 1.1]
              */
@@ -41975,7 +43894,7 @@ declare namespace Excel {
             showAxisFieldButtons?: boolean;
             /**
              *
-             * Specifies whether or not to display the legend field buttons on a PivotChart
+             * Specifies whether or not to display the legend field buttons on a PivotChart.
              *
              * [Api set: ExcelApi 1.9]
              */
@@ -41989,7 +43908,7 @@ declare namespace Excel {
             showReportFilterFieldButtons?: boolean;
             /**
              *
-             * Specifies whether or not to display the show value field buttons on a PivotChart
+             * Specifies whether or not to display the show value field buttons on a PivotChart.
              *
              * [Api set: ExcelApi 1.9]
              */
@@ -43795,6 +45714,13 @@ declare namespace Excel {
             autoFormat?: boolean;
             /**
              *
+             * Specifies whether the field list can be shown in the UI.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            enableFieldList?: boolean;
+            /**
+             *
              * This property indicates the PivotLayoutType of all fields on the PivotTable. If fields have different states, this will be null.
              *
              * [Api set: ExcelApi 1.8]
@@ -44772,6 +46698,62 @@ declare namespace Excel {
         interface StyleCollectionUpdateData {
             items?: Excel.Interfaces.StyleData[];
         }
+        /** An interface for updating data on the TableStyleCollection object, for use in `tableStyleCollection.set({ ... })`. */
+        interface TableStyleCollectionUpdateData {
+            items?: Excel.Interfaces.TableStyleData[];
+        }
+        /** An interface for updating data on the TableStyle object, for use in `tableStyle.set({ ... })`. */
+        interface TableStyleUpdateData {
+            /**
+             *
+             * Gets the name of the TableStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: string;
+        }
+        /** An interface for updating data on the PivotTableStyleCollection object, for use in `pivotTableStyleCollection.set({ ... })`. */
+        interface PivotTableStyleCollectionUpdateData {
+            items?: Excel.Interfaces.PivotTableStyleData[];
+        }
+        /** An interface for updating data on the PivotTableStyle object, for use in `pivotTableStyle.set({ ... })`. */
+        interface PivotTableStyleUpdateData {
+            /**
+             *
+             * Gets the name of the PivotTableStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: string;
+        }
+        /** An interface for updating data on the SlicerStyleCollection object, for use in `slicerStyleCollection.set({ ... })`. */
+        interface SlicerStyleCollectionUpdateData {
+            items?: Excel.Interfaces.SlicerStyleData[];
+        }
+        /** An interface for updating data on the SlicerStyle object, for use in `slicerStyle.set({ ... })`. */
+        interface SlicerStyleUpdateData {
+            /**
+             *
+             * Gets the name of the SlicerStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: string;
+        }
+        /** An interface for updating data on the TimelineStyleCollection object, for use in `timelineStyleCollection.set({ ... })`. */
+        interface TimelineStyleCollectionUpdateData {
+            items?: Excel.Interfaces.TimelineStyleData[];
+        }
+        /** An interface for updating data on the TimelineStyle object, for use in `timelineStyle.set({ ... })`. */
+        interface TimelineStyleUpdateData {
+            /**
+             *
+             * Gets the name of the TimelineStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: string;
+        }
         /** An interface for updating data on the PageLayout object, for use in `pageLayout.set({ ... })`. */
         interface PageLayoutUpdateData {
             /**
@@ -45027,6 +47009,34 @@ declare namespace Excel {
         interface RangeCollectionUpdateData {
             items?: Excel.Interfaces.RangeData[];
         }
+        /** An interface for updating data on the CommentCollection object, for use in `commentCollection.set({ ... })`. */
+        interface CommentCollectionUpdateData {
+            items?: Excel.Interfaces.CommentData[];
+        }
+        /** An interface for updating data on the Comment object, for use in `comment.set({ ... })`. */
+        interface CommentUpdateData {
+            /**
+             *
+             * Gets or sets the comment's content. The string is plain text.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            content?: string;
+        }
+        /** An interface for updating data on the CommentReplyCollection object, for use in `commentReplyCollection.set({ ... })`. */
+        interface CommentReplyCollectionUpdateData {
+            items?: Excel.Interfaces.CommentReplyData[];
+        }
+        /** An interface for updating data on the CommentReply object, for use in `commentReply.set({ ... })`. */
+        interface CommentReplyUpdateData {
+            /**
+             *
+             * Gets or sets the comment reply's content. The string is plain text.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            content?: string;
+        }
         /** An interface for updating data on the ShapeCollection object, for use in `shapeCollection.set({ ... })`. */
         interface ShapeCollectionUpdateData {
             items?: Excel.Interfaces.ShapeData[];
@@ -45098,6 +47108,13 @@ declare namespace Excel {
              * [Api set: ExcelApi 1.9]
              */
             name?: string;
+            /**
+             *
+             * Represents how the object is attached to the cells below it.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            placement?: Excel.Placement | "TwoCell" | "OneCell" | "Absolute";
             /**
              *
              * Represents the rotation, in degrees, of the shape.
@@ -45389,6 +47406,96 @@ declare namespace Excel {
              */
             underline?: Excel.ShapeFontUnderlineStyle | "None" | "Single" | "Double" | "Heavy" | "Dotted" | "DottedHeavy" | "Dash" | "DashHeavy" | "DashLong" | "DashLongHeavy" | "DotDash" | "DotDashHeavy" | "DotDotDash" | "DotDotDashHeavy" | "Wavy" | "WavyHeavy" | "WavyDouble";
         }
+        /** An interface for updating data on the Slicer object, for use in `slicer.set({ ... })`. */
+        interface SlicerUpdateData {
+            /**
+            *
+            * Represents the worksheet containing the slicer.
+            *
+            * [Api set: ExcelApi 1.10]
+            */
+            worksheet?: Excel.Interfaces.WorksheetUpdateData;
+            /**
+             *
+             * Represents the caption of slicer.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            caption?: string;
+            /**
+             *
+             * Represents the height, in points, of the slicer.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            height?: number;
+            /**
+             *
+             * Represents the distance, in points, from the left side of the slicer to the left of the worksheet.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            left?: number;
+            /**
+             *
+             * Represents the name of slicer.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: string;
+            /**
+             *
+             * Represents the sort order of the items in the slicer. Possible values are: "DataSourceOrder", "Ascending", "Descending".
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            sortBy?: Excel.SlicerSortType | "DataSourceOrder" | "Ascending" | "Descending";
+            /**
+             *
+             * Constant value that represents the Slicer style. Possible values are: "SlicerStyleLight1" through "SlicerStyleLight6", "TableStyleOther1" through "TableStyleOther2", "SlicerStyleDark1" through "SlicerStyleDark6". A custom user-defined style present in the workbook can also be specified.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            style?: string;
+            /**
+             *
+             * Represents the distance, in points, from the top edge of the slicer to the top of the worksheet.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            top?: number;
+            /**
+             *
+             * Represents the width, in points, of the slicer.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            width?: number;
+        }
+        /** An interface for updating data on the SlicerCollection object, for use in `slicerCollection.set({ ... })`. */
+        interface SlicerCollectionUpdateData {
+            items?: Excel.Interfaces.SlicerData[];
+        }
+        /** An interface for updating data on the SlicerItem object, for use in `slicerItem.set({ ... })`. */
+        interface SlicerItemUpdateData {
+            /**
+             *
+             * True if the slicer item is selected.
+            Setting this value will not clear other SlicerItems' selected state.
+            By default, if the slicer item is the only one selected, when it is deselected, all items will be selected.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            isSelected?: boolean;
+        }
+        /** An interface for updating data on the SlicerItemCollection object, for use in `slicerItemCollection.set({ ... })`. */
+        interface SlicerItemCollectionUpdateData {
+            items?: Excel.Interfaces.SlicerItemData[];
+        }
         /** An interface describing the data returned by calling `runtime.toJSON()`. */
         interface RuntimeData {
             /**
@@ -45467,6 +47574,13 @@ declare namespace Excel {
             bindings?: Excel.Interfaces.BindingData[];
             /**
             *
+            * Represents a collection of Comments associated with the workbook. Read-only.
+            *
+            * [Api set: ExcelApi 1.10]
+            */
+            comments?: Excel.Interfaces.CommentData[];
+            /**
+            *
             * Represents the collection of custom XML parts contained by this workbook. Read-only.
             *
             * [Api set: ExcelApi 1.5]
@@ -45479,6 +47593,13 @@ declare namespace Excel {
             * [Api set: ExcelApi 1.1]
             */
             names?: Excel.Interfaces.NamedItemData[];
+            /**
+            *
+            * Represents a collection of PivotTableStyles associated with the workbook. Read-only.
+            *
+            * [Api set: ExcelApi 1.10]
+            */
+            pivotTableStyles?: Excel.Interfaces.PivotTableStyleData[];
             /**
             *
             * Represents a collection of PivotTables associated with the workbook. Read-only.
@@ -45509,6 +47630,20 @@ declare namespace Excel {
             settings?: Excel.Interfaces.SettingData[];
             /**
             *
+            * Represents a collection of SlicerStyles associated with the workbook. Read-only.
+            *
+            * [Api set: ExcelApi 1.10]
+            */
+            slicerStyles?: Excel.Interfaces.SlicerStyleData[];
+            /**
+            *
+            * Represents a collection of Slicers associated with the workbook. Read-only.
+            *
+            * [Api set: ExcelApi 1.10]
+            */
+            slicers?: Excel.Interfaces.SlicerData[];
+            /**
+            *
             * Represents a collection of styles associated with the workbook. Read-only.
             *
             * [Api set: ExcelApi 1.7]
@@ -45516,11 +47651,25 @@ declare namespace Excel {
             styles?: Excel.Interfaces.StyleData[];
             /**
             *
+            * Represents a collection of TableStyles associated with the workbook. Read-only.
+            *
+            * [Api set: ExcelApi 1.10]
+            */
+            tableStyles?: Excel.Interfaces.TableStyleData[];
+            /**
+            *
             * Represents a collection of tables associated with the workbook. Read-only.
             *
             * [Api set: ExcelApi 1.1]
             */
             tables?: Excel.Interfaces.TableData[];
+            /**
+            *
+            * Represents a collection of TimelineStyles associated with the workbook. Read-only.
+            *
+            * [Api set: ExcelApi 1.10]
+            */
+            timelineStyles?: Excel.Interfaces.TimelineStyleData[];
             /**
             *
             * Represents a collection of worksheets associated with the workbook. Read-only.
@@ -45612,11 +47761,18 @@ declare namespace Excel {
             autoFilter?: Excel.Interfaces.AutoFilterData;
             /**
             *
-            * Returns collection of charts that are part of the worksheet. Read-only.
+            * Returns a collection of charts that are part of the worksheet. Read-only.
             *
             * [Api set: ExcelApi 1.1]
             */
             charts?: Excel.Interfaces.ChartData[];
+            /**
+            *
+            * Returns a collection of all the Comments objects on the worksheet. Read-only.
+            *
+            * [Api set: ExcelApi 1.10]
+            */
+            comments?: Excel.Interfaces.CommentData[];
             /**
             *
             * Gets the horizontal page break collection for the worksheet. This collection only contains manual page breaks.
@@ -45659,6 +47815,13 @@ declare namespace Excel {
             * [Api set: ExcelApi 1.9]
             */
             shapes?: Excel.Interfaces.ShapeData[];
+            /**
+            *
+            * Returns a collection of slicers that are part of the worksheet. Read-only.
+            *
+            * [Api set: ExcelApi 1.10]
+            */
+            slicers?: Excel.Interfaces.SlicerData[];
             /**
             *
             * Collection of tables that are part of the worksheet. Read-only.
@@ -45862,6 +48025,13 @@ declare namespace Excel {
             formulasR1C1?: any[][];
             /**
              *
+             * Returns the distance in points, for 100% zoom, from top edge of the range to bottom edge of the range. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            height?: number;
+            /**
+             *
              * Represents if all cells of the current range are hidden. Read-only.
              *
              * [Api set: ExcelApi 1.2]
@@ -45888,6 +48058,13 @@ declare namespace Excel {
              * [Api set: ExcelApi 1.7]
              */
             isEntireRow?: boolean;
+            /**
+             *
+             * Returns the distance in points, for 100% zoom, from left edge of the worksheet to left edge of the range. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            left?: number;
             /**
              *
              * Represents the data type state of each cell. Read-only.
@@ -45953,6 +48130,13 @@ declare namespace Excel {
             text?: string[][];
             /**
              *
+             * Returns the distance in points, for 100% zoom, from top edge of the worksheet to top edge of the range. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            top?: number;
+            /**
+             *
              * Represents the type of data of each cell. Read-only.
              *
              * [Api set: ExcelApi 1.1]
@@ -45966,6 +48150,13 @@ declare namespace Excel {
              * [Api set: ExcelApi 1.1]
              */
             values?: any[][];
+            /**
+             *
+             * Returns the distance in points, for 100% zoom, from left edge of the range to right edge of the range. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            width?: number;
         }
         /** An interface describing the data returned by calling `rangeAreas.toJSON()`. */
         interface RangeAreasData {
@@ -46372,7 +48563,7 @@ declare namespace Excel {
             showTotals?: boolean;
             /**
              *
-             * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleStyleDark1" through "TableStyleStyleDark11". A custom user-defined style present in the workbook can also be specified.
+             * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleDark1" through "TableStyleDark11". A custom user-defined style present in the workbook can also be specified.
              *
              * [Api set: ExcelApi 1.1]
              */
@@ -46993,7 +49184,7 @@ declare namespace Excel {
             showAxisFieldButtons?: boolean;
             /**
              *
-             * Specifies whether or not to display the legend field buttons on a PivotChart
+             * Specifies whether or not to display the legend field buttons on a PivotChart.
              *
              * [Api set: ExcelApi 1.9]
              */
@@ -47007,7 +49198,7 @@ declare namespace Excel {
             showReportFilterFieldButtons?: boolean;
             /**
              *
-             * Specifies whether or not to display the show value field buttons on a PivotChart
+             * Specifies whether or not to display the show value field buttons on a PivotChart.
              *
              * [Api set: ExcelApi 1.9]
              */
@@ -49091,6 +51282,13 @@ declare namespace Excel {
             autoFormat?: boolean;
             /**
              *
+             * Specifies whether the field list can be shown in the UI.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            enableFieldList?: boolean;
+            /**
+             *
              * This property indicates the PivotLayoutType of all fields on the PivotTable. If fields have different states, this will be null.
              *
              * [Api set: ExcelApi 1.8]
@@ -50187,6 +52385,90 @@ declare namespace Excel {
         interface StyleCollectionData {
             items?: Excel.Interfaces.StyleData[];
         }
+        /** An interface describing the data returned by calling `tableStyleCollection.toJSON()`. */
+        interface TableStyleCollectionData {
+            items?: Excel.Interfaces.TableStyleData[];
+        }
+        /** An interface describing the data returned by calling `tableStyle.toJSON()`. */
+        interface TableStyleData {
+            /**
+             *
+             * Gets the name of the TableStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: string;
+            /**
+             *
+             * Specifies whether this TableStyle object is read-only. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            readOnly?: boolean;
+        }
+        /** An interface describing the data returned by calling `pivotTableStyleCollection.toJSON()`. */
+        interface PivotTableStyleCollectionData {
+            items?: Excel.Interfaces.PivotTableStyleData[];
+        }
+        /** An interface describing the data returned by calling `pivotTableStyle.toJSON()`. */
+        interface PivotTableStyleData {
+            /**
+             *
+             * Gets the name of the PivotTableStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: string;
+            /**
+             *
+             * Specifies whether this PivotTableStyle object is read-only. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            readOnly?: boolean;
+        }
+        /** An interface describing the data returned by calling `slicerStyleCollection.toJSON()`. */
+        interface SlicerStyleCollectionData {
+            items?: Excel.Interfaces.SlicerStyleData[];
+        }
+        /** An interface describing the data returned by calling `slicerStyle.toJSON()`. */
+        interface SlicerStyleData {
+            /**
+             *
+             * Gets the name of the SlicerStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: string;
+            /**
+             *
+             * Specifies whether this SlicerStyle object is read-only. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            readOnly?: boolean;
+        }
+        /** An interface describing the data returned by calling `timelineStyleCollection.toJSON()`. */
+        interface TimelineStyleCollectionData {
+            items?: Excel.Interfaces.TimelineStyleData[];
+        }
+        /** An interface describing the data returned by calling `timelineStyle.toJSON()`. */
+        interface TimelineStyleData {
+            /**
+             *
+             * Gets the name of the TimelineStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: string;
+            /**
+             *
+             * Specifies whether this TimelineStyle object is read-only. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            readOnly?: boolean;
+        }
         /** An interface describing the data returned by calling `pageLayout.toJSON()`. */
         interface PageLayoutData {
             /**
@@ -50459,6 +52741,97 @@ declare namespace Excel {
         interface RangeCollectionData {
             items?: Excel.Interfaces.RangeData[];
         }
+        /** An interface describing the data returned by calling `commentCollection.toJSON()`. */
+        interface CommentCollectionData {
+            items?: Excel.Interfaces.CommentData[];
+        }
+        /** An interface describing the data returned by calling `comment.toJSON()`. */
+        interface CommentData {
+            /**
+            *
+            * Represents a collection of reply objects associated with the comment. Read-only.
+            *
+            * [Api set: ExcelApi 1.10]
+            */
+            replies?: Excel.Interfaces.CommentReplyData[];
+            /**
+             *
+             * Gets the email of the comment's author.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            authorEmail?: string;
+            /**
+             *
+             * Gets the name of the comment's author.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            authorName?: string;
+            /**
+             *
+             * Gets or sets the comment's content. The string is plain text.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            content?: string;
+            /**
+             *
+             * Gets the creation time of the comment. Returns null if the comment was converted from a note, since the comment does not have a creation date.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            creationDate?: Date;
+            /**
+             *
+             * Represents the comment identifier. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            id?: string;
+        }
+        /** An interface describing the data returned by calling `commentReplyCollection.toJSON()`. */
+        interface CommentReplyCollectionData {
+            items?: Excel.Interfaces.CommentReplyData[];
+        }
+        /** An interface describing the data returned by calling `commentReply.toJSON()`. */
+        interface CommentReplyData {
+            /**
+             *
+             * Gets the email of the comment reply's author.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            authorEmail?: string;
+            /**
+             *
+             * Gets the name of the comment reply's author.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            authorName?: string;
+            /**
+             *
+             * Gets or sets the comment reply's content. The string is plain text.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            content?: string;
+            /**
+             *
+             * Gets the creation time of the comment reply.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            creationDate?: Date;
+            /**
+             *
+             * Represents the comment reply identifier. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            id?: string;
+        }
         /** An interface describing the data returned by calling `shapeCollection.toJSON()`. */
         interface ShapeCollectionData {
             items?: Excel.Interfaces.ShapeData[];
@@ -50551,6 +52924,13 @@ declare namespace Excel {
              * [Api set: ExcelApi 1.9]
              */
             name?: string;
+            /**
+             *
+             * Represents how the object is attached to the cells below it.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            placement?: Excel.Placement | "TwoCell" | "OneCell" | "Absolute";
             /**
              *
              * Represents the rotation, in degrees, of the shape.
@@ -50949,6 +53329,138 @@ declare namespace Excel {
              */
             underline?: Excel.ShapeFontUnderlineStyle | "None" | "Single" | "Double" | "Heavy" | "Dotted" | "DottedHeavy" | "Dash" | "DashHeavy" | "DashLong" | "DashLongHeavy" | "DotDash" | "DotDashHeavy" | "DotDotDash" | "DotDotDashHeavy" | "Wavy" | "WavyHeavy" | "WavyDouble";
         }
+        /** An interface describing the data returned by calling `slicer.toJSON()`. */
+        interface SlicerData {
+            /**
+            *
+            * Represents the collection of SlicerItems that are part of the slicer. Read-only.
+            *
+            * [Api set: ExcelApi 1.10]
+            */
+            slicerItems?: Excel.Interfaces.SlicerItemData[];
+            /**
+            *
+            * Represents the worksheet containing the slicer. Read-only.
+            *
+            * [Api set: ExcelApi 1.10]
+            */
+            worksheet?: Excel.Interfaces.WorksheetData;
+            /**
+             *
+             * Represents the caption of slicer.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            caption?: string;
+            /**
+             *
+             * Represents the height, in points, of the slicer.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            height?: number;
+            /**
+             *
+             * Represents the unique id of slicer. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            id?: string;
+            /**
+             *
+             * True if all filters currently applied on the slicer are cleared.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            isFilterCleared?: boolean;
+            /**
+             *
+             * Represents the distance, in points, from the left side of the slicer to the left of the worksheet.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            left?: number;
+            /**
+             *
+             * Represents the name of slicer.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: string;
+            /**
+             *
+             * Represents the sort order of the items in the slicer. Possible values are: "DataSourceOrder", "Ascending", "Descending".
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            sortBy?: Excel.SlicerSortType | "DataSourceOrder" | "Ascending" | "Descending";
+            /**
+             *
+             * Constant value that represents the Slicer style. Possible values are: "SlicerStyleLight1" through "SlicerStyleLight6", "TableStyleOther1" through "TableStyleOther2", "SlicerStyleDark1" through "SlicerStyleDark6". A custom user-defined style present in the workbook can also be specified.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            style?: string;
+            /**
+             *
+             * Represents the distance, in points, from the top edge of the slicer to the top of the worksheet.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            top?: number;
+            /**
+             *
+             * Represents the width, in points, of the slicer.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            width?: number;
+        }
+        /** An interface describing the data returned by calling `slicerCollection.toJSON()`. */
+        interface SlicerCollectionData {
+            items?: Excel.Interfaces.SlicerData[];
+        }
+        /** An interface describing the data returned by calling `slicerItem.toJSON()`. */
+        interface SlicerItemData {
+            /**
+             *
+             * True if the slicer item has data.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            hasData?: boolean;
+            /**
+             *
+             * True if the slicer item is selected.
+            Setting this value will not clear other SlicerItems' selected state.
+            By default, if the slicer item is the only one selected, when it is deselected, all items will be selected.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            isSelected?: boolean;
+            /**
+             *
+             * Represents the unique value representing the slicer item.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            key?: string;
+            /**
+             *
+             * Represents the title displayed in the UI.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: string;
+        }
+        /** An interface describing the data returned by calling `slicerItemCollection.toJSON()`. */
+        interface SlicerItemCollectionData {
+            items?: Excel.Interfaces.SlicerItemData[];
+        }
         /** An interface describing the data returned by calling `functionResult.toJSON()`. */
         interface FunctionResultData<T> {
             /**
@@ -51207,7 +53719,7 @@ declare namespace Excel {
             autoFilter?: Excel.Interfaces.AutoFilterLoadOptions;
             /**
             *
-            * Returns collection of charts that are part of the worksheet.
+            * Returns a collection of charts that are part of the worksheet.
             *
             * [Api set: ExcelApi 1.1]
             */
@@ -51330,7 +53842,7 @@ declare namespace Excel {
             autoFilter?: Excel.Interfaces.AutoFilterLoadOptions;
             /**
             *
-            * For EACH ITEM in the collection: Returns collection of charts that are part of the worksheet.
+            * For EACH ITEM in the collection: Returns a collection of charts that are part of the worksheet.
             *
             * [Api set: ExcelApi 1.1]
             */
@@ -51561,6 +54073,13 @@ declare namespace Excel {
             formulasR1C1?: boolean;
             /**
              *
+             * Returns the distance in points, for 100% zoom, from top edge of the range to bottom edge of the range. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            height?: boolean;
+            /**
+             *
              * Represents if all cells of the current range are hidden. Read-only.
              *
              * [Api set: ExcelApi 1.2]
@@ -51587,6 +54106,13 @@ declare namespace Excel {
              * [Api set: ExcelApi 1.7]
              */
             isEntireRow?: boolean;
+            /**
+             *
+             * Returns the distance in points, for 100% zoom, from left edge of the worksheet to left edge of the range. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            left?: boolean;
             /**
              *
              * Represents the data type state of each cell. Read-only.
@@ -51652,6 +54178,13 @@ declare namespace Excel {
             text?: boolean;
             /**
              *
+             * Returns the distance in points, for 100% zoom, from top edge of the worksheet to top edge of the range. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            top?: boolean;
+            /**
+             *
              * Represents the type of data of each cell. Read-only.
              *
              * [Api set: ExcelApi 1.1]
@@ -51665,6 +54198,13 @@ declare namespace Excel {
              * [Api set: ExcelApi 1.1]
              */
             values?: boolean;
+            /**
+             *
+             * Returns the distance in points, for 100% zoom, from left edge of the range to right edge of the range. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            width?: boolean;
         }
         /**
          *
@@ -52341,7 +54881,7 @@ declare namespace Excel {
             showTotals?: boolean;
             /**
              *
-             * For EACH ITEM in the collection: Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleStyleDark1" through "TableStyleStyleDark11". A custom user-defined style present in the workbook can also be specified.
+             * For EACH ITEM in the collection: Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleDark1" through "TableStyleDark11". A custom user-defined style present in the workbook can also be specified.
              *
              * [Api set: ExcelApi 1.1]
              */
@@ -52465,7 +55005,7 @@ declare namespace Excel {
             showTotals?: boolean;
             /**
              *
-             * For EACH ITEM in the collection: Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleStyleDark1" through "TableStyleStyleDark11". A custom user-defined style present in the workbook can also be specified.
+             * For EACH ITEM in the collection: Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleDark1" through "TableStyleDark11". A custom user-defined style present in the workbook can also be specified.
              *
              * [Api set: ExcelApi 1.1]
              */
@@ -52590,7 +55130,7 @@ declare namespace Excel {
             showTotals?: boolean;
             /**
              *
-             * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleStyleDark1" through "TableStyleStyleDark11". A custom user-defined style present in the workbook can also be specified.
+             * Constant value that represents the Table style. Possible values are: "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleDark1" through "TableStyleDark11". A custom user-defined style present in the workbook can also be specified.
              *
              * [Api set: ExcelApi 1.1]
              */
@@ -53618,7 +56158,7 @@ declare namespace Excel {
             showAxisFieldButtons?: boolean;
             /**
              *
-             * Specifies whether or not to display the legend field buttons on a PivotChart
+             * Specifies whether or not to display the legend field buttons on a PivotChart.
              *
              * [Api set: ExcelApi 1.9]
              */
@@ -53632,7 +56172,7 @@ declare namespace Excel {
             showReportFilterFieldButtons?: boolean;
             /**
              *
-             * Specifies whether or not to display the show value field buttons on a PivotChart
+             * Specifies whether or not to display the show value field buttons on a PivotChart.
              *
              * [Api set: ExcelApi 1.9]
              */
@@ -56686,6 +59226,13 @@ declare namespace Excel {
             autoFormat?: boolean;
             /**
              *
+             * Specifies whether the field list can be shown in the UI.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            enableFieldList?: boolean;
+            /**
+             *
              * This property indicates the PivotLayoutType of all fields on the PivotTable. If fields have different states, this will be null.
              *
              * [Api set: ExcelApi 1.8]
@@ -58577,6 +61124,214 @@ declare namespace Excel {
         }
         /**
          *
+         * Represents a collection of TableStyles.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface TableStyleCollectionLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Gets the name of the TableStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Specifies whether this TableStyle object is read-only. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            readOnly?: boolean;
+        }
+        /**
+         *
+         * Represents a TableStyle, which defines the style elements by region of the Table.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface TableStyleLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * Gets the name of the TableStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: boolean;
+            /**
+             *
+             * Specifies whether this TableStyle object is read-only. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            readOnly?: boolean;
+        }
+        /**
+         *
+         * Represents a collection of PivotTable styles.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface PivotTableStyleCollectionLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Gets the name of the PivotTableStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Specifies whether this PivotTableStyle object is read-only. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            readOnly?: boolean;
+        }
+        /**
+         *
+         * Represents a PivotTable Style, which defines style elements by PivotTable region.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface PivotTableStyleLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * Gets the name of the PivotTableStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: boolean;
+            /**
+             *
+             * Specifies whether this PivotTableStyle object is read-only. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            readOnly?: boolean;
+        }
+        /**
+         *
+         * Represents a collection of SlicerStyle objects.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface SlicerStyleCollectionLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Gets the name of the SlicerStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Specifies whether this SlicerStyle object is read-only. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            readOnly?: boolean;
+        }
+        /**
+         *
+         * Represents a Slicer Style, which defines style elements by region of the slicer.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface SlicerStyleLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * Gets the name of the SlicerStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: boolean;
+            /**
+             *
+             * Specifies whether this SlicerStyle object is read-only. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            readOnly?: boolean;
+        }
+        /**
+         *
+         * Represents a collection of TimelineStyles.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface TimelineStyleCollectionLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Gets the name of the TimelineStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Specifies whether this TimelineStyle object is read-only. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            readOnly?: boolean;
+        }
+        /**
+         *
+         * Represents a Timeline style, which defines style elements by region in the Timeline.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface TimelineStyleLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * Gets the name of the TimelineStyle.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: boolean;
+            /**
+             *
+             * Specifies whether this TimelineStyle object is read-only. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            readOnly?: boolean;
+        }
+        /**
+         *
          * Represents layout and print settings that are not dependent any printer-specific implementation. These settings include margins, orientation, page numbering, title rows, and print area.
          *
          * [Api set: ExcelApi 1.9]
@@ -58986,6 +61741,13 @@ declare namespace Excel {
             formulasR1C1?: boolean;
             /**
              *
+             * For EACH ITEM in the collection: Returns the distance in points, for 100% zoom, from top edge of the range to bottom edge of the range. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            height?: boolean;
+            /**
+             *
              * For EACH ITEM in the collection: Represents if all cells of the current range are hidden. Read-only.
              *
              * [Api set: ExcelApi 1.2]
@@ -59012,6 +61774,13 @@ declare namespace Excel {
              * [Api set: ExcelApi 1.7]
              */
             isEntireRow?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Returns the distance in points, for 100% zoom, from left edge of the worksheet to left edge of the range. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            left?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Represents the data type state of each cell. Read-only.
@@ -59077,6 +61846,13 @@ declare namespace Excel {
             text?: boolean;
             /**
              *
+             * For EACH ITEM in the collection: Returns the distance in points, for 100% zoom, from top edge of the worksheet to top edge of the range. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            top?: boolean;
+            /**
+             *
              * For EACH ITEM in the collection: Represents the type of data of each cell. Read-only.
              *
              * [Api set: ExcelApi 1.1]
@@ -59090,6 +61866,201 @@ declare namespace Excel {
              * [Api set: ExcelApi 1.1]
              */
             values?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Returns the distance in points, for 100% zoom, from left edge of the range to right edge of the range. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            width?: boolean;
+        }
+        /**
+         *
+         * Represents a collection of comment objects that are part of the workbook.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface CommentCollectionLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Gets the email of the comment's author.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            authorEmail?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Gets the name of the comment's author.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            authorName?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Gets or sets the comment's content. The string is plain text.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            content?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Gets the creation time of the comment. Returns null if the comment was converted from a note, since the comment does not have a creation date.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            creationDate?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Represents the comment identifier. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            id?: boolean;
+        }
+        /**
+         *
+         * Represents a comment in the workbook.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface CommentLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * Gets the email of the comment's author.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            authorEmail?: boolean;
+            /**
+             *
+             * Gets the name of the comment's author.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            authorName?: boolean;
+            /**
+             *
+             * Gets or sets the comment's content. The string is plain text.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            content?: boolean;
+            /**
+             *
+             * Gets the creation time of the comment. Returns null if the comment was converted from a note, since the comment does not have a creation date.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            creationDate?: boolean;
+            /**
+             *
+             * Represents the comment identifier. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            id?: boolean;
+        }
+        /**
+         *
+         * Represents a collection of comment reply objects that are part of the comment.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface CommentReplyCollectionLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Gets the email of the comment reply's author.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            authorEmail?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Gets the name of the comment reply's author.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            authorName?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Gets or sets the comment reply's content. The string is plain text.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            content?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Gets the creation time of the comment reply.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            creationDate?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Represents the comment reply identifier. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            id?: boolean;
+        }
+        /**
+         *
+         * Represents a comment reply in the workbook.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface CommentReplyLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * Gets the email of the comment reply's author.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            authorEmail?: boolean;
+            /**
+             *
+             * Gets the name of the comment reply's author.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            authorName?: boolean;
+            /**
+             *
+             * Gets or sets the comment reply's content. The string is plain text.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            content?: boolean;
+            /**
+             *
+             * Gets the creation time of the comment reply.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            creationDate?: boolean;
+            /**
+             *
+             * Represents the comment reply identifier. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            id?: boolean;
         }
         /**
          *
@@ -59230,6 +62201,13 @@ declare namespace Excel {
              * [Api set: ExcelApi 1.9]
              */
             name?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Represents how the object is attached to the cells below it.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            placement?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Represents the rotation, in degrees, of the shape.
@@ -59415,6 +62393,13 @@ declare namespace Excel {
              * [Api set: ExcelApi 1.9]
              */
             name?: boolean;
+            /**
+             *
+             * Represents how the object is attached to the cells below it.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            placement?: boolean;
             /**
              *
              * Represents the rotation, in degrees, of the shape.
@@ -59684,6 +62669,13 @@ declare namespace Excel {
              * [Api set: ExcelApi 1.9]
              */
             name?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Represents how the object is attached to the cells below it.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            placement?: boolean;
             /**
              *
              * For EACH ITEM in the collection: Represents the rotation, in degrees, of the shape.
@@ -60115,6 +63107,276 @@ declare namespace Excel {
              * [Api set: ExcelApi 1.9]
              */
             underline?: boolean;
+        }
+        /**
+         *
+         * Represents a slicer object in the workbook.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface SlicerLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+            *
+            * Represents the worksheet containing the slicer.
+            *
+            * [Api set: ExcelApi 1.10]
+            */
+            worksheet?: Excel.Interfaces.WorksheetLoadOptions;
+            /**
+             *
+             * Represents the caption of slicer.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            caption?: boolean;
+            /**
+             *
+             * Represents the height, in points, of the slicer.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            height?: boolean;
+            /**
+             *
+             * Represents the unique id of slicer. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            id?: boolean;
+            /**
+             *
+             * True if all filters currently applied on the slicer are cleared.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            isFilterCleared?: boolean;
+            /**
+             *
+             * Represents the distance, in points, from the left side of the slicer to the left of the worksheet.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            left?: boolean;
+            /**
+             *
+             * Represents the name of slicer.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: boolean;
+            /**
+             *
+             * Represents the sort order of the items in the slicer. Possible values are: "DataSourceOrder", "Ascending", "Descending".
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            sortBy?: boolean;
+            /**
+             *
+             * Constant value that represents the Slicer style. Possible values are: "SlicerStyleLight1" through "SlicerStyleLight6", "TableStyleOther1" through "TableStyleOther2", "SlicerStyleDark1" through "SlicerStyleDark6". A custom user-defined style present in the workbook can also be specified.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            style?: boolean;
+            /**
+             *
+             * Represents the distance, in points, from the top edge of the slicer to the top of the worksheet.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            top?: boolean;
+            /**
+             *
+             * Represents the width, in points, of the slicer.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            width?: boolean;
+        }
+        /**
+         *
+         * Represents a collection of all the slicer objects on the workbook or a worksheet.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface SlicerCollectionLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+            *
+            * For EACH ITEM in the collection: Represents the worksheet containing the slicer.
+            *
+            * [Api set: ExcelApi 1.10]
+            */
+            worksheet?: Excel.Interfaces.WorksheetLoadOptions;
+            /**
+             *
+             * For EACH ITEM in the collection: Represents the caption of slicer.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            caption?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Represents the height, in points, of the slicer.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            height?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Represents the unique id of slicer. Read-only.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            id?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: True if all filters currently applied on the slicer are cleared.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            isFilterCleared?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Represents the distance, in points, from the left side of the slicer to the left of the worksheet.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            left?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Represents the name of slicer.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Represents the sort order of the items in the slicer. Possible values are: "DataSourceOrder", "Ascending", "Descending".
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            sortBy?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Constant value that represents the Slicer style. Possible values are: "SlicerStyleLight1" through "SlicerStyleLight6", "TableStyleOther1" through "TableStyleOther2", "SlicerStyleDark1" through "SlicerStyleDark6". A custom user-defined style present in the workbook can also be specified.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            style?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Represents the distance, in points, from the top edge of the slicer to the top of the worksheet.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            top?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Represents the width, in points, of the slicer.
+            Throws an "The argument is invalid or missing or has an incorrect format." exception when set with negative value or zero as input.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            width?: boolean;
+        }
+        /**
+         *
+         * Represents a slicer item in a slicer.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface SlicerItemLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * True if the slicer item has data.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            hasData?: boolean;
+            /**
+             *
+             * True if the slicer item is selected.
+            Setting this value will not clear other SlicerItems' selected state.
+            By default, if the slicer item is the only one selected, when it is deselected, all items will be selected.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            isSelected?: boolean;
+            /**
+             *
+             * Represents the unique value representing the slicer item.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            key?: boolean;
+            /**
+             *
+             * Represents the title displayed in the UI.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: boolean;
+        }
+        /**
+         *
+         * Represents a collection of all the slicer item objects on the slicer.
+         *
+         * [Api set: ExcelApi 1.10]
+         */
+        interface SlicerItemCollectionLoadOptions {
+            /**
+              Specifying `$all` for the LoadOptions loads all the scalar properties (e.g.: `Range.address`) but not the navigational properties (e.g.: `Range.format.fill.color`).
+             */
+            $all?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: True if the slicer item has data.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            hasData?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: True if the slicer item is selected.
+            Setting this value will not clear other SlicerItems' selected state.
+            By default, if the slicer item is the only one selected, when it is deselected, all items will be selected.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            isSelected?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Represents the unique value representing the slicer item.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            key?: boolean;
+            /**
+             *
+             * For EACH ITEM in the collection: Represents the title displayed in the UI.
+             *
+             * [Api set: ExcelApi 1.10]
+             */
+            name?: boolean;
         }
         /**
          *

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -63434,7 +63434,7 @@ declare namespace Word {
      */
     class Application extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Creates a new document by using an optional base64 encoded .docx file.
@@ -63464,7 +63464,7 @@ declare namespace Word {
      */
     class Body extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets the collection of rich text content control objects in the body. Read-only.
@@ -63880,7 +63880,7 @@ declare namespace Word {
      */
     class ContentControl extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets the collection of content control objects in the content control. Read-only.
@@ -64397,7 +64397,7 @@ declare namespace Word {
      */
     class ContentControlCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /** Gets the loaded child items in this collection. */
         readonly items: Word.ContentControl[];
         /**
@@ -64508,7 +64508,7 @@ declare namespace Word {
      */
     class CustomProperty extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets the key of the custom property. Read only.
@@ -64594,7 +64594,7 @@ declare namespace Word {
      */
     class CustomPropertyCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /** Gets the loaded child items in this collection. */
         readonly items: Word.CustomProperty[];
         /**
@@ -64679,7 +64679,7 @@ declare namespace Word {
      */
     class Document extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets the body object of the document. The body is the text that excludes headers, footers, footnotes, textboxes, etc.. Read-only.
@@ -64786,7 +64786,7 @@ declare namespace Word {
      */
     class DocumentCreated extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets the body object of the document. The body is the text that excludes headers, footers, footnotes, textboxes, etc.. Read-only.
@@ -64893,7 +64893,7 @@ declare namespace Word {
      */
     class DocumentProperties extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets the collection of custom properties of the document. Read only.
@@ -65077,7 +65077,7 @@ declare namespace Word {
      */
     class Font extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets or sets a value that indicates whether the font is bold. True if the font is formatted as bold, otherwise, false.
@@ -65213,7 +65213,7 @@ declare namespace Word {
      */
     class InlinePicture extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets the parent paragraph that contains the inline image. Read-only.
@@ -65573,7 +65573,7 @@ declare namespace Word {
      */
     class InlinePictureCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /** Gets the loaded child items in this collection. */
         readonly items: Word.InlinePicture[];
         /**
@@ -65630,7 +65630,7 @@ declare namespace Word {
      */
     class List extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets paragraphs in the list. Read-only.
@@ -65827,7 +65827,7 @@ declare namespace Word {
      */
     class ListCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /** Gets the loaded child items in this collection. */
         readonly items: Word.List[];
         /**
@@ -65911,7 +65911,7 @@ declare namespace Word {
      */
     class ListItem extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets or sets the level of the item in the list.
@@ -66017,7 +66017,7 @@ declare namespace Word {
      */
     class Paragraph extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets the collection of content control objects in the paragraph. Read-only.
@@ -66611,7 +66611,7 @@ declare namespace Word {
      */
     class ParagraphCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /** Gets the loaded child items in this collection. */
         readonly items: Word.Paragraph[];
         /**
@@ -66682,7 +66682,7 @@ declare namespace Word {
      */
     class Range extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets the collection of content control objects in the range. Read-only.
@@ -67213,7 +67213,7 @@ declare namespace Word {
      */
     class RangeCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /** Gets the loaded child items in this collection. */
         readonly items: Word.Range[];
         /**
@@ -67270,7 +67270,7 @@ declare namespace Word {
      */
     class SearchOptions extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         matchWildCards: boolean;
         /**
          *
@@ -67374,7 +67374,7 @@ declare namespace Word {
      */
     class Section extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets the body object of the section. This does not include the header/footer and other section metadata. Read-only.
@@ -67489,7 +67489,7 @@ declare namespace Word {
      */
     class SectionCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /** Gets the loaded child items in this collection. */
         readonly items: Word.Section[];
         /**
@@ -67546,7 +67546,7 @@ declare namespace Word {
      */
     class Table extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets the font. Use this to get and set font name, size, color, and other properties. Read-only.
@@ -68108,7 +68108,7 @@ declare namespace Word {
      */
     class TableCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /** Gets the loaded child items in this collection. */
         readonly items: Word.Table[];
         /**
@@ -68165,7 +68165,7 @@ declare namespace Word {
      */
     class TableRow extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets cells. Read-only.
@@ -68442,7 +68442,7 @@ declare namespace Word {
      */
     class TableRowCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /** Gets the loaded child items in this collection. */
         readonly items: Word.TableRow[];
         /**
@@ -68499,7 +68499,7 @@ declare namespace Word {
      */
     class TableCell extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets the body object of the cell. Read-only.
@@ -68762,7 +68762,7 @@ declare namespace Word {
      */
     class TableCellCollection extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /** Gets the loaded child items in this collection. */
         readonly items: Word.TableCell[];
         /**
@@ -68819,7 +68819,7 @@ declare namespace Word {
      */
     class TableBorder extends OfficeExtension.ClientObject {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
-        context: RequestContext; 
+        context: RequestContext;
         /**
          *
          * Gets or sets the table border color.

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -20185,7 +20185,7 @@ declare namespace Excel {
     interface SearchCriteria {
         /**
          *
-         * Specifies whether the match needs to be complete or partial. A complete match matches the entire contents of the cell. Default is false (partial).
+         * Specifies whether the match needs to be complete or partial. A complete match matches the entire contents of the cell. A partial match matches a substring within the content of the cell (e.g., `cat` partially matches `caterpillar` and `scatter`). Default is false (partial).
          *
          * [Api set: ExcelApi 1.9]
          */
@@ -20214,7 +20214,7 @@ declare namespace Excel {
     interface WorksheetSearchCriteria {
         /**
          *
-         * Specifies whether the match needs to be complete or partial. A complete match matches the entire contents of the cell. Default is false (partial).
+         * Specifies whether the match needs to be complete or partial. A complete match matches the entire contents of the cell. A partial match matches a substring within the content of the cell (e.g., `cat` partially matches `caterpillar` and `scatter`). Default is false (partial).
          *
          * [Api set: ExcelApi 1.9]
          */
@@ -20236,7 +20236,7 @@ declare namespace Excel {
     interface ReplaceCriteria {
         /**
          *
-         * Specifies whether the match needs to be complete or partial. Default is false (partial).
+         * Specifies whether the match needs to be complete or partial. A complete match matches the entire contents of the cell. A partial match matches a substring within the content of the cell (e.g., `cat` partially matches `caterpillar` and `scatter`). Default is false (partial).
          *
          * [Api set: ExcelApi 1.9]
          */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
Release URL: https://appsforoffice.officeapps.live.com/afo/lib/1.1/hosted/office.d.ts  
Beta URL: https://appsforoffice.officeapps.live.com/afo/lib/beta/hosted/office.d.ts  

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
