### PR TITLE
Update split.js destroy and drag methods

### DIFF
--- a/types/split.js/index.d.ts
+++ b/types/split.js/index.d.ts
@@ -83,6 +83,6 @@ declare namespace Split {
     collapse(index: number): void;
 
     // Destroy the instance. It removes the gutter elements, and the size CSS styles Split.js set.
-    destroy(): void;
+    destroy(preserveStyles?: boolean, preserveGutters?: boolean): void;
   }
 }

--- a/types/split.js/index.d.ts
+++ b/types/split.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for split.js 1.4.1
+// Type definitions for split.js 1.4
 // Project: https://github.com/nathancahill/Split.js, https://split.js.org
 // Definitions by: Ilia Choly <https://github.com/icholy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -39,13 +39,13 @@ declare namespace Split {
     cursor?: 'col-resize' | 'row-resize';
 
     // Callback on drag.
-    onDrag?(): void;
+    onDrag?(sizes: number[]): void;
 
     // Callback on drag start.
-    onDragStart?(): void;
+    onDragStart?(sizes: number[]): void;
 
     // Callback on drag end.
-    onDragEnd?(): void;
+    onDragEnd?(sizes: number[]): void;
 
     // Called to create each gutter element
     gutter?(

--- a/types/split.js/index.d.ts
+++ b/types/split.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for split.js 1.3
+// Type definitions for split.js 1.4.1
 // Project: https://github.com/nathancahill/Split.js, https://split.js.org
 // Definitions by: Ilia Choly <https://github.com/icholy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
-  Updated destroy method (added boolean parameters)
see:  https://www.npmjs.com/package/split.js#destroypreservestyles--false-preservegutters--false
- Updated onDrag methods (added sizes parameter)
see: https://github.com/nathancahill/split/tree/master/packages/splitjs#ondrag-ondragstart-ondragend
- Updated header version to 1.4 since destroy options have been introduced in 1.4.x  
