### PR TITLE
[react-resize-detector] Add new targetEl type to react-resize-detector

### DIFF
--- a/types/react-resize-detector/index.d.ts
+++ b/types/react-resize-detector/index.d.ts
@@ -1,12 +1,13 @@
-// Type definitions for react-resize-detector 4.0
+// Type definitions for react-resize-detector 4.2
 // Project: https://github.com/maslianok/react-resize-detector
 // Definitions by: Matthew James <https://github.com/matthew-matvei>
 //                 James Greenleaf <https://github.com/aMoniker>
 //                 Remin <https://github.com/rdrgn>
+//                 Lee Taylor <https://github.com/leettaylor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from "react";
+import * as React from 'react';
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
@@ -42,7 +43,7 @@ interface ReactResizeDetectorProps extends React.Props<ReactResizeDetector> {
      * undefined - callback will be fired for every frame.
      * Default: undefined
      */
-    refreshMode?: "throttle" | "debounce";
+    refreshMode?: 'throttle' | 'debounce';
     /**
      * Use this in conjunction with refreshMode.
      * Important! It's a numeric prop so set it accordingly, e.g. refreshRate={500}.
@@ -71,17 +72,23 @@ interface ReactResizeDetectorProps extends React.Props<ReactResizeDetector> {
      * Default: "div"
      */
     nodeType?: keyof React.ReactHTML; // will be passed to React.createElement()
+    /**
+     * A DOM element to observe.
+     * By default it's a parent element in relation to the ReactResizeDetector component.
+     * But you can pass any DOM element to observe.
+     * This property is omitted when you pass querySelector.
+     * Default: undefined
+     */
+    targetDomEl?: HTMLElement;
 
     render?: (props: ReactResizeDetectorDimensions) => React.ReactNode;
 }
 
-declare class ReactResizeDetector extends React.PureComponent<
-    ReactResizeDetectorProps
-> {}
+declare class ReactResizeDetector extends React.PureComponent<ReactResizeDetectorProps> {}
 
 export function withResizeDetector<T extends Partial<ReactResizeDetectorDimensions>>(
     WrappedComponent: React.ComponentType<T>,
-    props?: ReactResizeDetectorProps
+    props?: ReactResizeDetectorProps,
 ): React.ComponentType<Omit<T, keyof ReactResizeDetectorDimensions>>;
 
 export default ReactResizeDetector;

--- a/types/react-resize-detector/react-resize-detector-tests.tsx
+++ b/types/react-resize-detector/react-resize-detector-tests.tsx
@@ -52,7 +52,7 @@ class App extends React.PureComponent {
     private readonly handleResize = (width: number, height: number) => {
         console.log(`width = ${width}`);
         console.log(`height = ${height}`);
-    };
+    }
 
     private readonly resizeRef: React.RefObject<any>;
 }

--- a/types/react-resize-detector/react-resize-detector-tests.tsx
+++ b/types/react-resize-detector/react-resize-detector-tests.tsx
@@ -10,11 +10,12 @@ class App extends React.PureComponent {
         super(props);
 
         this.handleResize = this.handleResize.bind;
+        this.resizeRef = React.createRef();
     }
 
     render(): JSX.Element {
         return (
-            <div>
+            <div ref={this.resizeRef}>
                 <div>Some child content</div>
                 <ReactResizeDetector
                     onResize={this.handleResize}
@@ -26,6 +27,7 @@ class App extends React.PureComponent {
                     refreshOptions={{ leading: true, trailing: true }}
                     querySelector="someElement"
                     nodeType="span"
+                    targetDomEl={this.resizeRef.current}
                 />
                 <ReactResizeDetector handleWidth handleHeight>
                     {({ width, height }: { width: number; height: number }) => <div>{`${width}x${height}`}</div>}
@@ -50,7 +52,9 @@ class App extends React.PureComponent {
     private readonly handleResize = (width: number, height: number) => {
         console.log(`width = ${width}`);
         console.log(`height = ${height}`);
-    }
+    };
+
+    private readonly resizeRef: React.RefObject<any>;
 }
 
 interface WrappedComponentProps {


### PR DESCRIPTION
Add new `targetEl` prop to `react-resize-detector` which takes a DOM element (`HTMLElement`) from a React Ref.

---

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [URL](https://github.com/maslianok/react-resize-detector/releases/tag/v4.1.0)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
