### PR TITLE
Fix: rox-react-native `fetch` type

### DIFF
--- a/types/rox-react-native/index.d.ts
+++ b/types/rox-react-native/index.d.ts
@@ -109,7 +109,7 @@ export function unfreeze(namespace?: string): void;
  *
  * https://support.rollout.io/docs/reactnative#section-fetch
  */
-export function fetch(): Promise<unknown>;
+export function fetch(): void;
 
 /**
  * Default is untilForeground

--- a/types/rox-react-native/index.d.ts
+++ b/types/rox-react-native/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://rollout.io
 // Definitions by: ahanriat <https://github.com/ahanriat>
 //                 g-guirado <https://github.com/g-guirado>
+//                 glenna <https://github.com/glenna>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 


### PR DESCRIPTION
Updated the `fetch` function type -- it's not an async function. Tested the change in our repo.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: It's not an async method: https://support.rollout.io/docs/javascript-browser-api#section-fetch
