### PR TITLE
[react-relay] Handle all variations of nullability and arrays for `useFragment`

### DIFF
--- a/types/react-relay/lib/relay-experimental/useFragment.d.ts
+++ b/types/react-relay/lib/relay-experimental/useFragment.d.ts
@@ -9,13 +9,12 @@ import { GraphQLTaggedNode } from 'relay-runtime';
 
 type $Call<Fn extends (...args: any[]) => any> = Fn extends (arg: any) => infer RT ? RT : never;
 
-type KeyType = { readonly ' $data'?: unknown  }
+type KeyType = { readonly ' $data'?: unknown };
+type ArrayKeyType = ReadonlyArray<{ readonly ' $data'?: ReadonlyArray<unknown> }>;
 
 type ReturnType<T extends KeyType> = (arg: T) => NonNullable<T[' $data']>;
-type NonNullableArrayReturnType<T extends ReadonlyArray<KeyType>> = (arg: T) => ReadonlyArray<NonNullable<T[0][' $data']>>;
-type NullableArrayReturnType<T extends ReadonlyArray<KeyType>> = (
-    arg: T,
-) => ReadonlyArray<NonNullable<T[0][' $data']> | null>;
+type NonNullableArrayReturnType<T extends ArrayKeyType> = (arg: T) => ReadonlyArray<NonNullable<T[0][' $data']>[0]>;
+type NullableArrayReturnType<T extends ArrayKeyType> = (arg: T) => ReadonlyArray<NonNullable<T[0][' $data']>[0] | null>;
 
 export function useFragment<TKey extends KeyType>(
     fragmentInput: GraphQLTaggedNode,
@@ -27,22 +26,22 @@ export function useFragment<TKey extends KeyType>(
     fragmentRef: TKey | null,
 ): $Call<ReturnType<TKey>> | null;
 
-export function useFragment<TKey extends ReadonlyArray<KeyType>>(
+export function useFragment<TKey extends ArrayKeyType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey,
 ): $Call<NonNullableArrayReturnType<TKey>>;
 
-export function useFragment<TKey extends ReadonlyArray<KeyType>>(
+export function useFragment<TKey extends ArrayKeyType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey | null,
 ): $Call<NonNullableArrayReturnType<TKey>> | null;
 
-export function useFragment<TKey extends ReadonlyArray<KeyType>>(
+export function useFragment<TKey extends ArrayKeyType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: ReadonlyArray<TKey[0] | null>,
 ): $Call<NullableArrayReturnType<TKey>>;
 
-export function useFragment<TKey extends ReadonlyArray<KeyType>>(
+export function useFragment<TKey extends ArrayKeyType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: ReadonlyArray<TKey[0] | null> | null,
 ): $Call<NullableArrayReturnType<TKey>> | null;

--- a/types/react-relay/lib/relay-experimental/useFragment.d.ts
+++ b/types/react-relay/lib/relay-experimental/useFragment.d.ts
@@ -12,14 +12,10 @@ type $Call<Fn extends (...args: any[]) => any> = Fn extends (arg: any) => infer 
 interface KeyType {
     readonly ' $data'?: unknown;
 }
-type ArrayKeyType = ReadonlyArray<{ readonly ' $data'?: ReadonlyArray<unknown> }>;
-type NullableArrayKeyType = ReadonlyArray<{ readonly ' $data'?: ReadonlyArray<unknown> } | null>;
+type ArrayKeyType = ReadonlyArray<{ readonly ' $data'?: ReadonlyArray<unknown> } | null>;
 
 type KeyReturnType<T extends KeyType> = (arg: T) => NonNullable<T[' $data']>;
-type ArrayKeyReturnType<T extends ArrayKeyType> = (arg: T) => NonNullable<T[0][' $data']>[0];
-type NullableArrayKeyReturnType<T extends NullableArrayKeyType> = (
-    arg: T,
-) => NonNullable<NonNullable<T[0]>[' $data']>[0];
+type ArrayKeyReturnType<T extends ArrayKeyType> = (arg: T) => NonNullable<NonNullable<T[0]>[' $data']>[0];
 
 export function useFragment<TKey extends KeyType>(
     fragmentInput: GraphQLTaggedNode,
@@ -40,25 +36,5 @@ export function useFragment<TKey extends ArrayKeyType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey | null,
 ): ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>> | null;
-
-export function useFragment<TKey extends NullableArrayKeyType>(
-    fragmentInput: GraphQLTaggedNode,
-    fragmentRef: TKey,
-): ReadonlyArray<$Call<NullableArrayKeyReturnType<TKey>> | null>;
-
-export function useFragment<TKey extends NullableArrayKeyType>(
-    fragmentInput: GraphQLTaggedNode,
-    fragmentRef: TKey | null,
-): ReadonlyArray<$Call<NullableArrayKeyReturnType<TKey>> | null> | null;
-
-export function useFragment<TKey extends ArrayKeyType>(
-    fragmentInput: GraphQLTaggedNode,
-    fragmentRef: ReadonlyArray<TKey[0] | null>,
-): ReadonlyArray<$Call<ArrayKeyReturnType<TKey>> | null>;
-
-export function useFragment<TKey extends ArrayKeyType>(
-    fragmentInput: GraphQLTaggedNode,
-    fragmentRef: ReadonlyArray<TKey[0] | null> | null,
-): ReadonlyArray<$Call<ArrayKeyReturnType<TKey>> | null> | null;
 
 export {};

--- a/types/react-relay/lib/relay-experimental/useFragment.d.ts
+++ b/types/react-relay/lib/relay-experimental/useFragment.d.ts
@@ -9,41 +9,56 @@ import { GraphQLTaggedNode } from 'relay-runtime';
 
 type $Call<Fn extends (...args: any[]) => any> = Fn extends (arg: any) => infer RT ? RT : never;
 
-type KeyType = { readonly ' $data'?: unknown };
+interface KeyType {
+    readonly ' $data'?: unknown;
+}
 type ArrayKeyType = ReadonlyArray<{ readonly ' $data'?: ReadonlyArray<unknown> }>;
+type NullableArrayKeyType = ReadonlyArray<{ readonly ' $data'?: ReadonlyArray<unknown> } | null>;
 
-type ReturnType<T extends KeyType> = (arg: T) => NonNullable<T[' $data']>;
-type NonNullableArrayReturnType<T extends ArrayKeyType> = (arg: T) => ReadonlyArray<NonNullable<T[0][' $data']>[0]>;
-type NullableArrayReturnType<T extends ArrayKeyType> = (arg: T) => ReadonlyArray<NonNullable<T[0][' $data']>[0] | null>;
+type KeyReturnType<T extends KeyType> = (arg: T) => NonNullable<T[' $data']>;
+type ArrayKeyReturnType<T extends ArrayKeyType> = (arg: T) => NonNullable<T[0][' $data']>[0];
+type NullableArrayKeyReturnType<T extends NullableArrayKeyType> = (
+    arg: T,
+) => NonNullable<NonNullable<T[0]>[' $data']>[0];
 
 export function useFragment<TKey extends KeyType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey,
-): $Call<ReturnType<TKey>>;
+): $Call<KeyReturnType<TKey>>;
 
 export function useFragment<TKey extends KeyType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey | null,
-): $Call<ReturnType<TKey>> | null;
+): $Call<KeyReturnType<TKey>> | null;
 
 export function useFragment<TKey extends ArrayKeyType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey,
-): $Call<NonNullableArrayReturnType<TKey>>;
+): ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>;
 
 export function useFragment<TKey extends ArrayKeyType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey | null,
-): $Call<NonNullableArrayReturnType<TKey>> | null;
+): ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>> | null;
+
+export function useFragment<TKey extends NullableArrayKeyType>(
+    fragmentInput: GraphQLTaggedNode,
+    fragmentRef: TKey,
+): ReadonlyArray<$Call<NullableArrayKeyReturnType<TKey>> | null>;
+
+export function useFragment<TKey extends NullableArrayKeyType>(
+    fragmentInput: GraphQLTaggedNode,
+    fragmentRef: TKey | null,
+): ReadonlyArray<$Call<NullableArrayKeyReturnType<TKey>> | null> | null;
 
 export function useFragment<TKey extends ArrayKeyType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: ReadonlyArray<TKey[0] | null>,
-): $Call<NullableArrayReturnType<TKey>>;
+): ReadonlyArray<$Call<ArrayKeyReturnType<TKey>> | null>;
 
 export function useFragment<TKey extends ArrayKeyType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: ReadonlyArray<TKey[0] | null> | null,
-): $Call<NullableArrayReturnType<TKey>> | null;
+): ReadonlyArray<$Call<ArrayKeyReturnType<TKey>> | null> | null;
 
 export {};

--- a/types/react-relay/lib/relay-experimental/useFragment.d.ts
+++ b/types/react-relay/lib/relay-experimental/useFragment.d.ts
@@ -9,33 +9,42 @@ import { GraphQLTaggedNode } from 'relay-runtime';
 
 type $Call<Fn extends (...args: any[]) => any> = Fn extends (arg: any) => infer RT ? RT : never;
 
-type NonNullableReturnType<T extends { readonly ' $data'?: unknown }> = (arg: T) => NonNullable<T[' $data']>;
-type NullableReturnType<T extends { readonly ' $data'?: unknown | null }> = (arg: T) => T[' $data'] | null;
-type NonNullableArrayReturnType<T extends ReadonlyArray<{ readonly ' $data'?: unknown }>> = (arg: {
-    readonly ' $data': T;
-}) => Array<NonNullable<T[0][' $data']>>;
-type NullableArrayReturnType<T extends ReadonlyArray<{ readonly ' $data'?: unknown | null }>> = (
+type KeyType = { readonly ' $data'?: unknown  }
+
+type ReturnType<T extends KeyType> = (arg: T) => NonNullable<T[' $data']>;
+type NonNullableArrayReturnType<T extends ReadonlyArray<KeyType>> = (arg: T) => ReadonlyArray<NonNullable<T[0][' $data']>>;
+type NullableArrayReturnType<T extends ReadonlyArray<KeyType>> = (
     arg: T,
-) => Array<T[0][' $data']> | null;
+) => ReadonlyArray<NonNullable<T[0][' $data']> | null>;
 
-export function useFragment<TKey extends { readonly ' $data'?: unknown }>(
+export function useFragment<TKey extends KeyType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey,
-): $Call<NonNullableReturnType<TKey>>;
+): $Call<ReturnType<TKey>>;
 
-export function useFragment<TKey extends { readonly ' $data'?: unknown | null }>(
+export function useFragment<TKey extends KeyType>(
     fragmentInput: GraphQLTaggedNode,
-    fragmentRef: TKey,
-): $Call<NullableReturnType<TKey>>;
+    fragmentRef: TKey | null,
+): $Call<ReturnType<TKey>> | null;
 
-export function useFragment<TKey extends ReadonlyArray<{ readonly ' $data'?: unknown }>>(
+export function useFragment<TKey extends ReadonlyArray<KeyType>>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey,
 ): $Call<NonNullableArrayReturnType<TKey>>;
 
-export function useFragment<TKey extends ReadonlyArray<{ readonly ' $data'?: unknown | null }>>(
+export function useFragment<TKey extends ReadonlyArray<KeyType>>(
     fragmentInput: GraphQLTaggedNode,
-    fragmentRef: TKey,
+    fragmentRef: TKey | null,
+): $Call<NonNullableArrayReturnType<TKey>> | null;
+
+export function useFragment<TKey extends ReadonlyArray<KeyType>>(
+    fragmentInput: GraphQLTaggedNode,
+    fragmentRef: ReadonlyArray<TKey[0] | null>,
 ): $Call<NullableArrayReturnType<TKey>>;
+
+export function useFragment<TKey extends ReadonlyArray<KeyType>>(
+    fragmentInput: GraphQLTaggedNode,
+    fragmentRef: ReadonlyArray<TKey[0] | null> | null,
+): $Call<NullableArrayReturnType<TKey>> | null;
 
 export {};

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -309,10 +309,7 @@ function NullableArrayOfNonNullableFragment() {
 
 function NonNullableArrayOfNullableFragment() {
     interface Props {
-        users: ReadonlyArray<{
-            readonly ' $data'?: UserComponent_users$data;
-            readonly ' $fragmentRefs': FragmentRefs<'UserComponent_users'>;
-        } | null>;
+        users: ReadonlyArray<UserComponent_users$key[0] | null>;
     }
 
     return function UserComponent(props: Props) {
@@ -341,10 +338,7 @@ function NonNullableArrayOfNullableFragment() {
 
 function NullableArrayOfNullableFragment() {
     interface Props {
-        users: ReadonlyArray<{
-            readonly ' $data'?: UserComponent_users$data;
-            readonly ' $fragmentRefs': FragmentRefs<'UserComponent_users'>;
-        } | null> | null;
+        users: ReadonlyArray<UserComponent_users$key[0] | null> | null;
     }
 
     return function UserComponent(props: Props) {

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -169,27 +169,30 @@ function LazyLoadQuery() {
  * Tests for useFragment
  * see https://relay.dev/docs/en/experimental/api-reference#usefragment
  */
-function NonNullableFragment() {
-    interface UserComponent_user {
-        readonly id: string;
-        readonly name: string;
-        readonly profile_picture: {
-            readonly uri: string;
-        };
-        readonly ' $refType': 'UserComponent_user';
-    }
-    type UserComponent_user$data = UserComponent_user;
-    interface UserComponent_user$key {
-        readonly ' $data'?: UserComponent_user$data;
-        readonly ' $fragmentRefs': FragmentRefs<'UserComponent_user'>;
-    }
 
+// Regular fragment.
+interface UserComponent_user {
+    readonly id: string;
+    readonly name: string;
+    readonly profile_picture: {
+        readonly uri: string;
+    };
+    readonly ' $refType': 'UserComponent_user';
+}
+type UserComponent_user$data = UserComponent_user;
+interface UserComponent_user$key {
+    readonly ' $data'?: UserComponent_user$data;
+    readonly ' $fragmentRefs': FragmentRefs<'UserComponent_user'>;
+}
+
+function NonNullableFragment() {
     interface Props {
         user: UserComponent_user$key;
     }
 
     return function UserComponent(props: Props) {
-        const data = useFragment(
+        // $ExpectType UserComponent_user
+        useFragment(
             graphql`
                 fragment UserComponent_user on User {
                     name
@@ -201,37 +204,18 @@ function NonNullableFragment() {
             props.user,
         );
 
-        return (
-            <>
-                <h1>{data.name}</h1>
-                <div>
-                    <img src={data.profile_picture.uri} />
-                </div>
-            </>
-        );
+        return null;
     };
 }
-function NullableFragment() {
-    interface UserComponent_user {
-        readonly id: string;
-        readonly name: string | null;
-        readonly profile_picture: {
-            readonly uri: string | null;
-        } | null;
-        readonly ' $refType': 'UserComponent_user';
-    }
-    type UserComponent_user$data = UserComponent_user;
-    interface UserComponent_user$key {
-        readonly ' $data'?: UserComponent_user$data;
-        readonly ' $fragmentRefs': FragmentRefs<'UserComponent_user'>;
-    }
 
+function NullableFragment() {
     interface Props {
         user: UserComponent_user$key | null;
     }
 
     return function UserComponent(props: Props) {
-        const data = useFragment(
+        // $ExpectType UserComponent_user | null
+        useFragment(
             graphql`
                 fragment UserComponent_user on User {
                     name
@@ -242,52 +226,41 @@ function NullableFragment() {
             `,
             props.user,
         );
-
-        if (data === null) {
-            return null;
-        }
-
-        return (
-            <>
-                <h1>{data.name}</h1>
-                <div>
-                    <img src={data.profile_picture!.uri || undefined} />
-                </div>
-            </>
-        );
+        return null;
     };
 }
 
-function ArrayFragment() {
-    type NullableArrayFragment_user = ReadonlyArray<{
-        readonly id: string;
-        readonly name: string;
-        readonly profile_picture: {
-            readonly uri: string;
-        };
-        readonly ' $refType': 'NullableArrayFragment_user';
-    }>;
-    type NullableArrayFragment_user$data = NullableArrayFragment_user;
-    type NullableArrayFragment_user$key = ReadonlyArray<{
-        readonly ' $data'?: NullableArrayFragment_user$data;
-        readonly ' $fragmentRefs': FragmentRefs<'NullableArrayFragment_user'>;
-    }>;
+// Plural fragment @relay(plural: true)
+type UserComponent_users = ReadonlyArray<{
+    readonly id: string;
+    readonly name: string;
+    readonly profile_picture: {
+        readonly uri: string;
+    };
+    readonly ' $refType': 'UserComponent_users';
+}>;
+type UserComponent_users$data = UserComponent_users;
+type UserComponent_users$key = ReadonlyArray<{
+    readonly ' $data'?: UserComponent_users$data;
+    readonly ' $fragmentRefs': FragmentRefs<'UserComponent_users'>;
+}>;
 
+function NonNullableArrayOfNonNullableFragment() {
     interface Props {
-        user: NullableArrayFragment_user$key;
+        users: UserComponent_users$key;
     }
 
     return function UserComponent(props: Props) {
         const data = useFragment(
             graphql`
-                fragment UserComponent_user on User {
+                fragment UserComponent_users on User @relay(plural: true) {
                     name
                     profile_picture(scale: 2) {
                         uri
                     }
                 }
             `,
-            props.user,
+            props.users,
         );
 
         return data.map(d => (
@@ -295,6 +268,107 @@ function ArrayFragment() {
                 <h1>{d.name}</h1>
                 <div>
                     <img src={d.profile_picture.uri} />
+                </div>
+            </>
+        ));
+    };
+}
+
+function NullableArrayOfNonNullableFragment() {
+    interface Props {
+        users: UserComponent_users$key | null;
+    }
+
+    return function UserComponent(props: Props) {
+        const data = useFragment(
+            graphql`
+                fragment UserComponent_users on User @relay(plural: true) {
+                    name
+                    profile_picture(scale: 2) {
+                        uri
+                    }
+                }
+            `,
+            props.users,
+        );
+
+        if (data === null) {
+            return null;
+        }
+
+        return data.map(d => (
+            <>
+                <h1>{d.name}</h1>
+                <div>
+                    <img src={d.profile_picture.uri} />
+                </div>
+            </>
+        ));
+    };
+}
+
+function NonNullableArrayOfNullableFragment() {
+    interface Props {
+        users: ReadonlyArray<{
+            readonly ' $data'?: UserComponent_users$data;
+            readonly ' $fragmentRefs': FragmentRefs<'UserComponent_users'>;
+        } | null>;
+    }
+
+    return function UserComponent(props: Props) {
+        const data = useFragment(
+            graphql`
+                fragment UserComponent_users on User @relay(plural: true) {
+                    name
+                    profile_picture(scale: 2) {
+                        uri
+                    }
+                }
+            `,
+            props.users,
+        );
+
+        return data.map(d => (
+            <>
+                <h1>{d!.name}</h1>
+                <div>
+                    <img src={d!.profile_picture.uri} />
+                </div>
+            </>
+        ));
+    };
+}
+
+function NullableArrayOfNullableFragment() {
+    interface Props {
+        users: ReadonlyArray<{
+            readonly ' $data'?: UserComponent_users$data;
+            readonly ' $fragmentRefs': FragmentRefs<'UserComponent_users'>;
+        } | null> | null;
+    }
+
+    return function UserComponent(props: Props) {
+        const data = useFragment(
+            graphql`
+                fragment UserComponent_users on User @relay(plural: true) {
+                    name
+                    profile_picture(scale: 2) {
+                        uri
+                    }
+                }
+            `,
+            props.users,
+        );
+
+        if (data === null) {
+            return null;
+        }
+
+        return data.map(d => (
+            <>
+                <h1>{d!.name}</h1>
+                <div>
+                    <img src={d!.profile_picture.uri} />
                 </div>
             </>
         ));

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -292,11 +292,7 @@ function NullableArrayFragment() {
             props.users,
         );
 
-        if (data === null) {
-            return null;
-        }
-
-        return data.map(d => (
+        return data!.map(d => (
             <>
                 <h1>{d.name}</h1>
                 <div>
@@ -327,9 +323,9 @@ function ArrayOfNullableFragment() {
 
         return data.map(d => (
             <>
-                <h1>{d!.name}</h1>
+                <h1>{d.name}</h1>
                 <div>
-                    <img src={d!.profile_picture.uri} />
+                    <img src={d.profile_picture.uri} />
                 </div>
             </>
         ));

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -227,7 +227,7 @@ function NullableFragment() {
     }
 
     interface Props {
-        user: UserComponent_user$key;
+        user: UserComponent_user$key | null;
     }
 
     return function UserComponent(props: Props) {
@@ -243,6 +243,10 @@ function NullableFragment() {
             props.user,
         );
 
+        if (data === null) {
+            return null;
+        }
+
         return (
             <>
                 <h1>{data.name}</h1>
@@ -251,6 +255,49 @@ function NullableFragment() {
                 </div>
             </>
         );
+    };
+}
+
+function ArrayFragment() {
+    type NullableArrayFragment_user = ReadonlyArray<{
+        readonly id: string;
+        readonly name: string;
+        readonly profile_picture: {
+            readonly uri: string;
+        };
+        readonly ' $refType': 'NullableArrayFragment_user';
+    }>;
+    type NullableArrayFragment_user$data = NullableArrayFragment_user;
+    type NullableArrayFragment_user$key = ReadonlyArray<{
+        readonly ' $data'?: NullableArrayFragment_user$data;
+        readonly ' $fragmentRefs': FragmentRefs<'NullableArrayFragment_user'>;
+    }>;
+
+    interface Props {
+        user: NullableArrayFragment_user$key;
+    }
+
+    return function UserComponent(props: Props) {
+        const data = useFragment(
+            graphql`
+                fragment UserComponent_user on User {
+                    name
+                    profile_picture(scale: 2) {
+                        uri
+                    }
+                }
+            `,
+            props.user,
+        );
+
+        return data.map(d => (
+            <>
+                <h1>{d.name}</h1>
+                <div>
+                    <img src={d.profile_picture.uri} />
+                </div>
+            </>
+        ));
     };
 }
 

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -245,7 +245,7 @@ type UserComponent_users$key = ReadonlyArray<{
     readonly ' $fragmentRefs': FragmentRefs<'UserComponent_users'>;
 }>;
 
-function NonNullableArrayOfNonNullableFragment() {
+function NonNullableArrayFragment() {
     interface Props {
         users: UserComponent_users$key;
     }
@@ -274,7 +274,7 @@ function NonNullableArrayOfNonNullableFragment() {
     };
 }
 
-function NullableArrayOfNonNullableFragment() {
+function NullableArrayFragment() {
     interface Props {
         users: UserComponent_users$key | null;
     }
@@ -307,7 +307,7 @@ function NullableArrayOfNonNullableFragment() {
     };
 }
 
-function NonNullableArrayOfNullableFragment() {
+function ArrayOfNullableFragment() {
     interface Props {
         users: ReadonlyArray<UserComponent_users$key[0] | null>;
     }
@@ -324,39 +324,6 @@ function NonNullableArrayOfNullableFragment() {
             `,
             props.users,
         );
-
-        return data.map(d => (
-            <>
-                <h1>{d!.name}</h1>
-                <div>
-                    <img src={d!.profile_picture.uri} />
-                </div>
-            </>
-        ));
-    };
-}
-
-function NullableArrayOfNullableFragment() {
-    interface Props {
-        users: ReadonlyArray<UserComponent_users$key[0] | null> | null;
-    }
-
-    return function UserComponent(props: Props) {
-        const data = useFragment(
-            graphql`
-                fragment UserComponent_users on User @relay(plural: true) {
-                    name
-                    profile_picture(scale: 2) {
-                        uri
-                    }
-                }
-            `,
-            props.users,
-        );
-
-        if (data === null) {
-            return null;
-        }
 
         return data.map(d => (
             <>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The previous implementation did not detect nullability properly and also missed handling 2 cases for arrays (`[X]!` and `[X!]`). 

To do this we always use the `TKey` generic parameter which should be the exact type of `XFragment_foo$key`. Nullability is determined by the type of the `fragmentRef` parameter (the fragment type doesn't actually encode nullability anyway). For arrays the key type will already be an array so we have to handle then slightly differently. We have one overload for each possible combinaison of nullability (2 for regular fields, 4 for arrays).

- Type `ReturnType` is the non-nullable type for a regular field key. Nullability is added on usage.
- Type `NonNullableArrayReturnType` is the non-nullable array type for an array field key. Nullability of the **field** is added on usage.
- Type `NullableArrayReturnType` is the nullable array type for an array field key. Nullability of the **field** is added on usage.

Tested all 6 possible combinaisons of array / nullability with `useFragment<XFragment_foo$key>(...)` and validated that the ts type returned matched the nullability / and whether it's an array of the schema.

