### PR TITLE
Update react-filepond to flip error and file args in callback funcs

### DIFF
--- a/types/react-filepond/index.d.ts
+++ b/types/react-filepond/index.d.ts
@@ -288,11 +288,6 @@ interface FilePondErrorDescription {
     sub: string;
 }
 
-/**
- * Note that in my testing, callbacks that include an error prop
- * always give the error as the second prop, with the file as
- * the first prop.    This is contradictory to the current docs.
- */
 export interface FilePondCallbackProps {
     /** FilePond instance has been created and is ready. */
     oninit?: () => void;
@@ -307,13 +302,13 @@ export interface FilePondCallbackProps {
      * FilePond instance throws an error. Optionally receives
      * file if error is related to a file object.
      */
-    onerror?: (file?: File, error?: FilePondErrorDescription, status?: any) => void;
+    onerror?: (error: FilePondErrorDescription, file?: File, status?: any) => void;
     /** Started file load */
     onaddfilestart?: (file: File) => void;
     /** Made progress loading a file */
     onaddfileprogress?: (file: File, progress: number) => void;
     /** If no error, file has been successfully loaded */
-    onaddfile?: (file: File, error: FilePondErrorDescription) => void;
+    onaddfile?: (error: FilePondErrorDescription, file: File) => void;
     /** Started processing a file */
     onprocessfilestart?: (file: File) => void;
     /** Made progress processing a file */
@@ -323,7 +318,7 @@ export interface FilePondCallbackProps {
     /** Processing of a file has been undone */
     onprocessfileundo?: (file: File) => void;
     /** If no error, Processing of a file has been completed */
-    onprocessfile?: (file: File, error: FilePondErrorDescription) => void;
+    onprocessfile?: (error: FilePondErrorDescription, file: File) => void;
     /** File has been removed. */
     onremovefile?: (file: File) => void;
     /**


### PR DESCRIPTION
This functionality seems to now have been corrected in FilePond.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://pqina.nl/filepond/docs/patterns/api/filepond-instance/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
