### PR TITLE
Rewrite Roarr types to approximate extant Flow types (backwards incompatible)

### DIFF
--- a/types/roarr/index.d.ts
+++ b/types/roarr/index.d.ts
@@ -2,297 +2,177 @@
 // Project: https://github.com/gajus/roarr#readme
 // Definitions by: Philip Saxton <https://github.com/psaxton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
 
-export as namespace log;
+// the package defines a recursive type SerializeValueType but, fortunately, neither it nor SerializableObjectType are
+// used anywhere
+
+export interface WriterType {
+    write: (message: string) => void;
+}
+
+export interface RoarrGlobalStateType extends WriterType {
+    sequence: number;
+    versions: ReadonlyArray<string>;
+}
+
+export type SprintfArgumentType = string | number | boolean | null;
+
+export type MessageContextType = object;
+
+export interface MessageType {
+    context: MessageContextType;
+    message: string;
+    sequence: number;
+    time: number;
+    version: string;
+}
+
+export type TranslateMessageFunctionType = (message: MessageType) => MessageType;
+
+export interface Logger {
+    (
+        context: MessageContextType,
+        message: string,
+        c?: SprintfArgumentType,
+        d?: SprintfArgumentType,
+        e?: SprintfArgumentType,
+        f?: SprintfArgumentType,
+        g?: SprintfArgumentType,
+        h?: SprintfArgumentType,
+        i?: SprintfArgumentType,
+        k?: SprintfArgumentType
+    ): void;
+
+    (
+        message: string,
+        b?: SprintfArgumentType,
+        c?: SprintfArgumentType,
+        d?: SprintfArgumentType,
+        e?: SprintfArgumentType,
+        f?: SprintfArgumentType,
+        g?: SprintfArgumentType,
+        h?: SprintfArgumentType,
+        i?: SprintfArgumentType
+    ): void;
+}
+
+export interface LoggerType extends Logger {
+    /**
+     * Creates a child logger appending the provided context object to the previous logger context.
+     *
+     * @param contextOrFunction
+     * @example
+     * import Roarr from 'roarr';
+     *
+     * const log = Roarr.child({ module: "myModule" });
+     *
+     * log.debug("My Message");
+     * // {"context":{"logLevel":20},"Message":"My Message","sequence":0,"time":1531914529921,"version":"1.0.0"}
+     *
+     * @see https://www.npmjs.com/package/roarr#child
+     */
+    child(contextOrFunction: TranslateMessageFunctionType | MessageContextType):
+        LoggerType;
+
+    /**
+     * Returns the current context.
+     */
+    getContext(): MessageContextType;
+
+    /**
+     * Convenience method for logging a message with logLevel context property value set to 10 (LogLevel.Trace)
+     *
+     * @example
+     * import Roarr from 'roarr';
+     *
+     * const log = Roarr;
+     *
+     * log.trace('foo');
+     * // {"context":{"logLevel":10},"message":"foo","sequence":0,"time":1506776210000,"version":"1.0.0"}
+     *
+     * @see https://www.npmjs.com/package/roarr#trace
+     */
+    trace: Logger;
+
+    /**
+     * Convenience method for logging a message with logLevel context property value set to 20 (LogLevel.Debug)
+     *
+     * @example
+     * import Roarr from 'roarr';
+     *
+     * const log = Roarr;
+     *
+     * log.debug('foo');
+     * // {"context":{"logLevel":20},"message":"foo","sequence":0,"time":1506776210000,"version":"1.0.0"}
+     *
+     * @see https://www.npmjs.com/package/roarr#trace
+     */
+    debug: Logger;
+
+    /**
+     * Convenience method for logging a message with logLevel context property value set to 30 (LogLevel.Info)
+     *
+     * @example
+     * import Roarr from 'roarr';
+     *
+     * const log = Roarr;
+     *
+     * log.info('foo');
+     * // {"context":{"logLevel":30},"message":"foo","sequence":0,"time":1506776210000,"version":"1.0.0"}
+     *
+     * @see https://www.npmjs.com/package/roarr#trace
+     */
+    info: Logger;
+
+    /**
+     * Convenience method for logging a message with logLevel context property value set to 40 (LogLevel.Warn)
+     *
+     * @example
+     * import Roarr from 'roarr';
+     *
+     * const log = Roarr;
+     *
+     * log.warn('foo');
+     * // {"context":{"logLevel":40},"message":"foo","sequence":0,"time":1506776210000,"version":"1.0.0"}
+     *
+     * @see https://www.npmjs.com/package/roarr#trace
+     */
+    warn: Logger;
+
+    /**
+     * Convenience method for logging a message with logLevel context property value set to 50 (LogLevel.Error)
+     *
+     * @example
+     * import Roarr from 'roarr';
+     *
+     * const log = Roarr;
+     *
+     * log.error('foo');
+     * // {"context":{"logLevel":50},"message":"foo","sequence":0,"time":1506776210000,"version":"1.0.0"}
+     *
+     * @see https://www.npmjs.com/package/roarr#trace
+     */
+    error: Logger;
+
+    /**
+     * Convenience method for logging a message with logLevel context property value set to 60 (LogLevel.Fatal)
+     *
+     * @example
+     * import Roarr from 'roarr';
+     *
+     * const log = Roarr;
+     *
+     * log.fatal('foo');
+     * // {"context":{"logLevel":60},"message":"foo","sequence":0,"time":1506776210000,"version":"1.0.0"}
+     *
+     * @see https://www.npmjs.com/package/roarr#trace
+     */
+    fatal: Logger;
+}
+
+export type MessageEventHandlerType = (message: MessageType) => void;
+
+declare const log: LoggerType;
 
 export default log;
-
-declare let log: Roarr.RoarrType;
-
-declare namespace Roarr {
-	interface MessageContextType {
-		logLevel?: number;
-		[name: string]: any;
-	}
-
-    type TranslateMessageFunctionType = (message: MessageContextType) => MessageContextType;
-
-	interface SprintfArgumentType { toString(): string; }
-
-	interface RoarrType {
-		(
-			context: MessageContextType,
-			message: string,
-			_0?: SprintfArgumentType,
-			_1?: SprintfArgumentType,
-			_2?: SprintfArgumentType,
-			_3?: SprintfArgumentType,
-			_4?: SprintfArgumentType,
-			_5?: SprintfArgumentType,
-			_6?: SprintfArgumentType,
-			_7?: SprintfArgumentType
-		): void;
-
-		(
-			context: MessageContextType,
-			message: string,
-			_0?: SprintfArgumentType,
-			_1?: SprintfArgumentType,
-			_2?: SprintfArgumentType,
-			_3?: SprintfArgumentType,
-			_4?: SprintfArgumentType,
-			_5?: SprintfArgumentType,
-			_6?: SprintfArgumentType,
-			_7?: SprintfArgumentType
-		): void;
-
-		/**
-		 * Creates a child logger appending the provided context object to the previous logger context.
-		 *
-		 * @param contextOrFunction
-		 * @example
-		 * import Roarr from 'roarr';
-		 *
-		 * const log = Roarr.child({ module: "myModule" });
-		 *
-		 * log.debug("My Message");
-		 * // {"context":{"logLevel":20},"Message":"My Message","sequence":0,"time":1531914529921,"version":"1.0.0"}
-		 *
-		 * @see https://www.npmjs.com/package/roarr#child
-		 */
-		child(contextOrFunction: MessageContextType | TranslateMessageFunctionType): RoarrType;
-
-		/**
-		 * Returns the current context.
-		 */
-		getContext(): MessageContextType;
-
-		/**
-		 * Convenience method for logging a message with logLevel context property value set to 10 (LogLevel.Trace)
-		 *
-		 * @example
-		 * import Roarr from 'roarr';
-		 *
-		 * const log = Roarr;
-		 *
-		 * log.trace('foo');
-		 * // {"context":{"logLevel":10},"message":"foo","sequence":0,"time":1506776210000,"version":"1.0.0"}
-		 *
-		 * @see https://www.npmjs.com/package/roarr#trace
-		 */
-		trace(
-			context: MessageContextType,
-			message: string,
-			_0?: SprintfArgumentType,
-			_1?: SprintfArgumentType,
-			_2?: SprintfArgumentType,
-			_3?: SprintfArgumentType,
-			_4?: SprintfArgumentType,
-			_5?: SprintfArgumentType,
-			_6?: SprintfArgumentType,
-			_7?: SprintfArgumentType
-		): void;
-
-		trace(
-			message: string,
-			_0?: SprintfArgumentType,
-			_1?: SprintfArgumentType,
-			_2?: SprintfArgumentType,
-			_3?: SprintfArgumentType,
-			_4?: SprintfArgumentType,
-			_5?: SprintfArgumentType,
-			_6?: SprintfArgumentType,
-			_7?: SprintfArgumentType
-		): void;
-
-		/**
-		 * Convenience method for logging a message with logLevel context property value set to 20 (LogLevel.Debug)
-		 *
-		 * @example
-		 * import Roarr from 'roarr';
-		 *
-		 * const log = Roarr;
-		 *
-		 * log.debug('foo');
-		 * // {"context":{"logLevel":20},"message":"foo","sequence":0,"time":1506776210000,"version":"1.0.0"}
-		 *
-		 * @see https://www.npmjs.com/package/roarr#trace
-		 */
-		debug(
-			context: MessageContextType,
-			message: string,
-			_0?: SprintfArgumentType,
-			_1?: SprintfArgumentType,
-			_2?: SprintfArgumentType,
-			_3?: SprintfArgumentType,
-			_4?: SprintfArgumentType,
-			_5?: SprintfArgumentType,
-			_6?: SprintfArgumentType,
-			_7?: SprintfArgumentType
-		): void;
-
-		debug(
-			message: string,
-			_0?: SprintfArgumentType,
-			_1?: SprintfArgumentType,
-			_2?: SprintfArgumentType,
-			_3?: SprintfArgumentType,
-			_4?: SprintfArgumentType,
-			_5?: SprintfArgumentType,
-			_6?: SprintfArgumentType,
-			_7?: SprintfArgumentType
-		): void;
-
-		/**
-		 * Convenience method for logging a message with logLevel context property value set to 30 (LogLevel.Info)
-		 *
-		 * @example
-		 * import Roarr from 'roarr';
-		 *
-		 * const log = Roarr;
-		 *
-		 * log.info('foo');
-		 * // {"context":{"logLevel":30},"message":"foo","sequence":0,"time":1506776210000,"version":"1.0.0"}
-		 *
-		 * @see https://www.npmjs.com/package/roarr#trace
-		 */
-		info(
-			context: MessageContextType,
-			message: string,
-			_0?: SprintfArgumentType,
-			_1?: SprintfArgumentType,
-			_2?: SprintfArgumentType,
-			_3?: SprintfArgumentType,
-			_4?: SprintfArgumentType,
-			_5?: SprintfArgumentType,
-			_6?: SprintfArgumentType,
-			_7?: SprintfArgumentType
-		): void;
-
-		info(
-			message: string,
-			_0?: SprintfArgumentType,
-			_1?: SprintfArgumentType,
-			_2?: SprintfArgumentType,
-			_3?: SprintfArgumentType,
-			_4?: SprintfArgumentType,
-			_5?: SprintfArgumentType,
-			_6?: SprintfArgumentType,
-			_7?: SprintfArgumentType
-		): void;
-
-		/**
-		 * Convenience method for logging a message with logLevel context property value set to 40 (LogLevel.Warn)
-		 *
-		 * @example
-		 * import Roarr from 'roarr';
-		 *
-		 * const log = Roarr;
-		 *
-		 * log.warn('foo');
-		 * // {"context":{"logLevel":40},"message":"foo","sequence":0,"time":1506776210000,"version":"1.0.0"}
-		 *
-		 * @see https://www.npmjs.com/package/roarr#trace
-		 */
-		warn(
-			context: MessageContextType,
-			message: string,
-			_0?: SprintfArgumentType,
-			_1?: SprintfArgumentType,
-			_2?: SprintfArgumentType,
-			_3?: SprintfArgumentType,
-			_4?: SprintfArgumentType,
-			_5?: SprintfArgumentType,
-			_6?: SprintfArgumentType,
-			_7?: SprintfArgumentType
-		): void;
-
-		warn(
-			message: string,
-			_0?: SprintfArgumentType,
-			_1?: SprintfArgumentType,
-			_2?: SprintfArgumentType,
-			_3?: SprintfArgumentType,
-			_4?: SprintfArgumentType,
-			_5?: SprintfArgumentType,
-			_6?: SprintfArgumentType,
-			_7?: SprintfArgumentType
-		): void;
-
-		/**
-		 * Convenience method for logging a message with logLevel context property value set to 50 (LogLevel.Error)
-		 *
-		 * @example
-		 * import Roarr from 'roarr';
-		 *
-		 * const log = Roarr;
-		 *
-		 * log.error('foo');
-		 * // {"context":{"logLevel":50},"message":"foo","sequence":0,"time":1506776210000,"version":"1.0.0"}
-		 *
-		 * @see https://www.npmjs.com/package/roarr#trace
-		 */
-		error(
-			context: MessageContextType,
-			message: string,
-			_0?: SprintfArgumentType,
-			_1?: SprintfArgumentType,
-			_2?: SprintfArgumentType,
-			_3?: SprintfArgumentType,
-			_4?: SprintfArgumentType,
-			_5?: SprintfArgumentType,
-			_6?: SprintfArgumentType,
-			_7?: SprintfArgumentType
-		): void;
-
-		error(
-			message: string,
-			_0?: SprintfArgumentType,
-			_1?: SprintfArgumentType,
-			_2?: SprintfArgumentType,
-			_3?: SprintfArgumentType,
-			_4?: SprintfArgumentType,
-			_5?: SprintfArgumentType,
-			_6?: SprintfArgumentType,
-			_7?: SprintfArgumentType
-		): void;
-
-		/**
-		 * Convenience method for logging a message with logLevel context property value set to 60 (LogLevel.Fatal)
-		 *
-		 * @example
-		 * import Roarr from 'roarr';
-		 *
-		 * const log = Roarr;
-		 *
-		 * log.fatal('foo');
-		 * // {"context":{"logLevel":60},"message":"foo","sequence":0,"time":1506776210000,"version":"1.0.0"}
-		 *
-		 * @see https://www.npmjs.com/package/roarr#trace
-		 */
-		fatal(
-			context: MessageContextType,
-			message: string,
-			_0?: SprintfArgumentType,
-			_1?: SprintfArgumentType,
-			_2?: SprintfArgumentType,
-			_3?: SprintfArgumentType,
-			_4?: SprintfArgumentType,
-			_5?: SprintfArgumentType,
-			_6?: SprintfArgumentType,
-			_7?: SprintfArgumentType
-		): void;
-
-		fatal(
-			message: string,
-			_0?: SprintfArgumentType,
-			_1?: SprintfArgumentType,
-			_2?: SprintfArgumentType,
-			_3?: SprintfArgumentType,
-			_4?: SprintfArgumentType,
-			_5?: SprintfArgumentType,
-			_6?: SprintfArgumentType,
-			_7?: SprintfArgumentType
-		): void;
-	}
-}

--- a/types/roarr/roarr-tests.ts
+++ b/types/roarr/roarr-tests.ts
@@ -1,4 +1,16 @@
-import Roarr from "roarr";
+import { default as Roarr, MessageType, MessageContextType } from "roarr";
+
+const messageContextType = {
+    foo: "bar",
+};
+
+const messageType: MessageType = {
+    context: messageContextType,
+    message: "a message",
+    sequence: 1,
+    time: 1,
+    version: "1",
+};
 
 const log = Roarr.child({ module: "roarr-tests" });
 
@@ -15,9 +27,10 @@ log.error("Error log statement");
 log.error({ context: "error" }, "Error log statement");
 log.fatal("Fatal log statement");
 log.fatal({ context: "fatal" }, "Fatal log statement");
+log("Statement without context");
 
 // TS2.0-compatible reformulation of example at https://github.com/gajus/roarr#function-parameter
-const alternativeLog = Roarr.child((message) => {
+const alternativeLog = Roarr.child((message: MessageType) => {
     message["message"] = message["message"].replace("foo", "bar");
 
     return message;
@@ -26,3 +39,12 @@ const alternativeLog = Roarr.child((message) => {
 alternativeLog({ logLevel: 60 }, "Something critical");
 alternativeLog.debug({ foo: "bar" }, 'foo 1');
 alternativeLog.fatal('foo 2');
+
+const implicitLog = Roarr.child((message) => {
+    message;                    // $Expect MessageType
+    message["message"] = message["message"].replace("foo", "bar");
+
+    return message;
+});
+
+implicitLog("Implicit logger without context");


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gajus/roarr/blob/master/src/types.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
