### PR TITLE
Angular translate filter overload

### DIFF
--- a/types/angular-translate/angular-translate-tests.ts
+++ b/types/angular-translate/angular-translate-tests.ts
@@ -47,4 +47,8 @@ app.controller('Ctrl', ($scope: Scope, $translate: angular.translate.ITranslateS
     x = $filter('translate')('something');
     x = $filter('translate')('something', {});
     x = $filter('translate')('something', {}, '');
+    var o = $filter('translate')(['a', 'b', 'c']);
+    o.a;
+    o.b;
+    o.c;
 });

--- a/types/angular-translate/index.d.ts
+++ b/types/angular-translate/index.d.ts
@@ -122,6 +122,7 @@ declare module 'angular' {
     interface IFilterService {
         (name: 'translate'): {
             (translationId: string, interpolateParams?: any, interpolation?: string, forceLanguage?: string): string;
+            (translationIds: string[], interpolateParams?: any, interpolation?: string, forceLanguage?: string): { [key: string]: string };
         };
     }
 }


### PR DESCRIPTION
Added missing $filter overload that allows multiple strings to translate and returns an object.

This PR supersedes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40128

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://angular-translate.github.io/docs/#/api/pascalprecht.translate.$translate
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.