### PR TITLE
[react-jsonschema-form] Add onBlur to FormProps

### DIFF
--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -35,7 +35,7 @@ declare module 'react-jsonschema-form' {
         showErrorList?: boolean;
         ErrorList?: React.StatelessComponent<ErrorListProps>;
         validate?: (formData: T, errors: FormValidation) => FormValidation;
-        onBlur?: (...e: any[]) => any;
+        onBlur?: (id: string, value: boolean | number | string | null) => void;
         onChange?: (e: IChangeEvent<T>, es?: ErrorSchema) => any;
         onError?: (e: any) => any;
         onSubmit?: (e: ISubmitEvent<T>) => any;

--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -35,7 +35,7 @@ declare module 'react-jsonschema-form' {
         showErrorList?: boolean;
         ErrorList?: React.StatelessComponent<ErrorListProps>;
         validate?: (formData: T, errors: FormValidation) => FormValidation;
-        onBlur?: (e: any[]) => any;
+        onBlur?: (...e: any[]) => any;
         onChange?: (e: IChangeEvent<T>, es?: ErrorSchema) => any;
         onError?: (e: any) => any;
         onSubmit?: (e: ISubmitEvent<T>) => any;

--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -10,6 +10,7 @@
 //                 Saad Tazi <https://github.com/saadtazi>
 //                 Agustin N. R. Ramirez <https://github.com/agustin107>
 //                 Chancellor Clark <https://github.com/chanceaclark>
+//                 Benoît Sepe <https://github.com/ogdentrod>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.5
 
@@ -34,6 +35,7 @@ declare module 'react-jsonschema-form' {
         showErrorList?: boolean;
         ErrorList?: React.StatelessComponent<ErrorListProps>;
         validate?: (formData: T, errors: FormValidation) => FormValidation;
+        onBlur?: (e: any[]) => any;
         onChange?: (e: IChangeEvent<T>, es?: ErrorSchema) => any;
         onError?: (e: any) => any;
         onSubmit?: (e: ISubmitEvent<T>) => any;


### PR DESCRIPTION
As of the documentation (https://react-jsonschema-form.readthedocs.io/en/latest/#form-field-blur-events) and the code (https://github.com/rjsf-team/react-jsonschema-form/blob/master/src/components/Form.js#L229) the function onBlur should be a prop of the component Form

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-jsonschema-form.readthedocs.io/en/latest/#form-field-blur-events



