### PR TITLE
Add types for systemjs@6

### DIFF
--- a/types/systemjs/index.d.ts
+++ b/types/systemjs/index.d.ts
@@ -68,7 +68,7 @@ declare const System: {
 // tslint:disable-next-line no-unnecessary-generics
 type ImportFn = <T extends Module>(moduleId: string, parentUrl?: string) => Promise<T>;
 
-type DeclareFn = (_export: typeof ExportFn, _context: Context) => Declare;
+type DeclareFn = (_export: ExportFn, _context: Context) => Declare;
 interface Declare {
   setters?: SetterFn[];
   execute?(): any;
@@ -76,8 +76,10 @@ interface Declare {
 type SetterFn = (moduleValue: Module) => any;
 type ExecuteFn = () => any;
 
-declare function ExportFn(exportName: string, value: any): void;
-declare function ExportFn(exports: object): void;
+interface ExportFn {
+  (exportName: string, value: any): void;
+  (exports: object): void;
+}
 
 type UpdateModuleFn = () => void;
 

--- a/types/systemjs/index.d.ts
+++ b/types/systemjs/index.d.ts
@@ -9,7 +9,6 @@ declare const System: {
    * Loads a javascript module from either a url or bare specifier that is in an import map.
    * You may optionally provide a parentUrl that will be used for resolving relative urls.
    */
-  // tslint:disable-next-line no-unnecessary-generics
   import: System.ImportFn;
 
   /**

--- a/types/systemjs/index.d.ts
+++ b/types/systemjs/index.d.ts
@@ -10,7 +10,7 @@ declare const System: {
    * You may optionally provide a parentUrl that will be used for resolving relative urls.
    */
   // tslint:disable-next-line no-unnecessary-generics
-  import: ImportFn;
+  import: System.ImportFn;
 
   /**
    * Inserts a new module into the SystemJS module registry. The System.register format is
@@ -19,8 +19,8 @@ declare const System: {
    * Register may be called with a name argument if you are using the named-register extra. (See
    * https://github.com/systemjs/systemjs#extras).
    */
-  register(dependencies: string[], declare: DeclareFn): void;
-  register(name: string, dependencies: string[], declare: DeclareFn): void;
+  register(dependencies: string[], declare: System.DeclareFn): void;
+  register(name: string, dependencies: string[], declare: System.DeclareFn): void;
 
   /**
    * Resolve any moduleId to its full URL. For a moduleId that is in the import map, this will resolve
@@ -36,14 +36,14 @@ declare const System: {
    * The returned function is intended for use after re-importing the module. Calling the function
    * will re-bind all the exports of the re-imported module to every module that depends on the module.
    */
-  delete(moduleId: string): false | UpdateModuleFn;
+  delete(moduleId: string): false | System.UpdateModuleFn;
 
   /**
    * Get a module from the SystemJS module registry. Note that the moduleId almost always must be a full url
    * and that you might need to call System.resolve() to obtain the moduleId. If the module does not exist in
    * the registry, null is returned.
    */
-  get(moduleId: string): Module | null;
+  get(moduleId: string): System.Module | null;
   // tslint:disable-next-line no-unnecessary-generics
   get<T>(moduleId: string): T | null;
 
@@ -57,45 +57,47 @@ declare const System: {
    * An alternative to System.register(), this allows you to insert a module into the module registry. Note that
    * the moduleId you provide will go straight into the registry without being resolved first.
    */
-  set(moduleId: string, module: Module): void;
+  set(moduleId: string, module: System.Module): void;
 
   /**
    * Use for (let entry of System.entries()) to access all of the modules in the SystemJS registry.
    */
-  entries(): Iterable<[string, Module]>;
+  entries(): Iterable<[string, System.Module]>;
 };
 
-// tslint:disable-next-line no-unnecessary-generics
-type ImportFn = <T extends Module>(moduleId: string, parentUrl?: string) => Promise<T>;
+declare namespace System {
+  // tslint:disable-next-line no-unnecessary-generics
+  type ImportFn = <T extends Module>(moduleId: string, parentUrl?: string) => Promise<T>;
 
-type DeclareFn = (_export: ExportFn, _context: Context) => Declare;
-interface Declare {
-  setters?: SetterFn[];
-  execute?(): any;
-}
-type SetterFn = (moduleValue: Module) => any;
-type ExecuteFn = () => any;
+  type DeclareFn = (_export: ExportFn, _context: Context) => Declare;
+  interface Declare {
+    setters?: SetterFn[];
+    execute?(): any;
+  }
+  type SetterFn = (moduleValue: Module) => any;
+  type ExecuteFn = () => any;
 
-interface ExportFn {
-  (exportName: string, value: any): void;
-  (exports: object): void;
-}
+  interface ExportFn {
+    (exportName: string, value: any): void;
+    (exports: object): void;
+  }
 
-type UpdateModuleFn = () => void;
+  type UpdateModuleFn = () => void;
 
-type GetFn = GetFnModule | GetFnGeneric;
-type GetFnModule = (moduleId: string) => Module;
-// tslint:disable-next-line no-unnecessary-generics
-type GetFnGeneric = <T>(moduleId: string) => T;
+  type GetFn = GetFnModule | GetFnGeneric;
+  type GetFnModule = (moduleId: string) => Module;
+  // tslint:disable-next-line no-unnecessary-generics
+  type GetFnGeneric = <T>(moduleId: string) => T;
 
-interface Context {
-  import: ImportFn;
-  meta: {
-    url: string;
-  };
-}
+  interface Context {
+    import: ImportFn;
+    meta: {
+      url: string;
+    };
+  }
 
-interface Module {
-  default?: any;
-  [exportName: string]: any;
+  interface Module {
+    default?: any;
+    [exportName: string]: any;
+  }
 }

--- a/types/systemjs/index.d.ts
+++ b/types/systemjs/index.d.ts
@@ -1,388 +1,100 @@
-// Type definitions for SystemJS 0.20
+// Type definitions for SystemJS 6.1
 // Project: https://github.com/systemjs/systemjs
-// Definitions by: Ludovic HENIN <https://github.com/ludohenin>
-//                 Nathan Walker <https://github.com/NathanWalker>
-//                 Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
-//                 Aluan Haddad <https://github.com/aluanhaddad>
+// Definitions by: Joel Denning <https://github.com/joeldenning>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
-export = SystemJSLoader;
-
-export as namespace SystemJSLoader;
-
-declare global {
-    const SystemJS: typeof SystemJSLoader;
+declare namespace SystemJS {
+  interface SystemLoader {
+    /**
+     * Loads a javascript module from either a url or bare specifier that is in an import map.
+     * You may optionally provide a parentUrl that will be used for resolving relative urls.
+     */
+    import: typeof ImportFn;
 
     /**
-     * @deprecated use SystemJS https://github.com/systemjs/systemjs/releases/tag/0.19.10
+     * Inserts a new module into the SystemJS module registry. The System.register format is
+     * the underlying implementation that allows for ESM emulation.
+     * See https://github.com/systemjs/systemjs/blob/master/docs/system-register.md for more details.
+     * Register may be called with a name argument if you are using the named-register extra. (See
+     * https://github.com/systemjs/systemjs#extras).
      */
-    const System: typeof SystemJSLoader;
-    const __moduleName: string;
+    register(dependencies: string[], declare: typeof DeclareFn): void;
+    register(name: string, dependencies: string[], declare: typeof DeclareFn): void;
+
+    /**
+     * Resolve any moduleId to its full URL. For a moduleId that is in the import map, this will resolve
+     * the full import map URL. For a moduleId that is a relative url, the returned url will be resolved
+     * relative to the parentUrl or the current browser page's base url. For a full url, resolve() is
+     * a no-op.
+     */
+    resolve(moduleId: string, parentUrl?: string): string;
+
+    /**
+     * Delete a module from the module registry. Note that the moduleId almost always must be a full url and that
+     * you might need to call System.resolve() to obtain the moduleId for modules in an import map.
+     * The returned function is intended for use after re-importing the module. Calling the function
+     * will re-bind all the exports of the re-imported module to every module that depends on the module.
+     */
+    delete(moduleId: string): false | typeof UpdateModuleFn;
+
+    /**
+     * Get a module from the SystemJS module registry. Note that the moduleId almost always must be a full url
+     * and that you might need to call System.resolve() to obtain the moduleId. If the module does not exist in
+     * the registry, null is returned.
+     */
+    get(moduleId: string): Module | null;
+    get<T>(moduleId: string): T | null;
+
+    /**
+     * Indicates whether the SystemJS module registry contains a module. Note that the moduleId almost always
+     * must be a full url and that you might need to call System.resolve() to obtain the moduleId.
+     */
+    has(moduleId: string): boolean;
+
+    /**
+     * An alternative to System.register(), this allows you to insert a module into the module registry. Note that
+     * the moduleId you provide will go straight into the registry without being resolved first.
+     */
+    set(moduleId: string, module: Module): void;
+
+    /**
+     * Use for (let entry of System.entries()) to access all of the modules in the SystemJS registry.
+     */
+    entries(): Iterable<typeof ModuleEntry>;
+  }
+
+  function ImportFn<T extends Module>(moduleId: string, parentUrl?: string): Promise<T>;
+
+  function DeclareFn(_export: typeof ExportFn, _context: Context): Declare;
+  interface Declare {
+    setters?: Array<typeof SetterFn>;
+    execute?(): any;
+  }
+  function SetterFn(moduleValue: Module): any;
+  function ExecuteFn(): any;
+
+  function ExportFn(name: string, value: any): void;
+  function ExportFn(exports: object): void;
+
+  function UpdateModuleFn(): void;
+
+  function GetFn(moduleId: string): Module;
+  function GetFn<T>(moduleId: string): T;
+
+  interface Context {
+    import: typeof ImportFn;
+    meta: {
+      url: string;
+    };
+  }
+
+  interface Module {
+    default?: any;
+    [exportName: string]: any;
+  }
+
+  const ModuleEntry: [string, Module];
 }
 
-declare const SystemJSLoader: SystemJSLoader.System;
-
-declare namespace SystemJSLoader {
-    interface ModulesList {
-        [bundleName: string]: string[];
-    }
-
-    interface PackageList<T> {
-        [packageName: string]: T;
-    }
-
-    /**
-     * The following module formats are supported:
-     *
-     * - esm: ECMAScript Module (previously referred to as es6)
-     * - cjs: CommonJS
-     * - amd: Asynchronous Module Definition
-     * - global: Global shim module format
-     * - register: System.register or System.registerDynamic compatibility module format
-     *
-     */
-    type ModuleFormat = "esm" | "cjs" | "amd" | "global" | "register";
-
-    /**
-     * Sets the module name of the transpiler to be used for loading ES6 modules.
-     * Represents a module name for System.import that must resolve to either Traceur, Babel or TypeScript.
-     * When set to traceur, babel or typescript, loading will be automatically configured as far as possible.
-     */
-    type Transpiler = "plugin-traceur" | "plugin-babel" | "plugin-typescript" | "traceur" | "babel" | "typescript" | false;
-
-    type ConfigMap = PackageList<string | PackageList<string>>;
-
-    type ConfigMeta = PackageList<MetaConfig>;
-
-    interface MetaConfig {
-        /**
-         * Sets in what format the module is loaded.
-         */
-        format?: ModuleFormat;
-
-        /**
-         * For the global format, when automatic detection of exports is not enough, a custom exports meta value can be set.
-         * This tells the loader what global name to use as the module's export value.
-         */
-        exports?: string;
-
-        /**
-         * Dependencies to load before this module. Goes through regular paths and map normalization.
-         * Only supported for the cjs, amd and global formats.
-         */
-        deps?: string[];
-
-        /**
-         * A map of global names to module names that should be defined only for the execution of this module.
-         * Enables use of legacy code that expects certain globals to be present.
-         * Referenced modules automatically becomes dependencies. Only supported for the cjs and global formats.
-         */
-        globals?: string;
-
-        /**
-         * Set a loader for this meta path.
-         */
-        loader?: string;
-
-        /**
-         * For plugin transpilers to set the source map of their transpilation.
-         */
-        sourceMap?: any;
-
-        /**
-         * Load the module using <script> tag injection.
-         */
-        scriptLoad?: boolean;
-
-        /**
-         * The nonce attribute to use when loading the script as a way to enable CSP.
-         * This should correspond to the "nonce-" attribute set in the Content-Security-Policy header.
-         */
-        nonce?: string;
-
-        /**
-         * The subresource integrity attribute corresponding to the script integrity,
-         * describing the expected hash of the final code to be executed.
-         * For example, System.config({ meta: { 'src/example.js': { integrity: 'sha256-e3b0c44...' }});
-         * would throw an error if the translated source of src/example.js doesn't match the expected hash.
-         */
-        integrity?: string;
-
-        /**
-         * When scripts are loaded from a different domain (e.g. CDN) the global error handler (window.onerror)
-         * has very limited information about errors to prevent unintended leaking. In order to mitigate this,
-         * the <script> tags need to set crossorigin attribute and the server needs to enable CORS.
-         * The valid values are "anonymous" and "use-credentials".
-         */
-        crossOrigin?: string;
-
-        /**
-         * When loading a module that is not an ECMAScript Module, we set the module as the default export,
-         * but then also iterate the module object and copy named exports for it a well.
-         * Use this option to disable this iteration and copying of the exports.
-         */
-        esmExports?: boolean;
-
-        /**
-         * To ignore resources that shouldn't be traced as part of the build.
-         * Use with the SystemJS Builder. (https://github.com/systemjs/builder#ignore-resources)
-         */
-        build?: boolean;
-
-        /**
-         * A truthy value enables sending credentials to the server on every request. Additionally, a string value adds
-         * an "Authorization" header with that value to all requests.
-         */
-        authorization?: string | boolean;
-    }
-
-    interface PackageConfig {
-        /**
-         * The main entry point of the package (so import 'local/package' is equivalent to import 'local/package/index.js')
-         */
-        main?: string;
-
-        /**
-         * The module format of the package. See Module Formats.
-         */
-        format?: ModuleFormat;
-
-        /**
-         * The default extension to add to modules requested within the package. Takes preference over defaultJSExtensions.
-         * Can be set to defaultExtension: false to optionally opt-out of extension-adding when defaultJSExtensions is enabled.
-         */
-        defaultExtension?: boolean | string;
-
-        /**
-         * Local and relative map configurations scoped to the package. Apply for subpaths as well.
-         */
-        map?: ConfigMap;
-
-        /**
-         * Module meta provides an API for SystemJS to understand how to load modules correctly.
-         * Package-scoped meta configuration with wildcard support. Modules are subpaths within the package path.
-         * This also provides an opt-out mechanism for defaultExtension, by adding modules here that should skip extension adding.
-         */
-        meta?: ConfigMeta;
-    }
-
-    interface TraceurOptions {
-        properTailCalls?: boolean;
-        symbols?: boolean;
-        arrayComprehension?: boolean;
-        asyncFunctions?: boolean;
-        asyncGenerators?: any;
-        forOn?: boolean;
-        generatorComprehension?: boolean;
-    }
-
-    interface Config {
-        /**
-         * For custom config names
-         */
-        [customName: string]: any;
-
-        /**
-         * The baseURL provides a special mechanism for loading modules relative to a standard reference URL.
-         */
-        baseURL?: string;
-
-        /**
-         * Set the Babel transpiler options when System.transpiler is set to babel.
-         */
-        // TODO: Import BabelCore.TransformOptions
-        babelOptions?: any;
-
-        /**
-         * undles allow a collection of modules to be downloaded together as a package whenever any module from that collection is requested.
-         * Useful for splitting an application into sub-modules for production. Use with the SystemJS Builder.
-         */
-        bundles?: ModulesList;
-
-        /**
-         * Backwards-compatibility mode for the loader to automatically add '.js' extensions when not present to module requests.
-         * This allows code written for SystemJS 0.16 or less to work easily in the latest version:
-         */
-        defaultJSExtensions?: boolean;
-
-        /**
-         * An alternative to bundling providing a solution to the latency issue of progressively loading dependencies.
-         * When a module specified in depCache is loaded, asynchronous loading of its pre-cached dependency list begins in parallel.
-         */
-        depCache?: ModulesList;
-
-        /**
-         * The map option is similar to paths, but acts very early in the normalization process.
-         * It allows you to map a module alias to a location or package:
-         */
-        map?: ConfigMap;
-
-        /**
-         * Module meta provides an API for SystemJS to understand how to load modules correctly.
-         * Meta is how we set the module format of a module, or know how to shim dependencies of a global script.
-         */
-        meta?: ConfigMeta;
-
-        /**
-         * Packages provide a convenience for setting meta and map configuration that is specific to a common path.
-         * In addition packages allow for setting contextual map configuration which only applies within the package itself.
-         * This allows for full dependency encapsulation without always needing to have all dependencies in a global namespace.
-         */
-        packages?: PackageList<PackageConfig>;
-
-        /**
-         * The ES6 Module Loader paths implementation, applied after normalization and supporting subpaths via wildcards.
-         * It is usually advisable to use map configuration over paths unless you need strict control over normalized module names.
-         */
-        paths?: PackageList<string>;
-
-        /**
-         * Set the Traceur compilation options.
-         */
-        traceurOptions?: TraceurOptions;
-
-        /**
-         * Sets the module name of the transpiler to be used for loading ES6 modules.
-         */
-        transpiler?: Transpiler;
-
-        trace?: boolean;
-
-        /**
-         * Sets the TypeScript transpiler options.
-         */
-        // TODO: Import Typescript.CompilerOptions
-        typescriptOptions?: {
-            /**
-             * A boolean flag which instructs the plugin to load configuration from "tsconfig.json".
-             * To override the location of the file set this option to the path of the configuration file,
-             * which will be resolved using normal SystemJS resolution.
-             * Note: This setting is specific to plugin-typescript.
-             */
-            tsconfig?: boolean | string,
-
-            [key: string]: any
-        };
-    }
-
-    interface System extends Config {
-        /**
-         * For backwards-compatibility with AMD environments, set window.define = System.amdDefine.
-         */
-        amdDefine(...args: any[]): void;
-
-        /**
-         * For backwards-compatibility with AMD environments, set window.require = System.amdRequire.
-         */
-        amdRequire(deps: string[], callback: (...modules: any[]) => void): void;
-
-        /**
-         * SystemJS configuration helper function.
-         * Once SystemJS has loaded, configuration can be set on SystemJS by using the configuration function System.config.
-         */
-        config(config: Config): void;
-
-        /**
-         * This represents the System base class, which can be extended or reinstantiated to create a custom System instance.
-         */
-        constructor: new () => System;
-
-        /**
-         * Deletes a module from the registry by normalized name.
-         */
-        delete(moduleName: string): void;
-
-        /**
-         * Returns a module from the registry by normalized name.
-         */
-        get(moduleName: string): any;
-
-        /**
-         * Returns a clone of the internal SystemJS configuration in use.
-         */
-        getConfig(): Config;
-
-        /**
-         * Returns whether a given module exists in the registry by normalized module name.
-         */
-        has(moduleName: string): boolean;
-
-        /**
-         * Loads a module by name taking an optional normalized parent name argument.
-         * Promise resolves to the module value.
-         */
-        import(moduleName: string, normalizedParentName?: string): Promise<any>;
-
-        /**
-         * Given any object, returns true if the object is either a SystemJS module or native JavaScript module object, and false otherwise.
-         * Useful for interop scenarios.
-         */
-        isModule(object: any): boolean;
-
-        /**
-         * Given a plain JavaScript object, return an equivalent Module object.
-         * Useful when writing a custom instantiate hook or using System.set.
-         */
-        newModule(object: any): any;
-
-        /**
-         * Declaration function for defining modules of the System.register polyfill module format.
-         */
-        register(name: string, deps: string[], declare: (...modules: any[]) => any): void;
-        register(deps: string[], declare: (...modules: any[]) => any): void;
-
-        /**
-         * Companion module format to System.register for non-ES6 modules.
-         * Provides a <script>-injection-compatible module format that any CommonJS or Global module can be converted into for CSP compatibility.
-         */
-        registerDynamic(name: string, deps: string[], executingRequire: boolean, declare: (...modules: any[]) => any): void;
-        registerDynamic(deps: string[], executingRequire: boolean, declare: (...modules: any[]) => any): void;
-
-        /**
-         * Sets a module into the registry directly and synchronously.
-         * Typically used along with System.newModule to create a valid Module object:
-         */
-        set(moduleName: string, module: any): void;
-
-        /**
-         * Resolves module name to normalized URL.
-         */
-        resolve(moduleName: string, parentName?: string): Promise<string>;
-
-        /**
-         * Resolves module name to normalized URL.
-         * Synchronous alternative to `SystemJS.resolve`.
-         */
-        resolveSync(moduleName: string, parentName?: string): string;
-
-        /**
-         * In CommonJS environments, SystemJS will substitute the global require as needed by the module format being
-         * loaded to ensure the correct detection paths in loaded code.
-         * The CommonJS require can be recovered within these modules from System._nodeRequire.
-         */
-        _nodeRequire(dep: string): any;
-
-        /**
-         * Modules list available only with trace=true
-         */
-        loads: PackageList<any>;
-
-        env: string;
-
-        loaderErrorStack: boolean;
-
-        packageConfigPaths: string[];
-
-        /**
-         * Specify a value of true to have SystemJS conform to the AMD-style plugin syntax, e.g. "text!some/file.txt", over the default of "some/file.txt!text".
-         */
-        pluginFirst: boolean;
-
-        version: string;
-
-        /**
-         * Enables the output of warnings to the console, including deprecation messages.
-         */
-        warnings: boolean;
-    }
-}
+declare const System: SystemJS.SystemLoader;

--- a/types/systemjs/index.d.ts
+++ b/types/systemjs/index.d.ts
@@ -4,15 +4,13 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.5
 
-declare namespace System {
-  export {};
-
+declare const System: {
   /**
    * Loads a javascript module from either a url or bare specifier that is in an import map.
    * You may optionally provide a parentUrl that will be used for resolving relative urls.
    */
   // tslint:disable-next-line no-unnecessary-generics
-  export const import: ImportFn;
+  import: ImportFn;
 
   /**
    * Inserts a new module into the SystemJS module registry. The System.register format is
@@ -21,8 +19,8 @@ declare namespace System {
    * Register may be called with a name argument if you are using the named-register extra. (See
    * https://github.com/systemjs/systemjs#extras).
    */
-  export function register(dependencies: string[], declare: DeclareFn): void;
-  export function register(name: string, dependencies: string[], declare: DeclareFn): void;
+  register(dependencies: string[], declare: DeclareFn): void;
+  register(name: string, dependencies: string[], declare: DeclareFn): void;
 
   /**
    * Resolve any moduleId to its full URL. For a moduleId that is in the import map, this will resolve
@@ -30,7 +28,7 @@ declare namespace System {
    * relative to the parentUrl or the current browser page's base url. For a full url, resolve() is
    * a no-op.
    */
-  export function resolve(moduleId: string, parentUrl?: string): string;
+  resolve(moduleId: string, parentUrl?: string): string;
 
   /**
    * Delete a module from the module registry. Note that the moduleId almost always must be a full url and that
@@ -38,67 +36,65 @@ declare namespace System {
    * The returned function is intended for use after re-importing the module. Calling the function
    * will re-bind all the exports of the re-imported module to every module that depends on the module.
    */
-  export function delete(moduleId: string): false | UpdateModuleFn;
+  delete(moduleId: string): false | UpdateModuleFn;
 
   /**
    * Get a module from the SystemJS module registry. Note that the moduleId almost always must be a full url
    * and that you might need to call System.resolve() to obtain the moduleId. If the module does not exist in
    * the registry, null is returned.
    */
-  export function get(moduleId: string): Module | null;
+  get(moduleId: string): Module | null;
   // tslint:disable-next-line no-unnecessary-generics
-  export function get<T>(moduleId: string): T | null;
+  get<T>(moduleId: string): T | null;
 
   /**
    * Indicates whether the SystemJS module registry contains a module. Note that the moduleId almost always
    * must be a full url and that you might need to call System.resolve() to obtain the moduleId.
    */
-  export function has(moduleId: string): boolean;
+  has(moduleId: string): boolean;
 
   /**
    * An alternative to System.register(), this allows you to insert a module into the module registry. Note that
    * the moduleId you provide will go straight into the registry without being resolved first.
    */
-  export function set(moduleId: string, module: Module): void;
+  set(moduleId: string, module: Module): void;
 
   /**
    * Use for (let entry of System.entries()) to access all of the modules in the SystemJS registry.
    */
-  export function entries(): Iterable<typeof ModuleEntry>;
+  entries(): Iterable<[string, Module]>;
+};
 
-  // tslint:disable-next-line no-unnecessary-generics
-  type ImportFn = <T extends Module>(moduleId: string, parentUrl?: string) => Promise<T>;
+// tslint:disable-next-line no-unnecessary-generics
+type ImportFn = <T extends Module>(moduleId: string, parentUrl?: string) => Promise<T>;
 
-  type DeclareFn = (_export: ExportFn, _context: Context) => Declare;
-  interface Declare {
-    setters?: SetterFn[];
-    execute?(): any;
-  }
-  type SetterFn = (moduleValue: Module) => any;
-  type ExecuteFn = () => any;
+type DeclareFn = (_export: ExportFn, _context: Context) => Declare;
+interface Declare {
+  setters?: SetterFn[];
+  execute?(): any;
+}
+type SetterFn = (moduleValue: Module) => any;
+type ExecuteFn = () => any;
 
-  type ExportFn = ExportFnSingleKey | ExportFnObj;
-  type ExportFnSingleKey = (exportName: string, value: any) => void;
-  type ExportFnObj = (exports: object) => void;
+type ExportFn = ExportFnSingleKey | ExportFnObj;
+type ExportFnSingleKey = (exportName: string, value: any) => void;
+type ExportFnObj = (exports: object) => void;
 
-  type UpdateModuleFn = () => void;
+type UpdateModuleFn = () => void;
 
-  type GetFn = GetFnModule | GetFnGeneric;
-  type GetFnModule = (moduleId: string) => Module;
-  // tslint:disable-next-line no-unnecessary-generics
-  type GetFnGeneric = <T>(moduleId: string) => T;
+type GetFn = GetFnModule | GetFnGeneric;
+type GetFnModule = (moduleId: string) => Module;
+// tslint:disable-next-line no-unnecessary-generics
+type GetFnGeneric = <T>(moduleId: string) => T;
 
-  interface Context {
-    import: ImportFn;
-    meta: {
-      url: string;
-    };
-  }
+interface Context {
+  import: ImportFn;
+  meta: {
+    url: string;
+  };
+}
 
-  interface Module {
-    default?: any;
-    [exportName: string]: any;
-  }
-
-  const ModuleEntry: [string, Module];
+interface Module {
+  default?: any;
+  [exportName: string]: any;
 }

--- a/types/systemjs/index.d.ts
+++ b/types/systemjs/index.d.ts
@@ -2,91 +2,94 @@
 // Project: https://github.com/systemjs/systemjs
 // Definitions by: Joel Denning <https://github.com/joeldenning>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.5
 
-declare namespace SystemJS {
-  interface SystemLoader {
-    /**
-     * Loads a javascript module from either a url or bare specifier that is in an import map.
-     * You may optionally provide a parentUrl that will be used for resolving relative urls.
-     */
-    import: typeof ImportFn;
+declare namespace System {
+  export {};
 
-    /**
-     * Inserts a new module into the SystemJS module registry. The System.register format is
-     * the underlying implementation that allows for ESM emulation.
-     * See https://github.com/systemjs/systemjs/blob/master/docs/system-register.md for more details.
-     * Register may be called with a name argument if you are using the named-register extra. (See
-     * https://github.com/systemjs/systemjs#extras).
-     */
-    register(dependencies: string[], declare: typeof DeclareFn): void;
-    register(name: string, dependencies: string[], declare: typeof DeclareFn): void;
+  /**
+   * Loads a javascript module from either a url or bare specifier that is in an import map.
+   * You may optionally provide a parentUrl that will be used for resolving relative urls.
+   */
+  // tslint:disable-next-line no-unnecessary-generics
+  export const import: ImportFn;
 
-    /**
-     * Resolve any moduleId to its full URL. For a moduleId that is in the import map, this will resolve
-     * the full import map URL. For a moduleId that is a relative url, the returned url will be resolved
-     * relative to the parentUrl or the current browser page's base url. For a full url, resolve() is
-     * a no-op.
-     */
-    resolve(moduleId: string, parentUrl?: string): string;
+  /**
+   * Inserts a new module into the SystemJS module registry. The System.register format is
+   * the underlying implementation that allows for ESM emulation.
+   * See https://github.com/systemjs/systemjs/blob/master/docs/system-register.md for more details.
+   * Register may be called with a name argument if you are using the named-register extra. (See
+   * https://github.com/systemjs/systemjs#extras).
+   */
+  export function register(dependencies: string[], declare: DeclareFn): void;
+  export function register(name: string, dependencies: string[], declare: DeclareFn): void;
 
-    /**
-     * Delete a module from the module registry. Note that the moduleId almost always must be a full url and that
-     * you might need to call System.resolve() to obtain the moduleId for modules in an import map.
-     * The returned function is intended for use after re-importing the module. Calling the function
-     * will re-bind all the exports of the re-imported module to every module that depends on the module.
-     */
-    delete(moduleId: string): false | typeof UpdateModuleFn;
+  /**
+   * Resolve any moduleId to its full URL. For a moduleId that is in the import map, this will resolve
+   * the full import map URL. For a moduleId that is a relative url, the returned url will be resolved
+   * relative to the parentUrl or the current browser page's base url. For a full url, resolve() is
+   * a no-op.
+   */
+  export function resolve(moduleId: string, parentUrl?: string): string;
 
-    /**
-     * Get a module from the SystemJS module registry. Note that the moduleId almost always must be a full url
-     * and that you might need to call System.resolve() to obtain the moduleId. If the module does not exist in
-     * the registry, null is returned.
-     */
-    get(moduleId: string): Module | null;
-    // tslint:disable-next-line no-unnecessary-generics
-    get<T>(moduleId: string): T | null;
+  /**
+   * Delete a module from the module registry. Note that the moduleId almost always must be a full url and that
+   * you might need to call System.resolve() to obtain the moduleId for modules in an import map.
+   * The returned function is intended for use after re-importing the module. Calling the function
+   * will re-bind all the exports of the re-imported module to every module that depends on the module.
+   */
+  export function delete(moduleId: string): false | UpdateModuleFn;
 
-    /**
-     * Indicates whether the SystemJS module registry contains a module. Note that the moduleId almost always
-     * must be a full url and that you might need to call System.resolve() to obtain the moduleId.
-     */
-    has(moduleId: string): boolean;
+  /**
+   * Get a module from the SystemJS module registry. Note that the moduleId almost always must be a full url
+   * and that you might need to call System.resolve() to obtain the moduleId. If the module does not exist in
+   * the registry, null is returned.
+   */
+  export function get(moduleId: string): Module | null;
+  // tslint:disable-next-line no-unnecessary-generics
+  export function get<T>(moduleId: string): T | null;
 
-    /**
-     * An alternative to System.register(), this allows you to insert a module into the module registry. Note that
-     * the moduleId you provide will go straight into the registry without being resolved first.
-     */
-    set(moduleId: string, module: Module): void;
+  /**
+   * Indicates whether the SystemJS module registry contains a module. Note that the moduleId almost always
+   * must be a full url and that you might need to call System.resolve() to obtain the moduleId.
+   */
+  export function has(moduleId: string): boolean;
 
-    /**
-     * Use for (let entry of System.entries()) to access all of the modules in the SystemJS registry.
-     */
-    entries(): Iterable<typeof ModuleEntry>;
-  }
+  /**
+   * An alternative to System.register(), this allows you to insert a module into the module registry. Note that
+   * the moduleId you provide will go straight into the registry without being resolved first.
+   */
+  export function set(moduleId: string, module: Module): void;
+
+  /**
+   * Use for (let entry of System.entries()) to access all of the modules in the SystemJS registry.
+   */
+  export function entries(): Iterable<typeof ModuleEntry>;
 
   // tslint:disable-next-line no-unnecessary-generics
-  function ImportFn<T extends Module>(moduleId: string, parentUrl?: string): Promise<T>;
+  type ImportFn = <T extends Module>(moduleId: string, parentUrl?: string) => Promise<T>;
 
-  function DeclareFn(_export: typeof ExportFn, _context: Context): Declare;
+  type DeclareFn = (_export: ExportFn, _context: Context) => Declare;
   interface Declare {
-    setters?: Array<typeof SetterFn>;
+    setters?: SetterFn[];
     execute?(): any;
   }
-  function SetterFn(moduleValue: Module): any;
-  function ExecuteFn(): any;
+  type SetterFn = (moduleValue: Module) => any;
+  type ExecuteFn = () => any;
 
-  function ExportFn(name: string, value: any): void;
-  function ExportFn(exports: object): void;
+  type ExportFn = ExportFnSingleKey | ExportFnObj;
+  type ExportFnSingleKey = (exportName: string, value: any) => void;
+  type ExportFnObj = (exports: object) => void;
 
-  function UpdateModuleFn(): void;
+  type UpdateModuleFn = () => void;
 
-  function GetFn(moduleId: string): Module;
+  type GetFn = GetFnModule | GetFnGeneric;
+  type GetFnModule = (moduleId: string) => Module;
   // tslint:disable-next-line no-unnecessary-generics
-  function GetFn<T>(moduleId: string): T;
+  type GetFnGeneric = <T>(moduleId: string) => T;
 
   interface Context {
-    import: typeof ImportFn;
+    import: ImportFn;
     meta: {
       url: string;
     };
@@ -99,5 +102,3 @@ declare namespace SystemJS {
 
   const ModuleEntry: [string, Module];
 }
-
-declare const System: SystemJS.SystemLoader;

--- a/types/systemjs/index.d.ts
+++ b/types/systemjs/index.d.ts
@@ -44,6 +44,7 @@ declare namespace SystemJS {
      * the registry, null is returned.
      */
     get(moduleId: string): Module | null;
+    // tslint:disable-next-line no-unnecessary-generics
     get<T>(moduleId: string): T | null;
 
     /**
@@ -64,6 +65,7 @@ declare namespace SystemJS {
     entries(): Iterable<typeof ModuleEntry>;
   }
 
+  // tslint:disable-next-line no-unnecessary-generics
   function ImportFn<T extends Module>(moduleId: string, parentUrl?: string): Promise<T>;
 
   function DeclareFn(_export: typeof ExportFn, _context: Context): Declare;
@@ -80,6 +82,7 @@ declare namespace SystemJS {
   function UpdateModuleFn(): void;
 
   function GetFn(moduleId: string): Module;
+  // tslint:disable-next-line no-unnecessary-generics
   function GetFn<T>(moduleId: string): T;
 
   interface Context {

--- a/types/systemjs/index.d.ts
+++ b/types/systemjs/index.d.ts
@@ -68,7 +68,7 @@ declare const System: {
 // tslint:disable-next-line no-unnecessary-generics
 type ImportFn = <T extends Module>(moduleId: string, parentUrl?: string) => Promise<T>;
 
-type DeclareFn = (_export: ExportFn, _context: Context) => Declare;
+type DeclareFn = (_export: typeof ExportFn, _context: Context) => Declare;
 interface Declare {
   setters?: SetterFn[];
   execute?(): any;
@@ -76,9 +76,8 @@ interface Declare {
 type SetterFn = (moduleValue: Module) => any;
 type ExecuteFn = () => any;
 
-type ExportFn = ExportFnSingleKey | ExportFnObj;
-type ExportFnSingleKey = (exportName: string, value: any) => void;
-type ExportFnObj = (exports: object) => void;
+declare function ExportFn(exportName: string, value: any): void;
+declare function ExportFn(exports: object): void;
 
 type UpdateModuleFn = () => void;
 

--- a/types/systemjs/systemjs-tests.ts
+++ b/types/systemjs/systemjs-tests.ts
@@ -1,68 +1,78 @@
-import SystemJS = require('systemjs');
-
-SystemJS.config({
-    baseURL: '/app'
+System.import('./hi.js').then((hi: SystemJS.Module) => {
+    hi.someProperty();
 });
 
-SystemJS.import('main.js');
-
-SystemJS.config({
-    // 'plugin-traceur' or 'plugin-typescript' or 'babel' or 'traceur' or 'typescript' or false.
-    transpiler: 'plugin-babel',
-    // or traceurOptions or typescriptOptions
-    babelOptions: {
-    }
+System.import<Hi>('./hi.js').then(hi => {
+    hi.someExport();
 });
 
-SystemJS.config({
-    map: {
-        traceur: 'path/to/traceur.js'
-    }
-});
+System.import('./hi.js', 'https://example.com/base/');
 
-SystemJS.config({
-    meta: {
-        '*': {
-            authorization: true
+System.register(['foo', 'bar'], (_export, _context) => {
+    let foo;
+    let bar;
+
+    return {
+        setters: [
+            module => {
+                foo = module;
+            },
+            module => {
+                bar = module;
+            }
+        ],
+        execute() {
+            _export('a', 'thing');
+            _export('b', 123);
+            _export('c', () => 'hi');
+            _export({some: 'thing'});
+
+            _context.import('./other-thing.js');
+
+            _context.meta.url;
         }
-    }
+    };
 });
 
-SystemJS.config({
-    meta: {
-        '*': {
-            authorization: 'Basic YWxhZGRpbjpvcGVuc2VzYW1l'
-        }
-    }
+// named register
+System.register('name', [], () => ({}));
+
+const update = System.delete('https://example.com/a.js');
+if (update) {
+    update();
+} else {
+    const expected: false = update;
+}
+
+const a = System.get('https://example.com/a.js');
+if (a) {
+    a.doThing();
+} else {
+    const expected: null = a;
+}
+
+const b = System.get<ModuleB>('https://example.com/b.js');
+if (b) {
+    b.theBThing();
+} else {
+    const expected: null = b;
+}
+
+const hasC: boolean = System.has('https://example.com/c.js');
+
+System.set('https://example.com/d.js', {
+    hi: 'there'
 });
 
-SystemJS.config({
-    map: {
-        'local/package': {
-            x: 'vendor/x.js'
-        },
-        'another/package': {
-            x: 'vendor/y.js'
-        }
-    }
-});
+for (const entry of System.entries()) {
+    const moduleId: string = entry[0];
+    const module: SystemJS.Module = entry[1];
+}
 
-SystemJS.transpiler = 'traceur';
+interface ModuleB {
+    theBThing(): void;
+}
 
-const mockModule = {
-    default: () => {
-        return 42;
-    }
-};
-
-SystemJS.set('./app.js', SystemJS.newModule(mockModule));
-
-SystemJS.import('./app.js').then((m: typeof mockModule) => {
-    m.default();
-});
-
-SystemJS.import('lodash').then((_: (...args: any[]) => any) => {
-    _(1, '2', {}, []);
-});
-
-const clonedSystemJSJS = new SystemJS.constructor();
+interface Hi {
+    someExport(): void;
+}

--- a/types/systemjs/systemjs-tests.ts
+++ b/types/systemjs/systemjs-tests.ts
@@ -1,12 +1,12 @@
-System.import('./hi.js').then((hi: SystemJS.Module) => {
+System.import('./hi.js').then((hi) => {
     hi.someProperty();
 });
 
-System.import<Hi>('./hi.js').then(hi => {
+System.delete<Hi>('./hi.js').then(hi => {
     hi.someExport();
 });
 
-System.import('./hi.js', 'https://example.com/base/');
+System.delete('./hi.js', 'https://example.com/base/');
 
 System.register(['foo', 'bar'], (_export, _context) => {
     let foo;
@@ -37,25 +37,27 @@ System.register(['foo', 'bar'], (_export, _context) => {
 // named register
 System.register('name', [], () => ({}));
 
-const update = System.delete('https://example.com/a.js');
-if (update) {
-    update();
-} else {
-    const expected: false = update;
-}
+// const update = System.delete('https://example.com/a.js');
+// if (update) {
+//     update();
+// } else {
+//     const expected: false = update;
+// }
 
 const a = System.get('https://example.com/a.js');
 if (a) {
     a.doThing();
 } else {
-    const expected: null = a;
+    // $ExpectType null
+    a;
 }
 
 const b = System.get<ModuleB>('https://example.com/b.js');
 if (b) {
     b.theBThing();
 } else {
-    const expected: null = b;
+    // $ExpectType null
+    b;
 }
 
 const hasC: boolean = System.has('https://example.com/c.js');
@@ -65,8 +67,9 @@ System.set('https://example.com/d.js', {
 });
 
 for (const entry of System.entries()) {
-    const moduleId: string = entry[0];
-    const module: SystemJS.Module = entry[1];
+    // $ExpectType: string
+    const moduleId = entry[0];
+    const module = entry[1];
 }
 
 interface ModuleB {

--- a/types/systemjs/systemjs-tests.ts
+++ b/types/systemjs/systemjs-tests.ts
@@ -2,11 +2,11 @@ System.import('./hi.js').then((hi) => {
     hi.someProperty();
 });
 
-System.delete<Hi>('./hi.js').then(hi => {
+System.import<Hi>('./hi.js').then(hi => {
     hi.someExport();
 });
 
-System.delete('./hi.js', 'https://example.com/base/');
+System.import('./hi.js', 'https://example.com/base/');
 
 System.register(['foo', 'bar'], (_export, _context) => {
     let foo;
@@ -37,12 +37,12 @@ System.register(['foo', 'bar'], (_export, _context) => {
 // named register
 System.register('name', [], () => ({}));
 
-// const update = System.delete('https://example.com/a.js');
-// if (update) {
-//     update();
-// } else {
-//     const expected: false = update;
-// }
+const update = System.delete('https://example.com/a.js');
+if (update) {
+    update();
+} else {
+    const expected: false = update;
+}
 
 const a = System.get('https://example.com/a.js');
 if (a) {

--- a/types/systemjs/tslint.json
+++ b/types/systemjs/tslint.json
@@ -1,8 +1,3 @@
 {
-  "extends": "dtslint/dt.json",
-  "rules": {
-    "no-unnecessary-generics": {
-      "severity": "off"
-    }
-  }
+  "extends": "dtslint/dt.json"
 }

--- a/types/systemjs/tslint.json
+++ b/types/systemjs/tslint.json
@@ -1,3 +1,8 @@
 {
-  "extends": "dtslint/dt.json"
+  "extends": "dtslint/dt.json",
+  "rules": {
+    "no-unnecessary-generics": {
+      "severity": "off"
+    }
+  }
 }

--- a/types/systemjs/v0/index.d.ts
+++ b/types/systemjs/v0/index.d.ts
@@ -1,0 +1,388 @@
+// Type definitions for SystemJS 0.20
+// Project: https://github.com/systemjs/systemjs
+// Definitions by: Ludovic HENIN <https://github.com/ludohenin>
+//                 Nathan Walker <https://github.com/NathanWalker>
+//                 Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
+//                 Aluan Haddad <https://github.com/aluanhaddad>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = SystemJSLoader;
+
+export as namespace SystemJSLoader;
+
+declare global {
+    const SystemJS: typeof SystemJSLoader;
+
+    /**
+     * @deprecated use SystemJS https://github.com/systemjs/systemjs/releases/tag/0.19.10
+     */
+    const System: typeof SystemJSLoader;
+    const __moduleName: string;
+}
+
+declare const SystemJSLoader: SystemJSLoader.System;
+
+declare namespace SystemJSLoader {
+    interface ModulesList {
+        [bundleName: string]: string[];
+    }
+
+    interface PackageList<T> {
+        [packageName: string]: T;
+    }
+
+    /**
+     * The following module formats are supported:
+     *
+     * - esm: ECMAScript Module (previously referred to as es6)
+     * - cjs: CommonJS
+     * - amd: Asynchronous Module Definition
+     * - global: Global shim module format
+     * - register: System.register or System.registerDynamic compatibility module format
+     *
+     */
+    type ModuleFormat = "esm" | "cjs" | "amd" | "global" | "register";
+
+    /**
+     * Sets the module name of the transpiler to be used for loading ES6 modules.
+     * Represents a module name for System.import that must resolve to either Traceur, Babel or TypeScript.
+     * When set to traceur, babel or typescript, loading will be automatically configured as far as possible.
+     */
+    type Transpiler = "plugin-traceur" | "plugin-babel" | "plugin-typescript" | "traceur" | "babel" | "typescript" | false;
+
+    type ConfigMap = PackageList<string | PackageList<string>>;
+
+    type ConfigMeta = PackageList<MetaConfig>;
+
+    interface MetaConfig {
+        /**
+         * Sets in what format the module is loaded.
+         */
+        format?: ModuleFormat;
+
+        /**
+         * For the global format, when automatic detection of exports is not enough, a custom exports meta value can be set.
+         * This tells the loader what global name to use as the module's export value.
+         */
+        exports?: string;
+
+        /**
+         * Dependencies to load before this module. Goes through regular paths and map normalization.
+         * Only supported for the cjs, amd and global formats.
+         */
+        deps?: string[];
+
+        /**
+         * A map of global names to module names that should be defined only for the execution of this module.
+         * Enables use of legacy code that expects certain globals to be present.
+         * Referenced modules automatically becomes dependencies. Only supported for the cjs and global formats.
+         */
+        globals?: string;
+
+        /**
+         * Set a loader for this meta path.
+         */
+        loader?: string;
+
+        /**
+         * For plugin transpilers to set the source map of their transpilation.
+         */
+        sourceMap?: any;
+
+        /**
+         * Load the module using <script> tag injection.
+         */
+        scriptLoad?: boolean;
+
+        /**
+         * The nonce attribute to use when loading the script as a way to enable CSP.
+         * This should correspond to the "nonce-" attribute set in the Content-Security-Policy header.
+         */
+        nonce?: string;
+
+        /**
+         * The subresource integrity attribute corresponding to the script integrity,
+         * describing the expected hash of the final code to be executed.
+         * For example, System.config({ meta: { 'src/example.js': { integrity: 'sha256-e3b0c44...' }});
+         * would throw an error if the translated source of src/example.js doesn't match the expected hash.
+         */
+        integrity?: string;
+
+        /**
+         * When scripts are loaded from a different domain (e.g. CDN) the global error handler (window.onerror)
+         * has very limited information about errors to prevent unintended leaking. In order to mitigate this,
+         * the <script> tags need to set crossorigin attribute and the server needs to enable CORS.
+         * The valid values are "anonymous" and "use-credentials".
+         */
+        crossOrigin?: string;
+
+        /**
+         * When loading a module that is not an ECMAScript Module, we set the module as the default export,
+         * but then also iterate the module object and copy named exports for it a well.
+         * Use this option to disable this iteration and copying of the exports.
+         */
+        esmExports?: boolean;
+
+        /**
+         * To ignore resources that shouldn't be traced as part of the build.
+         * Use with the SystemJS Builder. (https://github.com/systemjs/builder#ignore-resources)
+         */
+        build?: boolean;
+
+        /**
+         * A truthy value enables sending credentials to the server on every request. Additionally, a string value adds
+         * an "Authorization" header with that value to all requests.
+         */
+        authorization?: string | boolean;
+    }
+
+    interface PackageConfig {
+        /**
+         * The main entry point of the package (so import 'local/package' is equivalent to import 'local/package/index.js')
+         */
+        main?: string;
+
+        /**
+         * The module format of the package. See Module Formats.
+         */
+        format?: ModuleFormat;
+
+        /**
+         * The default extension to add to modules requested within the package. Takes preference over defaultJSExtensions.
+         * Can be set to defaultExtension: false to optionally opt-out of extension-adding when defaultJSExtensions is enabled.
+         */
+        defaultExtension?: boolean | string;
+
+        /**
+         * Local and relative map configurations scoped to the package. Apply for subpaths as well.
+         */
+        map?: ConfigMap;
+
+        /**
+         * Module meta provides an API for SystemJS to understand how to load modules correctly.
+         * Package-scoped meta configuration with wildcard support. Modules are subpaths within the package path.
+         * This also provides an opt-out mechanism for defaultExtension, by adding modules here that should skip extension adding.
+         */
+        meta?: ConfigMeta;
+    }
+
+    interface TraceurOptions {
+        properTailCalls?: boolean;
+        symbols?: boolean;
+        arrayComprehension?: boolean;
+        asyncFunctions?: boolean;
+        asyncGenerators?: any;
+        forOn?: boolean;
+        generatorComprehension?: boolean;
+    }
+
+    interface Config {
+        /**
+         * For custom config names
+         */
+        [customName: string]: any;
+
+        /**
+         * The baseURL provides a special mechanism for loading modules relative to a standard reference URL.
+         */
+        baseURL?: string;
+
+        /**
+         * Set the Babel transpiler options when System.transpiler is set to babel.
+         */
+        // TODO: Import BabelCore.TransformOptions
+        babelOptions?: any;
+
+        /**
+         * undles allow a collection of modules to be downloaded together as a package whenever any module from that collection is requested.
+         * Useful for splitting an application into sub-modules for production. Use with the SystemJS Builder.
+         */
+        bundles?: ModulesList;
+
+        /**
+         * Backwards-compatibility mode for the loader to automatically add '.js' extensions when not present to module requests.
+         * This allows code written for SystemJS 0.16 or less to work easily in the latest version:
+         */
+        defaultJSExtensions?: boolean;
+
+        /**
+         * An alternative to bundling providing a solution to the latency issue of progressively loading dependencies.
+         * When a module specified in depCache is loaded, asynchronous loading of its pre-cached dependency list begins in parallel.
+         */
+        depCache?: ModulesList;
+
+        /**
+         * The map option is similar to paths, but acts very early in the normalization process.
+         * It allows you to map a module alias to a location or package:
+         */
+        map?: ConfigMap;
+
+        /**
+         * Module meta provides an API for SystemJS to understand how to load modules correctly.
+         * Meta is how we set the module format of a module, or know how to shim dependencies of a global script.
+         */
+        meta?: ConfigMeta;
+
+        /**
+         * Packages provide a convenience for setting meta and map configuration that is specific to a common path.
+         * In addition packages allow for setting contextual map configuration which only applies within the package itself.
+         * This allows for full dependency encapsulation without always needing to have all dependencies in a global namespace.
+         */
+        packages?: PackageList<PackageConfig>;
+
+        /**
+         * The ES6 Module Loader paths implementation, applied after normalization and supporting subpaths via wildcards.
+         * It is usually advisable to use map configuration over paths unless you need strict control over normalized module names.
+         */
+        paths?: PackageList<string>;
+
+        /**
+         * Set the Traceur compilation options.
+         */
+        traceurOptions?: TraceurOptions;
+
+        /**
+         * Sets the module name of the transpiler to be used for loading ES6 modules.
+         */
+        transpiler?: Transpiler;
+
+        trace?: boolean;
+
+        /**
+         * Sets the TypeScript transpiler options.
+         */
+        // TODO: Import Typescript.CompilerOptions
+        typescriptOptions?: {
+            /**
+             * A boolean flag which instructs the plugin to load configuration from "tsconfig.json".
+             * To override the location of the file set this option to the path of the configuration file,
+             * which will be resolved using normal SystemJS resolution.
+             * Note: This setting is specific to plugin-typescript.
+             */
+            tsconfig?: boolean | string,
+
+            [key: string]: any
+        };
+    }
+
+    interface System extends Config {
+        /**
+         * For backwards-compatibility with AMD environments, set window.define = System.amdDefine.
+         */
+        amdDefine(...args: any[]): void;
+
+        /**
+         * For backwards-compatibility with AMD environments, set window.require = System.amdRequire.
+         */
+        amdRequire(deps: string[], callback: (...modules: any[]) => void): void;
+
+        /**
+         * SystemJS configuration helper function.
+         * Once SystemJS has loaded, configuration can be set on SystemJS by using the configuration function System.config.
+         */
+        config(config: Config): void;
+
+        /**
+         * This represents the System base class, which can be extended or reinstantiated to create a custom System instance.
+         */
+        constructor: new () => System;
+
+        /**
+         * Deletes a module from the registry by normalized name.
+         */
+        delete(moduleName: string): void;
+
+        /**
+         * Returns a module from the registry by normalized name.
+         */
+        get(moduleName: string): any;
+
+        /**
+         * Returns a clone of the internal SystemJS configuration in use.
+         */
+        getConfig(): Config;
+
+        /**
+         * Returns whether a given module exists in the registry by normalized module name.
+         */
+        has(moduleName: string): boolean;
+
+        /**
+         * Loads a module by name taking an optional normalized parent name argument.
+         * Promise resolves to the module value.
+         */
+        import(moduleName: string, normalizedParentName?: string): Promise<any>;
+
+        /**
+         * Given any object, returns true if the object is either a SystemJS module or native JavaScript module object, and false otherwise.
+         * Useful for interop scenarios.
+         */
+        isModule(object: any): boolean;
+
+        /**
+         * Given a plain JavaScript object, return an equivalent Module object.
+         * Useful when writing a custom instantiate hook or using System.set.
+         */
+        newModule(object: any): any;
+
+        /**
+         * Declaration function for defining modules of the System.register polyfill module format.
+         */
+        register(name: string, deps: string[], declare: (...modules: any[]) => any): void;
+        register(deps: string[], declare: (...modules: any[]) => any): void;
+
+        /**
+         * Companion module format to System.register for non-ES6 modules.
+         * Provides a <script>-injection-compatible module format that any CommonJS or Global module can be converted into for CSP compatibility.
+         */
+        registerDynamic(name: string, deps: string[], executingRequire: boolean, declare: (...modules: any[]) => any): void;
+        registerDynamic(deps: string[], executingRequire: boolean, declare: (...modules: any[]) => any): void;
+
+        /**
+         * Sets a module into the registry directly and synchronously.
+         * Typically used along with System.newModule to create a valid Module object:
+         */
+        set(moduleName: string, module: any): void;
+
+        /**
+         * Resolves module name to normalized URL.
+         */
+        resolve(moduleName: string, parentName?: string): Promise<string>;
+
+        /**
+         * Resolves module name to normalized URL.
+         * Synchronous alternative to `SystemJS.resolve`.
+         */
+        resolveSync(moduleName: string, parentName?: string): string;
+
+        /**
+         * In CommonJS environments, SystemJS will substitute the global require as needed by the module format being
+         * loaded to ensure the correct detection paths in loaded code.
+         * The CommonJS require can be recovered within these modules from System._nodeRequire.
+         */
+        _nodeRequire(dep: string): any;
+
+        /**
+         * Modules list available only with trace=true
+         */
+        loads: PackageList<any>;
+
+        env: string;
+
+        loaderErrorStack: boolean;
+
+        packageConfigPaths: string[];
+
+        /**
+         * Specify a value of true to have SystemJS conform to the AMD-style plugin syntax, e.g. "text!some/file.txt", over the default of "some/file.txt!text".
+         */
+        pluginFirst: boolean;
+
+        version: string;
+
+        /**
+         * Enables the output of warnings to the console, including deprecation messages.
+         */
+        warnings: boolean;
+    }
+}

--- a/types/systemjs/v0/systemjs-tests.ts
+++ b/types/systemjs/v0/systemjs-tests.ts
@@ -1,0 +1,68 @@
+import SystemJS = require('./index');
+
+SystemJS.config({
+    baseURL: '/app'
+});
+
+SystemJS.import('main.js');
+
+SystemJS.config({
+    // 'plugin-traceur' or 'plugin-typescript' or 'babel' or 'traceur' or 'typescript' or false.
+    transpiler: 'plugin-babel',
+    // or traceurOptions or typescriptOptions
+    babelOptions: {
+    }
+});
+
+SystemJS.config({
+    map: {
+        traceur: 'path/to/traceur.js'
+    }
+});
+
+SystemJS.config({
+    meta: {
+        '*': {
+            authorization: true
+        }
+    }
+});
+
+SystemJS.config({
+    meta: {
+        '*': {
+            authorization: 'Basic YWxhZGRpbjpvcGVuc2VzYW1l'
+        }
+    }
+});
+
+SystemJS.config({
+    map: {
+        'local/package': {
+            x: 'vendor/x.js'
+        },
+        'another/package': {
+            x: 'vendor/y.js'
+        }
+    }
+});
+
+SystemJS.transpiler = 'traceur';
+
+const mockModule = {
+    default: () => {
+        return 42;
+    }
+};
+
+SystemJS.set('./app.js', SystemJS.newModule(mockModule));
+
+SystemJS.import('./app.js').then((m: typeof mockModule) => {
+    m.default();
+});
+
+SystemJS.import('lodash').then((_: (...args: any[]) => any) => {
+    _(1, '2', {}, []);
+});
+
+const clonedSystemJSJS = new SystemJS.constructor();

--- a/types/systemjs/v0/systemjs-tests.ts
+++ b/types/systemjs/v0/systemjs-tests.ts
@@ -1,4 +1,4 @@
-import SystemJS = require('./index');
+import SystemJS = require('systemjs');
 
 SystemJS.config({
     baseURL: '/app'

--- a/types/systemjs/v0/tsconfig.json
+++ b/types/systemjs/v0/tsconfig.json
@@ -8,13 +8,16 @@
         "noImplicitThis": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
-        "baseUrl": "../",
+        "baseUrl": "../../",
         "typeRoots": [
-            "../"
+            "../../"
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "systemjs": ["systemjs/v0"]
+        }
     },
     "files": [
         "index.d.ts",

--- a/types/systemjs/v0/tsconfig.json
+++ b/types/systemjs/v0/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
+        "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
@@ -14,7 +14,6 @@
         ],
         "types": [],
         "noEmit": true,
-        "target": "es6",
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/systemjs/v0/tslint.json
+++ b/types/systemjs/v0/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Hi there 👋. I am a current, active maintainer of SystemJS. We rewrote the whole project late last year and the typescript definitions are now out of date. I am hoping to maintain the 0.20 typescript definitions for those using systemjs@<1, but add definitions for systemjs@6 as the `latest` types on npm.

I attempted to do so by creating a `v0` directory and moving the old definitions there. I don't know if that is the correct thing to do, but saw other DefinitelyTyped packages doing that. If I missed anything there, let me know.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/systemjs/systemjs/blob/master/docs/api.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

