### PR TITLE
[@types/jest]: improve definition of MatcherUtils

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -453,6 +453,8 @@ declare namespace jest {
 
     type MatcherColorFn = ChalkFunction & { supportsColor: ChalkColorSupport };
 
+    type EqualityTester = (a: any, b: any) => boolean | undefined;
+
     interface MatcherUtils {
         readonly isNot: boolean;
         readonly dontThrow: () => void;
@@ -499,13 +501,13 @@ declare namespace jest {
 
             getLabelPrinter(...strings: string[]): PrintLabel;
 
-            iterableEquality: any;
-            subsetEquality: any;
+            iterableEquality: EqualityTester;
+            subsetEquality: EqualityTester;
         };
         /**
          *  This is a deep-equality function that will return true if two objects have the same values (recursively).
          */
-        equals(a: any, b: any): boolean;
+        equals(a: any, b: any, customTesters?: EqualityTester[], strictCheck?: boolean): boolean;
         [other: string]: any;
     }
 

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -424,33 +424,83 @@ declare namespace jest {
         each: Each;
     }
 
+    type PrintLabel = (string: string) => string;
+
+    type MatcherHintColor = (arg: string) => string;
+
+    interface MatcherHintOptions {
+        comment?: string;
+        expectedColor?: MatcherHintColor;
+        isDirectExpectCall?: boolean;
+        isNot?: boolean;
+        promise?: string;
+        receivedColor?: MatcherHintColor;
+        secondArgument?: string;
+        secondArgumentColor?: MatcherHintColor;
+    }
+
+    interface ChalkFunction {
+        (text: TemplateStringsArray, ...placeholders: any[]): string;
+        (...text: any[]): string;
+    }
+
+    interface ChalkColorSupport {
+        level: 0 | 1 | 2 | 3;
+        hasBasic: boolean;
+        has256: boolean;
+        has16m: boolean;
+    }
+
+    type MatcherColorFn = ChalkFunction & { supportsColor: ChalkColorSupport };
+
     interface MatcherUtils {
         readonly isNot: boolean;
         readonly dontThrow: () => void;
         readonly promise: string;
+        readonly assertionCalls: number;
+        readonly expectedAssertionsNumber: number | null;
+        readonly isExpectingAssertions: boolean;
+        readonly suppressedErrors: any[];
+        readonly expand: boolean;
+        readonly testPath: string;
+        readonly currentTestName: string;
         utils: {
-            readonly EXPECTED_COLOR: (text: string) => string;
-            readonly RECEIVED_COLOR: (text: string) => string;
-            diff: typeof import('jest-diff');
-            ensureActualIsNumber(actual: any, matcherName?: string): void;
-            ensureExpectedIsNumber(actual: any, matcherName?: string): void;
-            ensureNoExpected(actual: any, matcherName?: string): void;
-            ensureNumbers(actual: any, expected: any, matcherName?: string): void;
-            /**
-             * get the type of a value with handling of edge cases like `typeof []` and `typeof null`
-             */
-            getType(value: any): string;
+            readonly EXPECTED_COLOR: MatcherColorFn;
+            readonly RECEIVED_COLOR: MatcherColorFn;
+            readonly INVERTED_COLOR: MatcherColorFn;
+            readonly BOLD_WEIGHT: MatcherColorFn;
+            readonly DIM_COLOR: MatcherColorFn;
+            readonly SUGGEST_TO_CONTAIN_EQUAL: string;
+            diff(a: any, b: any, options?: import("jest-diff").DiffOptions): string | null;
+            ensureActualIsNumber(actual: any, matcherName: string, options?: MatcherHintOptions): void;
+            ensureExpectedIsNumber(actual: any, matcherName: string, options?: MatcherHintOptions): void;
+            ensureNoExpected(actual: any, matcherName: string, options?: MatcherHintOptions): void;
+            ensureNumbers(actual: any, expected: any, matcherName: string, options?: MatcherHintOptions): void;
+            ensureExpectedIsNonNegativeInteger(expected: any, matcherName: string, options?: MatcherHintOptions): void;
             matcherHint(
                 matcherName: string,
                 received?: string,
                 expected?: string,
-                options?: { secondArgument?: string; isDirectExpectCall?: boolean }
+                options?: MatcherHintOptions
+            ): string;
+            matcherErrorMessage(
+              hint: string,
+              generic: string,
+              specific: string
             ): string;
             pluralize(word: string, count: number): string;
+            printReceived(object: any): string;
             printExpected(value: any): string;
-            printReceived(value: any): string;
-            printWithType(name: string, received: any, print: (value: any) => string): string;
+            printWithType(name: string, value: any, print: (value: any) => string): string;
             stringify(object: {}, maxDepth?: number): string;
+            highlightTrailingWhitespace(text: string): string;
+
+            printDiffOrStringify(expected: any, received: any, expectedLabel: string, receivedLabel: string, expand: boolean): string;
+
+            getLabelPrinter(...strings: string[]): PrintLabel;
+
+            iterableEquality: any;
+            subsetEquality: any;
         };
         /**
          *  This is a deep-equality function that will return true if two objects have the same values (recursively).

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -725,21 +725,15 @@ expect.extend({
         const expectedColor = this.utils.EXPECTED_COLOR('blue');
         const receivedColor = this.utils.EXPECTED_COLOR('red');
 
-        const diff: string = this.utils.diff({}, {});
+        const diff: string | null = this.utils.diff({}, {});
 
-        this.utils.ensureActualIsNumber({});
         this.utils.ensureActualIsNumber({}, 'matcher');
 
-        this.utils.ensureExpectedIsNumber({});
         this.utils.ensureExpectedIsNumber({}, 'matcher');
 
-        this.utils.ensureNoExpected({});
         this.utils.ensureNoExpected({}, 'matcher');
 
-        this.utils.ensureNumbers({}, {});
         this.utils.ensureNumbers({}, {}, 'matcher');
-
-        const valueType: string = this.utils.getType({});
 
         this.utils.matcherHint('matcher');
         this.utils.matcherHint('matcher', 'received');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jest/blob/master/packages/jest-matcher-utils/src/index.ts
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
