### PR TITLE
[mongoose] Add a missing custom validator and error message param

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -1123,7 +1123,8 @@ declare module "mongoose" {
     validate?: RegExp | [RegExp, string] |
     SchemaTypeOpts.ValidateFn<T> | [SchemaTypeOpts.ValidateFn<T>, string] |
     SchemaTypeOpts.ValidateOpts | SchemaTypeOpts.AsyncValidateOpts |
-    SchemaTypeOpts.AsyncPromiseValidationFn<T> | SchemaTypeOpts.AsyncPromiseValidationOpts |
+    SchemaTypeOpts.AsyncPromiseValidationFn<T> | [SchemaTypeOpts.AsyncPromiseValidationFn<T>, string] |
+    SchemaTypeOpts.AsyncPromiseValidationOpts |
     (SchemaTypeOpts.ValidateOpts | SchemaTypeOpts.AsyncValidateOpts |
       SchemaTypeOpts.AsyncPromiseValidationFn<T> | SchemaTypeOpts.AsyncPromiseValidationOpts)[];
 
@@ -1198,6 +1199,7 @@ declare module "mongoose" {
 
     interface ValidateOptsBase {
       msg?: string;
+      message?: string;
       type?: string;
     }
 

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -631,6 +631,14 @@ new mongoose.Schema({
     }
   },
 });
+new mongoose.Schema({
+  fnOnly: { type: String, validate: () => true },
+  fnStringArray: { type: String, validate: [() => true, 'failed'] },
+  fnStringObject: { type: String, validate: { validator: () => true, message: 'failed' } },
+  promiseFnOnly: { type: String, validate: () => Promise.reject(new Error('oops')) },
+  promiseFnStringArray: { type: String, validate: [() => Promise.reject(), 'oops'] },
+  promiseFnStringObject: { type: String, validate: { validator: () => Promise.reject(), message: 'oops' } },
+});
 new mongoose.Schema({ name: { type: String, validate: [
   { validator: () => {return true}, msg: 'uh oh' },
   { validator: () => {return true}, msg: 'failed' }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: It's mentioned briefly in the [API docs](https://mongoosejs.com/docs/api.html#schematype_SchemaType-validate), but it's possible to provide an array of `[validator, message]` where `validator` is not only a `() => boolean` but also a `() => Promise<boolean>`. In other words, you can supply an async custom validator into the array as well! Also, `msg` seems to be the older prop, the [currently documented](https://mongoosejs.com/docs/validation.html#custom-validators) one is `message`. Both are [optional](https://github.com/Automattic/mongoose/blob/de3eee5122f462eff41c86fe39dec197d655afed/lib/schematype.js#L681), but `message` should certainly be included in the types.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

To sum it up, this PR enables two forms of syntax in `Schema.validate`:
1. `[(value: T) =>`**`Promise<boolean>`**`, string]` and
2. `{ validator: () => true,`**`message`**`: 'error' }`