### PR TITLE
fix(mark.js): add second param to `each` for `markRange`

### DIFF
--- a/types/mark.js/index.d.ts
+++ b/types/mark.js/index.d.ts
@@ -33,7 +33,7 @@ declare namespace Mark {
         ignorePunctuation?: string[];
         wildcards?: 'disabled' | 'enabled' | 'withSpaces';
 
-        each?(element: Element): void;
+        each?(element: Element, range: Range): void;
 
         filter?(
             textNode: Element,

--- a/types/mark.js/index.d.ts
+++ b/types/mark.js/index.d.ts
@@ -33,7 +33,7 @@ declare namespace Mark {
         ignorePunctuation?: string[];
         wildcards?: 'disabled' | 'enabled' | 'withSpaces';
 
-        each?(element: Element, range: Range): void;
+        each?(element: Element): void;
 
         filter?(
             textNode: Element,
@@ -59,6 +59,25 @@ declare namespace Mark {
         acrossElements?: boolean;
         ignoreGroups?: number;
         each?(element: Element): void;
+        filter?(
+            textNode: Element,
+            term: string,
+            marksSoFar: number,
+            marksTotal: number
+        ): boolean;
+        noMatch?(term: string): void;
+        done?(marksTotal: number): void;
+        debug?: boolean;
+        log?: object;
+    }
+
+    interface MarkRangesOptions {
+        element?: string;
+        className?: string;
+        exclude?: string[];
+        iframes?: boolean;
+        iframesTimeout?: number;
+        each?(element: Element, range: Range): void;
         filter?(
             textNode: Element,
             term: string,
@@ -124,7 +143,7 @@ declare class Mark {
      */
     markRanges(
         ranges: ReadonlyArray<Mark.Range>,
-        options?: Mark.MarkOptions
+        options?: Mark.MarkRangesOptions
     ): void;
 
     /**

--- a/types/mark.js/mark.js-tests.ts
+++ b/types/mark.js/mark.js-tests.ts
@@ -12,7 +12,12 @@ mark.mark('keyword', {
 });
 mark.mark(['keyword1', 'keyword2']);
 mark.markRegExp(/regex/, {className: 'highlight'});
-mark.markRanges([{start: 0, length: 10}], {className: 'highlight'});
+mark.markRanges([{start: 0, length: 10}], {
+    className: 'highlight',
+    each: (el: Element, range: Mark.Range) => {
+        el.id = '';
+    }
+});
 
 /* test jquery */
 $("div.context").mark("text", {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/julmot/mark.js/blob/8.11.1/src/lib/mark.js#L1230
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
