### PR TITLE
Added rudimentary types for @keystonejs/*

### DIFF
--- a/types/keystonejs__adapter-knex/index.d.ts
+++ b/types/keystonejs__adapter-knex/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for @keystonejs/adapter-knex 5.1
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/adapter-knex' {
+    import { Raw, ConnectionConfig, Config } from 'knex';
+    import { BaseKeystoneAdapter } from '@keystonejs/keystone';
+
+    interface KnexAdaptorOptions {
+        knexOptions?: Config;
+        schemaName?: string;
+        listAdapterClass?: any;
+    }
+    class KnexAdapter extends BaseKeystoneAdapter {
+        constructor(options?: KnexAdaptorOptions);
+
+        disconnect(): void;
+        dropDatabase(): Promise<Raw>;
+    }
+}

--- a/types/keystonejs__adapter-knex/keystonejs__adapter-knex-tests.ts
+++ b/types/keystonejs__adapter-knex/keystonejs__adapter-knex-tests.ts
@@ -1,0 +1,8 @@
+import { KnexAdapter } from '@keystonejs/adapter-knex';
+
+export const adapter = new KnexAdapter({
+    knexOptions: {
+        connection: {},
+    },
+    schemaName: 'whatever',
+});

--- a/types/keystonejs__adapter-knex/package.json
+++ b/types/keystonejs__adapter-knex/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "knex": "^0.20.1"
+  }
+}

--- a/types/keystonejs__adapter-knex/tsconfig.json
+++ b/types/keystonejs__adapter-knex/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/fields": ["keystonejs__fields"],
+            "@keystonejs/keystone": ["keystonejs__keystone"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "keystonejs__adapter-knex-tests.ts"
+    ]
+}

--- a/types/keystonejs__adapter-knex/tslint.json
+++ b/types/keystonejs__adapter-knex/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__adapter-mongoose/index.d.ts
+++ b/types/keystonejs__adapter-mongoose/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for @keystonejs/adapter-moogoose 5.1
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+//                 Timothee Clain <https://github.com/tclain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/adapter-mongoose' {
+    import { BaseKeystoneAdapter } from '@keystonejs/keystone';
+
+    interface MongooseAdaptorOptions {
+        mongoUri: string;
+        listAdapterClass?: any;
+    }
+
+    class MoogooseAdapter extends BaseKeystoneAdapter {
+        constructor(options?: MongooseAdaptorOptions);
+
+        disconnect(): void;
+        dropDatabase(): any;
+    }
+}

--- a/types/keystonejs__adapter-mongoose/keystonejs__adapter-mongoose-tests.ts
+++ b/types/keystonejs__adapter-mongoose/keystonejs__adapter-mongoose-tests.ts
@@ -1,0 +1,3 @@
+import { MoogooseAdapter } from '@keystonejs/adapter-mongoose';
+
+const adapter = new MoogooseAdapter();

--- a/types/keystonejs__adapter-mongoose/tsconfig.json
+++ b/types/keystonejs__adapter-mongoose/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/fields": ["keystonejs__fields"],
+            "@keystonejs/keystone": ["keystonejs__keystone"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "keystonejs__adapter-mongoose-tests.ts"
+    ]
+}

--- a/types/keystonejs__adapter-mongoose/tslint.json
+++ b/types/keystonejs__adapter-mongoose/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__apollo-helpers/index.d.ts
+++ b/types/keystonejs__apollo-helpers/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for @keystonejs/apollo-helpers 5.0
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+//                 Timothee Clain <https://github.com/tclain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/apollo-helpers' {
+    import * as React from 'react';
+    import { KeyValues } from '@keystonejs/keystone';
+
+    interface KeystoneQueryTypeProps {
+        query: string;
+    }
+
+    type KeystoneQueryType = React.ComponentType<KeystoneQueryTypeProps>;
+    const Query: KeystoneQueryType;
+
+    interface KeystoneMutationTypeProps {
+        mutation: string;
+        invalidatesTypes?: boolean;
+    }
+    type KeystoneMutationType = React.ComponentType<KeystoneMutationTypeProps>;
+    const Mutation: KeystoneMutationType;
+
+    const KeystoneProvider: React.ComponentType;
+
+    function injectIsOptimisticFlag(opts: any): any; // TODO: insert the apollo type here
+    function flattenApollo(
+        opts: KeyValues<
+            string,
+            | React.ReactElement<KeystoneMutationTypeProps>
+            | React.ReactElement<KeystoneMutationTypeProps>
+        >
+    ): React.ComponentType;
+}

--- a/types/keystonejs__apollo-helpers/tsconfig.json
+++ b/types/keystonejs__apollo-helpers/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/fields": ["keystonejs__fields"],
+            "@keystonejs/keystone": ["keystonejs__keystone"]
+        }
+    },
+    "files": ["index.d.ts"]
+}

--- a/types/keystonejs__apollo-helpers/tslint.json
+++ b/types/keystonejs__apollo-helpers/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__app-admin-ui/index.d.ts
+++ b/types/keystonejs__app-admin-ui/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for @keystonejs/app-admin-ui 5.1
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+//                 Timothee Clain <https://github.com/tclain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/app-admin-ui' {
+    import { BaseAuthStrategy, BaseApp } from '@keystonejs/keystone';
+    interface AdminUIOptions<ListNames extends string = string, UserType extends {} = any> {
+        adminPath?: string;
+        apiPath?: string;
+        graphiqlPath?: string;
+        pages?: any[];
+        schemaName?: string;
+        enableDefaultRoute?: boolean;
+        authStrategy?: BaseAuthStrategy;
+        isAccessAllowed?: (opts: {
+            authentication: { item: UserType; list: ListNames };
+        }) => boolean;
+    }
+
+    class AdminUIApp<ListNames extends string = string, UserType extends {} = any> extends BaseApp {
+        constructor(options?: AdminUIOptions<ListNames, UserType>);
+    }
+}

--- a/types/keystonejs__app-admin-ui/keystonejs__app-admin-ui-tests.ts
+++ b/types/keystonejs__app-admin-ui/keystonejs__app-admin-ui-tests.ts
@@ -1,0 +1,15 @@
+import { AdminUIApp } from '@keystonejs/app-admin-ui';
+
+new AdminUIApp();
+new AdminUIApp({
+    enableDefaultRoute: true,
+    authStrategy: 1,
+    isAccessAllowed: ({ authentication: { item } }) => true,
+});
+
+// with type configuration
+new AdminUIApp<'User', { role: 'admin' }>({
+    enableDefaultRoute: true,
+    authStrategy: 1,
+    isAccessAllowed: ({ authentication: { item } }) => item.role === 'admin',
+});

--- a/types/keystonejs__app-admin-ui/tsconfig.json
+++ b/types/keystonejs__app-admin-ui/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/fields": ["keystonejs__fields"],
+            "@keystonejs/keystone": ["keystonejs__keystone"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "keystonejs__app-admin-ui-tests.ts"
+    ]
+}

--- a/types/keystonejs__app-admin-ui/tslint.json
+++ b/types/keystonejs__app-admin-ui/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__app-graphql/index.d.ts
+++ b/types/keystonejs__app-graphql/index.d.ts
@@ -1,0 +1,42 @@
+// Type definitions for @keystonejs/app-graphql 5.0
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+//                 Timothee Clain <https://github.com/tclain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/app-graphql' {
+    import { Keystone } from '@keystonejs/keystone';
+
+    interface GraphQLValidation {
+        depthLimit: (limit: number) => any; // TODO: fetch the correct type in apollo server validations
+        definitionLimit: (limit: number) => any; // TODO: fetch the correct type in apollo server validations
+        fieldLimit: (limit: number) => any; // TODO: fetch the correct type in apollo server validations
+    }
+
+    interface GraphQLAppOptions {
+        apiPath?: string;
+        graphiqlPath?: string;
+        schemaName?: string;
+        apollo?: {
+            validationRules?: [];
+        };
+    }
+
+    interface PrepareMiddlewareOptions {
+        keystone: Keystone;
+        dev?: boolean;
+    }
+
+    class GraphQLApp {
+        constructor(opts?: GraphQLAppOptions);
+
+        build(): void;
+        prepareMiddleware(options: PrepareMiddlewareOptions): void;
+    }
+
+    const validation: GraphQLValidation;
+}

--- a/types/keystonejs__app-graphql/keystonejs__app-graphql-tests.ts
+++ b/types/keystonejs__app-graphql/keystonejs__app-graphql-tests.ts
@@ -1,0 +1,5 @@
+import { GraphQLApp, validation } from '@keystonejs/app-graphql';
+
+new GraphQLApp();
+
+validation.depthLimit(1);

--- a/types/keystonejs__app-graphql/tsconfig.json
+++ b/types/keystonejs__app-graphql/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/fields": ["keystonejs__fields"],
+            "@keystonejs/keystone": ["keystonejs__keystone"]
+        }
+    },
+    "files": ["index.d.ts", "keystonejs__app-graphql-tests.ts"]
+}

--- a/types/keystonejs__app-graphql/tslint.json
+++ b/types/keystonejs__app-graphql/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__app-next/index.d.ts
+++ b/types/keystonejs__app-next/index.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for @keystonejs/app-next 5.0
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+//                 Timothee Clain <https://github.com/tclain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/app-next' {
+    import { BaseApp } from '@keystonejs/keystone';
+
+    interface NextOptions {
+        dir: string;
+    }
+
+    class NextApp extends BaseApp {
+        constructor(options?: NextOptions);
+
+        prepareMiddleware({ dev }: { dev?: boolean }): Promise<void>;
+        build(): Promise<void>;
+    }
+}

--- a/types/keystonejs__app-next/keystonejs__app-next-tests.ts
+++ b/types/keystonejs__app-next/keystonejs__app-next-tests.ts
@@ -1,0 +1,6 @@
+import { NextApp } from '@keystonejs/app-next';
+
+new NextApp();
+new NextApp({
+    dir: 'whatever',
+});

--- a/types/keystonejs__app-next/tsconfig.json
+++ b/types/keystonejs__app-next/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/fields": ["keystonejs__fields"],
+            "@keystonejs/keystone": ["keystonejs__keystone"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "keystonejs__app-next-tests.ts"
+    ]
+}

--- a/types/keystonejs__app-next/tslint.json
+++ b/types/keystonejs__app-next/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__app-nuxt/index.d.ts
+++ b/types/keystonejs__app-nuxt/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for @keystonejs/app-nuxt 5.0
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+//                 Timothee Clain <https://github.com/tclain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/app-nuxt' {
+    import { BaseApp } from '@keystonejs/keystone';
+
+    interface NuxtOptions {
+        srcDir?: string;
+        buildDir?: string;
+    }
+
+    class NuxtApp extends BaseApp {
+        constructor(options?: NuxtOptions);
+
+        prepareMiddleware({ dev }: { dev?: boolean }): Promise<void>;
+        build(): Promise<void>;
+    }
+}

--- a/types/keystonejs__app-nuxt/keystonejs__app-nuxt-tests.ts
+++ b/types/keystonejs__app-nuxt/keystonejs__app-nuxt-tests.ts
@@ -1,0 +1,8 @@
+import { NuxtApp } from '@keystonejs/app-nuxt';
+
+new NuxtApp();
+new NuxtApp({});
+new NuxtApp({
+    srcDir: 'whatever',
+    buildDir: 'whatever',
+});

--- a/types/keystonejs__app-nuxt/tsconfig.json
+++ b/types/keystonejs__app-nuxt/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/fields": ["keystonejs__fields"],
+            "@keystonejs/keystone": ["keystonejs__keystone"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "keystonejs__app-nuxt-tests.ts"
+    ]
+}

--- a/types/keystonejs__app-nuxt/tslint.json
+++ b/types/keystonejs__app-nuxt/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__app-static/index.d.ts
+++ b/types/keystonejs__app-static/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for @keystonejs/app-static 5.0
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+//                 Timothee Clain <https://github.com/tclain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/app-static' {
+    import { BaseApp } from '@keystonejs/keystone';
+
+    interface StaticOptions {
+        path?: string;
+        src?: string;
+        fallback?: string;
+    }
+
+    class StaticApp extends BaseApp {
+        constructor(options?: StaticOptions);
+
+        prepareMiddleware({ dev }: { dev?: boolean }): Promise<void>;
+        build(): Promise<void>;
+    }
+}

--- a/types/keystonejs__app-static/keystonejs__app-static-tests.ts
+++ b/types/keystonejs__app-static/keystonejs__app-static-tests.ts
@@ -1,0 +1,9 @@
+import { StaticApp } from '@keystonejs/app-static';
+
+new StaticApp();
+new StaticApp({});
+new StaticApp({
+    path: 'whatever',
+    src: 'whatever',
+    fallback: 'whatever',
+});

--- a/types/keystonejs__app-static/tsconfig.json
+++ b/types/keystonejs__app-static/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/fields": ["keystonejs__fields"],
+            "@keystonejs/keystone": ["keystonejs__keystone"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "keystonejs__app-static-tests.ts"
+    ]
+}

--- a/types/keystonejs__app-static/tslint.json
+++ b/types/keystonejs__app-static/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__auth-passport/index.d.ts
+++ b/types/keystonejs__auth-passport/index.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for @keystonejs/auth-passport 5.1
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/auth-passport' {
+    import { Keystone } from '@keystonejs/keystone';
+
+    class GoogleAuthStrategy {}
+    class PassportAuthStrategy {
+        // TODO: Better types here: https://www.keystonejs.com/keystonejs/auth-passport/
+        constructor(
+            authType: string,
+            keystone: Keystone,
+            listKey: string,
+            config: any,
+            strategy: any
+        );
+    }
+}

--- a/types/keystonejs__auth-passport/index.d.ts
+++ b/types/keystonejs__auth-passport/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @keystonejs/auth-passport 5.1
+// Type definitions for @keystonejs/auth-passport 5.0
 // Project: https://github.com/keystonejs/keystone
 // Definitions by: Kevin Brown <https://github.com/thekevinbrown>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -10,7 +10,6 @@
 declare module '@keystonejs/auth-passport' {
     import { Keystone } from '@keystonejs/keystone';
 
-    class GoogleAuthStrategy {}
     class PassportAuthStrategy {
         // TODO: Better types here: https://www.keystonejs.com/keystonejs/auth-passport/
         constructor(
@@ -20,5 +19,12 @@ declare module '@keystonejs/auth-passport' {
             config: any,
             strategy: any
         );
+
+        public static authType: string;
     }
+
+    class GoogleAuthStrategy extends PassportAuthStrategy {}
+    class FacebookAuthStrategy extends PassportAuthStrategy {}
+    class GitHubAuthStrategy extends PassportAuthStrategy {}
+    class TwitterAuthStrategy extends PassportAuthStrategy {}
 }

--- a/types/keystonejs__auth-passport/index.d.ts
+++ b/types/keystonejs__auth-passport/index.d.ts
@@ -20,7 +20,9 @@ declare module '@keystonejs/auth-passport' {
             strategy: any
         );
 
-        public static authType: string;
+        static authType: string;
+
+        getInputFragment(): string;
     }
 
     class GoogleAuthStrategy extends PassportAuthStrategy {}

--- a/types/keystonejs__auth-passport/keystonejs__auth-passport-tests.ts
+++ b/types/keystonejs__auth-passport/keystonejs__auth-passport-tests.ts
@@ -1,0 +1,72 @@
+import { Keystone } from '@keystonejs/keystone';
+import { KnexAdapter } from '@keystonejs/adapter-knex';
+import { GoogleAuthStrategy } from '@keystonejs/auth-passport';
+
+const keystone = new Keystone({
+    name: 'Typescript Test',
+    adapter: new KnexAdapter(),
+});
+
+keystone.createAuthStrategy({
+    type: GoogleAuthStrategy,
+    list: 'User',
+    config: {
+        idField: 'googleId',
+        appId: '<Your Google App Id>',
+        appSecret: '<Your Google App Secret>',
+        loginPath: '/auth/google',
+        callbackPath: '/auth/google/callback',
+
+        loginPathMiddleware: (req: any, res: any, next: any) => {
+            // An express middleware executed before the Passport social signin flow
+            // begins. Useful for setting cookies, etc.
+            // Don't forget to call `next()`!
+            next();
+        },
+
+        callbackPathMiddleware: (req: any, res: any, next: any) => {
+            // An express middleware executed before the callback route is run. Useful
+            // for logging, etc.
+            // Don't forget to call `next()`!
+            next();
+        },
+
+        // Called when there's no existing user for the given googleId
+        // Default: resolveCreateData: () => ({})
+        resolveCreateData: (
+            { createData, actions: { pauseAuthentication } }: any,
+            req: any,
+            res: any
+        ) => {
+            // If we don't have the right data to continue with a creation
+            if (!createData.name) {
+                // then we pause the flow
+                pauseAuthentication();
+                // And redirect the user to a page where they can enter the data.
+                // Later, the `resolveCreateData()` method will be re-executed this
+                // time with the complete data.
+                res.redirect(`/auth/google/step-2`);
+                return;
+            }
+
+            return createData;
+        },
+
+        // Once a user is found/created and successfully matched to the
+        // googleId, they are authenticated, and the token is returned here.
+        // NOTE: By default KeystoneJS sets a `keystone.sid` which authenticates the
+        // user for the API domain. If you want to authenticate via another domain,
+        // you must pass the `token` as a Bearer Token to GraphQL requests.
+        onAuthenticated: ({ token, item, isNewItem }: any, req: any, res: any) => {
+            console.log(token);
+            res.redirect('/');
+        },
+
+        // If there was an error during any of the authentication flow, this
+        // callback is executed
+        onError: (error: any, req: any, res: any) => {
+            console.error(error);
+            res.redirect('/?error=Uh-oh');
+        },
+    },
+});

--- a/types/keystonejs__auth-passport/keystonejs__auth-passport-tests.ts
+++ b/types/keystonejs__auth-passport/keystonejs__auth-passport-tests.ts
@@ -1,6 +1,12 @@
 import { Keystone } from '@keystonejs/keystone';
 import { KnexAdapter } from '@keystonejs/adapter-knex';
-import { GoogleAuthStrategy } from '@keystonejs/auth-passport';
+import {
+    GoogleAuthStrategy,
+    FacebookAuthStrategy,
+    GitHubAuthStrategy,
+    TwitterAuthStrategy,
+    PassportAuthStrategy,
+} from '@keystonejs/auth-passport';
 
 const keystone = new Keystone({
     name: 'Typescript Test',
@@ -69,4 +75,24 @@ keystone.createAuthStrategy({
             res.redirect('/?error=Uh-oh');
         },
     },
+});
+
+keystone.createAuthStrategy({
+    type: FacebookAuthStrategy,
+    list: 'User',
+});
+
+keystone.createAuthStrategy({
+    type: GitHubAuthStrategy,
+    list: 'User',
+});
+
+keystone.createAuthStrategy({
+    type: TwitterAuthStrategy,
+    list: 'User',
+});
+
+keystone.createAuthStrategy({
+    type: PassportAuthStrategy,
+    list: 'User',
 });

--- a/types/keystonejs__auth-passport/tsconfig.json
+++ b/types/keystonejs__auth-passport/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/adapter-knex": ["keystonejs__adapter-knex"],
+            "@keystonejs/fields": ["keystonejs__fields"],
+            "@keystonejs/keystone": ["keystonejs__keystone"]
+        }
+    },
+    "files": ["index.d.ts", "keystonejs__auth-passport-tests.ts"]
+}

--- a/types/keystonejs__auth-passport/tslint.json
+++ b/types/keystonejs__auth-passport/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__auth-password/index.d.ts
+++ b/types/keystonejs__auth-password/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for @keystonejs/auth-password 5.0
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+//                 Timothee Clain <https://github.com/tclain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/auth-password' {
+    import { Keystone, BaseAuthStrategy } from '@keystonejs/keystone';
+
+    interface PasswordAuthStrategyConfig {
+        identityField: string;
+        secretField: string;
+    }
+
+    interface PasswordValidationResult {
+        success: boolean;
+        list: any;
+        item: any;
+        message: string;
+    }
+
+    class PasswordAuthStrategy extends BaseAuthStrategy {
+        constructor(keystone: Keystone, listKey: string, config: PasswordAuthStrategyConfig);
+        authType: string;
+
+        getList(): any; // TODO
+        getInputFragment(): string;
+
+        validate(args: any): Promise<PasswordValidationResult>; // TODO
+
+        getAdminMeta(): any; // TODO
+    }
+}

--- a/types/keystonejs__auth-password/keystonejs__auth-password-tests.ts
+++ b/types/keystonejs__auth-password/keystonejs__auth-password-tests.ts
@@ -1,0 +1,20 @@
+import { PasswordAuthStrategy } from '@keystonejs/auth-password';
+import { Keystone } from '@keystonejs/keystone';
+import { KnexAdapter } from '@keystonejs/adapter-knex';
+
+const adapter = new KnexAdapter();
+
+const keystone = new Keystone({
+    name: 'Typescript Test',
+    adapter,
+});
+
+keystone.createAuthStrategy({
+    type: PasswordAuthStrategy,
+    list: 'User',
+});
+
+new PasswordAuthStrategy(keystone, 'whatever', {
+    identityField: 'username',
+    secretField: 'password',
+});

--- a/types/keystonejs__auth-password/tsconfig.json
+++ b/types/keystonejs__auth-password/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/adapter-knex": ["keystonejs__adapter-knex"],
+            "@keystonejs/fields": ["keystonejs__fields"],
+            "@keystonejs/keystone": ["keystonejs__keystone"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "keystonejs__auth-password-tests.ts"
+    ]
+}

--- a/types/keystonejs__auth-password/tslint.json
+++ b/types/keystonejs__auth-password/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__email/index.d.ts
+++ b/types/keystonejs__email/index.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for @keystonejs/email 5.0
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+//                 Timothee Clain <https://github.com/tclain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/email' {
+    type Sender = (
+        fileName: string
+    ) => {
+        send: (rendererOpts: any, transportOptions: any) => any;
+    };
+    interface MailSenderBuilder {
+        mjml: (opts?: { root?: string; transport?: string }) => Sender;
+        jsx: (opts?: { root?: string; transport?: string }) => Sender;
+        pug: (opts?: { root?: string; transport?: string }) => Sender;
+    }
+
+    const emailSender: MailSenderBuilder;
+}

--- a/types/keystonejs__email/tsconfig.json
+++ b/types/keystonejs__email/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts"]
+}

--- a/types/keystonejs__email/tslint.json
+++ b/types/keystonejs__email/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__fields/index.d.ts
+++ b/types/keystonejs__fields/index.d.ts
@@ -1,0 +1,64 @@
+// Type definitions for @keystonejs/fields 5.1
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+//                 Timothee Clain <https://github.com/tclain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/fields' {
+    class AutoIncrement {}
+    class CalendarDay {}
+    class Checkbox {}
+    class CloudinaryImage {}
+    class Color {}
+    class Content {}
+    class DateTime {}
+    class DateTimeUtc {}
+    class Decimal {}
+    class File {}
+    class Float {}
+    class Integer {}
+    class Location {}
+    class Markdown {}
+    class MongoId {}
+    class OEmbed {}
+    class Password {}
+    class Relationship {}
+    class Select {}
+    class Slug {}
+    class Text {}
+    class Unsplash {}
+    class Url {}
+    class Uuid {}
+    class Wysiwyg {}
+
+    type FieldType =
+        | AutoIncrement
+        | CalendarDay
+        | Checkbox
+        | CloudinaryImage
+        | Color
+        | Content
+        | DateTime
+        | DateTimeUtc
+        | Decimal
+        | File
+        | Float
+        | Integer
+        | Location
+        | Markdown
+        | MongoId
+        | OEmbed
+        | Password
+        | Relationship
+        | Select
+        | Slug
+        | Text
+        | Unsplash
+        | Url
+        | Uuid
+        | Wysiwyg;
+}

--- a/types/keystonejs__fields/keystonejs__fields-tests.ts
+++ b/types/keystonejs__fields/keystonejs__fields-tests.ts
@@ -1,0 +1,18 @@
+import { Keystone } from '@keystonejs/keystone';
+import { KnexAdapter } from '@keystonejs/adapter-knex';
+import { Text, Checkbox, Password } from '@keystonejs/fields';
+
+const keystone = new Keystone({
+    name: 'Typescript Test',
+    adapter: new KnexAdapter(),
+});
+
+keystone.createList('Test', {
+    fields: {
+        name: { type: Text },
+        email: { type: Text, isUnique: true },
+        isAdmin: { type: Checkbox },
+        password: { type: Password },
+    },
+    access: true,
+});

--- a/types/keystonejs__fields/tsconfig.json
+++ b/types/keystonejs__fields/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/adapter-knex": ["keystonejs__adapter-knex"],
+            "@keystonejs/keystone": ["keystonejs__keystone"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "keystonejs__fields-tests.ts"
+    ]
+}

--- a/types/keystonejs__fields/tslint.json
+++ b/types/keystonejs__fields/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__file-adapters/index.d.ts
+++ b/types/keystonejs__file-adapters/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for @keystonejs/file-adapters 5.1
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/file-adapters' {
+    interface LocalFileAdapterConfig {
+        src: string;
+        path?: string;
+        getFilename?: (options: { id: string; originalFilename: string }) => string;
+    }
+
+    class LocalFileAdapter {
+        constructor(options: LocalFileAdapterConfig);
+
+        save(params: {
+            stream: any;
+            filename?: string;
+            id: string;
+        }): Promise<{ filename: string; id: string }>;
+        publicUrl(params: { filename: string }): string;
+    }
+
+    interface CloudinaryFileAdapterConfig {
+        cloudName: string;
+        apiKey: string;
+        apiSecret: string;
+        folder?: string;
+    }
+
+    class CloudinaryFileAdapter {
+        constructor(options: CloudinaryFileAdapterConfig);
+
+        save(params: {
+            stream: any;
+            filename?: string;
+            id: string;
+        }): Promise<{ filename: string; id: string }>;
+        publicUrl(params: { filename: string }): string;
+    }
+}

--- a/types/keystonejs__file-adapters/keystonejs__file-adapters-tests.ts
+++ b/types/keystonejs__file-adapters/keystonejs__file-adapters-tests.ts
@@ -1,0 +1,27 @@
+import { Keystone } from '@keystonejs/keystone';
+import { KnexAdapter } from '@keystonejs/adapter-knex';
+import { File } from '@keystonejs/fields';
+import { LocalFileAdapter, CloudinaryFileAdapter } from '@keystonejs/file-adapters';
+
+const keystone = new Keystone({
+    name: 'Typescript Test',
+    adapter: new KnexAdapter(),
+});
+
+const local = new LocalFileAdapter({
+    src: 'something',
+});
+
+const cloudinary = new CloudinaryFileAdapter({
+    cloudName: 'something',
+    apiKey: 'something',
+    apiSecret: 'something',
+});
+
+keystone.createList('Test', {
+    fields: {
+        file: { type: File, adapter: local },
+        cloudinaryFile: { type: File, adapter: cloudinary },
+    },
+    access: true,
+});

--- a/types/keystonejs__file-adapters/tsconfig.json
+++ b/types/keystonejs__file-adapters/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/adapter-knex": ["keystonejs__adapter-knex"],
+            "@keystonejs/fields": ["keystonejs__fields"],
+            "@keystonejs/keystone": ["keystonejs__keystone"]
+        }
+    },
+    "files": ["index.d.ts", "keystonejs__file-adapters-tests.ts"]
+}

--- a/types/keystonejs__file-adapters/tslint.json
+++ b/types/keystonejs__file-adapters/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__keystone/index.d.ts
+++ b/types/keystonejs__keystone/index.d.ts
@@ -1,0 +1,250 @@
+// Type definitions for @keystonejs/keystone 5.2
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+//                 Timothee Clain <https://github.com/tclain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/keystone' {
+    import { RequestHandler } from 'express';
+    import { GraphQLFieldResolver } from 'graphql';
+    import { FieldType, AutoIncrement, CalendarDay } from '@keystonejs/fields';
+
+    type KeyValues<Keys extends string = any, Values = any> = { [key in Keys]: Values };
+
+    class BaseKeystoneAdapter {}
+    class BaseAuthStrategy {}
+    class BaseApp {}
+
+    interface KeystoneOptions {
+        name: string;
+        adapter: BaseKeystoneAdapter;
+        adapters?: {
+            [key: string]: BaseKeystoneAdapter;
+        };
+        defaultAdapter?: string;
+        onConnect?: () => void;
+        cookieSecret?: string;
+        cookieMaxAge?: number;
+        secureCookies?: boolean;
+        sessionStore?: any; // TODO: bring in express session types
+        schemaNames?: string[];
+        defaultAcces?: {
+            list?: boolean;
+            field?: boolean;
+        };
+        queryLimits?: {
+            maxTotalResults?: number;
+        };
+    }
+
+    interface KeystonePrepareResult {
+        middlewares: RequestHandler[];
+    }
+
+    interface AuthenticationContext {
+        authentication: { item: any }; // TODO
+    }
+
+    interface GraphQLWhereClause {
+        [field: string]: any; // TODO: Can we make this generic?
+    }
+
+    type AccessCallback = (context: AuthenticationContext) => boolean | GraphQLWhereClause;
+
+    type Access =
+        | boolean // Shorthand documented here: https://www.keystonejs.com/api/access-control#booleans
+        | AccessCallback
+        | {
+              read?: boolean | GraphQLWhereClause | AccessCallback;
+              update?: boolean | AccessCallback;
+              create?: boolean | AccessCallback;
+              delete?: boolean | AccessCallback;
+              auth?: boolean;
+          };
+
+    type Plugin = any; // TODO: investigate what a plugin is
+
+    interface ResolveInputHooksOptions<Record extends {} = any> {
+        resolvedData: any;
+        originalInput: any; // todo: check
+        existingItem: Record;
+        updatedItem: Record;
+        context: any; // TODO: use apollo context
+        addFieldValidationError: (error: string) => any; // not clear in the documentation
+        list: {
+            query: (
+                args: any,
+                context: any,
+                options?: { skipAccessControl: boolean }
+            ) => Promise<Record>;
+            queryMany: (
+                args: any,
+                context: any,
+                options?: { skipAccessControl: boolean }
+            ) => Promise<Record[]>;
+            queryManyMeta: (
+                args: any,
+                context: any,
+                options?: { skipAccessControl: boolean }
+            ) => Promise<{ count: number }>;
+            getList: (key: string) => ResolveInputHooksOptions['list']; // TODO: create a List Object and returns it
+        };
+    }
+
+    type Hooks = Partial<{
+        resolveInput: (
+            opts: Omit<ResolveInputHooksOptions, 'addFieldValidationError' | 'updatedItem'>
+        ) => any; // TODO: return the same shape as resolvedData
+        validateInput: (opts: Omit<ResolveInputHooksOptions, 'updatedItem'>) => void;
+        beforeChange: (opts: Omit<ResolveInputHooksOptions, 'addFieldValidationError'>) => void;
+        afterChange: (
+            opts: Pick<
+                ResolveInputHooksOptions,
+                'updatedItem' | 'existingItem' | 'originalInput' | 'context' | 'list'
+            >
+        ) => void;
+        beforeDelete: (
+            opts: Pick<ResolveInputHooksOptions, 'existingItem' | 'context' | 'list'>
+        ) => void;
+        validateDelete: (
+            opts: Pick<
+                ResolveInputHooksOptions,
+                'existingItem' | 'context' | 'list' | 'addFieldValidationError'
+            >
+        ) => void;
+        afterDelete: (
+            opts: Pick<ResolveInputHooksOptions, 'existingItem' | 'context' | 'list'>
+        ) => void;
+    }>;
+
+    /**
+     * Lists
+     */
+    interface BaseFieldOptions {
+        type: FieldType;
+        isRequired?: boolean;
+        isUnique?: boolean;
+        hooks?: Hooks;
+        access?: Access;
+    }
+
+    interface AutoIncrementOptions extends BaseFieldOptions {
+        gqlType?: 'Int' | 'ID';
+    }
+
+    interface CalendarDayOptions extends BaseFieldOptions {
+        format?: string;
+        yearRangeFrom?: number;
+        yearRangeTo?: number;
+        yearPickerType?: string;
+    }
+
+    interface ContentOptions extends BaseFieldOptions {
+        blocks: any[]; // FIXME: describe the type of block using https://www.keystonejs.com/keystonejs/field-content/
+    }
+    interface DateTimeOptions extends CalendarDayOptions {
+        knexOptions: any; // FIXME: provide a more precise type from the knex adaptor
+    }
+    interface FileOptions extends BaseFieldOptions {
+        route?: string;
+        adapter?: any; // FIXME: provide a file adapter type
+    }
+
+    interface LocationOptions extends BaseFieldOptions {
+        googleMapsKey: string;
+    }
+
+    interface OEmbedOptions extends BaseFieldOptions {
+        adapter: any; // FIXME: use eombed adapters type
+    }
+
+    interface PasswordOptions extends BaseFieldOptions {
+        minLength: number;
+        rejectCommon: boolean;
+        workFactor: number;
+    }
+
+    interface RelationshipOptions extends BaseFieldOptions {
+        // TODO: add a more type safe solution if possible
+        ref: string;
+        many: boolean;
+    }
+    interface SelectOptions extends BaseFieldOptions {
+        // TODO: use a named type
+        options: string | string[] | Array<{ value: string; label: string }>;
+    }
+    interface SlugOptions<FieldNames extends string> extends BaseFieldOptions {
+        from: string;
+        // TODO: resolved data is of the same type as the current object list. Investigate if we can at least provide the available keys via a generic.
+        generate: (opts: { resolvedData: KeyValues<FieldNames> }) => string;
+    }
+
+    interface UnsplashOptions extends BaseFieldOptions {
+        accessKey: string;
+        secretKey: string;
+    }
+    interface UuidOptions extends BaseFieldOptions {
+        // do we have other possible values here ?
+        caseTo: 'upper' | 'lower';
+    }
+
+    type AllFieldsOptions<FieldNames extends string = string> =
+        | BaseFieldOptions
+        | AutoIncrementOptions
+        | CalendarDayOptions
+        | ContentOptions
+        | DateTimeOptions
+        | FileOptions
+        | LocationOptions
+        | OEmbedOptions
+        | PasswordOptions
+        | RelationshipOptions
+        | SelectOptions
+        | SlugOptions<FieldNames>
+        | UnsplashOptions
+        | UuidOptions;
+
+    /** Hooks */
+    interface ListSchema<Fields extends string = string> {
+        fields: { [fieldName in Fields]: AllFieldsOptions };
+        listAdapterClass?: any; // TODO: investigate if a specific type can be provided
+        access?: Access;
+        plugins?: Plugin[];
+        hooks?: Hooks;
+    }
+
+    interface GraphQLExtension<Source = any, Context = any> {
+        schema: string;
+        resolver: GraphQLFieldResolver<Source, Context>;
+        access?: Access;
+    }
+
+    interface GraphQLExtensionSchema {
+        types?: Array<{ type: string }>;
+        queries?: GraphQLExtension[];
+        mutations?: GraphQLExtension[];
+    }
+
+    class Keystone<ListNames extends string = string> {
+        constructor(options: KeystoneOptions);
+
+        createAuthStrategy(options: { type: BaseAuthStrategy; list: ListNames; config?: any }): any; // TODO
+        createList(name: string, schema: ListSchema): void;
+        extendGraphQLSchema(schema: GraphQLExtensionSchema): void;
+
+        prepare(options: { apps?: BaseApp[]; dev?: boolean }): Promise<KeystonePrepareResult>;
+
+        // The return type is actually important info here. I don't believe this generic is unnecessary.
+        // tslint:disable-next-line:no-unnecessary-generics
+        executeQuery<Output = any>(query: string, config: { variables: any; context: any }): Output;
+        connect(): Promise<void>;
+        disconnect(): Promise<void>;
+
+        // tslint:disable-next-line:no-unnecessary-generics
+        createItems<ItemType>(items: { [key in ListNames]: ItemType[] }): Promise<void>;
+    }
+}

--- a/types/keystonejs__keystone/keystonejs__keystone-tests.ts
+++ b/types/keystonejs__keystone/keystonejs__keystone-tests.ts
@@ -1,0 +1,122 @@
+import { Keystone, BaseApp } from '@keystonejs/keystone';
+import { PasswordAuthStrategy } from '@keystonejs/auth-password';
+import { GraphQLApp } from '@keystonejs/app-graphql';
+import { AdminUIApp } from '@keystonejs/app-admin-ui';
+import { KnexAdapter as Adapter } from '@keystonejs/adapter-knex';
+import { Text, Checkbox, Password, AutoIncrement, CalendarDay, Integer } from '@keystonejs/fields';
+import { NextApp } from '@keystonejs/app-next';
+import { StaticApp } from '@keystonejs/app-static';
+
+const keystone = new Keystone({
+    name: 'LiveCorp Backend',
+    adapter: new Adapter(),
+});
+
+keystone.createList('Test', {
+    fields: {},
+    access: true,
+});
+keystone.createList('Test', {
+    fields: {
+        autoincrement: { type: AutoIncrement, gqlType: 'ID' },
+        calendar: {
+            type: CalendarDay,
+            format: 'Do MMMM YYYY',
+            yearRangeFrom: 1901,
+            yearRangeTo: 2018,
+            yearPickerType: 'auto',
+        },
+        email: { type: Text, isUnique: true },
+        isAdmin: { type: Checkbox },
+        password: { type: Password },
+    },
+});
+
+keystone.createList('Test', {
+    fields: {
+        name: {
+            type: Integer,
+            hooks: {
+                afterChange: console.info,
+            },
+        },
+    },
+    access: {
+        create: true,
+        read: true,
+        update: false,
+        delete: false,
+    },
+    hooks: {
+        resolveInput: async ({ context }) => console.log(context),
+    },
+});
+keystone.createList('Test', {
+    fields: {
+        name: {
+            type: Integer,
+            access: ({ authentication: { item } }) => item,
+        },
+    },
+    access: {
+        create: () => true,
+        read: () => true,
+        update: () => false,
+        delete: () => false,
+        auth: true,
+    },
+});
+
+keystone.extendGraphQLSchema({});
+
+keystone.extendGraphQLSchema({
+    types: [{ type: 'type FooBar { foo: Int, bar: Float }' }],
+    queries: [
+        {
+            schema: 'double(x: Int): Int',
+            resolver: (source, args, context, info) => console.log('ARGS: ', args),
+            access: true,
+        },
+    ],
+    mutations: [
+        {
+            schema: 'double(x: Int): Int',
+            resolver: (source, args, context, info) => console.log('ARGS: ', args),
+            access: () => true,
+        },
+        {
+            schema: 'double(x: Int): Int',
+            resolver: (source, args, context, info) => console.log('ARGS: ', args),
+            access: {
+                create: true,
+                read: () => false,
+                update: false,
+                delete: false,
+            },
+        },
+    ],
+});
+
+const authStrategy = keystone.createAuthStrategy({
+    type: PasswordAuthStrategy,
+    list: 'User',
+});
+
+const apps: BaseApp[] = [
+    new GraphQLApp(),
+    new AdminUIApp({ enableDefaultRoute: true, authStrategy }),
+    new NextApp({
+        dir: './hello',
+    }),
+    new StaticApp({
+        path: '/',
+        src: 'public',
+        fallback: 'index.html',
+    }),
+];
+
+keystone
+    .prepare({ apps, dev: process.env.NODE_ENV !== 'production' })
+    .then(async ({ middlewares }) => {
+        await keystone.connect();
+    });

--- a/types/keystonejs__keystone/package.json
+++ b/types/keystonejs__keystone/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "graphql": "^14.5.8"
+    }
+}

--- a/types/keystonejs__keystone/tsconfig.json
+++ b/types/keystonejs__keystone/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/auth-password": ["keystonejs__auth-password"],
+            "@keystonejs/app-graphql": ["keystonejs__app-graphql"],
+            "@keystonejs/app-admin-ui": ["keystonejs__app-admin-ui"],
+            "@keystonejs/adapter-knex": ["keystonejs__adapter-knex"],
+            "@keystonejs/app-next": ["keystonejs__app-next"],
+            "@keystonejs/app-static": ["keystonejs__app-static"],
+            "@keystonejs/fields": ["keystonejs__fields"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "keystonejs__keystone-tests.ts"
+    ]
+}

--- a/types/keystonejs__keystone/tslint.json
+++ b/types/keystonejs__keystone/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__list-plugins/index.d.ts
+++ b/types/keystonejs__list-plugins/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for @keystonejs/list-plugins 5.0
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+//                 Timothee Clain <https://github.com/tclain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/list-plugins' {
+    import { BaseKeystoneAdapter, Plugin } from '@keystonejs/keystone';
+
+    interface TrackingOptions {
+        createdAtField?: string; // TODO: insert fields here
+        updatedAtField?: string;
+        access: any; // TODO: reuse the access controls type
+    }
+    interface AtTrackingOptions extends TrackingOptions {
+        format?: string;
+    }
+    interface ByTrackingOptions extends TrackingOptions {
+        ref?: string; // TODO: investigate list names
+    }
+
+    type AtTrackingPluginProvider = (options?: AtTrackingOptions) => Plugin;
+    type ByTrackingPluginProvider = (options?: ByTrackingOptions) => Plugin;
+
+    const atTracking: AtTrackingPluginProvider;
+    const byTracking: ByTrackingPluginProvider;
+}

--- a/types/keystonejs__list-plugins/keystonejs__list-plugins-tests.ts
+++ b/types/keystonejs__list-plugins/keystonejs__list-plugins-tests.ts
@@ -1,0 +1,15 @@
+import { atTracking, byTracking } from '@keystonejs/list-plugins';
+
+export const pluginWoOptions = atTracking();
+
+export const atTrackingPluginWithOptions = atTracking({
+    access: {},
+    createdAtField: 'field',
+});
+
+export const byTrackingPluginWithOptions = byTracking({
+    access: {},
+    createdAtField: 'field',
+    ref: 'User',
+});
+`z`;

--- a/types/keystonejs__list-plugins/tsconfig.json
+++ b/types/keystonejs__list-plugins/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/fields": ["keystonejs__fields"],
+            "@keystonejs/keystone": ["keystonejs__keystone"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "keystonejs__list-plugins-tests.ts"
+    ]
+}

--- a/types/keystonejs__list-plugins/tslint.json
+++ b/types/keystonejs__list-plugins/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__logger/index.d.ts
+++ b/types/keystonejs__logger/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for @keystonejs/logger 5.0
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+//                 Timothee Clain <https://github.com/tclain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/logger' {
+    function logger(name: string): void;
+}

--- a/types/keystonejs__logger/tsconfig.json
+++ b/types/keystonejs__logger/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts"]
+}

--- a/types/keystonejs__logger/tslint.json
+++ b/types/keystonejs__logger/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__oembed-adapters/index.d.ts
+++ b/types/keystonejs__oembed-adapters/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for @keystonejs/oembed-adapters 5.0
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/oembed-adapters' {
+    interface OEmbedAdapterConfig {
+        apiKey: string;
+    }
+
+    class IframelyOEmbedAdapter {
+        constructor(options: OEmbedAdapterConfig);
+
+        // Unlikely to be used in client apps, hence the any, but if you're using this, feel free to
+        // type it properly. It's a res.json response from Fetch, just didn't want to pull that in
+        // when it's unlikely to be actually used in client apps, Keystone calls this.
+        fetch(parameters: any): Promise<any>;
+    }
+}

--- a/types/keystonejs__oembed-adapters/keystonejs__oembed-adapters-tests.ts
+++ b/types/keystonejs__oembed-adapters/keystonejs__oembed-adapters-tests.ts
@@ -1,0 +1,22 @@
+import { Keystone } from '@keystonejs/keystone';
+import { KnexAdapter } from '@keystonejs/adapter-knex';
+import { OEmbed } from '@keystonejs/fields';
+import { IframelyOEmbedAdapter } from '@keystonejs/oembed-adapters';
+
+const keystone = new Keystone({
+    name: 'Typescript Test',
+    adapter: new KnexAdapter(),
+});
+
+const iframelyAdapter = new IframelyOEmbedAdapter({
+    apiKey: '...',
+});
+
+keystone.createList('User', {
+    fields: {
+        portfolio: {
+            type: OEmbed,
+            adapter: iframelyAdapter,
+        },
+    },
+});

--- a/types/keystonejs__oembed-adapters/tsconfig.json
+++ b/types/keystonejs__oembed-adapters/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@keystonejs/adapter-knex": ["keystonejs__adapter-knex"],
+            "@keystonejs/fields": ["keystonejs__fields"],
+            "@keystonejs/keystone": ["keystonejs__keystone"]
+        }
+    },
+    "files": ["index.d.ts", "keystonejs__oembed-adapters-tests.ts"]
+}

--- a/types/keystonejs__oembed-adapters/tslint.json
+++ b/types/keystonejs__oembed-adapters/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/keystonejs__session/index.d.ts
+++ b/types/keystonejs__session/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for @keystonejs/session 5.0
+// Project: https://github.com/keystonejs/keystone
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+//                 Timothee Clain <https://github.com/tclain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+// Because this is a scoped package, without this line Typescript doesn't associate the
+// types with the right package.
+// tslint:disable-next-line:no-single-declare-module
+declare module '@keystonejs/session' {}

--- a/types/keystonejs__session/tsconfig.json
+++ b/types/keystonejs__session/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts"]
+}

--- a/types/keystonejs__session/tslint.json
+++ b/types/keystonejs__session/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

This is the very first version of these types, and we expect to continue to improve them, just figured living on @types was the best way to get more feedback and keep working. I'm using these types locally already.

Let me know if you need any changes, happy to accommodate.