### PR TITLE
rimraf: fix emfileWait type

### DIFF
--- a/types/rimraf/index.d.ts
+++ b/types/rimraf/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>
 //                 e-cloud <https://github.com/e-cloud>
 //                 Ruben Schmidmeister <https://github.com/bash>
+//                 Oganexon <https://github.com/oganexon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Imported from: https://github.com/soywiz/typescript-node-definitions/rimraf.d.ts

--- a/types/rimraf/index.d.ts
+++ b/types/rimraf/index.d.ts
@@ -21,7 +21,7 @@ declare namespace rimraf {
     let BUSYTRIES_MAX: number;
     interface Options {
         maxBusyTries?: number;
-        emfileWait?: boolean;
+        emfileWait?: number;
         disableGlob?: boolean;
         glob?: glob.IOptions | false;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/isaacs/rimraf#options>>


`emfileWait` should be of the number type and not Boolean according to its definition and use.

[Definition](https://github.com/isaacs/rimraf/blob/d82bc81f251ba2cc86dc26361a820631091b3e9e/rimraf.js#L37)
```typescript
            options.emfileWait = options.emfileWait || 1000
```
[Use](https://github.com/isaacs/rimraf/blob/d82bc81f251ba2cc86dc26361a820631091b3e9e/rimraf.js#L91)
```typescript
          if (er.code === "EMFILE" && timeout < options.emfileWait) {
```
