### PR TITLE
[html-validator] improve response message typings

### DIFF
--- a/types/html-validator/html-validator-tests.ts
+++ b/types/html-validator/html-validator-tests.ts
@@ -14,24 +14,34 @@ const testHtml = `
 `;
 
 validateHtml({
-  data: testHtml,
-  format: 'json'
+    data: testHtml,
+    format: 'json',
+    headers: {
+        'Content-Type': 'text/html'
+    },
 }).then((validationResults: validateHtml.ParsedJsonAsValidationResults) => {
-  if (validationResults.messages.length === 0) {
-    console.warn(`File "test" contains W3C standard violations or guidelines neglects.`);
-    return;
-  }
-
-  validationResults.messages.forEach((violation: validateHtml.ValidationMessageObject) => {
-    if (violation.type === 'error') {
-      console.log(`W3C standard violation: ${violation.message}`);
+    if (validationResults.messages.length === 0) {
+        console.warn(`File "test" contains W3C standard violations or guidelines neglects.`);
+        return;
     }
 
-    if (violation.type === 'info') {
-      console.warn(`W3C guidelines neglect: ${violation.message}`);
-    }
+    validationResults.messages.forEach((violation: validateHtml.ValidationMessageObject) => {
+        switch (violation.type) {
+            case 'error':
+                console.log(`W3C standard violation: ${violation.message}`);
+                break;
+            case 'info':
+                console.warn(`W3C guidelines neglect: ${violation.message}`);
+                break;
+            case 'non-document-error':
+                console.log(`W3C Non-Document error: ${violation.message}`);
+                break;
+        }
 
-    console.log(violation.extract);
-    console.log(`line: ${violation.lastLine}, column: ${violation.firstColumn}-${violation.lastColumn}\n`);
-  });
+        if (!!(violation as validateHtml.ValidationMessageLocationObject).extract) {
+            const v = violation as validateHtml.ValidationMessageLocationObject;
+            console.log(v.extract);
+            console.log(`line: ${v.lastLine}, column: ${v.firstColumn}-${v.lastColumn}\n`);
+        }
+    });
 });

--- a/types/html-validator/index.d.ts
+++ b/types/html-validator/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for html-validator 4.1
+// Type definitions for html-validator 5.0
 // Project: https://github.com/zrrrzzt/html-validator
 // Definitions by: Takesi Tokugawa <https://github.com/TokugawaTakesi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -42,51 +42,77 @@ declare namespace HtmlValidator {
         xhtml = 'xhtml',
         xml = 'xml',
         gnu = 'gnu',
-        text = 'text'
+        text = 'text',
     }
 
     interface OptionsForHtmlFileAsValidationTargetAndObjectAsResult extends OptionsForHtmlFileAsValidationTarget {
-      format?: 'json';
+        format?: 'json';
     }
 
     interface OptionsForHtmlFileAsValidationTargetAndTextAsResults extends OptionsForHtmlFileAsValidationTarget {
-      format: 'html' | 'xhtml' | 'xml' | 'gnu' | 'text';
+        format: 'html' | 'xhtml' | 'xml' | 'gnu' | 'text';
     }
 
     interface OptionsForExternalUrlAsValidationTargetAndObjectAsResult extends OptionsForExternalUrlAsValidationTarget {
-      format?: 'json';
+        format?: 'json';
     }
 
     interface OptionsForExternalUrlAsValidationTargetAndTextAsResults extends OptionsForHtmlFileAsValidationTarget {
-      format: 'html' | 'xhtml' | 'xml' | 'gnu' | 'text';
+        format: 'html' | 'xhtml' | 'xml' | 'gnu' | 'text';
     }
 
     interface ParsedJsonAsValidationResults {
-      messages: ValidationMessageObject[];
+        messages: ValidationMessageObject[];
     }
 
     // Could be used to avoid string literals
     enum ValidationMessageTypes {
         error = 'error',
-        info = 'info'
+        info = 'info',
+        'non-document-error' = 'non-document-error',
     }
 
     // Could be used to avoid string literals
     enum ValidationMessageSubTypes {
-        warning = 'warning'
+        fatal = 'fatal',
+        internal = 'internal',
+        io = 'io',
+        schema = 'schema',
+        warning = 'warning',
     }
 
-    interface ValidationMessageObject {
-      type: 'error' | 'info';
-      subType?: 'warning';
-      lastLine: number;
-      firstColumn: number;
-      lastColumn: number;
-      hiliteStart: number;
-      hiliteLength: number;
-      message: string;
-      extract: string;
+    interface ValidationMessageBasicObject {
+        message: string;
     }
+
+    interface ValidationMessageBasicLocationObject {
+        lastLine: number;
+        firstColumn: number;
+        lastColumn: number;
+        hiliteStart: number;
+        hiliteLength: number;
+        extract: string;
+    }
+
+    interface ValidationMessageBasicErrorObject {
+        type: 'error';
+        subType?: 'fatal';
+    }
+
+    interface ValidationMessageBasicInfoObject {
+        type: 'info';
+        subType?: 'warning';
+    }
+
+    interface ValidationMessageBasicNonDocumentErrorObject {
+        type: 'non-document-error';
+        subType?: 'internal' | 'io' | 'schema';
+    }
+
+    type ValidationMessageSimpleObject = (ValidationMessageBasicErrorObject | ValidationMessageBasicInfoObject | ValidationMessageBasicNonDocumentErrorObject) & ValidationMessageBasicObject;
+    type ValidationMessageLocationObject = ValidationMessageSimpleObject & ValidationMessageBasicLocationObject;
+
+    type ValidationMessageObject = ValidationMessageSimpleObject | ValidationMessageLocationObject;
 }
 
 export = HtmlValidator;


### PR DESCRIPTION
Enhance response message typings to accurately reflect all of the
types and subtypes of the messages.  Peruse
https://github.com/validator/validator/tree/master/src/nu/validator/messages/types
to confirm the representations here are correct.

Reflect that a message either has or does not have location
information.  Note that this implementation results in the location
properties not being available on the returned messages without
asserting them to the ValidationMessageLocationObject type (see the
updated test).  This approach is more correct and easier when using
strict null checks, but makes it more cumbersome to access the
location properties when your TypeScript compiler configuration has
strict null checks set to false.  Another option would be to do away
with the concept of a separate location sub-object and just make all
the location properties optional.

There was recently a new major version release of the upstream
project, so this seems like a good time to introduce this breaking
change.

Fix indentation.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/validator/validator/tree/master/src/nu/validator/messages/types
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
