### PR TITLE
[@types/command-line-args]: it's now possible to pass an option that extends the base option

### DIFF
--- a/types/command-line-args/command-line-args-tests.ts
+++ b/types/command-line-args/command-line-args-tests.ts
@@ -9,16 +9,44 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
         multiple: true,
         lazyMultiple: true,
         defaultOption: true,
-        group: 'one'
-    }
+        group: 'one',
+    },
+];
+
+interface CustomDefinition extends commandLineArgs.OptionDefinition {
+    description: string;
+}
+
+const customOptionDefinitions: CustomDefinition[] = [
+    {
+        name: 'something',
+        alias: 's',
+        type: String,
+        defaultValue: '1',
+        multiple: true,
+        lazyMultiple: true,
+        defaultOption: true,
+        group: 'one',
+        description: 'Desc',
+    },
 ];
 
 const options = commandLineArgs(optionDefinitions, {
-    argv: [ '--one', '1' ],
+    argv: ['--one', '1'],
     partial: true,
     stopAtFirstUnknown: true,
-    camelCase: true
+    camelCase: true,
+});
+
+const customOptions = commandLineArgs(customOptionDefinitions, {
+    argv: ['--one', '1'],
+    partial: true,
+    stopAtFirstUnknown: true,
+    camelCase: true,
 });
 
 const unknown = options._unknown;
 const something = options.something;
+
+const customUnknown = customOptions._unknown;
+const customSomething = customOptions.something;

--- a/types/command-line-args/index.d.ts
+++ b/types/command-line-args/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for command-line-args 5.0
 // Project: https://github.com/75lb/command-line-args
-// Definitions by: Lloyd Brookes <https://github.com/75lb>
-// Definitions by: Emanuele Stoppa <https://github.com/ematipico>
+// Definitions by: Lloyd Brookes <https://github.com/75lb>,
+//                 Emanuele Stoppa <https://github.com/ematipico>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -9,8 +9,8 @@
  * Returns an object containing option values parsed from the command line. By default it parses the global `process.argv` array.
  * Parsing is strict by default. To be more permissive, enable `partial` or `stopAtFirstUnknown` modes.
  */
-declare function commandLineArgs<OptionDefinition = commandLineArgs.OptionDefinition>(
-    optionDefinitions: OptionDefinition[],
+declare function commandLineArgs(
+    optionDefinitions: commandLineArgs.OptionDefinition[] | Array<object & commandLineArgs.OptionDefinition>,
     options?: commandLineArgs.ParseOptions,
 ): commandLineArgs.CommandLineOptions;
 

--- a/types/command-line-args/index.d.ts
+++ b/types/command-line-args/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for command-line-args 5.0
 // Project: https://github.com/75lb/command-line-args
 // Definitions by: Lloyd Brookes <https://github.com/75lb>
+// Definitions by: Emanuele Stoppa <https://github.com/ematipico>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -8,7 +9,10 @@
  * Returns an object containing option values parsed from the command line. By default it parses the global `process.argv` array.
  * Parsing is strict by default. To be more permissive, enable `partial` or `stopAtFirstUnknown` modes.
  */
-declare function commandLineArgs(optionDefinitions: commandLineArgs.OptionDefinition[], options?: commandLineArgs.ParseOptions): commandLineArgs.CommandLineOptions;
+declare function commandLineArgs<OptionDefinition = commandLineArgs.OptionDefinition>(
+    optionDefinitions: OptionDefinition[],
+    options?: commandLineArgs.ParseOptions,
+): commandLineArgs.CommandLineOptions;
 
 declare namespace commandLineArgs {
     interface CommandLineOptions {


### PR DESCRIPTION
Possible now to pass an Option that extends the base type

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/75lb/command-line-args/blob/master/lib/option-definition.mjs#L246
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

The definitions provided should be accept extendable: meaning that it's possible to add any additional prop to the command definition