### PR TITLE
Remove duplicate type from forge-apis

### DIFF
--- a/types/forge-apis/index.d.ts
+++ b/types/forge-apis/index.d.ts
@@ -43,7 +43,7 @@ export type Scope =
 
 export interface ApiResponse {
     body: any;
-    headers: { [index: string]: string };
+    headers: { [header: string]: string };
     statusCode: number;
 }
 
@@ -717,11 +717,6 @@ export interface CreateItem {
     jsonapi?: JsonApiVersionJsonapi;
     data?: CreateItemData;
     included: CreateItemIncluded[];
-}
-
-export interface CreateRef {
-    jsonapi?: JsonApiVersionJsonapi;
-    data?: CreateRefData;
 }
 
 export class ItemsApi {


### PR DESCRIPTION
This pull request just removes a duplicate declaration from the type definition file of the `forge-apis` package.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/47ac3ef5e9b2e73b2975508884d7ee5e927353ce/types/forge-apis/index.d.ts#L545-L548 (existing duplicate)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.