### PR TITLE
@types/hummus-recipe - Adding missing property [metadata]

### DIFF
--- a/types/hummus-recipe/index.d.ts
+++ b/types/hummus-recipe/index.d.ts
@@ -188,6 +188,10 @@ declare namespace Recipe {
         rotation?: number;
         rotationOrigin?: number[];
     }
+    
+    interface PageInfo {
+        pages: number;
+    }
 
     type EndPDFCallback1 = () => any;
     type EndPDFCallback2 = (buffer: Buffer) => any;
@@ -198,6 +202,8 @@ declare class Recipe {
     constructor(src: string, output: string, options?: Recipe.RecipeOptions);
 
     constructor(buffer: Buffer, options?: Recipe.RecipeOptions);
+    
+    metadata: PageInfo;
 
     comment(
         text: string,


### PR DESCRIPTION
There's more to add, but the pages property is pretty neat and is pretty much needed every time you're looping through all pages.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chunyenHuang/hummusRecipe#page-info
