### PR TITLE
feat: Add `setImmediate`

### DIFF
--- a/types/setimmediate/index.d.ts
+++ b/types/setimmediate/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for setimmediate 1.0
+// Project: https://github.com/yuzujs/setImmediate#readme
+// Definitions by: ExE Boss <https://github.com/ExE-Boss>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Schedules a macrotask to run after the current events have been processed.
+ *
+ * Unlike microtasks (scheduled using the Node 0.10+ `process.nextTick` API),
+ * where scheduling additional microtasks inside a microtask will cause them
+ * to be run inside the same microtask checkpoint, any macrotasks scheduled
+ * inside a macrotask will not be executed until the next iteration
+ * of the event loop.
+ *
+ * @param callback The macrotask to schedule.
+ * @param args The arguments to pass to the macrotask callback.
+ *
+ * @return The ID of the macrotask, which can be used to abort
+ *         the macrotask with `clearImmediate`.
+ */
+declare function setImmediate(callback: (...args: any[]) => void, ...args: any[]): number;
+
+/**
+ * Aborts the specified macrotask before it's run.
+ *
+ * @param handle The ID of the macrotask to remove from the macrotask queue.
+ */
+declare function clearImmediate(handle: number): void;

--- a/types/setimmediate/package.json
+++ b/types/setimmediate/package.json
@@ -1,0 +1,11 @@
+{
+	"private": true,
+	"types": "index",
+	"typesVersions": {
+		">=3.1.0-0": {
+			"*": [
+				"ts3.1/*"
+			]
+		}
+	}
+}

--- a/types/setimmediate/setimmediate-tests.ts
+++ b/types/setimmediate/setimmediate-tests.ts
@@ -1,0 +1,21 @@
+import './index';
+
+// $ExpectType number
+const i = setImmediate((...args) => {
+	args; // $ExpectType any[]
+});
+
+clearImmediate(i);
+
+// Errors:
+setImmediate(); // $ExpectError
+
+clearImmediate(); // $ExpectError
+clearImmediate(null); // $ExpectError
+clearImmediate(undefined); // $ExpectError
+clearImmediate('string'); // $ExpectError
+clearImmediate(Symbol.iterator); // $ExpectError
+clearImmediate(true); // $ExpectError
+clearImmediate(false); // $ExpectError
+clearImmediate({}); // $ExpectError
+clearImmediate(Function); // $ExpectError

--- a/types/setimmediate/ts3.1/index.d.ts
+++ b/types/setimmediate/ts3.1/index.d.ts
@@ -1,0 +1,23 @@
+/**
+ * Schedules a macrotask to run after the current events have been processed.
+ *
+ * Unlike microtasks (scheduled using the Node 0.10+ `process.nextTick` API),
+ * where scheduling additional microtasks inside a microtask will cause them
+ * to be run inside the same microtask checkpoint, any macrotasks scheduled
+ * inside a macrotask will not be executed until the next iteration
+ * of the event loop.
+ *
+ * @param callback The macrotask to schedule.
+ * @param args The arguments to pass to the macrotask callback.
+ *
+ * @return The ID of the macrotask, which can be used to abort
+ *         the macrotask with `clearImmediate`.
+ */
+declare function setImmediate<T extends unknown[]>(callback: (...args: T) => void, ...args: T): number;
+
+/**
+ * Aborts the specified macrotask before it's run.
+ *
+ * @param handle The ID of the macrotask to remove from the macrotask queue.
+ */
+declare function clearImmediate(handle: number): void;

--- a/types/setimmediate/ts3.1/setimmediate-tests.ts
+++ b/types/setimmediate/ts3.1/setimmediate-tests.ts
@@ -1,0 +1,36 @@
+import './index';
+
+// $ExpectType number
+const i1 = setImmediate((...args) => {
+	args; // $ExpectType []
+});
+
+// $ExpectType number
+const i2 = setImmediate((...args) => {
+	args; // $ExpectType [number]
+}, 1);
+
+// $ExpectType number
+const i3 = setImmediate((foo, bar, baz) => {
+	foo; // $ExpectType number
+	bar; // $ExpectType string
+	baz; // $ExpectType boolean
+}, 1, 'a', true);
+
+clearImmediate(i1);
+clearImmediate(i2);
+clearImmediate(i3);
+
+// Errors:
+setImmediate(); // $ExpectError
+setImmediate((foo: unknown) => {}); // $ExpectError
+
+clearImmediate(); // $ExpectError
+clearImmediate(null); // $ExpectError
+clearImmediate(undefined); // $ExpectError
+clearImmediate('string'); // $ExpectError
+clearImmediate(Symbol.iterator); // $ExpectError
+clearImmediate(true); // $ExpectError
+clearImmediate(false); // $ExpectError
+clearImmediate({}); // $ExpectError
+clearImmediate(Function); // $ExpectError

--- a/types/setimmediate/ts3.1/tsconfig.json
+++ b/types/setimmediate/ts3.1/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": ["es6"],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"baseUrl": "../../",
+		"typeRoots": ["../../"],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.d.ts",
+		"setimmediate-tests.ts"
+	]
+}

--- a/types/setimmediate/ts3.1/tslint.json
+++ b/types/setimmediate/ts3.1/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/setimmediate/tsconfig.json
+++ b/types/setimmediate/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": ["es6"],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": ["../"],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.d.ts",
+		"setimmediate-tests.ts"
+	]
+}

--- a/types/setimmediate/tslint.json
+++ b/types/setimmediate/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
[The&nbsp;`setImmediate`&nbsp;polyfill](https://github.com/YuzuJS/setImmediate/blob/master/README.md) implements [the&nbsp;**Efficient&nbsp;Script&nbsp;Yielding**&nbsp;proposal](https://w3c.github.io/setImmediate/).

It’s&nbsp;used by&nbsp;the&nbsp;highly performant [`es6‑promise‑polyfill`](https://github.com/lahmatiy/es6-promise-polyfill).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

review?(@jessetrinity)