### PR TITLE
[depcheck] Update depcheck types to latest (0.9.0)

### DIFF
--- a/types/depcheck/depcheck-tests.ts
+++ b/types/depcheck/depcheck-tests.ts
@@ -1,7 +1,6 @@
 import depcheck = require('depcheck');
 
 const options: depcheck.Options = {
-    withoutDev: false,
     ignoreBinPackage: false,
     ignoreDirs: ['sandbox', 'dist', 'bower_components'],
     ignoreMatches: ['grunt-*'],

--- a/types/depcheck/index.d.ts
+++ b/types/depcheck/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for depcheck 0.8
+// Type definitions for depcheck 0.9
 // Project: https://github.com/depcheck/depcheck
 // Definitions by: ark120202 <https://github.com/ark120202>
 //                 jrnail23 <https://github.com/jrnail23>
+//                 rumpl <https://github.com/rumpl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare function depcheck(rootDir: string, options: depcheck.Options): Promise<depcheck.Results>;
@@ -22,7 +23,6 @@ declare namespace depcheck {
     type Detector = (node: Node) => ReadonlyArray<string> | string;
 
     interface Options {
-        withoutDev?: boolean;
         ignoreBinPackage?: boolean;
         skipMissing?: boolean;
         ignoreDirs?: ReadonlyArray<string>;
@@ -70,6 +70,7 @@ declare namespace depcheck {
         requireCallExpression: Detector;
         requireResolveCallExpression: Detector;
         typescriptImportEqualsDeclaration: Detector;
+        detectTypescriptImportType: Detector;
     };
 
     const special: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/depcheck/depcheck/releases/tag/0.9.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
