### PR TITLE
Improve lodash omit typings

### DIFF
--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -3078,10 +3078,10 @@ declare module "../index" {
         /**
          * @see _.omit
          */
-        omit<T extends object, K extends Array<Many<PropertyName>>>(
+        omit<T extends object>(
             object: T | null | undefined,
             ...paths: Array<Many<PropertyName>>
-        ): Pick<T, Exclude<keyof T, K[number]>>;
+        ): PartialObject<T>;
     }
 
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -3062,26 +3062,18 @@ declare module "../index" {
          * _.omit(object, ['a', 'c']);
          * // => { 'b': '2' }
          */
+        omit<T extends {}, P extends Array<Many<PropertyName>>>(
+            object: T | null | undefined,
+            ...paths: P
+        ): Pick<T, Exclude<keyof T, P[number]>>
+
+        /**
+         * @see _.omit
+         */
         omit<T extends AnyKindOfDictionary>(
             object: T | null | undefined,
             ...paths: Array<Many<PropertyName>>
         ): T;
-
-        /**
-         * @see _.omit
-         */
-        omit<T extends object, K extends keyof T>(
-            object: T | null | undefined,
-            ...paths: Array<Many<K>>
-        ): Omit<T, K>;
-
-        /**
-         * @see _.omit
-         */
-        omit<T extends object, K extends Array<Many<PropertyName>>>(
-            object: T | null | undefined,
-            ...paths: Array<Many<PropertyName>>
-        ): Pick<T, Exclude<keyof T, K[number]>>;
     }
 
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -3078,10 +3078,10 @@ declare module "../index" {
         /**
          * @see _.omit
          */
-        omit<T extends object>(
+        omit<T extends object, K extends Array<Many<PropertyName>>>(
             object: T | null | undefined,
             ...paths: Array<Many<PropertyName>>
-        ): PartialObject<T>;
+        ): Pick<T, Exclude<keyof T, K[number]>>;
     }
 
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -3062,18 +3062,26 @@ declare module "../index" {
          * _.omit(object, ['a', 'c']);
          * // => { 'b': '2' }
          */
-        omit<T extends {}, P extends Array<Many<PropertyName>>>(
-            object: T | null | undefined,
-            ...paths: P
-        ): Pick<T, Exclude<keyof T, P[number]>>
-
-        /**
-         * @see _.omit
-         */
         omit<T extends AnyKindOfDictionary>(
             object: T | null | undefined,
             ...paths: Array<Many<PropertyName>>
         ): T;
+
+        /**
+         * @see _.omit
+         */
+        omit<T extends object, K extends keyof T>(
+            object: T | null | undefined,
+            ...paths: Array<Many<K>>
+        ): Omit<T, K>;
+
+        /**
+         * @see _.omit
+         */
+        omit<T extends object, K extends Array<Many<PropertyName>>>(
+            object: T | null | undefined,
+            ...paths: Array<Many<PropertyName>>
+        ): Pick<T, Exclude<keyof T, K[number]>>;
     }
 
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/ts3.1/common/object.d.ts
+++ b/types/lodash/ts3.1/common/object.d.ts
@@ -1889,6 +1889,13 @@ declare module "../index" {
          * _.omit(object, ['a', 'c']);
          * // => { 'b': '2' }
          */
+        omit<T extends object, K extends PropertyName[]>(
+            object: T | null | undefined,
+            ...paths: K
+        ): Pick<T, Exclude<keyof T, K[number]>>;
+        /**
+         * @see _.omit
+         */
         omit<T extends object, K extends keyof T>(object: T | null | undefined, ...paths: Array<Many<K>>): Omit<T, K>;
         /**
          * @see _.omit

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -5606,8 +5606,7 @@ fp.now(); // $ExpectType number
     _.omit(obj, "a"); // $ExpectType Pick<AbcObject, "b" | "c">
     _.omit(obj, ["b", 1], 0, "a"); // $ExpectType Partial<AbcObject>
     _.omit(dictionary, "a"); // $ExpectType Pick<Dictionary<AbcObject>, string | number>
-    _.omit(numericDictionary, "a");  // $ExpectType Partial<NumericDictionary<AbcObject>>
-
+    _.omit(numericDictionary, "a"); // $ExpectType Pick<NumericDictionary<AbcObject>, number>
     _(obj).omit("a"); // $ExpectType Object<Pick<AbcObject, "b" | "c">>
     _(obj).omit(["b", 1], 0, "a"); // $ExpectType Object<Partial<AbcObject>>
     _(dictionary).omit("a"); // $ExpectType Object<Pick<Dictionary<AbcObject>, string | number>>


### PR DESCRIPTION
When omitting multiple properties, properly type-narrow the response

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.