### PR TITLE
relay-runtime: Add overloads to proxies

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -184,7 +184,7 @@ export { requestSubscription } from './lib/subscription/requestSubscription';
 
 // Utilities
 export { RelayProfiler } from './lib/util/RelayProfiler';
-export { getRelayHandleKey } from './lib/util/getRelayHandleKey'
+export { getRelayHandleKey } from './lib/util/getRelayHandleKey';
 
 // INTERNAL-ONLY
 export { RelayConcreteNode } from './lib/util/RelayConcreteNode';

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -184,6 +184,7 @@ export { requestSubscription } from './lib/subscription/requestSubscription';
 
 // Utilities
 export { RelayProfiler } from './lib/util/RelayProfiler';
+export { getRelayHandleKey } from './lib/util/getRelayHandleKey'
 
 // INTERNAL-ONLY
 export { RelayConcreteNode } from './lib/util/RelayConcreteNode';

--- a/types/relay-runtime/lib/mutations/commitMutation.d.ts
+++ b/types/relay-runtime/lib/mutations/commitMutation.d.ts
@@ -18,8 +18,8 @@ export interface MutationConfig<TOperation extends MutationParameters> {
         | ((response: TOperation['response'], errors: ReadonlyArray<PayloadError> | null | undefined) => void)
         | null;
     optimisticResponse?: TOperation['response'];
-    optimisticUpdater?: SelectorStoreUpdater | null;
-    updater?: SelectorStoreUpdater | null;
+    optimisticUpdater?: SelectorStoreUpdater<TOperation['response']> | null;
+    updater?: SelectorStoreUpdater<TOperation['response']> | null;
     uploadables?: UploadableMap | null;
     variables: TOperation['variables'];
 }

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -294,10 +294,10 @@ export interface Store {
  */
 export type Scheduler = (callback: () => void) => void;
 
-type MaybeNull<T> = null extends T ? null : never;
-type Unarray<T> = T extends Array<infer U> ? U : T;
-type NullableRecord<T> = RecordProxy<NonNullable<T>> | MaybeNull<T>;
-type DeepNullable<T> = {
+export type MaybeNull<T> = null extends T ? null : never;
+export type Unarray<T> = T extends Array<infer U> ? U : T;
+export type NullableRecord<T> = RecordProxy<NonNullable<T>> | MaybeNull<T>;
+export type DeepNullable<T> = {
     [P in keyof T]: T[P] extends Array<infer U>
         ? Array<DeepNullable<U>> | null
         : T[P] extends ReadonlyArray<infer U>
@@ -331,7 +331,7 @@ export interface RecordProxy<T = { [key: string]: any }> {
       name: K,
       args?: Variables | null,
     ): RecordProxy;
-    setValue<K extends keyof T>(value: any, name: K, args?: Variables | null): RecordProxy;
+    setValue(value: any, name: keyof T, args?: Variables | null): RecordProxy;
 }
 
 export interface ReadOnlyRecordProxy {
@@ -350,9 +350,9 @@ export interface ReadOnlyRecordProxy {
  */
 
 export interface RecordSourceProxy {
-    create<K = any>(dataID: DataID, typeName: string): RecordProxy<K>;
+    create(dataID: DataID, typeName: string): RecordProxy;
     delete(dataID: DataID): void;
-    get<K = { [key: string]: any }>(dataID: DataID): RecordProxy<K> | null | undefined;
+    get(dataID: DataID): RecordProxy | null | undefined;
     getRoot(): RecordProxy;
 }
 
@@ -366,8 +366,8 @@ export interface ReadOnlyRecordSourceProxy {
  * fields of a Selector.
  */
 export interface RecordSourceSelectorProxy<T = { [key: string]: any }> extends RecordSourceProxy {
-    getRootField<K extends keyof T>(fieldName: K): RecordProxy<NonNullable<T[K]>> | MaybeNull<T[K]>
-    getPluralRootField(fieldName: string): RecordProxy[] | null
+    getRootField<K extends keyof T>(fieldName: K): RecordProxy<NonNullable<T[K]>> | MaybeNull<T[K]>;
+    getPluralRootField(fieldName: string): RecordProxy[] | null;
     insertConnectionEdge_UNSTABLE(connectionID: ConnectionID, args: Variables, edge: RecordProxy): void;
 }
 

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -365,6 +365,7 @@ export interface ReadOnlyRecordProxy {
 export interface RecordSourceProxy {
     create(dataID: DataID, typeName: string): RecordProxy;
     delete(dataID: DataID): void;
+    // tslint:disable-next-line
     get<T = {}>(dataID: DataID): RecordProxy<T> | null | undefined;
     getRoot(): RecordProxy;
 }

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -321,7 +321,7 @@ export interface RecordProxy<T = {}> {
         NonNullable<H> extends Array<infer U> ?
             Array<RecordProxy<U>> | (H extends null ? null : never) :
             never;
-    getOrCreateLinkedRecord(name: string, typeName: string, args?: Variables): RecordProxy<T>;
+    getOrCreateLinkedRecord(name: string, typeName: string, args?: Variables | null): RecordProxy<T>;
     getType(): string;
     getValue<K extends keyof T>(name: K, args?: Variables | null): T[K];
     getValue(name: string, args?: Variables | null): Primitive | Primitive[];
@@ -334,12 +334,12 @@ export interface RecordProxy<T = {}> {
         name: string,
         args?: Variables | null): RecordProxy;
     setLinkedRecords<K extends keyof T>(
-        records: Array<RecordProxy<Unarray<T[K]>> | null> | null,
+        records: Array<RecordProxy<Unarray<T[K]>> | null> | null | undefined,
         name: K,
         args?: Variables | null,
     ): RecordProxy<T>;
     setLinkedRecords(
-        records: Array<RecordProxy | null> | null,
+        records: Array<RecordProxy | null> | null | undefined,
         name: string,
         args?: Variables | null,
     ): RecordProxy<T>;
@@ -379,10 +379,10 @@ export interface ReadOnlyRecordSourceProxy {
  * fields of a Selector.
  */
 
-export interface RecordSourceSelectorProxy<T = object> extends RecordSourceProxy {
+export interface RecordSourceSelectorProxy<T = {}> extends RecordSourceProxy {
     getRootField<K extends keyof T>(fieldName: K): RecordProxy<NonNullable<T[K]>>;
     getRootField(fieldName: string): RecordProxy | null;
-    getPluralRootField(fieldName: string): Array<RecordProxy<T>> | null;
+    getPluralRootField(fieldName: string): Array<RecordProxy<T> | null> | null;
     insertConnectionEdge_UNSTABLE(connectionID: ConnectionID, args: Variables, edge: RecordProxy): void;
 }
 
@@ -503,12 +503,12 @@ export interface Environment {
      * environment.executeMutation({...}).subscribe({...}).
      */
     executeMutation({
-                        operation,
-                        optimisticUpdater,
-                        optimisticResponse,
-                        updater,
-                        uploadables,
-                    }: {
+        operation,
+        optimisticUpdater,
+        optimisticResponse,
+        updater,
+        uploadables,
+    }: {
         operation: OperationDescriptor;
         optimisticUpdater?: SelectorStoreUpdater | null;
         optimisticResponse?: { [key: string]: any } | null;
@@ -526,9 +526,9 @@ export interface Environment {
      * environment.executeWithSource({...}).subscribe({...}).
      */
     executeWithSource({
-                          operation,
-                          source,
-                      }: {
+        operation,
+        source,
+    }: {
         operation: OperationDescriptor;
         source: RelayObservable<GraphQLResponse>;
     }): RelayObservable<GraphQLResponse>;
@@ -707,32 +707,32 @@ export interface OptimisticResponseConfig {
  */
 export type MissingFieldHandler =
     | {
-    kind: 'scalar';
-    handle: (
-        field: NormalizationScalarField,
-        record: Record | null | undefined,
-        args: Variables,
-        store: ReadOnlyRecordSourceProxy,
-    ) => unknown;
-}
+          kind: 'scalar';
+          handle: (
+              field: NormalizationScalarField,
+              record: Record | null | undefined,
+              args: Variables,
+              store: ReadOnlyRecordSourceProxy,
+          ) => unknown;
+      }
     | {
-    kind: 'linked';
-    handle: (
-        field: NormalizationLinkedField,
-        record: Record | null | undefined,
-        args: Variables,
-        store: ReadOnlyRecordSourceProxy,
-    ) => DataID | null | undefined;
-}
+          kind: 'linked';
+          handle: (
+              field: NormalizationLinkedField,
+              record: Record | null | undefined,
+              args: Variables,
+              store: ReadOnlyRecordSourceProxy,
+          ) => DataID | null | undefined;
+      }
     | {
-    kind: 'pluralLinked';
-    handle: (
-        field: NormalizationLinkedField,
-        record: Record | null | undefined,
-        args: Variables,
-        store: ReadOnlyRecordSourceProxy,
-    ) => Array<DataID | null | undefined> | null | undefined;
-};
+          kind: 'pluralLinked';
+          handle: (
+              field: NormalizationLinkedField,
+              record: Record | null | undefined,
+              args: Variables,
+              store: ReadOnlyRecordSourceProxy,
+          ) => Array<DataID | null | undefined> | null | undefined;
+      };
 
 /**
  * The results of normalizing a query.

--- a/types/relay-runtime/lib/subscription/requestSubscription.d.ts
+++ b/types/relay-runtime/lib/subscription/requestSubscription.d.ts
@@ -10,7 +10,7 @@ export interface GraphQLSubscriptionConfig<TSubscriptionPayload> {
     onCompleted?: () => void;
     onError?: (error: Error) => void;
     onNext?: (response: TSubscriptionPayload | null | undefined) => void;
-    updater?: SelectorStoreUpdater;
+    updater?: SelectorStoreUpdater<TSubscriptionPayload>;
 }
 
 export function requestSubscription<TSubscriptionPayload>(

--- a/types/relay-runtime/lib/util/getRelayHandleKey.d.ts
+++ b/types/relay-runtime/lib/util/getRelayHandleKey.d.ts
@@ -1,1 +1,1 @@
-export function getRelayHandleKey(handleName: string, key?: string | undefined | null, fieldName?: string | undefined | null): string
+export function getRelayHandleKey(handleName: string, key?: string | null, fieldName?: string | null): string;

--- a/types/relay-runtime/lib/util/getRelayHandleKey.d.ts
+++ b/types/relay-runtime/lib/util/getRelayHandleKey.d.ts
@@ -1,0 +1,1 @@
+export function getRelayHandleKey(handleName: string, key?: string | undefined | null, fieldName?: string | undefined | null): string

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -10,7 +10,7 @@ import {
     ROOT_ID,
     RelayNetworkLoggerTransaction,
     createRelayNetworkLogger,
-    RecordSourceSelectorProxy,
+    RecordSourceSelectorProxy, RecordProxy,
 } from 'relay-runtime';
 
 const source = new RecordSource();
@@ -76,16 +76,24 @@ function storeUpdater(store: RecordSourceSelectorProxy) {
     }
 }
 
+interface MessageEdge {
+    readonly id: string;
+}
+
 interface SendConversationMessageMutationResponse {
     readonly sendConversationMessage: {
-        readonly messageEdge: {
-            readonly id: string;
-        };
+        readonly messageEdge: MessageEdge & {
+            error: string
+        }
     };
 }
 
 interface TConversation {
     id: string;
+}
+
+function passToHelper(edge: RecordProxy<MessageEdge>) {
+    edge.getValue('id');
 }
 
 function storeUpdaterWithTypes(store: RecordSourceSelectorProxy<SendConversationMessageMutationResponse>) {
@@ -97,6 +105,7 @@ function storeUpdaterWithTypes(store: RecordSourceSelectorProxy<SendConversation
     if (connection) {
         ConnectionHandler.insertEdgeBefore(connection, newMessageEdge);
     }
+    passToHelper(newMessageEdge);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -76,6 +76,29 @@ function storeUpdater(store: RecordSourceSelectorProxy) {
     }
 }
 
+interface SendConversationMessageMutationResponse {
+    readonly sendConversationMessage: {
+        readonly messageEdge: {
+            readonly id: string;
+        };
+    };
+}
+
+interface TConversation {
+    id: string;
+}
+
+function storeUpdaterWithTypes(store: RecordSourceSelectorProxy<SendConversationMessageMutationResponse>) {
+    const mutationPayload = store.getRootField('sendConversationMessage');
+    const newMessageEdge = mutationPayload.getLinkedRecord('messageEdge');
+    const id = newMessageEdge.getValue('id');
+    const conversationStore = store.get<TConversation>(id);
+    const connection = ConnectionHandler.getConnection(conversationStore!, 'Messages_messages');
+    if (connection) {
+        ConnectionHandler.insertEdgeBefore(connection, newMessageEdge);
+    }
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~
 // Source
 // ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Goals:
- no breaking changes
- reduce the number of null checks & nonnull coercions 
- extra type info when you want it. just add a generic, e.g. `commitMutation<AddCommentMutation>` and type info will trickle down to your updater

Example:

  ```gql
graphql`
mutation AddComment($newComment: NewCommentInput!) {
  addComment(newComment: $newComment) {
    error {
      message
    }
    title
    body
    topicId
  }
}
`
```

```ts
updater: (store) => {
  store.getRootField('addCommentz') // returns `RecordProxy<{}> | null` instead of full shape, 
  const payload = store.getRootField('addComment') // OK
  payload.getLinkedPayload('random') // doesn't return full shape
  payload.getValue('tittle') // returns union of all possibilities
  const topicId = payload.getValue('topicId') // string  
  const topic = store.get<ITopic>(topicId) // it can take a hint! these types can be generated using gql2ts or similar
}
```

PS: I'd _love_ to have typos in prop names turn into red squiggles, but I'm not smart enough to do that and make the `passToHelper` test pass ☹️  


NOTE: 

This code generates the following error when running `yarn lint relay-runtime`:
```
Error: /Users/mattkrick/code/DefinitelyTyped/types/relay-runtime/lib/store/RelayStoreTypes.d.ts:368:46
ERROR: 368:46  no-unnecessary-generics  Type parameter T is used only once. See: https://github.com/Microsoft/dtslint/blob/master/docs/no-unnecessary-generics.md
```

This is an error with the linting rule. See https://github.com/Microsoft/dtslint/issues/212