### PR TITLE
[koa__multer] Allows to access the properties file and files through the koa context.

### DIFF
--- a/types/koa__multer/index.d.ts
+++ b/types/koa__multer/index.d.ts
@@ -19,6 +19,11 @@
  * async function uploadFile(ctx: Koa.Context){
  *     let multerReq = <multer.MulterIncomingMessage>ctx.req;
  *     let files = multerReq.files;
+ *
+ *     // You can also directly access the files property from the context object or request object:
+ *     files = ctx.files;
+ *     files = ctx.request.files;
+ *
  *     let baseFilePath: string = ctx.params.path || '';
  *     //...
  * }
@@ -31,6 +36,18 @@
 
 import * as Koa from 'koa';
 import { IncomingMessage } from 'http';
+
+declare module 'koa' {
+    interface DefaultContext {
+        file: multer.File;
+        files: multer.File[];
+    }
+
+    interface Request {
+        file: multer.File;
+        files: multer.File[];
+    }
+}
 
 declare namespace multer {
     interface File {

--- a/types/koa__multer/koa__multer-tests.ts
+++ b/types/koa__multer/koa__multer-tests.ts
@@ -1,5 +1,6 @@
 import Koa = require('koa');
 import multer = require('@koa/multer');
+import Router = require('koa-router');
 
 const upload = multer({
     dest: 'uploads/',
@@ -13,6 +14,12 @@ const app = new Koa();
 app.use(upload.single('avatar'));
 
 app.use(upload.array('photos', 12));
+app.use(async (ctx, next) => {
+    for (const file of ctx.request.files) {
+        console.info(`Received file: ${file.filename}`);
+    }
+    await next();
+});
 
 const cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }]);
 app.use(cpUpload);

--- a/types/koa__multer/koa__multer-tests.ts
+++ b/types/koa__multer/koa__multer-tests.ts
@@ -1,6 +1,5 @@
 import Koa = require('koa');
 import multer = require('@koa/multer');
-import Router = require('koa-router');
 
 const upload = multer({
     dest: 'uploads/',


### PR DESCRIPTION
Allows to access the multer properties file and files through the koa context.

* Extends the koa context and request by the fields file and files.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/multer
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
