### PR TITLE
[libsodium-wrappers] Update constants and functions

### DIFF
--- a/types/libsodium-wrappers-sumo/index.d.ts
+++ b/types/libsodium-wrappers-sumo/index.d.ts
@@ -21,6 +21,10 @@ export const crypto_auth_hmacsha512_KEYBYTES: number;
 export const crypto_box_curve25519xchacha20poly1305_NONCEBYTES: number;
 export const crypto_box_curve25519xchacha20poly1305_PUBLICKEYBYTES: number;
 export const crypto_box_curve25519xchacha20poly1305_SECRETKEYBYTES: number;
+export const crypto_core_hchacha20_CONSTBYTES: number;
+export const crypto_core_hchacha20_INPUTBYTES: number;
+export const crypto_core_hchacha20_KEYBYTES: number;
+export const crypto_core_hchacha20_OUTPUTBYTES: number;
 export const crypto_core_ristretto255_BYTES: number;
 export const crypto_core_ristretto255_HASHBYTES: number;
 export const crypto_core_ristretto255_NONREDUCEDSCALARBYTES: number;
@@ -56,12 +60,15 @@ export const crypto_scalarmult_ristretto255_SCALARBYTES: number;
 export const crypto_shorthash_siphashx24_BYTES: number;
 export const crypto_shorthash_siphashx24_KEYBYTES: number;
 export const crypto_stream_chacha20_ietf_KEYBYTES: number;
+export const crypto_stream_chacha20_ietf_MESSAGEBYTES_MAX: number;
 export const crypto_stream_chacha20_ietf_NONCEBYTES: number;
 export const crypto_stream_chacha20_KEYBYTES: number;
 export const crypto_stream_chacha20_NONCEBYTES: number;
 export const crypto_stream_KEYBYTES: number;
+export const crypto_stream_MESSAGEBYTES_MAX: number;
 export const crypto_stream_NONCEBYTES: number;
 export const crypto_stream_xchacha20_KEYBYTES: number;
+export const crypto_stream_xchacha20_MESSAGEBYTES_MAX: number;
 export const crypto_stream_xchacha20_NONCEBYTES: number;
 
 export function crypto_auth_hmacsha256(message: string | Uint8Array, key: Uint8Array, outputFormat?: Uint8ArrayOutputFormat | null): Uint8Array;
@@ -115,16 +122,16 @@ export function crypto_core_ristretto255_scalar_mul(x: Uint8Array, y: Uint8Array
 export function crypto_core_ristretto255_scalar_negate(scalar: string | Uint8Array, outputFormat?: Uint8ArrayOutputFormat | null): Uint8Array;
 export function crypto_core_ristretto255_scalar_negate(scalar: string | Uint8Array, outputFormat: StringOutputFormat): string;
 
-export function crypto_core_ristretto255_scalar_random(outputFormat?: Uint8ArrayOutputFormat): Uint8Array;
+export function crypto_core_ristretto255_scalar_random(outputFormat?: Uint8ArrayOutputFormat | null): Uint8Array;
 export function crypto_core_ristretto255_scalar_random(outputFormat: StringOutputFormat): string;
 
-export function crypto_core_ristretto255_scalar_reduce(secret: string | Uint8Array, outputFormat?: Uint8ArrayOutputFormat): Uint8Array;
+export function crypto_core_ristretto255_scalar_reduce(secret: string | Uint8Array, outputFormat?: Uint8ArrayOutputFormat | null): Uint8Array;
 export function crypto_core_ristretto255_scalar_reduce(secret: string | Uint8Array, outputFormat: StringOutputFormat): string;
 
-export function crypto_core_ristretto255_scalar_sub(x: Uint8Array, y: Uint8Array, outputFormat?: Uint8ArrayOutputFormat): Uint8Array;
+export function crypto_core_ristretto255_scalar_sub(x: Uint8Array, y: Uint8Array, outputFormat?: Uint8ArrayOutputFormat | null): Uint8Array;
 export function crypto_core_ristretto255_scalar_sub(x: Uint8Array, y: Uint8Array, outputFormat: StringOutputFormat): string;
 
-export function crypto_core_ristretto255_sub(p: Uint8Array, q: Uint8Array, outputFormat?: Uint8ArrayOutputFormat): Uint8Array;
+export function crypto_core_ristretto255_sub(p: Uint8Array, q: Uint8Array, outputFormat?: Uint8ArrayOutputFormat | null): Uint8Array;
 export function crypto_core_ristretto255_sub(p: Uint8Array, q: Uint8Array, outputFormat: StringOutputFormat): string;
 
 export function crypto_generichash_blake2b_salt_personal(subkey_len: number,
@@ -226,6 +233,9 @@ export function crypto_stream_chacha20_xor_ic(input_message: string | Uint8Array
     outputFormat?: Uint8ArrayOutputFormat | null,
 ): Uint8Array;
 export function crypto_stream_chacha20_xor_ic(input_message: string | Uint8Array, nonce: Uint8Array, nonce_increment: number, key: Uint8Array, outputFormat: StringOutputFormat): string;
+
+export function crypto_stream_keygen(outputFormat?: Uint8ArrayOutputFormat | null): Uint8Array;
+export function crypto_stream_keygen(outputFormat: StringOutputFormat): string;
 
 export function crypto_stream_xchacha20_keygen(outputFormat?: Uint8ArrayOutputFormat | null): Uint8Array;
 export function crypto_stream_xchacha20_keygen(outputFormat: StringOutputFormat): string;

--- a/types/libsodium-wrappers/index.d.ts
+++ b/types/libsodium-wrappers/index.d.ts
@@ -98,10 +98,6 @@ export const crypto_box_PUBLICKEYBYTES: number;
 export const crypto_box_SEALBYTES: number;
 export const crypto_box_SECRETKEYBYTES: number;
 export const crypto_box_SEEDBYTES: number;
-export const crypto_core_hchacha20_CONSTBYTES: number;
-export const crypto_core_hchacha20_INPUTBYTES: number;
-export const crypto_core_hchacha20_KEYBYTES: number;
-export const crypto_core_hchacha20_OUTPUTBYTES: number;
 export const crypto_generichash_BYTES_MAX: number;
 export const crypto_generichash_BYTES_MIN: number;
 export const crypto_generichash_BYTES: number;
@@ -148,8 +144,6 @@ export const crypto_secretstream_xchacha20poly1305_ABYTES: number;
 export const crypto_secretstream_xchacha20poly1305_HEADERBYTES: number;
 export const crypto_secretstream_xchacha20poly1305_KEYBYTES: number;
 export const crypto_secretstream_xchacha20poly1305_MESSAGEBYTES_MAX: number;
-export const crypto_secretstream_xchacha20poly1305_MESSAGESBYTES_MAX: number;
-export const crypto_secretstream_xchacha20poly1305_NPUBBYTES: number;
 export const crypto_secretstream_xchacha20poly1305_TAG_FINAL: number;
 export const crypto_secretstream_xchacha20poly1305_TAG_MESSAGE: number;
 export const crypto_secretstream_xchacha20poly1305_TAG_PUSH: number;
@@ -161,9 +155,6 @@ export const crypto_sign_MESSAGEBYTES_MAX: number;
 export const crypto_sign_PUBLICKEYBYTES: number;
 export const crypto_sign_SECRETKEYBYTES: number;
 export const crypto_sign_SEEDBYTES: number;
-export const crypto_stream_chacha20_ietf_MESSAGEBYTES_MAX: number;
-export const crypto_stream_MESSAGEBYTES_MAX: number;
-export const crypto_stream_xchacha20_MESSAGEBYTES_MAX: number;
 export const randombytes_SEEDBYTES: number;
 export const SODIUM_LIBRARY_VERSION_MAJOR: number;
 export const SODIUM_LIBRARY_VERSION_MINOR: number;
@@ -558,9 +549,6 @@ export function crypto_sign_update(state_address: StateAddress, message_chunk: s
 
 export function crypto_sign_verify_detached(signature: Uint8Array, message: string | Uint8Array, publicKey: Uint8Array): boolean;
 
-export function crypto_stream_keygen(outputFormat?: Uint8ArrayOutputFormat | null): Uint8Array;
-export function crypto_stream_keygen(outputFormat: StringOutputFormat): string;
-
 export function from_base64(input: string, variant?: base64_variants): Uint8Array;
 
 export function from_hex(input: string): Uint8Array;
@@ -575,6 +563,8 @@ export function memcmp(b1: Uint8Array, b2: Uint8Array): boolean;
 
 export function memzero(bytes: Uint8Array): void;
 
+export function output_formats(): Array<Uint8ArrayOutputFormat | StringOutputFormat>;
+
 export function pad(buf: Uint8Array, blocksize: number): Uint8Array;
 
 export function randombytes_buf(length: number, outputFormat?: Uint8ArrayOutputFormat | null): Uint8Array;
@@ -586,8 +576,6 @@ export function randombytes_buf_deterministic(length: number, seed: Uint8Array, 
 export function randombytes_close(): void;
 
 export function randombytes_random(): number;
-
-export function randombytes_set_implementation(implementation: Uint8Array): void;
 
 export function randombytes_stir(): void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [`constants.json`](https://github.com/jedisct1/libsodium.js/blob/d2b312b84ca9563972d2f67e9cfc37ab5c868245/wrapper/constants.json)
  - https://github.com/jedisct1/libsodium.js/issues/226
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

**Changes in detail**

- moved some constants and functions which were incorrectly exposed in `libsodium-wrappers` but are actually exposed only in `libsodium-wrappers-sumo`.
- removed `crypto_secretstream_xchacha20poly1305_MESSAGESBYTES_MAX`, `crypto_secretstream_xchacha20poly1305_NPUBBYTES` and `randombytes_set_implementation()` since they are defined in the source but not exposed in the library.
- added `output_formats()`