### PR TITLE
fix: correct prismic-dom's Elements type

### DIFF
--- a/types/prismic-dom/index.d.ts
+++ b/types/prismic-dom/index.d.ts
@@ -22,6 +22,7 @@ interface Elements {
     oListItem: 'o-list-item';
     list: 'group-list-item';
     oList: 'group-o-list-item';
+    image: 'image';
     embed: 'embed';
     hyperlink: 'hyperlink';
     label: 'label';

--- a/types/prismic-dom/index.d.ts
+++ b/types/prismic-dom/index.d.ts
@@ -3,31 +3,32 @@
 // Definitions by: Nick Whyte <https://github.com/nickw444>
 //                 Siggy Bilstein <https://github.com/sbilstein>
 //                 Douglas Nomizo <https://github.com/douglasnomizo>
+//                 Henry Myers <https://github.com/henrymyers>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-type ElementType =
-    | "heading1"
-    | "heading2"
-    | "heading3"
-    | "heading4"
-    | "heading5"
-    | "heading6"
-    | "paragraph"
-    | "preformatted"
-    | "strong"
-    | "em"
-    | "list-item"
-    | "o-list-item"
-    | "group-list-item"
-    | "group-o-list-item"
-    | "image"
-    | "embed"
-    | "hyperlink"
-    | "label"
-    | "span";
+interface Elements {
+    heading1: 'heading1';
+    heading2: 'heading2';
+    heading3: 'heading3';
+    heading4: 'heading4';
+    heading5: 'heading5';
+    heading6: 'heading6';
+    paragraph: 'paragraph';
+    preformatted: 'preformatted';
+    strong: 'strong';
+    em: 'em';
+    listItem: 'list-item';
+    oListItem: 'o-list-item';
+    list: 'group-list-item';
+    oList: 'group-o-list-item';
+    embed: 'embed';
+    hyperlink: 'hyperlink';
+    label: 'label';
+    span: 'span';
+}
 
-type Elements = {[key in ElementType]: string};
+type ElementType = Elements[keyof Elements];
 
 type HTMLSerializer<T> = (
     type: ElementType,


### PR DESCRIPTION
## Description
Previously, the strings contained in your `ElementType` were the _values_ of `Elements` rather than the _keys_. This meant that trying to access `Elements.oListItem` caused a tslint error, although it is part of [the actual object](https://github.com/prismicio/prismic-richtext/blob/master/src/types.ts#L3-L23) that prismic-dom imports from prismic-richtext.

As I also took the time to fix the type generation of the [prismic-richtext repo](https://github.com/prismicio/prismic-richtext/pull/27), you can see the "real" type generated from `Elements` [here](https://github.com/prismicio/prismic-richtext/pull/27/files#diff-d6f599f5fed52e501602d6edaf737c33R11-R31).

> Note: While the official type only specifies that the values are strings, I chose to specify the string literals here for more precision. I'd like to eventually convert prismic-richtext's `Elements` to a string enum (after which we can update this package to use `declare enum Elements`).

## Checklist
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~

