### PR TITLE
Update Roarr types to allow function argument to `child'.

### DIFF
--- a/types/roarr/index.d.ts
+++ b/types/roarr/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for roarr 2.13
+// Type definitions for roarr 2.14
 // Project: https://github.com/gajus/roarr#readme
 // Definitions by: Philip Saxton <https://github.com/psaxton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -14,6 +14,8 @@ declare namespace Roarr {
 		logLevel?: number;
 		[name: string]: any;
 	}
+
+    type TranslateMessageFunctionType = (message: MessageContextType) => MessageContextType;
 
 	interface SprintfArgumentType { toString(): string; }
 
@@ -47,7 +49,7 @@ declare namespace Roarr {
 		/**
 		 * Creates a child logger appending the provided context object to the previous logger context.
 		 *
-		 * @param context
+		 * @param contextOrFunction
 		 * @example
 		 * import Roarr from 'roarr';
 		 *
@@ -58,7 +60,7 @@ declare namespace Roarr {
 		 *
 		 * @see https://www.npmjs.com/package/roarr#child
 		 */
-		child(context: MessageContextType): RoarrType;
+		child(contextOrFunction: MessageContextType | TranslateMessageFunctionType): RoarrType;
 
 		/**
 		 * Returns the current context.

--- a/types/roarr/roarr-tests.ts
+++ b/types/roarr/roarr-tests.ts
@@ -15,3 +15,14 @@ log.error("Error log statement");
 log.error({ context: "error" }, "Error log statement");
 log.fatal("Fatal log statement");
 log.fatal({ context: "fatal" }, "Fatal log statement");
+
+// TS2.0-compatible reformulation of example at https://github.com/gajus/roarr#function-parameter
+const alternativeLog = Roarr.child((message) => {
+    message["message"] = message["message"].replace("foo", "bar");
+
+    return message;
+});
+
+alternativeLog({ logLevel: 60 }, "Something critical");
+alternativeLog.debug({ foo: "bar" }, 'foo 1');
+alternativeLog.fatal('foo 2');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gajus/roarr#function-parameter
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

I noticed that [the library has its own Flow type definitions](https://github.com/gajus/roarr/blob/master/src/types.js), and they don’t quite line up with the types we have here. I’ve stuck to the style of the types here for now, but is there a way to align them without breaking backwards compatibility?