### PR TITLE
[rosie] attrs() accepts a subset of keys

### DIFF
--- a/types/rosie/index.d.ts
+++ b/types/rosie/index.d.ts
@@ -116,7 +116,7 @@ declare namespace rosie {
       * @param {object} attributes
       * @return {Factory}
       */
-    attrs(attributes: { [K in keyof T]: T[K] | ((opts?: any) => T[K]) }): IFactory<T>;
+    attrs<Keys extends keyof T>(attributes: { [K in Keys]: T[K] | ((opts?: any) => T[K]) }): IFactory<T>;
 
     /**
      * Define an option for this factory. Options are values that may inform

--- a/types/rosie/rosie-tests.ts
+++ b/types/rosie/rosie-tests.ts
@@ -65,6 +65,12 @@ personFactory.attr('secretCode', ['firstName', 'lastName', 'age', 'age', 'firstN
 // You can go past five dependencies, but you need to specify types
 personFactory.attr('secretCode', ['firstName', 'lastName', 'age', 'age', 'firstName', 'firstName'], (firstName: string, lastName: string, age1: number, age2: number, firstNameAgain: string, firstNameThisIsTooMuch: string) => ({ name: firstNameAgain, value: age1 + age2 }));
 
+// attrs() supports subset of attributes.
+personFactory.attrs({
+  firstName: 'Bob',
+  lastName: 'Newbie'
+})
+
 // Having defined 'Person', `build` will return an object of type Person, using the generic type.
 const person = Factory.build<Person>('Person');
 let aString = '';


### PR DESCRIPTION
using `Pick` a la `React.setState`. This allows batch-defining most-but-not-all props.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rosiejs/rosie#batch-specification-of-attributes shows mixing `.attr()` and `.attrs()` in a single factory call.
- ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- ~~ If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
