### PR TITLE
Mongoose package: Added "arrayFilters" property to "QueryFindOneAndUpdateOptions" interface

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -32,6 +32,7 @@
 //                 Anton Kenikh <https://github.com/anthony-kenikh>
 //                 Chathu Vishwajith <https://github.com/iamchathu>
 //                 Tom Yam <https://github.com/tomyam1>
+//                 Tim Welter <https://github.com/TimWelter/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -2274,6 +2275,8 @@ declare module "mongoose" {
   interface QueryFindOneAndUpdateOptions extends QueryFindOneAndRemoveOptions {
     /** if true, return the modified document rather than the original. defaults to false (changed in 4.0) */
     new?: boolean;
+    /** When added, allows for filtering of deep nested arrays. */
+    arrayFilters: any[]
     /** creates the object if it doesn't exist. defaults to false. */
     upsert?: boolean;
     /** if true, runs update validators on this command. Update validators validate the update operation against the model's schema. */


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://docs.mongodb.com/manual/release-notes/3.6/#arrayfilters>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.