### PR TITLE
Provide types for convert-units package

### DIFF
--- a/types/convert-units/convert-units-tests.ts
+++ b/types/convert-units/convert-units-tests.ts
@@ -1,0 +1,6 @@
+import convert = require('convert-units');
+
+const convertedMass = convert(25).from('mcg').to('t');
+const convertedMassBack =  convert(convertedMass).from('t').to('mcg');
+
+const unit = convert(66).getUnit<'mcg'>('mcg');

--- a/types/convert-units/index.d.ts
+++ b/types/convert-units/index.d.ts
@@ -1,0 +1,134 @@
+// Type definitions for convert-units 2.3
+// Project: https://github.com/ben-ng/convert-units#readme
+// Definitions by: vladkampov <https://github.com/vladkampov>
+//                 ben-ng <https://github.com/ben-ng>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+type uDistance = "mm" | "cm" | "m" | "km" | "in" | "ft-us" | "ft" | "mi"; // Distance
+type uArea = "mm2" | "cm2" | "m2" | "ha" | "km2" | "in2" | "ft2" | "ac" | "mi2"; // Area
+type uMass = "mcg" | "mg" | "g" | "kg" | "oz" | "lb" | "mt" | "t"; // Mass
+type uVolume = "mm3" | "cm3" | "ml" | "l" | "kl" | "m3" | "km3" | "tsp" | "Tbs" | "in3" | "fl-oz" | "cup" | "pnt" | "qt" | "gal" | "ft3" | "yd3"; // Volume
+type uVolumeFlowRate =
+    | "mm3/s"
+    | "cm3/s"
+    | "ml/s"
+    | "cl/s"
+    | "dl/s"
+    | "l/s"
+    | "l/min"
+    | "l/h"
+    | "kl/s"
+    | "kl/min"
+    | "kl/h"
+    | "m3/s"
+    | "m3/min"
+    | "m3/h"
+    | "km3/s"
+    | "tsp/s"
+    | "Tbs/s"
+    | "in3/s"
+    | "in3/min"
+    | "in3/h"
+    | "fl-oz/s"
+    | "fl-oz/min"
+    | "fl-oz/h"
+    | "cup/s"
+    | "pnt/s"
+    | "pnt/min"
+    | "pnt/h"
+    | "qt/s"
+    | "gal/s"
+    | "gal/min"
+    | "gal/h"
+    | "ft3/s"
+    | "ft3/min"
+    | "ft3/h"
+    | "yd3/s"
+    | "yd3/min"
+    | "yd3/h"; // Volume Flow Rate
+type uTemperature = "C" | "F" | "K" | "R"; // Temperature
+type uTime = "ns" | "mu" | "ms" | "s" | "min" | "h" | "d" | "week" | "month" | "year"; // Time
+type uFrequency = "Hz" | "mHz" | "kHz" | "MHz" | "GHz" | "THz" | "rpm" | "deg/s" | "rad/s"; // Frequency
+type uSpeed = "m/s" | "km/h" | "m/h" | "knot" | "ft/s"; // Speed
+type uPace = "s/m" | "min/km" | "s/ft" | "min/km"; // Pace
+type uPressure = "Pa" | "hPa" | "kPa" | "MPa" | "bar" | "torr" | "psi" | "ksi"; // Pressure
+type uDitgital = "b" | "Kb" | "Mb" | "Gb" | "Tb" | "B" | "KB" | "MB" | "GB" | "TB"; // Digital
+type uIlluminance = "lx" | "ft-cd"; // Illumunance
+type uPartsPer = "ppm" | "ppb" | "ppt" | "ppq"; // Parts-Per
+type uVoltage = "V" | "mV" | "kV"; // Voltage
+type uCurrent = "A" | "mA" | "kA"; // Current
+type uPower = "W" | "mW" | "kM" | "MW" | "GW";
+type uApparentPower = "VA" | "mVA" | "kVA" | "MVA" | "GVA"; // Apparent Power
+type uReactivePower = "VAR" | "mVAR" | "kVAR" | "MVAR" | "GVAR"; // Reactive Power
+type uEnergy = "Wh" | "mWh" | "kWh" | "MWh" | "GWh" | "J" | "kJ"; // Energy
+type uReactiveEnergy = "VARh" | "mVARh" | "kVARh" | "MVARh" | "GVARH"; // Reactive Energy
+type uAngle = "deg" | "rad" | "grad" | "arcmin" | "arcsec"; // Angle
+
+type unit = uDistance
+    | uArea
+    | uMass
+    | uVolume
+    | uVolumeFlowRate
+    | uTemperature
+    | uTime
+    | uFrequency
+    | uSpeed
+    | uPace
+    | uPressure
+    | uDitgital
+    | uIlluminance
+    | uPartsPer
+    | uVoltage
+    | uCurrent
+    | uPower
+    | uApparentPower
+    | uReactivePower
+    | uEnergy
+    | uReactiveEnergy
+    | uAngle;
+
+type measure = "distance"
+    | "area"
+    | "mass"
+    | "volume"
+    | "volumeFlowRate"
+    | "temperature"
+    | "time"
+    | "frequency"
+    | "speed"
+    | "pace"
+    | "pressure"
+    | "ditgital"
+    | "illuminance"
+    | "partsPer"
+    | "voltage"
+    | "current"
+    | "power"
+    | "apparentPower"
+    | "reactivePower"
+    | "energy"
+    | "reactiveEnergy"
+    | "angle";
+
+type system = "metric"
+    | "imperial"
+    | "bits"
+    | "bytes";
+
+declare class Convert {
+    constructor(numerator: number, denominator: number);
+    from(from: unit): this;
+    to(to: unit): number;
+    toBest(options?: { exclude?: unit[], cutOffNumber?: number }): { val: number, unit: string, singular: string, plural: string };
+    getUnit<T extends unit>(abbr: T): { abbr: T, measure: measure, system: system, unit: { name: { singular: string, plural: string }, to_anchor: number } };
+    describe<T extends unit>(abbr: T): { abbr: T, measure: measure, system: system, singular: string, plural: string };
+    list(measure?: measure): unit[];
+    private throwUnsupportedUnitError(what: string): void;
+    possibilities(measure?: measure): unit[];
+    measures(): measure[];
+}
+
+declare function convert(value: number): Convert;
+
+export = convert;

--- a/types/convert-units/tsconfig.json
+++ b/types/convert-units/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "convert-units-tests.ts"
+    ]
+}

--- a/types/convert-units/tslint.json
+++ b/types/convert-units/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

