### PR TITLE
fix(cometd): Update Message interface for CometD 4.0

### DIFF
--- a/types/cometd/index.d.ts
+++ b/types/cometd/index.d.ts
@@ -4,6 +4,7 @@
 //                 Daniel Perez Alvarez <https://github.com/unindented>
 //                 Alex Henry <https://github.com/alxHenry>
 //                 Harald Gliebe <https://github.com/hagl>
+//                 P.J. Swesey <https://github.com/swese44>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -81,12 +82,57 @@ export interface Configuration {
     useWorkerScheduler?: boolean;
 }
 
-export interface Message {
+export type ConnectionType = 'long-polling' | 'callback-polling' | 'iframe' | 'flash';
+export type ReconnectAdvice = 'retry' | 'handshake' | 'none';
+
+export interface BaseMessage {
     successful: boolean;
-    data: any;
+    channel: string;
+    id?: string;
+    clientId?: string;
+    advice?: {
+        reconnect?: ReconnectAdvice;
+        timeout?: number;
+        interval?: number;
+        'multiple-clients'?: boolean;
+        hosts?: string[];
+    };
+    connectionType?: ConnectionType;
+    timestamp?: string;
+    data?: any;
+    error?: string;
+    ext?: any;
+    version?: string;
+    minimumVersion?: string;
 }
 
+export interface SuccessfulHandshakeMessage extends BaseMessage {
+    successful: true;
+    version: string;
+    supportedConnectionTypes: ConnectionType[];
+    clientId: string;
+    authSuccessful?: true;
+    reestablish: boolean;
+}
+
+export interface UnsuccessfulHandshakeMessage extends BaseMessage {
+    successful: false;
+    error: string;
+    supportedConnectionTypes?: ConnectionType[];
+    reestablish?: undefined;
+}
+
+export type HandshakeMessage = SuccessfulHandshakeMessage | UnsuccessfulHandshakeMessage;
+
+export interface SubscribeMessage extends BaseMessage {
+    subscription: string;
+}
+
+export type Message = BaseMessage | HandshakeMessage | SubscribeMessage;
+
 export type Listener = (message: Message) => void;
+export type HandshakeListener = (message: HandshakeMessage) => void;
+export type SubscribeListener = (message: SubscribeMessage) => void;
 export type Callback = (data: any) => void;
 
 export interface SubscriptionHandle {
@@ -160,7 +206,7 @@ export class CometD {
      *
      * @param handshakeCallback a function to be invoked when the handshake is acknowledged
      */
-    handshake(handshakeCallback: Listener): void;
+    handshake(handshakeCallback: HandshakeListener): void;
 
     /**
      * Establishes the Bayeux communication with the Bayeux server via a handshake and a subsequent
@@ -169,7 +215,7 @@ export class CometD {
      * @param handshakeProps an object to be merged with the handshake message
      * @param handshakeCallback a function to be invoked when the handshake is acknowledged
      */
-    handshake(handshakeProps: object, handshakeCallback: Listener): void;
+    handshake(handshakeProps: object, handshakeCallback: HandshakeListener): void;
 
     /**
      * Disconnects from the Bayeux server.
@@ -257,7 +303,7 @@ export class CometD {
      * @param subscribeCallback a function to be invoked when the subscription is acknowledged
      * @return the subscription handle to be passed to `unsubscribe`
      */
-    subscribe(channel: string, callback: Callback, subscribeCallback?: Listener): SubscriptionHandle;
+    subscribe(channel: string, callback: Callback, subscribeCallback?: SubscribeListener): SubscriptionHandle;
 
     /**
      * Subscribes to the given channel, performing the given callback in the given scope when a
@@ -278,7 +324,12 @@ export class CometD {
      * @param subscribeCallback a function to be invoked when the subscription is acknowledged
      * @return the subscription handle to be passed to `unsubscribe`
      */
-    subscribe(channel: string, callback: Callback, subscribeProps: object, subscribeCallback?: Listener): SubscriptionHandle;
+    subscribe(
+        channel: string,
+        callback: Callback,
+        subscribeProps: object,
+        subscribeCallback?: SubscribeListener,
+    ): SubscriptionHandle;
 
     /**
      * Unsubscribes the subscription obtained with a call to `subscribe`.
@@ -286,7 +337,7 @@ export class CometD {
      * @param subscription the subscription to unsubscribe.
      * @param unsubscribeCallback a function to be invoked when the unsubscription is acknowledged
      */
-    unsubscribe(subscription: SubscriptionHandle, unsubscribeCallback?: Listener): void;
+    unsubscribe(subscription: SubscriptionHandle, unsubscribeCallback?: SubscribeListener): void;
 
     /**
      * Unsubscribes the subscription obtained with a call to `subscribe`.
@@ -295,7 +346,11 @@ export class CometD {
      * @param unsubscribeProps an object to be merged with the unsubscribe message
      * @param unsubscribeCallback a function to be invoked when the unsubscription is acknowledged
      */
-    unsubscribe(subscription: SubscriptionHandle, unsubscribeProps: object, unsubscribeCallback?: Listener): void;
+    unsubscribe(
+        subscription: SubscriptionHandle,
+        unsubscribeProps: object,
+        unsubscribeCallback?: SubscribeListener,
+    ): void;
 
     /**
      * Resubscribes as necessary in case of a re-handshake.
@@ -349,7 +404,7 @@ export class CometD {
         data: ArrayBuffer | DataView | Uint8Array | Uint16Array | Uint32Array,
         last: boolean,
         meta?: object,
-        callback?: Listener
+        callback?: Listener,
     ): void;
 
     /**
@@ -410,7 +465,7 @@ export class CometD {
      *
      * @param level the log level string
      */
-    setLogLevel(level: "error" | "warn" | "info" | "debug"): void;
+    setLogLevel(level: 'error' | 'warn' | 'info' | 'debug'): void;
 
     /**
      * Registers an extension whose callbacks are called for every incoming message (that comes from
@@ -486,5 +541,10 @@ export class CometD {
      * @param isListener whether it was a listener
      * @param message the message received from the Bayeux server
      */
-    onListenerException: (exception: any, subscriptionHandle: SubscriptionHandle, isListener: boolean, message: string) => void;
+    onListenerException: (
+        exception: any,
+        subscriptionHandle: SubscriptionHandle,
+        isListener: boolean,
+        message: string,
+    ) => void;
 }


### PR DESCRIPTION
- Adds BaseMessage interface to include required and optional properties common to all Messages.
- Adds SuccessfulHandshakeMessage, UnsuccessfulHandshakeMessage, HandshakeMessage and SubscribeMessage interfaces with their appropriate fields.
- Replaces Message interface with a union type of the other messager interfaces.
- Adds specific Listener interfaces and uses them on the appropriate handlers.
- Implements all fields documented at https://docs.cometd.org/current4/reference/#_bayeux_message_fields, and SuccesfulHandshakeMessage's undocumented `reestablish` field implemented here: https://github.com/cometd/cometd/blob/bb64aa2dee3e56c63fcbd46e3951abe278417851/cometd-javascript/common/src/main/webapp/js/cometd/cometd.js#L2180
- Adds some formatting via prettier

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.cometd.org/current4/reference/#_bayeux_message_fields
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
