### PR TITLE
Add missing shelljs.exec option

### DIFF
--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -841,7 +841,7 @@ export interface ExecOptions extends child.ExecOptions {
 	 * @default false
 	 */
 	fatal?: boolean;
-	
+
 	/**
 	 * Asynchronous execution.
 	 *

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -836,7 +836,7 @@ export interface ExecOptions extends child.ExecOptions {
 	silent?: boolean;
 
 	/**
-	 * Exit when command return code is non-zero
+	 * Exit when command return code is non-zero.
 	 *
 	 * @default false
 	 */

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -837,7 +837,7 @@ export interface ExecOptions extends child.ExecOptions {
 
 	/**
 	 * Exit when command return code is non-zero
-	 *  
+	 *
 	 * @default false
 	 */
 	fatal?: boolean;

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -836,6 +836,13 @@ export interface ExecOptions extends child.ExecOptions {
 	silent?: boolean;
 
 	/**
+	 * Exit when command return code is non-zero
+	 *  
+	 * @default false
+	 */
+	fatal?: boolean;
+	
+	/**
 	 * Asynchronous execution.
 	 *
 	 * If a callback is provided, it will be set to `true`, regardless of the passed value.

--- a/types/shelljs/shelljs-tests.ts
+++ b/types/shelljs/shelljs-tests.ts
@@ -98,7 +98,7 @@ const output3 = version3.stdout;
 
 // $ExpectType ShellString
 const version4 = shell.exec("node --version", {async: false, fatal: true});
-const output4 = version3.stdout;
+const output4 = version4.stdout;
 
 // $ExpectType ChildProcess
 const asyncVersion3 = shell.exec("node --version", {async: true});

--- a/types/shelljs/shelljs-tests.ts
+++ b/types/shelljs/shelljs-tests.ts
@@ -92,6 +92,14 @@ const version = shell.exec("node --version").stdout;
 const version2 = shell.exec("node --version", {async: false});
 const output = version2.stdout;
 
+// $ExpectType ShellString
+const version3 = shell.exec("node --version", {async: false, fatal: false});
+const output3 = version3.stdout;
+
+// $ExpectType ShellString
+const version4 = shell.exec("node --version", {async: false, fatal: true});
+const output4 = version3.stdout;
+
 // $ExpectType ChildProcess
 const asyncVersion3 = shell.exec("node --version", {async: true});
 let pid = asyncVersion3.pid;


### PR DESCRIPTION
The shelljs `exec` function is missing the `fatal` option, which I want to use.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://documentup.com/shelljs/shelljs#execcommand--options--callback](https://documentup.com/shelljs/shelljs#execcommand--options--callback)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

