### PR TITLE
fix: update type of eureka-js-client config object

### DIFF
--- a/types/eureka-js-client/index.d.ts
+++ b/types/eureka-js-client/index.d.ts
@@ -61,8 +61,8 @@ export namespace EurekaClient {
         };
     }
     interface EurekaClientConfig {
-        host: string;
-        port: number;
+        host?: string;
+        port?: number;
         heartbeatInterval?: number;
         registryFetchInterval?: number;
         maxRetries?: number;
@@ -78,6 +78,9 @@ export namespace EurekaClient {
         registerWithEureka?: boolean;
         useLocalMetadata?: boolean;
         preferIpAddress?: boolean;
+        serviceUrls?: {
+            [index: string]: string[];
+        };
     }
     interface EurekaYmlConfig {
         cwd: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquatier/eureka-js-client/blob/master/src/ConfigClusterResolver.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.