### PR TITLE
Add types for json-schema-compare

### DIFF
--- a/types/json-schema-compare/index.d.ts
+++ b/types/json-schema-compare/index.d.ts
@@ -4,11 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
+import { JSONSchema4, JSONSchema6, JSONSchema7, JSONSchema6Definition, JSONSchema7Definition } from 'json-schema';
 
 export = compare;
 
-type JSONSchema = JSONSchema4 | JSONSchema6 | JSONSchema7;
+type JSONSchemaComparee = JSONSchema4 | JSONSchema6Definition | JSONSchema7Definition | undefined;
 type KnownKeys<T> = {
     [K in keyof T]: string extends K ? never : K
 } extends { [_ in keyof T]: infer U } ? U : never;
@@ -39,4 +39,4 @@ interface Options {
  * - For minLength, minItems and minProperties `undefined` and `0` are equal
  * - For uniqueItems, `undefined` and `false` are equal
  */
-declare function compare(a: JSONSchema, b: JSONSchema, options?: Options): boolean;
+declare function compare(a: JSONSchemaComparee, b: JSONSchemaComparee, options?: Options): boolean;

--- a/types/json-schema-compare/index.d.ts
+++ b/types/json-schema-compare/index.d.ts
@@ -1,0 +1,42 @@
+// Type definitions for json-schema-compare 0.2
+// Project: https://github.com/mokkabonna/json-schema-compare#readme
+// Definitions by: Emily Marigold Klassen <https://github.com/forivall>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
+
+export = compare;
+
+type JSONSchema = JSONSchema4 | JSONSchema6 | JSONSchema7;
+type KnownKeys<T> = {
+    [K in keyof T]: string extends K ? never : K
+} extends { [_ in keyof T]: infer U } ? U : never;
+/**
+ * The `string & {''?: never}` is a workaround for
+ * [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729).
+ * It will be removed as soon as it's not needed anymore.
+ */
+type JSONSchemaKeys = KnownKeys<JSONSchema4> | keyof JSONSchema6 | keyof JSONSchema7 | string & {''?: never};
+interface Options {
+    /**
+     * Ignores certain keywords, useful to exclude meta keywords like title,
+     * description etc or custom keywords. If all you want to know if they are
+     * the same in terms of validation keywords.
+     *
+     * @default []
+     */
+    ignore?: JSONSchemaKeys[];
+}
+
+/**
+ * Compare json schemas correctly.
+ *
+ * - Ignores sort for arrays where sort does not matter, like required, enum, type, anyOf, oneOf, anyOf, dependencies (if array)
+ * - Compares correctly type when array or string
+ * - Ignores duplicate values before comparing
+ * - For schemas and sub schemas `undefined`, `true` and `{}` are equal
+ * - For minLength, minItems and minProperties `undefined` and `0` are equal
+ * - For uniqueItems, `undefined` and `false` are equal
+ */
+declare function compare(a: JSONSchema, b: JSONSchema, options?: Options): boolean;

--- a/types/json-schema-compare/json-schema-compare-tests.ts
+++ b/types/json-schema-compare/json-schema-compare-tests.ts
@@ -1,0 +1,26 @@
+import compare = require('json-schema-compare');
+
+// @ExpectType boolean
+compare({
+  title: 'title 1',
+  type: ['object'],
+  uniqueItems: false,
+  dependencies: {
+    name: ['age', 'lastName']
+  },
+  required: ['name', 'age', 'name']
+}, {
+  title: 'title 2',
+  type: 'object',
+  required: ['age', 'name'],
+  dependencies: {
+    name: ['lastName', 'age']
+  },
+  properties: {
+    name: {
+      minLength: 0
+    }
+  }
+}, {
+  ignore: ['title', 'customKey']
+});

--- a/types/json-schema-compare/tsconfig.json
+++ b/types/json-schema-compare/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "json-schema-compare-tests.ts"
+    ]
+}

--- a/types/json-schema-compare/tslint.json
+++ b/types/json-schema-compare/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
