### PR TITLE
[office-js, office-js-preview] Documenting build number for the SVG limitation issue

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -3910,7 +3910,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>As of Excel build 16.0.11526.10000, there is a 64KB size limitation for SVG insertions.</td>
+         *     <td>(Excel only): There is a 64KB size limitation for SVG insertions as of build 16.0.11526.10000.</td>
          *   </tr>
          * </table>
          * 
@@ -4109,7 +4109,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>As of Excel build 16.0.11526.10000, there is a 64KB size limitation for SVG insertions.</td>
+         *     <td>(Excel only): There is a 64KB size limitation for SVG insertions as of build 16.0.11526.10000.</td>
          *   </tr>
          * </table>
          * 

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -3910,7 +3910,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 64KB size limitation for SVG insertions.</td>
+         *     <td>As of Excel build 16.0.11526.10000, there is a 64KB size limitation for SVG insertions.</td>
          *   </tr>
          * </table>
          * 
@@ -4109,7 +4109,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 64KB size limitation for SVG insertions.</td>
+         *     <td>As of Excel build 16.0.11526.10000, there is a 64KB size limitation for SVG insertions.</td>
          *   </tr>
          * </table>
          * 

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -3795,7 +3795,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 64KB size limitation for SVG insertions.</td>
+         *     <td>(Excel only): There is a 64KB size limitation for SVG insertions as of build 16.0.11526.10000.</td>
          *   </tr>
          * </table>
          * 
@@ -3993,7 +3993,7 @@ declare namespace Office {
          * <table>
          *   <tr>
          *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>There is a 64KB size limitation for SVG insertions.</td>
+         *     <td>(Excel only): There is a 64KB size limitation for SVG insertions as of build 16.0.11526.10000.</td>
          *   </tr>
          * </table>
          * 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OfficeDev/office-js/issues/744
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
