### PR TITLE
Updated simple-peer to v9.6

### DIFF
--- a/types/simple-peer/index.d.ts
+++ b/types/simple-peer/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for simple-peer 6.1
 // Project: https://github.com/feross/simple-peer
 // Definitions by: Tomasz Łaziuk <https://github.com/tlaziuk>
+//                 xWiiLLz <https://github.com/xWiiLLz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -35,12 +36,21 @@ declare namespace SimplePeer {
         readonly WEBRTC_SUPPORT: boolean;
     }
 
-    type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;
+    type TypedArray =
+        | Int8Array
+        | Uint8Array
+        | Uint8ClampedArray
+        | Int16Array
+        | Uint16Array
+        | Int32Array
+        | Uint32Array
+        | Float32Array
+        | Float64Array;
 
     type SimplePeerData = string | Buffer | TypedArray | ArrayBuffer | Blob;
 
     interface SignalData {
-        type?: "offer" | "pranswer" | "answer" | "rollback";
+        type?: 'offer' | 'pranswer' | 'answer' | 'rollback';
         sdp?: any;
         candidate?: any;
     }
@@ -52,6 +62,21 @@ declare namespace SimplePeer {
         // https://github.com/feross/simple-peer/tree/v6.1.5#peersenddata
         send(data: SimplePeerData): void;
 
+        // https://github.com/feross/simple-peer/tree/v9.6.1#peeraddstreamstream
+        addStream(stream: MediaStream): void;
+
+        // https://github.com/feross/simple-peer/tree/v9.6.1#peerremovestreamstream
+        removeStream(stream: MediaStream): void;
+
+        // https://github.com/feross/simple-peer/tree/v9.6.1#peeraddtracktrack-stream
+        addTrack(track: MediaStreamTrack, stream: MediaStream): void;
+
+        // https://github.com/feross/simple-peer/tree/v9.6.1#peerremovetracktrack-stream
+        removeTrack(track: MediaStreamTrack, stream: MediaStream): void;
+
+        // https://github.com/feross/simple-peer/blob/v9.6.1/index.js#L306
+        replaceTrack(oldTrack: MediaStreamTrack, newTrack: MediaStreamTrack, stream: MediaStream): void;
+
         // https://github.com/feross/simple-peer/tree/v6.1.5#peersenddata
         // TODO: https://github.com/feross/simple-peer/issues/187
         // destroy(onclose?: () => void): void;
@@ -61,7 +86,7 @@ declare namespace SimplePeer {
 
         // methods which are not documented
         readonly bufferSize: number;
-        address(): { port: string, family: string, address: string, };
+        address(): { port: string; family: string; address: string };
 
         // used for debug logging
         _debug(message?: any, ...optionalParams: any[]): void;

--- a/types/simple-peer/index.d.ts
+++ b/types/simple-peer/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for simple-peer 6.1
+// Type definitions for simple-peer 9.6
 // Project: https://github.com/feross/simple-peer
 // Definitions by: Tomasz Łaziuk <https://github.com/tlaziuk>
 //                 xWiiLLz <https://github.com/xWiiLLz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /// <reference types="node" />
 

--- a/types/simple-peer/simple-peer-tests.ts
+++ b/types/simple-peer/simple-peer-tests.ts
@@ -2,6 +2,10 @@ import SimplePeer = require('simple-peer');
 
 const peer = new SimplePeer();
 peer.write(new Buffer('hey'));
-peer.on('data', (chunk) => {
+peer.on('data', chunk => {
     console.log(`got a chunk: ${chunk}`);
 });
+
+const stream = new MediaStream();
+peer.addStream(stream);
+peer.removeStream(stream);


### PR DESCRIPTION
Hi, I've added the typings for the missing methods in the current version! :smile: 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/feross/simple-peer/tree/v9.6.1#peeraddstreamstream
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.