### PR TITLE
update import syntax for i18next dependents

### DIFF
--- a/types/i18next-node-fs-backend/i18next-node-fs-backend-tests.ts
+++ b/types/i18next-node-fs-backend/i18next-node-fs-backend-tests.ts
@@ -1,4 +1,4 @@
-import * as i18next from "i18next";
+import i18next from "i18next";
 import * as Backend from "i18next-node-fs-backend";
 
 var options = {

--- a/types/i18next-sprintf-postprocessor/i18next-sprintf-postprocessor-tests.ts
+++ b/types/i18next-sprintf-postprocessor/i18next-sprintf-postprocessor-tests.ts
@@ -1,4 +1,4 @@
-import * as i18next from "i18next";
+import i18next from "i18next";
 import * as sprintfA from "i18next-sprintf-postprocessor";
 import sprintfB from "i18next-sprintf-postprocessor/dist/commonjs";
 


### PR DESCRIPTION
i18next@19 uses default exports. This PR updates the tests of dependents to use them instead of `import * as i18next from 'i18next'`.
