### PR TITLE
Updated express-session types

### DIFF
--- a/types/express-session/express-session-tests.ts
+++ b/types/express-session/express-session-tests.ts
@@ -9,6 +9,22 @@ app.use(session({
 }));
 app.use(session({
   secret: 'keyboard cat',
+  cookie: { secure: 'auto' }
+}));
+app.use(session({
+  secret: 'keyboard cat',
+  cookie: { sameSite: 'none' }
+}));
+app.use(session({
+  secret: 'keyboard cat',
+  cookie: { sameSite: 'lax' }
+}));
+app.use(session({
+  secret: 'keyboard cat',
+  cookie: { sameSite: 'strict' }
+}));
+app.use(session({
+  secret: 'keyboard cat',
   name: 'connect.sid',
   store: new session.MemoryStore(),
   cookie: { path: '/', httpOnly: true, secure: false, sameSite: true },

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -4,6 +4,7 @@
 //                 Jacob Bogers <https://github.com/jacobbogers>
 //                 Naoto Yokoyama <https://github.com/builtinnya>
 //                 Ryan Cannon <https://github.com/ry7n>
+//                 Tom Spencer <https://github.com/fiznool>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -58,7 +59,17 @@ declare namespace session {
     secret: string | string[];
     name?: string;
     store?: Store | MemoryStore;
-    cookie?: express.CookieOptions;
+    cookie?: {
+      maxAge?: number;
+      signed?: boolean;
+      expires?: Date;
+      httpOnly?: boolean;
+      path?: string;
+      domain?: string;
+      secure?: boolean | 'auto';
+      encode?: (val: string) => string;
+      sameSite?: boolean | 'lax' | 'strict' | 'none';
+    };
     genid?(req: express.Request): string;
     rolling?: boolean;
     resave?: boolean;


### PR DESCRIPTION
Follow up to #39421, this PR adds support for the following:

- Allow `secure: 'auto'` cookie setting
- Restrict `sameSite` cookie setting to boolean or valid string value
  according to (draft) spec

Both options are outlined in the express-session documentation:

- [SameSite option](https://github.com/expressjs/session#cookiesamesite)
- [Secure option](https://github.com/expressjs/session#cookiesecure)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39421
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.