### PR TITLE
[styled-components] Add test for TypeScript 3.7 break

### DIFF
--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -728,7 +728,7 @@ async function typedThemes() {
         ${({ ok }: { ok: boolean }) =>
             ok &&
             css`
-                color: ${({ theme: { color } }: { theme: typeof theme }) => color};
+                color: ${({ theme: { color } }) => color};
             `}
     `;
 

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -714,6 +714,24 @@ async function typedThemes() {
         ${themedCssWithNesting}
     `;
 
+    const WithProp = styled.div`
+        ${({ ok, theme: { color } }: { ok: boolean; theme: typeof theme }) =>
+            ok &&
+            css`
+                color: ${color};
+            `}
+    `;
+
+    // TS 3.7 note: this breaks when FlattenInterpolation is an interface,
+    // it needs to be made a recursive type to fix.
+    const WithPropNested = styled.div`
+        ${({ ok }: { ok: boolean }) =>
+            ok &&
+            css`
+                color: ${({ theme: { color } }: { theme: typeof theme }) => color};
+            `}
+    `;
+
     return (
         <ThemeProvider theme={theme}>
             <>
@@ -728,6 +746,8 @@ async function typedThemes() {
                         return theme.color;
                     }}
                 </ThemeConsumer>
+                <WithProp ok />
+                <WithPropNested ok />
             </>
         </ThemeProvider>
     );


### PR DESCRIPTION
TypeScript 3.7 has a regression with type inference of self-referential interfaces, which I reported on https://github.com/microsoft/TypeScript/issues/34796, but couldn't find a good way of reducing it without involving styled-components itself.

Tests in this PR won't pass.

An alternative to work around it is to fork the styled-components code to a TS 3.7 version that uses `export type FlattenInterpolation<P> = ReadonlyArray<Interpolation<P>>` instead, but feels overkill to do it, especially if it's a bug workaround instead of an intended language change... but it is attractive as a chance to finally enable the proper generic `as` support.