### PR TITLE
Add format-link-header

### DIFF
--- a/types/format-link-header/format-link-header-tests.ts
+++ b/types/format-link-header/format-link-header-tests.ts
@@ -1,0 +1,25 @@
+import format = require("format-link-header");
+
+const link = {
+    next: {
+        page: '3',
+        per_page: '100',
+        rel: 'next',
+        url: 'https://api.github.com/user/9287/repos?page=3&per_page=100'
+    },
+    prev: {
+        page: '1',
+        per_page: '100',
+        rel: 'prev',
+        pet: 'cat',
+        url: 'https://api.github.com/user/9287/repos?page=1&per_page=100'
+    },
+    last: {
+        page: '5',
+        per_page: '100',
+        rel: 'last',
+        url: 'https://api.github.com/user/9287/repos?page=5&per_page=100'
+    }
+};
+
+const links: string = format(link);

--- a/types/format-link-header/index.d.ts
+++ b/types/format-link-header/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for format-link-header 2.1
+// Project: https://github.com/jonathansamines/format-link-header
+// Definitions by: Chris Wilkinson <https://github.com/thewilkybarkid>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace formatLinkHeader {
+    interface Link {
+        url: string;
+        rel: string;
+        [queryParam: string]: string;
+    }
+
+    interface Links {
+        [rel: string]: Link;
+    }
+}
+
+declare function formatLinkHeader(linkObject: formatLinkHeader.Links): string;
+export = formatLinkHeader;

--- a/types/format-link-header/tsconfig.json
+++ b/types/format-link-header/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "format-link-header-tests.ts"
+    ]
+}

--- a/types/format-link-header/tslint.json
+++ b/types/format-link-header/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Add definitions for https://www.npmjs.com/package/format-link-header (similar to `@types/parse-link-header`). 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.