### PR TITLE
@types/webpack: Ensure `ConfigurationFactory` args contain `mode`

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -136,14 +136,19 @@ declare namespace webpack {
         optimization?: Options.Optimization;
     }
 
+    type Args = Record<string, string> & {
+        /** See https://webpack.js.org/configuration/mode/ */
+        mode: Configuration['mode'];
+    };
+
     type ConfigurationFactory = ((
         env: string | Record<string, boolean | number | string>,
-        args: Record<string, string>,
+        args: Args,
     ) => Configuration | Promise<Configuration>);
 
     type MultiConfigurationFactory = ((
         env: string | Record<string, boolean | number | string>,
-        args: Record<string, string>,
+        args: Args,
     ) => Configuration[] | Promise<Configuration[]>);
 
     interface Entry {


### PR DESCRIPTION
Follow-up of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39390, https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37998, https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40078.
See my comment at https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40078#discussion_r342210145 for context.

@rubenspgcavalcante, I would love your help with the unchecked items, not sure how to run certain things!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- Add or edit tests to reflect the change. (Run with `npm test`.)
  - PRs referenced above did not add test for this code path.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
  - I could not get this to run for unrelated reasons (`@types/source-map` missing).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/configuration/mode/
- If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.