### PR TITLE
Update mui-datatables onFilterChange function signature

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -11,7 +11,7 @@ import * as React from 'react';
 
 export type Display = 'true' | 'false' | 'excluded';
 export type SortDirection = 'asc' | 'desc';
-export type FilterType = 'dropdown' | 'checkbox' | 'multiselect' | 'textField' | 'custom';
+export type FilterType = 'dropdown' | 'checkbox' | 'multiselect' | 'textField' | 'custom' | 'chip' | 'reset';
 export type Responsive = 'stacked' | 'scrollMaxHeight' | 'scrollFullHeight';
 export type SelectableRows = 'multiple' | 'single' | 'none';
 
@@ -192,7 +192,7 @@ export interface MUIDataTableOptions {
         columns: any,
         data: any
     ) => BlobPart;
-    onFilterChange?: (changedColumn: string, filterList: any[]) => void;
+    onFilterChange?: (changedColumn: string, filterList: any[], type: FilterType) => void;
     onFilterDialogOpen?: () => void;
     onFilterDialogClose?: () => void;
     onRowClick?: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => void;


### PR DESCRIPTION
Add type argument to onFilterChange function signature, which now accepts 3 arguments instead of 2.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gregnb/mui-datatables
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.