### PR TITLE
[react-dom/experimental]: add null type to createRoot

### DIFF
--- a/types/react-dom/experimental.d.ts
+++ b/types/react-dom/experimental.d.ts
@@ -74,7 +74,7 @@ declare module '.' {
      *
      * @see https://reactjs.org/docs/concurrent-mode-reference.html#createroot
      */
-    function createRoot(container: Element | Document | DocumentFragment | Comment, options?: RootOptions): Root;
+    function createRoot(container: Element | Document | DocumentFragment | Comment | null, options?: RootOptions): Root;
 
     function unstable_discreteUpdates<R>(callback: () => R): R;
 
@@ -98,5 +98,5 @@ declare module '.' {
     /**
      * @see https://github.com/facebook/react/commit/3a2b5f148d450c69aab67f055fc441d294c23518
      */
-    function unstable_scheduleHydration(target: Element | Document | DocumentFragment | Comment): void;
+    function unstable_scheduleHydration(target: Element | Document | DocumentFragment | Comment | null): void;
 }

--- a/types/react-dom/test/experimental-tests.tsx
+++ b/types/react-dom/test/experimental-tests.tsx
@@ -2,15 +2,29 @@ import React = require('react');
 import ReactDOM = require('react-dom');
 
 function createRoot() {
-    const root = ReactDOM.createRoot(document);
+    {
+        const root = ReactDOM.createRoot(document);
 
-    // NOTE: I don't know yet how to use this; this is just the type it expects
-    // in reality it will do nothing because the root isn't hydrate: true
-    ReactDOM.unstable_scheduleHydration(document);
+        // NOTE: I don't know yet how to use this; this is just the type it expects
+        // in reality it will do nothing because the root isn't hydrate: true
+        ReactDOM.unstable_scheduleHydration(document);
 
-    root.render(<div>initial render</div>, () => {
-        console.log('callback');
-    });
+        root.render(<div>initial render</div>, () => {
+            console.log('callback');
+        });
+    }
+
+    {
+        // baasic sanity checks here since things like *.getElementById can potentially return null.
+        // the type null should not be restricted since we have checks like isValidContainer
+        const root = ReactDOM.createRoot(null);
+
+        ReactDOM.unstable_scheduleHydration(null);
+
+        root.render(<div>initial render</div>, () => {
+            console.log('callback');
+        });
+    }
 }
 
 function createBlockingRoot() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

An element selector can potentially return null. But this case is handled by validity checks like isValidContainer. So one should be able to pass null which will then be rejected by the checks further down. Same goes for the hydration context.

Before:
![Screenshot 2019-11-12 at 14 15 16](https://user-images.githubusercontent.com/1132937/68674984-394f1880-0557-11ea-990c-10ddc2ea73fd.png)

After: 
![Screenshot 2019-11-12 at 14 14 52](https://user-images.githubusercontent.com/1132937/68674993-3e13cc80-0557-11ea-9b92-9fa404da3832.png)

// Validity checks (since these are in expermeintal builds i don't know where to reference it properly so i added screens:
![Screenshot 2019-11-12 at 14 25 25](https://user-images.githubusercontent.com/1132937/68675555-6cde7280-0558-11ea-8abe-f55eeea3636d.png)

![Screenshot 2019-11-12 at 14 25 42](https://user-images.githubusercontent.com/1132937/68675550-6a7c1880-0558-11ea-9d1b-21016eda9718.png)

