### PR TITLE
[jasmine] Generics for Spy Arguments

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -836,24 +836,24 @@ declare namespace jasmine {
         /** By chaining the spy with calls.count(), will return the number of times the spy was called */
         count(): number;
         /** By chaining the spy with calls.argsFor(), will return the arguments passed to call number index */
-        argsFor(index: number): any[];
+        argsFor<T = any>(index: number): T[];
         /** By chaining the spy with calls.allArgs(), will return the arguments to all calls */
-        allArgs(): any[];
+        allArgs<T = any>(): T[];
         /** By chaining the spy with calls.all(), will return the context (the this) and arguments passed all calls */
-        all(): CallInfo[];
+        all<T = any>(): CallInfo<T>[];
         /** By chaining the spy with calls.mostRecent(), will return the context (the this) and arguments for the most recent call */
-        mostRecent(): CallInfo;
+        mostRecent<T = any>(): CallInfo<T>;
         /** By chaining the spy with calls.first(), will return the context (the this) and arguments for the first call */
-        first(): CallInfo;
+        first<T = any>(): CallInfo<T>;
         /** By chaining the spy with calls.reset(), will clears all tracking for a spy */
         reset(): void;
     }
 
-    interface CallInfo {
+    interface CallInfo<T = any> {
         /** The context (the this) for the call */
         object: any;
         /** All arguments passed to the call */
-        args: any[];
+        args: T[];
         /** The return value of the call */
         returnValue: any;
     }

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -836,11 +836,11 @@ declare namespace jasmine {
         /** By chaining the spy with calls.count(), will return the number of times the spy was called */
         count(): number;
         /** By chaining the spy with calls.argsFor(), will return the arguments passed to call number index */
-        argsFor<T = any>(index: number): Array<T>;
+        argsFor<T = any>(index: number): T[];
         /** By chaining the spy with calls.allArgs(), will return the arguments to all calls */
-        allArgs<T = any>(): Array<T>;
+        allArgs<T = any>(): T[];
         /** By chaining the spy with calls.all(), will return the context (the this) and arguments passed all calls */
-        all<T = any>(): CallInfo<T>[];
+        all<T = any>(): Array<CallInfo<T>>;
         /** By chaining the spy with calls.mostRecent(), will return the context (the this) and arguments for the most recent call */
         mostRecent<T = any>(): CallInfo<T>;
         /** By chaining the spy with calls.first(), will return the context (the this) and arguments for the first call */
@@ -853,7 +853,7 @@ declare namespace jasmine {
         /** The context (the this) for the call */
         object: any;
         /** All arguments passed to the call */
-        args: Array<T>;
+        args: T[];
         /** The return value of the call */
         returnValue: any;
     }

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -836,9 +836,9 @@ declare namespace jasmine {
         /** By chaining the spy with calls.count(), will return the number of times the spy was called */
         count(): number;
         /** By chaining the spy with calls.argsFor(), will return the arguments passed to call number index */
-        argsFor<T = any>(index: number): T[];
+        argsFor<T = any>(index: number): Array<T>;
         /** By chaining the spy with calls.allArgs(), will return the arguments to all calls */
-        allArgs<T = any>(): T[];
+        allArgs<T = any>(): Array<T>;
         /** By chaining the spy with calls.all(), will return the context (the this) and arguments passed all calls */
         all<T = any>(): CallInfo<T>[];
         /** By chaining the spy with calls.mostRecent(), will return the context (the this) and arguments for the most recent call */
@@ -853,7 +853,7 @@ declare namespace jasmine {
         /** The context (the this) for the call */
         object: any;
         /** All arguments passed to the call */
-        args: T[];
+        args: Array<T>;
         /** The return value of the call */
         returnValue: any;
     }

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -836,11 +836,11 @@ declare namespace jasmine {
         /** By chaining the spy with calls.count(), will return the number of times the spy was called */
         count(): number;
         /** By chaining the spy with calls.argsFor(), will return the arguments passed to call number index */
-        argsFor<T = any>(index: number): T[];
+        argsFor<T extends any[] = any[]>(index: number): T;
         /** By chaining the spy with calls.allArgs(), will return the arguments to all calls */
-        allArgs<T = any>(): T[];
+        allArgs<T extends any[] = any[]>(): T;
         /** By chaining the spy with calls.all(), will return the context (the this) and arguments passed all calls */
-        all<T = any>(): Array<CallInfo<T>>;
+        all<T extends any[] = any[]>(): CallInfo<T>;
         /** By chaining the spy with calls.mostRecent(), will return the context (the this) and arguments for the most recent call */
         mostRecent<T = any>(): CallInfo<T>;
         /** By chaining the spy with calls.first(), will return the context (the this) and arguments for the first call */
@@ -849,11 +849,11 @@ declare namespace jasmine {
         reset(): void;
     }
 
-    interface CallInfo<T = any> {
+    interface CallInfo<T extends any[] = any[]> {
         /** The context (the this) for the call */
         object: any;
         /** All arguments passed to the call */
-        args: T[];
+        args: T;
         /** The return value of the call */
         returnValue: any;
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:

With this change we can have this clean test code:
````ts
jasmine.createSpy().calls.allArgs<[boolean, string]>().some((allParams) => {
    let firstVarOfCalledFunction = allParams[0]; // detected as bool
    let secondVarOfCalledFunction = allParams[1]; // detected as string
});
````