### PR TITLE
[@types/slate-react] Modify editor type on EventHook Type to Slate-React

### DIFF
--- a/types/slate-react/index.d.ts
+++ b/types/slate-react/index.d.ts
@@ -99,7 +99,7 @@ export interface RenderInlineProps extends RenderNodeProps {
     node: Inline;
 }
 
-export type EventHook<T = Event> = (event: T, editor: CoreEditor, next: () => any) => any;
+export type EventHook<T = Event> = (event: T, editor: Editor, next: () => any) => any;
 
 export interface Plugin extends CorePlugin {
     decorateNode?: (node: SlateNode, editor: CoreEditor, next: () => any) => any;


### PR DESCRIPTION
Using CoreEditor as the type for the EventHook is not picking functions like findEventRange so changing to Editor make sure it extends both the interface of Slate-React and Slate. Last related change from PR (#39113) and to issue (#38814)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Related to issue in Slate repository: https://github.com/ianstormtaylor/slate/issues/2901

Mention the authors (see Definitions by: in index.d.ts) so they can respond.
Authors: @andykent @majelbstoat @JanLoebel @YangusKhan @kalley @Kornil @isubasti @sgreav @jackall3n @benjiro

