### PR TITLE
pg-types: actually remove moment dependency

### DIFF
--- a/types/pg-types/package.json
+++ b/types/pg-types/package.json
@@ -1,6 +1,3 @@
 {
-    "private": true,
-    "dependencies": {
-        "moment": ">=2.14.0"
-    }
+    "private": true
 }


### PR DESCRIPTION
It seems to have not been removed from the package.json in fbdaba3edc1271d4a929ca2feaeccdaa2f7eb83d

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] n/a • Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
- [x] None of the above, this just corrects a prior commit.
