### PR TITLE
Added type definitions for connect-flash-plus

### DIFF
--- a/types/connect-flash-plus/connect-flash-plus-tests.ts
+++ b/types/connect-flash-plus/connect-flash-plus-tests.ts
@@ -9,7 +9,8 @@ app.use(flash({
 }));
 
 app.use((req: Express.Request, res: Express.Response, next: () => void) => {
-    req.flash('Message');
-    req.flash('info', 'Message');
+    req.flash('flashType');
+    req.flash('flashType', 'flashMessage');
+    req.flash('flashType', ['multipleMessages', 'oneOfMessages']);
     req.flash();
 });

--- a/types/connect-flash-plus/connect-flash-plus-tests.ts
+++ b/types/connect-flash-plus/connect-flash-plus-tests.ts
@@ -1,0 +1,15 @@
+import express = require('express');
+import flash = require('connect-flash-plus');
+
+const app = express();
+
+app.use(flash());
+app.use(flash({
+    unsafe: false
+}));
+
+app.use((req: Express.Request, res: Express.Response, next: () => void) => {
+    req.flash('Message');
+    req.flash('info', 'Message');
+    req.flash();
+});

--- a/types/connect-flash-plus/connect-flash-plus-tests.ts
+++ b/types/connect-flash-plus/connect-flash-plus-tests.ts
@@ -12,5 +12,6 @@ app.use((req: Express.Request, res: Express.Response, next: () => void) => {
     req.flash('flashType');
     req.flash('flashType', 'flashMessage');
     req.flash('flashType', ['multipleMessages', 'oneOfMessages']);
+    req.flash('info', 'Hello %s', 'Jared');
     req.flash();
 });

--- a/types/connect-flash-plus/index.d.ts
+++ b/types/connect-flash-plus/index.d.ts
@@ -9,11 +9,11 @@
 declare namespace Express {
     interface Request {
         flash(): { [key: string]: string[] };
-        flash(message: string, event?: string): any;
+        flash(message: string, event?: string | string[]): any;
     }
 }
 
-// tslint:disable-next-line [no-declare-current-package, no-single-declare-module]
+// tslint:disable-next-line:no-declare-current-package no-single-declare-module
 declare module "connect-flash-plus" {
     import express = require('express');
     interface FlashOptions {

--- a/types/connect-flash-plus/index.d.ts
+++ b/types/connect-flash-plus/index.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for connect-flash-plus 0.2
+// Project: https://github.com/martinkadlec0/connect-flash-plus
+// Definitions by: Michael V. Mykhaylov <https://github.com/MikeMikhailov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+/// <reference types="express" />
+
+declare namespace Express {
+    interface Request {
+        flash(): { [key: string]: string[] };
+        flash(message: string, event?: string): any;
+    }
+}
+
+// tslint:disable-next-line [no-declare-current-package, no-single-declare-module]
+declare module "connect-flash-plus" {
+    import express = require('express');
+    interface FlashOptions {
+        unsafe?: boolean;
+    }
+    function flash(options?: FlashOptions): express.RequestHandler;
+    export = flash;
+}

--- a/types/connect-flash-plus/index.d.ts
+++ b/types/connect-flash-plus/index.d.ts
@@ -9,7 +9,7 @@
 declare namespace Express {
     interface Request {
         flash(): { [key: string]: string[] };
-        flash(message: string, event?: string | string[]): any;
+        flash(type?: string, msg?: string | string[], ...args: string[]): any;
     }
 }
 

--- a/types/connect-flash-plus/tsconfig.json
+++ b/types/connect-flash-plus/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "connect-flash-plus-tests.ts"
+    ]
+}

--- a/types/connect-flash-plus/tslint.json
+++ b/types/connect-flash-plus/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
 