### PR TITLE
[redux-form] update to v8.2

### DIFF
--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for redux-form 8.1
+// Type definitions for redux-form 8.2
 // Project: https://github.com/erikras/redux-form, https://redux-form.com
 // Definitions by: Daniel Lytkin <https://github.com/aikoven>
 //                 Karol Janyst <https://github.com/LKay>
@@ -14,6 +14,7 @@
 //                 Ethan Setnik <https://github.com/esetnik>
 //                 Walter Barbagallo <https://github.com/bwlt>
 //                 Kota Marusue <https://github.com/mrsekut>
+//                 Adam Bouqdib <https://github.com/abemedia>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 import {

--- a/types/redux-form/lib/reduxForm.d.ts
+++ b/types/redux-form/lib/reduxForm.d.ts
@@ -126,6 +126,7 @@ export interface ConfigProps<FormData = {}, P = {}, ErrorType = string> {
     shouldError?(params: ValidateCallback<FormData, P, ErrorType>): boolean;
     shouldWarn?(params: ValidateCallback<FormData, P, ErrorType>): boolean;
     shouldAsyncValidate?(params: AsyncValidateCallback<FormData, ErrorType>): boolean;
+    submitAsSideEffect?: boolean;
     touchOnBlur?: boolean;
     touchOnChange?: boolean;
     persistentSubmitErrors?: boolean;


### PR DESCRIPTION
Added support for new prop `submitAsSideEffect`, introduced in redux-form v8.2.0.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/redux-form/redux-form/releases/tag/v8.2.0>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

