### PR TITLE
[react-select] export types from main entry-point

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -11,6 +11,20 @@ import { StateManager } from './src/stateManager';
 
 export default StateManager;
 
+export * from './src/types';
 export { createFilter } from './src/filters';
-export { components } from './src/components/index';
-export { mergeStyles } from './src/styles';
+export { mergeStyles, Styles, StylesConfig } from './src/styles';
+
+export { Props, FormatOptionLabelMeta } from './src/Select';
+
+export { components, SelectComponentsConfig, IndicatorComponentType } from './src/components';
+export { IndicatorProps } from './src/components/indicators';
+export { ControlProps } from './src/components/Control';
+export { GroupProps } from './src/components/Group';
+export { InputProps } from './src/components/Input';
+export { MenuProps, MenuListComponentProps } from './src/components/Menu';
+export { MultiValueProps } from './src/components/MultiValue';
+export { OptionProps } from './src/components/Option';
+export { PlaceholderProps } from './src/components/Placeholder';
+export { SingleValueProps } from './src/components/SingleValue';
+export { ValueContainerProps } from './src/components/containers';


### PR DESCRIPTION
## What? 
Re-exports internal types from the main entry point (`/index.d.ts`)

## Why? 
The current approach requires importing internal types like so:

`import { OptionsType } from 'react-select/src/types';`

Which can be quite counterintuitive based on my previous experiences with other libraries. You have to search the source code of the `node_module` to find the correct path then import that path explicitly. Internal changes to the types package would be a breaking change even if types are not altered.

It would be nice to make types accessible via the main entry-point, similar to other common libraries. For example: `import React, { ReactNode } from 'react';`

It looks like I'm not the only one, there are a few issues in DefinitelyTyped and ReactSelect stemming from the same confusion:

> It is weird to have a typing library for react-select and not be able to do anything with it. How do you guys customize components for a select if you're using typescript? What type hosts innerProps?

- https://github.com/JedWatson/react-select/issues/3509
- https://github.com/DefinitelyTyped/DefinitelyTyped/issues/38009
- https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37444
