### PR TITLE
fix(wordpress__data): improve type inference of `useDispatch` hook

### DIFF
--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -85,11 +85,11 @@ export const useDispatch: typeof dispatch & {
 // React HOCs
 //
 export function withDispatch<DP, P = {}, IP = {}>(
-    mapDispatchToProps: (disp: typeof dispatch, ownProps: P & IP, registry: { select: typeof select }) => DP
+    mapDispatchToProps: (disp: typeof dispatch, ownProps: P & IP, registry: { select: typeof select }) => DP,
 ): (component: ComponentType<P & IP & DP>) => ComponentType<P>;
 
 export function withSelect<SP, P = {}, IP = {}>(
-    mapSelectToProps: (sel: typeof select, ownProps: P & IP) => SP
+    mapSelectToProps: (sel: typeof select, ownProps: P & IP) => SP,
 ): (component: ComponentType<P & IP & SP>) => ComponentType<P>;
 
 export function withRegistry<P = {}>(component: ComponentType<P>): ComponentType<P & { registry: DataRegistry }>;
@@ -113,10 +113,10 @@ export function use<T>(plugin: Plugin<T>, options: T): DataRegistry;
 //
 // TODO: This is probably not completely accurate. Someone else can fix this if they need it. It's not used very much.
 export function createRegistrySelector<S extends typeof select, T>(
-    registrySelector: (select: S) => (state: any, ...args: any[]) => T
+    registrySelector: (select: S) => (state: any, ...args: any[]) => T,
 ): S;
 
 // TODO: This is probably not completely accurate. Someone else can fix this if they need it. It's not used very much.
 export function createRegistryControl<R extends DataRegistry, T>(
-    registryControl: (registry: R) => (args: { [k: string]: any }) => T
+    registryControl: (registry: R) => (args: { [k: string]: any }) => T,
 ): R;

--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -77,8 +77,9 @@ export const RegistryProvider: Provider<DataRegistry>;
 //
 export function useRegistry(): DataRegistry;
 export function useSelect<T>(mapSelect: (s: typeof select) => T, deps?: readonly any[]): T;
-export function useDispatch(storeName: string): DispatcherMap;
-export function useDispatch(): typeof dispatch;
+export const useDispatch: typeof dispatch & {
+    (): typeof dispatch;
+};
 
 //
 // React HOCs


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **N/A**
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

-----

**Note:** This change only affects type inference accuracy. No API changes were added.