### PR TITLE
Fix typings for tsc esModuleInterop=false

### DIFF
--- a/types/promise-retry/index.d.ts
+++ b/types/promise-retry/index.d.ts
@@ -24,4 +24,5 @@ type RetryableFn<ResolutionType> = ((retry: (error: any) => never, attempt: numb
  */
 declare function promiseRetry<ResolutionType>(retryableFn: RetryableFn<ResolutionType>, options?: OperationOptions): Promise<ResolutionType>;
 declare function promiseRetry<ResolutionType>(options: OperationOptions, retryableFn: RetryableFn<ResolutionType>): Promise<ResolutionType>;
+declare namespace promiseRetry {};
 export = promiseRetry;

--- a/types/promise-retry/index.d.ts
+++ b/types/promise-retry/index.d.ts
@@ -24,5 +24,5 @@ type RetryableFn<ResolutionType> = ((retry: (error: any) => never, attempt: numb
  */
 declare function promiseRetry<ResolutionType>(retryableFn: RetryableFn<ResolutionType>, options?: OperationOptions): Promise<ResolutionType>;
 declare function promiseRetry<ResolutionType>(options: OperationOptions, retryableFn: RetryableFn<ResolutionType>): Promise<ResolutionType>;
-declare namespace promiseRetry {};
+declare namespace promiseRetry {}
 export = promiseRetry;


### PR DESCRIPTION
Fix typings when the compilation options don't have "esModuleInterop" enabled.

The existing typings only works when "esModuleInterop" is enabled in the compilation options. i.e.

```
import promiseRetry from 'promise-retry'
```

However, some repositories don't have "esModuleInterop" enabled for compatibility reasons. i.e.

```
import * as promiseRetry from 'promise-retry'
```

And the error `error TS2497: This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export.` is raised on a compilation.

This change fixes the error and makes it also work in the environment doesn't' have "esModuleInterop" enabled.