### PR TITLE
analytics-node - export whole AnalyticsNode namespace

### DIFF
--- a/types/analytics-node/index.d.ts
+++ b/types/analytics-node/index.d.ts
@@ -4,7 +4,9 @@
 //                 Thomas Thiebaud <https://github.com/thomasthiebaud>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export = AnalyticsNode.Analytics;
+declare module 'analytics-node' {
+  export = AnalyticsNode;
+}
 
 declare namespace AnalyticsNode {
   interface Message {


### PR DESCRIPTION
Sometimes need access to the other items in the namespace - current export doesn't allow it

- [x] - this is a minor change