### PR TITLE
Update jspdf/index.d.ts

### DIFF
--- a/types/jspdf/index.d.ts
+++ b/types/jspdf/index.d.ts
@@ -147,7 +147,11 @@ declare module 'jspdf' {
         cellInitialize():void;
         cell(x:number, y:number, w:number, h:number, txt:string, ln:number, align:string):jsPDF;
         arrayMax(array:any[], comparisonFn?:Function):number;
-        table(x:number, y:number, data:any, headers:string[], config:any):jsPDF;
+        table(x:number, y:number, data:any, headers:{"name": string,
+            "prompt"?: string,
+            "width"?: number,
+            "align"?: string,
+            "padding"?: number}[], config:any):jsPDF;
         calculateLineHeight(headerNames:string[], columnWidths:number[], model:any[]):number;
         setTableHeaderRow(config:any[]):void;
         printHeaderRow(lineNumber:number, new_page?:boolean):void;


### PR DESCRIPTION
Change the type of the argument `headers`of the method `table` from a string array to an object array (with specific properties).

See: https://github.com/MrRio/jsPDF/issues/2223
(first answer)

Source code:
https://github.com/MrRio/jsPDF/blob/master/src/modules/cell.js

