### PR TITLE
[styled-system] fix: 'style' function returns a function, not an object

### DIFF
--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -17,6 +17,7 @@
 //                 Jack Caldwell <https://github.com/jackcaldwell>
 //                 Eliseu Monar dos Santos <https://github.com/eliseumds>
 //                 Craig Michael Thompson <https://github.com/craga89>
+//                 Nicholas Hehr <https://github.com/HipsterBrown>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -48,9 +49,7 @@ export interface LowLevelStyleFunctionArguments<N, S> {
 export function style<N = string | number, S = Scale>(
     // tslint:disable-next-line no-unnecessary-generics
     args: LowLevelStyleFunctionArguments<N, S>,
-): {
-    [cssProp: string]: string;
-};
+): styleFn;
 
 export interface styleFn {
     (...args: any[]): any;

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -512,6 +512,11 @@ const customFontStyles = system({
     letterSpacing: true,
 });
 
+const CustomFontGroup = compose(
+    customFontSize,
+    customFontSize,
+);
+
 const centerWithGenerics = style<boolean>({
     prop: 'center',
     cssProperty: 'justify-content',


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/styled-system/styled-system/blob/master/packages/styled-system/src/index.js#L191-L213

The definition for the `style` helper from `styled-system` has been incorrect for a while and makes it incompatible for using in the `compose` helper, which it should be able to do. This patch updated the definition to correctly return a `styleFn` instead of an object. 
