### PR TITLE
redux-async-queue > Added Action type

### DIFF
--- a/types/redux-async-queue/index.d.ts
+++ b/types/redux-async-queue/index.d.ts
@@ -1,10 +1,16 @@
 // Type definitions for redux-async-queue 1.0
 // Project: https://github.com/zackargyle/redux-async-queue
 // Definitions by: Andrei Horodinca <https://github.com/andreiho>
+//                 Dean van Niekerk <https://github.com/deanvanniekerk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { AnyAction } from 'redux';
+import { Action, AnyAction, Dispatch } from "redux";
+
+export interface AsyncQueueAction<T extends Action = AnyAction> {
+    queue: string;
+    callback: (next: () => void, dispatch: Dispatch<T>) => void;
+}
 
 declare function queueMiddleware(): (next: (action: AnyAction) => any) => any;
 


### PR DESCRIPTION
Adds a type for the redux async queue action.

Example usage

```
import { AsyncQueueAction } from "redux-async-queue";

export const doWorkAction = (): AsyncQueueAction => {
    return {
        queue: "MY_QUEUE",
        callback: (next, dispatch) => {
            //do work...
        },
    };
};
```

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/zackargyle/redux-async-queue/blob/master/src/index.js>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

