### PR TITLE
ActionCable: CreateMixin excess properties can be any type.

### DIFF
--- a/types/actioncable/index.d.ts
+++ b/types/actioncable/index.d.ts
@@ -28,7 +28,7 @@ declare module ActionCable {
     connected?(): void;
     disconnected?(): void;
     received?(obj: any): void;
-    [key: string]: Function;
+    [key: string]: any;
   }
 
   interface ChannelNameWithParams {


### PR DESCRIPTION
ActionCable.CreateMixin acts as, literally, a class mixin, thus, its properties can be anything.

See: https://github.com/rails/rails/blob/master/actioncable/app/assets/javascripts/action_cable.js#L328-L336