### PR TITLE
Changed body type to capture lack of middleware or invalid inputs on express-serve-static-core

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -460,7 +460,7 @@ export interface Request<P extends Params = ParamsDictionary> extends http.Incom
     xhr: boolean;
 
     //body: { username: string; password: string; remember: boolean; title: string; };
-    body: { [key: sting]: string | undefined };
+    body: { [key: string]: string | undefined };
 
     //cookies: { string; remember: boolean; };
     cookies: any;

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -16,22 +16,24 @@ declare global {
     namespace Express {
         // These open interfaces may be extended in an application-specific manner via declaration merging.
         // See for example method-override.d.ts (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/method-override/index.d.ts)
-        interface Request { }
-        interface Response { }
-        interface Application { }
+        interface Request {}
+        interface Response {}
+        interface Application {}
     }
 }
 
-import * as http from "http";
-import { EventEmitter } from "events";
-import { Options as RangeParserOptions, Result as RangeParserResult, Ranges as RangeParserRanges } from "range-parser";
+import * as http from 'http';
+import { EventEmitter } from 'events';
+import { Options as RangeParserOptions, Result as RangeParserResult, Ranges as RangeParserRanges } from 'range-parser';
 
 export interface NextFunction {
     // tslint:disable-next-line callable-types (In ts2.1 it thinks the type alias has no call signatures)
     (err?: any): void;
 }
 
-export interface Dictionary<T> { [key: string]: T; }
+export interface Dictionary<T> {
+    [key: string]: T;
+}
 
 export type ParamsDictionary = Dictionary<string>;
 export type ParamsArray = string[];
@@ -42,11 +44,19 @@ export interface RequestHandler<P extends Params = ParamsDictionary> {
     (req: Request<P>, res: Response, next: NextFunction): any;
 }
 
-export type ErrorRequestHandler<P extends Params = ParamsDictionary> = (err: any, req: Request<P>, res: Response, next: NextFunction) => any;
+export type ErrorRequestHandler<P extends Params = ParamsDictionary> = (
+    err: any,
+    req: Request<P>,
+    res: Response,
+    next: NextFunction,
+) => any;
 
 export type PathParams = string | RegExp | Array<string | RegExp>;
 
-export type RequestHandlerParams<P extends Params = ParamsDictionary> = RequestHandler<P> | ErrorRequestHandler<P> | Array<RequestHandler<P> | ErrorRequestHandler<P>>;
+export type RequestHandlerParams<P extends Params = ParamsDictionary> =
+    | RequestHandler<P>
+    | ErrorRequestHandler<P>
+    | Array<RequestHandler<P> | ErrorRequestHandler<P>>;
 
 export interface IRouterMatcher<T> {
     // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
@@ -118,7 +128,7 @@ export interface IRouter extends RequestHandler {
     mkactivity: IRouterMatcher<this>;
     mkcol: IRouterMatcher<this>;
     move: IRouterMatcher<this>;
-    "m-search": IRouterMatcher<this>;
+    'm-search': IRouterMatcher<this>;
     notify: IRouterMatcher<this>;
     propfind: IRouterMatcher<this>;
     proppatch: IRouterMatcher<this>;
@@ -158,7 +168,7 @@ export interface IRoute {
     mkactivity: IRouterHandler<this>;
     mkcol: IRouterHandler<this>;
     move: IRouterHandler<this>;
-    "m-search": IRouterHandler<this>;
+    'm-search': IRouterHandler<this>;
     notify: IRouterHandler<this>;
     purge: IRouterHandler<this>;
     report: IRouterHandler<this>;
@@ -169,7 +179,7 @@ export interface IRoute {
     unsubscribe: IRouterHandler<this>;
 }
 
-export interface Router extends IRouter { }
+export interface Router extends IRouter {}
 
 export interface CookieOptions {
     maxAge?: number;
@@ -183,9 +193,12 @@ export interface CookieOptions {
     sameSite?: boolean | string;
 }
 
-export interface ByteRange { start: number; end: number; }
+export interface ByteRange {
+    start: number;
+    end: number;
+}
 
-export interface RequestRanges extends RangeParserRanges { }
+export interface RequestRanges extends RangeParserRanges {}
 
 export type Errback = (err: Error) => void;
 
@@ -222,10 +235,10 @@ export interface Request<P extends Params = ParamsDictionary> extends http.Incom
      *
      * Aliased as `req.header()`.
      */
-    get(name: "set-cookie"): string[] | undefined;
+    get(name: 'set-cookie'): string[] | undefined;
     get(name: string): string | undefined;
 
-    header(name: "set-cookie"): string[] | undefined;
+    header(name: 'set-cookie'): string[] | undefined;
     header(name: string): string | undefined;
 
     /**
@@ -447,7 +460,7 @@ export interface Request<P extends Params = ParamsDictionary> extends http.Incom
     xhr: boolean;
 
     //body: { username: string; password: string; remember: boolean; title: string; };
-    body: any;
+    body: { [key: sting]: string | undefined };
 
     //cookies: { string; remember: boolean; };
     cookies: any;
@@ -860,11 +873,13 @@ export interface Response extends http.ServerResponse, Express.Response {
     req?: Request;
 }
 
-export interface Handler extends RequestHandler { }
+export interface Handler extends RequestHandler {}
 
 export type RequestParamHandler = (req: Request, res: Response, next: NextFunction, value: any, name: string) => any;
 
-export type ApplicationRequestHandler<T> = IRouterHandler<T> & IRouterMatcher<T> & ((...handlers: RequestHandlerParams[]) => T);
+export type ApplicationRequestHandler<T> = IRouterHandler<T> &
+    IRouterMatcher<T> &
+    ((...handlers: RequestHandlerParams[]) => T);
 
 export interface Application extends EventEmitter, IRouter, Express.Application {
     /**
@@ -915,7 +930,10 @@ export interface Application extends EventEmitter, IRouter, Express.Application 
      * engines to follow this convention, thus allowing them to
      * work seamlessly within Express.
      */
-    engine(ext: string, fn: (path: string, options: object, callback: (e: any, rendered: string) => void) => void): this;
+    engine(
+        ext: string,
+        fn: (path: string, options: object, callback: (e: any, rendered: string) => void) => void,
+    ): this;
 
     /**
      * Assign `setting` to `val`, or return `setting`'s value.


### PR DESCRIPTION
With current `body: any;` if we get a submission of some information with a totally invalid form, it either does not have any properties or the input names are wrong, type definition file currently will not be able to inform TypeScript to inform us, example:

```
router.get("/login", (req: Request, res: Response) => {
   res.send(
      `<form method="POST">
         <div><label>Email</label>
            <input name="em" />
         </div>
         <div><label>Password</label>
            <input name="pa" />
         </div>
         <button>Submit</button>
       </form>`
   );
});

router.post("/login", (req: Request, res: Response) => {
   const { email, password } = req.body;

   res.send(email.toUpperCase());
}
```

Because I changed the two names inside of `<input />` there will definitely not be an email and password property on `req.body`.

The above resulted in an error around the `toUpperCase()` call, there is no `email` property on the `body` object. Email is undefined and so its trying to call a function `toUpperCase()` on undefined.

The actual names submitted via http request was `em=email%40email.com&pa=password`.

Ideally, we would want TypeScript to understand that `req.body` will contain an object that might or might not have the properties I expect.

This tiny change in the type definition file would make this entire issue go away.

Right now the type definition file is telling me that `body` is going to be a type of `any` and that is not super helpful. Because we could be getting any keys we do not have any idea what keys it will be, so I expressed it accordingly. My change is telling TypeScript that we are going to eventually access some property on this object and its value will either be `string` or `undefined`, we do not know yet.

This would inform TypeScript to inform me to handle the fact that `email` could either be string or undefined. This pattern would definitely force me to deal with this issue, otherwise I would be unaware of it because TypeScript is unaware.