### PR TITLE
[unzipper] Fix CentralDirectory.extract type

### DIFF
--- a/types/unzipper/index.d.ts
+++ b/types/unzipper/index.d.ts
@@ -81,7 +81,7 @@ export interface CentralDirectory {
     offsetToStartOfCentralDirectory: number;
     commentLength: number;
     files: File[];
-    extract: (opts: ParseOptions) => ParseStream;
+    extract: (opts: ParseOptions) => Promise<void>;
 }
 
 export interface File {

--- a/types/unzipper/unzipper-tests.ts
+++ b/types/unzipper/unzipper-tests.ts
@@ -48,3 +48,10 @@ const dir1: Promise<CentralDirectory> = Open.file("Z:\\path\\to\\archive.zip");
 const dir2: Promise<CentralDirectory> = Open.url(get("url/to/archive.zip"), {});
 const dir3: Promise<CentralDirectory> = Open.s3("any", "any");
 const dir4: Promise<CentralDirectory> = Open.buffer(Buffer.from('ZIPDATA'));
+
+(async () => {
+    const cd = await dir1;
+    await cd.extract({
+        path: "path/to/extraction/root"
+    });
+})();


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ZJONSSON/node-unzipper/blob/f162a8590544bef8806668729f4e82e4d912398c/lib/Open/directory.js#L76
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header: Not applicable
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed: Not applicable