### PR TITLE
[react-select] export deeply non-nullable component interface

### DIFF
--- a/types/react-select/src/components/index.d.ts
+++ b/types/react-select/src/components/index.d.ts
@@ -82,7 +82,11 @@ export interface SelectComponents<OptionType extends OptionTypeBase> {
 
 export type SelectComponentsConfig<OptionType extends OptionTypeBase> = Partial<SelectComponents<OptionType>>;
 
-export const components: Required<SelectComponents<any>>;
+export type DeepNonNullable<T> = {
+    [P in keyof T]-?: NonNullable<T[P]>;
+};
+
+export const components: Required<DeepNonNullable<SelectComponents<any>>>;
 
 export interface Props<OptionType extends OptionTypeBase> {
   components: SelectComponentsConfig<OptionType>;


### PR DESCRIPTION
Updates the `components` type to ensure that the exported components are not considered null. 

**Previously 😞**
```typescript
import { components } from 'react-select';

<components.ClearIndicator {...} />
```

**Error 💥**
```
JSX element type 'components.ClearIndicator' does not have any construct or call signatures.

24         <components.ClearIndicator
```

Why is this happening? Turns out the `Components` interface contains definitions which are a union of `ComponentType` & `null`. See `SelectComponents`:

```typescript
export interface SelectComponents<OptionType extends OptionTypeBase> {
  ClearIndicator: IndicatorComponentType<OptionType> | null;
  Control: ComponentType<ControlProps<OptionType>>;
  DropdownIndicator: IndicatorComponentType<OptionType> | null;
  DownChevron: ComponentType<any>;
...
}
```

**Why is this an issue now?**
It looks like there was an attempt to make the components `Required` on this line...

```typescript
export const components: Required<SelectComponents<any>>;
```

but `Required` is not enough, since it only removes the optional `(?)` 

What we really needed in this case is to use a `DeepNonNullable` (which is what i've implemented)


**Please fill in this template.**

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <N/A>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.