### PR TITLE
update puppeteer to use the its generated cdp protocol types

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -15,6 +15,9 @@
 
 import { EventEmitter } from "events";
 import { ChildProcess } from "child_process";
+// @ts-ignore: suppress error if using an older version of puppeteer, which don't
+// publish types for the protocol.
+import Protocol from 'puppeteer/lib/protocol';
 
 import * as errors from "./Errors";
 import * as devices from "./DeviceDescriptors";
@@ -2155,10 +2158,13 @@ export interface CDPSession extends EventEmitter {
    */
   detach(): Promise<void>;
 
+  on<T extends keyof Protocol.Events>(event: T, listener: (arg: Protocol.Events[T]) => void): this;
+
   /**
    * @param method Protocol method name
+   * @param parameters Protocol parameters
    */
-  send(method: string, params?: object): Promise<object>;
+  send<T extends keyof Protocol.CommandParameters>(method: T, parameters?: Protocol.CommandParameters[T]): Promise<Protocol.CommandReturnValues[T]>;
 }
 
 export interface Coverage {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/GoogleChrome/puppeteer/pull/5174
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

