### PR TITLE
Added typings for CodeFlask

### DIFF
--- a/types/codeflask/codeflask-tests.ts
+++ b/types/codeflask/codeflask-tests.ts
@@ -1,0 +1,12 @@
+import CodeFlask from 'codeflask';
+
+const flask = new CodeFlask(new HTMLElement(), {
+  language: 'js',
+  defaultTheme: false
+});
+
+flask.onUpdate((code) => { });
+
+flask.updateCode('Test');
+
+const code: string = flask.getCode();

--- a/types/codeflask/index.d.ts
+++ b/types/codeflask/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://kazzkiq.github.io/CodeFlask/
 // Definitions by: Joachim Holwech <https://github.com/holwech>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
 
 import { Languages } from 'prismjs';
 

--- a/types/codeflask/index.d.ts
+++ b/types/codeflask/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for codeflask 1.4
+// Project: https://kazzkiq.github.io/CodeFlask/
+// Definitions by: Joachim Holwech <https://github.com/holwech>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Languages } from 'prismjs';
+
+export default class CodeFlask {
+    constructor(selectorOrElement: string | HTMLElement, opts: options);
+    onUpdate(callback: (code: string) => void): void;
+    updateCode(newCode: string): void;
+    getCode(): string;
+    addLanguage(name: string, options: Languages): void;
+}
+
+export interface options {
+    language?: string;
+    rtl?: boolean;
+    tabSize?: number;
+    enableAutocorrect?: boolean;
+    lineNumbers?: boolean;
+    defaultTheme?: boolean;
+    areaId?: string;
+    ariaLabelledby?: string;
+    readonly?: boolean;
+    handleTabs?: boolean;
+    handleSelfClosingCharacters?: boolean;
+    handleNewLineIndentation?: boolean;
+}

--- a/types/codeflask/tsconfig.json
+++ b/types/codeflask/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
+            "es5",
             "dom"
         ],
         "noImplicitAny": true,

--- a/types/codeflask/tsconfig.json
+++ b/types/codeflask/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "codeflask-tests.ts"
+    ]
+}

--- a/types/codeflask/tslint.json
+++ b/types/codeflask/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.