### PR TITLE
feat: Add `globalThis`

### DIFF
--- a/types/globalthis/globalthis-tests.ts
+++ b/types/globalthis/globalthis-tests.ts
@@ -1,0 +1,6 @@
+import getGlobal = require('globalthis');
+
+getGlobal(); // $ExpectType typeof globalThis
+getGlobal.implementation; // $ExpectType typeof globalThis
+getGlobal.getPolyfill; // $ExpectType () => typeof globalThis
+getGlobal.shim; // $ExpectType () => typeof globalThis

--- a/types/globalthis/implementation.d.ts
+++ b/types/globalthis/implementation.d.ts
@@ -1,0 +1,5 @@
+/**
+ * The `globalThis` object.
+ */
+declare const implementation: typeof globalThis;
+export = implementation;

--- a/types/globalthis/index.d.ts
+++ b/types/globalthis/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for globalthis 1.0
+// Project: https://github.com/ljharb/System.global#readme
+// Definitions by: ExE Boss <https://github.com/ExE-Boss>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.4
+
+/**
+ * Gets the `globalThis` object.
+ */
+declare function getGlobal(): typeof globalThis;
+
+declare namespace getGlobal {
+	/**
+	 * Gets the `globalThis` object.
+	 */
+	function getPolyfill(): ReturnType<typeof import('./polyfill')>;
+
+	/**
+	 * The `globalThis` object.
+	 */
+	const implementation: typeof import('./implementation');
+
+	/**
+	 * Installs the `globalThis` property onto the global object.
+	 */
+	function shim(): ReturnType<typeof import('./shim')>;
+}
+
+export = getGlobal;

--- a/types/globalthis/polyfill.d.ts
+++ b/types/globalthis/polyfill.d.ts
@@ -1,0 +1,7 @@
+import implementation = require('./implementation');
+
+/**
+ * Gets the `globalThis` object.
+ */
+declare function getPolyfill(): typeof implementation;
+export = getPolyfill;

--- a/types/globalthis/shim.d.ts
+++ b/types/globalthis/shim.d.ts
@@ -1,0 +1,7 @@
+import implementation = require('./implementation');
+
+/**
+ * Installs the `globalThis` property onto the global object.
+ */
+declare function shimGlobalThis(): typeof implementation;
+export = shimGlobalThis;

--- a/types/globalthis/tsconfig.json
+++ b/types/globalthis/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": ["es5"],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": ["../"],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"implementation.d.ts",
+		"index.d.ts",
+		"polyfill.d.ts",
+		"shim.d.ts",
+		"globalthis-tests.ts"
+	]
+}

--- a/types/globalthis/tslint.json
+++ b/types/globalthis/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
[The&nbsp;`globalThis`&nbsp;polyfill](https://github.com/es-shims/globalThis) implements a&nbsp;cross‑platform compatible implementation of&nbsp;the&nbsp;[ES2020&nbsp;`globalThis`&nbsp;property](https://tc39.es/ecma262/#sec-globalthis).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

review?(@ljharb)