### PR TITLE
[electron-localshortcut] Add types for electron-localshortcut

### DIFF
--- a/types/electron-localshortcut/electron-localshortcut-tests.ts
+++ b/types/electron-localshortcut/electron-localshortcut-tests.ts
@@ -1,0 +1,27 @@
+import * as electronLocalshortcut from 'electron-localshortcut';
+import { BrowserWindow } from 'electron';
+
+const win = new BrowserWindow();
+
+electronLocalshortcut.register(win, 'Ctrl+A', () => {
+    console.log('You pressed ctrl & A');
+});
+electronLocalshortcut.register('Ctrl+A', () => {
+    console.log('You pressed ctrl & A');
+});
+
+electronLocalshortcut.register(win, ['Ctrl+R', 'F5'], () => {
+    console.log('You pressed ctrl & R or F5');
+});
+
+electronLocalshortcut.register(['Ctrl+R', 'F5'], () => {
+    console.log('You pressed ctrl & R or F5');
+});
+
+electronLocalshortcut.isRegistered(win, 'Ctrl+A');
+electronLocalshortcut.isRegistered('Ctrl+A');
+
+electronLocalshortcut.unregister(win, 'Ctrl+A');
+electronLocalshortcut.unregister('Ctrl+A');
+
+electronLocalshortcut.unregisterAll(win);

--- a/types/electron-localshortcut/index.d.ts
+++ b/types/electron-localshortcut/index.d.ts
@@ -1,0 +1,66 @@
+// Type definitions for electron-localshortcut 3.1
+// Project: https://github.com/parro-it/electron-localshortcut#readme
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import { BrowserWindow } from 'electron';
+
+/**
+ * Disable all of the shortcuts registered on the BrowserWindow instance.
+ * Registered shortcuts no more works on the `window` instance, but the module
+ * keep a reference on them. You can reactivate them later by calling `enableAll`
+ * method on the same window instance.
+ */
+export function disableAll(win: BrowserWindow): void;
+
+/**
+ * Enable all of the shortcuts registered on the BrowserWindow instance that
+ * you had previously disabled calling `disableAll` method.
+ */
+export function enableAll(win: BrowserWindow): void;
+
+/**
+ * Returns `true` or `false` depending on whether the shortcut `accelerator`
+ * is registered on `window`.
+ * @param win BrowserWindow instance to check. This argument
+ * could be omitted, in this case the function returns whether the shortcut
+ * `accelerator` is registered on all app windows. If you registered the
+ * shortcut on a particular window instance, it returns false.
+ * @param accelerator the shortcut to check
+ * @return if the shortcut `accelerator` is registered on `window`.
+ */
+export function isRegistered(win: BrowserWindow, accelerator: string): boolean;
+export function isRegistered(accelerator: string): boolean;
+
+/**
+ * Registers the shortcut `accelerator`on the BrowserWindow instance.
+ *
+ * @param win BrowserWindow instance to register.
+ * This argument could be omitted, in this case the function register
+ * the shortcut on all app windows.
+ * @param accelerator the shortcut to register
+ * @param callback This function is called when the shortcut is pressed
+ * and the window is focused and not minimized.
+ */
+export function register(win: BrowserWindow, accelerator: string | string[], callback: () => void): void;
+export function register(accelerator: string | string[], callback: () => void): void;
+
+/**
+ * Unregisters the shortcut of `accelerator` registered on the BrowserWindow instance.
+ *
+ * @param win BrowserWindow instance to unregister.
+ * This argument could be omitted, in this case the function unregister the shortcut
+ * on all app windows. If you registered the shortcut on a particular window instance, it will do nothing.
+ * @param accelerator the shortcut to unregister
+ */
+export function unregister(win: BrowserWindow, accelerator: string | string[]): void;
+export function unregister(accelerator: string | string[]): void;
+
+/**
+ * Unregisters all of the shortcuts registered on any focused BrowserWindow
+ * instance. This method does not unregister any shortcut you registered on
+ * a particular window instance.
+ * @param win BrowserWindow instance
+ */
+export function unregisterAll(win: BrowserWindow): void;

--- a/types/electron-localshortcut/package.json
+++ b/types/electron-localshortcut/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "electron": "*"
+    }
+}

--- a/types/electron-localshortcut/tsconfig.json
+++ b/types/electron-localshortcut/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "dom",
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "electron-localshortcut-tests.ts"
+    ]
+}

--- a/types/electron-localshortcut/tslint.json
+++ b/types/electron-localshortcut/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
