### PR TITLE
Allow number input in getDuration() in `apicache` 

### DIFF
--- a/types/apicache/index.d.ts
+++ b/types/apicache/index.d.ts
@@ -29,7 +29,7 @@ export function getIndex(): any;
  * Third param is the options that will override global ones and affect this middleware only.
  */
 export function middleware(
-  duration?: string,
+  duration?: string | number,
   toggleMiddleware?: any,
   localOptions?: Options
 ): any;

--- a/types/apicache/index.d.ts
+++ b/types/apicache/index.d.ts
@@ -15,7 +15,7 @@ export function clear(target: string | any[]): any;
 /** used to create a new ApiCache instance with the same options as the current one */
 export function clone(): any;
 
-export function getDuration(duration: string): any;
+export function getDuration(duration: string | number): any;
 
 /**
  * returns current cache index [of keys]


### PR DESCRIPTION
The library allows a string like `1 minute` or a simple number representing ms in the middleware function.  This change allows the use of a number of ms in addition to a string.

See:
https://github.com/kwhitley/apicache/blob/master/src/apicache.js#L371

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/kwhitley/apicache/blob/master/src/apicache.js#L371](https://github.com/kwhitley/apicache/blob/master/src/apicache.js#L371)


