### PR TITLE
fix: type QueryRenderer environment prop as IEnvironment

### DIFF
--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -15,6 +15,7 @@
 import * as React from 'react';
 import {
     Environment,
+    IEnvironment,
     Variables,
     Disposable,
     Observer,
@@ -109,7 +110,7 @@ export {
 export type FetchPolicy = 'store-and-network' | 'network-only';
 
 interface QueryRendererProps<TOperation extends OperationType> {
-    environment: Environment;
+    environment: IEnvironment;
     query: GraphQLTaggedNode | null | undefined;
     render: (renderProps: {
         error: Error | null;

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -714,3 +714,45 @@ requestSubscription(
 
 ReactRelayContext.Consumer.prototype;
 ReactRelayContext.Provider.prototype;
+
+const MyRelayContextProvider: React.FunctionComponent = children => {
+    return (
+        <ReactRelayContext.Provider
+            value={{
+                environment: modernEnvironment,
+            }}>
+            {children}
+        </ReactRelayContext.Provider>
+    );
+};
+
+const MyRelayContextConsumer: React.FunctionComponent = () => {
+    const relayContext = React.useContext(ReactRelayContext);
+    if (!relayContext || !relayContext.environment) {
+        return null;
+    }
+
+    return (
+        <QueryRenderer<MyQuery>
+            environment={relayContext.environment}
+            query={graphql`
+                query ExampleQuery($pageID: ID!) {
+                    page(id: $pageID) {
+                        name
+                    }
+                }
+            `}
+            variables={{
+                pageID: '110798995619330',
+            }}
+            render={({ error, props }) => {
+                if (error) {
+                    return <div>{error.message}</div>;
+                } else if (props) {
+                    return <div>{props.name} is great!</div>;
+                }
+                return <div>Loading</div>;
+            }}
+        />
+    );
+};


### PR DESCRIPTION
Update `QueryRendererProps` so that `environment` is typed as `IEnvironment`, matching the [flow definitions in relay](https://github.com/facebook/relay/blob/master/packages/react-relay/ReactRelayQueryRenderer.js#L60). This then allows passing the `environment` property from `ReactRelayContext` as the value for the `environment` prop on `QueryRenderer`s

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/facebook/relay/blob/master/packages/react-relay/ReactRelayQueryRenderer.js#L60>
- ~[ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- ~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~