### PR TITLE
Bugfix: use "export =" instead of "export default" - @types/uid-generator

### DIFF
--- a/types/uid-generator/index.d.ts
+++ b/types/uid-generator/index.d.ts
@@ -28,4 +28,4 @@ interface UIDGeneratorClass {
 
 declare const UIDGenerator: UIDGeneratorClass;
 
-export { UIDGenerator as default, UIDGeneratorClass, UIDGeneratorInstance };
+export = UIDGenerator;

--- a/types/uid-generator/uid-generator-tests.ts
+++ b/types/uid-generator/uid-generator-tests.ts
@@ -1,4 +1,4 @@
-import { default as UIDGenerator } from 'uid-generator';
+import UIDGenerator = require('uid-generator');
 
 new UIDGenerator('abc'); // $ExpectType UIDGeneratorInstance
 const generator = new UIDGenerator(128, 'abc'); // $ExpectType UIDGeneratorInstance


### PR DESCRIPTION
### Motivation

With ES6 module syntax in Node.js:

```typescript
export { UIDGenerator as default, UIDGeneratorClass, UIDGeneratorInstance };
```

Below code will not be compiled correctly:

```typescript
import { default as UIDGenerator } from 'uid-generator';

new UIDGenerator(128, UIDGenerator.BASE58);

// will be compiled to JavaScript as:
const uid_generator1 = require("uid-generator");
new uid_generator1.default(128, uid_generator1.default.BASE58);

// Correct version should be:
const uid_generator1 = require("uid-generator");
new uid_generator1(128, uid_generator1.BASE58);
```

### Solution

Use "export =" syntax. Refer to <https://www.typescriptlang.org/docs/handbook/modules.html>
