### PR TITLE
refactor: sparql-http-client updated to use correct exports

### DIFF
--- a/types/sparql-http-client/index.d.ts
+++ b/types/sparql-http-client/index.d.ts
@@ -7,33 +7,40 @@
 import { Term } from 'rdf-js';
 import { URL } from 'url';
 
-export interface SparqlHttpOptions {
-    endpointUrl?: string;
-    updateUrl?: string;
+declare namespace SparqlHttp {
+  interface SparqlHttpOptions {
+      endpointUrl?: string;
+      updateUrl?: string;
+  }
+
+  interface SparqlClientOptions extends SparqlHttpOptions {
+        fetch?: typeof fetch;
+        URL?: typeof URL;
+  }
+
+  interface QueryRequestInit extends SparqlHttpOptions, RequestInit {}
+
+  interface SelectBindings {
+      results: { bindings: ReadonlyArray<Record<string, Term>> };
+  }
+
+  interface AskResult {
+        boolean: boolean;
+  }
+
+  interface SelectResponse {
+        json(): Promise<SelectBindings & AskResult>;
+  }
 }
 
-export interface SparqlClientOptions extends SparqlHttpOptions {
-    fetch?: typeof fetch;
-    URL?: typeof URL;
+declare class SparqlHttp<TResponse extends Response = Response> {
+    constructor(options?: SparqlHttp.SparqlClientOptions);
+
+    updateQuery(query: string, options?: SparqlHttp.QueryRequestInit): Promise<Response>;
+
+    selectQuery(query: string, options?: SparqlHttp.QueryRequestInit): Promise<SparqlHttp.SelectResponse & TResponse>;
+
+    constructQuery(query: string, options?: SparqlHttp.QueryRequestInit): Promise<TResponse>;
 }
 
-export interface QueryRequestInit extends SparqlHttpOptions, RequestInit {}
-
-export interface SelectBindings {
-    results: { bindings: ReadonlyArray<Record<string, Term>> };
-}
-
-export interface AskResult {
-    boolean: boolean;
-}
-
-export interface SelectResponse {
-    json(): Promise<SelectBindings & AskResult>;
-}
-
-export class SparqlHttp<TResponse extends Response = Response> {
-    constructor(options?: SparqlClientOptions);
-    updateQuery(query: string, options?: QueryRequestInit): Promise<Response>;
-    selectQuery(query: string, options?: QueryRequestInit): Promise<SelectResponse & TResponse>;
-    constructQuery(query: string, options?: QueryRequestInit): Promise<TResponse>;
-}
+export = SparqlHttp;

--- a/types/sparql-http-client/index.d.ts
+++ b/types/sparql-http-client/index.d.ts
@@ -31,7 +31,7 @@ export interface SelectResponse {
     json(): Promise<SelectBindings & AskResult>;
 }
 
-export default class SparqlHttp<TResponse extends Response = Response> {
+export class SparqlHttp<TResponse extends Response = Response> {
     constructor(options?: SparqlClientOptions);
     updateQuery(query: string, options?: QueryRequestInit): Promise<Response>;
     selectQuery(query: string, options?: QueryRequestInit): Promise<SelectResponse & TResponse>;

--- a/types/sparql-http-client/index.d.ts
+++ b/types/sparql-http-client/index.d.ts
@@ -5,7 +5,6 @@
 // TypeScript Version: 2.3
 
 import { Term } from 'rdf-js';
-import fetch, { Response, RequestInit } from 'node-fetch';
 import { URL } from 'url';
 
 export interface SparqlHttpOptions {
@@ -14,8 +13,8 @@ export interface SparqlHttpOptions {
 }
 
 export interface SparqlClientOptions extends SparqlHttpOptions {
-    fetch: typeof fetch;
-    URL: typeof URL;
+    fetch?: typeof fetch;
+    URL?: typeof URL;
 }
 
 export interface QueryRequestInit extends SparqlHttpOptions, RequestInit {}
@@ -32,8 +31,8 @@ export interface SelectResponse {
     json(): Promise<SelectBindings & AskResult>;
 }
 
-export class SparqlHttp<TResponse extends Response = Response> {
-    constructor(options?: SparqlHttpOptions);
+export default class SparqlHttp<TResponse extends Response = Response> {
+    constructor(options?: SparqlClientOptions);
     updateQuery(query: string, options?: QueryRequestInit): Promise<Response>;
     selectQuery(query: string, options?: QueryRequestInit): Promise<SelectResponse & TResponse>;
     constructQuery(query: string, options?: QueryRequestInit): Promise<TResponse>;

--- a/types/sparql-http-client/sparql-http-client-tests.ts
+++ b/types/sparql-http-client/sparql-http-client-tests.ts
@@ -1,4 +1,4 @@
-import { SparqlHttp } from 'sparql-http-client';
+import * as SparqlHttp from 'sparql-http-client';
 
 const client = new SparqlHttp();
 

--- a/types/sparql-http-client/sparql-http-client-tests.ts
+++ b/types/sparql-http-client/sparql-http-client-tests.ts
@@ -1,4 +1,4 @@
-import { SparqlHttp } from 'sparql-http-client';
+import SparqlHttp from 'sparql-http-client';
 
 const client = new SparqlHttp();
 

--- a/types/sparql-http-client/sparql-http-client-tests.ts
+++ b/types/sparql-http-client/sparql-http-client-tests.ts
@@ -1,4 +1,4 @@
-import SparqlHttp from 'sparql-http-client';
+import { SparqlHttp } from 'sparql-http-client';
 
 const client = new SparqlHttp();
 

--- a/types/sparql-http-client/tsconfig.json
+++ b/types/sparql-http-client/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "webworker"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/sparql-http-client/tslint.json
+++ b/types/sparql-http-client/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{ 
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+ }

--- a/types/sparql-http-client/tslint.json
+++ b/types/sparql-http-client/tslint.json
@@ -1,6 +1,3 @@
 { 
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "npm-naming": false
-    }
+    "extends": "dtslint/dt.json"
  }


### PR DESCRIPTION
Somehow GitHub did not update the previous PR #38994 so here's a new one.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zazuko/sparql-http-client/blob/master/index.js#L118

The package does commons default export and I got misled by the tslint error. Following numerous other packages I disabled that lint rule. Also switched to the default typing of fetch as the package does not really import `node-fetch`