### PR TITLE
Add className props to react-scrollspy core component

### DIFF
--- a/types/react-scrollspy/index.d.ts
+++ b/types/react-scrollspy/index.d.ts
@@ -30,6 +30,9 @@ export interface ScrollspyProps {
 
     // Function to be executed when the active item has been updated
     onUpdate?: (item: string) => void;
+
+    // ClassName attribute to be passed to the generated <ul /> element
+    className?: string;
 }
 
 export default class Scrollspy extends React.Component<ScrollspyProps> {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/makotot/react-scrollspy/pull/120
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header 
  - The className props seems to be there from the creation of the library.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
