### PR TITLE
Update three.js dependencies

### DIFF
--- a/types/aframe/index.d.ts
+++ b/types/aframe/index.d.ts
@@ -4,7 +4,7 @@
 //                 Roberto Ritger <https://github.com/bertoritger>
 //                 Trygve Wastvedt <https://github.com/twastvedt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.6
 
 /**
  * Extended tests and examples available at https://github.com/devpaul/aframe-experiments.git

--- a/types/aframe/package.json
+++ b/types/aframe/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "three": "^0.103.0"
+        "three": "*"
     }
 }

--- a/types/openjscad/index.d.ts
+++ b/types/openjscad/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/joostn/OpenJsCad
 // Definitions by: Dan Marshall <https://github.com/danmarshall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.6
 
 /// <reference types="three" />
 

--- a/types/openjscad/package.json
+++ b/types/openjscad/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "three": "^0.103.0"
+        "three": "*"
     }
 }

--- a/types/three-tds-loader/index.d.ts
+++ b/types/three-tds-loader/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Konstantin Lukaschenko <https://github.com/KonstantinLukaschenko>
 //                 Stefan Schönsee <https://github.com/sschoensee>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.6
 
 import * as THREE from 'three';
 

--- a/types/three-tds-loader/package.json
+++ b/types/three-tds-loader/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "three": "^0.103.0"
+        "three": "*"
     }
 }


### PR DESCRIPTION
three.js relies on some APIs newly added in 3.6, so I had to bump the Typescript version to 3.6.