### PR TITLE
Add types for syslog-client

### DIFF
--- a/types/syslog-client/index.d.ts
+++ b/types/syslog-client/index.d.ts
@@ -1,0 +1,76 @@
+// Type definitions for node-syslog-client 1.1
+// Project: https://github.com/paulgrove/node-syslog-client
+// Definitions by: Romain CONNESSON <https://github.com/helorem>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { EventEmitter } from 'events';
+
+export enum Transport {
+	Tcp = 1,
+	Udp = 2
+}
+
+export enum Facility {
+	Kernel =  0,
+	User   =  1,
+	System =  3,
+	Audit  = 13,
+	Alert  = 14,
+	Local0 = 16,
+	Local1 = 17,
+	Local2 = 18,
+	Local3 = 19,
+	Local4 = 20,
+	Local5 = 21,
+	Local6 = 22,
+	Local7 = 23
+}
+
+export enum Severity {
+	Emergency     = 0,
+	Alert         = 1,
+	Critical      = 2,
+	Error         = 3,
+	Warning       = 4,
+	Notice        = 5,
+	Informational = 6,
+	Debug         = 7
+}
+
+export interface ClientOptions {
+	syslogHostname?: string;
+	port?: number;
+	tcpTimeout?: number;
+	facility?: Facility;
+	severity?: Severity;
+	rfc3164?: boolean;
+	appName?: string;
+	dateFormatter?: (() => string);
+	transport?: Transport;
+	timestamp?: Date;
+	msgid?: string;
+}
+
+export interface MessageOptions {
+	syslogHostname?: string;
+	facility?: Facility;
+	severity?: Severity;
+	rfc3164?: boolean;
+	appName?: string;
+	timestamp?: Date;
+	msgid?: string;
+}
+
+export class Client extends EventEmitter {
+	constructor(target?: string, options?: ClientOptions);
+	buildFormattedMessage(message: string, options: MessageOptions): Buffer;
+	close(): Client;
+	log(message: string, options?: MessageOptions, cb?: ((error: Error | null) => void)): Client;
+	getTransport(cb: ((error: Error | null, transport: Transport) => void)): void;
+	onClose(): Client;
+	onError(error: Error): Client;
+}
+
+export function createClient(target: string, options: ClientOptions): Client;

--- a/types/syslog-client/syslog-client-tests.ts
+++ b/types/syslog-client/syslog-client-tests.ts
@@ -1,0 +1,11 @@
+import * as syslog from 'syslog-client';
+
+const syslog_client = syslog.createClient("127.0.0.1", {
+  port: 514,
+  transport: syslog.Transport.Tcp,
+  rfc3164: false,
+  appName: "testapp"
+});
+syslog_client.log("Test message", { severity: syslog.Severity.Warning }, (error: Error | null) => {
+  syslog_client.close();
+});

--- a/types/syslog-client/tsconfig.json
+++ b/types/syslog-client/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "syslog-client-tests.ts"
+    ]
+}

--- a/types/syslog-client/tslint.json
+++ b/types/syslog-client/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.