### PR TITLE
[@types/cytoscape] Adding missing EdgeLine and Gradient style properties

### DIFF
--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -3708,7 +3708,7 @@ declare namespace cytoscape {
             "pie-i-background-opacity": PropertyValueNode<number>;
         }
 
-        interface Edge extends EdgeLine, EdgeArrow, Partial<Overlay>, Partial<BezierEdges>, Partial<UnbundledBezierEdges>,
+        interface Edge extends EdgeLine, EdgeArrow, Partial<Gradient>, Partial<Overlay>, Partial<BezierEdges>, Partial<UnbundledBezierEdges>,
         Partial<HaystackEdges>, Partial<SegmentsEdges>, Partial<Visibility<EdgeSingular>>, Partial<Labels<EdgeSingular>> { }
 
         /**
@@ -3757,6 +3757,14 @@ declare namespace cytoscape {
              * The dashed line offset.
              */
             "line-dash-offset"?: PropertyValueEdge<number>;
+        }
+
+        /**
+         * These properties specify the gradient colouration of an edge's line:
+         * 
+         * https://js.cytoscape.org/#style/gradient
+         */
+        interface Gradient{
             /**
              * The colours of the gradient stops.
              */

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -3761,10 +3761,10 @@ declare namespace cytoscape {
 
         /**
          * These properties specify the gradient colouration of an edge's line:
-         * 
+         *
          * https://js.cytoscape.org/#style/gradient
          */
-        interface Gradient{
+        interface Gradient {
             /**
              * The colours of the gradient stops.
              */

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -6,6 +6,7 @@
 //                  Jan-Niclas Struewer <https://github.com/janniclas>
 //                  Cerberuser <https://github.com/cerberuser>
 //                  Andrej Kirejeŭ <https://github.com/gsbelarus>
+//                  Peter Ferrarotto <https://github.com/peterjferrarotto>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 //
 // Translation from Objects in help to Typescript interface.
@@ -3751,7 +3752,7 @@ declare namespace cytoscape {
             /**
              * The dashed line pattern which specifies alternating lengths of lines and gaps.
              */
-            "line-dash-pattern"?: PropertyValueEdge<number>[];
+            "line-dash-pattern"?: Array<PropertyValueEdge<number>>;
             /**
              * The dashed line offset.
              */
@@ -3759,12 +3760,12 @@ declare namespace cytoscape {
             /**
              * The colours of the gradient stops.
              */
-            "line-gradient-stop-colours"?: PropertyValueEdge<Colour>[];
+            "line-gradient-stop-colours"?: Array<PropertyValueEdge<Colour>>;
             /**
              * The positions of the gradient stops.
              * If not specified (or invalid), the stops will divide equally.
              */
-            "line-gradient-stop-positions"?: PropertyValueEdge<number>[];
+            "line-gradient-stop-positions"?: Array<PropertyValueEdge<number>>;
         }
 
         /**

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -3740,6 +3740,31 @@ declare namespace cytoscape {
              * The style of the edge’s line.
              */
             "line-style"?: PropertyValueEdge<LineStyle>;
+            /**
+             * The cap of the edge's line.
+             */
+            "line-cap"?: PropertyValueEdge<"butt" | "round" | "square">;
+            /**
+             * The filling style of the edge's line.
+             */
+            "line-fill"?: PropertyValueEdge<"solid" | "linear-gradient" | "radial-gradient">;
+            /**
+             * The dashed line pattern which specifies alternating lengths of lines and gaps.
+             */
+            "line-dash-pattern"?: PropertyValueEdge<number>[];
+            /**
+             * The dashed line offset.
+             */
+            "line-dash-offset"?: PropertyValueEdge<number>;
+            /**
+             * The colours of the gradient stops.
+             */
+            "line-gradient-stop-colours"?: PropertyValueEdge<Colour>[];
+            /**
+             * The positions of the gradient stops.
+             * If not specified (or invalid), the stops will divide equally.
+             */
+            "line-gradient-stop-positions"?: PropertyValueEdge<number>[];
         }
 
         /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://js.cytoscape.org/#style/edge-line>>
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://js.cytoscape.org/#style/gradient>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.