### PR TITLE
@wordpress/block-editor Add className prop to BlockList

### DIFF
--- a/types/wordpress__block-editor/components/block-list.d.ts
+++ b/types/wordpress__block-editor/components/block-list.d.ts
@@ -2,6 +2,7 @@ import { ComponentType } from '@wordpress/element';
 
 declare namespace BlockList {
     interface Props {
+        className?: string;
         /**
          * A 'render prop' function that can be used to customize the block's appender.
          */

--- a/types/wordpress__block-editor/index.d.ts
+++ b/types/wordpress__block-editor/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for @wordpress/block-editor 2.2
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/block-editor/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
+//                 Jon Surrell <https://github.com/sirreal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 import { BlockIconNormalized } from '@wordpress/blocks';

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -77,6 +77,11 @@ const STYLES = [{ css: '.foo { color: red; }' }, { css: '.bar { color: blue; }',
 <be.BlockIcon icon={<i>foo</i>} showColors />;
 
 //
+// block-list
+//
+<be.BlockList className="my-custom-class" />;
+
+//
 // block-mover
 //
 <be.BlockMover clientIds={['foo', 'bar']} />;


### PR DESCRIPTION
Adds missing `className` prop to `BlockList` component.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/61753df6a89c7be467c09a91c7ff18410e5685cf/packages/block-editor/src/components/block-list/index.js#L194-L213
- **Does not apply.** If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- **Does not apply.** If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.