### PR TITLE
Node: `util.promisify`: widen callback error parameter to `any`

### DIFF
--- a/types/node/ts3.2/node-tests.ts
+++ b/types/node/ts3.2/node-tests.ts
@@ -24,7 +24,7 @@ import '../util';
 import '../worker_threads';
 import '../zlib';
 
-import { types } from 'util';
+import { types, promisify } from 'util';
 import { BigIntStats, statSync, Stats } from 'fs';
 
 //////////////////////////////////////////////////////////
@@ -49,6 +49,9 @@ import { BigIntStats, statSync, Stats } from 'fs';
         // $ExpectType number
         const b = value;
     }
+
+    const arg1UnknownError: (arg: string) => Promise<number> = promisify((arg: string, cb: (err: unknown, result: number) => void): void => { });
+    const arg1AnyError: (arg: string) => Promise<number> = promisify((arg: string, cb: (err: any, result: number) => void): void => { });
 }
 
 // FS Tests

--- a/types/node/ts3.2/node-tests.ts
+++ b/types/node/ts3.2/node-tests.ts
@@ -24,7 +24,7 @@ import '../util';
 import '../worker_threads';
 import '../zlib';
 
-import { types } from 'util';
+import { types, promisify } from 'util';
 import { BigIntStats, statSync, Stats } from 'fs';
 
 //////////////////////////////////////////////////////////
@@ -49,6 +49,8 @@ import { BigIntStats, statSync, Stats } from 'fs';
         // $ExpectType number
         const b = value;
     }
+
+    const arg1UnknownErrorA: (arg: string) => Promise<number> = promisify((arg: string, cb: (err: unknown, result: number) => void): void => { });
 }
 
 // FS Tests

--- a/types/node/ts3.2/node-tests.ts
+++ b/types/node/ts3.2/node-tests.ts
@@ -24,7 +24,7 @@ import '../util';
 import '../worker_threads';
 import '../zlib';
 
-import { types, promisify } from 'util';
+import { types } from 'util';
 import { BigIntStats, statSync, Stats } from 'fs';
 
 //////////////////////////////////////////////////////////
@@ -49,8 +49,6 @@ import { BigIntStats, statSync, Stats } from 'fs';
         // $ExpectType number
         const b = value;
     }
-
-    const arg1UnknownErrorA: (arg: string) => Promise<number> = promisify((arg: string, cb: (err: unknown, result: number) => void): void => { });
 }
 
 // FS Tests

--- a/types/node/ts3.2/util.d.ts
+++ b/types/node/ts3.2/util.d.ts
@@ -5,9 +5,33 @@ declare module "util" {
     namespace inspect {
         const custom: unique symbol;
     }
+
     namespace promisify {
         const custom: unique symbol;
     }
+    function promisify<TCustom extends Function>(fn: CustomPromisify<TCustom>): TCustom;
+    function promisify<TResult>(fn: (callback: (err: unknown, result: TResult) => void) => void): () => Promise<TResult>;
+    function promisify(fn: (callback: (err?: unknown) => void) => void): () => Promise<void>;
+    function promisify<T1, TResult>(fn: (arg1: T1, callback: (err: unknown, result: TResult) => void) => void): (arg1: T1) => Promise<TResult>;
+    function promisify<T1>(fn: (arg1: T1, callback: (err?: unknown) => void) => void): (arg1: T1) => Promise<void>;
+    function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: (err: unknown, result: TResult) => void) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
+    function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: (err?: unknown) => void) => void): (arg1: T1, arg2: T2) => Promise<void>;
+    function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: unknown, result: TResult) => void) => void):
+        (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
+    function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: unknown) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
+    function promisify<T1, T2, T3, T4, TResult>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: unknown, result: TResult) => void) => void,
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
+    function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: unknown) => void) => void):
+        (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
+    function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: unknown, result: TResult) => void) => void,
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
+    function promisify<T1, T2, T3, T4, T5>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: unknown) => void) => void,
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
+    function promisify(fn: Function): Function;
+
     namespace types {
         function isBigInt64Array(value: any): value is BigInt64Array;
         function isBigUint64Array(value: any): value is BigUint64Array;

--- a/types/node/ts3.2/util.d.ts
+++ b/types/node/ts3.2/util.d.ts
@@ -5,33 +5,9 @@ declare module "util" {
     namespace inspect {
         const custom: unique symbol;
     }
-
     namespace promisify {
         const custom: unique symbol;
     }
-    function promisify<TCustom extends Function>(fn: CustomPromisify<TCustom>): TCustom;
-    function promisify<TResult>(fn: (callback: (err: unknown, result: TResult) => void) => void): () => Promise<TResult>;
-    function promisify(fn: (callback: (err?: unknown) => void) => void): () => Promise<void>;
-    function promisify<T1, TResult>(fn: (arg1: T1, callback: (err: unknown, result: TResult) => void) => void): (arg1: T1) => Promise<TResult>;
-    function promisify<T1>(fn: (arg1: T1, callback: (err?: unknown) => void) => void): (arg1: T1) => Promise<void>;
-    function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: (err: unknown, result: TResult) => void) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
-    function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: (err?: unknown) => void) => void): (arg1: T1, arg2: T2) => Promise<void>;
-    function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: unknown, result: TResult) => void) => void):
-        (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
-    function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: unknown) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
-    function promisify<T1, T2, T3, T4, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: unknown, result: TResult) => void) => void,
-    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
-    function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: unknown) => void) => void):
-        (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
-    function promisify<T1, T2, T3, T4, T5, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: unknown, result: TResult) => void) => void,
-    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
-    function promisify<T1, T2, T3, T4, T5>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: unknown) => void) => void,
-    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
-    function promisify(fn: Function): Function;
-
     namespace types {
         function isBigInt64Array(value: any): value is BigInt64Array;
         function isBigUint64Array(value: any): value is BigUint64Array;

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -84,25 +84,25 @@ declare module "util" {
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException | null, result: TResult) => void) => void;
 
     function promisify<TCustom extends Function>(fn: CustomPromisify<TCustom>): TCustom;
-    function promisify<TResult>(fn: (callback: (err: NodeJS.PoorMansUnknown, result: TResult) => void) => void): () => Promise<TResult>;
-    function promisify(fn: (callback: (err?: NodeJS.PoorMansUnknown) => void) => void): () => Promise<void>;
-    function promisify<T1, TResult>(fn: (arg1: T1, callback: (err: NodeJS.PoorMansUnknown, result: TResult) => void) => void): (arg1: T1) => Promise<TResult>;
-    function promisify<T1>(fn: (arg1: T1, callback: (err?: NodeJS.PoorMansUnknown) => void) => void): (arg1: T1) => Promise<void>;
-    function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: (err: NodeJS.PoorMansUnknown, result: TResult) => void) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
-    function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: (err?: NodeJS.PoorMansUnknown) => void) => void): (arg1: T1, arg2: T2) => Promise<void>;
-    function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: NodeJS.PoorMansUnknown, result: TResult) => void) => void):
+    function promisify<TResult>(fn: (callback: (err: any, result: TResult) => void) => void): () => Promise<TResult>;
+    function promisify(fn: (callback: (err?: any) => void) => void): () => Promise<void>;
+    function promisify<T1, TResult>(fn: (arg1: T1, callback: (err: any, result: TResult) => void) => void): (arg1: T1) => Promise<TResult>;
+    function promisify<T1>(fn: (arg1: T1, callback: (err?: any) => void) => void): (arg1: T1) => Promise<void>;
+    function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
+    function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: (err?: any) => void) => void): (arg1: T1, arg2: T2) => Promise<void>;
+    function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void) => void):
         (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
-    function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: NodeJS.PoorMansUnknown) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
+    function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: any) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
     function promisify<T1, T2, T3, T4, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: NodeJS.PoorMansUnknown, result: TResult) => void) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
-    function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: NodeJS.PoorMansUnknown) => void) => void):
+    function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: any) => void) => void):
         (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
     function promisify<T1, T2, T3, T4, T5, TResult>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: NodeJS.PoorMansUnknown, result: TResult) => void) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
     function promisify<T1, T2, T3, T4, T5>(
-        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: NodeJS.PoorMansUnknown) => void) => void,
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
     function promisify(fn: Function): Function;
 


### PR DESCRIPTION
In https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39173 I had to use `PoorMansUnknown` instead of `unknown` because the types had to support TS versions < 3 (i.e. when `unknown` support was added).

However, I didn't realise that this wouldn't allow `unknown` to be used by TS 3 users. E.g. this test would fail:

```ts
// Type '(arg1: string, arg2: (err: unknown, result: number) => void) => Promise<number>' is not assignable to type '(arg: string) => Promise<number>'.
const arg1UnknownErrorA: (arg: string) => Promise<number> = promisify((arg: string, cb: (err: unknown, result: number) => void): void => { });
```

This is because `unknown` is not assignable to `PoorMansUnknown`.

```ts
let unknown: unknown;
let poorMansUnknown: {} | null | undefined;

// error
poorMansUnknown = unknown;
```

~This PR adds types specifically for TS 3 users so they may use `unknown`, whilst < TS 3 users may continue to use `PoorMansUnknown`.~

This PR widens the error type to `any`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.