### PR TITLE
[office-js-preview] Fixing AttachmentsChangedEventArgs object links

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -10904,13 +10904,13 @@ declare namespace Office {
     export interface AttachmentsChangedEventArgs { 
         /** 
          * Represents the set of attachments that were added or removed. 
-         * For each such attachment, gets a subset of {@link AttachmentDetails} properties: `id`, `name`, `size`, and `attachmentType`.
+         * For each such attachment, gets a subset of {@link Office.AttachmentDetails} properties: `id`, `name`, `size`, and `attachmentType`.
          * 
          * [Api set: Mailbox Preview]
          */
         attachmentDetails: object[];
         /**
-         * Gets whether the attachments were added or removed. See {@link MailboxEnums.AttachmentStatus} for details.
+         * Gets whether the attachments were added or removed. See {@link Office.MailboxEnums.AttachmentStatus} for details.
          * 
          * [Api set: Mailbox Preview]
          */ 

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -10904,13 +10904,13 @@ declare namespace Office {
     export interface AttachmentsChangedEventArgs { 
         /** 
          * Represents the set of attachments that were added or removed. 
-         * For each such attachment, gets a subset of {@link Office.AttachmentDetails} properties: `id`, `name`, `size`, and `attachmentType`.
+         * For each such attachment, gets a subset of {@link Office.AttachmentDetails | AttachmentDetails} properties: `id`, `name`, `size`, and `attachmentType`.
          * 
          * [Api set: Mailbox Preview]
          */
         attachmentDetails: object[];
         /**
-         * Gets whether the attachments were added or removed. See {@link Office.MailboxEnums.AttachmentStatus} for details.
+         * Gets whether the attachments were added or removed. See {@link Office.MailboxEnums.AttachmentStatus | MailboxEnums.AttachmentStatus} for details.
          * 
          * [Api set: Mailbox Preview]
          */ 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.microsoft.com/en-us/javascript/api/outlook/office.attachmentschangedeventargs?view=outlook-js-preview
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.