### PR TITLE
Add type definitions for graphql-bigint

### DIFF
--- a/types/graphql-bigint/graphql-bigint-tests.ts
+++ b/types/graphql-bigint/graphql-bigint-tests.ts
@@ -1,0 +1,13 @@
+import { GraphQLObjectType } from 'graphql';
+import * as GraphQLBigInt from 'graphql-bigint';
+
+const fooType = new GraphQLObjectType({
+    name: 'Foo',
+    description: 'Some foo type',
+    fields: {
+        created: {
+            type: GraphQLBigInt,
+            description: 'BigInt foo was created',
+        }
+    }
+});

--- a/types/graphql-bigint/index.d.ts
+++ b/types/graphql-bigint/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for graphql-bigint 1.0
+// Project: https://github.com/stems/graphql-bigint#readme
+// Definitions by: proudrain <https://github.com/proudrain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+import { GraphQLScalarType } from 'graphql';
+
+declare const GraphQLBigInt: GraphQLScalarType;
+
+export = GraphQLBigInt;

--- a/types/graphql-bigint/package.json
+++ b/types/graphql-bigint/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "graphql": "^14.5.3"
+  }
+}

--- a/types/graphql-bigint/tsconfig.json
+++ b/types/graphql-bigint/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "esnext.asynciterable"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "graphql-bigint-tests.ts"
+    ]
+}

--- a/types/graphql-bigint/tslint.json
+++ b/types/graphql-bigint/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.