### PR TITLE
[@types/react-material-ui-form-validator 2.0.9] Added missing SelectValidator export.

### DIFF
--- a/types/react-material-ui-form-validator/index.d.ts
+++ b/types/react-material-ui-form-validator/index.d.ts
@@ -32,5 +32,6 @@ export interface ValidatorComponentProps {
     withRequiredValidator?: boolean;
     [key: string]: any;
 }
+export class ValidatorComponent extends React.Component<ValidatorComponentProps> {}
 export class TextValidator extends React.Component<ValidatorComponentProps & TextFieldProps> {}
 export class SelectValidator extends React.Component<ValidatorComponentProps & SelectFieldProps> {}

--- a/types/react-material-ui-form-validator/index.d.ts
+++ b/types/react-material-ui-form-validator/index.d.ts
@@ -5,8 +5,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
-import * as React from "react";
-import { TextFieldProps } from "material-ui";
+import * as React from 'react';
+import { TextFieldProps } from 'material-ui';
+import { SelectFieldProps } from 'material-ui';
 
 export interface ValidatorFormProps {
     className?: string;
@@ -32,5 +33,5 @@ export interface ValidatorComponentProps {
     withRequiredValidator?: boolean;
     [key: string]: any;
 }
-export class ValidatorComponent extends React.Component<ValidatorComponentProps & TextFieldProps> {}
-export class TextValidator extends ValidatorComponent {}
+export class TextValidator extends React.Component<ValidatorComponentProps & TextFieldProps> {}
+export class SelectValidator extends React.Component<ValidatorComponentProps & SelectFieldProps> {}

--- a/types/react-material-ui-form-validator/index.d.ts
+++ b/types/react-material-ui-form-validator/index.d.ts
@@ -6,8 +6,7 @@
 // TypeScript Version: 3.1
 
 import * as React from 'react';
-import { TextFieldProps } from 'material-ui';
-import { SelectFieldProps } from 'material-ui';
+import { SelectFieldProps, TextFieldProps } from 'material-ui';
 
 export interface ValidatorFormProps {
     className?: string;

--- a/types/react-material-ui-form-validator/react-material-ui-form-validator-tests.tsx
+++ b/types/react-material-ui-form-validator/react-material-ui-form-validator-tests.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
+
 import {
+    SelectValidator,
     TextValidator,
-    ValidatorComponent,
     ValidatorForm
 } from 'react-material-ui-form-validator';
+
+import { MenuItem } from 'material-ui'
 
 class Test extends React.Component {
     onSubmitted = (event: React.FormEvent) => {
@@ -28,14 +31,18 @@ class Test extends React.Component {
                 onSubmit={this.onSubmitted}
                 onError={this.onError}
             >
-                <ValidatorComponent
+                <SelectValidator
                     errorMessages={['Field is required']}
                     validators={['required']}
                     name={'Field'}
-                    value={'value'}
+                    value={'option1'}
                     validatorListener={this.onValidate}
                     withRequiredValidator={true}
-                />
+                >
+                     <MenuItem value='option1'>Option1</MenuItem>
+                     <MenuItem value='option2'>Option2</MenuItem>
+                     <MenuItem value='option3'>Option3</MenuItem>
+                </SelectValidator>
                 <TextValidator
                     name="textValidator"
                     value="value"

--- a/types/react-material-ui-form-validator/react-material-ui-form-validator-tests.tsx
+++ b/types/react-material-ui-form-validator/react-material-ui-form-validator-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { SelectValidator, TextValidator, ValidatorForm } from 'react-material-ui-form-validator';
+import { SelectValidator, TextValidator, ValidatorComponent, ValidatorForm } from 'react-material-ui-form-validator';
 
 import { MenuItem } from 'material-ui';
 
@@ -22,6 +22,14 @@ class Test extends React.Component {
     render() {
         return (
             <ValidatorForm instantValidate={true} debounceTime={10} onSubmit={this.onSubmitted} onError={this.onError}>
+                <ValidatorComponent
+                    errorMessages={['Field is required']}
+                    validators={['required']}
+                    name={'Field'}
+                    value={'value'}
+                    validatorListener={this.onValidate}
+                    withRequiredValidator={true}
+                />
                 <SelectValidator
                     errorMessages={['Field is required']}
                     validators={['required']}

--- a/types/react-material-ui-form-validator/react-material-ui-form-validator-tests.tsx
+++ b/types/react-material-ui-form-validator/react-material-ui-form-validator-tests.tsx
@@ -1,12 +1,8 @@
 import * as React from 'react';
 
-import {
-    SelectValidator,
-    TextValidator,
-    ValidatorForm
-} from 'react-material-ui-form-validator';
+import { SelectValidator, TextValidator, ValidatorForm } from 'react-material-ui-form-validator';
 
-import { MenuItem } from 'material-ui'
+import { MenuItem } from 'material-ui';
 
 class Test extends React.Component {
     onSubmitted = (event: React.FormEvent) => {
@@ -25,12 +21,7 @@ class Test extends React.Component {
 
     render() {
         return (
-            <ValidatorForm
-                instantValidate={true}
-                debounceTime={10}
-                onSubmit={this.onSubmitted}
-                onError={this.onError}
-            >
+            <ValidatorForm instantValidate={true} debounceTime={10} onSubmit={this.onSubmitted} onError={this.onError}>
                 <SelectValidator
                     errorMessages={['Field is required']}
                     validators={['required']}
@@ -39,9 +30,9 @@ class Test extends React.Component {
                     validatorListener={this.onValidate}
                     withRequiredValidator={true}
                 >
-                     <MenuItem value='option1'>Option1</MenuItem>
-                     <MenuItem value='option2'>Option2</MenuItem>
-                     <MenuItem value='option3'>Option3</MenuItem>
+                    <MenuItem value="option1">Option1</MenuItem>
+                    <MenuItem value="option2">Option2</MenuItem>
+                    <MenuItem value="option3">Option3</MenuItem>
                 </SelectValidator>
                 <TextValidator
                     name="textValidator"

--- a/types/react-material-ui-form-validator/react-material-ui-form-validator-tests.tsx
+++ b/types/react-material-ui-form-validator/react-material-ui-form-validator-tests.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
-
-import { SelectValidator, TextValidator, ValidatorComponent, ValidatorForm } from 'react-material-ui-form-validator';
-
+import {
+    SelectValidator,
+    TextValidator,
+    ValidatorComponent,
+    ValidatorForm
+} from 'react-material-ui-form-validator';
 import { MenuItem } from 'material-ui';
 
 class Test extends React.Component {
@@ -21,7 +24,12 @@ class Test extends React.Component {
 
     render() {
         return (
-            <ValidatorForm instantValidate={true} debounceTime={10} onSubmit={this.onSubmitted} onError={this.onError}>
+            <ValidatorForm
+                instantValidate={true}
+                debounceTime={10}
+                onSubmit={this.onSubmitted}
+                onError={this.onError}
+            >
                 <ValidatorComponent
                     errorMessages={['Field is required']}
                     validators={['required']}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/NewOldMax/react-material-ui-form-validator#readme> <https://github.com/NewOldMax/react-material-ui-form-validator/blob/master/src/SelectValidator.jsx>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
