### PR TITLE
[@ember/debug] Fix type for `assert`.

### DIFF
--- a/types/ember__debug/ember__debug-tests.ts
+++ b/types/ember__debug/ember__debug-tests.ts
@@ -30,8 +30,18 @@ debug('Too many tomsters!', 'foo'); // $ExpectError
 const str = 'hello';
 assert('Must pass a string', typeof str === 'string'); // $ExpectType void
 
+const anObject = {};
+assert('Must pass an object', anObject); // $ExpectType void
+
+// Test with null and undefined
+assert('Can handle falsiness', null); // $ExpectType void
+assert('Can handle falsiness', undefined); // $ExpectType void
+
 // Fail unconditionally
 assert('This code path should never be run'); // $ExpectType void
+
+// Require first argument
+assert(); // $ExpectError
 
 // next is not called, so no warnings get the default behavior
 registerWarnHandler(); // $ExpectError

--- a/types/ember__debug/index.d.ts
+++ b/types/ember__debug/index.d.ts
@@ -7,7 +7,7 @@
 /**
  * Define an assertion that will throw an exception if the condition is not met.
  */
-export function assert(desc: string, test?: boolean): void | never;
+export function assert(desc: string, test?: any): void | never;
 /**
  * Display a debug notice.
  */


### PR DESCRIPTION
- Loosen the type to match the actual implementation.
- Add tests for the new looser type, and backfill tests for other supported behavior at the same time.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/emberjs/ember.js/pull/18517>

    (Note: the changes are *inbound*, not yet merged; but the change is simply making the YUIDoc type match the description and implementation.)

---

Fixes #39407 