### PR TITLE
nodegit v0.25.0: gitRemotes returns Remote[] (reverts a previous commit)

### DIFF
--- a/types/nodegit/repository.d.ts
+++ b/types/nodegit/repository.d.ts
@@ -163,7 +163,7 @@ export class Repository {
     /**
      * Lists out the remotes in the given repository.
      */
-    getRemotes(callback?: Function): Promise<string[]>;
+    getRemotes(callback?: Function): Promise<Remote[]>;
     /**
      * Gets a remote from the repo
      */


### PR DESCRIPTION
This reverts d0bb9d962473201ea7bbcd3e7c80d3895dc58914 from #31420

release notes: https://github.com/nodegit/nodegit/releases/tag/v0.25.0

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodegit/nodegit/releases/tag/v0.25.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
