### PR TITLE
filesize-parser 1.5.0: Add types

### DIFF
--- a/types/filesize-parser/filesize-parser-tests.ts
+++ b/types/filesize-parser/filesize-parser-tests.ts
@@ -1,0 +1,4 @@
+import filesizeParser from 'filesize-parser';
+
+const size: number = filesizeParser('200kb');
+const sizeWithBase: number = filesizeParser('300mb', { base: 10 });

--- a/types/filesize-parser/filesize-parser-tests.ts
+++ b/types/filesize-parser/filesize-parser-tests.ts
@@ -1,4 +1,4 @@
-import filesizeParser from 'filesize-parser';
+import filesizeParser = require('filesize-parser');
 
 const size: number = filesizeParser('200kb');
 const sizeWithBase: number = filesizeParser('300mb', { base: 10 });

--- a/types/filesize-parser/index.d.ts
+++ b/types/filesize-parser/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for filesize-parser 1.5
+// Project: https://github.com/patrickkettner/filesize-parser#readme
+// Definitions by: Gary King <https://github.com/garyking>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function filesizeParser(size: string): number;
+declare function filesizeParser(size: string, options?: Options): number;
+
+interface Options {
+    base: 2 | 10;
+}
+
+export default filesizeParser;

--- a/types/filesize-parser/index.d.ts
+++ b/types/filesize-parser/index.d.ts
@@ -3,11 +3,10 @@
 // Definitions by: Gary King <https://github.com/garyking>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function filesizeParser(size: string): number;
 declare function filesizeParser(size: string, options?: Options): number;
 
 interface Options {
     base: 2 | 10;
 }
 
-export default filesizeParser;
+export = filesizeParser;

--- a/types/filesize-parser/tsconfig.json
+++ b/types/filesize-parser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "filesize-parser-tests.ts"
+    ]
+}

--- a/types/filesize-parser/tslint.json
+++ b/types/filesize-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

