### PR TITLE
react-router-dom: rollback ariaCurrent prop in favor of the anchor attribute

### DIFF
--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -52,7 +52,6 @@ export interface HashRouterProps {
 export class HashRouter extends React.Component<HashRouterProps, any> {}
 
 export interface LinkProps<S = H.LocationState> extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
-    ariaCurrent?: 'page' | 'step' | 'location' | 'date' | 'time' | 'true';
     component?: React.ComponentType<any>;
     to: H.LocationDescriptor<S> | ((location: H.Location<S>) => H.LocationDescriptor<S>);
     replace?: boolean;

--- a/types/react-router-dom/react-router-dom-tests.tsx
+++ b/types/react-router-dom/react-router-dom-tests.tsx
@@ -41,3 +41,5 @@ const refCallback: React.Ref<HTMLAnchorElement> = node => {};
 <Link to="/url" replace={true} innerRef={refCallback} />;
 const ref = React.createRef<HTMLAnchorElement>();
 <Link to="/url" replace={true} innerRef={ref} />;
+
+<Link to="/url" aria-current="page" />;


### PR DESCRIPTION
Sincerest apologies, I put this up late last night after looking at https://github.com/ReactTraining/react-router/pull/4708/files#diff-675251c4b99b8a7031054445159753efR49, but with the latest version, they're using the HTML anchor attribute `aria-current` instead.  The typings are already setup to do this properly.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/modules/NavLink.js#L110