### PR TITLE
cucumber: add missing props to ScenarioResult and StepDefinition

### DIFF
--- a/types/cucumber/cucumber-tests.ts
+++ b/types/cucumber/cucumber-tests.ts
@@ -60,6 +60,13 @@ function StepSampleWithoutDefineSupportCode() {
         callback();
     });
 
+    After((scenarioResult: HookScenarioResult, callback: Callback) => {
+        if (scenarioResult.result.exception) {
+            console.error(scenarioResult.result.exception);
+        }
+        callback();
+    });
+
     After({ timeout: 1000 }, (scenarioResult: HookScenarioResult, callback: Callback) => {
         console.log("After");
         callback();

--- a/types/cucumber/index.d.ts
+++ b/types/cucumber/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for cucumber-js 4.0
+// Type definitions for cucumber-js 6.0
 // Project: http://github.com/cucumber/cucumber-js
 // Definitions by: Abraão Alves <https://github.com/abraaoalves>
 //                 Jan Molak <https://github.com/jan-molak>

--- a/types/cucumber/index.d.ts
+++ b/types/cucumber/index.d.ts
@@ -255,8 +255,10 @@ export namespace events {
 }
 
 export interface StepDefinition {
-    // tslint:disable-next-line ban-types
+    // tslint:disable:ban-types
     code: Function;
+    unwrappedCode?: Function;
+    // tslint:enable:ban-types
     line: number;
     options: {};
     pattern: any;

--- a/types/cucumber/index.d.ts
+++ b/types/cucumber/index.d.ts
@@ -7,6 +7,7 @@
 //                 ErikSchierboom <https://github.com/ErikSchierboom>
 //                 Peter Morlion <https://github.com/petermorlion>
 //                 Don Jayamanne <https://github.com/DonJayamanne>
+//                 David Goss <https://github.com/davidjgoss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -97,6 +98,7 @@ export interface SourceLocation {
 export interface ScenarioResult {
     duration: number;
     status: Status;
+    exception?: Error;
 }
 
 export namespace pickle {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - Fixes cucumber/cucumber-js/issues/1245 - for `exception` in `ScenarioResult`
    - cucumber/cucumber-js/pull/1234 - for `unwrappedCode` in `StepDefinition`
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.