### PR TITLE
sloc 0.2: Add types

### DIFF
--- a/types/sloc/index.d.ts
+++ b/types/sloc/index.d.ts
@@ -1,0 +1,109 @@
+// Type definitions for sloc 0.2
+// Project: https://github.com/flosse/sloc#readme
+// Definitions by: Gary King <https://github.com/garyking>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+declare function sloc(code: string, extension: string, options?: sloc.Options): Record<sloc.Key, number>;
+
+declare namespace sloc {
+    const keys: Key[];
+
+    const extensions: Extension[];
+
+    interface Options {
+        debug: boolean;
+    }
+
+    type Extension =
+        | 'asm'
+        | 'brs'
+        | 'c'
+        | 'cc'
+        | 'clj'
+        | 'cljs'
+        | 'cls'
+        | 'coffee'
+        | 'cpp'
+        | 'cr'
+        | 'cs'
+        | 'css'
+        | 'cxx'
+        | 'erl'
+        | 'f90'
+        | 'f95'
+        | 'f03'
+        | 'f08'
+        | 'f18'
+        | 'fs'
+        | 'fsi'
+        | 'fsx'
+        | 'go'
+        | 'groovy'
+        | 'gs'
+        | 'h'
+        | 'handlebars'
+        | 'hbs'
+        | 'hpp'
+        | 'hr'
+        | 'hs'
+        | 'html'
+        | 'htm'
+        | 'hx'
+        | 'hxx'
+        | 'hy'
+        | 'iced'
+        | 'ily'
+        | 'ino'
+        | 'jade'
+        | 'java'
+        | 'jl'
+        | 'js'
+        | 'jsx'
+        | 'mjs'
+        | 'kt'
+        | 'kts'
+        | 'latex'
+        | 'less'
+        | 'ly'
+        | 'lua'
+        | 'ls'
+        | 'ml'
+        | 'mli'
+        | 'mochi'
+        | 'monkey'
+        | 'mustache'
+        | 'nix'
+        | 'nim'
+        | 'nut'
+        | 'php'
+        | 'php5'
+        | 'pl'
+        | 'py'
+        | 'r'
+        | 'rb'
+        | 'rkt'
+        | 'rs'
+        | 'sass'
+        | 'scala'
+        | 'scss'
+        | 'sty'
+        | 'styl'
+        | 'svg'
+        | 'sql'
+        | 'swift'
+        | 'tex'
+        | 'ts'
+        | 'tsx'
+        | 'vb'
+        | 'vue'
+        | 'xml'
+        | 'yaml'
+        | 'm'
+        | 'mm'
+        | 'bsl';
+
+    type Key = 'total' | 'source' | 'comment' | 'single' | 'block' | 'mixed' | 'blockEmpty' | 'empty' | 'todo';
+}
+
+export = sloc;

--- a/types/sloc/sloc-tests.ts
+++ b/types/sloc/sloc-tests.ts
@@ -1,0 +1,7 @@
+import sloc = require('sloc');
+
+const stats = sloc('const a = 1;\nconsole.log(a);', 'js');
+const statsDebugged = sloc('const a = 1;\nconsole.log(a);', 'ts', { debug: true });
+
+const keys = sloc.keys;
+const extensions = sloc.extensions;

--- a/types/sloc/tsconfig.json
+++ b/types/sloc/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "sloc-tests.ts"
+    ]
+}

--- a/types/sloc/tslint.json
+++ b/types/sloc/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

