### PR TITLE
Expand create-hash API support

### DIFF
--- a/types/create-hash/index.d.ts
+++ b/types/create-hash/index.d.ts
@@ -1,16 +1,24 @@
 // Type definitions for create-hash 1.2
 // Project: https://github.com/crypto-browserify/createHash
 // Definitions by: BendingBender <https://github.com/BendingBender>,
-//                 Konstantin Yuriev <https://github.com/gallowsmaker>
-//                 Max Boguslavskiy <https://github.com/maxbogus>
+//                 Konstantin Yuriev <https://github.com/gallowsmaker>,
+//                 Max Boguslavskiy <https://github.com/maxbogus>,
+//                 Jordan Sexton <https://github.com/jordansexton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
+/// <reference types="node" />
+
 declare namespace createHash {
+    type TypedArray = Uint8Array | Uint8ClampedArray | Uint16Array | Uint32Array | Int8Array | Int16Array | Int32Array | Float32Array | Float64Array;
+
     interface HashAlgorithm {
-        update(data: string): void;
-        digest(target?: encoding): string;
-        write(data: string): void;
+        digest(target: encoding): string;
+        digest(): Buffer;
+
+        update(data: string | Buffer | TypedArray | DataView, encoding?: string): this;
+        write(data: string | Buffer | TypedArray | DataView, encoding?: string): this;
+
         end(): void;
         read(): void;
     }


### PR DESCRIPTION
The `create-hash` project [README](https://github.com/crypto-browserify/createHash/blob/master/README.md) states

> API is the same as hashes in node

Referring to the Node API: https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm_options

The `update` and `write` methods should allow for input and output of `Buffer` and other binary data objects besides strings, and return a chainable interface.

The `digest` method should return a string or a `Buffer` depending on whether an argument is provided.

This can be further verified by reading the source implementation.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/crypto-browserify/createHash/blob/master/README.md