### PR TITLE
fix(sinon): sinon.spy property accessor types

### DIFF
--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -335,6 +335,8 @@ declare namespace Sinon {
         restore(): void;
     }
 
+    type PropertyAccessorType = 'get' | 'set';
+
     interface SinonSpyStatic {
         /**
          * Creates an anonymous function that records arguments, this value, exceptions and return values for all calls.
@@ -351,11 +353,23 @@ declare namespace Sinon {
          * The original method can be restored by calling object.method.restore().
          * The returned spy is the function object which replaced the original method. spy === object.method.
          */
-        <T, K extends keyof T>(obj: T, method: K, types?: string[]): T[K] extends (
+        <T, K extends keyof T>(obj: T, method: K): T[K] extends (
             ...args: infer TArgs
         ) => infer TReturnValue
             ? SinonSpy<TArgs, TReturnValue>
             : SinonSpy;
+
+        <T, K extends keyof T>(obj: T, method: K, types: PropertyAccessorType[]): {
+            [P in PropertyAccessorType]?: T[K] extends (
+                ...args: infer TArgs
+            ) => infer TReturnValue
+                    ? SinonSpy<TArgs, TReturnValue>
+                    : SinonSpy;
+        } & {
+            value?: typeof obj[K],
+            enumerable: boolean,
+            configurable: boolean,
+        };
     }
 
     interface SinonStub<TArgs extends any[] = any[], TReturnValue = any>


### PR DESCRIPTION
This can properly be done better.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
Note that running `npm test` on sinon without my changes currently fails with some errors beyond my current comprehension. No errors arose from dependencies.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
Same note as with `test`, there are currently linting issues with sinon in master.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

In sinon, one can spy on getters and setters like so:

```js
const sinon = require('sinon');
const foo = { get bar() {}, set bar() {} };
const s = sinon.spy(foo, 'bar', ['get']);
```

`s` now contains the property descriptor for `foo.bar`, where `s.get` is a spy for the getter, so:

```js
s.get.called; // false
foo.bar;
s.get.called; // true
```

The typings for `sinon.spy` did not support this overload. Linting the above code before would tell you how `s.get` is undefined, as it thinks `s` is a spy itself.
This patch attempts to type this overload. The returned value is an object which looks like a property descriptor, with the `get` and `set` as spies.

This however isn't foolproof. In the above example, while `s.get` is a spy, `s.set` is the original function. My typescript-fu isn't strong enough to solve this, but it's a start?