### PR TITLE
[styled-components] Update for TypeScript 3.7

### DIFF
--- a/types/styled-components/package.json
+++ b/types/styled-components/package.json
@@ -2,5 +2,9 @@
     "private": true,
     "dependencies": {
         "csstype": "^2.2.0"
+    },
+    "types": "index",
+    "typesVersions": {
+        ">=3.7.0-0": { "*": ["ts3.7/*"] }
     }
 }

--- a/types/styled-components/ts3.7/cssprop.d.ts
+++ b/types/styled-components/ts3.7/cssprop.d.ts
@@ -1,0 +1,19 @@
+import {} from "react";
+import { CSSProp } from ".";
+
+declare module "react" {
+  interface Attributes {
+      // NOTE: unlike the plain javascript version, it is not possible to get access
+      // to the element's own attributes inside function interpolations.
+      // Only theme will be accessible, and only with the DefaultTheme due to the global
+      // nature of this declaration.
+      // If you are writing this inline you already have access to all the attributes anyway,
+      // no need for the extra indirection.
+      /**
+       * If present, this React element will be converted by
+       * `babel-plugin-styled-components` into a styled component
+       * with the given css as its styles.
+       */
+      css?: CSSProp;
+  }
+}

--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -1,0 +1,514 @@
+// Type definitions for styled-components 4.1
+// Project: https://github.com/styled-components/styled-components, https://styled-components.com
+// Definitions by: Igor Oleinikov <https://github.com/Igorbek>
+//                 Ihor Chulinda <https://github.com/Igmat>
+//                 Adam Lavin <https://github.com/lavoaster>
+//                 Jessica Franco <https://github.com/Jessidhia>
+//                 Jason Killian <https://github.com/jkillian>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
+//                 David Ruisinger <https://github.com/flavordaaave>
+//                 Matthew Wagerfield <https://github.com/wagerfield>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
+
+// forward declarations
+declare global {
+    namespace NodeJS {
+        // tslint:disable-next-line:no-empty-interface
+        interface ReadableStream {}
+    }
+}
+
+import * as CSS from "csstype";
+import * as React from "react";
+
+export type CSSProperties = CSS.Properties<string | number>;
+
+export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject };
+
+export interface CSSObject extends CSSProperties, CSSPseudos {
+    [key: string]: CSSObject | string | number | undefined;
+}
+
+export type CSSKeyframes = object & { [key: string]: CSSObject };
+
+export interface ThemeProps<T> {
+    theme: T;
+}
+
+export type ThemedStyledProps<P, T> = P & ThemeProps<T>;
+export type StyledProps<P> = ThemedStyledProps<P, AnyIfEmpty<DefaultTheme>>;
+
+// Any prop that has a default prop becomes optional, but its type is unchanged
+// Undeclared default props are augmented into the resulting allowable attributes
+// If declared props have indexed properties, ignore default props entirely as keyof gets widened
+// Wrap in an outer-level conditional type to allow distribution over props that are unions
+type Defaultize<P, D> = P extends any
+    ? string extends keyof P ? P :
+        & Pick<P, Exclude<keyof P, keyof D>>
+        & Partial<Pick<P, Extract<keyof P, keyof D>>>
+        & Partial<Pick<D, Exclude<keyof D, keyof P>>>
+    : never;
+
+type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D; }
+    ? Defaultize<P, D>
+    : P;
+
+export type StyledComponentProps<
+    // The Component from whose props are derived
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+    // The Theme from the current context
+    T extends object,
+    // The other props added by the template
+    O extends object,
+    // The props that are made optional by .attrs
+    A extends keyof any
+> =
+    // Distribute O if O is a union type
+    O extends object
+    ? WithOptionalTheme<
+          Omit<ReactDefaultizedProps<C, React.ComponentPropsWithRef<C>> & O, A> &
+              Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,
+          T
+      > &
+          WithChildrenIfReactComponentClass<C>
+    : never;
+
+// Because of React typing quirks, when getting props from a React.ComponentClass,
+// we need to manually add a `children` field.
+// See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31945
+// and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32843
+type WithChildrenIfReactComponentClass<
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
+> = C extends React.ComponentClass<any> ? { children?: React.ReactNode } : {};
+
+type StyledComponentPropsWithAs<
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+    T extends object,
+    O extends object,
+    A extends keyof any
+> = StyledComponentProps<C, T, O, A> & { as?: C };
+
+export type FalseyValue = undefined | null | false;
+export type Interpolation<P> =
+    | InterpolationValue
+    | FlattenInterpolation<P>
+    | InterpolationFunction<P>;
+// must be an interface to be self-referential
+export interface FlattenInterpolation<P>
+    extends ReadonlyArray<Interpolation<P>> {}
+export type InterpolationValue =
+    | string
+    | number
+    | FalseyValue
+    | Keyframes
+    | StyledComponentInterpolation
+    | CSSObject;
+export type SimpleInterpolation =
+    | InterpolationValue
+    | FlattenSimpleInterpolation;
+// must be an interface to be self-referential
+export interface FlattenSimpleInterpolation
+    extends ReadonlyArray<SimpleInterpolation> {}
+
+export type InterpolationFunction<P> = (props: P) => Interpolation<P>;
+
+type Attrs<P, A extends Partial<P>, T> =
+    | ((props: ThemedStyledProps<P, T>) => A)
+    | A;
+type DeprecatedAttrs<P, A extends Partial<P>, T> = {
+    [K in keyof A]: ((props: ThemedStyledProps<P, T>) => A[K]) | A[K]
+};
+
+export type ThemedGlobalStyledClassProps<P, T> = WithOptionalTheme<P, T> & {
+    suppressMultiMountWarning?: boolean;
+};
+
+export interface GlobalStyleComponent<P, T>
+    extends React.ComponentClass<ThemedGlobalStyledClassProps<P, T>> {}
+
+// remove the call signature from StyledComponent so Interpolation can still infer InterpolationFunction
+type StyledComponentInterpolation =
+    | Pick<
+          StyledComponentBase<any, any, any, any>,
+          keyof StyledComponentBase<any, any>
+      >
+    | Pick<
+          StyledComponentBase<any, any, any>,
+          keyof StyledComponentBase<any, any>
+      >;
+
+// abuse Pick to strip the call signature from ForwardRefExoticComponent
+type ForwardRefExoticBase<P> = Pick<
+    React.ForwardRefExoticComponent<P>,
+    keyof React.ForwardRefExoticComponent<any>
+>;
+
+// extracts React defaultProps
+type ReactDefaultProps<C> = C extends { defaultProps: infer D; } ? D : never;
+
+// any doesn't count as assignable to never in the extends clause, and we default A to never
+export type AnyStyledComponent =
+    | StyledComponent<any, any, any, any>
+    | StyledComponent<any, any, any>;
+
+export type StyledComponent<
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+    T extends object,
+    O extends object = {},
+    A extends keyof any = never
+> = // the "string" allows this to be used as an object key
+    // I really want to avoid this if possible but it's the only way to use nesting with object styles...
+    string & StyledComponentBase<C, T, O, A>;
+
+export interface StyledComponentBase<
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+    T extends object,
+    O extends object = {},
+    A extends keyof any = never
+> extends ForwardRefExoticBase<StyledComponentProps<C, T, O, A>> {
+    // add our own fake call signature to implement the polymorphic 'as' prop
+    // NOTE: TS <3.2 will refuse to infer the generic and this component becomes impossible to use in JSX
+    // just the presence of the overload is enough to break JSX
+    //
+    // TODO (TypeScript 3.2): actually makes the 'as' prop polymorphic
+    // (
+    //     props: StyledComponentProps<C, T, O, A> & { as?: never }
+    //   ): React.ReactElement<StyledComponentProps<C, T, O, A>>
+    // <AsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C>(
+    //   props: StyledComponentPropsWithAs<AsC, T, O, A>
+    // ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A>>
+
+    // TODO (TypeScript 3.2): delete this overload
+    (
+        props: StyledComponentProps<C, T, O, A> & {
+            /**
+             * Typing Note: prefer using .withComponent for now as it is actually type-safe.
+             *
+             * String types need to be cast to themselves to become literal types (as={'a' as 'a'}).
+             */
+            as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+        }
+    ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
+
+    withComponent<WithC extends AnyStyledComponent>(
+        component: WithC
+    ): StyledComponent<
+        StyledComponentInnerComponent<WithC>,
+        T,
+        O & StyledComponentInnerOtherProps<WithC>,
+        A | StyledComponentInnerAttrs<WithC>
+    >;
+    withComponent<
+        WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>
+    >(
+        component: WithC
+    ): StyledComponent<WithC, T, O, A>;
+}
+
+export interface ThemedStyledFunctionBase<
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+    T extends object,
+    O extends object = {},
+    A extends keyof any = never
+> {
+    (first: TemplateStringsArray): StyledComponent<C, T, O, A>;
+    (
+        first:
+            | TemplateStringsArray
+            | CSSObject
+            | InterpolationFunction<
+                  ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>
+              >,
+        ...rest: Array<
+            Interpolation<
+                ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>
+            >
+        >
+    ): StyledComponent<C, T, O, A>;
+    <U extends object>(
+        first:
+            | TemplateStringsArray
+            | CSSObject
+            | InterpolationFunction<
+                  ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>
+              >,
+        ...rest: Array<
+            Interpolation<
+                ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>
+            >
+        >
+    ): StyledComponent<C, T, O & U, A>;
+}
+
+export interface ThemedStyledFunction<
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+    T extends object,
+    O extends object = {},
+    A extends keyof any = never
+> extends ThemedStyledFunctionBase<C, T, O, A> {
+    // Fun thing: 'attrs' can also provide a polymorphic 'as' prop
+    // My head already hurts enough so maybe later...
+    attrs<
+        U,
+        NewA extends Partial<StyledComponentPropsWithRef<C> & U> & {
+            [others: string]: any;
+        } = {}
+    >(
+        attrs: Attrs<StyledComponentPropsWithRef<C> & U, NewA, T>
+    ): ThemedStyledFunction<C, T, O & NewA, A | keyof NewA>;
+    // Only this overload is deprecated
+    // tslint:disable:unified-signatures
+    /** @deprecated Prefer using the new single function style, to be removed in v5 */
+    attrs<
+        U,
+        NewA extends Partial<StyledComponentPropsWithRef<C> & U> & {
+            [others: string]: any;
+        } = {}
+    >(
+        attrs: DeprecatedAttrs<StyledComponentPropsWithRef<C> & U, NewA, T>
+    ): ThemedStyledFunction<C, T, O & NewA, A | keyof NewA>;
+    // tslint:enable:unified-signatures
+}
+
+export type StyledFunction<
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
+> = ThemedStyledFunction<C, any>;
+
+type ThemedStyledComponentFactories<T extends object> = {
+    [TTag in keyof JSX.IntrinsicElements]: ThemedStyledFunction<TTag, T>
+};
+
+export type StyledComponentInnerComponent<
+    C extends React.ComponentType<any>
+> = C extends
+    | StyledComponent<infer I, any, any, any>
+    | StyledComponent<infer I, any, any>
+    ? I
+    : C;
+export type StyledComponentPropsWithRef<
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
+> = C extends AnyStyledComponent
+    ? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>>
+    : React.ComponentPropsWithRef<C>;
+export type StyledComponentInnerOtherProps<C extends AnyStyledComponent> = C extends
+    | StyledComponent<any, any, infer O, any>
+    | StyledComponent<any, any, infer O>
+    ? O
+    : never;
+export type StyledComponentInnerAttrs<
+    C extends AnyStyledComponent
+> = C extends StyledComponent<any, any, any, infer A> ? A : never;
+
+export interface ThemedBaseStyledInterface<T extends object>
+    extends ThemedStyledComponentFactories<T> {
+    <C extends AnyStyledComponent>(component: C): ThemedStyledFunction<
+        StyledComponentInnerComponent<C>,
+        T,
+        StyledComponentInnerOtherProps<C>,
+        StyledComponentInnerAttrs<C>
+    >;
+    <C extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(
+        // unfortunately using a conditional type to validate that it can receive a `theme?: Theme`
+        // causes tests to fail in TS 3.1
+        component: C
+    ): ThemedStyledFunction<C, T>;
+}
+
+export type ThemedStyledInterface<T extends object> = ThemedBaseStyledInterface<
+    AnyIfEmpty<T>
+>;
+export type StyledInterface = ThemedStyledInterface<DefaultTheme>;
+
+export interface BaseThemedCssFunction<T extends object> {
+    (
+        first: TemplateStringsArray | CSSObject,
+        ...interpolations: SimpleInterpolation[]
+    ): FlattenSimpleInterpolation;
+    (
+        first:
+            | TemplateStringsArray
+            | CSSObject
+            | InterpolationFunction<ThemedStyledProps<{}, T>>,
+        ...interpolations: Array<Interpolation<ThemedStyledProps<{}, T>>>
+    ): FlattenInterpolation<ThemedStyledProps<{}, T>>;
+    <P extends object>(
+        first:
+            | TemplateStringsArray
+            | CSSObject
+            | InterpolationFunction<ThemedStyledProps<P, T>>,
+        ...interpolations: Array<Interpolation<ThemedStyledProps<P, T>>>
+    ): FlattenInterpolation<ThemedStyledProps<P, T>>;
+}
+
+export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<
+    AnyIfEmpty<T>
+>;
+
+// Helper type operators
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, "theme"> & {
+    theme?: T;
+};
+type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
+
+export interface ThemedStyledComponentsModule<
+    T extends object,
+    U extends object = T
+> {
+    default: ThemedStyledInterface<T>;
+
+    css: ThemedCssFunction<T>;
+
+    // unfortunately keyframes can't interpolate props from the theme
+    keyframes(
+        strings: TemplateStringsArray | CSSKeyframes,
+        ...interpolations: SimpleInterpolation[]
+    ): Keyframes;
+
+    createGlobalStyle<P extends object = {}>(
+        first:
+            | TemplateStringsArray
+            | CSSObject
+            | InterpolationFunction<ThemedStyledProps<P, T>>,
+        ...interpolations: Array<Interpolation<ThemedStyledProps<P, T>>>
+    ): GlobalStyleComponent<P, T>;
+
+    withTheme: WithThemeFnInterface<T>;
+    ThemeProvider: ThemeProviderComponent<T, U>;
+    ThemeConsumer: React.Consumer<T>;
+    ThemeContext: React.Context<T>;
+
+    // This could be made to assert `target is StyledComponent<any, T>` instead, but that feels not type safe
+    isStyledComponent: typeof isStyledComponent;
+
+    ServerStyleSheet: typeof ServerStyleSheet;
+    StyleSheetManager: typeof StyleSheetManager;
+}
+
+declare const styled: StyledInterface;
+
+export const css: ThemedCssFunction<DefaultTheme>;
+
+export type BaseWithThemeFnInterface<T extends object> = <
+    C extends React.ComponentType<any>
+>(
+    // this check is roundabout because the extends clause above would
+    // not allow any component that accepts _more_ than theme as a prop
+    component: React.ComponentProps<C> extends { theme?: T } ? C : never
+) => React.ForwardRefExoticComponent<
+    WithOptionalTheme<React.ComponentPropsWithRef<C>, T>
+>;
+export type WithThemeFnInterface<T extends object> = BaseWithThemeFnInterface<
+    AnyIfEmpty<T>
+>;
+export const withTheme: WithThemeFnInterface<DefaultTheme>;
+
+/**
+ * This interface can be augmented by users to add types to `styled-components`' default theme
+ * without needing to reexport `ThemedStyledComponentsModule`.
+ */
+// Unfortunately, there is no way to write tests for this
+// as any augmentation will break the tests for the default case (not augmented).
+// tslint:disable-next-line:no-empty-interface
+export interface DefaultTheme {}
+
+export interface ThemeProviderProps<T extends object, U extends object = T> {
+    children?: React.ReactChild; // only one child is allowed, goes through React.Children.only
+    theme: T | ((theme: U) => T);
+}
+export type BaseThemeProviderComponent<
+    T extends object,
+    U extends object = T
+> = React.ComponentClass<ThemeProviderProps<T, U>>;
+export type ThemeProviderComponent<
+    T extends object,
+    U extends object = T
+> = BaseThemeProviderComponent<AnyIfEmpty<T>, AnyIfEmpty<U>>;
+export const ThemeProvider: ThemeProviderComponent<AnyIfEmpty<DefaultTheme>>;
+// NOTE: this technically starts as undefined, but allowing undefined is unhelpful when used correctly
+export const ThemeContext: React.Context<AnyIfEmpty<DefaultTheme>>;
+export const ThemeConsumer: typeof ThemeContext["Consumer"];
+
+export interface Keyframes {
+    getName(): string;
+}
+
+export function keyframes(
+    strings: TemplateStringsArray | CSSKeyframes,
+    ...interpolations: SimpleInterpolation[]
+): Keyframes;
+
+export function createGlobalStyle<P extends object = {}>(
+    first:
+        | TemplateStringsArray
+        | CSSObject
+        | InterpolationFunction<ThemedStyledProps<P, DefaultTheme>>,
+    ...interpolations: Array<Interpolation<ThemedStyledProps<P, DefaultTheme>>>
+): GlobalStyleComponent<P, DefaultTheme>;
+
+export function isStyledComponent(
+    target: any
+): target is StyledComponent<any, any>;
+
+export class ServerStyleSheet {
+    collectStyles(
+        tree: React.ReactNode
+    ): React.ReactElement<{ sheet: ServerStyleSheet }>;
+
+    getStyleTags(): string;
+    getStyleElement(): Array<React.ReactElement<{}>>;
+    interleaveWithNodeStream(
+        readableStream: NodeJS.ReadableStream
+    ): NodeJS.ReadableStream;
+    readonly instance: this;
+    seal(): void;
+}
+
+type StyleSheetManagerProps =
+    | {
+          sheet: ServerStyleSheet;
+          target?: never;
+      }
+    | {
+          sheet?: never;
+          target: HTMLElement;
+      };
+
+export class StyleSheetManager extends React.Component<
+    StyleSheetManagerProps
+> {}
+
+/**
+ * The CSS prop is not declared by default in the types as it would cause 'css' to be present
+ * on the types of anything that uses styled-components indirectly, even if they do not use the
+ * babel plugin.
+ *
+ * You can load a default declaration by using writing this special import from
+ * a typescript file. This module does not exist in reality, which is why the {} is important:
+ *
+ * ```ts
+ * import {} from 'styled-components/cssprop'
+ * ```
+ *
+ * Or you can declare your own module augmentation, which allows you to specify the type of Theme:
+ *
+ * ```ts
+ * import { CSSProp } from 'styled-components'
+ *
+ * interface MyTheme {}
+ *
+ * declare module 'react' {
+ *   interface Attributes {
+ *     css?: CSSProp<MyTheme>
+ *   }
+ * }
+ * ```
+ */
+// ONLY string literals and inline invocations of css`` are supported, anything else crashes the plugin
+export type CSSProp<T = AnyIfEmpty<DefaultTheme>> =
+    | string
+    | CSSObject
+    | FlattenInterpolation<ThemeProps<T>>;
+
+export default styled;

--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -153,28 +153,12 @@ export interface StyledComponentBase<
     A extends keyof any = never
 > extends ForwardRefExoticBase<StyledComponentProps<C, T, O, A>> {
     // add our own fake call signature to implement the polymorphic 'as' prop
-    // NOTE: TS <3.2 will refuse to infer the generic and this component becomes impossible to use in JSX
-    // just the presence of the overload is enough to break JSX
-    //
-    // TODO (TypeScript 3.2): actually makes the 'as' prop polymorphic
-    // (
-    //     props: StyledComponentProps<C, T, O, A> & { as?: never }
-    //   ): React.ReactElement<StyledComponentProps<C, T, O, A>>
-    // <AsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C>(
-    //   props: StyledComponentPropsWithAs<AsC, T, O, A>
-    // ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A>>
-
-    // TODO (TypeScript 3.2): delete this overload
     (
-        props: StyledComponentProps<C, T, O, A> & {
-            /**
-             * Typing Note: prefer using .withComponent for now as it is actually type-safe.
-             *
-             * String types need to be cast to themselves to become literal types (as={'a' as 'a'}).
-             */
-            as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
-        }
-    ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
+        props: StyledComponentProps<C, T, O, A> & { as?: never }
+      ): React.ReactElement<StyledComponentProps<C, T, O, A>>
+    <AsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C>(
+      props: StyledComponentPropsWithAs<AsC, T, O, A>
+    ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A>>
 
     withComponent<WithC extends AnyStyledComponent>(
         component: WithC

--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -94,7 +94,7 @@ export type InterpolationValue =
 export type SimpleInterpolation =
     | InterpolationValue
     | FlattenSimpleInterpolation;
-export type FlattenSimpleInterpolation = ReadonlyArray<SimpleInterpolation>
+export type FlattenSimpleInterpolation = ReadonlyArray<SimpleInterpolation>;
 
 export type InterpolationFunction<P> = (props: P) => Interpolation<P>;
 
@@ -155,10 +155,10 @@ export interface StyledComponentBase<
     // add our own fake call signature to implement the polymorphic 'as' prop
     (
         props: StyledComponentProps<C, T, O, A> & { as?: never }
-      ): React.ReactElement<StyledComponentProps<C, T, O, A>>
+      ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
     <AsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C>(
       props: StyledComponentPropsWithAs<AsC, T, O, A>
-    ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A>>
+    ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A>>;
 
     withComponent<WithC extends AnyStyledComponent>(
         component: WithC

--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -1,16 +1,3 @@
-// Type definitions for styled-components 4.1
-// Project: https://github.com/styled-components/styled-components, https://styled-components.com
-// Definitions by: Igor Oleinikov <https://github.com/Igorbek>
-//                 Ihor Chulinda <https://github.com/Igmat>
-//                 Adam Lavin <https://github.com/lavoaster>
-//                 Jessica Franco <https://github.com/Jessidhia>
-//                 Jason Killian <https://github.com/jkillian>
-//                 Sebastian Silbermann <https://github.com/eps1lon>
-//                 David Ruisinger <https://github.com/flavordaaave>
-//                 Matthew Wagerfield <https://github.com/wagerfield>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
-
 // forward declarations
 declare global {
     namespace NodeJS {
@@ -92,11 +79,11 @@ type StyledComponentPropsWithAs<
 export type FalseyValue = undefined | null | false;
 export type Interpolation<P> =
     | InterpolationValue
-    | FlattenInterpolation<P>
-    | InterpolationFunction<P>;
-// must be an interface to be self-referential
-export interface FlattenInterpolation<P>
-    extends ReadonlyArray<Interpolation<P>> {}
+    | InterpolationFunction<P>
+    | FlattenInterpolation<P>;
+// cannot be made a self-referential interface, breaks WithPropNested
+// see https://github.com/microsoft/TypeScript/issues/34796
+export type FlattenInterpolation<P> = ReadonlyArray<Interpolation<P>>;
 export type InterpolationValue =
     | string
     | number
@@ -107,9 +94,7 @@ export type InterpolationValue =
 export type SimpleInterpolation =
     | InterpolationValue
     | FlattenSimpleInterpolation;
-// must be an interface to be self-referential
-export interface FlattenSimpleInterpolation
-    extends ReadonlyArray<SimpleInterpolation> {}
+export type FlattenSimpleInterpolation = ReadonlyArray<SimpleInterpolation>
 
 export type InterpolationFunction<P> = (props: P) => Interpolation<P>;
 

--- a/types/styled-components/ts3.7/macro.d.ts
+++ b/types/styled-components/ts3.7/macro.d.ts
@@ -1,0 +1,7 @@
+export { default } from '.';
+export * from '.';
+
+/**
+ * Recommended: also `import {} from 'styled-components/cssprop'`,
+ * or augment react's `Attribute` interface with your own version.
+ */

--- a/types/styled-components/ts3.7/native.d.ts
+++ b/types/styled-components/ts3.7/native.d.ts
@@ -1,0 +1,229 @@
+import * as ReactNative from 'react-native';
+import * as React from 'react';
+
+export {
+  css,
+  DefaultTheme,
+  isStyledComponent,
+  ThemeConsumer,
+  ThemeContext,
+  ThemeProps,
+  ThemeProvider,
+  withTheme,
+} from './index';
+
+import {
+  AnyStyledComponent,
+  DefaultTheme,
+  isStyledComponent,
+  StyledComponentInnerAttrs,
+  StyledComponentInnerComponent,
+  StyledComponentInnerOtherProps,
+  ThemedCssFunction,
+  ThemedStyledFunction,
+  ThemedStyledInterface,
+  ThemeProviderComponent,
+  WithThemeFnInterface
+} from './index';
+
+type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
+
+export type ReactNativeThemedStyledFunction<
+  C extends React.ComponentType<any>,
+  T extends object,
+> = ThemedStyledFunction<C, T>;
+
+// Copied over from "ThemedBaseStyledInterface" in index.d.ts in order to remove DOM element typings
+interface ReactNativeThemedBaseStyledInterface<T extends object> {
+    <C extends AnyStyledComponent>(component: C): ThemedStyledFunction<
+        StyledComponentInnerComponent<C>,
+        T,
+        StyledComponentInnerOtherProps<C>,
+        StyledComponentInnerAttrs<C>
+    >;
+    <C extends React.ComponentType<any>>(
+        // unfortunately using a conditional type to validate that it can receive a `theme?: Theme`
+        // causes tests to fail in TS 3.1
+        component: C
+    ): ThemedStyledFunction<C, T>;
+}
+
+type ReactNativeThemedStyledInterface<T extends object> = ReactNativeThemedBaseStyledInterface<
+    AnyIfEmpty<T>
+>;
+
+export interface ReactNativeStyledInterface<T extends object> extends ReactNativeThemedStyledInterface<T> {
+  ActivityIndicator: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ActivityIndicator,
+    T
+  >;
+  ActivityIndicatorIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ActivityIndicator,
+    T
+  >;
+  Button: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Button,
+    T
+  >;
+  DatePickerIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.DatePickerIOS,
+    T
+  >;
+  DrawerLayoutAndroid: ReactNativeThemedStyledFunction<
+    typeof ReactNative.DrawerLayoutAndroid,
+    T
+  >;
+  Image: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Image,
+    T
+  >;
+  ImageBackground: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ImageBackground,
+    T
+  >;
+  KeyboardAvoidingView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.KeyboardAvoidingView,
+    T
+  >;
+  ListView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ListView,
+    T
+  >;
+  Modal: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Modal,
+    T
+  >;
+  NavigatorIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.NavigatorIOS,
+    T
+  >;
+  Picker: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Picker,
+    T
+  >;
+  PickerIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.PickerIOS,
+    T
+  >;
+  ProgressBarAndroid: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ProgressBarAndroid,
+    T
+  >;
+  ProgressViewIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ProgressViewIOS,
+    T
+  >;
+  ScrollView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ScrollView,
+    T
+  >;
+  SegmentedControlIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.SegmentedControlIOS,
+    T
+  >;
+  Slider: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Slider,
+    T
+  >;
+  SliderIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Slider,
+    T
+  >;
+  SnapshotViewIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.SnapshotViewIOS,
+    T
+  >;
+  Switch: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Switch,
+    T
+  >;
+  RecyclerViewBackedScrollView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.RecyclerViewBackedScrollView,
+    T
+  >;
+  RefreshControl: ReactNativeThemedStyledFunction<
+    typeof ReactNative.RefreshControl,
+    T
+  >;
+  SafeAreaView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.SafeAreaView,
+    T
+  >;
+  StatusBar: ReactNativeThemedStyledFunction<
+    typeof ReactNative.StatusBar,
+    T
+  >;
+  SwipeableListView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.SwipeableListView,
+    T
+  >;
+  SwitchAndroid: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Switch,
+    T
+  >;
+  SwitchIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.SwitchIOS,
+    T
+  >;
+  TabBarIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.TabBarIOS,
+    T
+  >;
+  Text: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Text,
+    T
+  >;
+  TextInput: ReactNativeThemedStyledFunction<
+    typeof ReactNative.TextInput,
+    T
+  >;
+  ToolbarAndroid: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ToolbarAndroid,
+    T
+  >;
+  TouchableHighlight: ReactNativeThemedStyledFunction<
+    typeof ReactNative.TouchableHighlight,
+    T
+  >;
+  TouchableNativeFeedback: ReactNativeThemedStyledFunction<
+    typeof ReactNative.TouchableNativeFeedback,
+    T
+  >;
+  TouchableOpacity: ReactNativeThemedStyledFunction<
+    typeof ReactNative.TouchableOpacity,
+    T
+  >;
+  TouchableWithoutFeedback: ReactNativeThemedStyledFunction<
+    typeof ReactNative.TouchableWithoutFeedback,
+    T
+  >;
+  View: ReactNativeThemedStyledFunction<
+    typeof ReactNative.View,
+    T
+  >;
+  ViewPagerAndroid: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ViewPagerAndroid,
+    T
+  >;
+}
+
+export interface ReactNativeThemedStyledComponentsModule<
+  T extends object,
+  U extends object = T
+> {
+  default: ReactNativeStyledInterface<T>;
+
+  css: ThemedCssFunction<T>;
+
+  withTheme: WithThemeFnInterface<T>;
+  ThemeProvider: ThemeProviderComponent<T, U>;
+  ThemeConsumer: React.Consumer<T>;
+  ThemeContext: React.Context<T>;
+
+  // This could be made to assert `target is StyledComponent<any, T>` instead, but that feels not type safe
+  isStyledComponent: typeof isStyledComponent;
+}
+
+declare const styled: ReactNativeStyledInterface<DefaultTheme>;
+
+export default styled;

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -714,6 +714,22 @@ async function typedThemes() {
         ${themedCssWithNesting}
     `;
 
+    const WithProp = styled.div`
+        ${({ ok, theme: { color } }: { ok: boolean; theme: typeof theme }) =>
+            ok &&
+            css`
+                color: ${color};
+            `}
+    `;
+
+    const WithPropNested = styled.div`
+        ${({ ok }: { ok: boolean }) =>
+            ok &&
+            css`
+                color: ${({ theme: { color } }) => color};
+            `}
+    `;
+
     return (
         <ThemeProvider theme={theme}>
             <>
@@ -728,6 +744,8 @@ async function typedThemes() {
                         return theme.color;
                     }}
                 </ThemeConsumer>
+                <WithProp ok />
+                <WithPropNested ok />
             </>
         </ThemeProvider>
     );

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -415,11 +415,10 @@ class MyComponent extends React.Component<ThemeProps<{}>> {
 
 const ThemedMyComponent = withTheme(MyComponent);
 
-// TODO: passes in TS@3.1, not in TS@3.0
-// <ThemedMyComponent ref={ref => {
-//     // $ExpectType MyComponent | null
-//     ref;
-// }}/>;
+<ThemedMyComponent ref={ref => {
+    // $ExpectType MyComponent | null
+    ref;
+}}/>;
 const themedRef = React.createRef<MyComponent>();
 <ThemedMyComponent ref={themedRef} />;
 
@@ -612,9 +611,7 @@ class Test2Container extends React.Component<Test2ContainerProps> {
 }
 
 const containerTest = (
-    // TODO (TypeScript 3.2): once the polymorphic overload is un-commented-out this should be the correct test
-    // <StyledTestContainer as={Test2Container} type='foo' />
-    <StyledTestContainer as={Test2Container} size="small" />
+    <StyledTestContainer as={Test2Container} type='foo' />
 );
 
 // 4.0 refs
@@ -989,8 +986,7 @@ function validateDefaultProps() {
         color: red
     `;
 
-    // this test is failing in TS 2.9 but not in 3.0
-    // <MyComponent requiredProp />;
+    <MyComponent requiredProp />;
 
     <StyledComponent requiredProp optionalProp="x" />;
 
@@ -1011,8 +1007,7 @@ function validateDefaultProps() {
         { requiredProp: true }
     );
 
-    // this test is failing in TS 3.1 but not in 3.2
-    // <OtherStyledComponent />;
+    <OtherStyledComponent />;
 
     <OtherStyledComponent requiredProp="1" />; // $ExpectError
 }

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -1,0 +1,1074 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import * as ReactDOMServer from "react-dom/server";
+
+import styled, {
+    css,
+    createGlobalStyle,
+    isStyledComponent,
+    keyframes,
+    ServerStyleSheet,
+    StyleSheetManager,
+    ThemeProps,
+    ThemeProvider,
+    withTheme,
+    ThemeConsumer,
+    StyledComponent,
+    ThemedStyledComponentsModule,
+    FlattenSimpleInterpolation,
+    SimpleInterpolation,
+    FlattenInterpolation
+} from "styled-components";
+import {} from "styled-components/cssprop";
+
+/**
+ * general usage
+ */
+
+// Create a <Title> react component that renders an <h1> which is
+// centered, palevioletred and sized at 1.5em
+const Title = styled.h1`
+    font-size: 1.5em;
+    text-align: center;
+    color: palevioletred;
+`;
+
+// Create a <Wrapper> react component that renders a <section> with
+// some padding and a papayawhip background
+const Wrapper = styled.section`
+    padding: 4em;
+    background: papayawhip;
+`;
+
+const Input = styled.input`
+    font-size: 1.25em;
+    padding: 0.5em;
+    margin: 0.5em;
+    color: palevioletred;
+    background: papayawhip;
+    border: none;
+    border-radius: 3px;
+
+    &:hover {
+        box-shadow: inset 1px 1px 2px rgba(0, 0, 0, 0.1);
+    }
+`;
+
+interface MyTheme {
+    primary: string;
+}
+
+interface ButtonProps {
+    name: string;
+    primary?: boolean;
+    theme: MyTheme;
+}
+
+class MyButton extends React.Component<ButtonProps> {
+    render() {
+        return <button>Custom button</button>;
+    }
+}
+
+const TomatoButton = styled(MyButton)`
+    color: tomato;
+    border-color: tomato;
+`;
+
+const CustomizableButton = styled(MyButton)`
+    /* Adapt the colors based on primary prop */
+    background: ${props => (props.primary ? "palevioletred" : "white")};
+    color: ${props => (props.primary ? "white" : "palevioletred")};
+
+    font-size: 1em;
+    margin: 1em;
+    padding: 0.25em 1em;
+    border: 2px solid ${props => props.theme.primary};
+    border-radius: 3px;
+`;
+
+const example = css`
+    font-size: 1.5em;
+    text-align: center;
+    color: ${props => props.theme.primary};
+    border-color: ${"red"};
+`;
+
+const fadeIn = keyframes`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+`;
+
+const showAnimation = css`
+    opacity: 1;
+    transform: scale(1) translateY(0);
+`;
+
+const hideAnimation = css`
+    opacity: 0;
+    transform: scale(0.95, 0.8) translateY(20px);
+`;
+
+const entryAnimation = keyframes`
+  from { ${hideAnimation} }
+  to { ${showAnimation} }
+`;
+
+const animationRule = css`
+    ${fadeIn} 1s infinite alternate;
+`;
+
+const ComponentWithKeyframe = styled.div`
+    animation: ${animationRule};
+`;
+
+const theme = {
+    main: "mediumseagreen"
+};
+
+const ExampleGlobalStyle = createGlobalStyle`
+  @font-face {
+      font-family: 'Operator Mono';
+      src: url('../fonts/Operator-Mono.ttf');
+    }
+
+    body {
+        margin: 0;
+    }
+`;
+
+class Example extends React.Component {
+    render() {
+        return (
+            <ThemeProvider theme={theme}>
+                <>
+                    <ExampleGlobalStyle />
+                    <Wrapper>
+                        <Title>
+                            Hello World, this is my first styled component!
+                        </Title>
+
+                        <Input placeholder="@mxstbr" type="text" />
+                        <TomatoButton name="demo" />
+                    </Wrapper>
+                </>
+            </ThemeProvider>
+        );
+    }
+}
+
+// css which only uses simple interpolations without functions
+const cssWithValues1 = css`
+    font-size: ${14} ${"pt"};
+`;
+// css which uses other simple interpolations without functions
+const cssWithValues2 = css`
+  ${cssWithValues1}
+  ${[cssWithValues1, cssWithValues1]}
+  font-weight: ${"bold"};
+`;
+
+// css which uses function interpolations with common props
+const cssWithFunc1 = css`
+    font-size: ${props => props.theme.fontSizePt}pt;
+`;
+const cssWithFunc2 = css`
+  ${cssWithFunc1}
+  ${props => cssWithFunc1}
+  ${[cssWithFunc1, cssWithValues1]}
+`;
+// such css can be used in styled components
+const styledButton = styled.button`
+  ${cssWithValues1} ${[cssWithValues1, cssWithValues2]}
+  ${cssWithFunc1} ${[cssWithFunc1, cssWithFunc2]}
+  ${() => [cssWithFunc1, cssWithFunc2]}
+`;
+
+const name = "hey";
+
+const ThemedMyButton = withTheme(MyButton);
+<ThemedMyButton name={name} />;
+
+/**
+ * nested styles
+ */
+
+const Link = styled.a`
+    color: red;
+`;
+
+const AlternativeLink = styled.a`
+    color: blue;
+`;
+
+const freeStyles = css`
+    background-color: black;
+    color: white;
+    ${Link} {
+        color: blue;
+    }
+`;
+
+const Article = styled.section`
+    color: red;
+    ${freeStyles}
+    & > ${Link} {
+        color: green;
+    }
+    ${p => (p.theme.useAlternativeLink ? AlternativeLink : Link)} {
+        color: black
+    }
+`;
+
+// A Link instance should be backed by an HTMLAnchorElement
+const ComposedLink = () => (
+    <Link onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined} />
+);
+
+/**
+ * construction via string tag
+ */
+
+// Create a <LinkFromString> react component that renders an <a> which is
+// centered, palevioletred and sized at 1.5em
+const LinkFromString = styled("a")`
+    font-size: 1.5em;
+    text-align: center;
+    color: palevioletred;
+`;
+
+// A LinkFromString instance should be backed by an HTMLAnchorElement
+const MyOtherComponent = () => (
+    <LinkFromString
+        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined}
+    />
+);
+
+// Create a <LinkFromStringWithProps> react component that renders an <a>
+// which takes extra props
+interface LinkProps {
+    canClick: boolean;
+}
+
+const LinkFromStringWithProps = styled("a")`
+    font-size: 1.5em;
+    text-align: center;
+    color: ${(a: LinkProps) => (a.canClick ? "palevioletred" : "gray")};
+`;
+
+// A LinkFromStringWithProps instance should be backed by an HTMLAnchorElement
+const MyOtherComponentWithProps = () => (
+    <LinkFromStringWithProps
+        canClick={false}
+        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined}
+    />
+);
+
+// Create a <LinkFromStringWithPropsAndGenerics> react component that renders an <a>
+// which takes extra props passed as a generic type argument
+const LinkFromStringWithPropsAndGenerics = styled("a")<LinkProps>`
+    font-size: 1.5em;
+    text-align: center;
+    color: ${a => (a.canClick ? "palevioletred" : "gray")};
+`;
+
+// A LinkFromStringWithPropsAndGenerics instance should be backed by an HTMLAnchorElement
+const MyOtherComponentWithPropsAndGenerics = () => (
+    <LinkFromStringWithPropsAndGenerics
+        canClick={false}
+        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined}
+    />
+);
+
+/**
+ * object styles
+ */
+
+interface ObjectStyleProps {
+    size: string;
+}
+
+const functionReturningStyleObject = (props: ObjectStyleProps) => ({
+    padding: props.size === "big" ? "10px" : 2
+});
+
+const ObjectStylesBox = styled.div`
+    ${functionReturningStyleObject} ${{
+        backgroundColor: "red",
+
+        // Supports nested objects (pseudo selectors, media queries, etc)
+        "@media screen and (min-width: 800px)": {
+            backgroundColor: "blue"
+        },
+
+        fontSize: 2
+    }};
+`;
+<ObjectStylesBox size="big" />;
+
+/**
+ * attrs
+ */
+
+const AttrsInput = styled.input.attrs({
+    // we can define static props
+    type: "password",
+
+    // or we can define dynamic ones
+    margin: (props: any) => (props.size as string) || "1em",
+    padding: (props: any) => (props.size as string) || "1em"
+})`
+    color: palevioletred;
+    font-size: 1em;
+    border: 2px solid palevioletred;
+    border-radius: 3px;
+
+    /* here we use the dynamically computed props */
+    margin: ${props => props.margin};
+    padding: ${props => props.padding};
+`;
+
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30042
+const AttrsWithOnlyNewProps = styled.h2.attrs({ as: "h1" })`
+    color: ${props => (props.as === "h1" ? "red" : "blue")};
+    font-size: ${props => (props.as === "h1" ? 2 : 1)};
+`;
+
+const AttrsInputExtra = styled(AttrsInput).attrs({ autoComplete: "off" })``;
+<AttrsInputExtra />;
+
+/**
+ * component type
+ */
+
+declare const A: React.ComponentClass;
+declare const B: React.StatelessComponent;
+declare const C: React.ComponentType;
+
+styled(A); // succeeds
+styled(B); // succeeds
+styled(C); // used to fail; see issue trail linked below
+
+// https://github.com/mui-org/material-ui/pull/8781#issuecomment-349460247
+// https://github.com/mui-org/material-ui/issues/9838
+// https://github.com/styled-components/styled-components/pull/1420
+// https://github.com/Microsoft/TypeScript/issues/21175
+// https://github.com/styled-components/styled-components/pull/1427
+
+/**
+ * function themes
+ */
+
+// Define our button, but with the use of props.theme this time
+const ThemedButton = styled.button`
+    color: ${props => props.theme.fg};
+    border: 2px solid ${props => props.theme.fg};
+    background: ${props => props.theme.bg};
+
+    font-size: 1em;
+    margin: 1em;
+    padding: 0.25em 1em;
+    border-radius: 3px;
+`;
+
+// Define our `fg` and `bg` on the theme
+const theme2 = {
+    fg: "palevioletred",
+    bg: "white"
+};
+
+// This theme swaps `fg` and `bg`
+const invertTheme = ({ fg, bg }: { fg: string; bg: string }) => ({
+    fg: bg,
+    bg: fg
+});
+
+const MyApp = (
+    <ThemeProvider theme={theme2}>
+        <div>
+            <ThemedButton>Default Theme</ThemedButton>
+
+            <ThemeProvider theme={invertTheme}>
+                <ThemedButton>Inverted Theme</ThemedButton>
+            </ThemeProvider>
+        </div>
+    </ThemeProvider>
+);
+
+/**
+ * withTheme HOC
+ */
+
+class MyComponent extends React.Component<ThemeProps<{}>> {
+    render() {
+        const { theme } = this.props;
+
+        console.log("Current theme: ", theme);
+
+        return <h1>Hello</h1>;
+    }
+}
+
+const ThemedMyComponent = withTheme(MyComponent);
+
+// TODO: passes in TS@3.1, not in TS@3.0
+// <ThemedMyComponent ref={ref => {
+//     // $ExpectType MyComponent | null
+//     ref;
+// }}/>;
+const themedRef = React.createRef<MyComponent>();
+<ThemedMyComponent ref={themedRef} />;
+
+interface WithThemeProps {
+    theme: {
+        color: string;
+    };
+    text: string;
+}
+
+const Component = (props: WithThemeProps) => (
+    <div style={{ color: props.theme.color }}>{props.text}</div>
+);
+
+const ComponentWithTheme = withTheme(Component);
+<ComponentWithTheme text={"hi"} />; // ok
+<ComponentWithTheme text={"hi"} theme={{ color: "red" }} />; // ok
+<ThemeConsumer>{theme => <Component text="hi" theme={theme} />}</ThemeConsumer>;
+
+/**
+ * isStyledComponent utility
+ */
+
+const StyledComponent = styled.h1``;
+
+const StatelessComponent = () => <div />;
+
+class ClassComponent extends React.Component {
+    render() {
+        return <div />;
+    }
+}
+
+isStyledComponent(StyledComponent);
+isStyledComponent(StatelessComponent);
+isStyledComponent(ClassComponent);
+isStyledComponent("div");
+
+/**
+ * server side rendering
+ */
+
+const SSRTitle = styled.h1`
+    font-size: 1.5em;
+    text-align: center;
+    color: palevioletred;
+`;
+
+const sheet = new ServerStyleSheet();
+const html = sheet.collectStyles(<SSRTitle>Hello world</SSRTitle>);
+const styleHtml = sheet.getStyleTags();
+const styleElement = sheet.getStyleElement();
+sheet.seal();
+
+const sheet2 = new ServerStyleSheet();
+const element = (
+    <StyleSheetManager sheet={sheet2.instance}>
+        <SSRTitle>Hello world</SSRTitle>
+    </StyleSheetManager>
+);
+
+const css2 = sheet2.getStyleElement();
+
+// Wrapping a node stream returned from renderToNodeStream with interleaveWithNodeStream
+
+const sheet3 = new ServerStyleSheet();
+const appStream = ReactDOMServer.renderToNodeStream(<Title>Hello world</Title>);
+const wrappedCssStream: NodeJS.ReadableStream = sheet3.interleaveWithNodeStream(
+    appStream
+);
+
+/**
+ * StyledComponent.withComponent
+ */
+
+const WithComponentH1 = styled.h1`
+    color: palevioletred;
+    font-size: 1em;
+`;
+
+function getRandomInt(min: number, max: number) {
+    min = Math.ceil(min);
+    max = Math.floor(max);
+    return Math.floor(Math.random() * (max - min)) + min;
+}
+
+class Random extends React.Component<any, any> {
+    render() {
+        const i = getRandomInt(1, 6);
+
+        switch (i) {
+            case 1:
+                return <h1>Hello World</h1>;
+            case 2:
+                return <h2>Hello World</h2>;
+            case 3:
+                return <h3>Hello World</h3>;
+            case 4:
+                return <h4>Hello World</h4>;
+            case 5:
+                return <h5>Hello World</h5>;
+            case 6:
+                return <h6>Hello World</h6>;
+            default:
+                return null;
+        }
+    }
+}
+
+const WithComponentH2 = WithComponentH1.withComponent("h2");
+const WithComponentAbbr = WithComponentH1.withComponent("abbr");
+
+const WithComponentAnchor = WithComponentH1.withComponent("a");
+const AnchorContainer = () => (
+    <WithComponentAnchor href="https://example.com">
+        withComponent Anchor
+    </WithComponentAnchor>
+);
+
+const WithComponentRandomHeading = WithComponentH1.withComponent(Random);
+
+const WithComponentCompA: React.SFC<{ a: number; className?: string }> = ({
+    className
+}) => <div className={className} />;
+const WithComponentCompB: React.SFC<{ b: number; className?: string }> = ({
+    className
+}) => <div className={className} />;
+const WithComponentStyledA = styled(WithComponentCompA)`
+    color: ${(props: { color: string }) => props.color};
+`;
+
+const WithComponentFirstStyledA = styled(WithComponentStyledA).attrs({
+    a: 1
+})``;
+
+const WithComponentFirstStyledB = WithComponentFirstStyledA.withComponent(
+    WithComponentCompB
+);
+
+const WithComponentFirstStyledANew = styled(WithComponentStyledA).attrs(
+    props => ({ a: 1 })
+)``;
+
+const test = () => [
+    <WithComponentFirstStyledA color={"black"} />,
+    <WithComponentFirstStyledB b={2} color={"black"} />,
+    <WithComponentFirstStyledANew color={"black"} />
+];
+
+const WithComponentRequired = styled((props: { to: string }) => (
+    <a href={props.to} />
+))``;
+// These tests pass in tsservice, but they fail in dtslint. I do not know why.
+// <WithComponentRequired href=''/>; // $ExpectError
+// <WithComponentRequired to=''/>;
+
+const WithComponentRequired2 = WithComponentRequired.withComponent("a");
+// These tests pass in tsservice, but they fail in dtslint. I do not know why.
+// <WithComponentRequired2 href=''/>;
+// <WithComponentRequired2 to=''/>; // $ExpectError
+
+// 4.0 With Component
+
+const asTest = (
+    <>
+        <WithComponentH1 as="h2" />
+        <WithComponentH1 as={WithComponentH2} />
+    </>
+);
+
+interface TestContainerProps {
+    size: "big" | "small";
+    test?: boolean;
+}
+const TestContainer = ({ size, test }: TestContainerProps) => {
+    return null;
+};
+
+const StyledTestContainer = styled(TestContainer)`
+    background: red;
+`;
+
+interface Test2ContainerProps {
+    type: "foo" | "bar";
+}
+class Test2Container extends React.Component<Test2ContainerProps> {
+    render() {
+        return null;
+    }
+}
+
+const containerTest = (
+    // TODO (TypeScript 3.2): once the polymorphic overload is un-commented-out this should be the correct test
+    // <StyledTestContainer as={Test2Container} type='foo' />
+    <StyledTestContainer as={Test2Container} size="small" />
+);
+
+// 4.0 refs
+
+const divFnRef = (ref: HTMLDivElement | null) => {
+    /* empty */
+};
+const divRef = React.createRef<HTMLDivElement>();
+
+const StyledDiv = styled.div``;
+<StyledDiv ref={divRef} />;
+<StyledDiv ref={divFnRef} />;
+<StyledDiv ref="string" />; // $ExpectError
+
+const StyledStyledDiv = styled(StyledDiv)``;
+<StyledStyledDiv ref={divRef} />;
+<StyledStyledDiv ref={divFnRef} />;
+<StyledStyledDiv ref="string" />; // $ExpectError
+
+const StyledA = StyledDiv.withComponent("a");
+// No longer generating a type error as of Feb. 6th, 2019
+// <StyledA ref={divRef} />; // $ExpectError
+<StyledA
+    ref={ref => {
+        // $ExpectType HTMLAnchorElement | null
+        ref;
+    }}
+/>;
+
+async function typedThemes() {
+    const theme = {
+        color: "green"
+    };
+
+    // abuse "await import(...)" to be able to reference the styled-components namespace
+    // without actually doing a top level namespace import
+    const {
+        default: styled,
+        css,
+        createGlobalStyle,
+        ThemeProvider,
+        ThemeConsumer
+    } = (await import("styled-components")) as any as ThemedStyledComponentsModule<
+        typeof theme
+    >;
+
+    const ThemedDiv = styled.div`
+        background: ${props => {
+            // $ExpectType string
+            props.theme.color;
+            // $ExpectType number | undefined
+            props.tabIndex;
+            return props.theme.color;
+        }};
+    `;
+    const ThemedDiv2 = styled.div(props => {
+        // $ExpectType string
+        props.theme.color;
+        // $ExpectType number | undefined
+        props.tabIndex;
+
+        return {
+            background: props.theme.color
+        };
+    });
+    const ThemedDiv3 = styled.div(props => {
+        // $ExpectType string
+        props.theme.color;
+        // $ExpectType number | undefined
+        props.tabIndex;
+
+        return css`
+            background: ${props.theme.color};
+        `;
+    });
+    const themedCss = css`
+        background: ${props => {
+            // $ExpectType string
+            props.theme.color;
+            // $ExpectType "theme"
+            type Keys = keyof typeof props;
+            return props.theme.color;
+        }};
+    `;
+    //  can't use a FlattenInterpolation as the first argument, would make broken css
+    // $ExpectError
+    const ThemedDiv4 = styled.div(themedCss);
+
+    const themedCssWithNesting = css(props => ({
+        color: props.theme.color,
+        [ThemedDiv3]: {
+            color: "green"
+        }
+    }));
+
+    const Global = createGlobalStyle`
+        ${themedCssWithNesting}
+    `;
+
+    return (
+        <ThemeProvider theme={theme}>
+            <>
+                <Global />
+                <ThemedDiv />
+                <ThemedDiv2 />
+                <ThemedDiv3 />
+                <ThemeConsumer>
+                    {theme => {
+                        // $ExpectType string
+                        theme.color;
+                        return theme.color;
+                    }}
+                </ThemeConsumer>
+            </>
+        </ThemeProvider>
+    );
+}
+
+async function reexportCompatibility() {
+    const sc = await import("styled-components");
+    const themed = sc as ThemedStyledComponentsModule<any>;
+
+    let { ...scExports } = sc;
+    let { ...themedExports } = themed;
+    // both branches must be assignable to each other
+    if (Math.random()) {
+        scExports = themedExports;
+    } else {
+        themedExports = scExports;
+    }
+}
+
+async function themeAugmentation() {
+    interface BaseTheme {
+        background: string;
+    }
+    interface ExtraTheme extends BaseTheme {
+        accent: string;
+    }
+
+    const base = (await import("styled-components")) as any as ThemedStyledComponentsModule<
+        BaseTheme
+    >;
+    const extra = (await import("styled-components")) as any as ThemedStyledComponentsModule<
+        ExtraTheme,
+        BaseTheme
+    >;
+
+    return (
+        <base.ThemeProvider
+            theme={{
+                background: "black"
+            }}
+        >
+            <>
+                <extra.ThemeProvider
+                    theme={base => base} // $ExpectError
+                >
+                    <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
+                </extra.ThemeProvider>
+                <extra.ThemeProvider
+                    theme={base => ({
+                        ...base,
+                        accent: "blue"
+                    })}
+                >
+                    <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
+                </extra.ThemeProvider>
+            </>
+        </base.ThemeProvider>
+    );
+}
+
+// NOTE: this is needed for some tests inside cssProp,
+// but actually running this module augmentation will cause
+// tests elsewhere to break, and there is no way to contain it.
+// Uncomment out as needed to run tests.
+
+// declare module "styled-components" {
+//     interface DefaultTheme {
+//         background: string;
+//     }
+// }
+
+function cssProp() {
+    function Custom(props: React.ComponentPropsWithoutRef<"div">) {
+        return <div {...props} />;
+    }
+
+    const myCss = "background: blue;";
+
+    return (
+        <>
+            <div css="background: blue;" />
+            <div css={{ background: "blue" }} />
+            <div
+                // would be nice to be able to turn this into an error as it also crashes the plugin,
+                // but this is how optional properties work in TypeScript...
+                css={undefined}
+            />
+            <div
+                // css used as tagged function is fine and is correctly handled by the plugin
+                css={css`
+                    background: blue;
+                `}
+            />
+            <div
+                // but this crashes the plugin, even though it's valid type-wise and we can't forbid it
+                css={css({ background: "blue" })}
+            />
+            <div
+                // this also crashes the plugin, only inline strings or css template tag work
+                css={myCss}
+            />
+            <div
+                css={css`
+                    background: ${() => "blue"};
+                `}
+            />
+            <div
+                css={css`
+                    background: ${props => {
+                        // This requires the DefaultTheme augmentation
+                        // // $ExpectType string
+                        // props.theme.background;
+                        return props.theme.background;
+                    }};
+                `}
+            />
+            <Custom css="background: blue;" />
+            <Custom css={undefined} />
+            <Custom
+                css={css`
+                    background: blue;
+                `}
+            />
+            <Custom
+                css={css`
+                    background: ${() => "blue"};
+                `}
+            />
+            <Custom
+                css={css`
+                    background: ${props => {
+                        // This requires the DefaultTheme augmentation
+                        // // $ExpectType string
+                        // props.theme.background;
+                        return props.theme.background;
+                    }};
+                `}
+            />
+        </>
+    );
+}
+
+function validateArgumentsAndReturns() {
+    const t1: FlattenSimpleInterpolation[] = [
+        css({ color: "blue" }),
+        css`
+            color: blue;
+        `,
+        css`
+            color: ${"blue"};
+        `
+    ];
+    const t4: FlattenInterpolation<any> = [
+        css`
+            color: ${() => "blue"};
+        `,
+        css(() => ({ color: "blue" })),
+        css(
+            () =>
+                css`
+                    color: "blue";
+                `
+        )
+    ];
+
+    // if the first argument is array-like it's always treated as a string[], this breaks things
+    css(
+        // $ExpectError
+        css`
+            ${{ color: "blue" }}
+        `
+    );
+    // _technically_ valid as styled-components doesn't look at .raw but best not to support it
+    // $ExpectError
+    css([]);
+
+    styled.div({ color: "blue" });
+    styled.div(props => ({ color: props.theme.color }));
+    styled.div`
+        color: ${"blue"};
+    `;
+    // These don't work for the same reason css doesn't work
+    styled.div(
+        // $ExpectError
+        css`
+            ${{ color: "blue" }}
+        `
+    );
+    // $ExpectError
+    styled.div([]);
+
+    createGlobalStyle({
+        ":root": {
+            color: "blue"
+        }
+    });
+    createGlobalStyle`
+        :root {
+            color: blue;
+        }
+    `;
+    createGlobalStyle(() => ({
+        ":root": {
+            color: "blue"
+        }
+    }));
+    // these are invalid for the same reason as in styled.div
+    // $ExpectError
+    createGlobalStyle(css`
+        :root {
+            color: ${() => "blue"};
+        }
+    `);
+    // $ExpectError
+    createGlobalStyle([]);
+}
+
+function validateDefaultProps() {
+    interface Props {
+        requiredProp: boolean;
+        optionalProp: string; // Shouldn't need to be optional here
+    }
+
+    class MyComponent extends React.PureComponent<Props> {
+        static defaultProps = {
+            optionalProp: 'fallback'
+        };
+
+        render() {
+            const { requiredProp, optionalProp } = this.props;
+            return (
+                <span>
+                    {requiredProp.toString()}
+                    {optionalProp.toString()}
+                </span>
+            );
+        }
+    }
+
+    const StyledComponent = styled(MyComponent)`
+        color: red
+    `;
+
+    // this test is failing in TS 2.9 but not in 3.0
+    // <MyComponent requiredProp />;
+
+    <StyledComponent requiredProp optionalProp="x" />;
+
+    <StyledComponent requiredProp />;
+
+    // still respects the type of optionalProp
+    <StyledComponent requiredProp optionalProp={1} />; // $ExpectError
+
+    // example of a simple helper that sets defaultProps and update the type
+    type WithDefaultProps<C, D> = C & { defaultProps: D };
+    function withDefaultProps<C, D>(component: C, defaultProps: D): WithDefaultProps<C, D> {
+        (component as WithDefaultProps<C, D>).defaultProps = defaultProps;
+        return component as WithDefaultProps<C, D>;
+    }
+
+    const OtherStyledComponent = withDefaultProps(
+        styled(MyComponent)` color: red `,
+        { requiredProp: true }
+    );
+
+    // this test is failing in TS 3.1 but not in 3.2
+    // <OtherStyledComponent />;
+
+    <OtherStyledComponent requiredProp="1" />; // $ExpectError
+}
+
+interface WrapperProps {
+    className?: string;
+}
+export class WrapperClass extends React.Component<WrapperProps> {
+    render() { return <div />; }
+}
+const StyledWrapperClass = styled(WrapperClass)``;
+// React.Component typings always add `children` to props, so this should accept children
+const wrapperClass = <StyledWrapperClass>Text</StyledWrapperClass>;
+
+export class WrapperClassFuncChild extends React.Component<WrapperProps & {children: () => any}> {
+    render() { return <div />; }
+}
+const StyledWrapperClassFuncChild = styled(WrapperClassFuncChild)``;
+// React.Component typings always add `children` to props, so this should accept children
+const wrapperClassNoChildrenGood = <StyledWrapperClassFuncChild>{() => "text"}</StyledWrapperClassFuncChild>;
+const wrapperClassNoChildren = <StyledWrapperClassFuncChild>Text</StyledWrapperClassFuncChild>; // $ExpectError
+
+const WrapperFunction: React.FunctionComponent<WrapperProps> = () => <div />;
+const StyledWrapperFunction = styled(WrapperFunction)``;
+// React.FunctionComponent typings always add `children` to props, so this should accept children
+const wrapperFunction = <StyledWrapperFunction>Text</StyledWrapperFunction>;
+
+const WrapperFunc = (props: WrapperProps) => <div />;
+const StyledWrapperFunc = styled(WrapperFunc)``;
+// No `children` in props, so this should generate an error
+const wrapperFunc = <StyledWrapperFunc>Text</StyledWrapperFunc>; // $ExpectError
+
+function unionTest() {
+    interface Book {
+        kind: 'book';
+        author: string;
+    }
+
+    interface Magazine {
+        kind: 'magazine';
+        issue: number;
+    }
+
+    type SomethingToRead = (Book | Magazine);
+
+    const Readable: React.FunctionComponent<SomethingToRead> = props => {
+        if (props.kind === 'magazine') {
+            return <div>magazine #{props.issue}</div>;
+        }
+
+        return <div>magazine #{props.author}</div>;
+    };
+
+    const StyledReadable = styled(Readable)`
+        font-size: ${props => props.kind === 'book' ? 16 : 14}
+    `;
+
+    // undesired, fix was reverted because of https://github.com/Microsoft/TypeScript/issues/30663
+    <StyledReadable kind="book" author="Hejlsberg" />; // $ExpectError
+    <StyledReadable kind="magazine" author="Hejlsberg" />; // $ExpectError
+}
+
+function unionTest2() {
+    // Union of two non-overlapping types
+    type Props = {
+        foo: number, bar?: undefined
+    } | {
+        foo?: undefined, bar: string
+    };
+
+    const C = styled.div<Props>``;
+
+    <C foo={123} />;
+    <C bar="foobar" />;
+    <C />; // $ExpectError
+    <C foo={123} bar="foobar" />; // $ExpectError
+}

--- a/types/styled-components/ts3.7/test/macro.tsx
+++ b/types/styled-components/ts3.7/test/macro.tsx
@@ -1,0 +1,20 @@
+import styled, { createGlobalStyle } from 'styled-components/macro';
+
+// Check that the default export works.
+const TitleFromMacro = styled.h1`
+    font-size: 1.5em;
+    text-align: center;
+    color: palevioletred;
+`;
+
+// Check that named exports work as well.
+const GlobalStyleFromMacro = createGlobalStyle`
+    @font-face {
+      font-family: 'Operator Mono';
+      src: url('../fonts/Operator-Mono.ttf');
+    }
+
+    body {
+        margin: 0;
+    }
+`;

--- a/types/styled-components/ts3.7/test/native.tsx
+++ b/types/styled-components/ts3.7/test/native.tsx
@@ -1,0 +1,198 @@
+import * as React from "react";
+import * as ReactNative from "react-native";
+import * as ReactDOMServer from "react-dom/server";
+
+import styled, {
+    css,
+    isStyledComponent,
+    ThemeProps,
+    ThemeProvider,
+    withTheme,
+    ThemeConsumer,
+    ReactNativeThemedStyledComponentsModule,
+} from "styled-components/native";
+import {} from "styled-components/cssprop";
+
+const StyledView = styled.View`
+  background-color: papayawhip;
+`;
+
+const StyledText = styled(ReactNative.Text)`
+  color: palevioletred;
+`;
+
+class MyReactNativeComponent extends React.Component {
+  render() {
+    return (
+      <StyledView>
+        <StyledText>Hello World!</StyledText>
+      </StyledView>
+    );
+  }
+}
+
+const ValidProp = <StyledText adjustsFontSizeToFit />;
+const invalidProp = <StyledText randoName={2} />; // $ExpectError
+const invalidTag = styled.div` margin-top: 5px; `; // $ExpectError
+
+interface MyTheme {
+    primary: string;
+}
+
+interface ButtonProps {
+    name: string;
+    primary?: boolean;
+    theme: MyTheme;
+}
+
+class MyButton extends React.Component<ButtonProps> {
+    render() {
+        return <ReactNative.TouchableOpacity>Custom button</ReactNative.TouchableOpacity>;
+    }
+}
+
+const TomatoButton = styled(MyButton)`
+    color: tomato;
+    border-color: tomato;
+`;
+
+// needs name prop, but not theme prop
+const tomatoElement = <TomatoButton name="needed" />;
+
+async function typedThemes() {
+  const theme = {
+      color: "green"
+  };
+
+  // abuse "await import(...)" to be able to reference the styled-components namespace
+  // without actually doing a top level namespace import
+  const {
+      default: styled,
+      css,
+      ThemeProvider,
+      ThemeConsumer
+  } = (await import("styled-components/native")) as any as ReactNativeThemedStyledComponentsModule<
+      typeof theme
+  >;
+
+  const ThemedView = styled.View`
+      background: ${props => {
+          // $ExpectType string
+          props.theme.color;
+          // $ExpectType string | undefined
+          props.testID;
+          return props.theme.color;
+      }};
+  `;
+  const ThemedView2 = styled.View(props => {
+    // $ExpectType string
+    props.theme.color;
+    // $ExpectType string | undefined
+    props.testID;
+
+    return {
+        background: props.theme.color
+    };
+  });
+  const ThemedView3 = styled.View(props => {
+    // $ExpectType string
+    props.theme.color;
+    // $ExpectType string | undefined
+    props.testID;
+
+    return css`
+        background: ${props.theme.color};
+    `;
+});
+const themedCss = css`
+    background: ${props => {
+        // $ExpectType string
+        props.theme.color;
+        // $ExpectType "theme"
+        type Keys = keyof typeof props;
+        return props.theme.color;
+    }};
+`;
+//  can't use a FlattenInterpolation as the first argument, would make broken css
+// $ExpectError
+const ThemedView4 = styled.View(themedCss);
+
+const themedCssWithNesting = css(props => ({
+    color: props.theme.color,
+    [ThemedView3]: {
+        color: "green"
+    }
+}));
+
+return (
+    <ThemeProvider theme={theme}>
+        <>
+            <ThemedView />
+            <ThemedView2 />
+            <ThemedView3 />
+            <ThemeConsumer>
+                {theme => {
+                    // $ExpectType string
+                    theme.color;
+                    return theme.color;
+                }}
+            </ThemeConsumer>
+        </>
+    </ThemeProvider>
+  );
+}
+
+async function reexportCompatibility() {
+  const sc = await import("styled-components/native");
+  const themed = sc as ReactNativeThemedStyledComponentsModule<any>;
+
+  let { ...scExports } = sc;
+  let { ...themedExports } = themed;
+  // both branches must be assignable to each other
+  if (Math.random()) {
+      scExports = themedExports;
+  } else {
+      themedExports = scExports;
+  }
+}
+
+async function themeAugmentation() {
+  interface BaseTheme {
+      background: string;
+  }
+  interface ExtraTheme extends BaseTheme {
+      accent: string;
+  }
+
+  const base = (await import("styled-components/native")) as any as ReactNativeThemedStyledComponentsModule<
+      BaseTheme
+  >;
+  const extra = (await import("styled-components/native")) as any as ReactNativeThemedStyledComponentsModule<
+      ExtraTheme,
+      BaseTheme
+  >;
+
+  return (
+      <base.ThemeProvider
+          theme={{
+              background: "black"
+          }}
+      >
+          <>
+              <extra.ThemeProvider
+                  theme={base => base} // $ExpectError
+              >
+                  <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
+              </extra.ThemeProvider>
+              <extra.ThemeProvider
+                  theme={base => ({
+                      ...base,
+                      accent: "blue"
+                  })}
+              >
+                  <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
+              </extra.ThemeProvider>
+          </>
+      </base.ThemeProvider>
+  );
+}

--- a/types/styled-components/ts3.7/tsconfig.json
+++ b/types/styled-components/ts3.7/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "baseUrl": "../../",
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "typeRoots": [
+            "../../"
+        ],
+        "types": []
+    },
+    "files": [
+        "index.d.ts",
+        "native.d.ts",
+        "macro.d.ts",
+        "cssprop.d.ts",
+        "test/index.tsx",
+        "test/native.tsx",
+        "test/macro.tsx"
+    ]
+}

--- a/types/styled-components/ts3.7/tslint.json
+++ b/types/styled-components/ts3.7/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Converts self-referential interfaces to recursive types (works around Microsoft/TypeScript#34796). Recursive types only exist in 3.7 so this uses typesVersions.

Finally enables code paths that were commented out because they'd break on TypeScript versions older than 3.2.

This replaces https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40064.

As this creates a `typesVersions` fork, I tried to separate the commits into one that just creates the fork, and did the changes in commits following it.

---

NOTE: testing locally is currently broken because of https://github.com/sandersn/dts-critic/issues/10

NOTE2: oops pushed to a branch in DT instead of in my own fork, CI is going to be annoying