### PR TITLE
fix(define‑properties): Improve `map` parameter type

### DIFF
--- a/types/define-properties/define-properties-tests.ts
+++ b/types/define-properties/define-properties-tests.ts
@@ -18,7 +18,7 @@ define(object);
 define(null, {});
 
 define(object, {
-	getFoo() {
+	getFoo() { // $ExpectType () => string
 		this; // $ExpectType any
 
 		return __classPrivateFieldGet(this, object_foo);
@@ -26,22 +26,21 @@ define(object, {
 });
 
 define(object, {
-	foo: 'any'
+	foo: 'any' // $ExpectType string
 }, {
 	foo: () => (object as any).foo !== 'any'
 });
 
-// $ExpectError
 define(object, {
-	foo: 'any'
+	foo: 'any' // $ExpectType string
 }, {
 	foo: () => (object as any).foo !== 'any',
-	bar: () => { throw new Error(); },
+	bar: () => { throw new Error(); }, // $ExpectError
 });
 
 define(object, {
-	foo: 'any',
-	bar: 'valid'
+	foo: 'any', // $ExpectType string
+	bar: 'valid' // $ExpectType string
 }, {
 	foo: () => (object as any).foo !== 'any',
 });

--- a/types/define-properties/index.d.ts
+++ b/types/define-properties/index.d.ts
@@ -19,9 +19,9 @@ declare namespace defineProperties {
  * @param map The map of newly defined properties.
  * @param predicates The optional predicates map, return `true` to override existing properties on `object`.
  */
-declare function defineProperties<K extends keyof any>(
+declare function defineProperties<M extends object>(
 	object: object,
-	map: Record<K, any> & ThisType<any>,
-	predicates?: Partial<Record<K, () => boolean>>,
+	map: M & ThisType<any>,
+	predicates?: Partial<Record<keyof M, () => boolean>>,
 ): void;
 export = defineProperties;


### PR DESCRIPTION
While&nbsp;using the&nbsp;current type&nbsp;definition for&nbsp;[`define‑properties`](https://github.com/ljharb/define-properties), I’ve&nbsp;noticed&nbsp;that it&nbsp;doesn’t&nbsp;really work&nbsp;well&nbsp;with&nbsp;**IntelliSense**, especially&nbsp;when&nbsp;using `define‑properties` to&nbsp;add&nbsp;methods.

This&nbsp;also&nbsp;moves the&nbsp;error&nbsp;reported when&nbsp;adding a&nbsp;predicate for&nbsp;a&nbsp;non‑existent&nbsp;property to&nbsp;the&nbsp;predicate’s&nbsp;location.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/ljharb/define-properties>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
