### PR TITLE
Added types for svg-intersections

### DIFF
--- a/types/svg-intersections/index.d.ts
+++ b/types/svg-intersections/index.d.ts
@@ -63,16 +63,25 @@ export interface Shape {
     params: object;
 }
 
+export interface Matrix2D {
+    a: number;
+    b: number;
+    c: number;
+    d: number;
+    e: number;
+    f: number;
+}
+
 export interface Point2D {
     x: number;
     y: number;
 }
 
-export class Intersection {
+export interface Intersection {
     status: string;
     points: Point2D[];
 }
 
 export function shape<T extends SvgElements>(svgElementName: T, svgProps: SvgProperties<typeof svgElementName>): Shape;
 
-export function intersect(shape1: Shape, shape2: Shape, m1?: any, m2?: any): Intersection;
+export function intersect(shape1: Shape, shape2: Shape, m1?: Matrix2D, m2?: Matrix2D): Intersection;

--- a/types/svg-intersections/index.d.ts
+++ b/types/svg-intersections/index.d.ts
@@ -1,0 +1,4 @@
+// Type definitions for svg-intersections 0.4
+// Project: https://github.com/effektif/svg-intersections#readme
+// Definitions by: xWiiLLz <https://github.com/xWiiLLz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/svg-intersections/index.d.ts
+++ b/types/svg-intersections/index.d.ts
@@ -15,8 +15,8 @@ export interface LineProps {
 }
 
 export interface RectProps {
-    rx: number;
-    ry: number;
+    rx?: number;
+    ry?: number;
     x: number;
     y: number;
     width: number;

--- a/types/svg-intersections/index.d.ts
+++ b/types/svg-intersections/index.d.ts
@@ -57,5 +57,11 @@ export type SvgProperties<T extends SvgElements> =
     never;
 
 
-export function shape<T extends SvgElements>(svgElementName: T, svgProps: SvgProperties<typeof svgElementName>): any;
+export interface Shape {
+    type: string;
+    meta: object;
+    params: object;
+}
+
+export function shape<T extends SvgElements>(svgElementName: T, svgProps: SvgProperties<typeof svgElementName>): Shape;
 

--- a/types/svg-intersections/index.d.ts
+++ b/types/svg-intersections/index.d.ts
@@ -29,10 +29,31 @@ export interface CircleProps {
     r: number;
 }
 
+export interface EllipseProps {
+    cx: number;
+    cy: number;
+    rx: number;
+    ry: number;
+}
+
+export interface PolygonProps {
+    points: string;
+}
+
+export interface PolylineProps extends PolygonProps {}
+
+export interface PathProps {
+    d: string;
+}
+
 export type SvgProperties<T extends SvgElements> =
     T extends 'line' ? LineProps :
     T extends 'rect' ? RectProps :
     T extends 'circle' ? CircleProps :
+    T extends 'ellipse' ? EllipseProps :
+    T extends 'polygon' ? PolygonProps :
+    T extends 'polyline' ? PolylineProps :
+    T extends 'path' ? PathProps :
     never;
 
 

--- a/types/svg-intersections/index.d.ts
+++ b/types/svg-intersections/index.d.ts
@@ -63,5 +63,16 @@ export interface Shape {
     params: object;
 }
 
+export interface Point2D {
+    x: number;
+    y: number;
+}
+
+export class Intersection {
+    status: string;
+    points: Point2D[];
+}
+
 export function shape<T extends SvgElements>(svgElementName: T, svgProps: SvgProperties<typeof svgElementName>): Shape;
 
+export function intersect(shape1: Shape, shape2: Shape, m1?: any, m2?: any): Intersection;

--- a/types/svg-intersections/index.d.ts
+++ b/types/svg-intersections/index.d.ts
@@ -81,7 +81,5 @@ export interface Intersection {
     points: Point2D[];
 }
 
-// tslint:disable-next-line: no-unnecessary-generics - Necessary for typeguard of svgProps based on svgElementName's value
-export function shape<T extends SvgElements>(svgElementName: T, svgProps: SvgProperties<typeof svgElementName>): Shape;
-
+export function shape<T extends SvgElements>(svgElementName: T, svgProps: SvgProperties<T>): Shape;
 export function intersect(shape1: Shape, shape2: Shape, m1?: Matrix2D, m2?: Matrix2D): Intersection;

--- a/types/svg-intersections/index.d.ts
+++ b/types/svg-intersections/index.d.ts
@@ -2,3 +2,39 @@
 // Project: https://github.com/effektif/svg-intersections#readme
 // Definitions by: xWiiLLz <https://github.com/xWiiLLz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+
+export type SvgElements = 'line' | 'rect' | 'circle' | 'ellipse' | 'polygon' | 'polyline' | 'path';
+
+// Svg element properties
+export interface LineProps {
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+}
+
+export interface RectProps {
+    rx: number;
+    ry: number;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+export interface CircleProps {
+    cx: number;
+    cy: number;
+    r: number;
+}
+
+export type SvgProperties<T extends SvgElements> =
+    T extends 'line' ? LineProps :
+    T extends 'rect' ? RectProps :
+    T extends 'circle' ? CircleProps :
+    never;
+
+
+export function shape<T extends SvgElements>(svgElementName: T, svgProps: SvgProperties<typeof svgElementName>): any;
+

--- a/types/svg-intersections/index.d.ts
+++ b/types/svg-intersections/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/effektif/svg-intersections#readme
 // Definitions by: xWiiLLz <https://github.com/xWiiLLz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
+// TypeScript Version: 2.8
 
 export type SvgElements = 'line' | 'rect' | 'circle' | 'ellipse' | 'polygon' | 'polyline' | 'path';
 
@@ -40,7 +40,7 @@ export interface PolygonProps {
     points: string;
 }
 
-export interface PolylineProps extends PolygonProps {}
+export type PolylineProps = PolygonProps;
 
 export interface PathProps {
     d: string;
@@ -55,7 +55,6 @@ export type SvgProperties<T extends SvgElements> =
     T extends 'polyline' ? PolylineProps :
     T extends 'path' ? PathProps :
     never;
-
 
 export interface Shape {
     type: string;
@@ -82,6 +81,7 @@ export interface Intersection {
     points: Point2D[];
 }
 
+// tslint:disable-next-line: no-unnecessary-generics - Necessary for typeguard of svgProps based on svgElementName's value
 export function shape<T extends SvgElements>(svgElementName: T, svgProps: SvgProperties<typeof svgElementName>): Shape;
 
 export function intersect(shape1: Shape, shape2: Shape, m1?: Matrix2D, m2?: Matrix2D): Intersection;

--- a/types/svg-intersections/svg-intersections-tests.ts
+++ b/types/svg-intersections/svg-intersections-tests.ts
@@ -1,3 +1,7 @@
 import { intersect, shape } from 'svg-intersections';
 
 const line = shape('line', {x1: 0, y1: 0, x2: 2, y2: 3});
+const rect = shape('rect', {x: 0, y: 0, width: 200, height: 100, rx: 4, ry: 4});
+const circle = shape('circle', {cx: 0, cy: 0, r: 100});
+const ellipse = shape('ellipse', {rx: 100, ry: 150, cx: 0, cy: 0});
+const polygon = shape('polygon', {points: '-5,0 0,10 5,0 0,-10'});

--- a/types/svg-intersections/svg-intersections-tests.ts
+++ b/types/svg-intersections/svg-intersections-tests.ts
@@ -1,7 +1,8 @@
 import { intersect, shape } from 'svg-intersections';
 
 const line = shape('line', {x1: 0, y1: 0, x2: 2, y2: 3});
-const rect = shape('rect', {x: 0, y: 0, width: 200, height: 100, rx: 4, ry: 4});
+const rect = shape('rect', {x: 0, y: 0, width: 200, height: 100});
+const rectWithOptional = shape('rect', {x: 0, y: 0, width: 200, height: 100, rx: 4, ry: 4});
 const circle = shape('circle', {cx: 0, cy: 0, r: 100});
 const ellipse = shape('ellipse', {rx: 100, ry: 150, cx: 0, cy: 0});
 const polygon = shape('polygon', {points: '-5,0 0,10 5,0 0,-10'});

--- a/types/svg-intersections/svg-intersections-tests.ts
+++ b/types/svg-intersections/svg-intersections-tests.ts
@@ -1,0 +1,3 @@
+import { intersect, shape } from 'svg-intersections';
+
+const line = shape('line', {x1: 0, y1: 0, x2: 2, y2: 3});

--- a/types/svg-intersections/svg-intersections-tests.ts
+++ b/types/svg-intersections/svg-intersections-tests.ts
@@ -7,3 +7,5 @@ const circle = shape('circle', {cx: 0, cy: 0, r: 100});
 const ellipse = shape('ellipse', {rx: 100, ry: 150, cx: 0, cy: 0});
 const polygon = shape('polygon', {points: '-5,0 0,10 5,0 0,-10'});
 const path = shape('path', {d: 'M 10 10 h 80 v 80 h -80 Z'});
+
+const intersections = intersect(line, rect);

--- a/types/svg-intersections/svg-intersections-tests.ts
+++ b/types/svg-intersections/svg-intersections-tests.ts
@@ -5,3 +5,4 @@ const rect = shape('rect', {x: 0, y: 0, width: 200, height: 100, rx: 4, ry: 4});
 const circle = shape('circle', {cx: 0, cy: 0, r: 100});
 const ellipse = shape('ellipse', {rx: 100, ry: 150, cx: 0, cy: 0});
 const polygon = shape('polygon', {points: '-5,0 0,10 5,0 0,-10'});
+const path = shape('path', {d: 'M 10 10 h 80 v 80 h -80 Z'});

--- a/types/svg-intersections/tsconfig.json
+++ b/types/svg-intersections/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "svg-intersections-tests.ts"
+    ]
+}

--- a/types/svg-intersections/tslint.json
+++ b/types/svg-intersections/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
