### PR TITLE
mithril - Remove inactive author

### DIFF
--- a/types/mithril/index.d.ts
+++ b/types/mithril/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Mithril 2.0
 // Project: https://mithril.js.org/, https://github.com/mithriljs/mithril.js
-// Definitions by: Mike Linkovich <https://github.com/spacejack>, András Parditka <https://github.com/andraaspar>, Isiah Meadows <https://github.com/isiahmeadows>
+// Definitions by: Mike Linkovich <https://github.com/spacejack>, Isiah Meadows <https://github.com/isiahmeadows>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 


### PR DESCRIPTION
@andraaspar reached out to us in the [Mithril chat room](https://gitter.im/mithriljs/mithril.js?at=5daef8a19825bd6baca9cadc) to notify us he was no longer involved with the typings and had moved away from Mithril at large. If this isn't the correct way to remove him from the list of people notified on GH typing updates, please let me know and I'll correct this PR appropriately.
