### PR TITLE
Add missing "getBy" types

### DIFF
--- a/types/testing-library__cypress/index.d.ts
+++ b/types/testing-library__cypress/index.d.ts
@@ -7,6 +7,7 @@
 //                 Brian Ng <https://github.com/existentialism>
 //                 Airat Aminev <https://github.com/airato>
 //                 Simon Jespersen <https://github.com/simjes>
+//                 Hugh Loughrey <https://github.com/hloughrey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -28,6 +29,262 @@ export type SelectorMatcherOptions = DTLSelectorMatcherOptions | CTLMatcherOptio
 declare global {
     namespace Cypress {
         interface Chainable<Subject = any> {
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByLabelText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByPlaceholderText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByDisplayValue(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByRole(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByLabelText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByPlaceholderText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByDisplayValue(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByRole(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+            /**
+             * dom-testing-library helpers for Cypress
+             *
+             * `findBy*` APIs search for an element and throw an error if nothing found
+             * `findAllBy*` APIs search for all elements and an error if nothing found
+             * `queryBy*` APIs search for an element and returns null if nothing found
+             * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+             * `getBy*` APIs search for an element and returns null if nothing found
+             * `getAllBy*` APIs search for all elements and return empty array if nothing found
+             *
+             *
+             * @see https://github.com/testing-library/cypress-testing-library#usage
+             * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+             */
+            getAllByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
             /**
              * dom-testing-library helpers for Cypress
              *

--- a/types/testing-library__cypress/testing-library__cypress-tests.ts
+++ b/types/testing-library__cypress/testing-library__cypress-tests.ts
@@ -49,3 +49,23 @@ cy.queryAllByRole('foo', { container }); // $ExpectType Chainable<JQuery<HTMLEle
 
 const $container = cy.$$('body').append('div');
 cy.queryAllByRole('foo', { container: $container }); // $ExpectType Chainable<JQuery<HTMLElement>>
+
+// getBy*
+cy.getByPlaceholderText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.getByText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.getByLabelText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.getByAltText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.getByTestId('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.getByTitle('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.getByDisplayValue('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.getByRole('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+
+// getAllBy*
+cy.getAllByPlaceholderText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.getAllByText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.getAllByLabelText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.getAllByAltText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.getAllByTestId('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.getAllByTitle('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.getAllByDisplayValue('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.getAllByRole('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.