### PR TITLE
[config] Fix the `raw` function in node-config.

### DIFF
--- a/types/config/raw.d.ts
+++ b/types/config/raw.d.ts
@@ -2,4 +2,9 @@
  * See: https://github.com/lorenwest/node-config/wiki/Special-features-for-JavaScript-configuration-files#using-promises-processstdout-and-other-objects-in-javascript-config-files
  */
 
-export function raw<T>(obj: T): T;
+export class RawConfig<T> {
+    constructor(rawObj: T);
+    resolve(): T;
+}
+
+export function raw<T>(obj: T): RawConfig<T>;


### PR DESCRIPTION
I submitted a patch previously that added the `raw` function but I
neglected to export the `RawConfig` class, which is what's actually
returned from that `raw` function. My apologies for not getting this
right the first time. Here is the implementation file that shows the
`RawConfig` class and its `resolve()` method: https://github.com/lorenwest/node-config/blob/master/raw.js

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lorenwest/node-config/blob/master/raw.js
