### PR TITLE
Bugfix: Change the Export Method of UIDGenerator Class from Named-Export to Default-Export - @types/uid-generator

### DIFF
--- a/types/uid-generator/index.d.ts
+++ b/types/uid-generator/index.d.ts
@@ -11,7 +11,7 @@ interface UIDGeneratorInstance {
   readonly base: number;
   generateSync(): string;
   generate(): Promise<string>;
-  generate(cb: (error: Error|null, uid?: string) => any): void;
+  generate(cb: (error: Error|null, uid: string) => any): void;
 }
 
 interface UIDGeneratorClass {

--- a/types/uid-generator/index.d.ts
+++ b/types/uid-generator/index.d.ts
@@ -11,7 +11,7 @@ interface UIDGeneratorInstance {
   readonly base: number;
   generateSync(): string;
   generate(): Promise<string>;
-  generate(cb: (error:Error|null, uid: string) => any): void;
+  generate(cb: (error:Error|null, uid?: string) => any): void;
 }
 
 interface UIDGeneratorClass {

--- a/types/uid-generator/index.d.ts
+++ b/types/uid-generator/index.d.ts
@@ -4,7 +4,7 @@
 //                 Kyle Chine <https://github.com/kylechine>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare interface UIDGenerator {
+interface UIDGenerator {
   readonly bitSize: number;
   readonly uidLength: number;
   readonly baseEncoding: string;
@@ -14,7 +14,7 @@ declare interface UIDGenerator {
   generate(cb: (uid: string) => any): void;
 }
 
-declare interface UIDGeneratorConstructor {
+interface UIDGeneratorConstructor {
   new (bitSize?: number, baseEncoding?: string): UIDGenerator;
   new (baseEncoding?: string): UIDGenerator;
   readonly BASE16: '0123456789abcdef';

--- a/types/uid-generator/index.d.ts
+++ b/types/uid-generator/index.d.ts
@@ -11,7 +11,7 @@ interface UIDGeneratorInstance {
   readonly base: number;
   generateSync(): string;
   generate(): Promise<string>;
-  generate(cb: (error:Error|null, uid?: string) => any): void;
+  generate(cb: (error: Error|null, uid?: string) => any): void;
 }
 
 interface UIDGeneratorClass {
@@ -28,4 +28,4 @@ interface UIDGeneratorClass {
 
 declare const UIDGenerator: UIDGeneratorClass;
 
-export {UIDGenerator as default, UIDGeneratorClass, UIDGeneratorInstance};
+export { UIDGenerator as default, UIDGeneratorClass, UIDGeneratorInstance };

--- a/types/uid-generator/index.d.ts
+++ b/types/uid-generator/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for uid-generator 2.0
 // Project: https://github.com/nwoltman/node-uid-generator
 // Definitions by: TheEmrio <https://github.com/TheEmrio>
-//                 Kyle Chine <https://github.com/kylechine>
+//                 KyleChine <https://github.com/kylechine>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface UIDGeneratorInstance {
@@ -28,4 +28,4 @@ interface UIDGeneratorClass {
 
 declare const UIDGenerator: UIDGeneratorClass;
 
-export { UIDGenerator as default, UIDGeneratorClass, UIDGeneratorInstance };
+export {UIDGenerator as default, UIDGeneratorClass, UIDGeneratorInstance};

--- a/types/uid-generator/index.d.ts
+++ b/types/uid-generator/index.d.ts
@@ -4,19 +4,19 @@
 //                 Kyle Chine <https://github.com/kylechine>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface UIDGenerator {
+interface UIDGeneratorInstance {
   readonly bitSize: number;
   readonly uidLength: number;
   readonly baseEncoding: string;
   readonly base: number;
   generateSync(): string;
   generate(): Promise<string>;
-  generate(cb: (uid: string) => any): void;
+  generate(cb: (error:Error|null, uid: string) => any): void;
 }
 
-interface UIDGeneratorConstructor {
-  new (bitSize?: number, baseEncoding?: string): UIDGenerator;
-  new (baseEncoding?: string): UIDGenerator;
+interface UIDGeneratorClass {
+  new (bitSize?: number, baseEncoding?: string): UIDGeneratorInstance;
+  new (baseEncoding?: string): UIDGeneratorInstance;
   readonly BASE16: '0123456789abcdef';
   readonly BASE36: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   readonly BASE58: '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
@@ -26,6 +26,6 @@ interface UIDGeneratorConstructor {
   readonly BASE94: "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
 }
 
-declare const UIDGenerator: UIDGeneratorConstructor;
+declare const UIDGenerator: UIDGeneratorClass;
 
-export = UIDGenerator;
+export {UIDGenerator as default, UIDGeneratorClass, UIDGeneratorInstance};

--- a/types/uid-generator/index.d.ts
+++ b/types/uid-generator/index.d.ts
@@ -1,9 +1,10 @@
 // Type definitions for uid-generator 2.0
 // Project: https://github.com/nwoltman/node-uid-generator
 // Definitions by: TheEmrio <https://github.com/TheEmrio>
+//                 Kyle Chine <https://github.com/kylechine>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export interface UIDGenerator {
+declare interface UIDGenerator {
   readonly bitSize: number;
   readonly uidLength: number;
   readonly baseEncoding: string;
@@ -13,7 +14,7 @@ export interface UIDGenerator {
   generate(cb: (uid: string) => any): void;
 }
 
-export interface UIDGeneratorConstructor {
+declare interface UIDGeneratorConstructor {
   new (bitSize?: number, baseEncoding?: string): UIDGenerator;
   new (baseEncoding?: string): UIDGenerator;
   readonly BASE16: '0123456789abcdef';
@@ -25,4 +26,6 @@ export interface UIDGeneratorConstructor {
   readonly BASE94: "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
 }
 
-export const UIDGenerator: UIDGeneratorConstructor;
+declare const UIDGenerator: UIDGeneratorConstructor;
+
+export = UIDGenerator;

--- a/types/uid-generator/index.d.ts
+++ b/types/uid-generator/index.d.ts
@@ -28,4 +28,4 @@ interface UIDGeneratorClass {
 
 declare const UIDGenerator: UIDGeneratorClass;
 
-export {UIDGenerator as default, UIDGeneratorClass, UIDGeneratorInstance};
+export { UIDGenerator as default, UIDGeneratorClass, UIDGeneratorInstance };

--- a/types/uid-generator/tsconfig.json
+++ b/types/uid-generator/tsconfig.json
@@ -4,7 +4,7 @@
         "lib": [
             "es6"
         ],
-        "target":            "ES2015",
+        "target": "ES2015",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/uid-generator/tsconfig.json
+++ b/types/uid-generator/tsconfig.json
@@ -4,7 +4,7 @@
         "lib": [
             "es6"
         ],
-        "target":            "ES2015",
+        "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/uid-generator/tsconfig.json
+++ b/types/uid-generator/tsconfig.json
@@ -4,7 +4,7 @@
         "lib": [
             "es6"
         ],
-        "target": "es6",
+        "target":            "ES2015",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/uid-generator/tsconfig.json
+++ b/types/uid-generator/tsconfig.json
@@ -4,7 +4,6 @@
         "lib": [
             "es6"
         ],
-        "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/uid-generator/tsconfig.json
+++ b/types/uid-generator/tsconfig.json
@@ -4,7 +4,7 @@
         "lib": [
             "es6"
         ],
-        "target": "ES2015",
+        "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/uid-generator/tsconfig.json
+++ b/types/uid-generator/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": [
             "es6"
         ],
+        "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/uid-generator/tsconfig.json
+++ b/types/uid-generator/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": [
             "es6"
         ],
+        "target":            "ES2015",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -6,7 +6,7 @@ const generator = new UIDGenerator(128, 'abc'); // $ExpectType UIDGeneratorInsta
 generator.generateSync(); // $ExpectType string
 generator.generate((err, uid?) => {
   err; // $ExpectType Error | null
-  uid; // $ExpectType string | undefined
+  uid; // $ExpectType string
 });
 generator.generate().then(uid => {
   uid; // $ExpectType string

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -4,7 +4,7 @@ new UIDGenerator('abc'); // $ExpectType UIDGeneratorInstance
 const generator = new UIDGenerator(128, 'abc'); // $ExpectType UIDGeneratorInstance
 
 generator.generateSync(); // $ExpectType string
-generator.generate((err, uid?) => {
+generator.generate((err, uid) => {
   err; // $ExpectType Error | null
   uid; // $ExpectType string
 });

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -4,20 +4,24 @@ let generator = new UIDGenerator('abc'); // $ExpectType UIDGeneratorInstance
     generator = new UIDGenerator(128, UIDGenerator.BASE58); // $ExpectType UIDGeneratorInstance
 
 generator.generateSync(); // $ExpectType string
-generator.generate((error, uid) => {
-  if (error === null)
-  {
-    error;  // $ExpectType Error
+
+generator.generate(
+  (error, uid) => {
+    if (error === null)
+    {
+      error;  // $ExpectType Error | null
+    }
+    else
+    {
+      uid; // $ExpectType string | undefined
+    }
   }
-  else
-  {
-    uid; // $ExpectType string|undefined
-  }
-});
+);
+
 generator.generate().then(uid => {
   uid; // $ExpectType string
 }).catch(e => {
-  e; // $ExpectType Error
+  e; // $ExpectType Error | null
 });
 
 generator.bitSize; // $ExpectType number

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -9,11 +9,11 @@ generator.generate(
   (error, uid) => {
     if (error === null)
     {
-      error;  // $ExpectType Error or null
+      error;  // $ExpectType <Error | null>
     }
     else
     {
-      uid; // $ExpectType string or undefined
+      uid; // $ExpectType <string | undefined>
     }
   }
 );

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -1,4 +1,4 @@
-import { default as UIDGenerator } from 'uid-generator';
+import { default as UIDGenerator, UIDGeneratorClass, UIDGeneratorInstance } from 'uid-generator';
 
 let generator = new UIDGenerator('abc'); // $ExpectType UIDGenerator
     generator = new UIDGenerator(128, UIDGenerator.BASE58); // $ExpectType UIDGenerator

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -1,21 +1,14 @@
-import { default as UIDGenerator } from 'uid-generator';
+import { UIDGenerator } from 'uid-generator';
 
-let generator = new UIDGenerator('abc'); // $ExpectType UIDGeneratorInstance
-    generator = new UIDGenerator(128, UIDGenerator.BASE58); // $ExpectType UIDGeneratorInstance
+new UIDGenerator('abc'); // $ExpectType UIDGenerator
+const generator = new UIDGenerator(128, 'abc'); // $ExpectType UIDGenerator
 
 generator.generateSync(); // $ExpectType string
-
-generator.generate(
-  (error, uid) => {
-    error;  // $ExpectType Error | null
-    uid; // $ExpectType string | undefined
-  }
-);
-
+generator.generate(uid => {
+  uid; // $ExpectType string
+});
 generator.generate().then(uid => {
   uid; // $ExpectType string
-}).catch(e => {
-  e;
 });
 
 generator.bitSize; // $ExpectType number

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -9,11 +9,11 @@ generator.generate(
   (error, uid) => {
     if (error === null)
     {
-      error;  // $ExpectType Error | null
+      error;  // $ExpectType Error or null
     }
     else
     {
-      uid; // $ExpectType string | undefined
+      uid; // $ExpectType string or undefined
     }
   }
 );
@@ -21,7 +21,7 @@ generator.generate(
 generator.generate().then(uid => {
   uid; // $ExpectType string
 }).catch(e => {
-  e; // $ExpectType Error | null
+  e;
 });
 
 generator.bitSize; // $ExpectType number

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -1,8 +1,15 @@
-import * as UIDGenerator from 'uid-generator';
+import {default as UIDGenerator} from 'uid-generator';
 
-const generator = new UIDGenerator(128, UIDGenerator.BASE58); // $ExpectType UIDGenerator
+let generator = new UIDGenerator('abc'); // $ExpectType UIDGenerator
+    generator = new UIDGenerator(128, UIDGenerator.BASE58); // $ExpectType UIDGenerator
 
 generator.generateSync(); // $ExpectType string
+generator.generate((error, uid)=>{
+  if (error)
+    { throw error; }
+  else
+    { uid; } // $ExpectType string
+});
 generator.generate().then(uid => {
   uid; // $ExpectType string
 });

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -1,4 +1,4 @@
-import { UIDGenerator } from 'uid-generator';
+import * as UIDGenerator from 'uid-generator';
 
 new UIDGenerator('abc'); // $ExpectType UIDGenerator
 const generator = new UIDGenerator(128, 'abc'); // $ExpectType UIDGenerator

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -1,18 +1,18 @@
-import {default as UIDGenerator} from 'uid-generator';
+import { default as UIDGenerator } from 'uid-generator';
 
 let generator = new UIDGenerator('abc'); // $ExpectType UIDGenerator
     generator = new UIDGenerator(128, UIDGenerator.BASE58); // $ExpectType UIDGenerator
 
 generator.generateSync(); // $ExpectType string
-generator.generate((error, uid)=>{
+generator.generate((error, uid) => {
   if (error)
-    { throw error; }
+  { throw error; }
   else
-    { uid; } // $ExpectType string
+  { uid; } // $ExpectType string
 });
 generator.generate().then(uid => {
   uid; // $ExpectType string
-}).catch( e=>{throw e;} );
+}).catch(e => { throw e; });
 
 generator.bitSize; // $ExpectType number
 generator.uidLength; // $ExpectType number

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -7,7 +7,7 @@ generator.generateSync(); // $ExpectType string
 
 generator.generate(
   (error, uid) => {
-    error;  // $ExpectType null
+    error;  // $ExpectType Error | null
     uid; // $ExpectType string | undefined
   }
 );

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -9,11 +9,11 @@ generator.generate(
   (error, uid) => {
     if (error === null)
     {
-      error;  // $ExpectType <Error | null>
+      error;  // $ExpectType null
     }
     else
     {
-      uid; // $ExpectType <string | undefined>
+      uid; // $ExpectType string | undefined
     }
   }
 );

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -7,14 +7,8 @@ generator.generateSync(); // $ExpectType string
 
 generator.generate(
   (error, uid) => {
-    if (error === null)
-    {
-      error;  // $ExpectType null
-    }
-    else
-    {
-      uid; // $ExpectType string | undefined
-    }
+    error;  // $ExpectType null
+    uid; // $ExpectType string | undefined
   }
 );
 

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -5,13 +5,13 @@ const generator = new UIDGenerator(128, 'abc'); // $ExpectType UIDGeneratorInsta
 
 generator.generateSync(); // $ExpectType string
 generator.generate((err, uid?) => {
-  err; // $ExpectType null
-  uid; // $ExpectType string
+  err; // $ExpectType Error | null
+  uid; // $ExpectType string | undefined
 });
 generator.generate().then(uid => {
   uid; // $ExpectType string
 }).catch(e => {
-  e;   // $ExpectType Error
+  e;   // $ExpectType any
 });
 
 generator.bitSize; // $ExpectType number

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -12,7 +12,7 @@ generator.generate((error, uid)=>{
 });
 generator.generate().then(uid => {
   uid; // $ExpectType string
-});
+}).catch( e=>{throw e;} );
 
 generator.bitSize; // $ExpectType number
 generator.uidLength; // $ExpectType number

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -6,13 +6,19 @@ let generator = new UIDGenerator('abc'); // $ExpectType UIDGenerator
 generator.generateSync(); // $ExpectType string
 generator.generate((error, uid) => {
   if (error)
-  { throw error; }
+  {
+    throw error;
+  }
   else
-  { uid; } // $ExpectType string
+  {
+    uid;
+  } // $ExpectType string
 });
 generator.generate().then(uid => {
   uid; // $ExpectType string
-}).catch(e => { throw e; });
+}).catch(e => {
+  throw e;
+});
 
 generator.bitSize; // $ExpectType number
 generator.uidLength; // $ExpectType number

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -1,12 +1,8 @@
 import * as UIDGenerator from 'uid-generator';
 
-new UIDGenerator('abc'); // $ExpectType UIDGenerator
-const generator = new UIDGenerator(128, 'abc'); // $ExpectType UIDGenerator
+const generator = new UIDGenerator(128, UIDGenerator.BASE58); // $ExpectType UIDGenerator
 
 generator.generateSync(); // $ExpectType string
-generator.generate(uid => {
-  uid; // $ExpectType string
-});
 generator.generate().then(uid => {
   uid; // $ExpectType string
 });

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -1,23 +1,23 @@
-import { default as UIDGenerator, UIDGeneratorClass, UIDGeneratorInstance } from 'uid-generator';
+import { default as UIDGenerator } from 'uid-generator';
 
-let generator = new UIDGenerator('abc'); // $ExpectType UIDGenerator
-    generator = new UIDGenerator(128, UIDGenerator.BASE58); // $ExpectType UIDGenerator
+let generator = new UIDGenerator('abc'); // $ExpectType UIDGeneratorInstance
+    generator = new UIDGenerator(128, UIDGenerator.BASE58); // $ExpectType UIDGeneratorInstance
 
 generator.generateSync(); // $ExpectType string
 generator.generate((error, uid) => {
-  if (error)
+  if (error === null)
   {
-    throw error;
+    error;  // $ExpectType Error
   }
   else
   {
-    uid;
-  } // $ExpectType string
+    uid; // $ExpectType string|undefined
+  }
 });
 generator.generate().then(uid => {
   uid; // $ExpectType string
 }).catch(e => {
-  throw e;
+  e; // $ExpectType Error
 });
 
 generator.bitSize; // $ExpectType number

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -1,14 +1,17 @@
-import { UIDGenerator } from 'uid-generator';
+import { default as UIDGenerator } from 'uid-generator';
 
-new UIDGenerator('abc'); // $ExpectType UIDGenerator
-const generator = new UIDGenerator(128, 'abc'); // $ExpectType UIDGenerator
+new UIDGenerator('abc'); // $ExpectType UIDGeneratorInstance
+const generator = new UIDGenerator(128, 'abc'); // $ExpectType UIDGeneratorInstance
 
 generator.generateSync(); // $ExpectType string
-generator.generate(uid => {
+generator.generate((err, uid?) => {
+  err; // $ExpectType null
   uid; // $ExpectType string
 });
 generator.generate().then(uid => {
   uid; // $ExpectType string
+}).catch(e => {
+  e;   // $ExpectType Error
 });
 
 generator.bitSize; // $ExpectType number


### PR DESCRIPTION
### Bugfix: Change the Export Method of UIDGenerator Class from Named-Export to Default-Export

#### Motivation

In the original package (uid-generator), the class is exported by Default-Export:

  `module.exports = UIDGenerator;`

But in the current version of the type definition, the class is exported by Named-Export:

  `export const UIDGenerator: UIDGeneratorConstructor;`

Which leads to a piece of wrong JavaScript code after compilation:

```
  const uid_generator_1 = require("uid-generator");
  const uidgen = new uid_generator_1.UIDGenerator(bitLength);
```

The correct piece should be:

```
  const uid_generator_1 = require("uid-generator");
  const uidgen = new uid_generator_1(bitLength);
```

So I feel it may be necessary to fix this.

#### Fixed List

1. Interface Renaming

```
UIDGenerator            -> UIDGeneratorInstance
UIDGeneratorConstructor -> UIDGeneratorClass
```

In the current version, the name UIDGenerator used as both the name of the interface and the class, which may leads to confusion. So I give them a little bit more clear names.

2. Default-Export UIDGenerator

3. UIDGeneratorInstance.generate(call-back): Error Parameter Added

In the orginal (uid-generator) package, the call-back function also accepts an error parameter. And when error did triggered, uid parameter may be optional.

4. Corresponding updates in test script
