### PR TITLE
[mongoose] fixes lean return type

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -2000,7 +2000,7 @@ declare module "mongoose" {
      * getters/setters or other Mongoose magic applied.
      * @param {Boolean|Object} bool defaults to true
      */
-    lean<P = any>(bool?: boolean | object): Query<T extends Array<any> ? P[] : P> & QueryHelpers;
+    lean<P = any>(bool?: boolean | object): Query<T extends Array<any> ? P[] : (P | null)> & QueryHelpers;
 
     /** Specifies the maximum number of documents the query will return. Cannot be used with distinct() */
     limit(val: number): this;

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -2000,7 +2000,7 @@ declare module "mongoose" {
      * getters/setters or other Mongoose magic applied.
      * @param {Boolean|Object} bool defaults to true
      */
-    lean<T>(bool?: boolean | object): Query<T> & QueryHelpers;
+    lean<P = any>(bool?: boolean | object): Query<T extends Array<any> ? P[] : P> & QueryHelpers;
 
     /** Specifies the maximum number of documents the query will return. Cannot be used with distinct() */
     limit(val: number): this;


### PR DESCRIPTION
commit https://github.com/DefinitelyTyped/DefinitelyTyped/commit/c74f860f8b80bb5542fbdafa0a81e260f2fec147#diff-ec6e6a45ee09ed93f5d81cb304c5a0b3 introduced typings for lean (instead of any). 
I like this approach, but it breaks old code, because type script assume T is undefined in this case. Also it didn't respect find or findOne and always used T directly.

This approach fixes therefore two issues:
- by default (if no type is provided), it is any again (backswards compatiblity)
- Depending on the used functino it either returns the given type or an array of the given type.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Improves an already existing defintion