### PR TITLE
node: Fix missing CustomPromisify for fs.link.

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -450,7 +450,7 @@ declare module "fs" {
          * @param existingPath A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function link(existingPath: PathLike, newPath: PathLike): Promise<void>;
+        function __promisify__(existingPath: PathLike, newPath: PathLike): Promise<void>;
     }
 
     /**

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -119,6 +119,10 @@ async function testPromisify() {
     const listDir: fs.Dirent[] = await rd('path', { withFileTypes: true });
     const listDir2: Buffer[] = await rd('path', { withFileTypes: false, encoding: 'buffer' });
     const listDir3: fs.Dirent[] = await rd('path', { encoding: 'utf8', withFileTypes: true });
+
+    const ln = util.promisify(fs.link);
+    // $ExpectType Promise<void>
+    ln("abc", "def");
 }
 
 {

--- a/types/node/v10/fs.d.ts
+++ b/types/node/v10/fs.d.ts
@@ -442,7 +442,7 @@ declare module "fs" {
          * @param existingPath A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function link(existingPath: PathLike, newPath: PathLike): Promise<void>;
+        function __promisify__(existingPath: PathLike, newPath: PathLike): Promise<void>;
     }
 
     /**

--- a/types/node/v11/fs.d.ts
+++ b/types/node/v11/fs.d.ts
@@ -442,7 +442,7 @@ declare module "fs" {
          * @param existingPath A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function link(existingPath: PathLike, newPath: PathLike): Promise<void>;
+        function __promisify__(existingPath: PathLike, newPath: PathLike): Promise<void>;
     }
 
     /**

--- a/types/node/v8/base.d.ts
+++ b/types/node/v8/base.d.ts
@@ -3469,7 +3469,7 @@ declare module "fs" {
          * @param existingPath A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        export function link(existingPath: PathLike, newPath: PathLike): Promise<void>;
+        export function __promisify__(existingPath: PathLike, newPath: PathLike): Promise<void>;
     }
 
     /**

--- a/types/node/v9/base.d.ts
+++ b/types/node/v9/base.d.ts
@@ -3873,7 +3873,7 @@ declare module "fs" {
          * @param existingPath A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        export function link(existingPath: PathLike, newPath: PathLike): Promise<void>;
+        export function __promisify__(existingPath: PathLike, newPath: PathLike): Promise<void>;
     }
 
     /**


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Due to a typo the instance of `CustomPromisify` was unintentionally missing for `fs.link`.

As it happens the compiler infers the type of `util.promisify(fs.link)` correctly anyway, but fixing the definition to work as intended probably gives a little performance boost at type checking time.