### PR TITLE
[react-router] useRouteMatch always returns match<Params> when no path

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -163,6 +163,7 @@ export function useLocation<S = H.LocationState>(): H.Location<S>;
 
 export function useParams<Params extends { [K in keyof Params]?: string } = {}>(): { [p in keyof Params]: string };
 
+export function useRouteMatch<Params extends { [K in keyof Params]?: string } = {}>(): match<Params>;
 export function useRouteMatch<Params extends { [K in keyof Params]?: string } = {}>(
-    path?: string | string[] | RouteProps,
+    path: string | string[] | RouteProps,
 ): match<Params> | null;

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -29,114 +29,122 @@ import * as H from 'history';
 // This is the type of the context object that will be passed down to all children of
 // a `Router` component:
 export interface RouterChildContext<Params extends { [K in keyof Params]?: string } = {}> {
-  router: {
-    history: H.History
-    route: {
-      location: H.Location
-      match: match<Params>
-    }
-  };
+    router: {
+        history: H.History;
+        route: {
+            location: H.Location;
+            match: match<Params>;
+        };
+    };
 }
 export interface MemoryRouterProps {
-  initialEntries?: H.LocationDescriptor[];
-  initialIndex?: number;
-  getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void);
-  keyLength?: number;
+    initialEntries?: H.LocationDescriptor[];
+    initialIndex?: number;
+    getUserConfirmation?: (message: string, callback: (ok: boolean) => void) => void;
+    keyLength?: number;
 }
 
-export class MemoryRouter extends React.Component<MemoryRouterProps, any> { }
+export class MemoryRouter extends React.Component<MemoryRouterProps, any> {}
 
 export interface PromptProps {
-  message: string | ((location: H.Location) => string | boolean);
-  when?: boolean;
+    message: string | ((location: H.Location) => string | boolean);
+    when?: boolean;
 }
-export class Prompt extends React.Component<PromptProps, any> { }
+export class Prompt extends React.Component<PromptProps, any> {}
 
 export interface RedirectProps {
-  to: H.LocationDescriptor;
-  push?: boolean;
-  from?: string;
-  path?: string;
-  exact?: boolean;
-  strict?: boolean;
+    to: H.LocationDescriptor;
+    push?: boolean;
+    from?: string;
+    path?: string;
+    exact?: boolean;
+    strict?: boolean;
 }
-export class Redirect extends React.Component<RedirectProps, any> { }
+export class Redirect extends React.Component<RedirectProps, any> {}
 
 export interface StaticContext {
-  statusCode?: number;
+    statusCode?: number;
 }
 
-export interface RouteComponentProps<Params extends { [K in keyof Params]?: string } = {}, C extends StaticContext = StaticContext, S = H.LocationState> {
-  history: H.History;
-  location: H.Location<S>;
-  match: match<Params>;
-  staticContext?: C;
-}
-
-export interface RouteChildrenProps<
-  Params extends { [K in keyof Params]?: string } = {},
-  S = H.LocationState
+export interface RouteComponentProps<
+    Params extends { [K in keyof Params]?: string } = {},
+    C extends StaticContext = StaticContext,
+    S = H.LocationState
 > {
-  history: H.History;
-  location: H.Location<S>;
-  match: match<Params> | null;
+    history: H.History;
+    location: H.Location<S>;
+    match: match<Params>;
+    staticContext?: C;
+}
+
+export interface RouteChildrenProps<Params extends { [K in keyof Params]?: string } = {}, S = H.LocationState> {
+    history: H.History;
+    location: H.Location<S>;
+    match: match<Params> | null;
 }
 
 export interface RouteProps {
-  location?: H.Location;
-  component?: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
-  render?: ((props: RouteComponentProps<any>) => React.ReactNode);
-  children?: ((props: RouteChildrenProps<any>) => React.ReactNode) | React.ReactNode;
-  path?: string | string[];
-  exact?: boolean;
-  sensitive?: boolean;
-  strict?: boolean;
+    location?: H.Location;
+    component?: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
+    render?: (props: RouteComponentProps<any>) => React.ReactNode;
+    children?: ((props: RouteChildrenProps<any>) => React.ReactNode) | React.ReactNode;
+    path?: string | string[];
+    exact?: boolean;
+    sensitive?: boolean;
+    strict?: boolean;
 }
-export class Route<T extends RouteProps = RouteProps> extends React.Component<T, any> { }
+export class Route<T extends RouteProps = RouteProps> extends React.Component<T, any> {}
 
 export interface RouterProps {
-  history: H.History;
+    history: H.History;
 }
-export class Router extends React.Component<RouterProps, any> { }
+export class Router extends React.Component<RouterProps, any> {}
 
 export interface StaticRouterContext extends StaticContext {
-  url?: string;
-  action?: 'PUSH' | 'REPLACE';
-  location?: object;
+    url?: string;
+    action?: 'PUSH' | 'REPLACE';
+    location?: object;
 }
 export interface StaticRouterProps {
-  basename?: string;
-  location?: string | object;
-  context?: StaticRouterContext;
+    basename?: string;
+    location?: string | object;
+    context?: StaticRouterContext;
 }
 
-export class StaticRouter extends React.Component<StaticRouterProps, any> { }
+export class StaticRouter extends React.Component<StaticRouterProps, any> {}
 export interface SwitchProps {
-  children?: React.ReactNode;
-  location?: H.Location;
+    children?: React.ReactNode;
+    location?: H.Location;
 }
-export class Switch extends React.Component<SwitchProps, any> { }
+export class Switch extends React.Component<SwitchProps, any> {}
 
 export interface match<Params extends { [K in keyof Params]?: string } = {}> {
-  params: Params;
-  isExact: boolean;
-  path: string;
-  url: string;
+    params: Params;
+    isExact: boolean;
+    path: string;
+    url: string;
 }
 
 // Omit taken from https://github.com/Microsoft/TypeScript/issues/28339#issuecomment-467220238
 export type Omit<T, K extends keyof T> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
 
-export function matchPath<Params extends { [K in keyof Params]?: string }>(pathname: string, props: string | string[] | RouteProps, parent?: match<Params> | null): match<Params> | null;
+export function matchPath<Params extends { [K in keyof Params]?: string }>(
+    pathname: string,
+    props: string | string[] | RouteProps,
+    parent?: match<Params> | null,
+): match<Params> | null;
 
-export function generatePath(pattern: string, params?: { [paramName: string]: string | number | boolean | undefined }): string;
+export function generatePath(
+    pattern: string,
+    params?: { [paramName: string]: string | number | boolean | undefined },
+): string;
 
 export type WithRouterProps<C extends React.ComponentType<any>> = C extends React.ComponentClass
-  ? { wrappedComponentRef?: React.Ref<InstanceType<C>> }
-  : {};
+    ? { wrappedComponentRef?: React.Ref<InstanceType<C>> }
+    : {};
 
 export interface WithRouterStatics<C extends React.ComponentType<any>> {
-  WrappedComponent: C;
+    WrappedComponent: C;
 }
 
 // There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
@@ -144,7 +152,7 @@ export interface WithRouterStatics<C extends React.ComponentType<any>> {
 // you will see a bunch of errors from TypeScript. The current workaround is to use withRouter() as a function call
 // on a separate line instead of as a decorator.
 export function withRouter<P extends RouteComponentProps<any>, C extends React.ComponentType<P>>(
-  component: C & React.ComponentType<P>,
+    component: C & React.ComponentType<P>,
 ): React.ComponentClass<Omit<P, keyof RouteComponentProps<any>> & WithRouterProps<C>> & WithRouterStatics<C>;
 
 export const __RouterContext: React.Context<RouteComponentProps>;

--- a/types/react-router/test/hooks.tsx
+++ b/types/react-router/test/hooks.tsx
@@ -14,9 +14,14 @@ const HooksTest: React.FC = () => {
     const location = useLocation<LocationState>();
     const { id } = useParams();
     const params = useParams<Params>();
+    // $ExpectType match<Params> | null
     const match1 = useRouteMatch<Params>('/:id');
+    // $ExpectType match<Params> | null
     const match2 = useRouteMatch<Params>(['/one/:id', '/two/:id']);
+    // $ExpectType match<Params> | null
     const match3 = useRouteMatch<Params>({ path: '/:id', exact: true });
+    // $ExpectType match<Params>
+    const match4 = useRouteMatch<Params>();
 
     history.location.state.s;
     location.state.s;
@@ -24,6 +29,8 @@ const HooksTest: React.FC = () => {
     params.id.replace;
     match1 && match1.params.id.replace;
     match2 && match2.params.id.replace;
+    match3 && match3.params.id.replace;
+    match4.params.id.replace;
 
     return null;
 };


### PR DESCRIPTION
A component [won't be rendered if there is no match](https://github.com/ReactTraining/react-router/blob/ef60b08d514e1db3354316c303783158f108bd3b/packages/react-router/modules/Route.js#L56), and if you don't pass a `path` to `useRouteMatch`, it returns the [current match](https://github.com/ReactTraining/react-router/blob/ef60b08d514e1db3354316c303783158f108bd3b/packages/react-router/modules/hooks.js#L54) from the context. This just makes it so you always get `match<Params>` if you don't pass an argument to `useRouteMatch`.

I move the `prettier` formatting into just the first commit. The second commit has the actual changes. Thought it might be easier for folks to review that way.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/react-router/blob/ef60b08d514e1db3354316c303783158f108bd3b/packages/react-router/modules/hooks.js#L54
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.