### PR TITLE
Exposing type for configuration as a function

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -139,12 +139,12 @@ declare namespace webpack {
     type ConfigurationFactory = ((
         env: string | Record<string, boolean | number | string>,
         args: Record<string, string>,
-    ) => webpack.Configuration | Promise<webpack.Configuration>);
+    ) => Configuration | Promise<Configuration>);
 
     type MultiConfigurationFactory = ((
         env: string | Record<string, boolean | number | string>,
         args: Record<string, string>,
-    ) => webpack.Configuration[] | Promise<webpack.Configuration[]>);
+    ) => Configuration[] | Promise<Configuration[]>);
 
     interface Entry {
         [name: string]: string | string[];

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -46,10 +46,7 @@ export = webpack;
 declare function webpack(
     options:
         | webpack.Configuration
-        | ((
-              env: string | Record<string, boolean | number | string>,
-              args: Record<string, string>,
-          ) => webpack.Configuration | Promise<webpack.Configuration>),
+        | webpack.ConfigurationFactory,
     handler: webpack.Compiler.Handler,
 ): webpack.Compiler.Watching | webpack.Compiler;
 declare function webpack(options?: webpack.Configuration): webpack.Compiler;
@@ -57,10 +54,7 @@ declare function webpack(options?: webpack.Configuration): webpack.Compiler;
 declare function webpack(
     options:
         | webpack.Configuration[]
-        | ((
-              env: string | Record<string, boolean | number | string>,
-              args: Record<string, string>,
-          ) => webpack.Configuration[] | Promise<webpack.Configuration[]>),
+        | webpack.MultiConfigurationFactory,
     handler: webpack.MultiCompiler.Handler
 ): webpack.MultiWatching | webpack.MultiCompiler;
 declare function webpack(options: webpack.Configuration[]): webpack.MultiCompiler;
@@ -141,6 +135,16 @@ declare namespace webpack {
         /** Optimization options */
         optimization?: Options.Optimization;
     }
+
+    type ConfigurationFactory = ((
+        env: string | Record<string, boolean | number | string>,
+        args: Record<string, string>,
+    ) => webpack.Configuration | Promise<webpack.Configuration>);
+
+    type MultiConfigurationFactory = ((
+        env: string | Record<string, boolean | number | string>,
+        args: Record<string, string>,
+    ) => webpack.Configuration[] | Promise<webpack.Configuration[]>);
 
     interface Entry {
         [name: string]: string | string[];


### PR DESCRIPTION
Refactoring:
Named as **ConfigurationFactory** for function returning a single configuration (or Promise), and **MultiConfigurationFactory** for array of configurations (or Promise)

Improvement for #37998

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
