### PR TITLE
[use-deep-compare-effect] Add package

### DIFF
--- a/types/use-deep-compare-effect/index.d.ts
+++ b/types/use-deep-compare-effect/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for use-deep-compare-effect 1.2
+// Project: https://github.com/kentcdodds/use-deep-compare-effect#readme
+// Definitions by: JPeer264 <https://github.com/JPeer264>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { useEffect } from 'react';
+
+export const useDeepCompareNoEffect: typeof useEffect;
+
+export default useEffect;

--- a/types/use-deep-compare-effect/index.d.ts
+++ b/types/use-deep-compare-effect/index.d.ts
@@ -5,6 +5,8 @@
 
 import { useEffect } from 'react';
 
-export const useDeepCompareNoEffect: typeof useEffect;
+export const useDeepCompareEffectNoCheck: typeof useEffect;
 
-export default useEffect;
+declare const useDeepCompareEffect: typeof useEffect;
+
+export default useDeepCompareEffect;

--- a/types/use-deep-compare-effect/tsconfig.json
+++ b/types/use-deep-compare-effect/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "use-deep-compare-effect-tests.ts"
+    ]
+}

--- a/types/use-deep-compare-effect/tslint.json
+++ b/types/use-deep-compare-effect/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/use-deep-compare-effect/use-deep-compare-effect-tests.ts
+++ b/types/use-deep-compare-effect/use-deep-compare-effect-tests.ts
@@ -1,0 +1,15 @@
+import useDeeCompareEffect, { useDeepCompareNoEffect } from 'use-deep-compare-effect';
+
+useDeeCompareEffect(() => {
+  return () => { };
+});
+
+useDeeCompareEffect(() => {
+});
+
+useDeepCompareNoEffect(() => {
+  return () => { };
+});
+
+useDeepCompareNoEffect(() => {
+});

--- a/types/use-deep-compare-effect/use-deep-compare-effect-tests.ts
+++ b/types/use-deep-compare-effect/use-deep-compare-effect-tests.ts
@@ -1,15 +1,15 @@
-import useDeeCompareEffect, { useDeepCompareNoEffect } from 'use-deep-compare-effect';
+import useDeepCompareEffect, { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect';
 
-useDeeCompareEffect(() => {
+useDeepCompareEffect(() => {
   return () => { };
 });
 
-useDeeCompareEffect(() => {
+useDeepCompareEffect(() => {
 });
 
-useDeepCompareNoEffect(() => {
+useDeepCompareEffectNoCheck(() => {
   return () => { };
 });
 
-useDeepCompareNoEffect(() => {
+useDeepCompareEffectNoCheck(() => {
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
