### PR TITLE
fix(node): fix opendirSync and promises.opendir return types

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -1932,7 +1932,7 @@ declare module "fs" {
         encoding?: BufferEncoding;
     }
 
-    function opendirSync(path: string, options?: OpenDirOptions): Dirent;
+    function opendirSync(path: string, options?: OpenDirOptions): Dir;
 
     function opendir(path: string, cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void): void;
     function opendir(path: string, options: OpenDirOptions, cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void): void;
@@ -2441,6 +2441,6 @@ declare module "fs" {
          */
         function readFile(path: PathLike | FileHandle, options?: { encoding?: string | null, flag?: string | number } | string | null): Promise<string | Buffer>;
 
-        function opendir(path: string, options?: OpenDirOptions): Promise<Dirent>;
+        function opendir(path: string, options?: OpenDirOptions): Promise<Dir>;
     }
 }

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -314,11 +314,17 @@ async function testPromisify() {
         const dirEnt: fs.Dirent | null = await dir.read();
     });
 
-    const dirEnt: fs.Dirent = fs.opendirSync('test', {
+    const dir: fs.Dir = fs.opendirSync('test', {
         encoding: 'utf8',
     });
 
-    const dirEntProm: Promise<fs.Dirent> = fs.promises.opendir('test', {
+    // Pending lib upgrade
+    // (async () => {
+    //     for await (const thing of dir) {
+    //     }
+    // });
+
+    const dirEntProm: Promise<fs.Dir> = fs.promises.opendir('test', {
         encoding: 'utf8',
     });
 }


### PR DESCRIPTION
Please fill in this template.

- [ x Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v13.x/docs/api/fs.html#fs_fspromises_opendir_path_options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/39994