### PR TITLE
[theme-ui] fix color mode definition

### DIFF
--- a/types/theme-ui/index.d.ts
+++ b/types/theme-ui/index.d.ts
@@ -4,6 +4,7 @@
 //                 Ifiok Jr. <https://github.com/ifiokjr>
 //                 Brian Andrews <https://github.com/sbardian>
 //                 Rodrigo Pombo <https://github.com/pomber>
+//                 Justin Hall <https://github.com/wKovacs64>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
@@ -29,8 +30,6 @@ export interface ThemeProviderProps<Theme> {
 // tslint:disable-next-line: no-unnecessary-generics
 export function ThemeProvider<Theme>(props: ThemeProviderProps<Theme>): React.ReactElement;
 
-type SSColors = StyledSystemTheme['colors'];
-
 /**
  * To use Theme UI color modes, color scales should include at least a text
  * and background color. These values are used in the ColorMode component to
@@ -41,20 +40,40 @@ type SSColors = StyledSystemTheme['colors'];
  * initialColorMode key is required to enable color modes and will be used as
  * the name for the root color palette.
  */
-export interface ColorModes {
-    [k: string]: {
-        /**
-         * This is required for a color mode.
-         */
-        text: string;
+export type ColorMode = {
+    [k: string]: CSS.ColorProperty | ObjectOrArray<CSS.ColorProperty>;
+} & {
+    /**
+     * Body background color
+     */
+    background: CSS.ColorProperty;
 
-        /**
-         * This is required for the color mode.
-         */
-        background: string;
-        [k: string]: Partial<Omit<StyledSystemTheme['colors'], 'modes'>>;
-    };
-}
+    /**
+     * Body foreground color
+     */
+    text: CSS.ColorProperty;
+
+    /**
+     * Primary brand color for links, buttons, etc.
+     */
+    primary?: CSS.ColorProperty;
+
+    /**
+     * A secondary brand color for alternative styling
+     */
+    secondary?: CSS.ColorProperty;
+
+    /**
+     * A faint color for backgrounds, borders, and accents that do not require
+     * high contrast with the background color
+     */
+    muted?: CSS.ColorProperty;
+
+    /**
+     * A contrast color for emphasizing UI
+     */
+    accent?: CSS.ColorProperty;
+};
 
 export interface Theme extends StyledSystemTheme {
     /**
@@ -65,43 +84,14 @@ export interface Theme extends StyledSystemTheme {
     /**
      * Define the colors that are available through this theme
      */
-    colors?: { [k: string]: CSS.ColorProperty | ObjectOrArray<CSS.ColorProperty> } & {
-        /**
-         * Body background color
-         */
-        background: CSS.ColorProperty;
-
-        /**
-         * Body foreground color
-         */
-        text: CSS.ColorProperty;
-
-        /**
-         * Primary brand color for links, buttons, etc.
-         */
-        primary?: CSS.ColorProperty;
-
-        /**
-         * A secondary brand color for alternative styling
-         */
-        secondary?: CSS.ColorProperty;
-
-        /**
-         * A faint color for backgrounds, borders, and accents that do not require
-         * high contrast with the background color
-         */
-        muted?: CSS.ColorProperty;
-
-        /**
-         * A contrast color for emphasizing UI
-         */
-        accent?: CSS.ColorProperty;
-
+    colors?: ColorMode & {
         /**
          * Nested color modes can provide overrides when used in conjunction with
          * `Theme.initialColorMode and `useColorMode()`
          */
-        modes?: ColorModes;
+        modes?: {
+            [k: string]: ColorMode;
+        };
     };
 
     /**


### PR DESCRIPTION
Also removed unused SSColors type (which was not exported).

BREAKING CHANGE: ColorModes is now ColorMode as it represents a single mode.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37846#issuecomment-548019149
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
