### PR TITLE
[@types/dotenv-safe] Updated to match version 8.1

### DIFF
--- a/types/dotenv-safe/dotenv-safe-tests.ts
+++ b/types/dotenv-safe/dotenv-safe-tests.ts
@@ -1,11 +1,5 @@
 import env = require("dotenv-safe")
 
-env.load({
-  allowEmptyValues: true,
-  path: "/foo/bar/baz.env",
-  sample: "/foo/bar/qux.env"
-})
-
 env.config({
   allowEmptyValues: true,
   path: "/foo/bar/baz.env",

--- a/types/dotenv-safe/index.d.ts
+++ b/types/dotenv-safe/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for dotenv-safe 5.0
+// Type definitions for dotenv-safe 8.1
 // Project: https://github.com/rolodato/dotenv-safe
 // Definitions by: Stan Goldmann <https://github.com/krenor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-import env = require("dotenv")
+import dotenv = require("dotenv")
 
 export interface MissingEnvVarsError extends Error {
   /**
@@ -18,32 +18,19 @@ export interface MissingEnvVarsError extends Error {
   missing: string[]
 }
 
-export interface DotenvSafeOptions {
-  /**
-   * You can specify a custom path if your file containing environment variables is named or located differently.
-   * @default '.env'
-   */
-  path?: string,
+export interface DotenvSafeOptions extends dotenv.DotenvConfigOptions {
   /**
    * Path to example environment file. (Option 1)
    * @default ".env.example"
    */
   example?: string,
+
   /**
-   * Path to example environment file. (Option 2 -- example takes precendence)
+   * Path to example environment file. (Option 2 -- example takes precedence)
    * @default ".env.example"
    */
   sample?: string,
-  /**
-   * Path to environment file.
-   * @default ".env"
-   */
-  silent?: boolean,
-  /**
-   * Encoding of your file containing environment variables.
-   * @default "utf8"
-   */
-  encoding?: string,
+
   /**
    * Enabling this option will not throw an error after loading.
    * @default false
@@ -56,11 +43,4 @@ export interface DotenvSafeOptions {
  *
  * @throws MissingEnvVarsError
  */
-export function load(options?: DotenvSafeOptions): env.DotenvConfigOutput
-
-/**
- * Loads environment variables file into 'process.env'.
- *
- * @throws MissingEnvVarsError
- */
-export function config(options?: DotenvSafeOptions): env.DotenvConfigOutput
+export function config(options?: DotenvSafeOptions): dotenv.DotenvConfigOutput


### PR DESCRIPTION
Updating the typings to match `dotenv-safe` version `8.1`.

The `.load()` alias for `.config()` was [removed](https://github.com/rolodato/dotenv-safe/commit/c861dde838068f484cb9743d8dae278dbc4448e3#diff-168726dbe96b3ce427e7fedce31bb0bcL50). And since this is a small wrapper around `dotenv` more of that package [its own typings](https://github.com/motdotla/dotenv/blob/master/types/index.d.ts) are used now.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rolodato/dotenv-safe#options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
