### PR TITLE
Add types for float-equal version 2.0.0

### DIFF
--- a/types/float-equal/float-equal-tests.ts
+++ b/types/float-equal/float-equal-tests.ts
@@ -1,0 +1,3 @@
+import floatEqual = require("float-equal");
+
+floatEqual(0.1 + 0.2, 0.3);  // $ExpectType boolean

--- a/types/float-equal/index.d.ts
+++ b/types/float-equal/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for float-equal 2.0
+// Project: https://github.com/sindresorhus/float-equal#readme
+// Definitions by: Dolan Murvihill <https://github.com/dmurvihill>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function floatEqual(a: number, b: number): boolean;
+export = floatEqual;

--- a/types/float-equal/tsconfig.json
+++ b/types/float-equal/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "float-equal-tests.ts"
+    ]
+}

--- a/types/float-equal/tslint.json
+++ b/types/float-equal/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Getting `dependency form-data not in the whitelist` errors from `npm test`, which doesn't seem like an issue this change caused.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [?] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.