### PR TITLE
Add type definitions for express-actuator

### DIFF
--- a/types/express-actuator/express-actuator-tests.ts
+++ b/types/express-actuator/express-actuator-tests.ts
@@ -1,0 +1,15 @@
+import express = require("express");
+import actuator = require("express-actuator");
+
+const app = express();
+
+/**
+ * @summary Test for {@see actuator}.
+ */
+function actuatorTest() {
+    app.use(actuator());
+    app.use(actuator({}));
+    app.use(actuator({ basePath: '/management' }));
+    app.use(actuator({ infoGitMode: 'simple' }));
+    app.use(actuator({ infoGitMode: 'full' }));
+}

--- a/types/express-actuator/index.d.ts
+++ b/types/express-actuator/index.d.ts
@@ -1,0 +1,30 @@
+// Type definitions for express-actuator 1.3
+// Project: https://www.npmjs.org/package/express-actuator
+// Definitions by:  Eduardo Silva <https://github.com/etruta>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import express = require('express');
+
+declare function actuator(options?: actuator.Options): express.RequestHandler;
+
+declare namespace actuator {
+    type InfoGitMode = "simple" | "full";
+
+    /**
+     * @summary Options for {@link Actuator} function.
+     */
+    interface Options {
+        /**
+         * @summary BasePath of Actuator.
+         */
+        basePath?: string;
+
+        /**
+         * @summary infoGitMode.
+         */
+        infoGitMode?: InfoGitMode;
+    }
+}
+
+export = actuator;

--- a/types/express-actuator/tsconfig.json
+++ b/types/express-actuator/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-actuator-tests.ts"
+    ]
+}

--- a/types/express-actuator/tslint.json
+++ b/types/express-actuator/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.