### PR TITLE
[aws-lambda] Add principalOrgId to APIGatewayEventRequestContext

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -108,6 +108,7 @@ strOrNull = apiGwEvtReqCtx.identity.cognitoAuthenticationProvider;
 strOrNull = apiGwEvtReqCtx.identity.cognitoAuthenticationType;
 strOrNull = apiGwEvtReqCtx.identity.cognitoIdentityId;
 strOrNull = apiGwEvtReqCtx.identity.cognitoIdentityPoolId;
+strOrNull = apiGwEvtReqCtx.identity.principalOrgId;
 str = apiGwEvtReqCtx.identity.sourceIp;
 strOrNull = apiGwEvtReqCtx.identity.user;
 strOrNull = apiGwEvtReqCtx.identity.userAgent;

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -31,6 +31,7 @@
 //                 Juan Carbonel <https://github.com/juancarbonel>
 //                 Peter McIntyre <https://github.com/pwmcintyre>
 //                 Alex Bolenok <https://github.com/alex-bolenok-centralreach>
+//                 Marian Zange <https://github.com/marianzange>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -56,6 +57,7 @@ export interface APIGatewayEventRequestContext {
         cognitoAuthenticationType: string | null;
         cognitoIdentityId: string | null;
         cognitoIdentityPoolId: string | null;
+        principalOrgId: string | null;
         sourceIp: string;
         user: string | null;
         userAgent: string | null;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
