### PR TITLE
[Fix] steam-totp

### DIFF
--- a/types/steam-totp/index.d.ts
+++ b/types/steam-totp/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for steam-totp 2.0
+// Type definitions for steam-totp 2.1
 // Project: https://github.com/DoctorMcKay/node-steam-totp
 // Definitions by: Max Uetrecht <https://github.com/phenomax>
+//                 Dariusz Syncerek <https://github.com/dsyncerek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -21,7 +22,7 @@ export function time(timeOffset?: number): number;
  * @param [timeOffset=0] - If you know how far off your clock is from the Steam servers, put the offset here in seconds
  * @returns the generated auth code
  */
-export function generateAuthCode(secret: string, timeOffset: number | TimeOffsetFunction): string;
+export function generateAuthCode(secret: string, timeOffset?: number | TimeOffsetFunction): string;
 
 /**
  * Generate a Steam-style TOTP authentication code.
@@ -29,7 +30,7 @@ export function generateAuthCode(secret: string, timeOffset: number | TimeOffset
  * @param [timeOffset=0] - If you know how far off your clock is from the Steam servers, put the offset here in seconds
  * @returns the generated auth code
  */
-export function getAuthCode(secret: string, timeOffset: number | TimeOffsetFunction): string;
+export function getAuthCode(secret: string, timeOffset?: number | TimeOffsetFunction): string;
 
 /**
  * Generate a base64 confirmation key for use with mobile trade confirmations. The key can only be used once.


### PR DESCRIPTION
I changed `timeOffset` argument in `generateAuthCode` function to optional. 

Source: 
https://github.com/DoctorMcKay/node-steam-totp#getauthcodesecret-timeoffset-callback
https://github.com/DoctorMcKay/node-steam-totp/blob/master/index.js#L17
