### PR TITLE
Add types for poker-evaluator 

### DIFF
--- a/types/poker-evaluator/index.d.ts
+++ b/types/poker-evaluator/index.d.ts
@@ -1,0 +1,89 @@
+// Type definitions for poker-evaluator 0.3
+// Project: http://github.com/chenosaurus/poker-evaluator
+// Definitions by: Rory McGuinness <https://github.com/rorymcgit>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+export const HANDTYPES: HandName[];
+export const CARDS: Deck;
+export const ranks: Buffer;
+
+export function evalHand(cards: Card[]): EvaluatedHand;
+export function evalCard(card: Card): number;
+
+export type HandName =
+    'invalid hand' |
+    'high card' |
+    'one pair' |
+    'two pairs' |
+    'three of a kind' |
+    'straight' |
+    'flush' |
+    'full house' |
+    'four of a kind' |
+    'straight flush';
+
+export interface Deck {
+    '2c': 1;
+    '2d': 2;
+    '2h': 3;
+    '2s': 4;
+    '3c': 5;
+    '3d': 6;
+    '3h': 7;
+    '3s': 8;
+    '4c': 9;
+    '4d': 10;
+    '4h': 11;
+    '4s': 12;
+    '5c': 13;
+    '5d': 14;
+    '5h': 15;
+    '5s': 16;
+    '6c': 17;
+    '6d': 18;
+    '6h': 19;
+    '6s': 20;
+    '7c': 21;
+    '7d': 22;
+    '7h': 23;
+    '7s': 24;
+    '8c': 25;
+    '8d': 26;
+    '8h': 27;
+    '8s': 28;
+    '9c': 29;
+    '9d': 30;
+    '9h': 31;
+    '9s': 32;
+    'tc': 33;
+    'td': 34;
+    'th': 35;
+    'ts': 36;
+    'jc': 37;
+    'jd': 38;
+    'jh': 39;
+    'js': 40;
+    'qc': 41;
+    'qd': 42;
+    'qh': 43;
+    'qs': 44;
+    'kc': 45;
+    'kd': 46;
+    'kh': 47;
+    'ks': 48;
+    'ac': 49;
+    'ad': 50;
+    'ah': 51;
+    'as': 52;
+}
+
+export type Card = keyof Deck;
+
+export interface EvaluatedHand {
+    handType: number; // Index of HANDTYPES array
+    handRank: number;
+    value: number;
+    handName: HandName;
+}

--- a/types/poker-evaluator/poker-evaluator-tests.ts
+++ b/types/poker-evaluator/poker-evaluator-tests.ts
@@ -1,0 +1,72 @@
+import { HandName, Deck, Card, EvaluatedHand, CARDS, HANDTYPES, evalHand, ranks, evalCard } from 'poker-evaluator';
+
+HANDTYPES; // $ExpectType HandName[]
+CARDS; // $ExpectType Deck
+ranks; // $ExpectType Buffer
+
+evalHand(['as', 'ks', 'qs', 'js', 'ts', '3c', '5h']); // $ExpectType EvaluatedHand
+const result: EvaluatedHand = {
+    handType: 9,
+    handRank: 10,
+    value: 36874,
+    handName: 'straight flush',
+};
+
+evalCard('as'); // $ExpectType number
+
+const highCardName: HandName = 'high card';
+const card: Card = '2c';
+const deck: Deck = {
+    '2c': 1,
+    '2d': 2,
+    '2h': 3,
+    '2s': 4,
+    '3c': 5,
+    '3d': 6,
+    '3h': 7,
+    '3s': 8,
+    '4c': 9,
+    '4d': 10,
+    '4h': 11,
+    '4s': 12,
+    '5c': 13,
+    '5d': 14,
+    '5h': 15,
+    '5s': 16,
+    '6c': 17,
+    '6d': 18,
+    '6h': 19,
+    '6s': 20,
+    '7c': 21,
+    '7d': 22,
+    '7h': 23,
+    '7s': 24,
+    '8c': 25,
+    '8d': 26,
+    '8h': 27,
+    '8s': 28,
+    '9c': 29,
+    '9d': 30,
+    '9h': 31,
+    '9s': 32,
+    tc: 33,
+    td: 34,
+    th: 35,
+    ts: 36,
+    jc: 37,
+    jd: 38,
+    jh: 39,
+    js: 40,
+    qc: 41,
+    qd: 42,
+    qh: 43,
+    qs: 44,
+    kc: 45,
+    kd: 46,
+    kh: 47,
+    ks: 48,
+    ac: 49,
+    ad: 50,
+    ah: 51,
+    as: 52
+};

--- a/types/poker-evaluator/tsconfig.json
+++ b/types/poker-evaluator/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": [
+			"es6"
+		],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": [
+			"../"
+		],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.d.ts",
+		"poker-evaluator-tests.ts"
+	]
+}

--- a/types/poker-evaluator/tslint.json
+++ b/types/poker-evaluator/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

