### PR TITLE
Add types for windows-foreground-love

### DIFF
--- a/types/windows-foreground-love/index.d.ts
+++ b/types/windows-foreground-love/index.d.ts
@@ -1,0 +1,6 @@
+// Type definitions for windows-foreground-love 0.3
+// Project: https://github.com/the-ress/node-windows-foreground-love#readme
+// Definitions by: Tereza Tomcova <https://github.com/the-ress>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function allowSetForegroundWindow(pid?: number): boolean;

--- a/types/windows-foreground-love/tsconfig.json
+++ b/types/windows-foreground-love/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "windows-foreground-love-tests.ts"
+    ]
+}

--- a/types/windows-foreground-love/tslint.json
+++ b/types/windows-foreground-love/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/windows-foreground-love/windows-foreground-love-tests.ts
+++ b/types/windows-foreground-love/windows-foreground-love-tests.ts
@@ -1,0 +1,4 @@
+import * as wfl from "windows-foreground-love";
+
+wfl.allowSetForegroundWindow(123); // $ExpectType boolean
+wfl.allowSetForegroundWindow(); // $ExpectType boolean


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`

[windows-foreground-love](https://github.com/the-ress/node-windows-foreground-love/) provides it's own types, but can be installed only on Windows. A @<!-- -->types package is needed for compilation on other platforms: https://github.com/microsoft/vscode/issues/83421#issuecomment-551849371

- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

/cc @bpasero