### PR TITLE
fix d3-array bin case

### DIFF
--- a/types/d3-array/d3-array-tests.ts
+++ b/types/d3-array/d3-array-tests.ts
@@ -869,10 +869,10 @@ undef = d3Array.histogram()([])[0].x0 as undefined;
 undef = d3Array.histogram<number | undefined, number | undefined>()([undefined])[0].x0 as undefined;
 
 // number - number
-let binsNumber_Number: Array<d3Array.Bin<number, number>>;
+let binsNumber_Number: Array<d3Array.bin<number, number>>;
 binsNumber_Number = histoNumber_Number([-1, 0, 1, 1, 3, 20, 234]);
 
-let binNumber_Number: d3Array.Bin<number, number>;
+let binNumber_Number: d3Array.bin<number, number>;
 binNumber_Number = binsNumber_Number[0];
 
 num = binNumber_Number.length;
@@ -881,10 +881,10 @@ numOrUndefined = binNumber_Number.x0;
 numOrUndefined = binNumber_Number.x1;
 
 // MixedObject - number | undefined
-let binsNumberMixed_NumberOrUndefined: Array<d3Array.Bin<MixedObject, number | undefined>>;
+let binsNumberMixed_NumberOrUndefined: Array<d3Array.bin<MixedObject, number | undefined>>;
 binsNumberMixed_NumberOrUndefined = histoMixed_NumberOrUndefined(mixedObjectArray);
 
-let binNumberMixed_NumberOrUndefined: d3Array.Bin<MixedObject, number | undefined>;
+let binNumberMixed_NumberOrUndefined: d3Array.bin<MixedObject, number | undefined>;
 binNumberMixed_NumberOrUndefined = binsNumberMixed_NumberOrUndefined[0];
 
 num = binNumberMixed_NumberOrUndefined.length;
@@ -893,10 +893,10 @@ numOrUndefined = binNumberMixed_NumberOrUndefined.x0;
 numOrUndefined = binNumberMixed_NumberOrUndefined.x1;
 
 // MixedObject | undefined - number | undefined
-let binsNumberMixedOrUndefined_NumberOrUndefined: Array<d3Array.Bin<MixedObject | undefined, number | undefined>>;
+let binsNumberMixedOrUndefined_NumberOrUndefined: Array<d3Array.bin<MixedObject | undefined, number | undefined>>;
 binsNumberMixedOrUndefined_NumberOrUndefined = histoMixedOrUndefined_NumberOrUndefined(mixedObjectArray);
 
-let binNumberMixedOrUndefined_NumberOrUndefined: d3Array.Bin<MixedObject | undefined, number | undefined>;
+let binNumberMixedOrUndefined_NumberOrUndefined: d3Array.bin<MixedObject | undefined, number | undefined>;
 binNumberMixedOrUndefined_NumberOrUndefined = binsNumberMixedOrUndefined_NumberOrUndefined[0];
 
 num = binNumberMixedOrUndefined_NumberOrUndefined.length;
@@ -905,10 +905,10 @@ numOrUndefined = binNumberMixedOrUndefined_NumberOrUndefined.x0;
 numOrUndefined = binNumberMixedOrUndefined_NumberOrUndefined.x1;
 
 // MixedObject | undefined - number
-let binsNumberMixedOrUndefined_Number: Array<d3Array.Bin<MixedObject | undefined, number>>;
+let binsNumberMixedOrUndefined_Number: Array<d3Array.bin<MixedObject | undefined, number>>;
 binsNumberMixedOrUndefined_Number = histoMixedOrUndefined_Number(mixedObjectArray);
 
-let binNumberMixedOrUndefined_Number: d3Array.Bin<MixedObject | undefined, number>;
+let binNumberMixedOrUndefined_Number: d3Array.bin<MixedObject | undefined, number>;
 binNumberMixedOrUndefined_Number = binsNumberMixedOrUndefined_Number[0];
 
 num = binNumberMixedOrUndefined_Number.length;
@@ -917,11 +917,11 @@ numOrUndefined = binNumberMixedOrUndefined_Number.x0;
 numOrUndefined = binNumberMixedOrUndefined_Number.x1;
 
 // MixedObject - Date
-let binsMixedObject_Date: Array<d3Array.Bin<MixedObject, Date>>;
+let binsMixedObject_Date: Array<d3Array.bin<MixedObject, Date>>;
 binsMixedObject_Date = histoMixedObject_Date(mixedObjectArray);
 binsMixedObject_Date = histoMixedObject_Date(readonlyMixedObjectArray);
 
-let binMixedObject_Date: d3Array.Bin<MixedObject, Date>;
+let binMixedObject_Date: d3Array.bin<MixedObject, Date>;
 binMixedObject_Date = binsMixedObject_Date[0];
 
 num = binMixedObject_Date.length;
@@ -930,10 +930,10 @@ dateOrUndefined = binMixedObject_Date.x0;
 dateOrUndefined = binMixedObject_Date.x1;
 
 // MixedObject - Date | undefined
-let binsMixedObject_DateOrUndefined: Array<d3Array.Bin<MixedObject, Date | undefined>>;
+let binsMixedObject_DateOrUndefined: Array<d3Array.bin<MixedObject, Date | undefined>>;
 binsMixedObject_DateOrUndefined = histoMixedObject_DateOrUndefined(mixedObjectArray);
 
-let binMixedObject_DateOrUndefined: d3Array.Bin<MixedObject, Date | undefined>;
+let binMixedObject_DateOrUndefined: d3Array.bin<MixedObject, Date | undefined>;
 binMixedObject_DateOrUndefined = binsMixedObject_DateOrUndefined[0];
 
 num = binMixedObject_DateOrUndefined.length;

--- a/types/d3-array/index.d.ts
+++ b/types/d3-array/index.d.ts
@@ -383,7 +383,7 @@ export function zip<T>(...arrays: Array<ArrayLike<T>>): T[][];
 // Histogram
 // --------------------------------------------------------------------------------------
 
-export interface Bin<Datum, Value extends number | Date | undefined> extends Array<Datum> {
+export interface bin<Datum, Value extends number | Date | undefined> extends Array<Datum> {
     x0: Value | undefined;
     x1: Value | undefined;
 }
@@ -407,7 +407,7 @@ export type ThresholdDateArrayGenerator<Value extends Date | undefined> =
     (values: ArrayLike<Value>, min: Date, max: Date) => Value[];
 
 export interface HistogramCommon<Datum, Value extends number | Date | undefined> {
-    (data: ArrayLike<Datum>): Array<Bin<Datum, Value>>;
+    (data: ArrayLike<Datum>): Array<bin<Datum, Value>>;
 
     value(): (d: Datum, i: number, data: ArrayLike<Datum>) => Value;
     value(valueAccessor: (d: Datum, i: number, data: ArrayLike<Datum>) => Value): this;


### PR DESCRIPTION
bin is lowercase, not uppercase.

When you import bin like so: `import { bin as d3Bin } from 'd3-array';` you get a type error:

> Module '"../../../../../../node_modules/@types/d3-array"' has no exported member 'bin'. Did you mean 'Bin'?ts(2724)

I tried changing it to Bin, uppercase b, but I got an error `'d3Bin' only refers to a type, but is being used as a value here.ts(2693)` when referencing it. I looked at https://github.com/d3/d3-array#bin and it appears that bin is lowercase, so when I tried importing the uppercase Bin it imported the type instead of the actual function I wanted.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-array#bin
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.