### PR TITLE
Fix return type of mysql's "queryFormat" function

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -511,7 +511,7 @@ export interface ConnectionConfig extends ConnectionOptions {
     /**
      * A custom query format function
      */
-    queryFormat?(query: string, values: any): void;
+    queryFormat?(query: string, values: any): string;
 
     /**
      * When dealing with big numbers (BIGINT and DECIMAL columns) in the database, you should enable this option

--- a/types/mysql/mysql-tests.ts
+++ b/types/mysql/mysql-tests.ts
@@ -129,6 +129,9 @@ connection.config.queryFormat = function(query, values) {
     });
 };
 
+// $ExpectType string
+connection.config.queryFormat("UPDATE posts SET title = :title", {title: "Hello MySQL"});
+
 connection.query("UPDATE posts SET title = :title", {title: "Hello MySQL"});
 
 const s: stream.Readable = connection.query("UPDATE posts SET title = :title", {title: "Hello MySQL"}).stream({highWaterMark: 5});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mysqljs/mysql#custom-format
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


This function is meant to return a string, as shown by the example.