### PR TITLE
[chart.js] Add weight property to ChartDataSets interface for Doughnut/Pie charts.

### DIFF
--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -26,18 +26,14 @@
 declare class Chart {
     static readonly Chart: typeof Chart;
     constructor(
-        context:
-            | string
-            | CanvasRenderingContext2D
-            | HTMLCanvasElement
-            | ArrayLike<CanvasRenderingContext2D | HTMLCanvasElement>,
-        options: Chart.ChartConfiguration,
+        context: string | CanvasRenderingContext2D | HTMLCanvasElement | ArrayLike<CanvasRenderingContext2D | HTMLCanvasElement>,
+        options: Chart.ChartConfiguration
     );
     config: Chart.ChartConfiguration;
     data: Chart.ChartData;
     destroy: () => {};
-    update: ({ duration, lazy, easing }?: Chart.ChartUpdateProps) => {};
-    render: ({ duration, lazy, easing }?: Chart.ChartRenderProps) => {};
+    update: ({duration, lazy, easing}?: Chart.ChartUpdateProps) => {};
+    render: ({duration, lazy, easing}?: Chart.ChartRenderProps) => {};
     stop: () => {};
     resize: () => {};
     clear: () => {};
@@ -82,12 +78,12 @@ interface Meta {
     type: Chart.ChartType;
     data: MetaData[];
     dataset?: Chart.ChartDataSets;
-    controller: { [key: string]: any };
+    controller: { [key: string]: any; };
     hidden?: boolean;
     total?: string;
     xAxisID?: string;
     yAxisID?: string;
-    $filler?: { [key: string]: any };
+    "$filler"?: { [key: string]: any; };
 }
 
 interface MetaData {
@@ -123,69 +119,22 @@ interface Model {
 }
 
 declare namespace Chart {
-    type ChartType =
-        | 'line'
-        | 'bar'
-        | 'horizontalBar'
-        | 'radar'
-        | 'doughnut'
-        | 'polarArea'
-        | 'bubble'
-        | 'pie'
-        | 'scatter';
+    type ChartType = 'line' | 'bar' | 'horizontalBar' | 'radar' | 'doughnut' | 'polarArea' | 'bubble' | 'pie' | 'scatter';
 
     type TimeUnit = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year';
 
     type ScaleType = 'category' | 'linear' | 'logarithmic' | 'time' | 'radialLinear';
 
-    type PointStyle =
-        | 'circle'
-        | 'cross'
-        | 'crossRot'
-        | 'dash'
-        | 'line'
-        | 'rect'
-        | 'rectRounded'
-        | 'rectRot'
-        | 'star'
-        | 'triangle';
+    type PointStyle = 'circle' | 'cross' | 'crossRot' | 'dash' | 'line' | 'rect' | 'rectRounded' | 'rectRot' | 'star' | 'triangle';
 
     type PositionType = 'left' | 'right' | 'top' | 'bottom' | 'chartArea';
 
     type InteractionMode = 'point' | 'nearest' | 'single' | 'label' | 'index' | 'x-axis' | 'dataset' | 'x' | 'y';
 
-    type Easing =
-        | 'linear'
-        | 'easeInQuad'
-        | 'easeOutQuad'
-        | 'easeInOutQuad'
-        | 'easeInCubic'
-        | 'easeOutCubic'
-        | 'easeInOutCubic'
-        | 'easeInQuart'
-        | 'easeOutQuart'
-        | 'easeInOutQuart'
-        | 'easeInQuint'
-        | 'easeOutQuint'
-        | 'easeInOutQuint'
-        | 'easeInSine'
-        | 'easeOutSine'
-        | 'easeInOutSine'
-        | 'easeInExpo'
-        | 'easeOutExpo'
-        | 'easeInOutExpo'
-        | 'easeInCirc'
-        | 'easeOutCirc'
-        | 'easeInOutCirc'
-        | 'easeInElastic'
-        | 'easeOutElastic'
-        | 'easeInOutElastic'
-        | 'easeInBack'
-        | 'easeOutBack'
-        | 'easeInOutBack'
-        | 'easeInBounce'
-        | 'easeOutBounce'
-        | 'easeInOutBounce';
+    type Easing = 'linear' | 'easeInQuad' | 'easeOutQuad' | 'easeInOutQuad' | 'easeInCubic' | 'easeOutCubic' | 'easeInOutCubic' |
+        'easeInQuart' | 'easeOutQuart' | 'easeInOutQuart' | 'easeInQuint' | 'easeOutQuint' | 'easeInOutQuint' | 'easeInSine' | 'easeOutSine' |
+        'easeInOutSine' | 'easeInExpo' | 'easeOutExpo' | 'easeInOutExpo' | 'easeInCirc' | 'easeOutCirc' | 'easeInOutCirc' | 'easeInElastic' |
+        'easeOutElastic' | 'easeInOutElastic' | 'easeInBack' | 'easeOutBack' | 'easeInOutBack' | 'easeInBounce' | 'easeOutBounce' | 'easeInOutBounce';
 
     type TextAlignment = 'left' | 'center' | 'right';
 
@@ -610,7 +559,7 @@ declare namespace Chart {
         fontFamily?: string;
         fontSize?: number;
         fontStyle?: string;
-        lineHeight?: number | string;
+        lineHeight?: number|string;
     }
 
     interface LinearTickOptions extends TickOptions {
@@ -622,14 +571,15 @@ declare namespace Chart {
     }
 
     // tslint:disable-next-line no-empty-interface
-    interface LogarithmicTickOptions extends TickOptions {}
+    interface LogarithmicTickOptions extends TickOptions {
+    }
 
     type ChartColor = string | CanvasGradient | CanvasPattern | string[];
 
     type Scriptable<T> = (ctx: {
         chart?: Chart;
         dataIndex?: number;
-        dataset?: ChartDataSets;
+        dataset?: ChartDataSets
         datasetIndex?: number;
     }) => T;
 
@@ -663,12 +613,7 @@ declare namespace Chart {
         pointHoverBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
         pointHoverBorderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
         pointHoverBorderWidth?: number | number[] | Scriptable<number>;
-        pointStyle?:
-            | PointStyle
-            | HTMLImageElement
-            | HTMLCanvasElement
-            | Array<PointStyle | HTMLImageElement | HTMLCanvasElement>
-            | Scriptable<PointStyle | HTMLImageElement | HTMLCanvasElement>;
+        pointStyle?: PointStyle | HTMLImageElement | HTMLCanvasElement | Array<PointStyle | HTMLImageElement | HTMLCanvasElement> | Scriptable<PointStyle | HTMLImageElement | HTMLCanvasElement>;
         radius?: number | number[] | Scriptable<number>;
         rotation?: number | number[] | Scriptable<number>;
         xAxisID?: string;
@@ -702,7 +647,7 @@ declare namespace Chart {
         position?: string;
         ticks?: TickOptions;
         gridLines?: GridLineOptions;
-        barThickness?: number | 'flex';
+        barThickness?: number | "flex";
         maxBarThickness?: number;
         minBarLength?: number;
         scaleLabel?: ScaleTitleOptions;
@@ -731,7 +676,8 @@ declare namespace Chart {
     }
 
     // tslint:disable-next-line no-empty-interface
-    interface ChartYAxe extends CommonAxe {}
+    interface ChartYAxe extends CommonAxe {
+    }
 
     interface LinearScale extends ChartScales {
         ticks?: LinearTickOptions;

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -624,6 +624,7 @@ declare namespace Chart {
         showLine?: boolean;
         stack?: string;
         spanGaps?: boolean;
+        weight?: number;
     }
 
     interface ChartScales {

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -26,14 +26,18 @@
 declare class Chart {
     static readonly Chart: typeof Chart;
     constructor(
-        context: string | CanvasRenderingContext2D | HTMLCanvasElement | ArrayLike<CanvasRenderingContext2D | HTMLCanvasElement>,
-        options: Chart.ChartConfiguration
+        context:
+            | string
+            | CanvasRenderingContext2D
+            | HTMLCanvasElement
+            | ArrayLike<CanvasRenderingContext2D | HTMLCanvasElement>,
+        options: Chart.ChartConfiguration,
     );
     config: Chart.ChartConfiguration;
     data: Chart.ChartData;
     destroy: () => {};
-    update: ({duration, lazy, easing}?: Chart.ChartUpdateProps) => {};
-    render: ({duration, lazy, easing}?: Chart.ChartRenderProps) => {};
+    update: ({ duration, lazy, easing }?: Chart.ChartUpdateProps) => {};
+    render: ({ duration, lazy, easing }?: Chart.ChartRenderProps) => {};
     stop: () => {};
     resize: () => {};
     clear: () => {};
@@ -78,12 +82,12 @@ interface Meta {
     type: Chart.ChartType;
     data: MetaData[];
     dataset?: Chart.ChartDataSets;
-    controller: { [key: string]: any; };
+    controller: { [key: string]: any };
     hidden?: boolean;
     total?: string;
     xAxisID?: string;
     yAxisID?: string;
-    "$filler"?: { [key: string]: any; };
+    $filler?: { [key: string]: any };
 }
 
 interface MetaData {
@@ -119,22 +123,69 @@ interface Model {
 }
 
 declare namespace Chart {
-    type ChartType = 'line' | 'bar' | 'horizontalBar' | 'radar' | 'doughnut' | 'polarArea' | 'bubble' | 'pie' | 'scatter';
+    type ChartType =
+        | 'line'
+        | 'bar'
+        | 'horizontalBar'
+        | 'radar'
+        | 'doughnut'
+        | 'polarArea'
+        | 'bubble'
+        | 'pie'
+        | 'scatter';
 
     type TimeUnit = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year';
 
     type ScaleType = 'category' | 'linear' | 'logarithmic' | 'time' | 'radialLinear';
 
-    type PointStyle = 'circle' | 'cross' | 'crossRot' | 'dash' | 'line' | 'rect' | 'rectRounded' | 'rectRot' | 'star' | 'triangle';
+    type PointStyle =
+        | 'circle'
+        | 'cross'
+        | 'crossRot'
+        | 'dash'
+        | 'line'
+        | 'rect'
+        | 'rectRounded'
+        | 'rectRot'
+        | 'star'
+        | 'triangle';
 
     type PositionType = 'left' | 'right' | 'top' | 'bottom' | 'chartArea';
 
     type InteractionMode = 'point' | 'nearest' | 'single' | 'label' | 'index' | 'x-axis' | 'dataset' | 'x' | 'y';
 
-    type Easing = 'linear' | 'easeInQuad' | 'easeOutQuad' | 'easeInOutQuad' | 'easeInCubic' | 'easeOutCubic' | 'easeInOutCubic' |
-        'easeInQuart' | 'easeOutQuart' | 'easeInOutQuart' | 'easeInQuint' | 'easeOutQuint' | 'easeInOutQuint' | 'easeInSine' | 'easeOutSine' |
-        'easeInOutSine' | 'easeInExpo' | 'easeOutExpo' | 'easeInOutExpo' | 'easeInCirc' | 'easeOutCirc' | 'easeInOutCirc' | 'easeInElastic' |
-        'easeOutElastic' | 'easeInOutElastic' | 'easeInBack' | 'easeOutBack' | 'easeInOutBack' | 'easeInBounce' | 'easeOutBounce' | 'easeInOutBounce';
+    type Easing =
+        | 'linear'
+        | 'easeInQuad'
+        | 'easeOutQuad'
+        | 'easeInOutQuad'
+        | 'easeInCubic'
+        | 'easeOutCubic'
+        | 'easeInOutCubic'
+        | 'easeInQuart'
+        | 'easeOutQuart'
+        | 'easeInOutQuart'
+        | 'easeInQuint'
+        | 'easeOutQuint'
+        | 'easeInOutQuint'
+        | 'easeInSine'
+        | 'easeOutSine'
+        | 'easeInOutSine'
+        | 'easeInExpo'
+        | 'easeOutExpo'
+        | 'easeInOutExpo'
+        | 'easeInCirc'
+        | 'easeOutCirc'
+        | 'easeInOutCirc'
+        | 'easeInElastic'
+        | 'easeOutElastic'
+        | 'easeInOutElastic'
+        | 'easeInBack'
+        | 'easeOutBack'
+        | 'easeInOutBack'
+        | 'easeInBounce'
+        | 'easeOutBounce'
+        | 'easeInOutBounce';
 
     type TextAlignment = 'left' | 'center' | 'right';
 
@@ -559,7 +610,7 @@ declare namespace Chart {
         fontFamily?: string;
         fontSize?: number;
         fontStyle?: string;
-        lineHeight?: number|string;
+        lineHeight?: number | string;
     }
 
     interface LinearTickOptions extends TickOptions {
@@ -571,15 +622,14 @@ declare namespace Chart {
     }
 
     // tslint:disable-next-line no-empty-interface
-    interface LogarithmicTickOptions extends TickOptions {
-    }
+    interface LogarithmicTickOptions extends TickOptions {}
 
     type ChartColor = string | CanvasGradient | CanvasPattern | string[];
 
     type Scriptable<T> = (ctx: {
         chart?: Chart;
         dataIndex?: number;
-        dataset?: ChartDataSets
+        dataset?: ChartDataSets;
         datasetIndex?: number;
     }) => T;
 
@@ -613,7 +663,12 @@ declare namespace Chart {
         pointHoverBackgroundColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
         pointHoverBorderColor?: ChartColor | ChartColor[] | Scriptable<ChartColor>;
         pointHoverBorderWidth?: number | number[] | Scriptable<number>;
-        pointStyle?: PointStyle | HTMLImageElement | HTMLCanvasElement | Array<PointStyle | HTMLImageElement | HTMLCanvasElement> | Scriptable<PointStyle | HTMLImageElement | HTMLCanvasElement>;
+        pointStyle?:
+            | PointStyle
+            | HTMLImageElement
+            | HTMLCanvasElement
+            | Array<PointStyle | HTMLImageElement | HTMLCanvasElement>
+            | Scriptable<PointStyle | HTMLImageElement | HTMLCanvasElement>;
         radius?: number | number[] | Scriptable<number>;
         rotation?: number | number[] | Scriptable<number>;
         xAxisID?: string;
@@ -647,7 +702,7 @@ declare namespace Chart {
         position?: string;
         ticks?: TickOptions;
         gridLines?: GridLineOptions;
-        barThickness?: number | "flex";
+        barThickness?: number | 'flex';
         maxBarThickness?: number;
         minBarLength?: number;
         scaleLabel?: ScaleTitleOptions;
@@ -676,8 +731,7 @@ declare namespace Chart {
     }
 
     // tslint:disable-next-line no-empty-interface
-    interface ChartYAxe extends CommonAxe {
-    }
+    interface ChartYAxe extends CommonAxe {}
 
     interface LinearScale extends ChartScales {
         ticks?: LinearTickOptions;


### PR DESCRIPTION
The Chart.js Doughnut/Pie chart can accept a `weight` property that will affect the ring weight but it wasn't yet supported by @types/chart.js so I created this PR. I also ran prettier on the index.d.ts file and added those changes to this PR. I put them on a separate commit to separate the actual change from the cosmetic changes.

Please let me know if you would prefer I remove the prettier fixes from this PR and put them on a different PR or just not do them at all.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * https://www.chartjs.org/docs/latest/charts/doughnut.html
  * https://github.com/chartjs/Chart.js/blob/master/src/controllers/controller.doughnut.js
