### PR TITLE
[mongodb] Fix and add watch to db definition

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -72,7 +72,7 @@ export class MongoClient extends EventEmitter {
     logout(options: { dbName?: string }, callback: MongoCallback<any>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html#startSession */
     startSession(options?: SessionOptions): ClientSession;
-    /** http://mongodb.github.io/node-mongodb-native/3.3/api/MongoClient.html#watch */
+    /** http://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html#watch */
     watch(pipeline?: object[], options?: ChangeStreamOptions & { session?: ClientSession }): ChangeStream;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html#withSession */
     withSession(operation: (session: ClientSession) => Promise<any>): Promise<void>;
@@ -681,7 +681,7 @@ export class Db extends EventEmitter {
     stats(callback: MongoCallback<any>): void;
     stats(options?: { scale?: number }): Promise<any>;
     stats(options: { scale?: number }, callback: MongoCallback<any>): void;
-    /** http://mongodb.github.io/node-mongodb-native/3.3/api/Db.html#watch */
+    /** http://mongodb.github.io/node-mongodb-native/3.1/api/Db.html#watch */
     watch(pipeline?: object[], options?: ChangeStreamOptions & { session?: ClientSession }): ChangeStream;
 }
 
@@ -1134,7 +1134,7 @@ export interface Collection<TSchema = Default> {
         options: UpdateOneOptions,
         callback: MongoCallback<UpdateWriteOpResult>,
     ): void;
-    /** http://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#watch */
+    /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#watch */
     watch(
         pipeline?: object[],
         options?: ChangeStreamOptions & { session?: ClientSession },

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2260,6 +2260,8 @@ export interface GridFSBucketWriteStreamOptions extends WriteConcern {
 
 /** http://mongodb.github.io/node-mongodb-native/3.1/api/ChangeStream.html */
 export class ChangeStream extends Readable {
+    resumeToken: ResumeToken;
+
     constructor(changeDomain: Db | Collection, pipeline: object[], options?: ChangeStreamOptions);
 
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/ChangeStream.html#close */
@@ -2279,6 +2281,10 @@ export class ChangeStream extends Readable {
 
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/ChangeStream.html#stream */
     stream(options?: { transform?: Function }): Cursor;
+}
+
+export interface ResumeToken {
+    _data: string;
 }
 
 /** https://mongodb.github.io/node-mongodb-native/3.3/api/global.html#ChangeStreamOptions */

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -26,6 +26,7 @@
 //                 Luis Pais <https://github.com/ranguna>
 //                 Hossein Saniei <https://github.com/HosseinAgha>
 //                 Alberto Silva <https://github.com/albertossilva>
+//                 Rauno Viskus <https://github.com/Rauno56>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -71,8 +72,8 @@ export class MongoClient extends EventEmitter {
     logout(options: { dbName?: string }, callback: MongoCallback<any>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html#startSession */
     startSession(options?: SessionOptions): ClientSession;
-    /** http://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html#watch */
-    watch(pipeline?: object[], options?: ChangeStreamOptions & { startAtOperationTime?: Timestamp, session?: ClientSession }): ChangeStream;
+    /** http://mongodb.github.io/node-mongodb-native/3.3/api/MongoClient.html#watch */
+    watch(pipeline?: object[], options?: ChangeStreamOptions & { session?: ClientSession }): ChangeStream;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html#withSession */
     withSession(operation: (session: ClientSession) => Promise<any>): Promise<void>;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html#withSession */
@@ -680,6 +681,8 @@ export class Db extends EventEmitter {
     stats(callback: MongoCallback<any>): void;
     stats(options?: { scale?: number }): Promise<any>;
     stats(options: { scale?: number }, callback: MongoCallback<any>): void;
+    /** http://mongodb.github.io/node-mongodb-native/3.3/api/Db.html#watch */
+    watch(pipeline?: object[], options?: ChangeStreamOptions & { session?: ClientSession }): ChangeStream;
 }
 
 export interface CommonOptions extends WriteConcern {
@@ -1131,10 +1134,10 @@ export interface Collection<TSchema = Default> {
         options: UpdateOneOptions,
         callback: MongoCallback<UpdateWriteOpResult>,
     ): void;
-    /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#watch */
+    /** http://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#watch */
     watch(
         pipeline?: object[],
-        options?: ChangeStreamOptions & { startAtOperationTime?: Timestamp; session?: ClientSession },
+        options?: ChangeStreamOptions & { session?: ClientSession },
     ): ChangeStream;
 }
 
@@ -2278,14 +2281,16 @@ export class ChangeStream extends Readable {
     stream(options?: { transform?: Function }): Cursor;
 }
 
+/** https://mongodb.github.io/node-mongodb-native/3.3/api/global.html#ChangeStreamOptions */
 export interface ChangeStreamOptions {
     fullDocument?: string;
     maxAwaitTimeMS?: number;
     resumeAfter?: object;
+    startAfter?: object;
+    startAtOperationTime?: Timestamp;
     batchSize?: number;
     collation?: CollationDocument;
     readPreference?: ReadPreference;
-    startAfter?: object;
 }
 
 type GridFSBucketWriteStreamId = string | number | object | ObjectId;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [ChangeStreamOptions](https://mongodb.github.io/node-mongodb-native/3.3/api/global.html#ChangeStreamOptions) & [watch](https://mongodb.github.io/node-mongodb-native/3.3/api/Db.html#watch)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
