### PR TITLE
@types/signalr: Exporting the interfaces and namespace

### DIFF
--- a/types/signalr/index.d.ts
+++ b/types/signalr/index.d.ts
@@ -8,7 +8,7 @@
 /// <reference types="jquery" />
 
 
-declare namespace SignalR {
+export namespace SignalR {
     
     const enum ConnectionState {
         Connecting = 0,
@@ -360,7 +360,7 @@ interface SignalR {
     version: string;
 }
 
-interface JQueryStatic {
+export interface JQueryStatic {
     signalR: SignalR;
     connection: SignalR;
     hubConnection: SignalR.Hub.HubCreator;


### PR DESCRIPTION
Without this, we cannot use this types with Angular application (or in any typescript project). 
We get below error while doing `import * from 'signalr'`.
`node_modules/@types/signalr/index.d.ts' is not a module`

Please fill in this template.

- [y ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ y] Test the change in your own code. (Compile and run.)
- [y ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [y ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ y] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [y ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
