### PR TITLE
Nightwatch Types - Support W3C ChromeOptions in nightwatch configuration

### DIFF
--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -88,7 +88,7 @@ export interface ChromeOptions {
     /**
      * Flag to activate W3C WebDriver API. Chromedriver (as of version 2.41 at least) simply does not support the W3C WebDriver API.
      */
-    w3c: boolean;
+    w3c?: boolean;
 }
 
 export interface NightwatchDesiredCapabilities {

--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -85,7 +85,6 @@ export interface ChromeOptions {
      * A list of window types that will appear in the list of window handles. For access to <webview> elements, include "webview" in this list.
      */
     windowTypes?: string[];
-    
     /**
      * Flag to activate W3C WebDriver API. Chromedriver (as of version 2.41 at least) simply does not support the W3C WebDriver API.
      */

--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -85,6 +85,11 @@ export interface ChromeOptions {
      * A list of window types that will appear in the list of window handles. For access to <webview> elements, include "webview" in this list.
      */
     windowTypes?: string[];
+    
+    /**
+     * Flag to activate W3C WebDriver API. Chromedriver (as of version 2.41 at least) simply does not support the W3C WebDriver API.
+     */
+    w3c: boolean;
 }
 
 export interface NightwatchDesiredCapabilities {


### PR DESCRIPTION
Related NPM Package: https://www.npmjs.com/package/@types/nightwatch

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:https://stackoverflow.com/questions/51229700/start-a-chromedriver-session-using-w3c-webdriver-api/52073966#52073966
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

