### PR TITLE
react-intl-redux: Add formats prop to IntlState

### DIFF
--- a/types/react-intl-redux/index.d.ts
+++ b/types/react-intl-redux/index.d.ts
@@ -11,7 +11,7 @@ import { IntlProvider as ReactIntlProvider } from "react-intl"
 interface IntlState {
     locale: string
     messages: any
-    formats: any
+    formats?: any
 }
 
 interface IntlAction extends Action {

--- a/types/react-intl-redux/index.d.ts
+++ b/types/react-intl-redux/index.d.ts
@@ -11,6 +11,7 @@ import { IntlProvider as ReactIntlProvider } from "react-intl"
 interface IntlState {
     locale: string
     messages: any
+    formats: any
 }
 
 interface IntlAction extends Action {


### PR DESCRIPTION
The updateIntl opts parameter can have a formats prop which is missing in the interface.
see https://github.com/ratson/react-intl-redux#formatting-data
