### PR TITLE
[@types/jquery.fancytree] various fixes

### DIFF
--- a/types/jquery.fancytree/index.d.ts
+++ b/types/jquery.fancytree/index.d.ts
@@ -63,6 +63,9 @@ declare namespace Fancytree {
         /** Write to browser console if debugLevel >= 2 (prepending tree name)  */
         debug(msg: any): void;
 
+        /** Expand (or collapse) all parent nodes. */
+        expandAll(flag?: boolean, options?: Object): void;
+
         /** [ext-filter] Dimm or hide whole branches.
          * @returns {integer} count
          */
@@ -837,7 +840,7 @@ declare namespace Fancytree {
         /** Add tabindex='0' to node title span, so it can receive keyboard focus */
         titlesTabbable?: boolean;
         /** Animation options, false:off (default: { effect: "blind", options: {direction: "vertical", scale: "box"}, duration: 200 }) */
-        toggleEffect?: JQueryUI.EffectOptions;
+        toggleEffect?: false | JQueryUI.EffectOptions;
         /** Tooltips */
         tooltip?: boolean;
 
@@ -863,19 +866,19 @@ declare namespace Fancytree {
         /**
          * "Loading..."  // &#8230; would be escaped when escapeTitles is true
          */
-        loading: string;
+        loading?: string;
         /**
          * "Load error!"
          */
-        loadError: string;
+        loadError?: string;
         /**
          * "More..."
          */
-        moreData: string;
+        moreData?: string;
         /**
          * "No data."
          */
-        noData: string;
+        noData?: string;
     }
 
     namespace Extensions {
@@ -970,43 +973,43 @@ declare namespace Fancytree {
             /**
              * Re-apply last filter if lazy data is loaded
              */
-            autoApply: boolean;
+            autoApply?: boolean;
             /**
              * Expand all branches that contain matches while filtered
              */
-            autoExpand: boolean;
+            autoExpand?: boolean;
             /**
              * Show a badge with number of matching child nodes near parent icons
              */
-            counter: boolean;
+            counter?: boolean;
             /**
              * Match single characters in order, e.g. 'fb' will match 'FooBar'
              */
-            fuzzy: boolean;
+            fuzzy?: boolean;
             /**
              * Hide counter badge if parent is expanded
              */
-            hideExpandedCounter: boolean;
+            hideExpandedCounter?: boolean;
             /**
              * Hide expanders if all child nodes are hidden by filter
              */
-            hideExpanders: boolean;
+            hideExpanders?: boolean;
             /**
              * Highlight matches by wrapping inside <mark> tags
              */
-            highlight: boolean;
+            highlight?: boolean;
             /**
              * Match end nodes only
              */
-            leavesOnly: boolean;
+            leavesOnly?: boolean;
             /**
              * Display a 'no data' status node if result is empty
              */
-            nodata: boolean;
+            nodata?: boolean;
             /**
              * Grayout unmatched nodes (pass "hide" to remove unmatched node instead); default 'dimm'
              */
-            mode: 'dimm' | 'string';
+            mode?: 'dimm' | 'hide';
             /**
              * Support misc options
              */

--- a/types/jquery.fancytree/jquery.fancytree-tests.ts
+++ b/types/jquery.fancytree/jquery.fancytree-tests.ts
@@ -50,6 +50,9 @@ $("#tree").fancytree(<Fancytree.FancytreeOptions>{
 	unselectableIgnore: false,
 	unselectableStatus: function (event, data) {
 		return false;
+	},
+	strings: {
+		noData: 'custom no data message'
 	}
 });
 
@@ -80,6 +83,11 @@ tree.loadKeyPath("/1/2", function (node, status) {
 		node.setActive();
 	}
 });
+
+tree.expandAll();
+tree.expandAll(false);
+tree.expandAll(true);
+tree.expandAll(true, { noAnimation: true });
 
 var node = $.ui.fancytree.getNode($("#tree"));
 alert($.ui.fancytree.version);


### PR DESCRIPTION
Add missing expandAll() method
https://wwwendt.de/tech/fancytree/doc/jsdoc/Fancytree.html#expandAll

All options to filter are optional
https://github.com/mar10/fancytree/blob/v2.33.0/src/jquery.fancytree.filter.js#L353

Fix typing for filter.mode option: can be either "dimm" or "hide"
"string" seems like just a mistake, the code doesn't use it

All translation strings are optional
This is because options are deep merged
https://github.com/jquery/jquery-ui/blob/1.12.1/ui/widget.js#L324
https://github.com/jquery/jquery-ui/blob/1.12.1/ui/widget.js#L180

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>