### PR TITLE
chore(package): Remove empty dependencies object

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
         "prettier": "^1.17.1",
         "types-publisher": "github:Microsoft/types-publisher#production"
     },
-    "dependencies": {},
     "husky": {
         "hooks": {
             "_comment": "This will remove husky from when we started migrating to use prettier",


### PR DESCRIPTION
The `dependecines` field in `pacakge.json` is extraneous, and it gets automatically removed whenever I run <code><a href="https://pnpm.js.org">pnpm</a> add ‑D &lt;temp‑pkg‑for‑dts‑gen&gt;</code>, so I’m removing it, since it’s unnecessary.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
