### PR TITLE
[jump.js] Add option for passing duration as a function

### DIFF
--- a/types/jump.js/index.d.ts
+++ b/types/jump.js/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for jump.js 1.0
 // Project: https://github.com/callmecavs/jump.js
 // Definitions by: rhysd <https://rhysd.github.io>
-//                 jcharlesworthuk <https://github.com/jcharlesworthuk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = jump;

--- a/types/jump.js/index.d.ts
+++ b/types/jump.js/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for jump.js 1.0
 // Project: https://github.com/callmecavs/jump.js
 // Definitions by: rhysd <https://rhysd.github.io>
+//                 jcharlesworthuk <https://github.com/jcharlesworthuk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = jump;
@@ -10,7 +11,7 @@ declare function jump(target: string | Element | number, opts?: jump.Options): v
 declare namespace jump {
     type TransitionFunc = (t: number, b: number, c: number, d: number) => number;
     interface Options {
-        duration?: number;
+        duration?: number | ((distance: number) => number);
         offset?: number;
         callback?(): void;
         easing?: TransitionFunc;

--- a/types/jump.js/jump.js-tests.ts
+++ b/types/jump.js/jump.js-tests.ts
@@ -7,6 +7,9 @@ jump('.target', {
   duration: 1000,
 });
 jump('.target', {
+  duration: distance => Math.abs(distance)
+});
+jump('.target', {
   duration: 200,
   offset: 10
 });


### PR DESCRIPTION
### Passing a function to duration has been supported from the beginning, just missing from typings 
### https://github.com/callmecavs/jump.js/blob/master/src/jump.js#L133

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/callmecavs/jump.js/blob/master/README.md
- [x] **N/A** If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. 
- [x] **N/A** If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. 