### PR TITLE
Node-Geocoder: Added StateCode to Entry interface

### DIFF
--- a/types/node-geocoder/index.d.ts
+++ b/types/node-geocoder/index.d.ts
@@ -105,6 +105,7 @@ declare namespace node_geocoder {
         zipcode?: string;
         provider?: string;
         state?: string;
+        stateCode?: string;
         county?: string;
         district?: string;
         building?: string;

--- a/types/node-geocoder/node-geocoder-tests.ts
+++ b/types/node-geocoder/node-geocoder-tests.ts
@@ -29,6 +29,10 @@ geocoder.geocode(query, (err: any, entries: NodeGeocoder.Entry[]) => {
     console.log(JSON.stringify(entries, null, 2));
 });
 
+geocoder.geocode('Austin, TX, USA', (err: any, entries: NodeGeocoder.Entry[]) => {
+    console.log(JSON.stringify(entries, null, 2));
+});
+
 geocoder.batchGeocode([ 'Kraków', 'Warszawa' ]).then((entries) => {
     if (entries.length !== 2) {
         return;

--- a/types/node-geocoder/tsconfig.json
+++ b/types/node-geocoder/tsconfig.json
@@ -13,7 +13,7 @@
             "../"
         ],
         "types": [],
-        "noEmit": true,
+        "noEmit": false,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/node-geocoder/tsconfig.json
+++ b/types/node-geocoder/tsconfig.json
@@ -13,7 +13,7 @@
             "../"
         ],
         "types": [],
-        "noEmit": false,
+        "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [


### PR DESCRIPTION
StateCode (for US states) was not present in the Node-Geocoder typings.  This has been present for 6 years and my best guess is that the typings were created by somebody outside of the USA where this is not applicable.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nchaulet/node-geocoder/blob/c2c29b164e445393757ca84df8846be390a63e6b/lib/formatter/stringformatter.js#L23
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
