### PR TITLE
fix: axisPointer.label.margin should be number

### DIFF
--- a/types/echarts/index.d.ts
+++ b/types/echarts/index.d.ts
@@ -1488,7 +1488,7 @@ declare namespace echarts {
                     show?: boolean;
                     precision?: number | string;
                     formatter?: string | Function;
-                    margin?: boolean;
+                    margin?: number;
                     color?: string;
                     fontStyle?: 'normal' | 'italic' | 'oblique';
                     fontWeight?: 'normal' | 'bold' | 'bolder' | 'lighter'

--- a/types/echarts/options/series/line.d.ts
+++ b/types/echarts/options/series/line.d.ts
@@ -1,6 +1,35 @@
 declare namespace echarts {
     namespace EChartOption {
         /**
+         * Color type for itemStyle / areaStyle etc.
+         * [Color](https://echarts.apache.org/zh/option.html#series-line.areaStyle)
+         * + Linear gradient. First four parameters are x0, y0, x2, and y2, each ranged from 0 to 1, standing for percentage in the bounding box. If global is `true`, then the first four parameters are in absolute pixel positions.
+         * + Radial gradient. First three parameters are x and y positions of center, and radius, similar to linear gradient.
+         * + Fill with texture
+         */
+        type Color = string | {
+            type: 'linear';
+            x: number;
+            y: number;
+            x2: number;
+            y2: number;
+            colorStops: Array<{offset: number; color: string}>;
+            global?: boolean
+        } | {
+            type: 'radial';
+            x: number;
+            y: number;
+            r: number;
+            colorStops: Array<{offset: number, color: string}>;
+            global?: boolean;
+        } | {
+            /**
+             * HTMLImageElement, and HTMLCanvasElement are supported, while string path is not supported
+             */
+            image: HTMLImageElement | HTMLCanvasElement,
+            repeat?: 'repeat' | 'repeat-x' | 'repeat-y' | 'no-repeat' // 是否平铺, 可以是 'repeat-x', 'repeat-y', 'no-repeat'
+        }
+        /**
          * **broken line chart**
          *
          * Broken line chart relates all the data points
@@ -7000,7 +7029,7 @@ declare namespace echarts {
                      * "#000"
                      * @see https://ecomfe.github.io/echarts-doc/public/en/option.html#series-line.markLine.lineStyle.color
                      */
-                    color?: string;
+                    color?: Color;
 
                     /**
                      * line width.
@@ -7488,7 +7517,7 @@ declare namespace echarts {
                              * "#000"
                              * @see https://ecomfe.github.io/echarts-doc/public/en/option.html#series-line.markLine.data.0.lineStyle.color
                              */
-                            color?: string;
+                            color?: Color;
 
                             /**
                              * line width.
@@ -8103,7 +8132,7 @@ declare namespace echarts {
                              * "#000"
                              * @see https://ecomfe.github.io/echarts-doc/public/en/option.html#series-line.markLine.data.1.lineStyle.color
                              */
-                            color?: string;
+                            color?: Color;
 
                             /**
                              * line width.


### PR DESCRIPTION
(xAxis | yAxis).axisPointer.label.margin should be number instead of boolean.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://echarts.apache.org/zh/option.html#xAxis.axisPointer.label.margin>>



