### PR TITLE
Fix electron dependency in electron-clipboard-extended to 6

### DIFF
--- a/types/electron-clipboard-extended/package.json
+++ b/types/electron-clipboard-extended/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "electron": "latest"
+        "electron": "6"
     }
 }


### PR DESCRIPTION
Electron 7's Clipboard doesn't have the `on` method anymore.