### PR TITLE
[recharts] Mark most of array props as readonly

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -28,13 +28,13 @@ export type Percentage = string;
 export type RechartsFunction = (...args: any[]) => void;
 export type LegendValueFormatter = (value?: LegendPayload['value'], entry?: LegendPayload, i?: number) => any;
 export type TickFormatterFunction = (value: any) => any;
-export type TickGeneratorFunction = (noTicksProps: object) => any[];
+export type TickGeneratorFunction = (noTicksProps: object) => ReadonlyArray<any>;
 export type LabelFormatter = (label: string | number) => React.ReactNode;
 export type TooltipFormatter = (value: string | number | Array<string | number>, name: string,
     entry: TooltipPayload, index: number) => React.ReactNode;
 export type ItemSorter<T> = (a: T, b: T) => number;
 export type ContentRenderer<P> = (props: P) => React.ReactNode;
-export type DataKey = string | number | ((dataObject: any) => string | number | [number, number] | null);
+export type DataKey = string | number | ((dataObject: any) => string | number | Readonly<[number, number]> | null);
 
 export type IconType = 'plainline' | 'line' | 'square' | 'rect' | 'circle' | 'cross' | 'diamond' | 'star' | 'triangle' | 'wye' | 'plainline';
 export type LegendType = IconType | 'none';
@@ -78,7 +78,7 @@ export interface ContainerSize {
 export interface Point {
     x: number;
     y: number;
-    value: number | any[];
+    value: number | ReadonlyArray<any>;
 }
 
 export interface Margin {
@@ -192,9 +192,9 @@ export interface AreaProps extends EventAttributes, Partial<PresentationAttribut
     label?: boolean | object | ContentRenderer<any> | React.ReactElement;
     hide?: boolean;
     layout?: LayoutType;
-    baseLine?: number | any[];
+    baseLine?: number | ReadonlyArray<any>;
     isRange?: boolean;
-    points?: Point[];
+    points?: ReadonlyArray<Point>;
     id?: string;
 }
 
@@ -210,15 +210,15 @@ export interface BarData {
     y: number;
     width: number;
     height: number;
-    radius: number | any[];
-    value: number | string | any[];
+    radius: number | ReadonlyArray<any>;
+    value: number | string | ReadonlyArray<any>;
 }
 
 export interface BarProps extends EventAttributes, Partial<PresentationAttributes>, Animatable {
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
     className?: string;
     fill?: string;
-    radius?: number | number[];
+    radius?: number | ReadonlyArray<number>;
     layout?: LayoutType;
     xAxisId?: string | number;
     yAxisId?: string | number;
@@ -233,7 +233,7 @@ export interface BarProps extends EventAttributes, Partial<PresentationAttribute
     maxBarSize?: number;
     hide?: boolean;
     shape?: React.ReactElement | ContentRenderer<RectangleProps>;
-    data?: BarData[];
+    data?: ReadonlyArray<BarData>;
     background?: boolean | React.ReactElement | ContentRenderer<any> | object;
     // see label section at http://recharts.org/#/en-US/api/Bar
     label?: boolean | Label | LabelProps | React.SFC<LabelProps> | React.ReactElement<LabelProps> | ContentRenderer<any>;
@@ -258,7 +258,7 @@ export interface BrushProps {
     travellerWidth?: number;
     padding?: Partial<Margin>;
     dataKey?: DataKey;
-    data?: any[];
+    data?: ReadonlyArray<any>;
     startIndex?: number;
     endIndex?: number;
     tickFormatter?: TickFormatterFunction;
@@ -284,7 +284,7 @@ export interface CartesianAxisProps extends EventAttributes, Partial<Presentatio
     tickLine?: boolean | object;
     mirror?: boolean;
     minTickGap?: number;
-    ticks?: any[];
+    ticks?: ReadonlyArray<any>;
     tickSize?: number;
     stroke?: string;
     tickFormatter?: TickFormatterFunction;
@@ -299,7 +299,7 @@ export type CoordinatesGenerator = (arg: {
     width: CartesianGridProps['chartWidth'];
     height: CartesianGridProps['chartHeight'];
     offset: CartesianGridProps['offset'];
-}) => number[];
+}) => ReadonlyArray<number>;
 
 export interface CartesianGridProps extends Partial<PresentationAttributes> {
     y?: number;
@@ -307,8 +307,8 @@ export interface CartesianGridProps extends Partial<PresentationAttributes> {
     height?: number;
     horizontal?: object | React.ReactElement | ContentRenderer<LineProps & CartesianGridProps> | boolean;
     vertical?: object | React.ReactElement | ContentRenderer<LineProps & CartesianGridProps> | boolean;
-    horizontalPoints?: number[];
-    verticalPoints?: number[];
+    horizontalPoints?: ReadonlyArray<number>;
+    verticalPoints?: ReadonlyArray<number>;
     horizontalCoordinatesGenerator?: CoordinatesGenerator;
     verticalCoordinatesGenerator?: CoordinatesGenerator;
     xAxis?: object;
@@ -316,8 +316,8 @@ export interface CartesianGridProps extends Partial<PresentationAttributes> {
     offset?: object;
     chartWidth?: number;
     chartHeight?: number;
-    horizontalFill?: string[];
-    verticalFill?: string[];
+    horizontalFill?: ReadonlyArray<string>;
+    verticalFill?: ReadonlyArray<string>;
 }
 
 export class CartesianGrid extends React.Component<CartesianGridProps> { }
@@ -350,8 +350,8 @@ export interface CurveProps extends EventAttributes, Partial<PresentationAttribu
     className?: string;
     type?: LineType;
     layout?: LayoutType;
-    baseLine?: number | any[];
-    points?: object[];
+    baseLine?: number | ReadonlyArray<any>;
+    points?: ReadonlyArray<object>;
     connectNulls?: boolean;
     path?: string;
     pathRef?: React.Ref<any>;
@@ -373,7 +373,7 @@ export type DataPointFormatter = (entry: any, dataKey: DataKey) => { x: number; 
 
 export interface ErrorBarProps {
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
-    data?: any[];
+    data?: ReadonlyArray<any>;
     xAxis?: object;
     yAxis?: object;
     layout?: string;
@@ -408,7 +408,7 @@ export interface LegendProps {
     align?: 'left' | 'center' | 'right';
     verticalAlign?: 'top' | 'middle' | 'bottom';
     margin?: Partial<Margin>;
-    payload?: LegendPayload[];
+    payload?: ReadonlyArray<LegendPayload>;
     formatter?: LegendValueFormatter;
     onClick?: RechartsFunction;
     onMouseEnter?: RechartsFunction;
@@ -440,7 +440,7 @@ export interface LineProps extends EventAttributes, Partial<PresentationAttribut
     data?: ReadonlyArray<object>;
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
     label?: boolean | object | React.ReactElement | ContentRenderer<any>;
-    points?: Point[];
+    points?: ReadonlyArray<Point>;
     id?: string;
 }
 
@@ -469,14 +469,14 @@ export interface PieProps extends EventAttributes, Partial<PresentationAttribute
     minAngle?: number;
     legendType?: LegendType;
     maxRadius?: number;
-    sectors?: object[];
+    sectors?: ReadonlyArray<object>;
     hide?: boolean;
     labelLine?: object | ContentRenderer<LineProps & any> | React.ReactElement | boolean;
     label?: {
         offsetRadius: number;
     } | React.ReactElement | ContentRenderer<PieLabelRenderProps> | boolean;
     activeShape?: object | ContentRenderer<any> | React.ReactElement;
-    activeIndex?: number | number[];
+    activeIndex?: number | ReadonlyArray<number>;
     blendStroke?: boolean;
 }
 
@@ -523,7 +523,7 @@ export interface PolarAngleAxisProps extends EventAttributes, Partial<Presentati
     axisLineType?: 'polygon' | 'circle';
     tickLine?: boolean | object;
     tick?: boolean | ContentRenderer<any> | object | React.ReactElement;
-    ticks?: PolarAngleAxisTick[];
+    ticks?: ReadonlyArray<PolarAngleAxisTick>;
     stroke?: string;
     orientation?: 'inner' | 'outer';
     tickFormatter?: TickFormatterFunction;
@@ -536,8 +536,8 @@ export interface PolarGridProps extends Partial<PresentationAttributes> {
     cy?: number;
     innerRadius?: number;
     outerRadius?: number;
-    polarAngles?: number[];
-    polarRadius?: number[];
+    polarAngles?: ReadonlyArray<number>;
+    polarRadius?: ReadonlyArray<number>;
     gridType?: 'polygon' | 'circle';
 }
 
@@ -558,13 +558,13 @@ export interface PolarRadiusAxisProps extends EventAttributes, Partial<Presentat
     radiusAxisId?: string | number;
     angle?: number;
     tickCount?: number;
-    ticks?: PolarRadiusAxisTick[];
+    ticks?: ReadonlyArray<PolarRadiusAxisTick>;
     orientation?: "left" | "right" | "middle";
     axisLine?: boolean | object;
     tick?: boolean | object | React.ReactElement | ContentRenderer<any>;
     stroke?: string;
     tickFormatter?: TickFormatterFunction;
-    domain?: [PolarRadiusAxisDomain, PolarRadiusAxisDomain];
+    domain?: Readonly<[PolarRadiusAxisDomain, PolarRadiusAxisDomain]>;
     scale?: ScaleType | RechartsFunction;
     allowDataOverflow?: boolean;
 }
@@ -578,7 +578,7 @@ export interface PolygonPoint {
 
 export interface PolygonProps extends EventAttributes, Partial<PresentationAttributes> {
     className?: string;
-    points?: PolygonPoint[];
+    points?: ReadonlyArray<PolygonPoint>;
 }
 
 export class Polygon extends React.Component<PolygonProps> { }
@@ -598,7 +598,7 @@ export interface RadarProps extends EventAttributes, Partial<PresentationAttribu
     className?: string;
     name?: string;
     dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
-    points?: RadarPoint[];
+    points?: ReadonlyArray<RadarPoint>;
     shape?: React.ReactElement | ContentRenderer<RadarProps>;
     activeDot?: object | React.ReactElement | ContentRenderer<any> | boolean;
     dot?: object | React.ReactElement | ContentRenderer<DotProps> | boolean;
@@ -639,7 +639,7 @@ export interface RadialBarProps extends EventAttributes, Partial<PresentationAtt
     cornerRadius?: number | string;
     minPointSize?: number;
     maxBarSize?: number;
-    data?: RadialBarData[];
+    data?: ReadonlyArray<RadialBarData>;
     legendType?: LegendType;
     label?: boolean | React.ReactElement | ContentRenderer<any> | object;
     background?: boolean | React.ReactElement | ContentRenderer<any> | object;
@@ -665,7 +665,7 @@ export interface RectangleProps extends EventAttributes, Partial<PresentationAtt
     y?: number;
     width?: number;
     height?: number;
-    radius?: number | any[];
+    radius?: number | ReadonlyArray<any>;
 }
 
 export class Rectangle extends React.Component<RectangleProps> { }
@@ -776,7 +776,7 @@ export interface ScatterProps extends EventAttributes, Partial<PresentationAttri
     activeIndex?: number;
     activeShape?: object | RechartsFunction | React.ReactElement;
     shape?: 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | React.ReactElement | ContentRenderer<any>;
-    points?: ScatterPoint[];
+    points?: ReadonlyArray<ScatterPoint>;
     hide?: boolean;
     data?: ReadonlyArray<object>;
     dataKey?: DataKey;
@@ -841,7 +841,7 @@ export type AllowEscapeViewBox = { x: boolean } | { y: boolean } | { x: boolean,
 
 export interface TooltipPayload {
     name: string;
-    value: string | number | Array<string | number>;
+    value: string | number | ReadonlyArray<(string | number)>;
     unit?: string;
     color?: string;
     fill?: string;
@@ -867,7 +867,7 @@ export interface TooltipProps extends Animatable {
     position?: Coordinate;
     label?: string | number;
     labelFormatter?: LabelFormatter;
-    payload?: TooltipPayload[];
+    payload?: ReadonlyArray<TooltipPayload>;
     itemSorter?: ItemSorter<TooltipPayload>;
     filterNull?: boolean;
     useTranslate3d?: boolean;
@@ -878,7 +878,7 @@ export class Tooltip extends React.Component<TooltipProps, BoxSize> { }
 export interface TreemapProps extends EventAttributes, Animatable {
     width?: number;
     height?: number;
-    data?: any[];
+    data?: ReadonlyArray<any>;
     style?: object;
     aspectRatio?: number;
     content?: React.ReactElement | ContentRenderer<any>;
@@ -943,7 +943,7 @@ export interface XAxisProps extends EventAttributes {
     unit?: string | number;
     // The unique id of x-axis
     xAxisId?: string | number;
-    domain?: [AxisDomain, AxisDomain];
+    domain?: Readonly<[AxisDomain, AxisDomain]>;
     // The key of data displayed in the axis
     dataKey?: DataKey;
     // The width of axis which is usually calculated internally
@@ -962,7 +962,7 @@ export interface XAxisProps extends EventAttributes {
     type?: 'number' | 'category';
     // Ticks can be any type when the axis is the type of category
     // Ticks must be numbers when the axis is the type of number
-    ticks?: any[];
+    ticks?: ReadonlyArray<any>;
     // The count of ticks
     tickCount?: number;
     // The formatter function of tick
@@ -1003,12 +1003,12 @@ export interface YAxisProps extends EventAttributes {
     unit?: string | number;
     // The unique id of y-axis
     yAxisId?: string | number;
-    domain?: [AxisDomain, AxisDomain];
+    domain?: Readonly<[AxisDomain, AxisDomain]>;
     // The key of data displayed in the axis
     dataKey?: DataKey;
     // Ticks can be any type when the axis is the type of category
     // Ticks must be numbers when the axis is the type of number
-    ticks?: any[];
+    ticks?: ReadonlyArray<any>;
     // The count of ticks
     tickCount?: number;
     // Rotation of tick labels
@@ -1057,7 +1057,7 @@ export interface ZAxisProps {
     // The key of data displayed in the axis
     dataKey?: DataKey;
     // The range of axis
-    range?: number[];
+    range?: ReadonlyArray<number>;
     scale?: ScaleType | RechartsFunction;
 }
 


### PR DESCRIPTION
Recharts does not modify them internally and having 'readonly' modifier allows both readonly and non-readonly arrays to be passed

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
