### PR TITLE
[meteor] Change the '_id' property in Meteor.User from optional to non-optional.

### DIFF
--- a/types/meteor/globals/meteor.d.ts
+++ b/types/meteor/globals/meteor.d.ts
@@ -23,7 +23,7 @@ declare module Meteor {
         verified: boolean;
     }
     interface User {
-        _id?: string;
+        _id: string;
         username?: string;
         emails?: UserEmail[];
         createdAt?: Date;

--- a/types/meteor/meteor.d.ts
+++ b/types/meteor/meteor.d.ts
@@ -28,7 +28,7 @@ declare module "meteor/meteor" {
             verified: boolean;
         }
         interface User {
-            _id?: string;
+            _id: string;
             username?: string;
             emails?: UserEmail[];
             createdAt?: Date;

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -520,7 +520,7 @@ Accounts.validateNewUser(function (user: { username: string }) {
 /**
  * From Accounts, Accounts.onCreateUser section
  */
-Accounts.onCreateUser(function (options, user) {
+Accounts.onCreateUser(function (options: { profile: any }, user) {
     var d6 = function () { return Math.floor(Math.random() * 6) + 1; };
     user.dexterity = d6() + d6() + d6();
     // We still want the default hook's 'profile' behavior.

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -520,7 +520,7 @@ Accounts.validateNewUser(function (user: { username: string }) {
 /**
  * From Accounts, Accounts.onCreateUser section
  */
-Accounts.onCreateUser(function (options: { profile: any }, user: { profile: any, dexterity: number }) {
+Accounts.onCreateUser(function (options, user) {
     var d6 = function () { return Math.floor(Math.random() * 6) + 1; };
     user.dexterity = d6() + d6() + d6();
     // We still want the default hook's 'profile' behavior.
@@ -534,7 +534,7 @@ Accounts.onCreateUser(function (options: { profile: any }, user: { profile: any,
  */
 Accounts.emailTemplates.siteName = "AwesomeSite";
 Accounts.emailTemplates.from = "AwesomeSite Admin <accounts@example.com>";
-Accounts.emailTemplates.enrollAccount.subject = function (user: { profile: { name: string } }) {
+Accounts.emailTemplates.enrollAccount.subject = function (user) {
     return "Welcome to Awesome Town, " + user.profile.name;
 };
 Accounts.emailTemplates.enrollAccount.text = function (user: any, url: string) {

--- a/types/meteor/test/globals/userAugment.d.ts
+++ b/types/meteor/test/globals/userAugment.d.ts
@@ -1,0 +1,6 @@
+declare module Meteor {
+    interface User {
+        // One of the tests assigns a new property to the user so it has to be typed
+        dexterity?: number;
+    }
+}

--- a/types/meteor/test/globals/userAugment.d.ts
+++ b/types/meteor/test/globals/userAugment.d.ts
@@ -1,6 +1,0 @@
-declare module Meteor {
-    interface User {
-        // One of the tests assigns a new property to the user so it has to be typed
-        dexterity?: number;
-    }
-}

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -23,6 +23,8 @@ import { Accounts } from "meteor/accounts-base";
 import { BrowserPolicy } from "meteor/browser-policy-common";
 import { DDPRateLimiter } from "meteor/ddp-rate-limiter";
 
+import './userAugment'
+
 // Avoid conflicts between `meteor-tests.ts` and `globals/meteor-tests.ts`.
 namespace MeteorTests {
 
@@ -532,7 +534,7 @@ Accounts.validateNewUser(function (user: { username: string }) {
 /**
  * From Accounts, Accounts.onCreateUser section
  */
-Accounts.onCreateUser(function (options: { profile: any }, user: { profile: any, dexterity: number }) {
+Accounts.onCreateUser(function (options: { profile: any }, user) {
     var d6 = function () { return Math.floor(Math.random() * 6) + 1; };
     user.dexterity = d6() + d6() + d6();
     // We still want the default hook's 'profile' behavior.
@@ -546,7 +548,7 @@ Accounts.onCreateUser(function (options: { profile: any }, user: { profile: any,
  */
 Accounts.emailTemplates.siteName = "AwesomeSite";
 Accounts.emailTemplates.from = "AwesomeSite Admin <accounts@example.com>";
-Accounts.emailTemplates.enrollAccount.subject = function (user: { profile: { name: string } }) {
+Accounts.emailTemplates.enrollAccount.subject = function (user) {
     return "Welcome to Awesome Town, " + user.profile.name;
 };
 Accounts.emailTemplates.enrollAccount.text = function (user: any, url: string) {

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -23,8 +23,6 @@ import { Accounts } from "meteor/accounts-base";
 import { BrowserPolicy } from "meteor/browser-policy-common";
 import { DDPRateLimiter } from "meteor/ddp-rate-limiter";
 
-import './userAugment'
-
 // Avoid conflicts between `meteor-tests.ts` and `globals/meteor-tests.ts`.
 namespace MeteorTests {
 

--- a/types/meteor/test/userAugment.d.ts
+++ b/types/meteor/test/userAugment.d.ts
@@ -6,3 +6,10 @@ declare module 'meteor/meteor' {
         }
     }
 }
+
+declare module Meteor {
+    interface User {
+        // One of the tests assigns a new property to the user so it has to be typed
+        dexterity?: number;
+    }
+}

--- a/types/meteor/test/userAugment.d.ts
+++ b/types/meteor/test/userAugment.d.ts
@@ -1,0 +1,8 @@
+declare module 'meteor/meteor' {
+    module Meteor {
+        interface User {
+            // One of the tests assigns a new property to the user so it has to be typed
+            dexterity?: number;
+        }
+    }
+}

--- a/types/meteor/tsconfig.json
+++ b/types/meteor/tsconfig.json
@@ -62,6 +62,7 @@
         "index.d.ts",
         "test/meteor-tests.ts",
         "test/globals/meteor-tests.ts",
+        "test/globals/userAugment.d.ts",
         "test/meteor-tests-module-only.ts",
         "test/server-render.tsx",
         "react-meteor-data.d.ts",

--- a/types/meteor/tsconfig.json
+++ b/types/meteor/tsconfig.json
@@ -62,7 +62,7 @@
         "index.d.ts",
         "test/meteor-tests.ts",
         "test/globals/meteor-tests.ts",
-        "test/globals/userAugment.d.ts",
+        "test/userAugment.d.ts",
         "test/meteor-tests-module-only.ts",
         "test/server-render.tsx",
         "react-meteor-data.d.ts",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.meteor.com/api/accounts.html#Meteor-users

There doesn't seem to be any case in which a User object would not contain an `_id`. As such it seems like a reasonable change to change it to `string`. Until now there were too many asserts that the `user._id` (because Typescript complained), even though it could never be undefined.

The `userAugment.d.ts` were added because one of the tests was writing to a new property on the `User` object. The `globals/userAugment.d.ts` was created manually since the script for generating them, doesn't touch test files.