### PR TITLE
[@types/prosemirror-transform] Fix `canSplit` type

### DIFF
--- a/types/prosemirror-transform/index.d.ts
+++ b/types/prosemirror-transform/index.d.ts
@@ -532,7 +532,7 @@ export function canSplit<S extends Schema = any>(
   doc: ProsemirrorNode<S>,
   pos: number,
   depth?: number,
-  typesAfter?: Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null }>
+  typesAfter?: Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null } | null | undefined>
 ): boolean;
 /**
  * Test whether the blocks before and after a given position can be

--- a/types/prosemirror-transform/index.d.ts
+++ b/types/prosemirror-transform/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prosemirror-transform 1.1
+// Type definitions for prosemirror-transform 1.1.5
 // Project: https://github.com/ProseMirror/prosemirror-transform
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>

--- a/types/prosemirror-transform/index.d.ts
+++ b/types/prosemirror-transform/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prosemirror-transform 1.1.5
+// Type definitions for prosemirror-transform 1.1
 // Project: https://github.com/ProseMirror/prosemirror-transform
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/ProseMirror/prosemirror-transform/blob/1.1.5/src/structure.js#L156-L158> `(Node, number, number, ?[?{type: NodeType, attrs: ?Object}]) → bool`
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
