### PR TITLE
mui-datatables@2.12 Missing fields…

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -28,9 +28,15 @@ interface MUIDataTableStateRows {
 export interface MUIDataTableState {
     activeColumn: string | null;
     announceText: string | null;
+    columns: MUIDataTableColumnState[];
+    // TODO count is also returned
+    // TODO data
+    // TODO displayData
     expandedRows: MUIDataTableStateRows;
+    // TODO filterData
     filterList: string[][];
     page: number;
+    // TODO previousSelectedRow
     rowsPerPage: number;
     rowsPerPageOptions: number[];
     searchText: string | null;
@@ -109,6 +115,11 @@ export interface MUIDataTableFilterOptions {
     logic?: (prop: string, filterValue: any[]) => boolean;
 }
 
+export interface MUIDataTableColumnState extends MUIDataTableColumnOptions {
+    name: string;
+    label?: string;
+}
+
 export interface MUIDataTableColumnOptions {
     customBodyRender?: (value: any, tableMeta: MUIDataTableMeta, updateValue: (s: any, c: any, p: any) => any) => string | React.ReactNode;
     customHeadRender?: (columnMeta: MUIDataTableCustomHeadRenderer, updateDirection: (params: any) => any) => string | React.ReactNode;
@@ -116,6 +127,7 @@ export interface MUIDataTableColumnOptions {
     download?: boolean;
     empty?: boolean;
     filter?: boolean;
+    filterType?: FilterType;
     filterList?: string[];
     filterOptions?: MUIDataTableFilterOptions;
     hint?: string;
@@ -123,7 +135,7 @@ export interface MUIDataTableColumnOptions {
     searchable?: boolean;
     setCellProps?: (cellValue: string, rowIndex: number, columnIndex: number) => object;
     sort?: boolean;
-    sortDirection?: 'asc' | 'desc';
+    sortDirection?: 'asc' | 'desc' | 'none'; // TODO why 'none' might be on this field in practice? it should be just undefined. and it should reuse SortDirection type
     viewColumns?: boolean;
 }
 
@@ -174,7 +186,7 @@ export interface MUIDataTableOptions {
     expandableRows?: boolean;
     expandableRowsOnClick?: boolean;
     filter?: boolean;
-    filterType?: 'dropdown' | 'checkbox' | 'multiselect' | 'textField';
+    filterType?: FilterType;
     fixedHeader?: boolean;
     isRowExpandable?: (dataIndex: number, expandedRows?: MUIDataTableIsRowCheck) => boolean;
     isRowSelectable?: (dataIndex: number, selectedRows?: MUIDataTableIsRowCheck) => boolean;

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -1,4 +1,4 @@
-import MUIDataTable, { MUIDataTableOptions, MUIDataTableTextLabels } from 'mui-datatables';
+import MUIDataTable, { MUIDataTableOptions, MUIDataTableTextLabels, MUIDataTableState, MUIDataTableColumn } from 'mui-datatables';
 import * as React from 'react';
 
 interface Props extends MUIDataTableOptions {
@@ -9,11 +9,25 @@ interface Props extends MUIDataTableOptions {
 
 const MuiCustomTable: React.FC<Props> = (props) => {
     const data: string[][] = props.data.map((asset: any) => Object.values(asset));
-    const columns = props.data
-        .map((entry: any) => Object.keys(entry))
-        .flat()
-        .map((title: string) => title.toUpperCase())
-        .filter((element: string, index: number, array: string[]) => array.indexOf(element) === index);
+    const columns: MUIDataTableColumn[] = [
+        {
+            name: 'id',
+            label: 'id'
+        },
+        {
+            name: 'name',
+            label: 'Name',
+            options: {
+                filterType: 'custom',
+                sortDirection: 'none'
+            }
+        },
+        {
+            name: 'amount',
+            label: 'Amount'
+        }
+    ];
+
     const TableOptions: MUIDataTableOptions = {
         filterType: 'checkbox',
         responsive: 'scrollFullHeight',
@@ -49,6 +63,16 @@ const MuiCustomTable: React.FC<Props> = (props) => {
                     </button>
                 </span>
             );
+        },
+        onTableChange: (action, tableState: MUIDataTableState) => {
+            switch (action) {
+                case 'sort':
+                    tableState.columns.forEach(c => {
+                        if (c.sort && (c.sortDirection === 'asc' || c.sortDirection === 'desc')) {
+                            console.log(`${c.sortDirection} sort set on ${c.name}`);
+                        }
+                    });
+            }
         },
         textLabels: {
             body: {


### PR DESCRIPTION
Changes:
- add `filterType` as column option using FilterType enum [documented in README](https://github.com/gregnb/mui-datatables)
- add missing field `columns` on `TableState` (I'm using that to detect which sorting was enabled instead of parsing announceText which seemed to me like a hack)
- added `"none"` as a possible value of `sortDirection`. Warning: I don't believe this should be a valid value as `undefined` is possible as well, but I was receiving `none` so wanted to account that. Is that a bug that should be fixed?

CC @gabrielliwerant @MasterKale could you review it? It might be also good to pack definitions along mui-datatables to keep it up to date.

Checks:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Check If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gregnb/mui-datatables (README)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (it updates the given version)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
