### PR TITLE
test(jest): Assert `it.each(…)` callback args are correct for tuples

### DIFF
--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1534,3 +1534,16 @@ test.only.each`
 });
 
 expect('').toHaveProperty('path.to.thing');
+
+declare const constCases: [['a', 'b', 'ab'], ['d', 2, 'd2']];
+test.each(constCases)('%s + %s', (...args) => {
+    args; // $ExpectType ["a", "b", "ab"] | ["d", 2, "d2"]
+});
+
+declare const constCasesWithMoreThanTen: [
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+    [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
+];
+test.each(constCasesWithMoreThanTen)('should work fine with more than 10 args', (...args) => {
+    args; // $ExpectType [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] | [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
+});

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1536,7 +1536,7 @@ test.only.each`
 expect('').toHaveProperty('path.to.thing');
 
 declare const constCases: [['a', 'b', 'ab'], ['d', 2, 'd2']];
-test.each(constCases)('%s + %s', (...args) => {
+test.each(constCases)('%s + %s', (...args: ['a', 'b', 'ab'] | ['d', 2, 'd2']) => {
     args; // $ExpectType ["a", "b", "ab"] | ["d", 2, "d2"]
 });
 
@@ -1544,6 +1544,9 @@ declare const constCasesWithMoreThanTen: [
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
     [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
 ];
-test.each(constCasesWithMoreThanTen)('should work fine with more than 10 args', (...args) => {
-    args; // $ExpectType [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] | [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
-});
+it.each(constCasesWithMoreThanTen)(
+    'should work fine with more than 10 args',
+    (...args: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] | [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]) => {
+        args; // $ExpectType [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] | [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
+    },
+);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39291>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
