### PR TITLE
[underscore] Fixes sortBy on chained array wrapper

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5306,13 +5306,13 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.sortBy
         **/
-        sortBy(iterator?: _.ListIterator<T, any>, context?: any): _Chain<T>;
+        sortBy(iterator?: _.ListIterator<T, any>, context?: any): _Chain<T, V>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.sortBy
         **/
-        sortBy(iterator: string, context?: any): _Chain<T>;
+        sortBy(iterator: string, context?: any): _Chain<T, V>;
 
         /**
         * Wrapped type `any[]`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5306,13 +5306,13 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.sortBy
         **/
-        sortBy(iterator?: _.ListIterator<T, any>, context?: any): _Chain<T, V>;
+        sortBy<TSort>(iterator?: _.ListIterator<T, TSort>, context?: any): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.
         * @see _.sortBy
         **/
-        sortBy(iterator: string, context?: any): _Chain<T, V>;
+        sortBy(iterator: string, context?: any): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5306,7 +5306,7 @@ declare module _ {
         * Wrapped type `any[]`.
         * @see _.sortBy
         **/
-        sortBy<TSort>(iterator?: _.ListIterator<T, TSort>, context?: any): _Chain<T, T[]>;
+        sortBy(iterator?: _.ListIterator<T, any>, context?: any): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -196,6 +196,11 @@ _.min(numbers);
 
 _.sortBy([1, 2, 3, 4, 5, 6], (num) => Math.sin(num));
 
+_([1, 2, 3]).chain()
+    .sortBy(x => -x)
+    .sortBy(x => -x)
+    .value().length;
+
 _([1.3, 2.1, 2.4]).groupBy((e) => Math.floor(e));
 _.groupBy([1.3, 2.1, 2.4], (num) => Math.floor(num).toString());
 _.groupBy(['one', 'two', 'three'], 'length');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/#sortBy

Calling `_([1, 2, 3]).chain()` correctly returns a `_Chain<number, number[]>` type, due to:

```ts
interface UnderscoreStatic {
    chain<T>(obj: T[]): _Chain<T, T[]>;
}
```

However, a subsequent `sortBy` call then returns a `_Chain<number, number>` type, due to:

```ts
interface _Chain<T, V = T> {
    sortBy(iterator?: _.ListIterator<T, any>, context?: any): _Chain<T>;
}
```

As a result, `_([1, 2, 3]).chain().sortBy(x => -x).value()` returns a `number` type instead of `number[]`, which doesn't match the implementation.

This PR sorts that out by trying to more closely match the other `sortBy` type specifications, specifically returning a `_Chain<T, T[]>`.