### PR TITLE
react-query: improve types for useQuery in paginated mode

### DIFF
--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-query 0.3
+// Type definitions for react-query 0.3.12
 // Project: https://github.com/tannerlinsley/react-query
 // Definitions by: Lukasz Fiszer <https://github.com/lukaszfiszer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -11,6 +11,13 @@ export function useQuery<TResult, TVariables extends object>(
     options?: QueryOptions<TResult>
 ): QueryResult<TResult, TVariables>;
 
+// overloaded useQuery function with pagination
+export function useQuery<TResult, TVariables extends object>(
+    queryKey: QueryKey<TVariables>,
+    queryFn: QueryFunction<TResult, TVariables>,
+    options?: QueryOptionsPaginated<TResult>
+): QueryResultPaginated<TResult, TVariables>;
+
 export type QueryKey<TVariables> = string | [string, TVariables] | false | null | QueryKeyFunction<TVariables>;
 export type QueryKeyFunction<TVariables> = () => string | [string, TVariables] | false | null;
 
@@ -18,8 +25,6 @@ export type QueryFunction<TResult, TVariables extends object> = (variables: TVar
 
 export interface QueryOptions<TResult> {
     manual?: boolean;
-    paginated?: boolean;
-    getCanFetchMore?: (lastPage: number, allPages: number) => boolean;
     retry?: boolean | number;
     retryDelay?: (retryAttempt: number) => number;
     staleTime?: number;
@@ -30,6 +35,11 @@ export interface QueryOptions<TResult> {
     suspense?: boolean;
 }
 
+export interface QueryOptionsPaginated<TResult> extends QueryOptions<TResult> {
+    paginated: true;
+    getCanFetchMore: (lastPage: number, allPages: number) => boolean;
+}
+
 export interface QueryResult<TResult, TVariables> {
     data: null | TResult;
     error: null | Error;
@@ -38,6 +48,9 @@ export interface QueryResult<TResult, TVariables> {
     isCached: boolean;
     failureCount: number;
     refetch: (arg?: {variables?: TVariables, merge?: (...args: any[]) => any, disableThrow?: boolean}) => void;
+}
+
+export interface QueryResultPaginated<TResult, TVariables> extends QueryResult<TResult[], TVariables> {
     isFetchingMore: boolean;
     canFetchMore: boolean;
     fetchMore: (variables?: TVariables) => Promise<TResult>;

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-query 0.3.12
+// Type definitions for react-query 0.3
 // Project: https://github.com/tannerlinsley/react-query
 // Definitions by: Lukasz Fiszer <https://github.com/lukaszfiszer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -9,6 +9,9 @@ querySimple.data; // $ExpectType string | null
 querySimple.error; // $ExpectType Error | null
 querySimple.isLoading; // $ExpectType boolean
 querySimple.refetch(); // $ExpectType void
+queryPaginated.fetchMore; // $ExpectError
+queryPaginated.canFetchMore; // $ExpectError
+queryPaginated.isFetchingMore; // $ExpectError
 
 // Query Variables
 const param = 'test';
@@ -32,6 +35,19 @@ const queryNested = useQuery(['key', {
     }
 }], (variables) => Promise.resolve(variables.nested.props[0]));
 queryNested.data; // $ExpectType number | null
+
+// Paginated mode
+const queryPaginated = useQuery('key', () => Promise.resolve([1, 2, 3]), {
+    paginated: true,
+    getCanFetchMore: (lastPage, allPages) => true
+});
+queryPaginated.data; // $ExpectType number[][] | null
+queryPaginated.fetchMore; // $ExpectType (variables?: {} | undefined) => Promise<number[]> || (variables?: object | undefined) => Promise<number[]>
+queryPaginated.canFetchMore; // $ExpectType boolean
+queryPaginated.isFetchingMore; // $ExpectType boolean
+
+// Paginated mode - check if getCanFetchMore is required
+useQuery('key', () => Promise.resolve(), {paginated: true}); // $ExpectError
 
 // Simple mutation
 const mutation = () => Promise.resolve(['foo', 1]);


### PR DESCRIPTION
This pull-request improves recently added typings of react-query package by providing overload definition of `useQuery` function in paginated mode, as discussed in https://github.com/tannerlinsley/react-query/issues/23#issuecomment-552791559

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tannerlinsley/react-query#usequery
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
