### PR TITLE
[@types/react-draft-wysiwyg] Update Editor Props

### DIFF
--- a/types/react-draft-wysiwyg/index.d.ts
+++ b/types/react-draft-wysiwyg/index.d.ts
@@ -6,7 +6,7 @@
 //                 Munif Tanjim <https://github.com/MunifTanjim>
 //                 Nathan Zeplowitz <https://github.com/n-zeplo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.6
+// TypeScript Version: 2.9
 
 import * as React from 'react';
 import * as Draft from 'draft-js';

--- a/types/react-draft-wysiwyg/index.d.ts
+++ b/types/react-draft-wysiwyg/index.d.ts
@@ -1,11 +1,12 @@
-// Type definitions for react-draft-wysiwyg 1.12
+// Type definitions for react-draft-wysiwyg 1.13
 // Project: https://github.com/jpuri/react-draft-wysiwyg#readme
 // Definitions by: imechZhangLY <https://github.com/imechZhangLY>
 //                 brunoMaurice <https://github.com/brunoMaurice>
 //                 ldanet <https://github.com/ldanet>
 //                 Munif Tanjim <https://github.com/MunifTanjim>
+//                 Nathan Zeplowitz <https://github.com/n-zeplo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// TypeScript Version: 3.6
 
 import * as React from 'react';
 import * as Draft from 'draft-js';
@@ -46,11 +47,6 @@ export interface EditorProps {
     onFocus?(event: SyntheticEvent): void;
     onBlur?(event: SyntheticEvent): void;
     onTab?(event: SyntheticKeyboardEvent): void;
-    onEscape?(e: SyntheticKeyboardEvent): void;
-    onUpArrow?(e: SyntheticKeyboardEvent): void;
-    onDownArrow?(e: SyntheticKeyboardEvent): void;
-    onRightArrow?(e: SyntheticKeyboardEvent): void;
-    onLeftArrow?(e: SyntheticKeyboardEvent): void;
     mention?: object;
     hashtag?: object;
     textAlignment?: string;
@@ -74,6 +70,7 @@ export interface EditorProps {
         editorState: EditorState,
         onChange: (editorState: EditorState) => void
     ): boolean;
+    customStyleMap?: object;
 }
 
 export class Editor extends React.Component<EditorProps> {

--- a/types/react-draft-wysiwyg/test/custom-style-map-tests.tsx
+++ b/types/react-draft-wysiwyg/test/custom-style-map-tests.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { Editor } from 'react-draft-wysiwyg';
+
+const CustomStyleMapEditor = () => (<div>
+  <Editor
+    customStyleMap={{
+      STRIKETHROUGH: {
+        textDecoration: 'line-through',
+        color: 'red',
+      },
+    }}
+  />
+</div>);
+
+ReactDOM.render(<CustomStyleMapEditor />, document.getElementById('target'));

--- a/types/react-draft-wysiwyg/tsconfig.json
+++ b/types/react-draft-wysiwyg/tsconfig.json
@@ -25,6 +25,7 @@
         "test/basic-tests.tsx",
         "test/custom-toolbar-tests.tsx",
         "test/focus-blur-callbacks-tests.tsx",
-        "test/uncontrolled-raw-draft-content-state.tsx"
+        "test/uncontrolled-raw-draft-content-state.tsx",
+        "test/custom-style-map-tests.tsx"
     ]
 }


### PR DESCRIPTION
Remove props no longer used by draftJS and add customStyleMap Prop

* Add customStyleMap to editor props
* Remove props for arrow key and escape event handlers that are no longer supported

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
    - PR for new Editor Prop (merged and available in 1.13): https://github.com/jpuri/react-draft-wysiwyg/pull/746
    - Removed Props Missing from Prop List: https://github.com/jpuri/react-draft-wysiwyg/blob/1c8e85c45e466884b1e4494b50242442de27aa6e/src/Editor/index.js#L41

- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


