### PR TITLE
Improve deprecation for worker.suicide

### DIFF
--- a/types/node/v10/cluster.d.ts
+++ b/types/node/v10/cluster.d.ts
@@ -24,7 +24,6 @@ declare module "cluster" {
     class Worker extends events.EventEmitter {
         id: number;
         process: child.ChildProcess;
-        suicide: boolean;
         send(message: any, sendHandle?: any, callback?: (error: Error) => void): boolean;
         kill(signal?: string): void;
         destroy(signal?: string): void;

--- a/types/node/v6/base.d.ts
+++ b/types/node/v6/base.d.ts
@@ -957,6 +957,7 @@ declare module "cluster" {
     export class Worker extends events.EventEmitter {
         id: number;
         process: child.ChildProcess;
+        /** @deprecated since v6.0.0 - use `worker.exitedAfterDisconnect` instead. */
         suicide: boolean;
         send(message: any, sendHandle?: any, callback?: (error: Error) => void): boolean;
         kill(signal?: string): void;

--- a/types/node/v7/base.d.ts
+++ b/types/node/v7/base.d.ts
@@ -960,6 +960,7 @@ declare module "cluster" {
     export class Worker extends events.EventEmitter {
         id: number;
         process: child.ChildProcess;
+        /** @deprecated since v6.0.0 - use `worker.exitedAfterDisconnect` instead. */
         suicide: boolean;
         send(message: any, sendHandle?: any, callback?: (error: Error) => void): boolean;
         kill(signal?: string): void;

--- a/types/node/v8/base.d.ts
+++ b/types/node/v8/base.d.ts
@@ -1182,6 +1182,7 @@ declare module "cluster" {
     export class Worker extends events.EventEmitter {
         id: number;
         process: child.ChildProcess;
+        /** @deprecated since v6.0.0 - use `worker.exitedAfterDisconnect` instead. */
         suicide: boolean;
         send(message: any, sendHandle?: any, callback?: (error: Error) => void): boolean;
         kill(signal?: string): void;

--- a/types/node/v9/base.d.ts
+++ b/types/node/v9/base.d.ts
@@ -1265,7 +1265,6 @@ declare module "cluster" {
     export class Worker extends events.EventEmitter {
         id: number;
         process: child.ChildProcess;
-        suicide: boolean;
         send(message: any, sendHandle?: any, callback?: (error: Error) => void): boolean;
         kill(signal?: string): void;
         destroy(signal?: string): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/deprecations.html#deprecations_dep0007_replace_cluster_worker_suicide_with_worker_exitedafterdisconnect
