### PR TITLE
Added type definitions for react-loader-spinner

### DIFF
--- a/types/react-loader-spinner/index.d.ts
+++ b/types/react-loader-spinner/index.d.ts
@@ -26,7 +26,7 @@ type Types =
     | 'None'
     | 'NotSpecified';
 
-interface ILoaderProps {
+interface LoaderProps {
     type?: Types;
     color?: string;
     timeout?: number; // in milliseconds
@@ -35,5 +35,5 @@ interface ILoaderProps {
     visible?: boolean | string;
 }
 
-declare const Loader: FC<ILoaderProps>;
+declare const Loader: FC<LoaderProps>;
 export default Loader;

--- a/types/react-loader-spinner/index.d.ts
+++ b/types/react-loader-spinner/index.d.ts
@@ -6,28 +6,6 @@
 
 import { FC } from 'react';
 
-/**
- * Possible Types:
- * Audio
- * BallTriangle
- * Bars
- * Circles
- * Grid
- * Hearts
- * Oval
- * Puff
- * Rings
- * TailSpin
- * ThreeDots
- * Watch
- * RevolvingDot
- * Triangle
- * Plane
- * MutatingDots
- * None (Will default to Audio)
- * NotSpecified (Will default to Audio)
- **/
-
 type Types =
     | 'Audio'
     | 'BallTriangle'

--- a/types/react-loader-spinner/index.d.ts
+++ b/types/react-loader-spinner/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mhnpd/react-loader-spinner
 // Definitions by: Rayhan Wirjowerdojo <https://github.com/rayhanw>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.6.4
+// TypeScript Version: 3.6
 
 import { FC } from 'react';
 

--- a/types/react-loader-spinner/index.d.ts
+++ b/types/react-loader-spinner/index.d.ts
@@ -1,0 +1,61 @@
+// Type definitions for react-loader-spinner
+// Project: https://github.com/mhnpd/react-loader-spinner
+// Definitions by: Rayhan Wirjowerdojo <https://github.com/rayhanw>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.6.4
+
+import { FC } from 'react';
+
+/**
+ * Possible Types:
+ * Audio
+ * BallTriangle
+ * Bars
+ * Circles
+ * Grid
+ * Hearts
+ * Oval
+ * Puff
+ * Rings
+ * TailSpin
+ * ThreeDots
+ * Watch
+ * RevolvingDot
+ * Triangle
+ * Plane
+ * MutatingDots
+ * None (Will default to Audio)
+ * NotSpecified (Will default to Audio)
+ **/
+
+type Types =
+    | 'Audio'
+    | 'BallTriangle'
+    | 'Bars'
+    | 'Circles'
+    | 'Grid'
+    | 'Hearts'
+    | 'Oval'
+    | 'Puff'
+    | 'Rings'
+    | 'TailSpin'
+    | 'ThreeDots'
+    | 'Watch'
+    | 'RevolvingDot'
+    | 'Triangle'
+    | 'Plane'
+    | 'MutatingDots'
+    | 'None'
+    | 'NotSpecified';
+
+interface ILoaderProps {
+    type?: Types;
+    color?: string;
+    timeout?: number; // in milliseconds
+    height?: number;
+    width?: number;
+    visible?: boolean | string;
+}
+
+declare const Loader: FC<ILoaderProps>;
+export default Loader;

--- a/types/react-loader-spinner/index.d.ts
+++ b/types/react-loader-spinner/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-loader-spinner
+// Type definitions for react-loader-spinner 3.1
 // Project: https://github.com/mhnpd/react-loader-spinner
 // Definitions by: Rayhan Wirjowerdojo <https://github.com/rayhanw>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-loader-spinner/test/react-loader-spinner-tests.tsx
+++ b/types/react-loader-spinner/test/react-loader-spinner-tests.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import Loader from 'react-loader-spinner';
+
+const App = () => {
+    return (
+        <div>
+            <Loader type="Audio" color="#8000FF" timeout={3000} height={80} width={80} visible={true} />
+        </div>
+    );
+};

--- a/types/react-loader-spinner/tsconfig.json
+++ b/types/react-loader-spinner/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "jsx": "react",
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "test/react-loader-spinner-tests.tsx"
+  ]
+}

--- a/types/react-loader-spinner/tslint.json
+++ b/types/react-loader-spinner/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.