### PR TITLE
[next@8.0] Add statusCode to `err` object in NextContext

### DIFF
--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -89,7 +89,7 @@ declare namespace next {
         /** Fetch Response object (client only) - from https://developer.mozilla.org/en-US/docs/Web/API/Response */
         jsonPageRes?: NodeResponse;
         /** Error object if any error is encountered during the rendering */
-        err?: Error;
+        err?: Error & { statusCode?: number };
     }
 
     /**


### PR DESCRIPTION
Fixes #34419.

**Note:** This is a maintenance fix for `next@^8.0.0`. Next.js already includes their own typings as of `v9.0.0`, so if you're already running that version, you don't need to install `@types/next`.

cc: @Dru89 @brikou @jthegedus @scottdj92 @joaovieira @ajliv

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34419
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
