### PR TITLE
initial Apple Music API typings 

### DIFF
--- a/types/apple-music-api/apple-music-api-tests.ts
+++ b/types/apple-music-api/apple-music-api-tests.ts
@@ -1,0 +1,66 @@
+const songResponse: AppleMusicApi.SongResponse = {
+    data: [
+        {
+            id: '897072750',
+            type: 'songs',
+            href: '/v1/catalog/us/songs/897072750',
+            attributes: {
+                previews: [
+                    {
+                        url:
+                            'https://audio-ssl.itunes.apple.com/itunes-assets/Music6/v4/d0/fb/ac/d0fbac69-1a09-9e09-99d7-0ce20dca9a31/mzaf_3801033891693354111.plus.aac.p.m4a',
+                    },
+                ],
+                artwork: {
+                    width: 1482,
+                    height: 1482,
+                    url:
+                        'https://is5-ssl.mzstatic.com/image/thumb/Music4/v4/d1/5e/bf/d15ebf24-733b-980d-d582-e27f72001ff8/3149027001014.jpg/{w}x{h}bb.jpeg',
+                    bgColor: '08080a',
+                    textColor1: 'fafafc',
+                    textColor2: 'dfdfdf',
+                    textColor3: 'cacacc',
+                    textColor4: 'b4b4b5',
+                },
+                artistName: 'Ahmad Jamal',
+                url: 'https://music.apple.com/us/album/invitation-live/897072740?i=897072750',
+                discNumber: 1,
+                genreNames: ['Jazz', 'Music'],
+                durationInMillis: 672280,
+                releaseDate: '2014-07-28',
+                name: 'Invitation (Live)',
+                isrc: 'FR5FH1300035',
+                hasLyrics: false,
+                albumName: 'Live At the Olympia - June 27, 2012 (Live) [feat. Yusef Lateef]',
+                playParams: {
+                    id: '897072750',
+                    kind: 'song',
+                },
+                trackNumber: 4,
+                composerName: 'Bronisław Kaper',
+            },
+            relationships: {
+                artists: {
+                    data: [
+                        {
+                            id: '76328',
+                            type: 'artists',
+                            href: '/v1/catalog/us/artists/76328',
+                        },
+                    ],
+                    href: '/v1/catalog/us/songs/897072750/artists',
+                },
+                albums: {
+                    data: [
+                        {
+                            id: '897072740',
+                            type: 'albums',
+                            href: '/v1/catalog/us/albums/897072740',
+                        },
+                    ],
+                    href: '/v1/catalog/us/songs/897072750/albums',
+                },
+            },
+        },
+    ],
+};

--- a/types/apple-music-api/index.d.ts
+++ b/types/apple-music-api/index.d.ts
@@ -5,60 +5,66 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace AppleMusicApi {
+    // https://developer.apple.com/documentation/applemusicapi/songresponse
     interface SongResponse {
         data: Song[];
     }
 
-    interface Song {
-        id: string;
+    // https://developer.apple.com/documentation/applemusicapi/relationship
+    interface Relationship<ResourceType> {
+        data: ResourceType[];
         href: string;
+        meta?: any;
+        next?: string;
+    }
+
+    // https://developer.apple.com/documentation/applemusicapi/resource
+    interface Resource {
+        href?: string;
+        id: string;
+        type: string;
+    }
+
+    // https://developer.apple.com/documentation/applemusicapi/song
+    interface Song extends Resource {
         type: 'songs';
-        attributes: SongAttributes;
-        relationships: SongRelationships;
+        // https://developer.apple.com/documentation/applemusicapi/song/attributes
+        attributes?: {
+            albumName: string;
+            artistName: string;
+            artwork?: Artwork;
+            composerName?: string;
+            contentRating?: string;
+            discNumber: number;
+            durationInMillis: number;
+            editorialNotes?: EditorialNotes;
+            genreNames: string[];
+            hasLyrics: boolean;
+            isrc: string;
+            movementCount?: number;
+            movementName?: string;
+            movementNumber?: string;
+            name: string;
+            playParams?: PlayParameters;
+            previews: Preview[];
+            releaseDate: string;
+            trackNumber: number;
+            url: string;
+            workName?: string;
+        };
+        relationships?: SongRelationships;
     }
 
-    // https://developer.apple.com/documentation/applemusicapi/song/attributes
-    interface SongAttributes {
-        albumName: string;
-        artistName: string;
-        artwork?: Artwork;
-        composerName?: string;
-        contentRating?: string;
-        discNumber: number;
-        durationInMillis: number;
-        editorialNotes?: EditorialNotes;
-        genreNames: string[];
-        hasLyrics: boolean;
-        isrc: string;
-        movementCount?: number;
-        movementName?: string;
-        movementNumber?: string;
-        name: string;
-        playParams?: PlayParameters;
-        previews: Preview[];
-        releaseDate: string;
-        trackNumber: number;
-        url: string;
-        workName?: string;
-    }
-
+    // https://developer.apple.com/documentation/applemusicapi/song/relationships
     interface SongRelationships {
-        albums: {
-            data: any[];
-            href: string;
-        };
-        artists: {
-            data: any[];
-            href: string;
-        };
-        genres?: {
-            data: any[];
-            href: string;
-        };
+        albums: Relationship<Album>;
+        artists: Relationship<Artist>;
+        genres?: Relationship<Genre>;
         station?: { data: Station };
     }
 
-    interface Station {
+    // https://developer.apple.com/documentation/applemusicapi/station
+    interface Station extends Resource {
         type: 'stations';
         artwork: Artwork;
         durationInMillis?: number;
@@ -69,7 +75,7 @@ declare namespace AppleMusicApi {
         url: string;
     }
 
-    // TODO: someone please flesh this out - https://developer.apple.com/documentation/applemusicapi/artwork
+    // https://developer.apple.com/documentation/applemusicapi/artwork
     interface Artwork {
         width: number;
         height: number;
@@ -97,5 +103,62 @@ declare namespace AppleMusicApi {
     interface Preview {
         artwork?: Artwork;
         url: string;
+    }
+
+    // https://developer.apple.com/documentation/applemusicapi/artist
+    interface Artist extends Resource {
+        attributes?: {
+            editorialNotes?: EditorialNotes;
+            genreNames: string[];
+            name: string;
+            url: string;
+        };
+        relationships?: ArtistRelationships;
+        type: 'artists';
+    }
+
+    // https://developer.apple.com/documentation/applemusicapi/artist/relationships
+    interface ArtistRelationships {
+        albums: Relationship<Album>;
+        genres: Relationship<Genre>;
+    }
+
+    // https://developer.apple.com/documentation/applemusicapi/album
+    interface Album extends Resource {
+        // https://developer.apple.com/documentation/applemusicapi/album/attributes
+        attributes?: {
+            albumName: string;
+            artistName: string;
+            artwork?: Artwork;
+            contentRating?: 'clean' | 'explicit';
+            copyright?: string;
+            editorialNotes?: EditorialNotes;
+            genreNames: string[];
+            isComplete: boolean;
+            isSingle: boolean;
+            name: string;
+            playParams?: PlayParameters;
+            recordLabel: string;
+            releaseDate: string;
+            trackCount: number;
+            url: string;
+            isMasteredForItunes: boolean;
+        };
+        relationships?: AlbumRelationships;
+        type: 'albums';
+    }
+
+    // https://developer.apple.com/documentation/applemusicapi/album/relationships
+    interface AlbumRelationships {
+        artists: Relationship<Artist>;
+        genres: {};
+    }
+
+    // https://developer.apple.com/documentation/applemusicapi/genre
+    interface Genre extends Resource {
+        attributes: {
+            name: string;
+        };
+        type: 'genres';
     }
 }

--- a/types/apple-music-api/index.d.ts
+++ b/types/apple-music-api/index.d.ts
@@ -1,0 +1,101 @@
+// Type definitions for non-npm package Apple Music API 0.1
+// Project: https://developer.apple.com/documentation/applemusicapi/
+// Definitions by: Noah Chase <https://github.com/nchase>
+//                 Useff Chase <https://github.com/useffc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace AppleMusicApi {
+    interface SongResponse {
+        data: Song[];
+    }
+
+    interface Song {
+        id: string;
+        href: string;
+        type: 'songs';
+        attributes: SongAttributes;
+        relationships: SongRelationships;
+    }
+
+    // https://developer.apple.com/documentation/applemusicapi/song/attributes
+    interface SongAttributes {
+        albumName: string;
+        artistName: string;
+        artwork?: Artwork;
+        composerName?: string;
+        contentRating?: string;
+        discNumber: number;
+        durationInMillis: number;
+        editorialNotes?: EditorialNotes;
+        genreNames: string[];
+        hasLyrics: boolean;
+        isrc: string;
+        movementCount?: number;
+        movementName?: string;
+        movementNumber?: string;
+        name: string;
+        playParams?: PlayParameters;
+        previews: Preview[];
+        releaseDate: string;
+        trackNumber: number;
+        url: string;
+        workName?: string;
+    }
+
+    interface SongRelationships {
+        albums: {
+            data: any[];
+            href: string;
+        };
+        artists: {
+            data: any[];
+            href: string;
+        };
+        genres?: {
+            data: any[];
+            href: string;
+        };
+        station?: { data: Station };
+    }
+
+    interface Station {
+        type: 'stations';
+        artwork: Artwork;
+        durationInMillis?: number;
+        editorialNotes?: EditorialNotes;
+        episodeNumber?: number;
+        isLive: boolean;
+        name: string;
+        url: string;
+    }
+
+    // TODO: someone please flesh this out - https://developer.apple.com/documentation/applemusicapi/artwork
+    interface Artwork {
+        width: number;
+        height: number;
+        url: string;
+        bgColor?: string;
+        textColor1?: string;
+        textColor2?: string;
+        textColor3?: string;
+        textColor4?: string;
+    }
+
+    // https://developer.apple.com/documentation/applemusicapi/editorialnotes
+    interface EditorialNotes {
+        short: string;
+        standard: string;
+    }
+
+    // https://developer.apple.com/documentation/applemusicapi/playparameters
+    interface PlayParameters {
+        id: string;
+        kind: string;
+    }
+
+    // https://developer.apple.com/documentation/applemusicapi/preview
+    interface Preview {
+        artwork?: Artwork;
+        url: string;
+    }
+}

--- a/types/apple-music-api/tsconfig.json
+++ b/types/apple-music-api/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "apple-music-api-tests.ts"
+    ]
+}

--- a/types/apple-music-api/tslint.json
+++ b/types/apple-music-api/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
I didn't see any typings for the Apple Music API, and this is my attempt at getting that started.  See API here: https://developer.apple.com/documentation/applemusicapi/

Is this actually a new typing, or did I miss something elsewhere?

This pull request adds some rudimentary support for `Song`/`SongResponse` and some stuff on the periphery of `Song`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
