### PR TITLE
[superagent] Use base http.Agent instead of https.Agent

### DIFF
--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -9,6 +9,7 @@
 //                 Lukas Elmer <https://github.com/lukaselmer>
 //                 Jesse Rogers <https://github.com/theQuazz>
 //                 Chris Arnesen <https://github.com/carnesen>
+//                 Anders Kindberg <https://github.com/ghostganz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -16,7 +17,7 @@
 /// <reference lib="dom" />
 
 import * as fs from 'fs';
-import * as https from 'https';
+import * as http from 'http';
 import * as stream from 'stream';
 import * as cookiejar from 'cookiejar';
 
@@ -38,7 +39,7 @@ declare const request: request.SuperAgentStatic;
 
 declare namespace request {
     interface SuperAgentRequest extends Request {
-        agent(agent?: https.Agent): this;
+        agent(agent?: http.Agent): this;
 
         cookies: string;
         method: string;


### PR DESCRIPTION
It's valid to provide either http.Agent or https.Agent to agent() method, but the types only allowed https.Agent. Since https.Agent extends http.Agent, changing to http.Agent makes both work.

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
