### PR TITLE
[jasmine] Add definition for jasmine.Env.configure and mark methods as deprecated

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -15,6 +15,7 @@
 //                 Stephen Farrar <https://github.com/stephenfarrar>
 //                 Mochamad Arfin <https://github.com/ndunks>
 //                 Alex Povar <https://github.com/zvirja>
+//                 Dominik Ehrenberg <https://github.com/djungowski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts
@@ -157,6 +158,18 @@ interface DoneFn extends Function {
 
     /** fails the spec and indicates that it has completed. If the message is an Error, Error.message is used */
     fail: (message?: Error | string) => void;
+}
+
+/**
+ * Configuration that can be used when configuring Jasmine via {@link jasmine.Env.configure}
+ */
+interface EnvConfiguration {
+    random?: boolean;
+    seed?: number;
+    failFast?: boolean;
+    oneFailurePerSpec?: boolean;
+    hideDisabled?: boolean;
+    specFilter?: Function;
 }
 
 /**
@@ -372,14 +385,28 @@ declare namespace jasmine {
         addCustomEqualityTester(equalityTester: CustomEqualityTester): void;
         addMatchers(matchers: CustomMatcherFactories): void;
         specFilter(spec: Spec): boolean;
+        /**
+         * @deprecated Use oneFailurePerSpec option in {@link jasmine.Env.configure} instead.
+         */
         throwOnExpectationFailure(value: boolean): void;
+        /**
+         * @deprecated Use failFast option in {@link jasmine.Env.configure} instead.
+         */
+        stopOnSpecFailure(value: boolean): void;
+        /**
+         * @deprecated Use seed option in {@link jasmine.Env.configure} instead.
+         */
         seed(seed: string | number): string | number;
         provideFallbackReporter(reporter: Reporter): void;
         throwingExpectationFailures(): boolean;
         allowRespy(allow: boolean): void;
         randomTests(): boolean;
+        /**
+         * @deprecated Use random option in {@link jasmine.Env.configure} instead.
+         */
         randomizeTests(b: boolean): void;
         clearReporters(): void;
+        configure(configuration: EnvConfiguration): void;
     }
 
     interface FakeTimer {

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -161,18 +161,6 @@ interface DoneFn extends Function {
 }
 
 /**
- * Configuration that can be used when configuring Jasmine via {@link jasmine.Env.configure}
- */
-interface EnvConfiguration {
-    random?: boolean;
-    seed?: number;
-    failFast?: boolean;
-    oneFailurePerSpec?: boolean;
-    hideDisabled?: boolean;
-    specFilter?: Function;
-}
-
-/**
  * Install a spy onto an existing object.
  * @param object The object upon which to install the `Spy`.
  * @param method The name of the method to replace with a `Spy`.
@@ -216,6 +204,18 @@ declare namespace jasmine {
         T extends undefined ?
             (ReadonlyArray<string> | { [methodName: string]: any }) :
             (ReadonlyArray<keyof T> | { [P in keyof T]?: T[P] extends Func ? ReturnType<T[P]> : any });
+
+    /**
+     * Configuration that can be used when configuring Jasmine via {@link jasmine.Env.configure}
+     */
+    interface EnvConfiguration {
+        random?: boolean;
+        seed?: number;
+        failFast?: boolean;
+        oneFailurePerSpec?: boolean;
+        hideDisabled?: boolean;
+        specFilter?: Function;
+    }
 
     function clock(): Clock;
 

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1413,15 +1413,19 @@ describe("Randomize Tests", () => {
     it("should allow randomization of the order of tests", () => {
         expect(() => {
             const env = jasmine.getEnv();
-            env.randomizeTests(true);
+            env.configure({
+                random: true
+            });
         }).not.toThrow();
     });
 
     it("should allow a seed to be passed in for randomization", () => {
         expect(() => {
             const env = jasmine.getEnv();
-            env.randomizeTests(true);
-            return env.seed(1234);
+            env.configure({
+                random: true,
+                seed: 1234
+            });
         }).not.toThrow();
     });
 });

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -157,18 +157,6 @@ interface DoneFn extends Function {
 }
 
 /**
- * Configuration that can be used when configuring Jasmine via {@link jasmine.Env.configure}
- */
-interface EnvConfiguration {
-    random?: boolean;
-    seed?: number;
-    failFast?: boolean;
-    oneFailurePerSpec?: boolean;
-    hideDisabled?: boolean;
-    specFilter?: Function;
-}
-
-/**
  * Install a spy onto an existing object.
  * @param object The object upon which to install the `Spy`.
  * @param method The name of the method to replace with a `Spy`.
@@ -218,6 +206,18 @@ declare namespace jasmine {
         T extends undefined ?
             (ReadonlyArray<string> | { [methodName: string]: any }) :
             (ReadonlyArray<keyof T> | { [P in keyof T]?: T[P] extends Func ? ReturnType<T[P]> : any });
+
+    /**
+     * Configuration that can be used when configuring Jasmine via {@link jasmine.Env.configure}
+     */
+    interface EnvConfiguration {
+        random?: boolean;
+        seed?: number;
+        failFast?: boolean;
+        oneFailurePerSpec?: boolean;
+        hideDisabled?: boolean;
+        specFilter?: Function;
+    }
 
     function clock(): Clock;
 

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -13,6 +13,7 @@
 //                 Stephen Farrar <https://github.com/stephenfarrar>
 //                 Mochamad Arfin <https://github.com/ndunks>
 //                 Alex Povar <https://github.com/zvirja>
+//                 Dominik Ehrenberg <https://github.com/djungowski>
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts
 
 /**
@@ -153,6 +154,18 @@ interface DoneFn extends Function {
 
     /** fails the spec and indicates that it has completed. If the message is an Error, Error.message is used */
     fail: (message?: Error | string) => void;
+}
+
+/**
+ * Configuration that can be used when configuring Jasmine via {@link jasmine.Env.configure}
+ */
+interface Configuration {
+    random?: boolean;
+    seed?: number;
+    failFast?: boolean;
+    oneFailurePerSpec?: boolean;
+    hideDisabled?: boolean;
+    specFilter?: Function;
 }
 
 /**
@@ -374,14 +387,28 @@ declare namespace jasmine {
         addCustomEqualityTester(equalityTester: CustomEqualityTester): void;
         addMatchers(matchers: CustomMatcherFactories): void;
         specFilter(spec: Spec): boolean;
+        /**
+         * @deprecated Use oneFailurePerSpec option in {@link jasmine.Env.configure} instead.
+         */
         throwOnExpectationFailure(value: boolean): void;
+        /**
+         * @deprecated Use failFast option in {@link jasmine.Env.configure} instead.
+         */
+        stopOnSpecFailure(value: boolean): void;
+        /**
+         * @deprecated Use seed option in {@link jasmine.Env.configure} instead.
+         */
         seed(seed: string | number): string | number;
         provideFallbackReporter(reporter: Reporter): void;
         throwingExpectationFailures(): boolean;
         allowRespy(allow: boolean): void;
         randomTests(): boolean;
+        /**
+         * @deprecated Use random option in {@link jasmine.Env.configure} instead.
+         */
         randomizeTests(b: boolean): void;
         clearReporters(): void;
+        configure(configuration: Configuration): void;
     }
 
     interface FakeTimer {

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -159,7 +159,7 @@ interface DoneFn extends Function {
 /**
  * Configuration that can be used when configuring Jasmine via {@link jasmine.Env.configure}
  */
-interface Configuration {
+interface EnvConfiguration {
     random?: boolean;
     seed?: number;
     failFast?: boolean;
@@ -408,7 +408,7 @@ declare namespace jasmine {
          */
         randomizeTests(b: boolean): void;
         clearReporters(): void;
-        configure(configuration: Configuration): void;
+        configure(configuration: EnvConfiguration): void;
     }
 
     interface FakeTimer {

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -1413,15 +1413,19 @@ describe("Randomize Tests", () => {
     it("should allow randomization of the order of tests", () => {
         expect(() => {
             const env = jasmine.getEnv();
-            env.randomizeTests(true);
+            env.configure({
+                random: true
+            });
         }).not.toThrow();
     });
 
     it("should allow a seed to be passed in for randomization", () => {
         expect(() => {
             const env = jasmine.getEnv();
-            env.randomizeTests(true);
-            return env.seed(1234);
+            env.configure({
+                random: true,
+                seed: 1234
+            });
         }).not.toThrow();
     });
 });


### PR DESCRIPTION
Add definition for jasmine.Env.configure and mark Env methods throwOnExpectationFailure, stopOnSpecFailure, seed and randomizeTests as deprecated

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://jasmine.github.io/api/3.4/Env.html
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
