### PR TITLE
feat: Add `internal‑slot`

### DIFF
--- a/types/internal-slot/index.d.ts
+++ b/types/internal-slot/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for internal-slot 1.0
+// Project: https://github.com/ljharb/internal-slot#readme
+// Definitions by: ExE Boss <https://github.com/ExE-Boss>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+/**
+ * Asserts that `O` is an `object`, `slot` is a `string`
+ * and `O` has the internal slot `slot`.
+ */
+export function assert(O: object, slot: string): void;
+
+/**
+ * Gets the value of `O`'s internal slot `slot`.
+ */
+export function get(O: object, slot: string): any;
+
+/**
+ * Checks that `O` has the internal slot `slot`.
+ */
+export function has(O: object, slot: string): boolean;
+
+/**
+ * Sets the object `O`'s internal slot `slot`'s value to `V`.
+ */
+export function set(O: object, slot: string, V: any): void;

--- a/types/internal-slot/internal-slot-tests.ts
+++ b/types/internal-slot/internal-slot-tests.ts
@@ -1,0 +1,81 @@
+import SLOT = require('internal-slot');
+
+const PRIMITIVES: [null, undefined, true, false, string, '', number, 0] = [
+	null,
+	undefined,
+	true,
+	false,
+	'foo',
+	'',
+	42,
+	0,
+];
+const NON_STRINGS: [null, undefined, true, false, number, 0, object, any[], () => void, RegExp] = [
+	null,
+	undefined,
+	true,
+	false,
+	42,
+	0,
+	{},
+	[],
+	() => {},
+	/a/g,
+];
+
+//#region assert
+{
+	PRIMITIVES.forEach(primitive => {
+		SLOT.assert(primitive, ''); // $ExpectError
+	});
+
+	NON_STRINGS.forEach(nonString => {
+		SLOT.assert({}, nonString); // $ExpectError
+	});
+
+	SLOT.assert({}, ''); // $ExpectType void
+}
+//#endregion
+
+//#region has
+{
+	PRIMITIVES.forEach(primitive => {
+		SLOT.has(primitive, ''); // $ExpectError
+	});
+
+	NON_STRINGS.forEach(nonString => {
+		SLOT.has({}, nonString); // $ExpectError
+	});
+
+	SLOT.has({}, 'any'); // $ExpectType boolean
+}
+//#endregion
+
+//#region get
+{
+	PRIMITIVES.forEach(primitive => {
+		SLOT.get(primitive, ''); // $ExpectError
+	});
+
+	NON_STRINGS.forEach(nonString => {
+		SLOT.get({}, nonString); // $ExpectError
+	});
+
+	SLOT.get({}, 'any'); // $ExpectType any
+}
+//#endregion
+
+//#region set
+{
+	PRIMITIVES.forEach(primitive => {
+		SLOT.set(primitive, '', null); // $ExpectError
+	});
+
+	NON_STRINGS.forEach(nonString => {
+		SLOT.set({}, nonString, null); // $ExpectError
+	});
+
+	SLOT.set({}, 'any', 42); // $ExpectType void
+	SLOT.set({}, 'any', Infinity); // $ExpectType void
+}
+//#endregion

--- a/types/internal-slot/tsconfig.json
+++ b/types/internal-slot/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": ["es5"],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": ["../"],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.d.ts",
+		"internal-slot-tests.ts"
+	]
+}

--- a/types/internal-slot/tslint.json
+++ b/types/internal-slot/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

review?(@ljharb)