### PR TITLE
Add definitions for react-toast-notifications

### DIFF
--- a/types/react-toast-notifications/index.d.ts
+++ b/types/react-toast-notifications/index.d.ts
@@ -1,0 +1,84 @@
+// Type definitions for react-toast-notifications 2.0
+// Project: https://github.com/jossmac/react-toast-notifications
+// Definitions by: Spencer Elliott <https://github.com/elliottsj>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import { ReactNode, ComponentType } from 'react';
+
+export type AppearanceTypes = 'error' | 'info' | 'success' | 'warning';
+
+export type Placement = 'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right';
+
+export type TransitionState = 'entering' | 'entered' | 'exiting' | 'exited';
+
+export interface ToastProps {
+    appearance: AppearanceTypes;
+    autoDismiss: boolean | number;
+    autoDismissTimeout: number; // inherited from ToastProvider
+    children: ReactNode;
+    isRunning: boolean;
+    onDismiss: (id?: string) => void;
+    onMouseEnter: () => void;
+    onMouseLeave: () => void;
+    placement: Placement;
+    transitionDuration: number; // inherited from ToastProvider
+    transitionState: TransitionState; // inherited from ToastProvider
+}
+
+export interface ToastConsumerContext {
+    add: AddToast;
+    remove: RemoveToast;
+    toasts: Array<{
+        content: ReactNode;
+        id: string;
+        appearance: AppearanceTypes;
+    }>;
+}
+
+export interface ToastConsumerProps {
+    children: (context: ToastConsumerContext) => ReactNode;
+}
+
+export interface ToastContainerProps {
+    children: ReactNode;
+    hasToasts: boolean;
+    placement: Placement;
+}
+
+export interface ToastProviderProps {
+    autoDismissTimeout?: number;
+    children: ReactNode;
+    components?: {
+        ToastContainer?: ComponentType<ToastContainerProps>;
+        Toast?: ComponentType<ToastProps>;
+    };
+    placement?: Placement;
+    transitionDuration?: number;
+}
+
+export interface Options {
+    appearance: AppearanceTypes;
+    autoDismiss?: boolean;
+    onDismiss?: (id: string) => void;
+    pauseOnHover?: boolean;
+}
+
+export type AddToast = (content: ReactNode, options?: Options, callback?: (id: string) => void) => void;
+
+export type RemoveToast = (id: string, callback: () => void) => void;
+
+export const DefaultToastContainer: ComponentType<ToastContainerProps>;
+export const DefaultToast: ComponentType<ToastProps>;
+export const ToastConsumer: ComponentType<ToastConsumerProps>;
+export const ToastProvider: ComponentType<ToastProviderProps>;
+export function withToastManager(...args: any[]): any;
+export function useToasts(): {
+    addToast: AddToast;
+    removeToast: RemoveToast;
+    toastStack: Array<{
+        content: ReactNode;
+        id: string;
+        appearance: AppearanceTypes;
+    }>;
+};

--- a/types/react-toast-notifications/react-toast-notifications-tests.tsx
+++ b/types/react-toast-notifications/react-toast-notifications-tests.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { DefaultToast, ToastProps, ToastProvider, useToasts, ToastConsumer } from 'react-toast-notifications';
+
+const CustomToast: React.FC<ToastProps> = ({ children, ...props }) => (
+    <DefaultToast {...props}>
+        <div className="custom">{children}</div>
+    </DefaultToast>
+);
+
+const MyApp: React.FC = () => (
+    <ToastProvider>
+        <Main1 />
+        <Main2 />
+    </ToastProvider>
+);
+
+const Main1: React.FC = () => (
+    <ToastConsumer>
+        {context => (
+            <div>
+                <button onClick={() => context.add('Toast')}>Add</button>
+            </div>
+        )}
+    </ToastConsumer>
+);
+
+const Main2: React.FC = () => {
+    const { addToast, removeToast, toastStack } = useToasts();
+
+    return (
+        <div>
+            <button onClick={() => addToast('Toast')}>Add</button>
+        </div>
+    );
+};

--- a/types/react-toast-notifications/tsconfig.json
+++ b/types/react-toast-notifications/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "jsx": "react",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-toast-notifications-tests.tsx"
+    ]
+}

--- a/types/react-toast-notifications/tslint.json
+++ b/types/react-toast-notifications/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

    Failed with:

    ```
    Error: Errors in typescript@next for external dependencies:
    ../react/index.d.ts(33,22): error TS2307: Cannot find module 'csstype'.
    ```

    https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24788

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
