### PR TITLE
[node] ensure compatiblity between http.request and url.parse

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -69,18 +69,18 @@ declare module "http" {
     }
 
     interface ClientRequestArgs {
-        protocol?: string;
-        host?: string;
-        hostname?: string;
+        protocol?: string | null;
+        host?: string | null;
+        hostname?: string | null;
         family?: number;
-        port?: number | string;
+        port?: number | string | null;
         defaultPort?: number | string;
         localAddress?: string;
         socketPath?: string;
         method?: string;
-        path?: string;
+        path?: string | null;
         headers?: OutgoingHttpHeaders;
-        auth?: string;
+        auth?: string | null;
         agent?: Agent | boolean;
         _defaultAgent?: Agent;
         timeout?: number;

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -139,7 +139,7 @@ import * as net from 'net';
     http.request({ agent: false });
     http.request({ agent });
     http.request({ agent: undefined });
-    // ensure compatibility wiht url.parse()
+    // ensure compatibility with url.parse()
     http.request(url.parse("http://www.example.org/xyz"));
 }
 

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -139,6 +139,8 @@ import * as net from 'net';
     http.request({ agent: false });
     http.request({ agent });
     http.request({ agent: undefined });
+    // ensure compatibility wiht url.parse()
+    http.request(url.parse("http://www.example.org/xyz"));
 }
 
 {


### PR DESCRIPTION
Ensure that output of url.parse() fits into http.request() as indicated at https://nodejs.org/dist/latest-v12.x/docs/api/http.html#http_http_request_url_options_callback

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v12.x/docs/api/http.html#http_http_request_url_options_callback
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Refs: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40118 (fyi @OliverJAsh)
