### PR TITLE
[insert-text-at-cursor] Add types for insert-text-at-cursor

### DIFF
--- a/types/insert-text-at-cursor/index.d.ts
+++ b/types/insert-text-at-cursor/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for insert-text-at-cursor 0.3
+// Project: https://github.com/grassator/insert-text-at-cursor#readme
+// Definitions by: Christophe Coevoet <https://github.com/stof>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace insertTextAtCursor;
+
+export = insertTextAtCursor;
+
+declare function insertTextAtCursor(input: HTMLTextAreaElement | HTMLInputElement, text: string): void;

--- a/types/insert-text-at-cursor/insert-text-at-cursor-tests.ts
+++ b/types/insert-text-at-cursor/insert-text-at-cursor-tests.ts
@@ -1,0 +1,7 @@
+import insertTextAtCursor = require('insert-text-at-cursor');
+
+const t = document.getElementById('text') as HTMLTextAreaElement;
+const i = document.getElementById('input') as HTMLInputElement;
+
+insertTextAtCursor(t, 'foobar');
+insertTextAtCursor(i, 'hello');

--- a/types/insert-text-at-cursor/tsconfig.json
+++ b/types/insert-text-at-cursor/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "insert-text-at-cursor-tests.ts"
+    ]
+}

--- a/types/insert-text-at-cursor/tslint.json
+++ b/types/insert-text-at-cursor/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.


Note that the package source is using ES modules with a default export. But the build process creates 2 output:
- a ES module using default export, referenced in `module` in package.json
- a UMD module setting the function as the export, referenced in `main` in package.json

For now, I used `export =` in the types, as that's what tsc is expecting when generating code for the commonjs target (which is what dts-gen configures by default). But that makes it incompatible with using es6 as target. If I change the code to using default exports, things will work fine when targetting es6, but not when targetting commonjs (without enabling esModuleInterop).
I'd like some guidance on what should be the types when the library makes such a difference between its UMD and ESM output.