### PR TITLE
Add js roman numerals lib

### DIFF
--- a/types/js-roman-numerals/index.d.ts
+++ b/types/js-roman-numerals/index.d.ts
@@ -1,12 +1,12 @@
-// Type definitions for js-roman-numerals
+// Type definitions for js-roman-numerals 1.1.0
 // Project: https://github.com/bcotrim/roman-numerals
 // Definitions by: Reece Dunham <https://rdil.rocks>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 
 export namespace RomanNumeral {
-    constructor(value: number): void
-    constructor(value: String): void
-    toInt(): number
-    toString(): String
+    constructor(value: number): void;
+    constructor(value: String): void;
+    toInt(): number;
+    toString(): String;
 }

--- a/types/js-roman-numerals/index.d.ts
+++ b/types/js-roman-numerals/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for js-roman-numerals
+// Project: https://github.com/bcotrim/roman-numerals
+// Definitions by: Reece Dunham <https://rdil.rocks>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.6
+
+export namespace RomanNumeral {
+    constructor(value: number): void
+    constructor(value: string): void
+}

--- a/types/js-roman-numerals/index.d.ts
+++ b/types/js-roman-numerals/index.d.ts
@@ -6,5 +6,7 @@
 
 export namespace RomanNumeral {
     constructor(value: number): void
-    constructor(value: string): void
+    constructor(value: String): void
+    toInt(): number
+    toString(): String
 }

--- a/types/js-roman-numerals/js-roman-numerals-tests.ts
+++ b/types/js-roman-numerals/js-roman-numerals-tests.ts
@@ -1,7 +1,7 @@
 import RomanNumeral = require('js-roman-numerals');
 
-let firstvar = new RomanNumeral("IV");
-let secondvar = new RomanNumeral(4);
+const firstvar = new RomanNumeral("IV");
+const secondvar = new RomanNumeral(4);
 
 let testIntThing: number = firstvar.toInt();
 let testStringThing: String = secondvar.toString();

--- a/types/js-roman-numerals/js-roman-numerals-tests.ts
+++ b/types/js-roman-numerals/js-roman-numerals-tests.ts
@@ -1,0 +1,7 @@
+import RomanNumeral = require('js-roman-numerals');
+
+let firstvar = new RomanNumeral("IV");
+let secondvar = new RomanNumeral(4);
+
+let testIntThing: number = firstvar.toInt();
+let testStringThing: String = secondvar.toString();

--- a/types/js-roman-numerals/js-roman-numerals-tests.ts
+++ b/types/js-roman-numerals/js-roman-numerals-tests.ts
@@ -2,6 +2,5 @@ import RomanNumeral = require('js-roman-numerals');
 
 const firstvar = new RomanNumeral("IV");
 const secondvar = new RomanNumeral(4);
-
-let testIntThing: number = firstvar.toInt();
-let testStringThing: String = secondvar.toString();
+const testInt: Number = firstvar.toInt();
+const testString: String = secondvar.toString();

--- a/types/js-roman-numerals/tsconfig.json
+++ b/types/js-roman-numerals/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "js-roman-numerals-tests.ts"
+    ]
+}

--- a/types/js-roman-numerals/tslint.json
+++ b/types/js-roman-numerals/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
fixes #39330 

I have no idea what I'm doing so I most likely messed up.

For anybody willing to help:
the module exposes a class, with a constructor that accepts:
* `value: String`
* `value: number`
and has the methods:
* `toInt: number`
* `toString: String`
once initialized