### PR TITLE
[timeago] Add types for the timeago jQuery plugin

### DIFF
--- a/types/timeago/index.d.ts
+++ b/types/timeago/index.d.ts
@@ -1,0 +1,60 @@
+// Type definitions for timeago 1.6
+// Project: http://timeago.yarp.com/
+// Definitions by: Christophe Coevoet <https://github.com/stof>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="jquery" />
+
+declare namespace Timeago {
+    type DynamicMessage = (n: number, distanceMillis: number) => string;
+
+    interface LocalizedStrings {
+        prefixAgo: string | null;
+        prefixFromNow: string | null;
+        suffixAgo: string | null;
+        suffixFromNow: string | null;
+        inPast: string;
+        seconds: string | DynamicMessage;
+        minute: string | DynamicMessage;
+        minutes: string | DynamicMessage;
+        hour: string | DynamicMessage;
+        hours: string | DynamicMessage;
+        day: string | DynamicMessage;
+        days: string | DynamicMessage;
+        month: string | DynamicMessage;
+        months: string | DynamicMessage;
+        year: string | DynamicMessage;
+        years: string | DynamicMessage;
+        wordSeparator: string;
+        numbers: string[];
+    }
+
+    interface Settings {
+        refreshMillis: number;
+        allowPast: boolean;
+        allowFuture: boolean;
+        localeTitle: boolean;
+        cutoff: number;
+        autoDispose: boolean;
+        strings: LocalizedStrings;
+    }
+
+    interface TimeagoStatic {
+        (timestamp: Date | string | number | Element): string;
+        parse(timestamp: string): Date;
+        inWords(distanceMillis: number): string;
+        datetime(elem: Element): Date;
+        isTime(elem: Element): boolean;
+        settings: Settings;
+    }
+}
+
+interface JQuery {
+    timeago(action: 'update', timestamp: Date | string): this;
+    timeago(action?: 'init' | 'updateFromDOM' | 'dispose'): this;
+}
+
+interface JQueryStatic {
+    timeago: Timeago.TimeagoStatic;
+}

--- a/types/timeago/timeago-tests.ts
+++ b/types/timeago/timeago-tests.ts
@@ -1,0 +1,10 @@
+$('.js-timeago').timeago()
+    .timeago('update', '2019-12-25T01:17:13');
+$('.js-timeago2')
+    .timeago('updateFromDOM')
+    .timeago('dispose');
+
+$.timeago.settings.cutoff = 86400;
+$.timeago.settings.allowFuture = true;
+
+const a: string = $.timeago('2019-12-25T01:17:13');

--- a/types/timeago/tsconfig.json
+++ b/types/timeago/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "timeago-tests.ts"
+    ]
+}

--- a/types/timeago/tslint.json
+++ b/types/timeago/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
