### PR TITLE
Fix mergerino types and tests in preparation for TS #34742

### DIFF
--- a/types/mergerino/index.d.ts
+++ b/types/mergerino/index.d.ts
@@ -26,7 +26,7 @@ export type DeletePatch = undefined;
  * and the merge function as the second. The return value will be the replacement.
  * The value you return will bypass merging logic and simply overwrite the property.
  */
-export type FunctionPatch<T> = (val: Exclude<T, undefined>, merge: Merge<T extends object ? T : never>) => T;
+export type FunctionPatch<T> = (val: T, merge: Merge<T extends object ? T : never>) => T;
 
 /**
  * If you want to replace a array specify new array as the value.

--- a/types/mergerino/index.d.ts
+++ b/types/mergerino/index.d.ts
@@ -26,7 +26,7 @@ export type DeletePatch = undefined;
  * and the merge function as the second. The return value will be the replacement.
  * The value you return will bypass merging logic and simply overwrite the property.
  */
-export type FunctionPatch<T> = (val: T, merge: Merge<T extends object ? T : never>) => T;
+export type FunctionPatch<T> = (val: Exclude<T, undefined>, merge: Merge<T extends object ? T : never>) => T;
 
 /**
  * If you want to replace a array specify new array as the value.

--- a/types/mergerino/mergerino-tests.ts
+++ b/types/mergerino/mergerino-tests.ts
@@ -149,7 +149,7 @@ function multiArrayFalsyPatches() {
         0,
         null,
         (s, m) => m(s, { age: 10 }),
-        [[[[{ age: (x: number) => x * 3 }]]]],
+        [[[[{ age: (x?: number) => (x || 0) * 3 }]]]],
     );
 }
 

--- a/types/mergerino/mergerino-tests.ts
+++ b/types/mergerino/mergerino-tests.ts
@@ -149,7 +149,7 @@ function multiArrayFalsyPatches() {
         0,
         null,
         (s, m) => m(s, { age: 10 }),
-        [[[[{ age: x => x * 3 }]]]],
+        [[[[{ age: (x: number) => x * 3 }]]]],
     );
 }
 

--- a/types/mergerino/mergerino-tests.ts
+++ b/types/mergerino/mergerino-tests.ts
@@ -149,7 +149,7 @@ function multiArrayFalsyPatches() {
         0,
         null,
         (s, m) => m(s, { age: 10 }),
-        [[[[[[[{ age: (x: number) => x * 3 }]]]]]]],
+        [[[[{ age: x => x * 3 }]]]],
     );
 }
 


### PR DESCRIPTION
This PR prepares for microsoft/TypeScript#34742 by making a couple of changes to `mergerino`. The `FunctionPatch<T>` type now excludes `undefined` from `T` when it is passed as the first parameter, and a test with seven levels of array nesting is reduced to four such that it is fully checked with older versions of the TypeScript compiler.