### PR TITLE
[react-responsive] Add `device` prop on `MediaQuery` component

### DIFF
--- a/types/react-responsive/index.d.ts
+++ b/types/react-responsive/index.d.ts
@@ -80,7 +80,7 @@ export interface MediaQueryProps extends MediaQueryAllQueryable {
     style?: React.CSSProperties;
     className?: string;
     children?: React.ReactNode | ((matches: boolean) => React.ReactNode);
-    device?: MediaQueryMatchers,
+    device?: MediaQueryMatchers;
     values?: Partial<MediaQueryMatchers>;
     onBeforeChange?: (matches: boolean) => void;
     onChange?: (matches: boolean) => void;

--- a/types/react-responsive/index.d.ts
+++ b/types/react-responsive/index.d.ts
@@ -80,6 +80,7 @@ export interface MediaQueryProps extends MediaQueryAllQueryable {
     style?: React.CSSProperties;
     className?: string;
     children?: React.ReactNode | ((matches: boolean) => React.ReactNode);
+    device?: MediaQueryMatchers,
     values?: Partial<MediaQueryMatchers>;
     onBeforeChange?: (matches: boolean) => void;
     onChange?: (matches: boolean) => void;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/react-responsive#with-components

The documentation shows a code sample with the `device` prop being used.

I compiled and ran the following code sample in my own project:
`<MediaQuery handheld={true} device={{ type: 'handheld' }}>`

It works as expected, forcing the media query to match a handheld device.