### PR TITLE
Added property disable boundary checks to react-avatar-editor.

### DIFF
--- a/types/react-avatar-editor/index.d.ts
+++ b/types/react-avatar-editor/index.d.ts
@@ -4,6 +4,7 @@
 //                 Gabriel Prates <https://github.com/gabsprates>
 //                 Laurent Senta <https://github.com/lsenta>
 //                 David Spiess <https://github.com/davidspiess>
+//                 John Grisham <https://github.com/JohnGrisham>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-avatar-editor/index.d.ts
+++ b/types/react-avatar-editor/index.d.ts
@@ -36,6 +36,7 @@ export interface AvatarEditorProps {
     position?: Position;
     rotate?: number;
     crossOrigin?: string;
+    disableBoundaryChecks?: boolean;
     disableDrop?: boolean;
     onDropFile?(event: DragEvent): void;
     onLoadFailure?(event: Event): void;

--- a/types/react-avatar-editor/react-avatar-editor-tests.tsx
+++ b/types/react-avatar-editor/react-avatar-editor-tests.tsx
@@ -45,6 +45,7 @@ class AvatarEditorTest extends React.Component {
                 <AvatarEditor image="" position={position} />
                 <AvatarEditor image="" rotate={1} />
                 <AvatarEditor image="" crossOrigin="" />
+                <AvatarEditor image="" disableBoundaryChecks={true} />
                 <AvatarEditor image="" disableDrop={true} />
                 <AvatarEditor image="" onDropFile={event => {}} />
                 <AvatarEditor image="" onLoadFailure={event => {}} />


### PR DESCRIPTION
React Avatar Editor / DisableBoundaryChecks optional prop

- [ ] Code tested locally and works.

- [ ] Tests ran and passed.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/mosch/react-avatar-editor/blob/master/src/index.js>> line 176