### PR TITLE
[react-helmet] relax htmlAttributes and bodyAttributes types

### DIFF
--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -9,11 +9,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from "react";
+import * as React from 'react';
 
 type HtmlProps = JSX.IntrinsicElements['html'];
 
-type BodyProps = JSX.IntrinsicElements['body']
+type BodyProps = JSX.IntrinsicElements['body'];
 
 type LinkProps = JSX.IntrinsicElements['link'];
 
@@ -36,11 +36,7 @@ export interface HelmetProps {
     defer?: boolean;
     encodeSpecialCharacters?: boolean;
     htmlAttributes?: HtmlProps;
-    onChangeClientState?: (
-        newState: any,
-        addedTags: HelmetTags,
-        removedTags: HelmetTags,
-    ) => void;
+    onChangeClientState?: (newState: any, addedTags: HelmetTags, removedTags: HelmetTags) => void;
     link?: LinkProps[];
     meta?: MetaProps[];
     noscript?: Array<any>;

--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -6,14 +6,19 @@
 //                 Kok Sam <https://github.com/sammkj>
 //                 Yui T. <https://github.com/yuit>
 //                 Yamagishi Kazutoshi <https://github.com/ykzts>
+//                 Justin Hall <https://github.com/wKovacs64>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import * as React from 'react';
 
-type HtmlProps = JSX.IntrinsicElements['html'];
+type HtmlProps = JSX.IntrinsicElements['html'] & {
+    [key: string]: string;
+};
 
-type BodyProps = JSX.IntrinsicElements['body'];
+type BodyProps = JSX.IntrinsicElements['body'] & {
+    [key: string]: string;
+};
 
 type LinkProps = JSX.IntrinsicElements['link'];
 

--- a/types/react-helmet/react-helmet-tests.tsx
+++ b/types/react-helmet/react-helmet-tests.tsx
@@ -109,10 +109,6 @@ function HTML() {
 </HelmetDefaultExport>;
 
 // $ExpectError
-<Helmet htmlAttributes={{ invalidProp: 'foo' }} />;
-// $ExpectError
-<Helmet bodyAttributes={{ invalidProp: 'foo' }} />;
-// $ExpectError
 <Helmet link={[ invalidProp: 'foo' ]} />;
 // $ExpectError
 <Helmet meta={[ invalidProp: 'foo' ]} />;


### PR DESCRIPTION
This augments (and partially reverts) #39161 to preserve type-checking of known attributes but also allow for arbitrary attributes like `data-*`.

Closes #39357
Closes #39430

**P.S.** Sorry about the formatting commit, but it was wrong so I corrected it. If you want this PR to be more pure, I can remove it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/39357#issuecomment-547630291
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
