### PR TITLE
node-ipc: add number type to maxRetries

### DIFF
--- a/types/node-ipc/index.d.ts
+++ b/types/node-ipc/index.d.ts
@@ -287,7 +287,7 @@ declare namespace NodeIPC {
          * if set, it represents the maximum number of retries after each disconnect before giving up
          * and completely killing a specific connection
          */
-        maxRetries: boolean;
+        maxRetries: boolean | number;
         /**
          * Default: false
          * Defaults to false meaning clients will continue to retry to connect to servers indefinitely at the retry interval.


### PR DESCRIPTION
maxRetries can also be a number to specify the number of retries. Currently it is only possible to either do no retry or 1 retry (with setting to true).

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
