### PR TITLE
[express-session] Add 'auto' value to cookie.secure

### DIFF
--- a/types/connect-pg-simple/index.d.ts
+++ b/types/connect-pg-simple/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/voxpelli/node-connect-pg-simple#readme
 // Definitions by: Pasi Eronen <https://github.com/pasieronen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.8
 
 import { RequestHandler } from "express";
 import { Store, SessionOptions } from "express-session";

--- a/types/connect-redis/index.d.ts
+++ b/types/connect-redis/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Xavier Stouder <https://github.com/xstoudi>
 //				   Seth Butler <https://github.com/sbutler2901>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="express" />
 /// <reference types="express-session" />

--- a/types/documentdb-session/index.d.ts
+++ b/types/documentdb-session/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/dwhieb/documentdb-session#readme
 // Definitions by: Daniel Rosenwasser <https://github.com/DanielRosenwasser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import session = require("express-session");
 

--- a/types/easy-session/index.d.ts
+++ b/types/easy-session/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/DeadAlready/node-easy-session
 // Definitions by: Karl Düüna <https://github.com/DeadAlready>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="express" />
 

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -5,7 +5,7 @@
 //                 Naoto Yokoyama <https://github.com/builtinnya>
 //                 Ryan Cannon <https://github.com/ry7n>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="node" />
 
@@ -53,12 +53,14 @@ declare global {
 
 declare function session(options?: session.SessionOptions): express.RequestHandler;
 
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
 declare namespace session {
   interface SessionOptions {
     secret: string | string[];
     name?: string;
     store?: Store | MemoryStore;
-    cookie?: express.CookieOptions;
+    cookie?: Omit<express.CookieOptions, 'secure'> & { secure?: boolean | 'auto' };
     genid?(req: express.Request): string;
     rolling?: boolean;
     resave?: boolean;

--- a/types/express-socket.io-session/index.d.ts
+++ b/types/express-socket.io-session/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/oskosk/express-socket.io-session
 // Definitions by: AylaJK <https://github.com/AylaJK>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import socketio = require('socket.io');
 import express = require('express');

--- a/types/koa-passport/index.d.ts
+++ b/types/koa-passport/index.d.ts
@@ -4,7 +4,7 @@
 //                 Tomek Łaziuk <https://github.com/tlaziuk>
 //                 Tümay Çeber <https://github.com/brendtumi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /* =================== USAGE ===================
 

--- a/types/passport-anonymous/index.d.ts
+++ b/types/passport-anonymous/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/passport-anonymous
 // Definitions by: Pavel Puchkov <https://github.com/0x6368656174>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as passport from "passport";
 

--- a/types/passport-auth0/index.d.ts
+++ b/types/passport-auth0/index.d.ts
@@ -4,7 +4,7 @@
 //                 Vishnu Sankar <https://github.com/iamvishnusankar>
 //                 Duncan Hall <https://github.com/duncanhall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import passport = require('passport');
 import express = require('express');

--- a/types/passport-beam/index.d.ts
+++ b/types/passport-beam/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/alfw/passport-beam
 // Definitions by: AtlasDev <https://github.com/AtlasDev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 ///<reference types="passport"/>
 ///<reference types="express"/>

--- a/types/passport-bnet/index.d.ts
+++ b/types/passport-bnet/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Blizzard/passport-bnet#readme
 // Definitions by: Ivan Fernandes <https://github.com/ivan94>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import { Strategy as OAuth2Strategy, VerifyFunction, VerifyFunctionWithRequest, _StrategyOptionsBase } from 'passport-oauth2';
 

--- a/types/passport-cognito/index.d.ts
+++ b/types/passport-cognito/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kndt84/passport-cognito
 // Definitions by: Maksym Butsykin <https://github.com/mbutsykin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import passport = require('passport');
 import express = require('express');

--- a/types/passport-discord/index.d.ts
+++ b/types/passport-discord/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nicholastay/passport-discord#readme
 // Definitions by: Gonthier Renaud <https://github.com/kzay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as passport from 'passport';
 import * as express from 'express';

--- a/types/passport-facebook-token/index.d.ts
+++ b/types/passport-facebook-token/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/drudge/passport-facebook-token
 // Definitions by: Ray Martone <https://github.com/rmartone>, Michael Randolph <https://github.com/mrand01>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as passport from 'passport';
 import * as express from 'express';

--- a/types/passport-facebook/index.d.ts
+++ b/types/passport-facebook/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/passport-facebook
 // Definitions by: James Roland Cabresos <https://github.com/staticfunction>, Lucas Acosta <https://github.com/lucasmacosta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import passport = require('passport');
 import express = require('express');

--- a/types/passport-google-oauth/index.d.ts
+++ b/types/passport-google-oauth/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/passport-google-oauth
 // Definitions by: James Roland Cabresos <https://github.com/staticfunction>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="passport"/>
 

--- a/types/passport-http-bearer/index.d.ts
+++ b/types/passport-http-bearer/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/passport-http-bearer
 // Definitions by: Isman Usoh <https://github.com/isman-usoh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="passport"/>
 /// <reference types="express" />

--- a/types/passport-http/index.d.ts
+++ b/types/passport-http/index.d.ts
@@ -5,7 +5,7 @@
 //                 Chris Barth <https://github.com/cjbarth>
 //                 James Adarich <https://github.com/jamesadarich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import passport = require("passport");
 import express = require("express");

--- a/types/passport-jwt/index.d.ts
+++ b/types/passport-jwt/index.d.ts
@@ -7,7 +7,7 @@
 //                 Byungjin Kim <https://github.com/jindev>
 //                 Svyatoslav Bychkov <https://github.com/stbychkov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import { Strategy as PassportStrategy } from 'passport-strategy';
 import {Request} from 'express';

--- a/types/passport-kakao/index.d.ts
+++ b/types/passport-kakao/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Park9eon <https://github.com/Park9eon>
 //                 ZeroCho <https://github.com/zerocho>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import passport = require("passport");
 import express = require("express");

--- a/types/passport-linkedin-oauth2/index.d.ts
+++ b/types/passport-linkedin-oauth2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/auth0/passport-linkedin-oauth2
 // Definitions by: Andrew Vetovitz <https://github.com/andrewvetovitz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import { Profile as passportProfile, AuthenticateOptions as PassportAuthenticateOptions, Strategy as passportStrategy } from 'passport';
 import { Request } from 'express';

--- a/types/passport-local/index.d.ts
+++ b/types/passport-local/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/passport-local
 // Definitions by: Maxime LUCE <https://github.com/SomaticIT>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="passport"/>
 

--- a/types/passport-naver/index.d.ts
+++ b/types/passport-naver/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Park9eon <https://github.com/Park9eon>
 //                 ZeroCho <https://github.com/zerocho>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import passport = require("passport");
 import express = require("express");

--- a/types/passport-oauth2-client-password/index.d.ts
+++ b/types/passport-oauth2-client-password/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/passport-oauth2-client-password
 // Definitions by: Ivan Zubok <https://github.com/akaNightmare>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="passport"/>
 /// <reference types="express"/>

--- a/types/passport-oauth2/index.d.ts
+++ b/types/passport-oauth2/index.d.ts
@@ -5,7 +5,7 @@
 //                 Eduardo AC <https://github.com/EduardoAC>
 //                 Ivan Fernandes <https://github.com/ivan94>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import { Request } from 'express';
 import { Strategy } from 'passport';

--- a/types/passport-remember-me-extended/index.d.ts
+++ b/types/passport-remember-me-extended/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/dereklakin/passport-remember-me
 // Definitions by: AylaJK <https://github.com/AylaJK>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import passport = require('passport');
 import express = require('express');

--- a/types/passport-steam/index.d.ts
+++ b/types/passport-steam/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/liamcurry/passport-steam
 // Definitions by: Gonthier Renaud <https://github.com/kzay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 export = passport_steam;
 

--- a/types/passport-strategy/index.d.ts
+++ b/types/passport-strategy/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/passport-strategy
 // Definitions by: Lior Mualem <https://github.com/liorm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="passport"/>
 

--- a/types/passport-twitter/index.d.ts
+++ b/types/passport-twitter/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/passport-twitter
 // Definitions by: James Roland Cabresos <https://github.com/staticfunction>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="passport"/>
 

--- a/types/passport-unique-token/index.d.ts
+++ b/types/passport-unique-token/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: briman0094 <https://github.com/briman0094>
 //                 Maxime LUCE <https://github.com/SomaticIT>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import passport = require('passport');
 import express = require('express');

--- a/types/passport-vkontakte/index.d.ts
+++ b/types/passport-vkontakte/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/stevebest/passport-vkontakte#readme
 // Definitions by: Anton Lobashev <https://github.com/soulthreads>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as passport from 'passport';
 import * as express from 'express';

--- a/types/passport-windowsauth/index.d.ts
+++ b/types/passport-windowsauth/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/auth0/passport-windowsauth#readme
 // Definitions by: Emily Marigold Klassen <https://github.com/forivall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as express from 'express';
 import * as passport from 'passport';

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -8,7 +8,7 @@
 //                 Kevin Stiehl <https://github.com/kstiehl>
 //                 Oleg Vaskevich <https://github.com/vaskevich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 declare global {
     namespace Express {

--- a/types/samlp/index.d.ts
+++ b/types/samlp/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/auth0/node-samlp
 // Definitions by: horiuchi <https://github.com/horiuchi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="express" />
 /// <reference types="passport" />

--- a/types/session-file-store/index.d.ts
+++ b/types/session-file-store/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Gevik Babakhani <https://github.com/blendsdk>
 //                 Junyoung Choi <https://github.com/rokt33r>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as express from "express";
 import * as session from "express-session";

--- a/types/socket.io.users/index.d.ts
+++ b/types/socket.io.users/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nodets/socket.io.users
 // Definitions by: Makis Maropoulos <https://github.com/kataras>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import { EventEmitter } from 'events';
 import { Application } from "express";

--- a/types/steam-login/index.d.ts
+++ b/types/steam-login/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://github.com/cpancake/steam-login
 // Definitions by: Nick Winans <https://github.com/Nicell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import { Request, RequestHandler } from 'express';
 


### PR DESCRIPTION
https://github.com/expressjs/session/issues/703

express-session supports the `auto` value for the `cookie.secure` option.
https://github.com/expressjs/session#cookiesecure
https://github.com/expressjs/session/blob/master/index.js#L163
> The cookie.secure option can also be set to the special value 'auto' to have this setting automatically match the determined security of the connection.

Updated TypeScript Version with dependencies and passed the npm test.
