### PR TITLE
[DataTables.net-buttons] Added LanguageSettings

### DIFF
--- a/types/datatables.net-buttons/datatables.net-buttons-tests.ts
+++ b/types/datatables.net-buttons/datatables.net-buttons-tests.ts
@@ -150,6 +150,45 @@ const config_3: DataTables.ButtonsSettings = {
     }
 };
 
+const config_4: DataTables.Settings = {
+    // Buttons change text
+    buttons: [{
+        extend: 'excel',
+        text: 'Excel',
+        className: 'class',
+        filename: "exported_file.csv",
+        exportOptions: {
+            columns: ':visible'
+        }
+    },
+    {
+        extend: 'excel',
+        text: 'Excel',
+        className: 'class',
+        filename: "exported_file.csv",
+        exportOptions: {
+            columns: [1, 6, 2, 3, 4]
+        }
+    },
+    {
+        action(e, dt, node, config) { },
+        available(dt, config) { return true; },
+        destroy(dt, node, config) { },
+        enabled: true,
+        init(dt, node, config) { },
+        key: 'a',
+        name: 'name',
+        namespace: 'namespace',
+        titleAttr: 'title',
+        title: 'title'
+    }],
+    language: {
+        buttons: {
+            excel: 'this is excel button'
+        }
+    },
+};
+
 // Statics
 const buttons = new $.fn.dataTable.Buttons($("selector").DataTable(), config_3);
 const version = $.fn.dataTable.Buttons.version;

--- a/types/datatables.net-buttons/index.d.ts
+++ b/types/datatables.net-buttons/index.d.ts
@@ -15,6 +15,10 @@ declare namespace DataTables {
         buttons?: boolean | string[] | ButtonsSettings | ButtonSettings[];
     }
 
+    interface LanguageSettings {
+        buttons?: {};
+    }
+
     interface StaticFunctions {
         Buttons: ButtonStaticFunctions;
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://datatables.net/extensions/buttons/examples/column_visibility/text.html>