### PR TITLE
[dot-prop-immutable] Allow passing undefined as object

### DIFF
--- a/types/dot-prop-immutable/dot-prop-immutable-tests.ts
+++ b/types/dot-prop-immutable/dot-prop-immutable-tests.ts
@@ -1,5 +1,8 @@
 import dotProp = require('dot-prop-immutable');
 
+dotProp.get(undefined, 'foo.bar');  // $ExpectType any
+dotProp.get<string>(undefined, 'foo.bar', 'default value');  // $ExpectType string
+
 dotProp.get({foo: {bar: 'unicorn'}}, 'foo.bar');  // $ExpectType any
 dotProp.get({foo: {bar: 'a'}}, 'foo.notDefined.deep');  // $ExpectType any
 dotProp.get<string>({foo: {bar: 'a'}}, 'foo.notDefined.deep', 'default value');  // $ExpectType string

--- a/types/dot-prop-immutable/index.d.ts
+++ b/types/dot-prop-immutable/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for dot-prop-immutable 1.5
 // Project: https://github.com/debitoor/dot-prop-immutable
 // Definitions by: Paul Brussee <https://github.com/brussee>
+//                 Linus Unnebäck <https://github.com/LinusU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -56,12 +57,12 @@ export type Path = number | string | Array<number|string>;
  * ```
  */
 export function get(
-    object: ArrayOrObject,
+    object: ArrayOrObject | undefined,
     path: Path
 ): any;
 
 export function get<V>(
-    object: ArrayOrObject,
+    object: ArrayOrObject | undefined,
     path: Path,
     defaultValue: V
 ): V;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/debitoor/dot-prop-immutable/blob/5bb16c47a084e14d527d4eb3f850a4517d206033/index.js#L41-L43
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
