### PR TITLE
[@types/react-datepicker] fix a definition for renderDayContents

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -12,6 +12,7 @@
 //                 Avi Klaiman <https://github.com/aviklai>
 //                 Naoki Sekiguchi <https://github.com/seckie>
 //                 tu4mo <https://github.com/tu4mo>
+//                 Kerry Gougeon <https://github.com/kerry-g>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -107,7 +108,7 @@ export interface ReactDatePickerProps {
         prevMonthButtonDisabled: boolean;
         nextMonthButtonDisabled: boolean;
     }): React.ReactNode;
-    renderDayContents?(dayOfMonth: number): React.ReactNode;
+    renderDayContents?(dayOfMonth: number, date?: Date): React.ReactNode;
     required?: boolean;
     scrollableMonthYearDropdown?: boolean;
     scrollableYearDropdown?: boolean;


### PR DESCRIPTION
As you can see on the official [docs](https://reactdatepicker.com/#example-custom-day-class-name), renderDayContents can take a number and a date to render custom days.

```javascript
  const renderDayContents = (day, date) => {
    const tooltipText = `Tooltip for date: ${date}`;
    return <span title={tooltipText}>{getDate(date)}</span>;
  };
```