### PR TITLE
Allowing group of columns

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -1051,8 +1051,11 @@ You can pass an optional additional property with sorter, sorterParams that shou
         /** Show/Hide a particular column in the HTML output*/
         htmlOutput?: boolean;
 
-        /**If you don't want to show a particular column in the clipboard output you can set the clipboard property in its column definition object to false */
+        /** If you don't want to show a particular column in the clipboard output you can set the clipboard property in its column definition object to false */
         clipboard?: boolean;
+
+        /** A column can be a "group" of columns (Example: group header column -> Measurements, grouped column -> Length, Width, Height) */
+        columns?: ColumnDefinition[];
     }
 
     interface CellCallbacks {

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -526,7 +526,7 @@ colDef.editor = (cell, onRendered, success, cancel, editorParams) => {
     return editor;
 };
 
-let groupColDef: Tabulator.ColumnDefinition = { 
+let groupColDef: Tabulator.ColumnDefinition = {
     title: 'Full name', field: '',
     columns: [
         {title: "First name", field: ''},

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -525,3 +525,11 @@ colDef.editor = (cell, onRendered, success, cancel, editorParams) => {
     const successful: boolean = success('test');
     return editor;
 };
+
+let groupColDef: Tabulator.ColumnDefinition = { 
+    title: 'Full name', field: '',
+    columns: [
+        {title: "First name", field: ''},
+        {title: "Last name", field: ''}
+    ]
+};

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -533,5 +533,3 @@ let groupColDef: Tabulator.ColumnDefinition = {
         {title: "Last name", field: ''}
     ]
 };
-    
-    

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -533,3 +533,5 @@ let groupColDef: Tabulator.ColumnDefinition = {
         {title: "Last name", field: ''}
     ]
 };
+    
+    


### PR DESCRIPTION
A column can be a "group" of columns (Example: group header column -> Measurements, grouped column -> Length, Width, Height)