### PR TITLE
[jsforce] Add typing for get-recent-items method

### DIFF
--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -143,7 +143,8 @@ export abstract class BaseConnection extends EventEmitter {
     describeGlobal<T>(callback?: (err: Error, result: DescribeGlobalResult) => void): Promise<DescribeGlobalResult>;
     // we want any object to be accepted if the user doesn't decide to give an explicit type
     sobject<T = object>(resource: string): SObject<T>;
-    recent(param?: number | string, callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
+    recent(callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
+    recent(param: number | string, callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
     recent(type: string, limit: number, callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
 }
 

--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -143,9 +143,7 @@ export abstract class BaseConnection extends EventEmitter {
     describeGlobal<T>(callback?: (err: Error, result: DescribeGlobalResult) => void): Promise<DescribeGlobalResult>;
     // we want any object to be accepted if the user doesn't decide to give an explicit type
     sobject<T = object>(resource: string): SObject<T>;
-    recent(callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
-    recent(type: string, callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
-    recent(limit: number, callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
+    recent(param?: number | string, callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
     recent(type: string, limit: number, callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
 }
 

--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -143,6 +143,10 @@ export abstract class BaseConnection extends EventEmitter {
     describeGlobal<T>(callback?: (err: Error, result: DescribeGlobalResult) => void): Promise<DescribeGlobalResult>;
     // we want any object to be accepted if the user doesn't decide to give an explicit type
     sobject<T = object>(resource: string): SObject<T>;
+    recent(callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
+    recent(type: string, callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
+    recent(limit: number, callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
+    recent(type: string, limit: number, callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
 }
 
 export class Connection extends BaseConnection {

--- a/types/jsforce/jsforce-tests.ts
+++ b/types/jsforce/jsforce-tests.ts
@@ -403,6 +403,26 @@ async function testSObject(connection: sf.Connection) {
             ret; // $ExpectType RecordResult[]
         });
     }
+
+    { // Test salesforceConnection.recent
+        // $ExpectType RecordResult[]
+        await salesforceConnection.recent();
+
+        // $ExpectType RecordResult[]
+        await salesforceConnection.recent('Account');
+
+        // $ExpectType RecordResult[]
+        await salesforceConnection.recent(5);
+
+        // $ExpectType RecordResult[]
+        await salesforceConnection.recent('Account', 5);
+
+        // with callback
+        salesforceConnection.recent((err, ret) => {
+            err; // $ExpectType Error
+            ret; // $ExpectType RecordResult[]
+        });
+    }
 }
 
 const requestInfo: sf.RequestInfo = {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jsforce.github.io/jsforce/doc/connection.js.html#line1164
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
