### PR TITLE
Lodash: add support for user-defined type guards to `overSome` and `overEvery`

### DIFF
--- a/types/lodash/common/util.d.ts
+++ b/types/lodash/common/util.d.ts
@@ -968,6 +968,10 @@ declare module "../index" {
          * @param predicates The predicates to check.
          * @return Returns the new function.
          */
+        overEvery<T, Result1 extends T, Result2 extends T>(
+            a: (arg: T) => arg is Result1,
+            b: (arg: T) => arg is Result2
+        ): (arg: T) => Result1 & Result2;
         overEvery<T>(...predicates: Array<Many<(...args: T[]) => boolean>>): (...args: T[]) => boolean;
     }
 
@@ -995,6 +999,10 @@ declare module "../index" {
          * @param predicates The predicates to check.
          * @return Returns the new function.
          */
+        overSome<T, Result1 extends T, Result2 extends T>(
+            a: (arg: T) => arg is Result1,
+            b: (arg: T) => arg is Result2
+        ): (arg: T) => Result1 | Result2;
         overSome<T>(...predicates: Array<Many<(...args: T[]) => boolean>>): (...args: T[]) => boolean;
     }
 

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -6841,6 +6841,11 @@ fp.now(); // $ExpectType number
 // _.overEvery
 // _.overSome
 {
+    const userDefinedTypeGuard1 = (item: any): item is number => typeof item === "number";
+    const userDefinedTypeGuard2 = (item: any): item is string => typeof item === "string";
+
+    _.overEvery(userDefinedTypeGuard1, userDefinedTypeGuard2); // $ExpectType (arg: any) => number & string
+
     _.overEvery((number: number) => true); // $ExpectType (...args: number[]) => boolean
     _.overEvery((number: number) => true, (number: number) => true); // $ExpectType (...args: number[]) => boolean
     _.overEvery([(number: number) => true]); // $ExpectType (...args: number[]) => boolean
@@ -6856,6 +6861,8 @@ fp.now(); // $ExpectType number
 
     fp.overEvery((number: number) => true); // $ExpectType (...args: number[]) => boolean
     fp.overEvery([(number: number) => true, (number: number) => true]); // $ExpectType (...args: number[]) => boolean
+
+    _.overSome(userDefinedTypeGuard1, userDefinedTypeGuard2); // $ExpectType (arg: any) => string | number
 
     _.overSome((number: number) => true); // $ExpectType (...args: number[]) => boolean
     _.overSome((number: number) => true, (number: number) => true); // $ExpectType (...args: number[]) => boolean

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -6841,10 +6841,10 @@ fp.now(); // $ExpectType number
 // _.overEvery
 // _.overSome
 {
-    const userDefinedTypeGuard1 = (item: any): item is number => typeof item === "number";
-    const userDefinedTypeGuard2 = (item: any): item is string => typeof item === "string";
+    const userDefinedTypeGuard1: (item: object) => item is { a: 1 } = anything;
+    const userDefinedTypeGuard2: (item: object) => item is { b: 1 } = anything;
 
-    _.overEvery(userDefinedTypeGuard1, userDefinedTypeGuard2); // $ExpectType (arg: any) => number & string
+    _.overEvery(userDefinedTypeGuard1, userDefinedTypeGuard2); // $ExpectType (arg: object) => { a: 1; } & { b: 1; }
 
     _.overEvery((number: number) => true); // $ExpectType (...args: number[]) => boolean
     _.overEvery((number: number) => true, (number: number) => true); // $ExpectType (...args: number[]) => boolean
@@ -6862,7 +6862,7 @@ fp.now(); // $ExpectType number
     fp.overEvery((number: number) => true); // $ExpectType (...args: number[]) => boolean
     fp.overEvery([(number: number) => true, (number: number) => true]); // $ExpectType (...args: number[]) => boolean
 
-    _.overSome(userDefinedTypeGuard1, userDefinedTypeGuard2); // $ExpectType (arg: any) => string | number
+    _.overSome(userDefinedTypeGuard1, userDefinedTypeGuard2); // $ExpectType (arg: object) => { a: 1; } | { b: 1; }
 
     _.overSome((number: number) => true); // $ExpectType (...args: number[]) => boolean
     _.overSome((number: number) => true, (number: number) => true); // $ExpectType (...args: number[]) => boolean

--- a/types/lodash/ts3.1/common/util.d.ts
+++ b/types/lodash/ts3.1/common/util.d.ts
@@ -752,6 +752,10 @@ declare module "../index" {
          * @param predicates The predicates to check.
          * @return Returns the new function.
          */
+        overEvery<T, Result1 extends T, Result2 extends T>(...predicates: [
+            (arg: T) => arg is Result1,
+            (arg: T) => arg is Result2
+        ]): (arg: T) => Result1 & Result2;
         overEvery<T>(...predicates: Array<Many<(...args: T[]) => boolean>>): (...args: T[]) => boolean;
     }
     interface Collection<T> {
@@ -787,6 +791,10 @@ declare module "../index" {
          * @param predicates The predicates to check.
          * @return Returns the new function.
          */
+        overSome<T, Result1 extends T, Result2 extends T>(...predicates: [
+            (arg: T) => arg is Result1,
+            (arg: T) => arg is Result2
+        ]): (arg: T) => Result1 | Result2;
         overSome<T>(...predicates: Array<Many<(...args: T[]) => boolean>>): (...args: T[]) => boolean;
     }
     interface Collection<T> {


### PR DESCRIPTION
If this change looks good, I can add more overloads to extend support for more user-defined type guards (> 2), and I will also update the other Lodash variants (implicit/explicit chains and FP).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.