### PR TITLE
webpack: add `Stats.presetToOptions` method

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1214,7 +1214,7 @@ declare namespace webpack {
         hash?: string;
         startTime?: number;
         endTime?: number;
-        /** Retuns the default options object from the stats preset **/
+        /** Returns the default options object from the stats preset. **/
         static presetToOptions( preset?: Stats.Preset ): Stats.ToJsonOptionsObject;
         /** Returns true if there were errors while compiling. */
         hasErrors(): boolean;

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1214,8 +1214,11 @@ declare namespace webpack {
         hash?: string;
         startTime?: number;
         endTime?: number;
-        /** Returns the default options object from the stats preset. **/
-        static presetToOptions( preset?: Stats.Preset ): Stats.ToJsonOptionsObject;
+        /**
+         * Returns the default json options from the stats preset.
+         * @param preset The preset to be transformed into json options.
+         */
+         static presetToOptions( preset?: Stats.Preset ): Stats.ToJsonOptionsObject;
         /** Returns true if there were errors while compiling. */
         hasErrors(): boolean;
         /** Returns true if there were warnings while compiling. */

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1218,7 +1218,7 @@ declare namespace webpack {
          * Returns the default json options from the stats preset.
          * @param preset The preset to be transformed into json options.
          */
-         static presetToOptions( preset?: Stats.Preset ): Stats.ToJsonOptionsObject;
+        static presetToOptions(preset?: Stats.Preset): Stats.ToJsonOptionsObject;
         /** Returns true if there were errors while compiling. */
         hasErrors(): boolean;
         /** Returns true if there were warnings while compiling. */

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1214,6 +1214,8 @@ declare namespace webpack {
         hash?: string;
         startTime?: number;
         endTime?: number;
+        /** Retuns the default options object from the stats preset **/
+        static presetToOptions( preset?: Stats.Preset ): Stats.ToJsonOptionsObject;
         /** Returns true if there were errors while compiling. */
         hasErrors(): boolean;
         /** Returns true if there were warnings while compiling. */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack/blob/v4.41.2/lib/Stats.js#L1589
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
