### PR TITLE
Add types for `@ember/ordered-set`.

### DIFF
--- a/types/ember__ordered-set/index.d.ts
+++ b/types/ember__ordered-set/index.d.ts
@@ -23,8 +23,8 @@ export default class OrderedSet<T = unknown> {
     add(value: T): this;
     clear(): void;
     delete(value: T): boolean;
-    forEach(callbackfn: (this: undefined, value: T, value2: T, set: Set<T>) => void): void;
-    forEach<Ctx>(callbackfn: (this: Ctx, value: T, value2: T, set: Set<T>) => void, context: Ctx): void;
+    forEach(callbackfn: (this: undefined, value: T, value2: T, set: OrderedSet<T>) => void): void;
+    forEach<Ctx>(callbackfn: (this: Ctx, value: T, value2: T, set: OrderedSet<T>) => void, context: Ctx): void;
     has(value: T): boolean;
     isEmpty(): boolean;
     toArray(): T[];

--- a/types/ember__ordered-set/index.d.ts
+++ b/types/ember__ordered-set/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @ember/object 2.0
+// Type definitions for @ember/ordered-set 2.0
 // Project: https://github.com/emberjs/ember-ordered-set
 // Definitions by: Chris Krycho <https://github.com/chriskrycho>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/ember__ordered-set/index.d.ts
+++ b/types/ember__ordered-set/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for @ember/object 2.0
+// Project: https://github.com/emberjs/ember-ordered-set
+// Definitions by: Chris Krycho <https://github.com/chriskrycho>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+/**
+ * The `OrderedSet` class lets you store unique values of any type, whether
+ * primitive values or object references. It is mostly similar to the native
+ * `Set` class introduced in ES2015.
+ */
+export default class OrderedSet<T = unknown> {
+    constructor();
+
+    // Disable this to let users call like `OrderedSet.create<string>();`. This
+    // is a rare case where it's preferable, because it's *much* briefer than
+    // `let set: OrderedSet<string> = OrderedSet.create();`. If TS could infer
+    // from usage what the type would be, this wouldn't be required, but until
+    // it does, this is better than *not* allowing it.
+    // tslint:disable-next-line:no-unnecessary-generics
+    static create<T = unknown>(): OrderedSet<T>;
+
+    add(value: T): this;
+    clear(): void;
+    delete(value: T): boolean;
+    forEach(callbackfn: (this: undefined, value: T, value2: T, set: Set<T>) => void): void;
+    forEach<Ctx>(callbackfn: (this: Ctx, value: T, value2: T, set: Set<T>) => void, context: Ctx): void;
+    has(value: T): boolean;
+    isEmpty(): boolean;
+    toArray(): T[];
+    copy(): OrderedSet<T>;
+}

--- a/types/ember__ordered-set/test/ember__ordered-set-tests.ts
+++ b/types/ember__ordered-set/test/ember__ordered-set-tests.ts
@@ -1,0 +1,84 @@
+// Note -- these tests are derived from the actual tests used to test the Ember
+// addon package: https://github.com/emberjs/ember-ordered-set/blob/master/addon/index.js
+// They have been tweaked as necessary, but that starting point means they
+// *should* cover the expected API.
+
+import OrderedSet from '@ember/ordered-set';
+import { assertType } from './lib/assert';
+
+interface Dict<T> {
+    [key: string]: T | undefined;
+}
+
+// new OrderedSet() creates an empty new instance
+new OrderedSet(); // $ExpectType OrderedSet<unknown>
+new OrderedSet(1234); // $ExpectError
+
+// create() creates an empty new instance
+OrderedSet.create(); // $ExpectType OrderedSet<unknown>
+OrderedSet.create(1234); // $ExpectError
+
+// clear() removes any existing entries
+OrderedSet.create().clear(); // $ExpectType void
+
+// add() adds an entry
+// add() returns the set
+OrderedSet.create<string>().add('foo'); // $ExpectType OrderedSet<string>
+
+// add() can handle non-string objects
+const setForDict = OrderedSet.create<Dict<string>>(); // $ExpectType OrderedSet<Dict<string>>
+setForDict.add({ bar: 'baz' });
+
+// delete() deletes an entry
+// delete() returns whether object was part of the set
+OrderedSet.create<string>().delete('foo'); // $ExpectType boolean
+
+// delete() can handle non-string objects
+setForDict.delete({ bar: 'baz' }); // $ExpectType boolean
+
+// isEmpty() returns whether the set has any entries
+OrderedSet.create().isEmpty(); // $ExpectType boolean
+
+// has() returns whether an object is part of the set
+OrderedSet.create().has('foo'); // $ExpectType boolean
+
+// has() supports non-string objects
+OrderedSet.create<Dict<string>>().has({ bar: 'baz' });
+
+// forEach() iterates over all entries
+const stringEntries: string[] = [];
+OrderedSet.create<string>().forEach(entry => stringEntries.push(entry));
+
+// forEach() is called with no context by default
+const sansContext = OrderedSet.create<string>();
+
+sansContext.add('foo');
+
+sansContext.forEach(function(entry) {
+    assertType<string>(entry);
+    assertType<void>(this);
+});
+
+// forEach() context can be set as second argument
+const withContext = OrderedSet.create<string>();
+const context = { bar: 'baz' };
+withContext.forEach(function(entry) {
+    assertType<string>(entry);
+    assertType<Dict<string>>(this);
+}, context);
+
+// toArray() returns an array of all entries
+OrderedSet.create<number>().toArray(); // $ExpectType number[]
+
+// copy() copies all entries into a new set
+OrderedSet.create<number>().copy(); // $ExpectType OrderedSet<number>
+
+// sets by default accept anything
+const anythingGoesYo = OrderedSet.create(); // $ExpectType OrderedSet<unknown>
+anythingGoesYo.add('strings'); // $ExpectType OrderedSet<unknown>
+anythingGoesYo.add(123); // $ExpectType OrderedSet<unknown>
+
+// sets can be constrained
+const constrained = OrderedSet.create<string>(); // $ExpectType OrderedSet<string>
+constrained.add('strings are fine'); // $ExpectType OrderedSet<string>
+constrained.add({ otherStuff: 'not so much' }); // $ExpectError

--- a/types/ember__ordered-set/test/lib/assert.ts
+++ b/types/ember__ordered-set/test/lib/assert.ts
@@ -1,0 +1,5 @@
+/** Static assertion that `value` has type `T` */
+// Disable tslint here b/c the generic is used to let us do a type coercion and
+// validate that coercion works for the type value "passed into" the function.
+// tslint:disable-next-line:no-unnecessary-generics
+export declare function assertType<T>(value: T): T;

--- a/types/ember__ordered-set/tsconfig.json
+++ b/types/ember__ordered-set/tsconfig.json
@@ -1,0 +1,30 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@ember/ordered-set": ["ember__ordered-set"],
+            "@ember/ordered-set/*": ["ember__ordered-set/*"],
+            "@ember/utils": ["ember__utils"],
+            "@ember/utils/*": ["ember__utils/*"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "test/ember__ordered-set-tests.ts",
+        "test/lib/assert.ts"
+    ]
+}

--- a/types/ember__ordered-set/tslint.json
+++ b/types/ember__ordered-set/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": false // The ember addon package exports *build-time*, not *run-time* code.
+    }
+}


### PR DESCRIPTION
Defines the public API for [@ember/ordered-set](https://github.com/emberjs/ember-ordered-set). Note that the API is only documented thus:

> The `OrderedSet` class has mostly the same API as the native [`Set`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set)
class with a few differences:
>
> - The constructor does not take any arguments
> - A static `create()` method exists for symmetry with `Ember.Object`
> - A static `length` property does not exist on `OrderedSet`
> - `OrderedSet` has an `isEmpty()` method
> - There are no `entries()`, `keys()` and `values()` methods, but there is a
>   `toArray()` method instead
> - The `@@iterator` symbol is not defined
> - `OrderedSet` has a `copy()` method

As such I used the test suite as a guide to the API, and used the same naming conventions as those used in the TS `Set` definition.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.

    ***Note:** I've added it for the npm-naming rule, but also added a comment to clarify why!*

- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

cc. @rwjblue @dfreeman @jamescdavis @mike-north 

---

Resolves typed-ember/ember-cli-typescript#884