### PR TITLE
[@types/webpack] Configuration as a function

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -44,32 +44,24 @@ import { ConcatSource } from 'webpack-sources';
 export = webpack;
 
 declare function webpack(
-    options: webpack.Configuration,
-    handler: webpack.Compiler.Handler
+    options:
+        | webpack.Configuration
+        | ((
+              env: string | Record<string, boolean | number | string>,
+              args: Record<string, string>,
+          ) => webpack.Configuration | Promise<webpack.Configuration>),
+    handler: webpack.Compiler.Handler,
 ): webpack.Compiler.Watching | webpack.Compiler;
 declare function webpack(options?: webpack.Configuration): webpack.Compiler;
 
 declare function webpack(
-    options: webpack.Configuration[],
+    options:
+        | webpack.Configuration[]
+        | ((
+              env: string | Record<string, boolean | number | string>,
+              args: Record<string, string>,
+          ) => webpack.Configuration[] | Promise<webpack.Configuration[]>),
     handler: webpack.MultiCompiler.Handler
-): webpack.MultiWatching | webpack.MultiCompiler;
-declare function webpack(options: webpack.Configuration[]): webpack.MultiCompiler;
-
-declare function webpack(
-    options: (
-        env: string | Record<string, boolean | number | string>,
-        args: Record<string, string>,
-    ) => webpack.Configuration | Promise<webpack.Configuration>,
-    handler: webpack.Compiler.Handler
-): webpack.Compiler.Watching | webpack.Compiler;
-declare function webpack(options: webpack.Configuration[]): webpack.Compiler;
-
-declare function webpack(
-    options: (
-        env: string | Record<string, boolean | number | string>,
-        args: Record<string, string>,
-    ) => webpack.Configuration[] | Promise<webpack.Configuration[]>,
-    handler: webpack.MultiCompiler.Handler,
 ): webpack.MultiWatching | webpack.MultiCompiler;
 declare function webpack(options: webpack.Configuration[]): webpack.MultiCompiler;
 

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -55,6 +55,24 @@ declare function webpack(
 ): webpack.MultiWatching | webpack.MultiCompiler;
 declare function webpack(options: webpack.Configuration[]): webpack.MultiCompiler;
 
+declare function webpack(
+    options: (
+        env: string | Record<string, boolean | number | string>,
+        args: Record<string, string>,
+    ) => webpack.Configuration | Promise<webpack.Configuration>,
+    handler: webpack.Compiler.Handler
+): webpack.Compiler.Watching | webpack.Compiler;
+declare function webpack(options: webpack.Configuration[]): webpack.Compiler;
+
+declare function webpack(
+    options: (
+        env: string | Record<string, boolean | number | string>,
+        args: Record<string, string>,
+    ) => webpack.Configuration[] | Promise<webpack.Configuration[]>,
+    handler: webpack.MultiCompiler.Handler,
+): webpack.MultiWatching | webpack.MultiCompiler;
+declare function webpack(options: webpack.Configuration[]): webpack.MultiCompiler;
+
 declare namespace webpack {
     /** Webpack package version. */
     const version: string | undefined;


### PR DESCRIPTION
Webpack option is supported as a function which can return:
- Configuration (for Compiler)
- Configuration[] (for MultiCompiler)
- Promise\<Configuration> (for Compiler)
- Promise<Configuration[]> (for MultiCompiler)

Closes #37998
---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
Resources for types of options here:
https://webpack.js.org/configuration/configuration-types/#exporting-a-function
Resource for arguments of the configuration function here:
https://webpack.js.org/api/cli/#environment-options

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
