### PR TITLE
(feat): add sharedworker options

### DIFF
--- a/types/sharedworker/index.d.ts
+++ b/types/sharedworker/index.d.ts
@@ -1,8 +1,9 @@
 // Type definitions for SharedWorker
 // Project: http://www.w3.org/TR/workers/
 // Definitions by: Toshiya Nakakura <https://github.com/nakakura>
+//                 M. Boughaba <https://github.com/mboughaba>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 declare namespace SharedWorker {
     interface AbstractWorker extends EventTarget {
@@ -23,12 +24,20 @@ declare namespace SharedWorker {
     }
 }
 
+interface SharedWorkerOptions {
+    credentials?: RequestCredentials;
+    name?: string;
+    type?: WorkerType;
+}
+
 declare var SharedWorker: {
     prototype: SharedWorker.SharedWorker;
-    /***
+
+    /**
      *
-     * @param {string} stringUrl    Pathname to JavaScript file
-     * @param {string} name         Name of the worker to execute
+     * @param {string} stringUrl                          Pathname to JavaScript file
+     * @param {string|SharedWorkerOptions} [options]      Name of the worker to execute
+     *                                                    or an object containing option properties
      */
-    new(stringUrl: string, name?: string): SharedWorker.SharedWorker;
+    new(stringUrl: string, options?: string | SharedWorkerOptions): SharedWorker.SharedWorker;
 };

--- a/types/sharedworker/sharedworker-tests.ts
+++ b/types/sharedworker/sharedworker-tests.ts
@@ -1,25 +1,30 @@
-var worker_with_name = new SharedWorker('worker.js', "worker");
+var worker_with_name = new SharedWorker('worker.js', 'worker');
+var worker_with_opts = new SharedWorker('worker.js', {
+    name: 'worker',
+    type: 'module',
+    credentials: 'same-origin'
+});
 
 /* Caller */
 let worker = new SharedWorker('worker.js');
 worker.port.start();
 
-worker.port.onmessage = function (e) {
+worker.port.onmessage = function(e) {
     console.log('Caller Received:', e.data);
-}
+};
 
 worker.port.postMessage('Message');
 
 /* Worker */
 const _self: SharedWorker.SharedWorkerGlobalScope = self as any;
 
-_self.onconnect = function (e) {
+_self.onconnect = function(e) {
     var port = e.ports[0];
 
-    port.addEventListener('message', function (e) {
+    port.addEventListener('message', function(e) {
         console.log('Worker Received', e.data);
         port.postMessage('Result');
     });
 
     port.start();
-}
+};


### PR DESCRIPTION
package: sharedworker
in addition to the url string, sharedworker constructor takes as an argument a name string or an options object.
reference: https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/SharedWorker

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
