### PR TITLE
reference @types/node in vfile-location

### DIFF
--- a/types/vfile-location/index.d.ts
+++ b/types/vfile-location/index.d.ts
@@ -5,6 +5,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
+/// <reference types="node" />
+
 import * as VFile from "vfile";
 
 declare function vfileLocation(vfile: string | VFile.VFile): vfileLocation.Location;


### PR DESCRIPTION
vfile references @types/node but types-publisher doesn't know that. Instead, reference @types/node in vfile-location, since it now depends on vfile instead of @types/vfile.