### PR TITLE
@types/node: Added the possibility to specify input encoding in Decipher.update when passing a Buffer as source

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -245,7 +245,7 @@ declare module "crypto" {
         private constructor();
         update(data: NodeJS.ArrayBufferView): Buffer;
         update(data: string, input_encoding: HexBase64BinaryEncoding): Buffer;
-        update(data: NodeJS.ArrayBufferView, input_encoding: undefined, output_encoding: Utf8AsciiBinaryEncoding): string;
+        update(data: NodeJS.ArrayBufferView, input_encoding: HexBase64BinaryEncoding | undefined, output_encoding: Utf8AsciiBinaryEncoding): string;
         update(data: string, input_encoding: HexBase64BinaryEncoding | undefined, output_encoding: Utf8AsciiBinaryEncoding): string;
         final(): Buffer;
         final(output_encoding: string): string;

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -164,6 +164,33 @@ import { promisify } from 'util';
 }
 
 {
+    const key: string | null = 'keykeykeykeykeykeykeykey';
+    const nonce = crypto.randomBytes(12);
+    const aad = Buffer.from('0123456789', 'hex');
+
+    const cipher = crypto.createCipheriv('aes-192-ccm', key, nonce, {
+        authTagLength: 16
+    });
+    const plaintext = 'Hello world';
+    cipher.setAAD(aad, {
+        plaintextLength: Buffer.byteLength(plaintext)
+    });
+    const ciphertext = cipher.update(plaintext, 'utf8');
+    cipher.final();
+    const tag = cipher.getAuthTag();
+
+    const decipher = crypto.createDecipheriv('aes-192-ccm', key, nonce, {
+        authTagLength: 16
+    });
+    decipher.setAuthTag(tag);
+    decipher.setAAD(aad, {
+        plaintextLength: ciphertext.length
+    });
+    const receivedPlaintext: string = decipher.update(ciphertext, 'binary', 'utf8');
+    decipher.final();
+}
+
+{
     // crypto_timingsafeequal_buffer_test
     const buffer1: Buffer = new Buffer([1, 2, 3, 4, 5]);
     const buffer2: Buffer = new Buffer([1, 2, 3, 4, 5]);

--- a/types/node/v10/crypto.d.ts
+++ b/types/node/v10/crypto.d.ts
@@ -112,7 +112,7 @@ declare module "crypto" {
     interface Decipher extends stream.Transform {
         update(data: Buffer | NodeJS.TypedArray | DataView): Buffer;
         update(data: string, input_encoding: HexBase64BinaryEncoding): Buffer;
-        update(data: Buffer | NodeJS.TypedArray | DataView, input_encoding: any, output_encoding: Utf8AsciiBinaryEncoding): string;
+        update(data: Buffer | NodeJS.TypedArray | DataView, input_encoding: HexBase64BinaryEncoding | undefined, output_encoding: Utf8AsciiBinaryEncoding): string;
         // second arg is ignored
         update(data: string, input_encoding: HexBase64BinaryEncoding, output_encoding: Utf8AsciiBinaryEncoding): string;
         final(): Buffer;

--- a/types/node/v10/node-tests.ts
+++ b/types/node/v10/node-tests.ts
@@ -1390,6 +1390,33 @@ async function asyncStreamPipelineFinished() {
     }
 
     {
+        const key: string | null = 'keykeykeykeykeykeykeykey';
+        const nonce = crypto.randomBytes(12);
+        const aad = Buffer.from('0123456789', 'hex');
+
+        const cipher = crypto.createCipheriv('aes-192-ccm', key, nonce, {
+            authTagLength: 16
+        });
+        const plaintext = 'Hello world';
+        cipher.setAAD(aad, {
+            plaintextLength: Buffer.byteLength(plaintext)
+        });
+        const ciphertext = cipher.update(plaintext, 'utf8');
+        cipher.final();
+        const tag = cipher.getAuthTag();
+
+        const decipher = crypto.createDecipheriv('aes-192-ccm', key, nonce, {
+            authTagLength: 16
+        });
+        decipher.setAuthTag(tag);
+        decipher.setAAD(aad, {
+            plaintextLength: ciphertext.length
+        });
+        const receivedPlaintext: string = decipher.update(ciphertext, 'binary', 'utf8');
+        decipher.final();
+    }
+
+    {
         // crypto_timingsafeequal_buffer_test
         const buffer1: Buffer = new Buffer([1, 2, 3, 4, 5]);
         const buffer2: Buffer = new Buffer([1, 2, 3, 4, 5]);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Cannot provide URL, it's a private repo, but I can provide the snippet:

```ts
async decrypt(encryptedString: string, key: Buffer): Promise<string> {
  const encryptedBuffer = Buffer.from(encryptedString, 'base64')

  const iv = encryptedBuffer.slice(0, 16)
  const tag = encryptedBuffer.slice(16, 32)
  const text = encryptedBuffer.slice(32)

  const decipher = createDecipheriv('aes-256-gcm', key, iv)
  decipher.setAuthTag(tag)

  return decipher.update(text, 'binary', 'utf8') + decipher.final('utf8')
}
```

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
