### PR TITLE
[leveldown] Move destroy() and repair() methods to static

### DIFF
--- a/types/leveldown/index.d.ts
+++ b/types/leveldown/index.d.ts
@@ -43,14 +43,14 @@ export interface LevelDown extends AbstractLevelDOWN<Bytes, Bytes> {
   approximateSize(start: Bytes, end: Bytes, cb: ErrorSizeCallback): void;
   compactRange(start: Bytes, end: Bytes, cb: ErrorCallback): void;
   getProperty(property: string): string;
-  destroy(location: string, cb: ErrorCallback): void;
-  repair(location: string, cb: ErrorCallback): void;
   iterator(options?: LevelDownIteratorOptions): LevelDownIterator;
 }
 
 interface LevelDownConstructor {
   new(location: string): LevelDown;
   (location: string): LevelDown;
+  destroy(location: string, cb: ErrorCallback): void;
+  repair(location: string, cb: ErrorCallback): void;
 }
 
 export interface LevelDownOpenOptions extends AbstractOpenOptions {

--- a/types/leveldown/leveldown-tests.ts
+++ b/types/leveldown/leveldown-tests.ts
@@ -1,19 +1,22 @@
-import LevelDOWN from 'leveldown';
+import LevelDOWN, { Bytes } from 'leveldown';
 
-// can use new, or not.
-const a = new LevelDOWN("./tmp/leveldown");
-const b = LevelDOWN("./tmp/leveldown");
+// Can use new, or not.
+const a = new LevelDOWN("/tmp/db");
+const b = LevelDOWN("/tmp/db");
 
-const down = new LevelDOWN("./tmp/leveldown");
+const down = new LevelDOWN("/tmp/db");
 
 down.open(() => {
-  down.put("key", "value", (err?) => { });
-  down.put(Buffer.from([1]), "value", { something: true }, (err?) => { });
+  down.put("key", "value", (err: Error | undefined) => { });
+  down.put(Buffer.from([1]), "value", { something: true }, (err: Error | undefined) => { });
 
-  down.get("key", (err?) => { });
-  down.get(Buffer.from([1]), { something: true }, (err: Error | undefined, value: any) => { });
+  down.get("key", (err: Error | undefined) => { });
+  down.get(Buffer.from([1]), { something: true }, (err: Error | undefined, value: Bytes) => { });
 
-  down.close(() => {
+  down.close((err: Error | undefined) => {
     // do nothing
   });
 });
+
+down.destroy("/tmp/db", (err: Error | undefined) => { });
+down.repair("/tmp/db", (err: Error | undefined) => { });


### PR DESCRIPTION
Move `destroy()` and `repair()` of `LevelDOWN` class to static methods. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [destroy](https://github.com/Level/leveldown/blob/f637eb79d52b211494e61e47610a5c6112f4f25a/binding.cc#L1164)
  - [repair](https://github.com/Level/leveldown/blob/f637eb79d52b211494e61e47610a5c6112f4f25a/binding.cc#L1200)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.