### PR TITLE
Add types for sic-list

### DIFF
--- a/types/sic-list/index.d.ts
+++ b/types/sic-list/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sic-list 0.5.1
+// Type definitions for sic-list 0.5
 // Project: https://github.com/596050/sic
 // Definitions by: TP <https://github.com/596050>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/sic-list/index.d.ts
+++ b/types/sic-list/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for sic-list 0.5.1
+// Project: https://github.com/596050/sic
+// Definitions by: TP <https://github.com/596050>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Expects a two-digit sic code. Returns the description for that sic. If not found, it returns undefined.
+ */
+export function getDescription(code: string): string | undefined;
+
+/**
+ * Expects the English sic description. Returns the code for that sic. If not found, it returns undefined.
+ */
+export function getCode(description: string): string | undefined;
+
+/**
+ * Returns an array of all sic descriptions.
+ */
+export function getDescriptions(): string[];
+
+/**
+ * Returns an array of all sic codes.
+ */
+export function getCodes(): string[];
+
+/**
+ * Returns a key-value object of all sics using the description as key.
+ */
+export function getDescriptionList(): { [description: string]: string };
+
+/**
+ * Returns a key-value object of all sics using the code as key.
+ */
+export function getCodeList(): { [code: string]: string };
+
+/**
+ * Returns an array of all sic information, in the same format as it gets imported.
+ */
+export function getData(): Array<{ code: string; description: string }>;
+
+/**
+ * Expects an array of code and sic description pairs to add to the list. Doesn't return anything.
+ */
+export function overwrite(sics: ReadonlyArray<{ code: string; description: string }>): void;

--- a/types/sic-list/sic-list-tests.ts
+++ b/types/sic-list/sic-list-tests.ts
@@ -23,4 +23,4 @@ const codeList: { [code: string]: string } = getCodeList();
 
 const data: Array<{ code: string; description: string }> = getData();
 
-const overwrit: void = overwrite([{ code: '1234', description: '' }]);
+overwrite([{ code: '1234', description: '' }]);

--- a/types/sic-list/sic-list-tests.ts
+++ b/types/sic-list/sic-list-tests.ts
@@ -1,0 +1,16 @@
+import {
+    getDescription,
+    getCode,
+    getDescriptions,
+    getCodes,
+    getDescriptionList,
+    getCodeList,
+    getData,
+    overwrite,
+} from './index';
+
+const description: string | undefined = getDescription('1');
+
+const code: string | undefined = getCode('1234');
+
+const descriptions: string[] = getDescriptions();

--- a/types/sic-list/sic-list-tests.ts
+++ b/types/sic-list/sic-list-tests.ts
@@ -7,10 +7,20 @@ import {
     getCodeList,
     getData,
     overwrite,
-} from './index';
+} from 'sic-list';
 
-const description: string | undefined = getDescription('1');
+const description: string | undefined = getDescription('');
 
 const code: string | undefined = getCode('1234');
 
 const descriptions: string[] = getDescriptions();
+
+const codes: string[] = getCodes();
+
+const descriptionList: { [description: string]: string } = getDescriptionList();
+
+const codeList: { [code: string]: string } = getCodeList();
+
+const data: Array<{ code: string; description: string }> = getData();
+
+const overwrit: void = overwrite([{ code: '1234', description: '' }]);

--- a/types/sic-list/tsconfig.json
+++ b/types/sic-list/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "sic-list-tests.ts"
+    ]
+}

--- a/types/sic-list/tslint.json
+++ b/types/sic-list/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.