### PR TITLE
ActionCable: Subscriptions.create obj is optional.

### DIFF
--- a/types/actioncable/index.d.ts
+++ b/types/actioncable/index.d.ts
@@ -13,7 +13,7 @@ declare module ActionCable {
   }
 
   interface Subscriptions {
-    create(channel: string|ChannelNameWithParams, obj: CreateMixin): Channel;
+    create(channel: string|ChannelNameWithParams, obj?: CreateMixin): Channel;
   }
 
   interface Cable {


### PR DESCRIPTION
See:
- https://guides.rubyonrails.org/action_cable_overview.html#subscriber
- https://guides.rubyonrails.org/action_cable_overview.html#client-server-interactions-subscriptions
- https://github.com/rails/rails/blob/master/actioncable/app/javascript/action_cable/subscription.js#L59-L67