### PR TITLE
Add type definitions for the connect-azuretables package

### DIFF
--- a/types/connect-azuretables/connect-azuretables-tests.ts
+++ b/types/connect-azuretables/connect-azuretables-tests.ts
@@ -1,0 +1,65 @@
+import express = require('express');
+import session = require('express-session');
+import connectAzureTables = require('connect-azuretables');
+
+const app = express();
+
+/// Create Azure Tables Store Factory
+
+const AzureTablesStoreFactory = connectAzureTables(session);
+
+/// Use AzureTableStore
+
+// Default settings
+app.use(
+    session({
+        secret: 'secret',
+        store: AzureTablesStoreFactory.create({}),
+    }),
+);
+
+// Loggers
+app.use(
+    session({
+        secret: 'secret',
+        store: AzureTablesStoreFactory.create({
+            logger: console.log,
+            errorLogger: console.error,
+        }),
+    }),
+);
+
+// Override Azure Table keys
+app.use(
+    session({
+        secret: 'secret',
+        store: AzureTablesStoreFactory.create({
+            accessKey: '',
+            storageAccount: '',
+            table: '',
+        }),
+    }),
+);
+
+// Override cron settings and timeout
+app.use(
+    session({
+        secret: 'secret',
+        store: AzureTablesStoreFactory.create({
+            overrideCron: '',
+            sessionTimeOut: 30,
+        }),
+    }),
+);
+
+// Manual methods
+
+const store = AzureTablesStoreFactory.create({});
+app.use(
+    session({
+        secret: 'secret',
+        store,
+    }),
+);
+
+store.startBackgroundCleanUp();

--- a/types/connect-azuretables/index.d.ts
+++ b/types/connect-azuretables/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for connect-azuretables 1.0
+// Project: https://github.com/mike-goodwin/connect-azuretables
+// Definitions by: Mikael Brevik <https://github.com/mikaelbr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import * as express from 'express';
+import * as session from 'express-session';
+
+declare function connectAzureTable(
+    session: (options?: session.SessionOptions) => express.RequestHandler,
+): connectAzureTable.AzureTableStoreFactory;
+
+declare namespace connectAzureTable {
+    interface AzureTableStoreFactory {
+        create(options: AzureTableStoreOptions): AzureTableStore;
+    }
+    interface AzureTableStore extends session.Store {
+        startBackgroundCleanUp(): void;
+        cleanUp(): void;
+        update(method: 'SET' | 'TOUCH', sid: string, session: Express.SessionData, callback?: (err: any) => void): void;
+    }
+    interface AzureTableStoreOptions {
+        logger?: (message: string) => void;
+        errorLogger?: (message: string) => void;
+        sessionTimeOut?: number; // sessionTimeOut in minutes
+        overrideCron?: string; // cron job description
+        storageAccount?: string;
+        accessKey?: string;
+        table?: string;
+    }
+}
+
+export = connectAzureTable;

--- a/types/connect-azuretables/tsconfig.json
+++ b/types/connect-azuretables/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "connect-azuretables-tests.ts"
+    ]
+}

--- a/types/connect-azuretables/tslint.json
+++ b/types/connect-azuretables/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Add definitions for [connect-azuretables](https://www.npmjs.com/package/connect-azuretables).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


Adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.