### PR TITLE
columnify 1.5: Add type definitions

### DIFF
--- a/types/columnify/columnify-tests.ts
+++ b/types/columnify/columnify-tests.ts
@@ -1,0 +1,198 @@
+import columnify = require('columnify');
+
+/**
+ * Objects
+ */
+let data: any = {
+    'commander@0.6.1': 1,
+    'minimatch@0.2.14': 3,
+    'mkdirp@0.3.5': 2,
+    'sigmund@1.0.0': 3,
+};
+
+columnify(data);
+
+/**
+ * Column Names
+ */
+data = {
+    'commander@0.6.1': 1,
+    'minimatch@0.2.14': 3,
+    'mkdirp@0.3.5': 2,
+    'sigmund@1.0.0': 3,
+};
+
+columnify(data, { columns: ['MODULE', 'COUNT'] });
+
+/**
+ * Arrays of Objects
+ */
+columnify([
+    {
+        name: 'mod1',
+        version: '0.0.1',
+    },
+    {
+        name: 'module2',
+        version: '0.2.0',
+    },
+]);
+
+/**
+ * Filtering & Ordering
+ */
+data = [
+    {
+        name: 'module1',
+        description: 'some description',
+        version: '0.0.1',
+    },
+    {
+        name: 'module2',
+        description: 'another description',
+        version: '0.2.0',
+    },
+];
+
+columnify(data, {
+    columns: ['name', 'version'],
+});
+
+/**
+ * Maximum and Minimum Column Widths
+ */
+columnify(
+    [
+        {
+            name: 'mod1',
+            description: 'some description which happens to be far larger than the max',
+            version: '0.0.1',
+        },
+        {
+            name: 'module-two',
+            description: 'another description larger than the max',
+            version: '0.2.0',
+        },
+    ],
+    {
+        minWidth: 20,
+        config: {
+            description: { maxWidth: 30 },
+        },
+    },
+);
+
+/**
+ * Truncating
+ */
+columnify(data, {
+    truncate: true,
+    config: {
+        description: {
+            maxWidth: 20,
+        },
+    },
+});
+
+/**
+ * Align Right/Center
+ */
+data = {
+    'mocha@1.18.2': 1,
+    'commander@2.0.0': 1,
+    'debug@0.8.1': 1,
+};
+
+columnify(data, { config: { value: { align: 'right' } } });
+
+/**
+ * Padding Character
+ */
+data = {
+    shortKey: 'veryVeryVeryVeryVeryLongVal',
+    veryVeryVeryVeryVeryLongKey: 'shortVal',
+};
+
+columnify(data, { paddingChr: '.' });
+
+/**
+ * Preserve Existing Newlines
+ */
+data = [
+    {
+        name: 'glob@3.2.9',
+        paths: ['node_modules/tap/node_modules/glob', 'node_modules/tape/node_modules/glob'].join('\n'),
+    },
+    {
+        name: 'nopt@2.2.1',
+        paths: ['node_modules/tap/node_modules/nopt'],
+    },
+    {
+        name: 'runforcover@0.0.2',
+        paths: 'node_modules/tap/node_modules/runforcover',
+    },
+];
+
+columnify(data, { preserveNewLines: true });
+
+/**
+ * Custom Truncation Marker
+ */
+columnify(data, {
+    truncate: true,
+    truncateMarker: '>',
+    widths: {
+        description: {
+            maxWidth: 20,
+        },
+    },
+});
+
+/**
+ * Custom Column Splitter
+ */
+columnify(data, {
+    columnSplitter: ' | ',
+});
+
+/**
+ * Control Header Display
+ */
+columnify(data, {
+    showHeaders: false,
+});
+
+columnify(data, {
+    config: {
+        id: { showHeaders: false },
+    },
+});
+
+/**
+ * Transforming Column Data and Headers
+ */
+columnify(
+    [
+        {
+            name: 'mod1',
+            description: 'SOME DESCRIPTION TEXT.',
+        },
+        {
+            name: 'module-two',
+            description: 'SOME SLIGHTLY LONGER DESCRIPTION TEXT.',
+        },
+    ],
+    {
+        dataTransform: function(data) {
+            return data.toLowerCase();
+        },
+        config: {
+            name: {
+                headingTransform: function(heading) {
+                    heading = 'module ' + heading;
+                    return '*' + heading.toUpperCase() + '*';
+                },
+            },
+        },
+    },
+);

--- a/types/columnify/columnify-tests.ts
+++ b/types/columnify/columnify-tests.ts
@@ -183,14 +183,14 @@ columnify(
         },
     ],
     {
-        dataTransform: function(data) {
+        dataTransform(data) {
             return data.toLowerCase();
         },
         config: {
             name: {
-                headingTransform: function(heading) {
+                headingTransform(heading) {
                     heading = 'module ' + heading;
-                    return '*' + heading.toUpperCase() + '*';
+                    return `*${heading.toUpperCase()}*`;
                 },
             },
         },

--- a/types/columnify/index.d.ts
+++ b/types/columnify/index.d.ts
@@ -1,39 +1,35 @@
 // Type definitions for columnify 1.5
 // Project: https://github.com/timoxley/columnify
-// Definitions by: Gary King <https://github.com/DefinitelyTyped>
+// Definitions by: Gary King <https://github.com/garyking>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/*~ If this module is a UMD module that exposes a global variable 'myLib' when
- *~ loaded outside a module loader environment, declare that global here.
- *~ Otherwise, delete this declaration.
- */
-export as namespace myLib;
+declare function columnify(data: Record<string, any> | any[], options?: columnify.GlobalOptions): string;
 
-/*~ If this module has methods, declare them as functions like so.
- */
-export function myMethod(a: string): string;
-export function myOtherMethod(a: number): number;
+declare namespace columnify {
+    export interface Options {
+        align?: 'left' | 'center' | 'centre' | 'right';
+        dataTransform?: (data: string) => string;
+        headingTransform?: (data: string) => string;
+        minWidth?: number;
+        maxWidth?: number;
+        paddingChr?: string;
+        preserveNewLines?: boolean;
+        showHeaders?: boolean;
+        truncateMarker?: string;
+    }
 
-/*~ You can declare types that are available via importing the module */
-export interface someType {
-    name: string;
-    length: number;
-    extras?: string[];
+    export interface GlobalOptions extends Options {
+        columns?: string[];
+        columnSplitter?: string;
+        config?: {
+            [columnName: string]: Options;
+        };
+        maxLineWidth?: number;
+        truncate?: boolean;
+        widths?: {
+            [columnName: string]: Pick<Options, 'minWidth' | 'maxWidth'>;
+        };
+    }
 }
 
-/*~ You can declare properties of the module using const, let, or var */
-export const myField: number;
-
-/*~ If there are types, properties, or methods inside dotted names
- *~ of the module, declare them inside a 'namespace'.
- */
-export namespace subProp {
-    /*~ For example, given this definition, someone could write:
-     *~   import { subProp } from 'yourModule';
-     *~   subProp.foo();
-     *~ or
-     *~   import * as yourMod from 'yourModule';
-     *~   yourMod.subProp.foo();
-     */
-    function foo(): void;
-}
+export = columnify;

--- a/types/columnify/index.d.ts
+++ b/types/columnify/index.d.ts
@@ -2,11 +2,12 @@
 // Project: https://github.com/timoxley/columnify
 // Definitions by: Gary King <https://github.com/garyking>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 declare function columnify(data: Record<string, any> | any[], options?: columnify.GlobalOptions): string;
 
 declare namespace columnify {
-    export interface Options {
+    interface Options {
         align?: 'left' | 'center' | 'centre' | 'right';
         dataTransform?: (data: string) => string;
         headingTransform?: (data: string) => string;
@@ -18,7 +19,7 @@ declare namespace columnify {
         truncateMarker?: string;
     }
 
-    export interface GlobalOptions extends Options {
+    interface GlobalOptions extends Options {
         columns?: string[];
         columnSplitter?: string;
         config?: {

--- a/types/columnify/index.d.ts
+++ b/types/columnify/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for columnify 1.5
+// Project: https://github.com/timoxley/columnify
+// Definitions by: Gary King <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*~ If this module is a UMD module that exposes a global variable 'myLib' when
+ *~ loaded outside a module loader environment, declare that global here.
+ *~ Otherwise, delete this declaration.
+ */
+export as namespace myLib;
+
+/*~ If this module has methods, declare them as functions like so.
+ */
+export function myMethod(a: string): string;
+export function myOtherMethod(a: number): number;
+
+/*~ You can declare types that are available via importing the module */
+export interface someType {
+    name: string;
+    length: number;
+    extras?: string[];
+}
+
+/*~ You can declare properties of the module using const, let, or var */
+export const myField: number;
+
+/*~ If there are types, properties, or methods inside dotted names
+ *~ of the module, declare them inside a 'namespace'.
+ */
+export namespace subProp {
+    /*~ For example, given this definition, someone could write:
+     *~   import { subProp } from 'yourModule';
+     *~   subProp.foo();
+     *~ or
+     *~   import * as yourMod from 'yourModule';
+     *~   yourMod.subProp.foo();
+     */
+    function foo(): void;
+}

--- a/types/columnify/tsconfig.json
+++ b/types/columnify/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "columnify-tests.ts"
+    ]
+}

--- a/types/columnify/tslint.json
+++ b/types/columnify/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

