### PR TITLE
[@types/babel__traverse] Add typedef for push/unshift container

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -71,6 +71,9 @@ const v1: Visitor = {
             return a + b;
         }`);
 
+        path.get('body').unshiftContainer('body', t.expressionStatement(t.stringLiteral("Start of function")));
+        path.get('body').pushContainer('body', t.expressionStatement(t.stringLiteral("End of function")));
+
         path.insertBefore(t.expressionStatement(t.stringLiteral("Because I'm easy come, easy go.")));
         path.insertAfter(t.expressionStatement(t.stringLiteral("A little high, little low.")));
         path.remove();

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -4,6 +4,7 @@
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
 //                 Ryan Petrich <https://github.com/rpetrich>
 //                 Melvin Groenhoff <https://github.com/mgroenhoff>
+//                 Dean L. <https://github.com/dlgrit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -427,6 +427,20 @@ export class NodePath<T = Node> {
     /** Update all sibling node paths after `fromIndex` by `incrementBy`. */
     updateSiblingKeys(fromIndex: number, incrementBy: number): void;
 
+    /**
+     * Insert child nodes at the start of the current node.
+     * @param listKey - The key at which the child nodes are stored (usually body).
+     * @param nodes - the nodes to insert.
+     */
+    unshiftContainer(listKey: string, nodes: Node | Node[]): void;
+
+    /**
+     * Insert child nodes at the end of the current node.
+     * @param listKey - The key at which the child nodes are stored (usually body).
+     * @param nodes - the nodes to insert.
+     */
+    pushContainer(listKey: string, nodes: Node | Node[]): void;
+
     /** Hoist the current node to the highest scope possible and return a UID referencing it. */
     hoist(scope: Scope): void;
 


### PR DESCRIPTION
The typedefs for `pushContainer` and `unshiftContainer` were missing.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md#inserting-into-a-container
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
