### PR TITLE
Fix relative paths in tests, part 1

### DIFF
--- a/types/ansi-styles/ansi-styles-tests.ts
+++ b/types/ansi-styles/ansi-styles-tests.ts
@@ -1,4 +1,3 @@
-import { EscapeCode } from './escape-code';
 import AnsiStyles = require('ansi-styles');
 
 let ansiStyles = AnsiStyles as any,

--- a/types/athenajs/test/tetris/grid.ts
+++ b/types/athenajs/test/tetris/grid.ts
@@ -1,5 +1,5 @@
 import { Scene, Map, Tile, Dom, SimpleText, AudioManager as AM, Deferred } from "athenajs";
-import Shape from "./shape";
+import Shape from "athenajs/shape";
 import FlashLines from "./flash_lines";
 
 // size constants

--- a/types/athenajs/test/tetris/grid.ts
+++ b/types/athenajs/test/tetris/grid.ts
@@ -1,5 +1,5 @@
 import { Scene, Map, Tile, Dom, SimpleText, AudioManager as AM, Deferred } from "athenajs";
-import Shape from "athenajs/shape";
+import Shape from "./shape";
 import FlashLines from "./flash_lines";
 
 // size constants

--- a/types/baidumap-web-sdk/baidumap-web-sdk-tests.ts
+++ b/types/baidumap-web-sdk/baidumap-web-sdk-tests.ts
@@ -1,4 +1,4 @@
-import "./index";
+import "baidumap-web-sdk";
 
 class TestFixture {
 	// document: http://lbsyun.baidu.com/index.php?title=jspopular3.0

--- a/types/behavior3/behavior3-tests.ts
+++ b/types/behavior3/behavior3-tests.ts
@@ -1,4 +1,4 @@
-import '../behavior3';
+import 'behavior3';
 
 // Test decode
 const blackboard = new b3.Blackboard();

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -1,5 +1,5 @@
-import { ApplePay } from "..";
-import * as braintree from "..";
+import { ApplePay } from "braintree-web";
+import * as braintree from "braintree-web";
 
 let version: string = braintree.VERSION;
 

--- a/types/clearbladejs-node/clearbladejs-node-tests.ts
+++ b/types/clearbladejs-node/clearbladejs-node-tests.ts
@@ -3,7 +3,7 @@
 // Definitions by: Jim Bouquet <https://github.com/ClearBlade>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ClearBlade, Resp, QuerySortDirections, QueryConditions } from ".";
+import { ClearBlade, Resp, QuerySortDirections, QueryConditions } from "clearbladejs-node";
 
 // Sample code for clearbladejs Node SDK v1.0.0 used to test typescript definitions
 

--- a/types/config/config-tests.ts
+++ b/types/config/config-tests.ts
@@ -1,7 +1,7 @@
 
 import * as config from "config";
-import { deferConfig } from './defer';
-import { raw } from './raw';
+import { deferConfig } from 'config/defer';
+import { raw } from 'config/raw';
 
 var class1: config.IConfig = config;
 

--- a/types/crypto-js/test/submodule-tests.ts
+++ b/types/crypto-js/test/submodule-tests.ts
@@ -1,55 +1,55 @@
-import Core = require('../core');
-import X64Core = require('../x64-core');
-import LibTypedarrays = require('../lib-typedarrays');
+import Core = require('crypto-js/core');
+import X64Core = require('crypto-js/x64-core');
+import LibTypedarrays = require('crypto-js/lib-typedarrays');
 // ---
-import MD5 = require('../md5');
-import SHA1 = require('../sha1');
-import SHA256 = require('../sha256');
-import SHA224 = require('../sha224');
-import SHA512 = require('../sha512');
-import SHA384 = require('../sha384');
-import SHA3 = require('../sha3');
-import RIPEMD160 = require('../ripemd160');
+import MD5 = require('crypto-js/md5');
+import SHA1 = require('crypto-js/sha1');
+import SHA256 = require('crypto-js/sha256');
+import SHA224 = require('crypto-js/sha224');
+import SHA512 = require('crypto-js/sha512');
+import SHA384 = require('crypto-js/sha384');
+import SHA3 = require('crypto-js/sha3');
+import RIPEMD160 = require('crypto-js/ripemd160');
 // ---
-import HmacMD5 = require('../hmac-md5');
-import HmacSHA1 = require('../hmac-sha1');
-import HmacSHA256 = require('../hmac-sha256');
-import HmacSHA224 = require('../hmac-sha224');
-import HmacSHA512 = require('../hmac-sha512');
-import HmacSHA384 = require('../hmac-sha384');
-import HmacSHA3 = require('../hmac-sha3');
-import HmacRIPEMD160 = require('../hmac-ripemd160');
+import HmacMD5 = require('crypto-js/hmac-md5');
+import HmacSHA1 = require('crypto-js/hmac-sha1');
+import HmacSHA256 = require('crypto-js/hmac-sha256');
+import HmacSHA224 = require('crypto-js/hmac-sha224');
+import HmacSHA512 = require('crypto-js/hmac-sha512');
+import HmacSHA384 = require('crypto-js/hmac-sha384');
+import HmacSHA3 = require('crypto-js/hmac-sha3');
+import HmacRIPEMD160 = require('crypto-js/hmac-ripemd160');
 // ---
-import PBKDF2 = require('../pbkdf2');
+import PBKDF2 = require('crypto-js/pbkdf2');
 // ---
-import AES = require('../aes');
-import TripleDES = require('../tripledes');
-import RC4 = require('../rc4');
-import Rabbit = require('../rabbit');
-import RabbitLegacy = require('../rabbit-legacy');
-import EvpKDF = require('../evpkdf');
+import AES = require('crypto-js/aes');
+import TripleDES = require('crypto-js/tripledes');
+import RC4 = require('crypto-js/rc4');
+import Rabbit = require('crypto-js/rabbit');
+import RabbitLegacy = require('crypto-js/rabbit-legacy');
+import EvpKDF = require('crypto-js/evpkdf');
 // ---
-import FormatOpenSSL = require('../format-openssl');
-import FormatHex = require('../format-hex');
+import FormatOpenSSL = require('crypto-js/format-openssl');
+import FormatHex = require('crypto-js/format-hex');
 // ---
-import EncLatin1 = require('../enc-latin1');
-import EncUtf8 = require('../enc-utf8');
-import EncHex = require('../enc-hex');
-import EncUtf16 = require('../enc-utf16');
-import EncBase64 = require('../enc-base64');
+import EncLatin1 = require('crypto-js/enc-latin1');
+import EncUtf8 = require('crypto-js/enc-utf8');
+import EncHex = require('crypto-js/enc-hex');
+import EncUtf16 = require('crypto-js/enc-utf16');
+import EncBase64 = require('crypto-js/enc-base64');
 // ---
-import ModeCFB = require('../mode-cfb');
-import ModeCTR = require('../mode-ctr');
-import ModeCTRGladman = require('../mode-ctr-gladman');
-import ModeOFB = require('../mode-ofb');
-import ModeECB = require('../mode-ecb');
+import ModeCFB = require('crypto-js/mode-cfb');
+import ModeCTR = require('crypto-js/mode-ctr');
+import ModeCTRGladman = require('crypto-js/mode-ctr-gladman');
+import ModeOFB = require('crypto-js/mode-ofb');
+import ModeECB = require('crypto-js/mode-ecb');
 // ---
-import PadPkcs7 = require('../pad-pkcs7');
-import PadAnsiX923 = require('../pad-ansix923');
-import PadIso10126 = require('../pad-iso10126');
-import PadIso97971 = require('../pad-iso97971');
-import PadZeroPadding = require('../pad-zeropadding');
-import PadNoPadding = require('../pad-nopadding');
+import PadPkcs7 = require('crypto-js/pad-pkcs7');
+import PadAnsiX923 = require('crypto-js/pad-ansix923');
+import PadIso10126 = require('crypto-js/pad-iso10126');
+import PadIso97971 = require('crypto-js/pad-iso97971');
+import PadZeroPadding = require('crypto-js/pad-zeropadding');
+import PadNoPadding = require('crypto-js/pad-nopadding');
 
 // Hashers
 var wordArray: CryptoJS.WordArray;

--- a/types/cssbeautify/cssbeautify-tests.ts
+++ b/types/cssbeautify/cssbeautify-tests.ts
@@ -1,4 +1,4 @@
-import cssbeautify = require('./index');
+import cssbeautify = require('cssbeautify');
 
 var str = '';
 

--- a/types/d3-cloud/d3-cloud-tests.ts
+++ b/types/d3-cloud/d3-cloud-tests.ts
@@ -1,4 +1,4 @@
-import d3Cloud = require('./index.d');
+import d3Cloud = require('d3-cloud');
 import d3 = require('d3');
 
 // $ExpectType Cloud<Word>

--- a/types/eonasdan-bootstrap-datetimepicker/eonasdan-bootstrap-datetimepicker-tests.ts
+++ b/types/eonasdan-bootstrap-datetimepicker/eonasdan-bootstrap-datetimepicker-tests.ts
@@ -1,5 +1,5 @@
 import * as moment from 'moment';
-import * as EonasdanBootstrapDatetimepicker from './index';
+import * as EonasdanBootstrapDatetimepicker from 'eonasdan-bootstrap-datetimepicker';
 
 // Minimum Setup
 $("#datetimepicker1").datetimepicker();

--- a/types/google-protobuf/google-protobuf-tests.ts
+++ b/types/google-protobuf/google-protobuf-tests.ts
@@ -1,17 +1,17 @@
-import * as jspb from "./index";
+import * as jspb from "google-protobuf";
 
-import * as google_protobuf_compiler_plugin_pb from "./google/protobuf/compiler/plugin_pb";
-import * as google_protobuf_any_pb from "./google/protobuf/any_pb";
-import * as google_protobuf_api_pb from "./google/protobuf/api_pb";
-import * as google_protobuf_descriptor_pb from "./google/protobuf/descriptor_pb";
-import * as google_protobuf_duration_pb from "./google/protobuf/duration_pb";
-import * as google_protobuf_empty_pb from "./google/protobuf/empty_pb";
-import * as google_protobuf_field_mask_pb from "./google/protobuf/field_mask_pb";
-import * as google_protobuf_source_context_pb from "./google/protobuf/source_context_pb";
-import * as google_protobuf_struct_pb from "./google/protobuf/struct_pb";
-import * as google_protobuf_timestamp_pb from "./google/protobuf/timestamp_pb";
-import * as google_protobuf_type_pb from "./google/protobuf/type_pb";
-import * as google_protobuf_wrappers_pb from "./google/protobuf/wrappers_pb";
+import * as google_protobuf_compiler_plugin_pb from "google-protobuf/google/protobuf/compiler/plugin_pb";
+import * as google_protobuf_any_pb from "google-protobuf/google/protobuf/any_pb";
+import * as google_protobuf_api_pb from "google-protobuf/google/protobuf/api_pb";
+import * as google_protobuf_descriptor_pb from "google-protobuf/google/protobuf/descriptor_pb";
+import * as google_protobuf_duration_pb from "google-protobuf/google/protobuf/duration_pb";
+import * as google_protobuf_empty_pb from "google-protobuf/google/protobuf/empty_pb";
+import * as google_protobuf_field_mask_pb from "google-protobuf/google/protobuf/field_mask_pb";
+import * as google_protobuf_source_context_pb from "google-protobuf/google/protobuf/source_context_pb";
+import * as google_protobuf_struct_pb from "google-protobuf/google/protobuf/struct_pb";
+import * as google_protobuf_timestamp_pb from "google-protobuf/google/protobuf/timestamp_pb";
+import * as google_protobuf_type_pb from "google-protobuf/google/protobuf/type_pb";
+import * as google_protobuf_wrappers_pb from "google-protobuf/google/protobuf/wrappers_pb";
 
 /* This is a typescript version of a simple generated class from a proto file that is shown below. In order to make
  this ES5 JS file into TypeScript there have been quite a few modifications, but the same calls are made to the library

--- a/types/hapi/v16/test/connection/table.ts
+++ b/types/hapi/v16/test/connection/table.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#servertablehost
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80, host: 'example.com' });
 server.route({ method: 'GET', path: '/example', handler: function (request, reply) { return reply(); } });

--- a/types/hapi/v16/test/path/catch-all.ts
+++ b/types/hapi/v16/test/path/catch-all.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#catch-all-route
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/path/parameters.ts
+++ b/types/hapi/v16/test/path/parameters.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#path-parameters
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/plugins/options.ts
+++ b/types/hapi/v16/test/plugins/options.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverinfo
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 // added in addition to code from docs
 interface PluginOptions {

--- a/types/hapi/v16/test/reply/continue.ts
+++ b/types/hapi/v16/test/reply/continue.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#replycontinueresult
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/reply/entity.ts
+++ b/types/hapi/v16/test/reply/entity.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#replyentityoptions
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/reply/redirect.ts
+++ b/types/hapi/v16/test/reply/redirect.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#replyredirecturi
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const handler: Hapi.RouteHandler = function (request, reply) {
 
     return reply.redirect('http://example.com');

--- a/types/hapi/v16/test/reply/reply.ts
+++ b/types/hapi/v16/test/reply/reply.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#replyerr-result
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 // verbose notation
 

--- a/types/hapi/v16/test/reply/state_cookie.ts
+++ b/types/hapi/v16/test/reply/state_cookie.ts
@@ -1,7 +1,7 @@
 
 // from https://hapijs.com/tutorials/cookies?lang=en_US
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 const server = new Hapi.Server();
 server.connection({ port: 80 });

--- a/types/hapi/v16/test/request/event-types.ts
+++ b/types/hapi/v16/test/request/event-types.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#requestsetmethodmethod
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const Crypto = require('crypto');
 const server = new Hapi.Server();
 server.connection({ port: 80 });

--- a/types/hapi/v16/test/request/generate-response.ts
+++ b/types/hapi/v16/test/request/generate-response.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#requestgenerateresponsesource-options
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 // Added in addition to code from docs
 function promiseMethod() {

--- a/types/hapi/v16/test/request/get-log.ts
+++ b/types/hapi/v16/test/request/get-log.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#requestgetlogtags-internal
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 declare const request: Hapi.Request;
 

--- a/types/hapi/v16/test/request/log.ts
+++ b/types/hapi/v16/test/request/log.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#requestlogtags-data-timestamp
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80, routes: { log: true, security: false } });
 

--- a/types/hapi/v16/test/request/query.ts
+++ b/types/hapi/v16/test/request/query.ts
@@ -1,6 +1,6 @@
 // Added test in addition to docs, for request.query
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 interface GetThingQuery {
     name: string;

--- a/types/hapi/v16/test/request/set-method.ts
+++ b/types/hapi/v16/test/request/set-method.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#requestsetmethodmethod
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/request/set-url.ts
+++ b/types/hapi/v16/test/request/set-url.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#requestseturlurl-striptrailingslash
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 
@@ -17,7 +17,7 @@ server.ext('onRequest', onRequest);
 // Example 2
 
 const Url = require('url');
-const Qs = require('../../../../qs');
+const Qs = require('hapi../../qs');
 
 onRequest = function (request, reply) {
 

--- a/types/hapi/v16/test/request/tail.ts
+++ b/types/hapi/v16/test/request/tail.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#requestsetmethodmethod
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/response/error-representation.ts
+++ b/types/hapi/v16/test/response/error-representation.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#error-transformation
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/response/error.ts
+++ b/types/hapi/v16/test/response/error.ts
@@ -1,8 +1,8 @@
 
 // From https://hapijs.com/api/16.1.1#error-response
 
-import * as Hapi from '../../';
-const Boom = require('../../../../boom');
+import * as Hapi from 'hapi';
+const Boom = require('hapi../../boom');
 
 const server = new Hapi.Server();
 

--- a/types/hapi/v16/test/response/events.ts
+++ b/types/hapi/v16/test/response/events.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#response-events
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const Crypto = require('crypto');
 const server = new Hapi.Server();
 server.connection({ port: 80 });

--- a/types/hapi/v16/test/response/flow-control.ts
+++ b/types/hapi/v16/test/response/flow-control.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#flow-control
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 const handler = function (request: Hapi.Request, reply: Hapi.ReplyWithContinue) {
 

--- a/types/hapi/v16/test/route/additional-options.ts
+++ b/types/hapi/v16/test/route/additional-options.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 var authConfig: Hapi.RouteAdditionalConfigurationOptions = {
     app: {},

--- a/types/hapi/v16/test/route/auth.ts
+++ b/types/hapi/v16/test/route/auth.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 var routeMoreConfig: Hapi.RouteAdditionalConfigurationOptions = {
     auth: false,

--- a/types/hapi/v16/test/route/config.ts
+++ b/types/hapi/v16/test/route/config.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 // different methods
 var routeConfig: Hapi.RouteConfiguration = {

--- a/types/hapi/v16/test/route/handler.ts
+++ b/types/hapi/v16/test/route/handler.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 var handler: Hapi.RouteHandler = function(request, reply) {
     reply('success');

--- a/types/hapi/v16/test/route/plugins.ts
+++ b/types/hapi/v16/test/route/plugins.ts
@@ -1,9 +1,9 @@
 // Added in addition to code from https://hapijs.com/api/16.1.1#route-options > plugins
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 // In the plugin code
-declare module '../../' {
+declare module 'hapi' {
     interface PluginSpecificConfiguration {
         coolPlugin: {
             optionA: string;

--- a/types/hapi/v16/test/route/prerequisites.ts
+++ b/types/hapi/v16/test/route/prerequisites.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#route-prerequisites
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/route/public-interface.ts
+++ b/types/hapi/v16/test/route/public-interface.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 var route = {} as Hapi.RoutePublicInterface;
 

--- a/types/hapi/v16/test/route/validate.ts
+++ b/types/hapi/v16/test/route/validate.ts
@@ -1,8 +1,8 @@
 
 // Added from: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/16065#issuecomment-302216131
 
-import * as Hapi from '../../';
-import * as Joi from '../../../../joi';
+import * as Hapi from 'hapi';
+import * as Joi from 'hapi../../joi';
 
 const validate: Hapi.RouteValidationConfigurationObject = {
     headers: true,

--- a/types/hapi/v16/test/server/app.ts
+++ b/types/hapi/v16/test/server/app.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverapp
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 var server = new Hapi.Server();
 server.app.key = 'value';
 

--- a/types/hapi/v16/test/server/auth.ts
+++ b/types/hapi/v16/test/server/auth.ts
@@ -1,8 +1,8 @@
 
 // From https://hapijs.com/api/16.1.1#serverauthapi
 
-import * as Hapi from '../../';
-import * as Boom from '../../../../boom';
+import * as Hapi from 'hapi';
+import * as Boom from 'hapi../../boom';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/bind.ts
+++ b/types/hapi/v16/test/server/bind.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverbindcontext
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 interface HandlerThis {
     message: string;

--- a/types/hapi/v16/test/server/cache.ts
+++ b/types/hapi/v16/test/server/cache.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#servercacheoptions
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/connection-options.ts
+++ b/types/hapi/v16/test/server/connection-options.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverconnectionoptions
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 
 const web = server.connection({ port: 8000, host: 'example.com', labels: ['web'] });

--- a/types/hapi/v16/test/server/connections.ts
+++ b/types/hapi/v16/test/server/connections.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverconnections
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 var server = new Hapi.Server();
 server.connection({ port: 80, labels: 'a' });
 server.connection({ port: 8080, labels: 'b' });

--- a/types/hapi/v16/test/server/decoder.ts
+++ b/types/hapi/v16/test/server/decoder.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverdecoderencoding-decoder
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 import * as Zlib from 'zlib';
 const server = new Hapi.Server();
 server.connection({ port: 80, routes: { payload: { compression: { special: { chunkSize: 16 * 1024 } } } } });

--- a/types/hapi/v16/test/server/decorate.ts
+++ b/types/hapi/v16/test/server/decorate.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverdecoratetype-property-method-options
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 
@@ -12,7 +12,7 @@ const success = function (this: Hapi.ReplyNoContinue) {
 
 server.decorate('reply', 'success', success);
 
-declare module '../../' {
+declare module 'hapi' {
     interface Base_Reply {
         success: () => Response;
     }
@@ -36,7 +36,7 @@ server.decorate('request', 'some_request_method', (request) => {
     }
 }, {apply: true});
 
-declare module '../../' {
+declare module 'hapi' {
     interface Request {
         some_request_method(): void;
     }
@@ -59,7 +59,7 @@ server.decorate('server', 'some_server_method', (server: Hapi.Server) => {
     }
 });
 
-declare module '../../' {
+declare module 'hapi' {
     interface Server {
         some_server_method(arg1: number): string;
     }

--- a/types/hapi/v16/test/server/dependency.ts
+++ b/types/hapi/v16/test/server/dependency.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverdependencydependencies-after
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 const after: Hapi.AfterDependencyLoadCallback = function (server, next) {
 

--- a/types/hapi/v16/test/server/emit.ts
+++ b/types/hapi/v16/test/server/emit.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serveremitcriteria-data-callback
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/encoder.ts
+++ b/types/hapi/v16/test/server/encoder.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverencoderencoding-encoder
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 import * as Zlib from 'zlib';
 const server = new Hapi.Server();
 server.connection({ port: 80, routes: { compression: { special: { chunkSize: 16 * 1024 } } } });

--- a/types/hapi/v16/test/server/event.ts
+++ b/types/hapi/v16/test/server/event.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#servereventevents
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/expose.ts
+++ b/types/hapi/v16/test/server/expose.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverexposekey-value
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 var register: Hapi.PluginFunction<{}> = function (server, options, next) {
 
     server.expose('util', function () { console.log('something'); });

--- a/types/hapi/v16/test/server/ext.ts
+++ b/types/hapi/v16/test/server/ext.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverextevents
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/handler.ts
+++ b/types/hapi/v16/test/server/handler.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverhandlername-method
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ host: 'localhost', port: 8000 });
 
@@ -20,7 +20,7 @@ interface TestPluginConfig {
     msg: string;
 }
 
-declare module '../../' {
+declare module 'hapi' {
     interface RouteHandlerPlugins {
         test?: TestPluginConfig;
     }

--- a/types/hapi/v16/test/server/info.ts
+++ b/types/hapi/v16/test/server/info.ts
@@ -2,7 +2,7 @@
 // From https://hapijs.com/api/16.1.1#serverinfo
 
 import assert = require('assert');
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 var options: Hapi.ServerConnectionOptions = { port: 80 };
 server.connection(options);

--- a/types/hapi/v16/test/server/initialize.ts
+++ b/types/hapi/v16/test/server/initialize.ts
@@ -1,8 +1,8 @@
 
 // From https://hapijs.com/api/16.1.1#serverinitializecallback
 
-import * as Hapi from '../../';
-const Hoek = require('../../../../hoek');
+import * as Hapi from 'hapi';
+const Hoek = require('hapi../../hoek');
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/inject.ts
+++ b/types/hapi/v16/test/server/inject.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverinjectoptions-callback
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/listener.ts
+++ b/types/hapi/v16/test/server/listener.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverlistener
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 import SocketIO = require('socket.io');
 
 const server = new Hapi.Server();

--- a/types/hapi/v16/test/server/load.ts
+++ b/types/hapi/v16/test/server/load.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverload
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server({ load: { sampleInterval: 1000 } });
 
 var d: number = server.load.rss;

--- a/types/hapi/v16/test/server/log.ts
+++ b/types/hapi/v16/test/server/log.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverlogtags-data-timestamp
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/lookup.ts
+++ b/types/hapi/v16/test/server/lookup.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverlookupid
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection();
 server.route({

--- a/types/hapi/v16/test/server/match.ts
+++ b/types/hapi/v16/test/server/match.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#servermatchmethod-path-host
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection();
 server.route({

--- a/types/hapi/v16/test/server/method.ts
+++ b/types/hapi/v16/test/server/method.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#servermethodname-method-options
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/methods.ts
+++ b/types/hapi/v16/test/server/methods.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#servermethods
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 
 const add = function (a: number, b: number, next: (err: Error | null, result: number) => void) {

--- a/types/hapi/v16/test/server/mime.ts
+++ b/types/hapi/v16/test/server/mime.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#servermime
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 const options: Hapi.ServerOptions = {
     mime: {

--- a/types/hapi/v16/test/server/new.ts
+++ b/types/hapi/v16/test/server/new.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 new Hapi.Server();
 new Hapi.Server({
@@ -45,7 +45,7 @@ new Hapi.Server({
 });
 
 //+ Code added in addition to docs
-declare module '../../' {
+declare module 'hapi' {
     interface PluginSpecificConfiguration {
         // Set this to non optional if plugin config is non optional
         'some-plugin-name'?: {options: string;};

--- a/types/hapi/v16/test/server/on.ts
+++ b/types/hapi/v16/test/server/on.ts
@@ -2,7 +2,7 @@
 // From https://hapijs.com/api/16.1.1#serveroncriteria-listener
 // From https://hapijs.com/api/16.1.1#server-events
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 const server = new Hapi.Server();
 server.connection({ port: 80 });

--- a/types/hapi/v16/test/server/once.ts
+++ b/types/hapi/v16/test/server/once.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serveroncecriteria-listener
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 const server = new Hapi.Server();
 server.connection({ port: 80 });

--- a/types/hapi/v16/test/server/path.ts
+++ b/types/hapi/v16/test/server/path.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverpathrelativeto
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 var register: Hapi.PluginFunction<{}> = function (server, options, next) {
 

--- a/types/hapi/v16/test/server/plugins.ts
+++ b/types/hapi/v16/test/server/plugins.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverplugins
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 var registerFunction: Hapi.PluginFunction<{}> = function(server, options, next) {
 

--- a/types/hapi/v16/test/server/realm.ts
+++ b/types/hapi/v16/test/server/realm.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverrealm
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 var registerFunction: Hapi.PluginFunction<{}> = function(server, options, next) {
 

--- a/types/hapi/v16/test/server/register.ts
+++ b/types/hapi/v16/test/server/register.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverregisterplugins-options-callback
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 
 const server = new Hapi.Server();
 

--- a/types/hapi/v16/test/server/route.ts
+++ b/types/hapi/v16/test/server/route.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverrouteoptions
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/select.ts
+++ b/types/hapi/v16/test/server/select.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverselectlabels
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80, labels: ['a', 'b'] });
 server.connection({ port: 8080, labels: ['a', 'c'] });

--- a/types/hapi/v16/test/server/settings.ts
+++ b/types/hapi/v16/test/server/settings.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serversettings
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server({
     app: {
         key: 'value'

--- a/types/hapi/v16/test/server/start.ts
+++ b/types/hapi/v16/test/server/start.ts
@@ -1,8 +1,8 @@
 
 // From https://hapijs.com/api/16.1.1#serverstartcallback
 
-import * as Hapi from '../../';
-import * as Hoek from '../../../../hoek';
+import * as Hapi from 'hapi';
+import * as Hoek from 'hapi../../hoek';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/state.ts
+++ b/types/hapi/v16/test/server/state.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverstatename-options
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/stop.ts
+++ b/types/hapi/v16/test/server/stop.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#serverstopoptions-callback
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80 });
 

--- a/types/hapi/v16/test/server/table.ts
+++ b/types/hapi/v16/test/server/table.ts
@@ -1,7 +1,7 @@
 
 // From https://hapijs.com/api/16.1.1#servertablehost
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.connection({ port: 80, host: 'example.com' });
 server.route({ method: 'GET', path: '/example', handler: function (request, reply) { return reply(); } });

--- a/types/hapi/v16/test/server/version.ts
+++ b/types/hapi/v16/test/server/version.ts
@@ -1,6 +1,6 @@
 
 // From http://hapijs.com/api#serversettings
 
-import * as Hapi from '../../';
+import * as Hapi from 'hapi';
 const server = new Hapi.Server();
 server.version === '8.0.0'


### PR DESCRIPTION
Relative paths in tests can point directly to `.d.ts` files. However, those references don't reflect what users can actually write. This PR rewrites references like `'./index'` and `".."` to the name of the package.

ansi-styles had an unused reference, so I just deleted that one.