### PR TITLE
[set-cookie-parser] Add sameSite property to Cookie interface

### DIFF
--- a/types/set-cookie-parser/index.d.ts
+++ b/types/set-cookie-parser/index.d.ts
@@ -25,6 +25,7 @@ declare module "set-cookie-parser" {
             domain?: string;
             secure?: boolean;
             httpOnly?: boolean;
+            sameSite?: string;
         }
 
         type Options = {

--- a/types/set-cookie-parser/set-cookie-parser-tests.ts
+++ b/types/set-cookie-parser/set-cookie-parser-tests.ts
@@ -17,7 +17,7 @@ assert.equal(cookies[0].name, "foo");
 assert.equal(cookies[0].value, "bar");
 
 // Optional properties included test
-var optionalIncluded = "foo=bar; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure";
+var optionalIncluded = "foo=bar; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure; SameSite=Strict";
 cookies = setCookie(optionalIncluded);
 assert.equal(cookies.length, 1);
 assert.equal(cookies[0].name, "foo");
@@ -28,6 +28,7 @@ assert.deepEqual(cookies[0].expires, new Date('Tue Jul 01 2025 06:01:11 GMT-0400
 assert.equal(cookies[0].maxAge, 1000);
 assert.equal(cookies[0].httpOnly, true);
 assert.equal(cookies[0].secure, true);
+assert.equal(cookies[0].sameSite, "Strict");
 
 // Array of strings test
 var arrayOfCookies = ["bam=baz", "foo=bar"];


### PR DESCRIPTION
See https://github.com/nfriedly/set-cookie-parser/pull/16 and https://github.com/nfriedly/set-cookie-parser/issues/26

This adds `sameSite` for the `Cookie` interface. (A stand-in until the lib itself is TypeScript.)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nfriedly/set-cookie-parser#usage
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.