### PR TITLE
Revert "[styled-components] Make `Omit` a distributive conditional type to support union prop types"

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -346,7 +346,7 @@ export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<
 >;
 
 // Helper type operators
-type Omit<T, K extends keyof T> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, "theme"> & {
     theme?: T;
 };

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1052,7 +1052,8 @@ function unionTest() {
         font-size: ${props => props.kind === 'book' ? 16 : 14}
     `;
 
-    <StyledReadable kind="book" author="Hejlsberg" />;
+    // undesired, fix was reverted because of https://github.com/Microsoft/TypeScript/issues/30663
+    <StyledReadable kind="book" author="Hejlsberg" />; // $ExpectError
     <StyledReadable kind="magazine" author="Hejlsberg" />; // $ExpectError
 }
 


### PR DESCRIPTION
Performance issues were reported:
- https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34391#issuecomment-548701239
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39323#issuecomment-549015652

I suggest we revert DefinitelyTyped/DefinitelyTyped#39323, for now, then re-attempt after @typescript-bot’s [performance metrics](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39323#issuecomment-545026384) have been extended to catch the reported issues.