### PR TITLE
[passport-oauth2-refresh] Updated types

### DIFF
--- a/types/passport-oauth2-refresh/index.d.ts
+++ b/types/passport-oauth2-refresh/index.d.ts
@@ -1,13 +1,16 @@
 // Type definitions for passport-oauth2-refresh 1.1
 // Project: https://github.com/fiznool/passport-oauth2-refresh#readme
 // Definitions by: Daphne Smit <https://github.com/daphnesmit>
+//                 Brian Torres-Gil <https://github.com/btorresgil>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
 import { Strategy } from 'passport-oauth2';
+import { oauth2tokenCallback } from 'oauth';
 
 export function use(name: string | Strategy, strategy?: Strategy): void;
 
 export function has(name: string): boolean;
 
-export function requestNewAccessToken(name: string, refreshToken: string, params: any, done: () => any): any;
+export function requestNewAccessToken(name: string, refreshToken: string, done: oauth2tokenCallback): any;
+export function requestNewAccessToken(name: string, refreshToken: string, params: any, done: oauth2tokenCallback): any;

--- a/types/passport-oauth2-refresh/passport-oauth2-refresh-tests.ts
+++ b/types/passport-oauth2-refresh/passport-oauth2-refresh-tests.ts
@@ -17,4 +17,5 @@ const strategy1: OAuth2Strategy = new OAuth2Strategy(strategyOptions1, verifyFun
 
 use('strategy1', strategy1);
 
-requestNewAccessToken('strategy1', 'exampleRefreshToken', {}, () => {});
+requestNewAccessToken('strategy1', 'exampleRefreshToken', (err, accessToken, refreshToken, results) => {});
+requestNewAccessToken('strategy1', 'exampleRefreshToken', {}, (err, accessToken, refreshToken, results) => {});


### PR DESCRIPTION
Adds missing type definitions including an overload for the main function and the type for the callbacks.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/fiznool/passport-oauth2-refresh
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - Same version, but types are more fleshed out.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.