### PR TITLE
website-scraper: Make `Source.attr` optional. Add more options.

### DIFF
--- a/types/website-scraper/index.d.ts
+++ b/types/website-scraper/index.d.ts
@@ -13,17 +13,21 @@ declare namespace websiteScraper {
         url: string;
         filename: string;
     }
+
     interface SubDirectory {
         directory: string;
         extensions: string[];
     }
+
     interface Source {
         selector: string;
         attr?: string;
     }
+
     interface RequestOptions {
         headers: request.Headers;
     }
+
     interface Options {
         urls: (string | Url)[];
         directory: string;
@@ -38,11 +42,13 @@ declare namespace websiteScraper {
         maxDepth?: number;
         ignoreErrors?: boolean;
     }
+
     interface Resource {
         url: string;
         filename: string;
         assets: Resource[];
     }
+
     interface Callback {
         (error: any | null, result: Resource[] | null): void;
     }

--- a/types/website-scraper/index.d.ts
+++ b/types/website-scraper/index.d.ts
@@ -41,6 +41,9 @@ declare namespace websiteScraper {
         recursive?: boolean;
         maxDepth?: number;
         ignoreErrors?: boolean;
+        maxRecursiveDepth?: number;
+        requestConcurrency?: number;
+        plugins?: object[];
     }
 
     interface Resource {

--- a/types/website-scraper/index.d.ts
+++ b/types/website-scraper/index.d.ts
@@ -19,7 +19,7 @@ declare namespace websiteScraper {
     }
     interface Source {
         selector: string;
-        attr: string;
+        attr?: string;
     }
     interface RequestOptions {
         headers: request.Headers

--- a/types/website-scraper/index.d.ts
+++ b/types/website-scraper/index.d.ts
@@ -25,7 +25,7 @@ declare namespace websiteScraper {
         headers: request.Headers
     }
     interface Options {
-        urls: Array<string | Url>;
+        urls: (string | Url)[];
         directory: string;
         urlFilter?: (url: string) => boolean;
         filenameGenerator?: string;

--- a/types/website-scraper/index.d.ts
+++ b/types/website-scraper/index.d.ts
@@ -46,12 +46,13 @@ declare namespace websiteScraper {
     interface Callback {
         (error: any | null, result: Resource[] | null): void;
     }
-    interface scrape {
+
+    interface Scrape {
         (options: Options, callback: Callback): void;
         (options: Options): Promise<Resource[]>;
     }
 }
 
-declare var websiteScraper: websiteScraper.scrape;
+declare const websiteScraper: websiteScraper.Scrape;
 
 export = websiteScraper;

--- a/types/website-scraper/index.d.ts
+++ b/types/website-scraper/index.d.ts
@@ -22,7 +22,7 @@ declare namespace websiteScraper {
         attr?: string;
     }
     interface RequestOptions {
-        headers: request.Headers
+        headers: request.Headers;
     }
     interface Options {
         urls: (string | Url)[];

--- a/types/website-scraper/website-scraper-tests.ts
+++ b/types/website-scraper/website-scraper-tests.ts
@@ -13,7 +13,7 @@ scraper({
         { directory: 'css', extensions: ['.css'] },
     ],
     sources: [
-        { selector: 'img', attr: 'src' },
+        { selector: 'img' },
         { selector: 'link[rel="stylesheet"]', attr: 'href' },
         { selector: 'script', attr: 'src' },
     ],

--- a/types/website-scraper/website-scraper-tests.ts
+++ b/types/website-scraper/website-scraper-tests.ts
@@ -1,31 +1,33 @@
-import scraper = require("website-scraper");
+import scraper = require('website-scraper');
 
 scraper({
     urls: [
-        "http://nodejs.org/",
-        { url: "http://nodejs.org/about", filename: "about.html" },
-        { url: "http://blog.nodejs.org/", filename: "blog.html" }
+        'http://nodejs.org/',
+        { url: 'http://nodejs.org/about', filename: 'about.html' },
+        { url: 'http://blog.nodejs.org/', filename: 'blog.html' },
     ],
-    directory: "/path/to/save",
+    directory: '/path/to/save',
     subdirectories: [
-        { directory: "img", extensions: [".jpg", ".png", ".svg"] },
-        { directory: "js", extensions: [".js"] },
-        { directory: "css", extensions: [".css"] }
+        { directory: 'img', extensions: ['.jpg', '.png', '.svg'] },
+        { directory: 'js', extensions: ['.js'] },
+        { directory: 'css', extensions: ['.css'] },
     ],
     sources: [
-        { selector: "img", attr: "src" },
-        { selector: "link[rel=\"stylesheet\"]", attr: "href" },
-        { selector: "script", attr: "src" }
+        { selector: 'img', attr: 'src' },
+        { selector: 'link[rel="stylesheet"]', attr: 'href' },
+        { selector: 'script', attr: 'src' },
     ],
     request: {
         headers: {
-            "User-Agent":
-            "Mozilla/5.0 (Linux; Android 4.2.1; en-us; Nexus 4 Build/JOP40D)\
-             AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"
-        }
-    }
-}).then(function(result) {
-    console.log(result);
-}).catch(function(err) {
-    console.log(err);
-});
+            'User-Agent':
+                'Mozilla/5.0 (Linux; Android 4.2.1; en-us; Nexus 4 Build/JOP40D)\
+             AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19',
+        },
+    },
+})
+    .then(function(result) {
+        console.log(result);
+    })
+    .catch(function(err) {
+        console.log(err);
+    });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: As seen [here](https://github.com/website-scraper/node-website-scraper/blob/050cdd011231033477264df9f432a7925927575f/lib/config/defaults.js#L5), `attr` can be optional. Also, [all available options](https://github.com/website-scraper/node-website-scraper#options).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.