### PR TITLE
[ioredis] Add methods for Cluster

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -913,11 +913,65 @@ declare namespace IORedis {
         quit(callback?: CallbackFunction<'OK'>): Promise<'OK'>;
         get(key: KeyType, callback: (err: Error, res: string | null) => void): void;
         get(key: KeyType): Promise<string | null>;
+
+        getBuffer(key: KeyType, callback: (err: Error, res: Buffer) => void): void;
+        getBuffer(key: KeyType): Promise<Buffer>;
+
         set(key: KeyType, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<string>;
         set(key: KeyType, value: any, callback: (err: Error, res: string) => void): void;
         set(key: KeyType, value: any, setMode: string | any[], callback: (err: Error, res: string) => void): void;
         set(key: KeyType, value: any, expiryMode: string, time: number | string, callback: (err: Error, res: string) => void): void;
         set(key: KeyType, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: string) => void): void;
+
+        setBuffer(key: KeyType, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<Buffer>;
+        setBuffer(key: KeyType, value: any, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: any, setMode: string, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: any, expiryMode: string, time: number, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: Buffer) => void): void;
+
+        setnx(key: KeyType, value: any, callback: (err: Error, res: any) => void): void;
+        setnx(key: KeyType, value: any): Promise<any>;
+
+        del(...keys: KeyType[]): Promise<number>;
+
+        incr(key: KeyType, callback: (err: Error, res: number) => void): void;
+        incr(key: KeyType): Promise<number>;
+
+        decr(key: KeyType, callback: (err: Error, res: number) => void): void;
+        decr(key: KeyType): Promise<number>;
+
+        rpush(key: KeyType, ...values: any[]): any;
+
+        rpushBuffer(key: string, ...values: Buffer[]): any;
+
+        lpopBuffer(key: KeyType, callback: (err: Error, res: Buffer) => void): void;
+        lpopBuffer(key: KeyType): Promise<Buffer>;
+
+        llen(key: KeyType, callback: (err: Error, res: number) => void): void;
+        llen(key: KeyType): Promise<number>;
+
+        lrangeBuffer(key: KeyType, start: number, stop: number, callback: (err: Error, res: Buffer[]) => void): void;
+        lrangeBuffer(key: KeyType, start: number, stop: number): Promise<Buffer[]>;
+
+        zadd(key: KeyType, ...args: string[]): Promise<number | string>;
+
+        zrem(key: KeyType, ...members: any[]): any;
+
+        zrange(key: KeyType, start: number, stop: number, callback: (err: Error, res: any) => void): void;
+        zrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback: (err: Error, res: any) => void): void;
+        zrange(key: KeyType, start: number, stop: number, withScores?: "WITHSCORES"): Promise<any>;
+
+        hset(key: KeyType, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
+        hset(key: KeyType, field: string, value: any): Promise<0 | 1>;
+
+        hget(key: KeyType, field: string, callback: (err: Error, res: string | null) => void): void;
+        hget(key: KeyType, field: string): Promise<string | null>;
+
+        expire(key: KeyType, seconds: number, callback: (err: Error, res: 0 | 1) => void): void;
+        expire(key: KeyType, seconds: number): Promise<0 | 1>;
+
+        keys(pattern: string, callback: (err: Error, res: string[]) => void): void;
+        keys(pattern: string): Promise<string[]>;
     }
 
     interface ClusterStatic extends NodeJS.EventEmitter, Commander {

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -258,6 +258,72 @@ cluster.connect(() => {
 })
 .then(result => console.log(result))
 .then(reason => console.error(reason));
+
+cluster.setBuffer('key', '100', 'NX', 'EX', 10, (err, data) => { });
+cluster.getBuffer('key', (err, data) => {
+    // [null, '100']
+});
+
+cluster.setnx('keynx', '100', (err, data) => {
+    // [null, 'OK']
+});
+cluster.setnx('keynx', '200', (err, data) => {
+    // [null, 'NOT OK']
+});
+cluster.get('keynx', (err, data) => {
+    // [null, '100']
+});
+
+cluster.del('keynx');
+
+cluster.incr('key', (err, data) => {
+    // [null, '101']
+});
+
+cluster.decr('key', (err, data) => {
+    // [null, '100']
+});
+
+listData.forEach(value => {
+    cluster.rpushBuffer('bufferlist', Buffer.from(value));
+});
+
+cluster.llen('bufferlist', (err, data) => {
+    if (data !== listData.length) {
+        console.log(data);
+    }
+});
+
+cluster.lpopBuffer('bufferlist', (err, data) => {
+    if (data.toString() !== listData[0]) {
+        console.log(data.toString());
+    }
+});
+
+cluster.lrangeBuffer('bufferlist', 0, listData.length - 2, (err, data) => {
+    data.forEach((value, index) => {
+        if (value.toString() !== listData[index + 1]) {
+            console.log(value.toString());
+        }
+    });
+});
+
+cluster.zadd('sorted', '1', 'foo');
+cluster.zadd('sorted', '1', 'bar');
+cluster.zrange('sorted', 0, 1, (err, data) => {
+    // [null, ['foo', 'bar']]
+});
+cluster.zrem('sorted', 'foo');
+
+cluster.hset('hash', 'foo', '4');
+cluster.hget('hash', 'foo', (err, data) => {
+    // [null, '4']
+});
+
+cluster.expire('key', 300, (err, res) => {
+    // [null, 1]
+});
+
 cluster.disconnect();
 cluster.quit(result => {
     console.log(result);


### PR DESCRIPTION
In @types/ioredis, only set()/get() are defined for Cluster.
However, there are more methods as shown [here](https://npmdoc.github.io/node-npmdoc-ioredis/build/apidoc.html#apidoc.module.ioredis.Cluster.prototype), and I'm actually using some of them.
So, I want to add them.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://npmdoc.github.io/node-npmdoc-ioredis/build/apidoc.html>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.