### PR TITLE
Added typing for string-placeholder

### DIFF
--- a/types/string-placeholder/index.d.ts
+++ b/types/string-placeholder/index.d.ts
@@ -7,11 +7,11 @@
 export = template;
 export as namespace template;
 
-declare function template(str: string, data: [] | {}, options?: Options): string;
+declare function template(str: string, data: Readonly<[]> | Readonly<{}>, options?: Options): string;
 
 interface Options {
     before?: string;
     after?: string;
     escape?: string;
-    clean?: boolean | [];
+    clean?: boolean | Readonly<[]>;
 }

--- a/types/string-placeholder/index.d.ts
+++ b/types/string-placeholder/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
-export function template(str: string, data: Readonly<[]> | Readonly<{}>, options?: Options): string;
+export function template(str: string, data: Readonly<unknown>, options?: Readonly<Options>): string;
 
 interface Options {
     before?: string;

--- a/types/string-placeholder/index.d.ts
+++ b/types/string-placeholder/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/crysalead-js/string-placeholder#readme
 // Definitions by: Filipe Ferreira <https://github.com/iTsFILIPOficial>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 export = template;
 export as namespace template;

--- a/types/string-placeholder/index.d.ts
+++ b/types/string-placeholder/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for string-placeholder 1.0
+// Project: https://github.com/crysalead-js/string-placeholder#readme
+// Definitions by: Filipe Ferreira <https://github.com/iTsFILIPOficial>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = template;
+export as namespace template;
+
+declare function template(str: string, data: [] | {}, options?: Options): string;
+
+interface Options {
+    before?: string;
+    after?: string;
+    escape?: string;
+    clean?: boolean | [];
+}

--- a/types/string-placeholder/index.d.ts
+++ b/types/string-placeholder/index.d.ts
@@ -4,10 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
-export = template;
-export as namespace template;
-
-declare function template(str: string, data: Readonly<[]> | Readonly<{}>, options?: Options): string;
+export function template(str: string, data: Readonly<[]> | Readonly<{}>, options?: Options): string;
 
 interface Options {
     before?: string;
@@ -15,3 +12,5 @@ interface Options {
     escape?: string;
     clean?: boolean | Readonly<[]>;
 }
+
+export default template;

--- a/types/string-placeholder/index.d.ts
+++ b/types/string-placeholder/index.d.ts
@@ -13,4 +13,4 @@ interface Options {
     clean?: boolean;
 }
 
-export default template;
+export = template;

--- a/types/string-placeholder/index.d.ts
+++ b/types/string-placeholder/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/crysalead-js/string-placeholder#readme
 // Definitions by: Filipe Ferreira <https://github.com/iTsFILIPOficial>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 export = template;
 export as namespace template;

--- a/types/string-placeholder/index.d.ts
+++ b/types/string-placeholder/index.d.ts
@@ -10,7 +10,7 @@ interface Options {
     before?: string;
     after?: string;
     escape?: string;
-    clean?: boolean | Readonly<[]>;
+    clean?: boolean;
 }
 
 export default template;

--- a/types/string-placeholder/index.d.ts
+++ b/types/string-placeholder/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
-export function template(str: string, data: Readonly<unknown>, options?: Readonly<Options>): string;
+declare function template(str: string, data: Readonly<unknown>, options?: Readonly<Options>): string;
 
 interface Options {
     before?: string;

--- a/types/string-placeholder/string-placeholder-tests.ts
+++ b/types/string-placeholder/string-placeholder-tests.ts
@@ -1,4 +1,4 @@
-import template = require('string-placeholder');
+import template from 'string-placeholder';
 
 // $ExpectType string
 template('{0} test', ['here']);

--- a/types/string-placeholder/string-placeholder-tests.ts
+++ b/types/string-placeholder/string-placeholder-tests.ts
@@ -17,6 +17,3 @@ template('${0} test', ['here'], { escape: '\\' });
 
 // $ExpectType string
 template('${0} test', ['here'], { clean: true });
-
-// $ExpectType string
-template('${0} test', ['here'], { clean: []});

--- a/types/string-placeholder/string-placeholder-tests.ts
+++ b/types/string-placeholder/string-placeholder-tests.ts
@@ -1,0 +1,19 @@
+import template = require('string-placeholder');
+
+// $ExpectType string
+template('${0} test', ['here']);
+
+// $ExpectType string
+template('${0} test', ['here'], { after: '[:' });
+
+// $ExpectType string
+template('${0} test', ['here'], { before: ']' });
+
+// $ExpectType string
+template('${0} test', ['here'], { escape: '\\' });
+
+// $ExpectType string
+template('${0} test', ['here'], { clean: true });
+
+// $ExpectType string
+template('${0} test', ['here'], { clean: []});

--- a/types/string-placeholder/string-placeholder-tests.ts
+++ b/types/string-placeholder/string-placeholder-tests.ts
@@ -1,19 +1,22 @@
 import template from 'string-placeholder';
 
 // $ExpectType string
-template('{0} test', ['here']);
+template('${0} test', ['here']);
 
 // $ExpectType string
-template('{0} test', ['here'], { after: '[:' });
+template('${foo} test ${bar}', {foo: 'Bob', bar: '65'});
 
 // $ExpectType string
-template('{0} test', ['here'], { before: ']' });
+template('${0} test', ['here'], { after: '[:' });
 
 // $ExpectType string
-template('{0} test', ['here'], { escape: '\\' });
+template('${0} test', ['here'], { before: ']' });
 
 // $ExpectType string
-template('{0} test', ['here'], { clean: true });
+template('${0} test', ['here'], { escape: '\\' });
 
 // $ExpectType string
-template('{0} test', ['here'], { clean: []});
+template('${0} test', ['here'], { clean: true });
+
+// $ExpectType string
+template('${0} test', ['here'], { clean: []});

--- a/types/string-placeholder/string-placeholder-tests.ts
+++ b/types/string-placeholder/string-placeholder-tests.ts
@@ -1,19 +1,19 @@
 import template = require('string-placeholder');
 
 // $ExpectType string
-template('${0} test', ['here']);
+template('{0} test', ['here']);
 
 // $ExpectType string
-template('${0} test', ['here'], { after: '[:' });
+template('{0} test', ['here'], { after: '[:' });
 
 // $ExpectType string
-template('${0} test', ['here'], { before: ']' });
+template('{0} test', ['here'], { before: ']' });
 
 // $ExpectType string
-template('${0} test', ['here'], { escape: '\\' });
+template('{0} test', ['here'], { escape: '\\' });
 
 // $ExpectType string
-template('${0} test', ['here'], { clean: true });
+template('{0} test', ['here'], { clean: true });
 
 // $ExpectType string
-template('${0} test', ['here'], { clean: []});
+template('{0} test', ['here'], { clean: []});

--- a/types/string-placeholder/tsconfig.json
+++ b/types/string-placeholder/tsconfig.json
@@ -14,7 +14,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",

--- a/types/string-placeholder/tsconfig.json
+++ b/types/string-placeholder/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "string-placeholder-tests.ts"
+    ]
+}

--- a/types/string-placeholder/tslint.json
+++ b/types/string-placeholder/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/string-placeholder/tslint.json
+++ b/types/string-placeholder/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-invalid-template-strings": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
-  [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

