### PR TITLE
fix(pino): changing type from false to boolean of  LoggerOptions.time…

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -7,6 +7,7 @@
 //                 Alex Ferrando <https://github.com/alferpal>
 //                 Oleksandr Sidko <https://github.com/mortiy>
 //                 Harris Lummis <https://github.com/lummish>
+//                 Raoul Jaeckel <https://github.com/raoulus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
@@ -151,7 +152,10 @@ declare namespace P {
      * @param [handler]: Function that will be called by the handler returned from this function
      * @returns Exit listener function that can be supplied to process exit events and will call the supplied handler function
      */
-    function final(logger: Logger, handler: (error: Error, finalLogger: Logger, ...args: any[]) => void): (error: Error | null, ...args: any[]) => void;
+    function final(
+        logger: Logger,
+        handler: (error: Error, finalLogger: Logger, ...args: any[]) => void,
+    ): (error: Error | null, ...args: any[]) => void;
 
     /**
      * The pino.final method can be used to acquire a final logger instance that synchronously flushes on every write.
@@ -164,11 +168,11 @@ declare namespace P {
         /**
          * Returns the mappings of level names to their respective internal number representation.
          */
-        values: { [level: string]: number; };
+        values: { [level: string]: number };
         /**
          * Returns the mappings of level internal level numbers to their string representations.
          */
-        labels: { [level: number]: string; };
+        labels: { [level: number]: string };
     }
     type TimeFn = () => string;
 
@@ -197,7 +201,7 @@ declare namespace P {
          * See stdTimeFunctions for a set of available functions for passing in as a value for this option.
          * Caution: any sort of formatted time will significantly slow down Pino's performance.
          */
-        timestamp?: TimeFn | false;
+        timestamp?: TimeFn | boolean;
         /**
          * One of the supported levels or `silent` to disable logging. Any other value defines a custom level and
          * requires supplying a level value via `levelVal`. Default: 'info'.
@@ -268,21 +272,23 @@ declare namespace P {
              * This option will create a pino-like log object instead of passing all arguments to a console method.
              * When `write` is set, `asObject` will always be `true`.
              */
-            asObject?: boolean,
+            asObject?: boolean;
             /**
              * Instead of passing log messages to console.log they can be passed to a supplied function. If `write` is
              * set to a single function, all logging objects are passed to this function. If write is an object, it can
              * have methods that correspond to the levels. When a message is logged at a given level, the corresponding
              * method is called. If a method isn't present, the logging falls back to using the `console`.
              */
-            write?: WriteFn | ({
-                fatal?: WriteFn;
-                error?: WriteFn;
-                warn?: WriteFn;
-                info?: WriteFn;
-                debug?: WriteFn;
-                trace?: WriteFn;
-            } & { [logLevel: string]: WriteFn });
+            write?:
+                | WriteFn
+                | ({
+                      fatal?: WriteFn;
+                      error?: WriteFn;
+                      warn?: WriteFn;
+                      info?: WriteFn;
+                      debug?: WriteFn;
+                      trace?: WriteFn;
+                  } & { [logLevel: string]: WriteFn });
         };
         /**
          * key-value object added as child logger to each log line. If set to null the base child logger is not added
@@ -353,7 +359,7 @@ declare namespace P {
         [key: string]: any;
     }
 
-    type Logger = BaseLogger & { [key: string]: LogFn; };
+    type Logger = BaseLogger & { [key: string]: LogFn };
 
     interface BaseLogger extends EventEmitter {
         /**
@@ -496,7 +502,12 @@ declare namespace P {
         isLevelEnabled(level: LevelWithSilent | string): boolean;
     }
 
-    type LevelChangeEventListener = (lvl: LevelWithSilent | string, val: number, prevLvl: LevelWithSilent | string, prevVal: number) => void;
+    type LevelChangeEventListener = (
+        lvl: LevelWithSilent | string,
+        val: number,
+        prevLvl: LevelWithSilent | string,
+        prevVal: number,
+    ) => void;
 
     interface LogFn {
         (msg: string, ...args: any[]): void;


### PR DESCRIPTION
Some code formatting was done as well, sorry for that.

The only change was from `timestamp?: TimeFn | false` to `timestamp?: TimeFn | boolean`

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

