### PR TITLE
[react-linkify] Export namespace to expose props type defs

### DIFF
--- a/types/react-linkify/index.d.ts
+++ b/types/react-linkify/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-linkify 0.2
+// Type definitions for react-linkify 1.0.0-alpha
 // Project: http://tasti.github.io/react-linkify/
 // Definitions by: Michael James <https://github.com/majames>
 //                 Jacky Wang <https://github.com/jackywang529>

--- a/types/react-linkify/index.d.ts
+++ b/types/react-linkify/index.d.ts
@@ -7,7 +7,7 @@
 
 import * as React from "react";
 
-declare namespace ReactLinkify {
+export declare namespace ReactLinkify {
     /**
      * Matching information
      */

--- a/types/react-linkify/index.d.ts
+++ b/types/react-linkify/index.d.ts
@@ -2,64 +2,61 @@
 // Project: http://tasti.github.io/react-linkify/
 // Definitions by: Michael James <https://github.com/majames>
 //                 Jacky Wang <https://github.com/jackywang529>
+//                 Akhil Stanislavose <https://github.com/akhilstanis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.4
 
 import * as React from "react";
 
-export namespace ReactLinkify {
-    /**
-     * Matching information
-     */
-    interface MatchInfo {
-        /**
-         * Link schema, can be empty for fuzzy links, or for protocol-neutral links
-         */
-        schema: string;
-        /**
-         * Offset of matched text
-         */
-        index: number;
-        /**
-         * Index of next char after the end of the matched text
-         */
-        lastIndex: number;
-        /**
-         * Normalized text
-         */
-        text: string;
-        /**
-         * Link, generated from matched text
-         */
-        url: string;
-    }
-
-    interface Props {
-        children: React.ReactNode;
-        /**
-         * Custom anchor tag creator
-         * Default to using exisint <a> tag with the provided href={decoratedHref}, key={key}
-         * and children={decoratedText}, without additional styling
-         */
-        componentDecorator?: (decoratedHref: string, decoratedText: string, key: number) => React.ReactNode;
-        /**
-         * Custom href decorator or mapper on the matched (url) href
-         * Default to no transformation
-         */
-        hrefDecorator?: (urlHref: string) => string;
-        /**
-         * Custom matcher for (url), that returns each match with the matching information
-         * Default to https://github.com/markdown-it/linkify-it's LinkifyIt().tlds(tlds).match
-         */
-        matchDecorator?: (text: string) => MatchInfo[] | null;
-        /**
-         * Custom text decorator or mapper on the matched (url) text
-         * Default to no transformation
-         */
-        textDecorator?: (urlText: string) => string;
-    }
-
-    class ReactLinkify extends React.Component<Props> {}
+/**
+ * Matching information
+ */
+export interface MatchInfo {
+  /**
+   * Link schema, can be empty for fuzzy links, or for protocol-neutral links
+   */
+  schema: string;
+  /**
+   * Offset of matched text
+   */
+  index: number;
+  /**
+   * Index of next char after the end of the matched text
+   */
+  lastIndex: number;
+  /**
+   * Normalized text
+   */
+  text: string;
+  /**
+   * Link, generated from matched text
+   */
+  url: string;
 }
 
-export default ReactLinkify.ReactLinkify;
+export interface Props {
+  children: React.ReactNode;
+  /**
+   * Custom anchor tag creator
+   * Default to using exisint <a> tag with the provided href={decoratedHref}, key={key}
+   * and children={decoratedText}, without additional styling
+   */
+  componentDecorator?: (decoratedHref: string, decoratedText: string, key: number) => React.ReactNode;
+  /**
+   * Custom href decorator or mapper on the matched (url) href
+   * Default to no transformation
+   */
+  hrefDecorator?: (urlHref: string) => string;
+  /**
+   * Custom matcher for (url), that returns each match with the matching information
+   * Default to https://github.com/markdown-it/linkify-it's LinkifyIt().tlds(tlds).match
+   */
+  matchDecorator?: (text: string) => MatchInfo[] | null;
+  /**
+   * Custom text decorator or mapper on the matched (url) text
+   * Default to no transformation
+   */
+  textDecorator?: (urlText: string) => string;
+}
+
+export default class ReactLinkify extends React.Component<Props> { }

--- a/types/react-linkify/index.d.ts
+++ b/types/react-linkify/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-linkify 1.0.0-alpha
+// Type definitions for react-linkify 1.0
 // Project: http://tasti.github.io/react-linkify/
 // Definitions by: Michael James <https://github.com/majames>
 //                 Jacky Wang <https://github.com/jackywang529>
@@ -7,7 +7,7 @@
 
 import * as React from "react";
 
-export declare namespace ReactLinkify {
+export namespace ReactLinkify {
     /**
      * Matching information
      */


### PR DESCRIPTION
It would be nice to expose the props type definition which would allow users to extend the original component.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://gist.github.com/akhilstanis/5eba81c6721b349cc1da919d2f0548f6
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
