### PR TITLE
[webpack] Updates definitions for Chunk and Module

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webpack 4.39
+// Type definitions for webpack 4.41
 // Project: https://github.com/webpack/webpack
 // Definitions by: Qubo <https://github.com/tkqubo>
 //                 Benjamin Lim <https://github.com/bumbleblym>

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -18,6 +18,7 @@
 //                 Grgur Grisogono <https://github.com/grgur>
 //                 Rubens Pinheiro Gonçalves Cavalcante <https://github.com/rubenspgcavalcante>
 //                 Anders Kaseorg <https://github.com/andersk>
+//                 Felix Haus <https://github.com/ofhouse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -722,66 +723,158 @@ declare namespace webpack {
         class Asset {
         }
 
-        class Module {
+        class DependenciesBlock {
+        }
+
+        class Module extends DependenciesBlock {
+            constructor(type: string, context?: string);
+            type: string;
+            context: string | null;
+            debugId: number;
+            hash: string | undefined;
+            renderedHash: string | undefined;
+            resolveOptions: any;
+            factoryMeta: any;
+            warnings: any[];
+            errors: any[];
+            buildMeta: any;
+            buildInfo: any;
+            reasons: any[];
+            _chunks: SortableSet<Chunk>;
+            id: number | string | null;
+            index: number | null;
+            index2: number | null;
+            depth: number | null;
+            issuer: Module | null;
+            profile: any;
+            prefetched: boolean;
+            built: boolean;
+
+            used: null | boolean;
+            usedExports: false | true | string[] | null;
+            optimizationBailout: string | any[];
+            _rewriteChunkInReasons: {
+                oldChunk: Chunk, newChunks: Chunk[]
+            } | undefined;
+            useSourceMap: boolean;
+            _source: any;
+
+            exportsArgument: string | 'exports';
+            moduleArgument: string | 'module';
+
+            disconnect(): void;
+            unseal(): void;
+            setChunks(chunks: Chunk[]): void;
+            addChunk(chunk: Chunk): boolean;
+            removeChunk(chunk: Chunk): boolean;
+            isInChunk(chunk: Chunk): boolean;
+            isEntryModule(): boolean;
+            optional: boolean;
+            getChunks(): Chunk[];
+            getNumberOfChunks: number;
+            chunksIterable: SortableSet<Chunk>;
+            hasEqualsChunks(module: Module): boolean;
+            addReason(module: Module, dependency: any, explanation: any): void;
+            removeReason(module: Module, dependency: any): boolean;
+            hasReasonForChunk(chunk: Chunk): boolean;
+            hasReasons(): boolean;
+            rewriteChunkInReasons(oldChunk: Chunk, newChunks: Chunk[]): void;
+            _doRewriteChunkInReasons(oldChunk: Chunk, newChunks: Chunk[]): void;
+            isUsed(exportName?: string): boolean | string;
+            isProvided(exportName: string): boolean | null;
+            toString(): string;
+            needRebuild(fileTimestamps: any, contextTimestamps: any): boolean;
+            updateHash(hash: any): void;
+            sortItems(sortChunks?: boolean): void;
+            unbuild(): void;
         }
 
         class Record {
         }
 
         class Chunk {
-            constructor(name: string);
-            id: any;
-            ids: any;
+            constructor(name?: string);
+            id: number | null;
+            ids: number[] | null;
             debugId: number;
-            name: any;
-            entryModule: any;
-            files: any[];
+            name: string;
+            preventIntegration: boolean;
+            entryModule: Module | undefined;
+            _modules: SortableSet<Module>;
+            filenameTemplate: string | undefined;
+            _groups: SortableSet<ChunkGroup>;
+            files: string[];
             rendered: boolean;
-            hash: any;
-            renderedHash: any;
-            chunkReason: any;
+            hash: string | undefined;
+            contentHash: object;
+            renderedHash: string | undefined;
+            chunkReason: string | undefined;
             extraAsync: boolean;
+            removedModules: any;
 
             hasRuntime(): boolean;
             canBeInitial(): boolean;
             isOnlyInitial(): boolean;
             hasEntryModule(): boolean;
 
-            addModule(module: any): boolean;
-            removeModule(module: any): boolean;
-            setModules(modules: any): void;
+            addModule(module: Module): boolean;
+            removeModule(module: Module): boolean;
+            setModules(modules: Module[]): void;
             getNumberOfModules(): number;
-            modulesIterable: any[];
+            // Internally returns this._modules
+            // So it should have the same type as this._modules
+            modulesIterable: SortableSet<Module>;
 
-            addGroup(chunkGroup: any): boolean;
-            removeGroup(chunkGroup: any): boolean;
-            isInGroup(chunkGroup: any): boolean;
+            addGroup(chunkGroup: ChunkGroup): boolean;
+            removeGroup(chunkGroup: ChunkGroup): boolean;
+            isInGroup(chunkGroup: ChunkGroup): boolean;
             getNumberOfGroups(): number;
-            groupsIterable: any[];
+            // Internally returns this._groups
+            // So it should have the same type as this._groups
+            groupsIterable: SortableSet<ChunkGroup>;
 
-            compareTo(otherChunk: any): -1 | 0 | 1;
-            containsModule(module: any): boolean;
-            getModules(): any[];
+            compareTo(otherChunk: Chunk): -1 | 0 | 1;
+            containsModule(module: Module): boolean;
+            getModules(): Module[];
             getModulesIdent(): any[];
-            remove(reason: any): void;
-            moveModule(module: any, otherChunk: any): void;
-            integrate(otherChunk: any, reason: any): boolean;
-            split(newChunk: any): void;
+            remove(reason?: string): void;
+            moveModule(module: Module, otherChunk: Chunk): void;
+            integrate(otherChunk: Chunk, reason: string): boolean;
+            split(newChunk: Chunk): void;
             isEmpty(): boolean;
             updateHash(hash: any): void;
-            canBeIntegrated(otherChunk: any): boolean;
-            addMultiplierAndOverhead(size: number, options: any): number;
+            canBeIntegrated(otherChunk: Chunk): boolean;
+            addMultiplierAndOverhead(
+                size: number,
+                options: {
+                    chunkOverhead?: number;
+                    entryChunkMultiplicator?: number
+                },
+            ): number;
             modulesSize(): number;
-            size(options: any): number;
-            integratedSize(otherChunk: any, options: any): number;
+            size(options?: {
+                chunkOverhead?: number;
+                entryChunkMultiplicator?: number
+            }): number;
+            integratedSize(otherChunk: Chunk, options: any): number | false;
+            sortModules(
+                sortByFn: (module1: Module, module2: Module) => -1 | 0 | 1
+            ): void;
+            sortItems(): void;
+            getAllAsyncChunks(): Set<Chunk>;
+            getChunkMaps(realHash: boolean): {
+                hash: any;
+                contentHash: any;
+                name: any;
+            };
+            getChildIdsByOrders(): any;
+            getChildIdsByOrdersMap(includeDirectChildren?: boolean): any;
             // tslint:disable-next-line:ban-types
-            sortModules(sortByFn: Function): void;
-            getAllAsyncChunks(): Set<any>;
-            getChunkMaps(realHash: any): { hash: any, name: any };
-            // tslint:disable-next-line:ban-types
-            getChunkModuleMaps(filterFn: Function): { id: any, hash: any };
-            // tslint:disable-next-line:ban-types
-            hasModuleInGraph(filterFn: Function, filterChunkFn: Function): boolean;
+            getChunkModuleMaps(filterFn: Function): { id: any; hash: any };
+            hasModuleInGraph(
+                filterFn: (module: Module) => boolean,
+                filterChunkFn: (chunk: Chunk) => boolean
+            ): boolean;
             toString(): string;
         }
 

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -971,6 +971,30 @@ function testTemplateFn() {
 }
 
 const chunk = new webpack.compilation.Chunk('name');
+
+chunk.sortModules((module1, module2) => {
+  if (module1)
+      return 1;
+  else if (module2)
+      return -1;
+  return 0;
+});
+chunk.addMultiplierAndOverhead(12, {});
+chunk.addMultiplierAndOverhead(12, {
+  chunkOverhead: 1,
+  entryChunkMultiplicator: 2
+});
+chunk.size();
+chunk.size({});
+chunk.size({
+  chunkOverhead: 1,
+  entryChunkMultiplicator: 2
+});
+chunk.hasModuleInGraph(
+  m => m.type === "webassembly/async",
+  chunk => chunk.name === "vendor"
+);
+
 const moduleTemplate = ({} as any) as webpack.compilation.ModuleTemplate;
 webpack.Template.renderChunkModules(
   chunk,


### PR DESCRIPTION
Hi,

I made some some contributions to two compilation classes to improve the types for them.

In this PR:
* Updates definitions for [`webpack.compilation.Chunk`](https://github.com/webpack/webpack/blob/v4.41.2/lib/Chunk.js)
* Adds definitions for [`webpack.compilation.Module`](https://github.com/webpack/webpack/blob/v4.41.2/lib/Module.js)

The types are mostly copy-pasted from the JS-doc from the linked source.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/webpack/webpack/blob/v4.41.2/lib/Chunk.js
  - https://github.com/webpack/webpack/blob/v4.41.2/lib/Module.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.