### PR TITLE
Howler: allow "off" to be called without arguments

### DIFF
--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -119,6 +119,7 @@ interface Howl {
     once(event: 'unlock', callback: (soundId: number) => void, id?: number): this;
 
     off(event: string, callback?: Function, id?: number): this;
+    off(): this;
 
     stereo(pan: number, id?: number): this | void;
     pos(x: number, y: number, z: number, id?: number): this | void;

--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -28,11 +28,11 @@ interface HowlerGlobal {
 declare let Howler: HowlerGlobal;
 
 interface IHowlSoundSpriteDefinition {
-    [name: string]: [number, number]|[number, number, boolean]
+    [name: string]: [number, number] | [number, number, boolean]
 }
 
 interface IHowlProperties {
-    src: string|string[];
+    src: string | string[];
     volume?: number;
     html5?: boolean;
     loop?: boolean;
@@ -60,7 +60,7 @@ interface IHowlProperties {
 }
 
 interface Howl {
-    play(spriteOrId?: string|number): number; // .play() is not chainable; the other methods are
+    play(spriteOrId?: string | number): number; // .play() is not chainable; the other methods are
     pause(id?: number): this;
     stop(id?: number): this;
 
@@ -78,10 +78,10 @@ interface Howl {
     rate(rate: number, id: number): this;
 
     seek(seek?: number, id?: number): this | number;
-    
+
     loop(id?: number): boolean;
     loop(loop: boolean, id?: number): this;
-    
+
     playing(id?: number): boolean;
     duration(id?: number): number;
     state(): 'unloaded' | 'loading' | 'loaded';
@@ -124,14 +124,16 @@ interface Howl {
     stereo(pan: number, id?: number): this | void;
     pos(x: number, y: number, z: number, id?: number): this | void;
     orientation(x: number, y: number, z: number, xUp: number, yUp: number, zUp: number): this | void;
-    pannerAttr(o: {coneInnerAngle?: number,
+    pannerAttr(o: {
+        coneInnerAngle?: number,
         coneOuterAngle?: number, coneOuterGain?: number,
         distanceModel: 'inverse' | 'linear', maxDistance: number,
-        panningModel: 'HRTF' | 'equalpower', refDistance: number, rolloffFactor: number}, id?: number): this;
+        panningModel: 'HRTF' | 'equalpower', refDistance: number, rolloffFactor: number
+    }, id?: number): this;
 }
 
 interface HowlStatic {
-    new (properties: IHowlProperties): Howl;
+    new(properties: IHowlProperties): Howl;
 }
 
 declare let Howl: HowlStatic;


### PR DESCRIPTION
Howler allows the removal of all event listeners by [calling "off" without arguments](https://github.com/goldfire/howler.js#offevent-function-id).

Following the pull request guide, I ran lint which I placed in a separate commit so that the code change is clear. Hope this is okay.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

**If changing an existing definition:**
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/goldfire/howler.js#offevent-function-id
  Key line: **Call without parameters to remove all events.**
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
