### PR TITLE
Add typings for the promise-hash library, v1.3

### DIFF
--- a/types/promise-hash/index.d.ts
+++ b/types/promise-hash/index.d.ts
@@ -5,12 +5,12 @@
 
 export = hash;
 
-type PromiseHash<T> = { [P in keyof T]: PromiseLike<T[P]> | T[P] };
+type PromiseHash = <T>(promiseHash: { [P in keyof T]: PromiseLike<T[P]> | T[P] }) => Promise<T>;
 
 declare global {
     interface PromiseConstructor {
-        hash<T>(promiseHash: PromiseHash<T>): Promise<{ [P in keyof T]: T[P] }>;
+        hash: PromiseHash;
     }
 }
 
-declare function hash<T>(promiseHash: PromiseHash<T>): Promise<{ [P in keyof T]: T[P] }>;
+declare const hash: PromiseHash;

--- a/types/promise-hash/index.d.ts
+++ b/types/promise-hash/index.d.ts
@@ -5,13 +5,12 @@
 
 export = hash;
 
+type PromiseHash<T> = { [P in keyof T]: PromiseLike<T[P]> | T[P] };
+
 declare global {
     interface PromiseConstructor {
-        hash<T>(promiseHash: { [P in keyof T]: PromiseLike<T[P]> | T[P] }):
-            Promise<{ [P in keyof T]: T[P] }>;
+        hash<T>(promiseHash: PromiseHash<T>): Promise<{ [P in keyof T]: T[P] }>;
     }
 }
 
-declare function hash<T>(
-    promiseHash: { [P in keyof T]: PromiseLike<T[P]> | T[P]}):
-    Promise<{ [P in keyof T]: T[P] }>;
+declare function hash<T>(promiseHash: PromiseHash<T>): Promise<{ [P in keyof T]: T[P] }>;

--- a/types/promise-hash/index.d.ts
+++ b/types/promise-hash/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for promise-hash 1.3
+// Project: https://github.com/mtimofiiv/promise-hash
+// Definitions by: Michael Shafir <https://github.com/mshafir>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = hash;
+
+declare global {
+    interface PromiseConstructor {
+        hash<T>(promiseHash: { [P in keyof T]: PromiseLike<T[P]> | T[P] }):
+            Promise<{ [P in keyof T]: T[P] }>;
+    }
+}
+
+declare function hash<T>(
+    promiseHash: { [P in keyof T]: PromiseLike<T[P]> | T[P]}):
+    Promise<{ [P in keyof T]: T[P] }>;

--- a/types/promise-hash/promise-hash-tests.ts
+++ b/types/promise-hash/promise-hash-tests.ts
@@ -1,0 +1,18 @@
+import hash = require('promise-hash');
+
+const result = Promise.hash({
+    a: Promise.resolve(5),
+    b: Promise.resolve("test"),
+    c: hash({
+        d: Promise.resolve(true),
+        e: Promise.resolve("again")
+    })
+});
+
+result; // $ExpectType Promise<{ a: number; b: string; c: { d: boolean; e: string; }; }>
+
+const result2 = hash({
+    test: Promise.resolve("hello world")
+});
+
+result2; // $ExpectType Promise<{ test: string; }>

--- a/types/promise-hash/promise-hash-tests.ts
+++ b/types/promise-hash/promise-hash-tests.ts
@@ -1,15 +1,20 @@
 import hash = require('promise-hash');
 
 const result = Promise.hash({
-    a: Promise.resolve(5),
+    a: 5,
     b: Promise.resolve("test"),
-    c: hash({
+    c: Promise.hash({
         d: Promise.resolve(true),
         e: Promise.resolve("again")
     })
 });
 
-result; // $ExpectType Promise<{ a: number; b: string; c: { d: boolean; e: string; }; }>
+type expectedType = Promise<{ a: number; b: string; c: { d: boolean; e: string; } }>;
+type resultIsExpected = typeof result extends expectedType ? true : false; // $ExpectType true
+type expectedIsResult = expectedType extends typeof result ? true : false; // $ExpectType true
+
+const dResult = result.then(x => x.c.d);
+dResult; // $ExpectType Promise<boolean>
 
 const result2 = hash({
     test: Promise.resolve("hello world")

--- a/types/promise-hash/tsconfig.json
+++ b/types/promise-hash/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "promise-hash-tests.ts"
+    ]
+}

--- a/types/promise-hash/tslint.json
+++ b/types/promise-hash/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
