### PR TITLE
Fix JSDOC for `react-textarea-autosize`

### DIFF
--- a/types/react-textarea-autosize/index.d.ts
+++ b/types/react-textarea-autosize/index.d.ts
@@ -31,7 +31,7 @@ declare module "react-textarea-autosize" {
          * Try to cache DOM measurements performed by component so that we don't
          * touch DOM when it's not needed.
          *
-         * This optimization doesn't work if we dynamically style <textarea />
+         * This optimization doesn't work if we dynamically style `<textarea />`
          * component.
          * @default false
          */


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

The reason I am putting the `<textarea>` in a code-fence so that it will not be rendered as textarea element when the JSDoc comment is used to generate markdown.
