### PR TITLE
Add types for windows-process-tree

### DIFF
--- a/types/windows-process-tree/index.d.ts
+++ b/types/windows-process-tree/index.d.ts
@@ -1,0 +1,61 @@
+// Type definitions for windows-process-tree 0.2
+// Project: https://github.com/Microsoft/vscode-windows-process-tree
+// Definitions by: Rachel Macfarlane <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export enum ProcessDataFlag {
+    None = 0,
+    Memory = 1,
+    CommandLine = 2
+}
+
+export interface ProcessInfo {
+    pid: number;
+    ppid: number;
+    name: string;
+
+    /**
+     * The working set size of the process, in bytes.
+     */
+    memory?: number;
+
+    /**
+     * The string returned is at most 512 chars, strings exceeding this length are truncated.
+     */
+    commandLine?: string;
+}
+
+export interface ProcessCpuInfo extends ProcessInfo {
+    cpu?: number;
+}
+
+export interface ProcessTreeNode {
+    pid: number;
+    name: string;
+    memory?: number;
+    commandLine?: string;
+    children: ProcessTreeNode[];
+}
+
+/**
+ * Returns a tree of processes with the rootPid process as the root.
+ * @param rootPid - The pid of the process that will be the root of the tree.
+ * @param callback - The callback to use with the returned list of processes.
+ * @param flags - The flags for what process data should be included.
+ */
+export function getProcessTree(rootPid: number, callback: (tree: ProcessTreeNode) => void, flags?: ProcessDataFlag): void;
+
+/**
+ * Returns a list of processes containing the rootPid process and all of its descendants.
+ * @param rootPid - The pid of the process of interest.
+ * @param callback - The callback to use with the returned set of processes.
+ * @param flags - The flags for what process data should be included.
+ */
+export function getProcessList(rootPid: number, callback: (processList: ProcessInfo[]) => void, flags?: ProcessDataFlag): void;
+
+/**
+ * Returns the list of processes annotated with cpu usage information.
+ * @param processList - The list of processes.
+ * @param callback - The callback to use with the returned list of processes.
+ */
+export function getProcessCpuUsage(processList: ReadonlyArray<ProcessInfo>, callback: (processListWithCpu: ProcessCpuInfo[]) => void): void;

--- a/types/windows-process-tree/tsconfig.json
+++ b/types/windows-process-tree/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "windows-process-tree-tests.ts"
+    ]
+}

--- a/types/windows-process-tree/tslint.json
+++ b/types/windows-process-tree/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/windows-process-tree/windows-process-tree-tests.ts
+++ b/types/windows-process-tree/windows-process-tree-tests.ts
@@ -1,0 +1,7 @@
+import * as windowsProcessTree from "windows-process-tree";
+
+windowsProcessTree.getProcessCpuUsage([], () => { });
+windowsProcessTree.getProcessList(1, () => { });
+windowsProcessTree.getProcessTree(1, () => { }, windowsProcessTree.ProcessDataFlag.CommandLine);
+windowsProcessTree.getProcessTree(1, () => { }, windowsProcessTree.ProcessDataFlag.Memory);
+windowsProcessTree.getProcessTree(1, () => { }, windowsProcessTree.ProcessDataFlag.None);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
