### PR TITLE
@types/signalr: Exporting the interfaces and namespace

### DIFF
--- a/types/signalr/index.d.ts
+++ b/types/signalr/index.d.ts
@@ -333,7 +333,7 @@ declare namespace SignalR {
     }
 }
 
-interface SignalR {
+export interface SignalR {
     /**
     * Creates a new SignalR connection for the given url
     *
@@ -360,7 +360,7 @@ interface SignalR {
     version: string;
 }
 
-interface JQueryStatic {
+export interface JQueryStatic {
     signalR: SignalR;
     connection: SignalR;
     hubConnection: SignalR.Hub.HubCreator;


### PR DESCRIPTION
Without this, we cannot use this types with Angular application (or in any typescript project).
We get below error while doing `import * from 'signalr'`.

    node_modules/@types/signalr/index.d.ts' is not a module

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

