### PR TITLE
[minio] Add additional overload for `putObject`

### DIFF
--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -124,6 +124,7 @@ export class Client {
     putObject(bucketName: string, objectName: string, stream: Stream|Buffer|string, size: number, callback: ResultCallback<string>): void;
     putObject(bucketName: string, objectName: string, stream: Stream|Buffer|string, size: number, metaData: ItemBucketMetadata, callback: ResultCallback<string>): void;
     putObject(bucketName: string, objectName: string, stream: Stream|Buffer|string, size?: number, metaData?: ItemBucketMetadata): Promise<string>;
+    putObject(bucketName: string, objectName: string, stream: Stream|Buffer|string, metaData?: ItemBucketMetadata): Promise<string>;
 
     fPutObject(bucketName: string, objectName: string, filePath: string, metaData: ItemBucketMetadata, callback: ResultCallback<string>): void;
     fPutObject(bucketName: string, objectName: string, filePath: string, metaData: ItemBucketMetadata): Promise<string>;

--- a/types/minio/minio-tests.ts
+++ b/types/minio/minio-tests.ts
@@ -56,6 +56,7 @@ minio.putObject('testBucket', 'hello.txt', 'hello.txt content', 100, metaData, (
 minio.putObject('testBucket', 'hello.jpg', new Stream());
 minio.putObject('testBucket', 'hello.jpg', new Buffer('string'), 100);
 minio.putObject('testBucket', 'hello.txt', 'hello.txt content', 100, metaData);
+minio.putObject('testBucket', 'hello.txt', 'hello.txt content', metaData);
 
 minio.fPutObject('testBucket', 'hello.jpg', 'file/path', metaData, (error: Error|null, etag: string) => { console.log(error, etag); });
 minio.fPutObject('testBucket', 'hello.jpg', 'file/path', metaData);


### PR DESCRIPTION
Add overload for [`putObject`](https://github.com/minio/minio-js/blob/master/src/main/minio.js#L1044) such that `metaData` can be passed without the `size`. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`putObject`](https://github.com/minio/minio-js/blob/master/src/main/minio.js#L1044)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
