### PR TITLE
Add end method to d3 transition definition

### DIFF
--- a/types/d3-transition/d3-transition-tests.ts
+++ b/types/d3-transition/d3-transition-tests.ts
@@ -421,6 +421,9 @@ if (listener) {
 // remove listener
 enterTransition = enterTransition.on('end', null); // check chaining return type by re-assigning
 
+// check end method exists
+enterTransition.end();
+
 // --------------------------------------------------------------------------
 // Test Control Flow
 // --------------------------------------------------------------------------

--- a/types/d3-transition/index.d.ts
+++ b/types/d3-transition/index.d.ts
@@ -456,6 +456,11 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
      */
     on(type: string, listener: ValueFn<GElement, Datum, void>): this;
 
+    /**
+     * Returns a promise that resolves when every selected element finishes transitioning. If any element’s transition is cancelled or interrupted, the promise rejects.
+     */
+    end(): Promise<void>;
+
     // Control Flow ----------------------
 
     /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-transition#transition_end
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
