### PR TITLE
[koa] [koa-compose] [koa-convert] [koa-joi-router] [@koa/router] Add Next type to Koa

### DIFF
--- a/types/koa-compose/index.d.ts
+++ b/types/koa-compose/index.d.ts
@@ -50,8 +50,8 @@ declare function compose<T1, U1, T2, U2, T3, U3, T4, U4, T5, U5, T6, U6, T7, U7,
 declare function compose<T>(middleware: Array<compose.Middleware<T>>): compose.ComposedMiddleware<T>;
 
 declare namespace compose {
-    type Middleware<T> = (context: T, next: () => Promise<any>) => any;
-    type ComposedMiddleware<T> = (context: T, next?: () => Promise<any>) => Promise<void>;
+    type Middleware<T> = (context: T, next: Koa.Next) => any;
+    type ComposedMiddleware<T> = (context: T, next?: Koa.Next) => Promise<void>;
 }
 
 export = compose;

--- a/types/koa-convert/index.d.ts
+++ b/types/koa-convert/index.d.ts
@@ -4,10 +4,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { Context, Middleware } from "koa";
+import { Context, Middleware, Next } from "koa";
 
 declare function convert(
-    mw: (context: Context, next: () => Promise<any>) => Generator
+    mw: (context: Context, next: Next) => Generator
 ): Middleware;
 
 export = convert;

--- a/types/koa-joi-router/index.d.ts
+++ b/types/koa-joi-router/index.d.ts
@@ -25,7 +25,7 @@ interface createRouter {
 }
 
 declare namespace createRouter {
-    type FullHandler = (ctx: Koa.Context, next: () => Promise<any>) => any;
+    type FullHandler = (ctx: Koa.Context, next: Koa.Next) => any;
     interface NestedHandler extends ReadonlyArray<Handler> {}
     type Handler = FullHandler | NestedHandler;
 

--- a/types/koa-joi-router/koa-joi-router-tests.ts
+++ b/types/koa-joi-router/koa-joi-router-tests.ts
@@ -160,14 +160,14 @@ const spec9Handler = (ctx: koa.Context) => {
 
 router().get('/user', spec9, spec9Handler);
 
-const middleware1 = async (ctx: koa.Context, next: () => Promise<any>) => {
+const middleware1 = async (ctx: koa.Context, next: koa.Next) => {
   console.log('middleware1');
   await next();
 };
 
 router().get('/', middleware1, handler1);
 
-const middleware2 = async (ctx: koa.Context, next: () => Promise<any>) => {
+const middleware2 = async (ctx: koa.Context, next: koa.Next) => {
   console.log('middleware2');
   await next();
 };
@@ -178,7 +178,7 @@ router().use(middleware1);
 
 router().use('/:id', middleware1);
 
-router().param('/:id', async (id: string, ctx: koa.Context, next: () => Promise<any>) => {
+router().param('/:id', async (id: string, ctx: koa.Context, next: koa.Next) => {
   ctx.state.id = id;
   await next();
 });

--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -12,7 +12,7 @@
     import * as Koa from "koa"
     const app = new Koa()
 
-    async function (ctx: Koa.Context, next: Function) {
+    async function (ctx: Koa.Context, next: Koa.Next) {
       // ...
     }
 
@@ -729,6 +729,8 @@ declare namespace Application {
     } & CustomT;
 
     interface Context extends ParameterizedContext {}
+
+    type Next = () => Promise<any>;
 }
 
 export = Application;

--- a/types/koa__router/index.d.ts
+++ b/types/koa__router/index.d.ts
@@ -64,7 +64,7 @@
     type Middleware<StateT = any, CustomT = {}> = Koa.Middleware<StateT, CustomT & RouterParamContext<StateT, CustomT>>;
 
     interface ParamMiddleware {
-        (param: string, ctx: RouterContext, next: () => Promise<any>): any;
+        (param: string, ctx: RouterContext, next: Koa.Next): any;
     }
 
     interface RouterAllowedMethodsOptions {


### PR DESCRIPTION
Adds a dedicated type for the `next` argument in Koa middleware, and updates uses (that I can find).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- ~[ ] Add or edit tests to reflect the change. (Run with `npm test`.)~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- ~[ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~
- ~[ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- ~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~