### PR TITLE
chromecast-caf-receiver: RequestData.type should just have message types

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -832,7 +832,7 @@ export class ResumeSessionRequestData extends RequestData {
  * Media event request data.
  */
 export class RequestData {
-    constructor(type: MessageType | EventType);
+    constructor(type: MessageType);
 
     /**
      * Application-specific data for this request.
@@ -854,7 +854,7 @@ export class RequestData {
     /**
      * Message type.
      */
-    type: MessageType | EventType;
+    type: MessageType;
 }
 
 /**

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -31,9 +31,11 @@ const breakClip = new cast.framework.messages.BreakClip('id');
 // tslint:disable-next-line
 const adBreak = new cast.framework.messages.Break('id', ['id'], 1);
 // tslint:disable-next-line
-const rEvent = new cast.framework.events.RequestEvent(EventType.BITRATE_CHANGED, {
+const rEvent = new cast.framework.events.RequestEvent(EventType.LOAD_START, {
     requestId: 2,
-    type: EventType.BITRATE_CHANGED,
+    type: MessageType.LOAD,
+    // TODO: Do some testing on the receiver and see what a real world
+    // TODO: `RequestEvent` looks like.
 });
 // tslint:disable-next-line
 const pManager = new cast.framework.PlayerManager();


### PR DESCRIPTION
I mistakenly updated `RequestData` to allow `EventTypes`, but as far as I can tell, this doesn't reflect the SDK or the behavior that we want, so this change reverts back to the original behavior of `RequestData.type` only accepting a `MessageType`.

It's my (perhaps wrong?) understanding that the patch version will be incremented by this change, so not updating the major or minor version.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.events.RequestEvent>, <https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.RequestData.html>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. 
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.