### PR TITLE
OptionsCells allowed in Options Interface. Setted field to not required in ColumnLayout.

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -25,6 +25,7 @@ declare namespace Tabulator {
             OptionsClipboard,
             OptionsDataTree,
             OptionsCell,
+            OptionsCells,
             OptionsHTML {}
 
     interface OptionsCells extends CellCallbacks {
@@ -834,7 +835,7 @@ declare namespace Tabulator {
         /** title - Required This is the title that will be displayed in the header for this column */
         title: string;
         /** field - Required (not required in icon/button columns) this is the key for this column in the data array*/
-        field: string;
+        field?: string;
         /** visible - (boolean, default - true) determines if the column is visible. (see Column Visibility for more details */
         visible?: boolean;
 


### PR DESCRIPTION
OptionsCells: validationFailed were not referenced in any part of index.d.ts. Adding it in Options interface allows the use for tabulator tables (As showed in examples: http://tabulator.info/examples/4.4?#validation)

Field not required in OptionsCells: as commented in old PR field is not required for some type of column (as written in comment: not required in icon/button columns)