### PR TITLE
[bluebird] Fix typings for .all() and .some()

### DIFF
--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -1,4 +1,4 @@
-// Tests by: Bart van der Schoor <https://github.com/Bartvds>
+// Tests by: Bart van der Schoor <https://github.com/Bartvds>, thislooksfun <https://github.com/thislooksfun>
 
 // Note: replicate changes to all overloads in both definition and test file
 // Note: keep both static and instance members inline (so similar)
@@ -106,6 +106,7 @@ let anyArrProm: Bluebird<any[]>;
 
 let fooArrProm: Bluebird<Foo[]> = Bluebird.resolve(fooArr);
 let barArrProm: Bluebird<Bar[]>;
+let fooOrNullArrProm: Bluebird<Array<Foo | null>> = Bluebird.resolve(fooArr);
 
 // - - - - - - - - - - - - - - - - -
 
@@ -609,7 +610,11 @@ barProm = fooArrProm.spread((one: Foo, two: Foo, twotwo: Foo) => {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+// $ExpectType Bluebird<Foo[]>
 fooArrProm = fooArrProm.all();
+
+// $ExpectType Bluebird<(Foo | null)[]>
+fooOrNullArrProm = fooOrNullArrProm.all();
 
 // $ExpectType Bluebird<never>
 fooProm.all();
@@ -619,7 +624,11 @@ fooProm = fooArrProm.any();
 // $ExpectType Bluebird<never>
 fooProm.any();
 
+// $ExpectType Bluebird<Foo[]>
 fooArrProm = fooArrProm.some(num);
+
+// $ExpectType Bluebird<(Foo | null)[]>
+fooOrNullArrProm = fooOrNullArrProm.some(num);
 
 // $ExpectType Bluebird<never>
 fooProm.some(num);

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for bluebird 3.5
 // Project: https://github.com/petkaantonov/bluebird
-// Definitions by: Leonard Hecker <https://github.com/lhecker>
+// Definitions by: Leonard Hecker <https://github.com/lhecker>, thislooksfun <https://github.com/thislooksfun>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 
@@ -566,7 +566,7 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
   /**
    * Same as calling `Promise.all(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
-  all(this: Bluebird<Iterable<{}>>): Bluebird<R>;
+  all<Q>(this: Bluebird<R & Iterable<Q>>): Bluebird<R>;
 
   /**
    * Same as calling `Promise.all(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
@@ -593,7 +593,7 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    * Same as calling `Promise.some(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    * Same as calling `Promise.some(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
-  some(this: Bluebird<Iterable<{}>>, count: number): Bluebird<R>;
+  some<Q>(this: Bluebird<R & Iterable<Q>>, count: number): Bluebird<R>;
 
   /**
    * Same as calling `Promise.some(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.


### PR DESCRIPTION
When calling `.all()` or `.some(<count>)` before with complex types, it would default to the `.all(): Promise<never>` definition, and likewise for `.some()`. This change fixes those issues, bringing them in line with the implementations of `.each()`, `.map()`, and the like.

Example of previous (incorrect) behavior:
```typescript
import Promise from "bluebird"
const p1: Promise<Array<Foo | null>> = Promise.resolve([]);
const p2 = p1.all();  // Here p2 has type Promise<never>
```

Example of fixed behavior:
```typescript
import Promise from "bluebird"
const p1: Promise<Array<Foo | null>> = Promise.resolve([]);
const p2 = p1.all();  // Here p2 has type Promise<(Foo | null)[]>
```

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
