### PR TITLE
helmet: Add featurePolicy

### DIFF
--- a/types/helmet/helmet-tests.ts
+++ b/types/helmet/helmet-tests.ts
@@ -18,6 +18,16 @@ function helmetTest() {
         action: 'deny'
       }
     }));
+    app.use(helmet({
+      featurePolicy: {
+        features: {
+          fullscreen: ["'self'"],
+          vibrate: ["'none'"],
+          payment: ['example.com'],
+          syncXhr: ["'none'"]
+        }
+      }
+    }))
 }
 
 /**
@@ -244,3 +254,18 @@ function permittedCrossDomainPoliciesTest() {
     app.use(helmet.permittedCrossDomainPolicies({}));
     app.use(helmet.permittedCrossDomainPolicies({ permittedPolicies: 'none' }));
 }
+
+/**
+ * @summary Test for {@see helmet#featurePolicy} function.
+ */
+function featurePolicyTest() {
+  app.use(helmet.featurePolicy({
+    features: {
+      fullscreen: ["'self'"],
+      vibrate: ["'none'"],
+      payment: ['example.com'],
+      syncXhr: ["'none'"]
+    }
+  }));
+}
+

--- a/types/helmet/index.d.ts
+++ b/types/helmet/index.d.ts
@@ -13,6 +13,7 @@ declare namespace helmet {
     export interface IHelmetConfiguration {
         contentSecurityPolicy?: boolean | IHelmetContentSecurityPolicyConfiguration;
         dnsPrefetchControl?: boolean | IHelmetDnsPrefetchControlConfiguration;
+        featurePolicy?: IFeaturePolicyOptions;
         frameguard?: boolean | IHelmetFrameguardConfiguration;
         hidePoweredBy?: boolean | IHelmetHidePoweredByConfiguration;
         hpkp?: boolean | IHelmetHpkpConfiguration;
@@ -24,6 +25,12 @@ declare namespace helmet {
         xssFilter?: boolean | IHelmetXssFilterConfiguration;
         expectCt?: boolean | IHelmetExpectCtConfiguration;
         permittedCrossDomainPolicies?: boolean | IHelmetPermittedCrossDomainPoliciesConfiguration;
+    }
+
+    export interface IFeaturePolicyOptions {
+        features: {
+            [featureName: string]: string[];
+        };
     }
 
     export interface IHelmetPermittedCrossDomainPoliciesConfiguration {
@@ -195,6 +202,13 @@ declare namespace helmet {
          * @return {RequestHandler} The Request handler
          */
         dnsPrefetchControl(options?: IHelmetDnsPrefetchControlConfiguration): express.RequestHandler;
+
+        /**
+         * @summary Restrict which browser features can be used
+         * @param {IFeaturePolicyOptions} options The options
+         * @return {RequestHandler} The Request handler
+         */
+        featurePolicy(options: IFeaturePolicyOptions): express.RequestHandler;
 
         /**
          * @summary Prevent clickjacking.


### PR DESCRIPTION
feture-policy provides TS typings with it, but it doesn't export the
interface for the options parameter. We could have used conditional
typings and infered the type of the parameter, but that would have
restricted the minimum TS version to 2.8, so instead I created the
interface definition here.

Resolves #37627

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://helmetjs.github.io/docs/feature-policy/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
