### PR TITLE
[mongodb] loosen PullOperator (fixes nested arrays)

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1202,7 +1202,7 @@ export type PushOperator<TSchema> = ({
 };
 
 export type PullOperator<TSchema> = ({
-    readonly [key in KeysOfAType<TSchema, any[]>]?: Unpacked<TSchema[key]> | QuerySelector<Unpacked<TSchema[key]>>;
+    readonly [key in KeysOfAType<TSchema, any[]>]?: Partial<Unpacked<TSchema[key]>> | ObjectQuerySelector<Unpacked<TSchema[key]>>;
 } &
     NotAcceptedFields<TSchema, any[]>) & {
     readonly [key: string]: QuerySelector<any> | any;
@@ -1358,6 +1358,8 @@ export type RootQuerySelector<T> = {
     // this will mark all unrecognized properties as any (including nested queries)
     [key: string]: any;
 };
+
+export type ObjectQuerySelector<T> = T extends object ? {[key in keyof T]?: QuerySelector<T[key]> } : QuerySelector<T>;
 
 export type Condition<T> = MongoAltQuery<T> | QuerySelector<MongoAltQuery<T>>;
 

--- a/types/mongodb/test/collection/updateX.ts
+++ b/types/mongodb/test/collection/updateX.ts
@@ -7,7 +7,8 @@ async function run() {
     const db = client.db('test');
 
     interface SubTestModel {
-        field: string;
+        field1: string;
+        field2: string;
     }
 
     // test with collection type
@@ -106,6 +107,8 @@ async function run() {
     buildUpdateQuery({ $pull: { fruitTags: { $in: ['a'] } } });
     buildUpdateQuery({ $pull: { 'dot.notation': 1 } });
     buildUpdateQuery({ $pull: { 'subInterfaceArray.$[]': { $in: ['a'] } } });
+    buildUpdateQuery({ $pull: { subInterfaceArray: { field1: 'a' } }});
+    buildUpdateQuery({ $pull: { subInterfaceArray: { field1: { $in: ['a'] } }  }});
 
     buildUpdateQuery({ $push: { fruitTags: 'a' } });
     buildUpdateQuery({ $push: { fruitTags: { $each: ['a'] } } });


### PR DESCRIPTION
This fixes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29911

I just made it looser, and you still get typings.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29911

Authors: @CaselIT @daprahamian @andy-ms @bitjson @Dante-101 @mcortesi @EnricoPicci @AJCStriker @julien-c @daprahamian @Denys-Bushulyak @BastienAr @sindbach @geraldinelemeur @jishi @various89 @angela-1 @lirbank @hector7 @floric
