### PR TITLE
Add type for ajv-keywords

### DIFF
--- a/types/ajv-keywords/ajv-keywords-tests.ts
+++ b/types/ajv-keywords/ajv-keywords-tests.ts
@@ -1,0 +1,5 @@
+import Ajv from 'ajv';
+import defineKeywords = require('ajv-keywords');
+
+let ajv = new Ajv();
+ajv = defineKeywords(ajv);

--- a/types/ajv-keywords/index.d.ts
+++ b/types/ajv-keywords/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for ajv-keywords 3.4
+// Project: https://github.com/epoberezkin/ajv-keywords#readme
+// Definitions by: Eric Gonzalez <https://github.com/lochiego>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+import { Ajv } from "ajv";
+
+export { };
+
+/**
+ * Defines one or several keywords in ajv instance
+ * @param  ajv validator instance
+ * @param  keywords keyword(s) to define
+ * @return ajv instance (for chaining)
+ */
+declare function defineKeywords(ajv: Ajv, keywords?: string | ReadonlyArray<string>): Ajv;
+
+export = defineKeywords;

--- a/types/ajv-keywords/package.json
+++ b/types/ajv-keywords/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "ajv": "^6.9.1"
+    }
+}

--- a/types/ajv-keywords/tsconfig.json
+++ b/types/ajv-keywords/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "ajv-keywords-tests.ts"
+    ]
+}

--- a/types/ajv-keywords/tslint.json
+++ b/types/ajv-keywords/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
