### PR TITLE
Add overrridePosition to react-tooltip

### DIFF
--- a/types/react-tooltip/index.d.ts
+++ b/types/react-tooltip/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-tooltip 3.9
+// Type definitions for react-tooltip 3.11.1
 // Project: https://github.com/wwayne/react-tooltip
 // Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>,
 //                 Vijayasingam <https://github.com/Vijayasingam>

--- a/types/react-tooltip/index.d.ts
+++ b/types/react-tooltip/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for react-tooltip 3.9
 // Project: https://github.com/wwayne/react-tooltip
-// Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>, Vijayasingam <https://github.com/Vijayasingam>
+// Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>,
+//                 Vijayasingam <https://github.com/Vijayasingam>
+//                 Alec Brunelle <https://github.com/aleccool213>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -109,6 +111,16 @@ declare namespace ReactTooltip {
         watchWindow?: boolean;
         sanitizeHtmlOptions?: SanitizeHtmlOptions;
         clickable?: boolean;
+        overridePosition?: (
+            position: { left: number; top: number },
+            currentEvent: Event,
+            currentTarget: Element,
+            node: any,
+            place: Place,
+            desiredPlace: Place,
+            effect: Effect,
+            offset: Offset,
+        ) => { left: number; top: number };
     }
 }
 

--- a/types/react-tooltip/index.d.ts
+++ b/types/react-tooltip/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-tooltip 3.11.1
+// Type definitions for react-tooltip 3.11
 // Project: https://github.com/wwayne/react-tooltip
 // Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>,
 //                 Vijayasingam <https://github.com/Vijayasingam>
@@ -6,9 +6,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from "react";
+import * as React from 'react';
 
-declare class ReactTooltip extends React.Component<ReactTooltip.Props> { }
+declare class ReactTooltip extends React.Component<ReactTooltip.Props> {}
 
 declare namespace ReactTooltip {
     /**
@@ -44,9 +44,9 @@ declare namespace ReactTooltip {
     type GetContentCallback = (dataTip: string) => React.ReactNode;
     type GetContent = GetContentCallback | [GetContentCallback, number];
 
-    type Place = "top" | "right" | "bottom" | "left";
-    type Type = "dark" | "success" | "warning" | "error" | "info" | "light";
-    type Effect = "float" | "solid";
+    type Place = 'top' | 'right' | 'bottom' | 'left';
+    type Type = 'dark' | 'success' | 'warning' | 'error' | 'info' | 'light';
+    type Effect = 'float' | 'solid';
     interface SanitizeHtmlParserOptions {
         decodeEntities?: boolean;
     }
@@ -105,7 +105,7 @@ declare namespace ReactTooltip {
         disable?: boolean;
         scrollHide?: boolean;
         resizeHide?: boolean;
-        wrapper?: "div" | "span";
+        wrapper?: 'div' | 'span';
         role?: string;
         class?: string;
         watchWindow?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wwayne/react-tooltip/pull/502
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
