### PR TITLE
Prepare for TS #34742

### DIFF
--- a/types/mergerino/index.d.ts
+++ b/types/mergerino/index.d.ts
@@ -26,7 +26,7 @@ export type DeletePatch = undefined;
  * and the merge function as the second. The return value will be the replacement.
  * The value you return will bypass merging logic and simply overwrite the property.
  */
-export type FunctionPatch<T> = (val: T, merge: Merge<T extends object ? T : never>) => T;
+export type FunctionPatch<T> = (val: Exclude<T, undefined>, merge: Merge<T extends object ? T : never>) => T;
 
 /**
  * If you want to replace a array specify new array as the value.

--- a/types/mergerino/mergerino-tests.ts
+++ b/types/mergerino/mergerino-tests.ts
@@ -149,7 +149,7 @@ function multiArrayFalsyPatches() {
         0,
         null,
         (s, m) => m(s, { age: 10 }),
-        [[[[[[[{ age: (x: number) => x * 3 }]]]]]]],
+        [[[[{ age: x => x * 3 }]]]],
     );
 }
 

--- a/types/node/v10/node-tests.ts
+++ b/types/node/v10/node-tests.ts
@@ -70,11 +70,11 @@ import { Buffer as ImportedBuffer, SlowBuffer as ImportedSlowBuffer, transcode, 
 
         assert.equal(3, "3", "uses == comparator");
 
-        assert.fail('stuff broke');
+        if (!!true) assert.fail('stuff broke');
 
-        assert.fail('actual', 'expected', 'message');
+        if (!!true) assert.fail('actual', 'expected', 'message');
 
-        assert.fail(1, 2, undefined, '>');
+        if (!!true) assert.fail(1, 2, undefined, '>');
 
         assert.ifError(0);
 

--- a/types/vfile/vfile-tests.ts
+++ b/types/vfile/vfile-tests.ts
@@ -40,7 +40,7 @@ file.message('test', {
 
 file.message('test', { start: 'invalid point' }); // $ExpectError
 
-file.fail('test');
+if (!!true) file.fail('test');
 
 const infoMessage: vfileMessage.VFileMessage = file.info('test');
 


### PR DESCRIPTION
This PR prepares for microsoft/TypeScript#34742 by making a couple of changes to `mergerino`. The `FunctionPatch<T>` type now excludes `undefined` from `T` when it is passed as the first parameter, and a test with seven levels of array nesting is reduced to four such that it is fully checked with older versions of the TypeScript compiler.