### PR TITLE
Add type definitions for js-roman-numerals

### DIFF
--- a/types/js-roman-numerals/index.d.ts
+++ b/types/js-roman-numerals/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for js-roman-numerals 1.1
+// Project: https://github.com/bcotrim/roman-numerals
+// Definitions by: Ricardo Mello <https://github.com/ricardo-mello>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+declare class RomanNumeral {
+    constructor(value: number | string);
+    toInt(): number;
+    toString(): string;
+}
+
+export = RomanNumeral;

--- a/types/js-roman-numerals/js-roman-numerals-tests.ts
+++ b/types/js-roman-numerals/js-roman-numerals-tests.ts
@@ -1,0 +1,12 @@
+import RomanNumeral = require('js-roman-numerals');
+
+function constructorTests() {
+    const x = new RomanNumeral(10); // '10' | 'X'
+    const y = new RomanNumeral('V'); // '5' | 'V'
+}
+
+function functionTests() {
+    const x = new RomanNumeral(10);
+    const y: number = x.toInt();
+    const z: string = x.toString();
+}

--- a/types/js-roman-numerals/tsconfig.json
+++ b/types/js-roman-numerals/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "js-roman-numerals-tests.ts"]
+}

--- a/types/js-roman-numerals/tslint.json
+++ b/types/js-roman-numerals/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Closes #39330 