### PR TITLE
react-native-dialog: Make container's modal props optional

### DIFF
--- a/types/react-native-dialog/index.d.ts
+++ b/types/react-native-dialog/index.d.ts
@@ -61,7 +61,7 @@ interface DescriptionProps {
     children: string;
 }
 
-type reactNativeModalContainerProps = Pick<reactNativeModal.ModalProps, Exclude<keyof reactNativeModal.ModalProps, "isVisible">>;
+type reactNativeModalContainerProps = Partial<Pick<reactNativeModal.ModalProps, Exclude<keyof reactNativeModal.ModalProps, "isVisible">>>;
 
 export namespace Dialog {
     class Button extends PureComponent<


### PR DESCRIPTION
The tests use them in a way that indicates they are not required, so I added Partial around reactNativeModal.ModalProps.

This probably resulted from a recent update to react-native-modal.

I think react-native-dialog also needs [a second fix to react-native-modal's import syntax](https://github.com/react-native-community/react-native-modal/pull/372) before the build will pass.

Edit: That fix has now shipped.