### PR TITLE
[pdfkit] 2019-11-08 add Security and PdfVersion options

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -4,6 +4,7 @@
 //                 Erik Berreßem <https://github.com/she11sh0cked>
 //                 Jeroen Vervaeke <https://github.com/jeroenvervaeke/>
 //                 Thales Agapito <https://github.com/thalesagapito/>
+//                 Evgeny Baram <https://github.com/r4tz52/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -249,9 +250,27 @@ declare namespace PDFKit {
         ModDate?: Date;
     }
 
+    interface DocumentSecurity {
+        userPassword?: string;
+        ownerPassword?: string;
+        permissions?: DocumentPermissions;
+    }
+
+    interface DocumentPermissions {
+        modifying?: boolean;
+        copying?: boolean;
+        annotating?: boolean;
+        fillingForms?: boolean;
+        contentAccessibility?: boolean;
+        documentAssembly?: boolean;
+        printing?: 'lowResolution' | 'highResolution';
+    }
+
     interface PDFDocumentOptions {
         compress?: boolean;
         info?: DocumentInfo;
+        security?: DocumentSecurity;
+        pdfVersion?: '1.3' | '1.4' | '1.5' | '1.6' | '1.7' | '1.7ext3';
         autoFirstPage?: boolean;
         size?: number[] | string;
         margin?: number;

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -250,12 +250,6 @@ declare namespace PDFKit {
         ModDate?: Date;
     }
 
-    interface DocumentSecurity {
-        userPassword?: string;
-        ownerPassword?: string;
-        permissions?: DocumentPermissions;
-    }
-
     interface DocumentPermissions {
         modifying?: boolean;
         copying?: boolean;
@@ -269,7 +263,9 @@ declare namespace PDFKit {
     interface PDFDocumentOptions {
         compress?: boolean;
         info?: DocumentInfo;
-        security?: DocumentSecurity;
+        userPassword?: string;
+        ownerPassword?: string;
+        permissions?: DocumentPermissions;
         pdfVersion?: '1.3' | '1.4' | '1.5' | '1.6' | '1.7' | '1.7ext3';
         autoFirstPage?: boolean;
         size?: number[] | string;

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -14,7 +14,20 @@ import text = require('pdfkit/js/mixins/text');
 font.registerFont('Arial');
 text.widthOfString('Kila', { ellipsis: true });
 
-var doc = new PDFDocument({ compress: false, size: [526, 525], autoFirstPage: true });
+var doc = new PDFDocument({
+    compress: false,
+    size: [526, 525],
+    autoFirstPage: true,
+    pdfVersion: '1.6',
+    security: {
+        ownerPassword: 'ownerPassword',
+        permissions: {
+            modifying: true,
+            annotating: false,
+            printing: 'lowResolution'
+        }
+    }
+});
 
 doc.addPage({
     margin: 50,

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -18,14 +18,11 @@ var doc = new PDFDocument({
     compress: false,
     size: [526, 525],
     autoFirstPage: true,
-    pdfVersion: '1.6',
-    security: {
-        ownerPassword: 'ownerPassword',
-        permissions: {
-            modifying: true,
-            annotating: false,
-            printing: 'lowResolution'
-        }
+    ownerPassword: 'ownerPassword',
+    permissions: {
+        modifying: true,
+        annotating: false,
+        printing: 'lowResolution'
     }
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://pdfkit.org/docs/getting_started.html#encryption_and_access_privileges
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

