### PR TITLE
[webpack] Adding client config options to the ConfigurationFactory

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -138,12 +138,12 @@ declare namespace webpack {
 
     interface CliConfigOptions {
         config?: string;
-        mode?: Configuration["mode"],
-        env?: string,
+        mode?: Configuration["mode"];
+        env?: string;
         'config-register'?: string;
         configRegister?: string;
         'config-name'?: string;
-        configName?: string
+        configName?: string;
     }
 
     type ConfigurationFactory = ((

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -136,14 +136,24 @@ declare namespace webpack {
         optimization?: Options.Optimization;
     }
 
+    interface CliConfigOptions {
+        config?: string;
+        mode?: Configuration["mode"],
+        env?: string,
+        'config-register'?: string;
+        configRegister?: string;
+        'config-name'?: string;
+        configName?: string
+    }
+
     type ConfigurationFactory = ((
         env: string | Record<string, boolean | number | string>,
-        args: Record<string, string>,
+        args: CliConfigOptions,
     ) => Configuration | Promise<Configuration>);
 
     type MultiConfigurationFactory = ((
         env: string | Record<string, boolean | number | string>,
-        args: Record<string, string>,
+        args: CliConfigOptions,
     ) => Configuration[] | Promise<Configuration[]>);
 
     interface Entry {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/api/cli/#config-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.