### PR TITLE
Add node-beanstalkd-worker library types

### DIFF
--- a/types/beanstalkd-worker/beanstalkd-worker-tests.ts
+++ b/types/beanstalkd-worker/beanstalkd-worker-tests.ts
@@ -1,0 +1,52 @@
+import BeanstalkdWorker from 'beanstalkd-worker';
+
+const host = '127.0.0.1';
+const port = 11300;
+const tube = 'TestTube';
+
+const worker = new BeanstalkdWorker(host, port);
+
+// Spawning Jobs
+
+worker.spawn(tube, {
+    // job payload/values
+}, {
+    delay: 0,
+    priority: 1000,
+    timeout: 10 * 60 * 1000 // ms
+}).then(job => {
+    console.log(job.id);
+});
+
+// Handling Jobs
+
+worker.handle(tube, async function(payload) {
+    // Complete job
+    // return Promise.resolve();
+
+    // Job error
+    // return Promise.reject();
+
+    // Spawn a job
+    this.spawn('newTube', {});
+
+    // Refresh timeout
+    this.touch();
+
+    // Spawn child job and wait for completion before completing this job
+    await this.child('anotherTube', { /* payload */ });
+
+    // Await another job
+    await this.wait('anotherTube', 'jobId');
+
+    // Puts current job back in queue with delay, does not affect retries counter
+    return this.delay(5000); // ms, default: original timeout
+}, {
+    tries: 3, // Total amount of tries including the first one
+    backoff: {
+        initial: 60 * 1000, // ms
+        exponential: 1.5 // multiple backoff by N each try
+    }
+});
+
+worker.start(); // Enable handlers and start processing jobs, make sure handlers are setup before calling start

--- a/types/beanstalkd-worker/beanstalkd-worker-tests.ts
+++ b/types/beanstalkd-worker/beanstalkd-worker-tests.ts
@@ -1,4 +1,4 @@
-import BeanstalkdWorker from 'beanstalkd-worker';
+import * as BeanstalkdWorker from 'beanstalkd-worker';
 
 const host = '127.0.0.1';
 const port = 11300;

--- a/types/beanstalkd-worker/index.d.ts
+++ b/types/beanstalkd-worker/index.d.ts
@@ -1,0 +1,248 @@
+// Type definitions for beanstalkd-worker 1.2
+// Project: https://github.com/burstable/node-beanstalkd-worker
+// Definitions by: Maxime LUCE <https://github.com/SomaticIT>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import BeanstalkdClient, { BeanstalkdJobState, BeanstalkdJobStats } from "beanstalkd";
+
+export default class BeanstalkdWorker {
+                   host?: string;
+                   port?: number;
+                   options?: {};
+                   running: boolean;
+
+                   constructor(host?: string, port?: number, options?: {});
+
+                   /**
+                    * Create or reuse a connection to Beanstalkd with given id.
+                    *
+                    * @param id Id for the connection.
+                    */
+                   connection(id: string): Promise<BeanstalkdClient>;
+
+                   /**
+                    * Get or create a Tube.
+                    *
+                    * @param name The Tube name to get or create.
+                    */
+                   tube(name: string): Tube;
+
+                   /**
+                    * Spawn a new Job on given Tube.
+                    *
+                    * @param tube The tube to spawn new job on.
+                    * @param payload The message payload.
+                    * @param options The options for the new job.
+                    */
+                   spawn(tube: string, payload: object, options?: BeanstalkdSpawnOptions): Promise<Job>;
+
+                   /**
+                    * Handle jobs from given Tube.
+                    *
+                    * @param tube The tube to handle jobs on.
+                    * @param handler The callback for handling jobs.
+                    * @param options The options for the handler.
+                    */
+                   handle(tube: string, handler: TubeHandler, options?: BeanstalkdHandleOptions): void;
+
+                   /**
+                    * Creates a new Job representation.
+                    *
+                    * @param tube The tube to create job for.
+                    * @param jobId The job id for the new job.
+                    */
+                   job(tube: string, jobId: string): Job;
+
+                   /**
+                    * Wait for the given job on specifed tube to be done.
+                    * If provided, calls the `onPoll` handler on each check (500ms).
+                    *
+                    * @param tube The tube that contains the job.
+                    * @param jobId The job id to wait for.
+                    * @param onPoll The poll handler called on each check.
+                    */
+                   done(tube: string, jobId: string, onPoll?: JobPollHandler): Promise<void>;
+
+                   /** Enable handlers and start processing jobs, make sure handlers are setup before calling start. */
+                   start(): void;
+
+                   /** Start handling configured tubes. */
+                   startTubes(): void;
+
+                   /** Stop the Worker process and all associated tubes. */
+                   stop(): Promise<void>;
+
+                   /** Stop handling the configured tubes. */
+                   stopTubes(): Promise<void>;
+
+                   /**
+                    * Checks if the given tube is currently working.
+                    *
+                    * @param tube The tube to check if currently working.
+                    */
+                   working(tube: string): boolean;
+               }
+
+export type TubeHandler = (this: WatcherJob, payload?: any) => any;
+export type JobPollHandler = (state: BeanstalkdJobState) => any;
+
+export type JobStatus = BeanstalkdJobState | "success";
+
+export interface Tube {
+    /**
+     * Gets or creates a new Client for given id.
+     *
+     * @param id The id for the connection.
+     */
+    connection(id: string): Promise<BeanstalkdClient>;
+
+    /**
+     * Executes given command on this Tube.
+     *
+     * @param command The command to execute.
+     * @param args The arguments for the command.
+     */
+    command(command: string, ...args: any[]): Promise<any>;
+
+    /**
+     * Handle jobs from this Tube.
+     *
+     * @param handler The callback for handling jobs.
+     * @param options The options for the handler.
+     */
+    handle(handler: TubeHandler, options?: BeanstalkdHandleOptions): void;
+
+    /** Start watchers for this Tube. */
+    start(): void;
+
+    /** Stop watching for new Job on this Tube. */
+    stop(): Promise<void>;
+
+    /** Check whether this Tube is currently working. */
+    working(): boolean;
+}
+
+export interface Job {
+    tube: string;
+    id: string;
+
+    /**
+     * Executes given command on the Tube that contains the Job.
+     *
+     * @param command The command to execute.
+     * @param args The arguments for the command.
+     */
+    command(command: string, ...args: any[]): Promise<any>;
+
+    /**
+     * Requests stats for this job.
+     * If `catchNotFound` is true, and `NOT_FOUND` error is thrown, returns null.
+     *
+     * @param catchNotFound Whether to catch `NOT_FOUND` error and return null.
+     */
+    stats(catchNotFound?: boolean): Promise<BeanstalkdJobStats>;
+
+    /** Query current status for this Job. */
+    status(): Promise<JobStatus>;
+
+    /**
+     * Wait for this job to be done.
+     * If provided, calls the `onPoll` handler on each check (500ms).
+     *
+     * @param onPoll The poll handler called on each check.
+     */
+    done(onPoll?: JobPollHandler): Promise<void>;
+}
+
+export interface WatcherJob extends Job {
+    /** Inform the server that the client is still processing this job, thus requesting more time to work on it. */
+    touch(): void;
+
+    /**
+     * Initialize a timeout with given delay for this Job.
+     *
+     * @param delay The delay to wait before rejecting the Promise.
+     */
+    timeout(delay: number): Promise<never>;
+    /**
+     * Initialize a timeout with given delay for specified action.
+     *
+     * @param delay The delay to wait before rejecting the Promise.
+     * @param action The Promise to check for timeout resolution.
+     */
+    timeout<T>(delay: number, action: T | Promise<T>): Promise<T>;
+
+    /**
+     * Advanced use only! Mainly internal usage.
+     * Reset the configured timeout.
+     */
+    refreshTimeout(): void;
+
+    /**
+     * Advanced use only! Mainly internal usage.
+     * Cancel the configured timeout.
+     */
+    cancelTimeout(): void;
+
+    /**
+     * Spawn a new Job on given Tube.
+     *
+     * @param tube The tube to spawn new job on.
+     * @param payload The message payload.
+     * @param options The options for the new job.
+     */
+    spawn(tube: string, payload: object, options?: BeanstalkdSpawnOptions): Promise<Job>;
+
+    /**
+     * Spawn a new child Job on given Tube and make this Job to wait for its resolution.
+     * This automatically touch this Job during the wait time.
+     *
+     * @param tube The tube to spawn new job on.
+     * @param payload The message payload.
+     * @param options The options for the new job.
+     */
+    child(tube: string, payload: object, options?: BeanstalkdSpawnOptions): Promise<void>;
+
+    /**
+     * Wait for the given job on specifed tube to be done.
+     * This automatically touch this Job during the wait time.
+     *
+     * @param tube The tube that contains the job.
+     * @param jobId The job id to wait for.
+     */
+    wait(tube: string, jobId: string): Promise<void>;
+
+    /**
+     * Puts current job back in queue with delay (in milliseconds), does not affect retries counter.
+     *
+     * @param delay The time to delay (in milliseconds).
+     * @param exponent The exponent to for calculating the final delay (delay^exponent).
+     */
+    delay(delay?: number, exponent?: number): Promise<1>;
+}
+
+export interface BeanstalkdSpawnOptions {
+    /** The priority for the new Job. */
+    priority?: number;
+    /** The timeout for the new Job (in milliseconds). */
+    timeout?: number;
+    /** The delay before making the new Job visible (in milliseconds). */
+    delay?: number;
+}
+
+export interface BeanstalkdHandleOptions {
+    /** Total number of watcher handling this Tube simultaneously. */
+    width?: number;
+    /** Total amount of tries including the first one. */
+    tries?: number;
+    /** Backoff handling options */
+    backoff?: BeanstalkdHandleBackoff;
+}
+
+export interface BeanstalkdHandleBackoff {
+    /** Initial time to wait (in milliseconds). */
+    initial?: number;
+    /** Multiple backoff by N each try. */
+    exponential?: number;
+}

--- a/types/beanstalkd-worker/index.d.ts
+++ b/types/beanstalkd-worker/index.d.ts
@@ -6,184 +6,29 @@
 
 import BeanstalkdClient, { BeanstalkdJobState, BeanstalkdJobStats } from "beanstalkd";
 
-export default class BeanstalkdWorker {
-                   host?: string;
-                   port?: number;
-                   options?: {};
-                   running: boolean;
+export = BeanstalkdWorker;
 
-                   constructor(host?: string, port?: number, options?: {});
+declare class BeanstalkdWorker {
+    host?: string;
+    port?: number;
+    options?: {};
+    running: boolean;
 
-                   /**
-                    * Create or reuse a connection to Beanstalkd with given id.
-                    *
-                    * @param id Id for the connection.
-                    */
-                   connection(id: string): Promise<BeanstalkdClient>;
+    constructor(host?: string, port?: number, options?: {});
 
-                   /**
-                    * Get or create a Tube.
-                    *
-                    * @param name The Tube name to get or create.
-                    */
-                   tube(name: string): Tube;
-
-                   /**
-                    * Spawn a new Job on given Tube.
-                    *
-                    * @param tube The tube to spawn new job on.
-                    * @param payload The message payload.
-                    * @param options The options for the new job.
-                    */
-                   spawn(tube: string, payload: object, options?: BeanstalkdSpawnOptions): Promise<Job>;
-
-                   /**
-                    * Handle jobs from given Tube.
-                    *
-                    * @param tube The tube to handle jobs on.
-                    * @param handler The callback for handling jobs.
-                    * @param options The options for the handler.
-                    */
-                   handle(tube: string, handler: TubeHandler, options?: BeanstalkdHandleOptions): void;
-
-                   /**
-                    * Creates a new Job representation.
-                    *
-                    * @param tube The tube to create job for.
-                    * @param jobId The job id for the new job.
-                    */
-                   job(tube: string, jobId: string): Job;
-
-                   /**
-                    * Wait for the given job on specifed tube to be done.
-                    * If provided, calls the `onPoll` handler on each check (500ms).
-                    *
-                    * @param tube The tube that contains the job.
-                    * @param jobId The job id to wait for.
-                    * @param onPoll The poll handler called on each check.
-                    */
-                   done(tube: string, jobId: string, onPoll?: JobPollHandler): Promise<void>;
-
-                   /** Enable handlers and start processing jobs, make sure handlers are setup before calling start. */
-                   start(): void;
-
-                   /** Start handling configured tubes. */
-                   startTubes(): void;
-
-                   /** Stop the Worker process and all associated tubes. */
-                   stop(): Promise<void>;
-
-                   /** Stop handling the configured tubes. */
-                   stopTubes(): Promise<void>;
-
-                   /**
-                    * Checks if the given tube is currently working.
-                    *
-                    * @param tube The tube to check if currently working.
-                    */
-                   working(tube: string): boolean;
-               }
-
-export type TubeHandler = (this: WatcherJob, payload?: any) => any;
-export type JobPollHandler = (state: BeanstalkdJobState) => any;
-
-export type JobStatus = BeanstalkdJobState | "success";
-
-export interface Tube {
     /**
-     * Gets or creates a new Client for given id.
+     * Create or reuse a connection to Beanstalkd with given id.
      *
-     * @param id The id for the connection.
+     * @param id Id for the connection.
      */
     connection(id: string): Promise<BeanstalkdClient>;
 
     /**
-     * Executes given command on this Tube.
+     * Get or create a Tube.
      *
-     * @param command The command to execute.
-     * @param args The arguments for the command.
+     * @param name The Tube name to get or create.
      */
-    command(command: string, ...args: any[]): Promise<any>;
-
-    /**
-     * Handle jobs from this Tube.
-     *
-     * @param handler The callback for handling jobs.
-     * @param options The options for the handler.
-     */
-    handle(handler: TubeHandler, options?: BeanstalkdHandleOptions): void;
-
-    /** Start watchers for this Tube. */
-    start(): void;
-
-    /** Stop watching for new Job on this Tube. */
-    stop(): Promise<void>;
-
-    /** Check whether this Tube is currently working. */
-    working(): boolean;
-}
-
-export interface Job {
-    tube: string;
-    id: string;
-
-    /**
-     * Executes given command on the Tube that contains the Job.
-     *
-     * @param command The command to execute.
-     * @param args The arguments for the command.
-     */
-    command(command: string, ...args: any[]): Promise<any>;
-
-    /**
-     * Requests stats for this job.
-     * If `catchNotFound` is true, and `NOT_FOUND` error is thrown, returns null.
-     *
-     * @param catchNotFound Whether to catch `NOT_FOUND` error and return null.
-     */
-    stats(catchNotFound?: boolean): Promise<BeanstalkdJobStats>;
-
-    /** Query current status for this Job. */
-    status(): Promise<JobStatus>;
-
-    /**
-     * Wait for this job to be done.
-     * If provided, calls the `onPoll` handler on each check (500ms).
-     *
-     * @param onPoll The poll handler called on each check.
-     */
-    done(onPoll?: JobPollHandler): Promise<void>;
-}
-
-export interface WatcherJob extends Job {
-    /** Inform the server that the client is still processing this job, thus requesting more time to work on it. */
-    touch(): void;
-
-    /**
-     * Initialize a timeout with given delay for this Job.
-     *
-     * @param delay The delay to wait before rejecting the Promise.
-     */
-    timeout(delay: number): Promise<never>;
-    /**
-     * Initialize a timeout with given delay for specified action.
-     *
-     * @param delay The delay to wait before rejecting the Promise.
-     * @param action The Promise to check for timeout resolution.
-     */
-    timeout<T>(delay: number, action: T | Promise<T>): Promise<T>;
-
-    /**
-     * Advanced use only! Mainly internal usage.
-     * Reset the configured timeout.
-     */
-    refreshTimeout(): void;
-
-    /**
-     * Advanced use only! Mainly internal usage.
-     * Cancel the configured timeout.
-     */
-    cancelTimeout(): void;
+    tube(name: string): BeanstalkdWorker.Tube;
 
     /**
      * Spawn a new Job on given Tube.
@@ -192,57 +37,216 @@ export interface WatcherJob extends Job {
      * @param payload The message payload.
      * @param options The options for the new job.
      */
-    spawn(tube: string, payload: object, options?: BeanstalkdSpawnOptions): Promise<Job>;
+    spawn(tube: string, payload: object, options?: BeanstalkdWorker.BeanstalkdSpawnOptions): Promise<BeanstalkdWorker.Job>;
 
     /**
-     * Spawn a new child Job on given Tube and make this Job to wait for its resolution.
-     * This automatically touch this Job during the wait time.
+     * Handle jobs from given Tube.
      *
-     * @param tube The tube to spawn new job on.
-     * @param payload The message payload.
-     * @param options The options for the new job.
+     * @param tube The tube to handle jobs on.
+     * @param handler The callback for handling jobs.
+     * @param options The options for the handler.
      */
-    child(tube: string, payload: object, options?: BeanstalkdSpawnOptions): Promise<void>;
+    handle(tube: string, handler: BeanstalkdWorker.TubeHandler, options?: BeanstalkdWorker.BeanstalkdHandleOptions): void;
+
+    /**
+     * Creates a new Job representation.
+     *
+     * @param tube The tube to create job for.
+     * @param jobId The job id for the new job.
+     */
+    job(tube: string, jobId: string): BeanstalkdWorker.Job;
 
     /**
      * Wait for the given job on specifed tube to be done.
-     * This automatically touch this Job during the wait time.
+     * If provided, calls the `onPoll` handler on each check (500ms).
      *
      * @param tube The tube that contains the job.
      * @param jobId The job id to wait for.
+     * @param onPoll The poll handler called on each check.
      */
-    wait(tube: string, jobId: string): Promise<void>;
+    done(tube: string, jobId: string, onPoll?: BeanstalkdWorker.JobPollHandler): Promise<void>;
+
+    /** Enable handlers and start processing jobs, make sure handlers are setup before calling start. */
+    start(): void;
+
+    /** Start handling configured tubes. */
+    startTubes(): void;
+
+    /** Stop the Worker process and all associated tubes. */
+    stop(): Promise<void>;
+
+    /** Stop handling the configured tubes. */
+    stopTubes(): Promise<void>;
 
     /**
-     * Puts current job back in queue with delay (in milliseconds), does not affect retries counter.
+     * Checks if the given tube is currently working.
      *
-     * @param delay The time to delay (in milliseconds).
-     * @param exponent The exponent to for calculating the final delay (delay^exponent).
+     * @param tube The tube to check if currently working.
      */
-    delay(delay?: number, exponent?: number): Promise<1>;
+    working(tube: string): boolean;
 }
 
-export interface BeanstalkdSpawnOptions {
-    /** The priority for the new Job. */
-    priority?: number;
-    /** The timeout for the new Job (in milliseconds). */
-    timeout?: number;
-    /** The delay before making the new Job visible (in milliseconds). */
-    delay?: number;
-}
+declare namespace BeanstalkdWorker {
+    type TubeHandler = (this: WatcherJob, payload?: any) => any;
+    type JobPollHandler = (state: BeanstalkdJobState) => any;
 
-export interface BeanstalkdHandleOptions {
-    /** Total number of watcher handling this Tube simultaneously. */
-    width?: number;
-    /** Total amount of tries including the first one. */
-    tries?: number;
-    /** Backoff handling options */
-    backoff?: BeanstalkdHandleBackoff;
-}
+    type JobStatus = BeanstalkdJobState | "success";
 
-export interface BeanstalkdHandleBackoff {
-    /** Initial time to wait (in milliseconds). */
-    initial?: number;
-    /** Multiple backoff by N each try. */
-    exponential?: number;
+    interface Tube {
+        /**
+         * Gets or creates a new Client for given id.
+         *
+         * @param id The id for the connection.
+         */
+        connection(id: string): Promise<BeanstalkdClient>;
+
+        /**
+         * Executes given command on this Tube.
+         *
+         * @param command The command to execute.
+         * @param args The arguments for the command.
+         */
+        command(command: string, ...args: any[]): Promise<any>;
+
+        /**
+         * Handle jobs from this Tube.
+         *
+         * @param handler The callback for handling jobs.
+         * @param options The options for the handler.
+         */
+        handle(handler: TubeHandler, options?: BeanstalkdHandleOptions): void;
+
+        /** Start watchers for this Tube. */
+        start(): void;
+
+        /** Stop watching for new Job on this Tube. */
+        stop(): Promise<void>;
+
+        /** Check whether this Tube is currently working. */
+        working(): boolean;
+    }
+
+    interface Job {
+        tube: string;
+        id: string;
+
+        /**
+         * Executes given command on the Tube that contains the Job.
+         *
+         * @param command The command to execute.
+         * @param args The arguments for the command.
+         */
+        command(command: string, ...args: any[]): Promise<any>;
+
+        /**
+         * Requests stats for this job.
+         * If `catchNotFound` is true, and `NOT_FOUND` error is thrown, returns null.
+         *
+         * @param catchNotFound Whether to catch `NOT_FOUND` error and return null.
+         */
+        stats(catchNotFound?: boolean): Promise<BeanstalkdJobStats>;
+
+        /** Query current status for this Job. */
+        status(): Promise<JobStatus>;
+
+        /**
+         * Wait for this job to be done.
+         * If provided, calls the `onPoll` handler on each check (500ms).
+         *
+         * @param onPoll The poll handler called on each check.
+         */
+        done(onPoll?: JobPollHandler): Promise<void>;
+    }
+
+    interface WatcherJob extends Job {
+        /** Inform the server that the client is still processing this job, thus requesting more time to work on it. */
+        touch(): void;
+
+        /**
+         * Initialize a timeout with given delay for this Job.
+         *
+         * @param delay The delay to wait before rejecting the Promise.
+         */
+        timeout(delay: number): Promise<never>;
+        /**
+         * Initialize a timeout with given delay for specified action.
+         *
+         * @param delay The delay to wait before rejecting the Promise.
+         * @param action The Promise to check for timeout resolution.
+         */
+        timeout<T>(delay: number, action: T | Promise<T>): Promise<T>;
+
+        /**
+         * Advanced use only! Mainly internal usage.
+         * Reset the configured timeout.
+         */
+        refreshTimeout(): void;
+
+        /**
+         * Advanced use only! Mainly internal usage.
+         * Cancel the configured timeout.
+         */
+        cancelTimeout(): void;
+
+        /**
+         * Spawn a new Job on given Tube.
+         *
+         * @param tube The tube to spawn new job on.
+         * @param payload The message payload.
+         * @param options The options for the new job.
+         */
+        spawn(tube: string, payload: object, options?: BeanstalkdSpawnOptions): Promise<Job>;
+
+        /**
+         * Spawn a new child Job on given Tube and make this Job to wait for its resolution.
+         * This automatically touch this Job during the wait time.
+         *
+         * @param tube The tube to spawn new job on.
+         * @param payload The message payload.
+         * @param options The options for the new job.
+         */
+        child(tube: string, payload: object, options?: BeanstalkdSpawnOptions): Promise<void>;
+
+        /**
+         * Wait for the given job on specifed tube to be done.
+         * This automatically touch this Job during the wait time.
+         *
+         * @param tube The tube that contains the job.
+         * @param jobId The job id to wait for.
+         */
+        wait(tube: string, jobId: string): Promise<void>;
+
+        /**
+         * Puts current job back in queue with delay (in milliseconds), does not affect retries counter.
+         *
+         * @param delay The time to delay (in milliseconds).
+         * @param exponent The exponent to for calculating the final delay (delay^exponent).
+         */
+        delay(delay?: number, exponent?: number): Promise<1>;
+    }
+
+    interface BeanstalkdSpawnOptions {
+        /** The priority for the new Job. */
+        priority?: number;
+        /** The timeout for the new Job (in milliseconds). */
+        timeout?: number;
+        /** The delay before making the new Job visible (in milliseconds). */
+        delay?: number;
+    }
+
+    interface BeanstalkdHandleOptions {
+        /** Total number of watcher handling this Tube simultaneously. */
+        width?: number;
+        /** Total amount of tries including the first one. */
+        tries?: number;
+        /** Backoff handling options */
+        backoff?: BeanstalkdHandleBackoff;
+    }
+
+    interface BeanstalkdHandleBackoff {
+        /** Initial time to wait (in milliseconds). */
+        initial?: number;
+        /** Multiple backoff by N each try. */
+        exponential?: number;
+    }
 }

--- a/types/beanstalkd-worker/tsconfig.json
+++ b/types/beanstalkd-worker/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "beanstalkd-worker-tests.ts"
+    ]
+}

--- a/types/beanstalkd-worker/tslint.json
+++ b/types/beanstalkd-worker/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

**/!\ Note and Warning: Depends on PR #39434**