### PR TITLE
feat(@types/ospec):  Add missing declaration for `o.only()`

### DIFF
--- a/types/ospec/index.d.ts
+++ b/types/ospec/index.d.ts
@@ -57,6 +57,9 @@ declare namespace o {
         /** Defines a test */
         (name: string, assertions: Definer): void;
 
+        /** Defines a test */
+        only(name: string, assertions: Definer, silent?: boolean): void;
+
         /** Defines a group of tests */
         spec(name: string, tests: () => void): void;
 

--- a/types/ospec/index.d.ts
+++ b/types/ospec/index.d.ts
@@ -58,7 +58,7 @@ declare namespace o {
         (name: string, assertions: Definer): void;
 
         /** Defines a test */
-        only(name: string, assertions: Definer, silent?: boolean): void;
+        only(name: string, assertions: Definer): void;
 
         /** Defines a group of tests */
         spec(name: string, tests: () => void): void;

--- a/types/ospec/ospec-tests.ts
+++ b/types/ospec/ospec-tests.ts
@@ -227,6 +227,31 @@ o.spec('ospec typings', () => {
 
     // ======================================================================
 
+    // $ExpectType void
+    o.only('only this test should run', () => {
+        o(true).equals(true);
+    });
+    o.only(
+        '...and this also',
+        () => {
+            o(true).equals(true);
+        },
+        false,
+    );
+    o.only(
+        'And this one, but silently',
+        () => {
+            o(true).equals(true);
+        },
+        true,
+    );
+    // $ExpectError
+    o.only('definer function missing');
+    // $ExpectError
+    o.only(() => {}); // Missing name parameter
+
+    // ======================================================================
+
     const o2: o.Ospec = o.new();
     o2.spec('New Ospec instance', () => {
         o2('Works?', done => {

--- a/types/ospec/ospec-tests.ts
+++ b/types/ospec/ospec-tests.ts
@@ -231,20 +231,6 @@ o.spec('ospec typings', () => {
     o.only('only this test should run', () => {
         o(true).equals(true);
     });
-    o.only(
-        '...and this also',
-        () => {
-            o(true).equals(true);
-        },
-        false,
-    );
-    o.only(
-        'And this one, but silently',
-        () => {
-            o(true).equals(true);
-        },
-        true,
-    );
     // $ExpectError
     o.only('definer function missing');
     // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/MithrilJS/mithril.js/tree/next/ospec#running-only-some-tests>>
