### PR TITLE
feat(@types/ospec): Relax object-only requirement of the ".deep*" methods

### DIFF
--- a/types/ospec/index.d.ts
+++ b/types/ospec/index.d.ts
@@ -28,9 +28,9 @@ declare namespace o {
         notEquals(value: T): AssertionDescriber;
 
         /** Asserts that two objects are recursively equal */
-        deepEquals(this: Assertion<object>, expected: T): AssertionDescriber;
+        deepEquals(expected: T): AssertionDescriber;
         /** Asserts that two objects are **not** recursively equal */
-        notDeepEquals(this: Assertion<object>, value: T): AssertionDescriber;
+        notDeepEquals(value: T): AssertionDescriber;
 
         /** Asserts that the function throws an error of a given type */
         throws(this: Assertion<() => any>, error: string | ObjectConstructor): AssertionDescriber;

--- a/types/ospec/ospec-tests.ts
+++ b/types/ospec/ospec-tests.ts
@@ -66,36 +66,46 @@ o.spec('ospec typings', () => {
         o(arr).notEquals(['hi']);
     });
 
-    o('.deepEquals()/.notDeepEquals() only compares objects to object values', () => {
-        o(obj).deepEquals({
-            a: 1,
-        });
-        o(arr).deepEquals([1]); // $ExpectType AssertionDescriber
-        o(fn).deepEquals(() => {}); // $ExpectType AssertionDescriber
-        o(obj).notDeepEquals({
-            a: 1,
-        });
-        o(arr).notDeepEquals([1]); // $ExpectType AssertionDescriber
-        o(fn).notDeepEquals(() => {}); // $ExpectType AssertionDescriber
+    o('.deepEquals() is similarily type safe', () => {
+        o(bool).deepEquals(true); // $ExpectType AssertionDescriber
+        o(bool).deepEquals(true)('description text');
+        o(numOrStr).deepEquals('hello');
+        o(numOrStr).deepEquals(1);
+        o(fn).deepEquals(() => {});
+        o(obj).deepEquals({ a: 1 });
+        o(arr).deepEquals([1, 2]);
 
-        // $ExpectError
-        o(obj).deepEquals(1);
-        // $ExpectError
-        o(obj).notDeepEquals(1);
         // $ExpectError
         o(bool).deepEquals(1);
         // $ExpectError
+        o(numOrStr).deepEquals(true);
+        // $ExpectError
+        o(fn).deepEquals(1);
+        // $ExpectError
+        o(obj).deepEquals({});
+        // $ExpectError
+        o(arr).deepEquals(['hi']);
+    });
+
+    o('and .notDeepEquals() is also type safe', () => {
+        o(bool).notDeepEquals(true); // $ExpectType AssertionDescriber
+        o(bool).notDeepEquals(true)('description text');
+        o(numOrStr).notDeepEquals('hello');
+        o(numOrStr).notDeepEquals(1);
+        o(fn).notDeepEquals(() => {});
+        o(obj).notDeepEquals({ a: 1 });
+        o(arr).notDeepEquals([1, 2]);
+
+        // $ExpectError
         o(bool).notDeepEquals(1);
         // $ExpectError
-        o(numOrStr).deepEquals(1);
+        o(numOrStr).notDeepEquals(true);
         // $ExpectError
-        o(numOrStr).notDeepEquals(1);
+        o(fn).notDeepEquals(1);
         // $ExpectError
         o(obj).notDeepEquals({});
         // $ExpectError
-        o(arr).notDeepEquals(['hi']); // $ExpectType AssertionDescriber
-        // $ExpectError
-        o(fn).notDeepEquals({}); // $ExpectType AssertionDescriber
+        o(arr).notDeepEquals(['hi']);
     });
 
     o('.throws()/.notThrows() only available for function values', () => {


### PR DESCRIPTION
See rationale here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37645/files/99d3472488ef8df7f6cd529a7799f99971f56de8#diff-4a55ff58701161f211e3b6ccfa23aea2R30-R33

IMO we made the mistake of making `o.deepEquals()` and `o.notDeepEquals()` too opinionated about the types it compares.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
