### PR TITLE
Updated `latlon-geohash` type definitions for version 2.0.0

### DIFF
--- a/types/latlon-geohash/index.d.ts
+++ b/types/latlon-geohash/index.d.ts
@@ -1,94 +1,97 @@
-// Type definitions for latlon-geohash 1.1
+// Type definitions for latlon-geohash 2.0
 // Project: https://github.com/chrisveness/latlon-geohash, http://www.movable-type.co.uk/scripts/geohash.html
 // Definitions by: Robert Imig <https://github.com/rimig>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-export enum Direction {
-    North = "N",
-    South = "S",
-    East = "E",
-    West = "W"
+declare namespace Geohash {
+    enum Direction {
+        North = "N",
+        South = "S",
+        East = "E",
+        West = "W"
+    }
+
+    interface Neighbours {
+        n: string;
+        ne: string;
+        e: string;
+        se: string;
+        s: string;
+        sw: string;
+        w: string;
+        nw: string;
+    }
+
+    interface Bounds {
+        sw: Point;
+        ne: Point;
+    }
+
+    interface Point {
+        lat: number;
+        lon: number;
+    }
+
+    /**
+     * Encodes latitude/longitude to geohash, either to specified precision or to automatically
+     * evaluated precision.
+     *
+     * @param   lat - Latitude in degrees.
+     * @param   lon - Longitude in degrees.
+     * @param   [precision] - Number of characters in resulting geohash.
+     * @returns Geohash of supplied latitude/longitude.
+     * @throws  Invalid geohash.
+     *
+     * @example
+     *     var geohash = Geohash.encode(52.205, 0.119, 7); // geohash: 'u120fxw'
+     */
+    function encode(
+        latitude: number,
+        longitude: number,
+        precision?: number
+    ): string;
+
+    /**
+     * Decode geohash to latitude/longitude (location is approximate centre of geohash cell,
+     *     to reasonable precision).
+     *
+     * @param   geohash - Geohash string to be converted to latitude/longitude.
+     * @returns (Center of) geohashed location.
+     * @throws  Invalid geohash.
+     *
+     * @example
+     *     var latlon = Geohash.decode('u120fxw'); // latlon: { lat: 52.205, lon: 0.1188 }
+     */
+    function decode(geohash: string): Point;
+
+    /**
+     * Returns SW/NE latitude/longitude bounds of specified geohash.
+     *
+     * @param   geohash - Cell that bounds are required of.
+     * @returns The Bounds
+     * @throws  Invalid geohash.
+     */
+    function bounds(geohash: string): Bounds;
+
+    /**
+     * Determines adjacent cell in given direction.
+     *
+     * @param   geohash - Cell to which adjacent cell is required.
+     * @param   direction - Direction from geohash (N/S/E/W).
+     * @returns Geocode of adjacent cell.
+     * @throws  Invalid geohash.
+     */
+    function adjacent(geohash: string, direction: Direction | string): string;
+
+    /**
+     * Returns all 8 adjacent cells to specified geohash.
+     *
+     * @param   geohash - Geohash neighbours are required of.
+     * @returns The neighbours
+     * @throws  Invalid geohash.
+     */
+    function neighbours(geohash: string): Neighbours;
 }
 
-export interface Neighbours {
-    n: string;
-    ne: string;
-    e: string;
-    se: string;
-    s: string;
-    sw: string;
-    w: string;
-    nw: string;
-}
-
-export interface Bounds {
-    sw: Point;
-    ne: Point;
-}
-
-export interface Point {
-    lat: number;
-    lon: number;
-}
-
-/**
- * Encodes latitude/longitude to geohash, either to specified precision or to automatically
- * evaluated precision.
- *
- * @param   lat - Latitude in degrees.
- * @param   lon - Longitude in degrees.
- * @param   [precision] - Number of characters in resulting geohash.
- * @returns Geohash of supplied latitude/longitude.
- * @throws  Invalid geohash.
- *
- * @example
- *     var geohash = Geohash.encode(52.205, 0.119, 7); // geohash: 'u120fxw'
- */
-
-export function encode(
-    latitude: number,
-    longitude: number,
-    precision?: number
-): string;
-
-/**
- * Decode geohash to latitude/longitude (location is approximate centre of geohash cell,
- *     to reasonable precision).
- *
- * @param   geohash - Geohash string to be converted to latitude/longitude.
- * @returns (Center of) geohashed location.
- * @throws  Invalid geohash.
- *
- * @example
- *     var latlon = Geohash.decode('u120fxw'); // latlon: { lat: 52.205, lon: 0.1188 }
- */
-export function decode(geohash: string): Point;
-
-/**
- * Returns SW/NE latitude/longitude bounds of specified geohash.
- *
- * @param   geohash - Cell that bounds are required of.
- * @returns The Bounds
- * @throws  Invalid geohash.
- */
-export function bounds(geohash: string): Bounds;
-
-/**
- * Determines adjacent cell in given direction.
- *
- * @param   geohash - Cell to which adjacent cell is required.
- * @param   direction - Direction from geohash (N/S/E/W).
- * @returns Geocode of adjacent cell.
- * @throws  Invalid geohash.
- */
-export function adjacent(geohash: string, direction: Direction | string): string;
-
-/**
- * Returns all 8 adjacent cells to specified geohash.
- *
- * @param   geohash - Geohash neighbours are required of.
- * @returns The neighbours
- * @throws  Invalid geohash.
- */
-export function neighbours(geohash: string): Neighbours;
+export default Geohash;

--- a/types/latlon-geohash/latlon-geohash-tests.ts
+++ b/types/latlon-geohash/latlon-geohash-tests.ts
@@ -1,4 +1,4 @@
-import * as Geohash from "latlon-geohash";
+import Geohash from "latlon-geohash";
 
 // Encoding
 const atx_geohash: string = Geohash.encode(30.2672, -97.7431);


### PR DESCRIPTION
Updated `latlon-geohash` type definitions to fit new import syntax of version 2.0.0.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chrisveness/latlon-geohash
New import syntax in version 2.0.0 is: `import Geohash from "latlon-geohash";`.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.