### PR TITLE
Add types for react-query

### DIFF
--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -1,0 +1,121 @@
+// Type definitions for react-query 0.3
+// Project: https://github.com/tannerlinsley/react-query
+// Definitions by: Lukasz Fiszer <https://github.com/lukaszfiszer>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { ComponentType } from 'react';
+
+export function useQuery<TResult, TVariables extends object>(
+    queryKey: QueryKey<TVariables>,
+    queryFn: QueryFunction<TResult, TVariables>,
+    options?: QueryOptions<TResult>
+): QueryResult<TResult, TVariables>;
+
+export type QueryKey<TVariables> = string | [string, TVariables] | false | null | QueryKeyFunction<TVariables>;
+export type QueryKeyFunction<TVariables> = () => string | [string, TVariables] | false | null;
+
+export type QueryFunction<TResult, TVariables extends object> = (variables: TVariables) => Promise<TResult>;
+
+export interface QueryOptions<TResult> {
+    manual?: boolean;
+    pagination?: boolean;
+    getCanFetchMore?: (lastPage: number, allPages: number) => boolean;
+    retry?: boolean | number;
+    retryDelay?: (retryAttempt: number) => number;
+    staleTime?: number;
+    cacheTime?: number;
+    refetchInterval?: false | number;
+    onError?: (err: any) => void;
+    onSucess?: (data: TResult) => void;
+    suspense?: boolean;
+}
+
+export interface QueryResult<TResult, TVariables> {
+    data: null | TResult;
+    error: null | Error;
+    isLoading: boolean;
+    isFetching: boolean;
+    isCached: boolean;
+    failureCount: number;
+    refetch: (arg?: {variables?: TVariables, merge?: (...args: any[]) => any, disableThrow?: boolean}) => void;
+    isFetchingMore: boolean;
+    canFetchMore: boolean;
+    fetchMore: (variables?: TVariables) => Promise<TResult>;
+}
+
+export function prefetchQuery<TResult, TVariables extends object>(
+    queryKey: QueryKey<TVariables>,
+    queryFn: QueryFunction<TResult, TVariables>,
+    options?: PrefetchQueryOptions<TResult>
+): Promise<TResult>;
+
+export interface PrefetchQueryOptions<TResult> extends QueryOptions<TResult> {
+    force?: boolean;
+}
+
+export function useMutation<TResults, TVariables extends object>(
+    mutationFn: MutationFunction<TResults, TVariables>,
+    mutationOptions?: MutationOptions
+): [MutateFunction<TResults, TVariables>, MutationResult<TResults>];
+
+export type MutationFunction<TResults, TVariables extends object> = (
+    variables: TVariables,
+) => Promise<TResults>;
+
+export interface MutationOptions {
+    refetchQueries?: Array<string | [string, object]>;
+    refetchQueriesOnFailure?: boolean;
+}
+
+export type MutateFunction<TResults, TVariables extends object> = (
+    variables?: TVariables,
+    options?: {
+        updateQuery?: string | [string, object],
+        waitForRefetchQueries?: boolean;
+    }
+) => Promise<TResults>;
+
+export interface MutationResult<TResults> {
+    data: TResults | null;
+    isLoading: boolean;
+    error: null | Error;
+    promise: Promise<TResults>;
+}
+
+export function setQueryData(
+    queryKey: string | [string, object],
+    data: any,
+    options?: {
+        shouldRefetch?: boolean
+    }
+): void | Promise<void>;
+
+export function refetchQuery(
+    queryKey: string | [string, object] | [string, false],
+    force?: {
+        force?: boolean
+    }
+): Promise<void>;
+
+export function refetchAllQueries(
+    options?: {
+        force?: boolean,
+        includeInactive: boolean
+    }
+): Promise<void>;
+
+export function useIsFetching(): boolean;
+
+export const ReactQueryConfigProvider: React.ComponentType<{
+    config?: ReactQueryProviderConfig
+}>;
+
+export interface ReactQueryProviderConfig {
+    retry: number;
+    retryDelay: (attempt: number) => number;
+    staleTime: number;
+    cacheTime: number;
+    refetchAllOnWindowFocus: boolean;
+    refetchInterval: boolean;
+    suspense: boolean;
+}

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -18,7 +18,7 @@ export type QueryFunction<TResult, TVariables extends object> = (variables: TVar
 
 export interface QueryOptions<TResult> {
     manual?: boolean;
-    pagination?: boolean;
+    paginated?: boolean;
     getCanFetchMore?: (lastPage: number, allPages: number) => boolean;
     retry?: boolean | number;
     retryDelay?: (retryAttempt: number) => number;
@@ -119,3 +119,5 @@ export interface ReactQueryProviderConfig {
     refetchInterval: boolean;
     suspense: boolean;
 }
+
+export function clearQueryCache(): void;

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -1,0 +1,66 @@
+import { useMutation, useQuery } from "react-query";
+
+const queryFn = () => Promise.resolve();
+
+// Query - simple case
+const querySimple = useQuery('todos',
+    () => Promise.resolve('test'));
+querySimple.data; // $ExpectType string | null
+querySimple.error; // $ExpectType Error | null
+querySimple.isLoading; // $ExpectType boolean
+querySimple.refetch(); // $ExpectType void
+
+// Query Variables
+const param = 'test';
+const queryVariables = useQuery(['todos', {param}],
+    (variables) => Promise.resolve(variables.param === 'test'));
+
+queryVariables.data; // $ExpectType boolean | null
+queryVariables.refetch({variables: {param: 'foo'}}); // $ExpectType void
+queryVariables.refetch({variables: {other: 'foo'}}); // $ExpectError
+
+// Query with falsey query key
+useQuery(false && ['foo', { bar: 'baz' }], queryFn);
+
+// Query with query key function
+useQuery(() => ['foo', { bar: 'baz' }], queryFn);
+
+// Query with nested variabes
+const queryNested = useQuery(['key', {
+    nested: {
+        props: [1, 2]
+    }
+}], (variables) => Promise.resolve(variables.nested.props[0]));
+queryNested.data; // $ExpectType number | null
+
+// Simple mutation
+const mutation = () => Promise.resolve(['foo', 1]);
+
+const [mutate] = useMutation(mutation, {
+    refetchQueries: ['todos', ['todo', { id: 5 }], 'reminders'],
+    refetchQueriesOnFailure: false
+});
+mutate();
+mutate(undefined, {
+    updateQuery: 'query',
+    waitForRefetchQueries: false
+});
+
+// Invalid mutatation funciton
+useMutation((arg1: string, arg2: string) => Promise.resolve()); // $ExpectError
+useMutation((arg1: string) => null); // $ExpectError
+
+// Mutation with variables
+const [mutateWithVars] = useMutation(
+    ({param}: {param: number}) => Promise.resolve(Boolean(param)),
+    {
+    refetchQueries: ['todos', ['todo', { id: 5 }], 'reminders'],
+    refetchQueriesOnFailure: false
+});
+
+mutateWithVars({param: 1}, {
+  updateQuery: 'query',
+  waitForRefetchQueries: false
+});
+
+mutateWithVars({param: 'test'}); // $ExpectError

--- a/types/react-query/tsconfig.json
+++ b/types/react-query/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+      "index.d.ts",
+      "react-query-tests.ts"
+    ]
+}

--- a/types/react-query/tslint.json
+++ b/types/react-query/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR includes typings for react-query package (npm: https://www.npmjs.com/package/react-query, github: https://github.com/tannerlinsley/react-query).

The package author does not plan to provide types to do the package - as discussed with https://github.com/tannerlinsley/react-query/issues/23.  


- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

