### PR TITLE
[fs-ext] Update definition to v2

### DIFF
--- a/types/fs-ext/fs-ext-tests.ts
+++ b/types/fs-ext/fs-ext-tests.ts
@@ -1,25 +1,55 @@
-import fs = require('fs-ext');
+import fsExt = require('fs-ext');
 
-var num:number;
-var str:string;
+const fd = 1;
 
-//from node.js 'fs' module
-fs.appendFileSync(str, "data");
-
-fs.flock(num, str, (err)=>{
+fsExt.flock(fd, 'sh', (err) => {
+    const _err: Error | null = err;
 });
-fs.flockSync(num, str);
+fsExt.flock(fd, fsExt.constants.LOCK_SH, (err) => {
+    const _err: Error | null = err;
+});
+fsExt.flockSync(fd, 'ex');
+fsExt.flockSync(fd, fsExt.constants.LOCK_EX);
 
-fs.fcntl(num, str, num, (err, res)=>{
+fsExt.fcntl(fd, 'setlkw', fsExt.constants.F_WRLCK, (err) => {
+    const _err: Error | null = err;
 });
-fs.fcntl(num, str, (err, res)=>{
+fsExt.fcntl(fd, fsExt.constants.F_SETLKW, fsExt.constants.F_WRLCK, (err) => {
+    const _err: Error | null = err;
 });
-fs.fcntlSync(num, str, num);
+fsExt.fcntlSync(fd, fsExt.constants.F_SETLKW, fsExt.constants.F_WRLCK);
 
-fs.seek(num, num, num, (err, pos)=>{
+fsExt.fcntl(fd, 'getfd', (err, flags) => {
+    const _err: Error | null = err;
+    const _flags: number = flags;
 });
-fs.seekSync(num, num, num);
+fsExt.fcntl(fd, fsExt.constants.F_GETFD, (err, flags) => {
+    const _err: Error | null = err;
+    const _flags: number = flags;
+});
+{
+    const flags: number = fsExt.fcntlSync(fd, fsExt.constants.F_GETFD);
+}
 
-fs.utime(str, num, num, (err)=>{
+fsExt.seek(fd, 2, fsExt.constants.SEEK_SET, (err, pos) => {
+    const _err: Error | null = err;
+    const _pos: number = pos;
 });
-fs.utimeSync(str, num, num);
+{
+    const result: number = fsExt.seekSync(fd, 2, fsExt.constants.SEEK_SET);
+}
+
+fsExt.statVFS((err, stat) => {
+    const _err: Error | null = err;
+    const _stat: fsExt.StatFVS = stat;
+});
+fsExt.statVFS('/some/path', (err, stat) => {
+    const _err: Error | null = err;
+    const _stat: fsExt.StatFVS = stat;
+});
+{
+    const stat: fsExt.StatFVS = fsExt.statVFS();
+}
+{
+    const stat: fsExt.StatFVS = fsExt.statVFS('/some/path');
+}

--- a/types/fs-ext/fs-ext-tests.ts
+++ b/types/fs-ext/fs-ext-tests.ts
@@ -3,28 +3,28 @@ import fsExt = require('fs-ext');
 const fd = 1;
 
 fsExt.flock(fd, 'sh', (err) => {
-    const _err: Error | null = err;
+    const _err: NodeJS.ErrnoException | null = err;
 });
 fsExt.flock(fd, fsExt.constants.LOCK_SH, (err) => {
-    const _err: Error | null = err;
+    const _err: NodeJS.ErrnoException | null = err;
 });
 fsExt.flockSync(fd, 'ex');
 fsExt.flockSync(fd, fsExt.constants.LOCK_EX);
 
 fsExt.fcntl(fd, 'setlkw', fsExt.constants.F_WRLCK, (err) => {
-    const _err: Error | null = err;
+    const _err: NodeJS.ErrnoException | null = err;
 });
 fsExt.fcntl(fd, fsExt.constants.F_SETLKW, fsExt.constants.F_WRLCK, (err) => {
-    const _err: Error | null = err;
+    const _err: NodeJS.ErrnoException | null = err;
 });
 fsExt.fcntlSync(fd, fsExt.constants.F_SETLKW, fsExt.constants.F_WRLCK);
 
 fsExt.fcntl(fd, 'getfd', (err, flags) => {
-    const _err: Error | null = err;
+    const _err: NodeJS.ErrnoException | null = err;
     const _flags: number = flags;
 });
 fsExt.fcntl(fd, fsExt.constants.F_GETFD, (err, flags) => {
-    const _err: Error | null = err;
+    const _err: NodeJS.ErrnoException | null = err;
     const _flags: number = flags;
 });
 {
@@ -32,7 +32,7 @@ fsExt.fcntl(fd, fsExt.constants.F_GETFD, (err, flags) => {
 }
 
 fsExt.seek(fd, 2, fsExt.constants.SEEK_SET, (err, pos) => {
-    const _err: Error | null = err;
+    const _err: NodeJS.ErrnoException | null = err;
     const _pos: number = pos;
 });
 {
@@ -40,11 +40,11 @@ fsExt.seek(fd, 2, fsExt.constants.SEEK_SET, (err, pos) => {
 }
 
 fsExt.statVFS((err, stat) => {
-    const _err: Error | null = err;
+    const _err: NodeJS.ErrnoException | null = err;
     const _stat: fsExt.StatFVS = stat;
 });
 fsExt.statVFS('/some/path', (err, stat) => {
-    const _err: Error | null = err;
+    const _err: NodeJS.ErrnoException | null = err;
     const _stat: fsExt.StatFVS = stat;
 });
 {

--- a/types/fs-ext/index.d.ts
+++ b/types/fs-ext/index.d.ts
@@ -4,18 +4,20 @@
 //                 Konstantin Ikonnikov <https://github.com/ikokostya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+///<reference types="node"/>
+
 /**
  * Asynchronous flock(2). No arguments other than a possible error are passed to the callback.
- * @param fd File descriptor
+ * @param fd File descriptor.
  * @param flags Flags can be 'sh', 'ex', 'shnb', 'exnb', 'un' and correspond to the various LOCK_SH,
  *      LOCK_EX, LOCK_SH | LOCK_NB, etc.
  */
-export function flock(fd: number, flags: 'sh' | 'ex' | 'shnb' | 'exnb' | 'un', callback: (err: Error | null) => void): void;
-export function flock(fd: number, flags: number, callback: (err: Error | null) => void): void;
+export function flock(fd: number, flags: 'sh' | 'ex' | 'shnb' | 'exnb' | 'un', callback: (err: NodeJS.ErrnoException | null) => void): void;
+export function flock(fd: number, flags: number, callback: (err: NodeJS.ErrnoException | null) => void): void;
 
 /**
  * Synchronous flock(2). Throws an exception on error.
- * @param fd File descriptor
+ * @param fd File descriptor.
  * @param flags Flags can be 'sh', 'ex', 'shnb', 'exnb', 'un' and correspond to the various LOCK_SH,
  *      LOCK_EX, LOCK_SH | LOCK_NB, etc.
  */
@@ -29,10 +31,10 @@ export function flockSync(fd: number, flags: number): void;
  *      'setlkw' (F_SETLKW), 'getlk' (F_GETLK).
  * @param arg
  */
-export function fcntl(fd: number, cmd: 'getfd' | 'setfd' | 'setlk' | 'setlkw' | 'getlk', arg: number, callback: (err: Error | null, result: number) => void): void;
-export function fcntl(fd: number, cmd: number, arg: number, callback: (err: Error | null, result: number) => void): void;
-export function fcntl(fd: number, cmd: 'getfd' | 'setfd' | 'setlk' | 'setlkw' | 'getlk', callback: (err: Error | null, result: number) => void): void;
-export function fcntl(fd: number, cmd: number, callback: (err: Error | null, result: number) => void): void;
+export function fcntl(fd: number, cmd: 'getfd' | 'setfd' | 'setlk' | 'setlkw' | 'getlk', arg: number, callback: (err: NodeJS.ErrnoException | null, result: number) => void): void;
+export function fcntl(fd: number, cmd: number, arg: number, callback: (err: NodeJS.ErrnoException | null, result: number) => void): void;
+export function fcntl(fd: number, cmd: 'getfd' | 'setfd' | 'setlk' | 'setlkw' | 'getlk', callback: (err: NodeJS.ErrnoException | null, result: number) => void): void;
+export function fcntl(fd: number, cmd: number, callback: (err: NodeJS.ErrnoException | null, result: number) => void): void;
 
 /**
  * Synchronous fcntl(2). Throws an exception on error.
@@ -58,7 +60,7 @@ export function fcntlSync(fd: number, cmd: number, arg?: number): number;
  *      (SEEK_END) to set to the end of the file plus offset bytes (usually negative or zero to seek
  *      to the end of the file).
  */
-export function seek(fd: number, offset: number, whence: number, callback: (err: Error | null, currFilePos: number) => void): void;
+export function seek(fd: number, offset: number, whence: number, callback: (err: NodeJS.ErrnoException | null, currFilePos: number) => void): void;
 
 /**
  * Synchronous lseek(2). Throws an exception on error. Returns current file position.
@@ -76,8 +78,8 @@ export function seekSync(fd: number, offset: number, whence: number): number;
  * Asynchronous/synchronous statvfs(2).
  * @param path Pathname of any file within the mounted file system. Default is `/`.
  */
-export function statVFS(path: string, callback: (err: Error | null, stat: StatFVS) => void): void;
-export function statVFS(callback: (err: Error | null, stat: StatFVS) => void): void;
+export function statVFS(path: string, callback: (err: NodeJS.ErrnoException | null, stat: StatFVS) => void): void;
+export function statVFS(callback: (err: NodeJS.ErrnoException | null, stat: StatFVS) => void): void;
 export function statVFS(path?: string): StatFVS;
 
 /**

--- a/types/fs-ext/index.d.ts
+++ b/types/fs-ext/index.d.ts
@@ -1,101 +1,185 @@
-// Type definitions for fs-ext
+// Type definitions for fs-ext 2.0.0
 // Project: https://github.com/baudehlo/node-fs-ext
 // Definitions by: Oguzhan Ergin <https://github.com/OguzhanE>
+//                 Konstantin Ikonnikov <https://github.com/ikokostya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-///<reference types="node"/>
-
-
-export * from "fs";
+/**
+ * Asynchronous flock(2). No arguments other than a possible error are passed to the callback.
+ * @param fd File descriptor
+ * @param flags Flags can be 'sh', 'ex', 'shnb', 'exnb', 'un' and correspond to the various LOCK_SH,
+ *      LOCK_EX, LOCK_SH | LOCK_NB, etc.
+ */
+export function flock(fd: number, flags: 'sh' | 'ex' | 'shnb' | 'exnb' | 'un', callback: (err: Error | null) => void): void;
+export function flock(fd: number, flags: number, callback: (err: Error | null) => void): void;
 
 /**
-* Asynchronous flock(2). No arguments other than a possible error are passed to the callback. 
-* @param fd File Descriptor
-* @param flags Flags can be 'sh', 'ex', 'shnb', 'exnb', 'un' and correspond to the various LOCK_SH, LOCK_EX, LOCK_SH|LOCK_NB, etc.
-**/
-export declare function flock(fd: number, flags: string, callback: (err: Error) => void): void;
+ * Synchronous flock(2). Throws an exception on error.
+ * @param fd File descriptor
+ * @param flags Flags can be 'sh', 'ex', 'shnb', 'exnb', 'un' and correspond to the various LOCK_SH,
+ *      LOCK_EX, LOCK_SH | LOCK_NB, etc.
+ */
+export function flockSync(fd: number, flags: 'sh' | 'ex' | 'shnb' | 'exnb' | 'un'): void;
+export function flockSync(fd: number, flags: number): void;
 
 /**
-* Synchronous flock(2). Throws an exception on error.
-* @param fd File Descriptor
-* @param flags Flags can be 'sh', 'ex', 'shnb', 'exnb', 'un' and correspond to the various LOCK_SH, LOCK_EX, LOCK_SH|LOCK_NB, etc.
-  **/
-export declare function flockSync(fd: number, flags: string): void;
+ * Asynchronous fcntl(2).
+ * @param fd File descriptor.
+ * @param cmd The supported commands are: 'getfd' (F_GETFD), 'setfd' (F_SETFD), 'setlk' (F_SETLK),
+ *      'setlkw' (F_SETLKW), 'getlk' (F_GETLK).
+ * @param arg
+ */
+export function fcntl(fd: number, cmd: 'getfd' | 'setfd' | 'setlk' | 'setlkw' | 'getlk', arg: number, callback: (err: Error | null, result: number) => void): void;
+export function fcntl(fd: number, cmd: number, arg: number, callback: (err: Error | null, result: number) => void): void;
+export function fcntl(fd: number, cmd: 'getfd' | 'setfd' | 'setlk' | 'setlkw' | 'getlk', callback: (err: Error | null, result: number) => void): void;
+export function fcntl(fd: number, cmd: number, callback: (err: Error | null, result: number) => void): void;
 
 /**
-* Asynchronous fcntl(2).
-* @param fd File Descriptor
-* @param cmd The supported commands are: 'getfd' ( F_GETFD ) , 'setfd' ( F_SETFD )
-* Requiring this module adds FD_CLOEXEC to the constants module, for use with F_SETFD.
-* @param arg arg
-**/
-export declare function fcntl(fd: number, cmd: string, arg: number, callback: (err: Error, result: number) => void): void;
+ * Synchronous fcntl(2). Throws an exception on error.
+ * @param fd File descriptor.
+ * @param cmd The supported commands are:  'getfd' (F_GETFD), 'setfd' (F_SETFD), 'setlk' (F_SETLK),
+ *      'setlkw' (F_SETLKW), 'getlk' (F_GETLK).
+ * @param arg arg
+ * @return For a successful call, the return value depends on the operation:
+ *      F_GETFD
+ *          Value of file descriptor flags.
+ *      All other commands
+ *          Zero.
+ */
+export function fcntlSync(fd: number, cmd: 'getfd' | 'setfd' | 'setlk' | 'setlkw' | 'getlk', arg?: number): number;
+export function fcntlSync(fd: number, cmd: number, arg?: number): number;
 
 /**
-* Asynchronous fcntl(2).
-* @param fd File Descriptor
-* @param cmd The supported commands are: 'getfd' ( F_GETFD ) , 'setfd' ( F_SETFD )
-* Requiring this module adds FD_CLOEXEC to the constants module, for use with F_SETFD.
-**/
-export declare function fcntl(fd: number, cmd: string, callback: (err: Error, result: number) => void): void;
+ * Asynchronous lseek(2).
+ * @param fd File descriptor.
+ * @param offset Offset in bytes.
+ * @param whence Whence can be 0 (SEEK_SET) to set the new position in bytes to offset, 1 (SEEK_CUR)
+ *      to set the new position to the current position plus offset bytes (can be negative), or 2
+ *      (SEEK_END) to set to the end of the file plus offset bytes (usually negative or zero to seek
+ *      to the end of the file).
+ */
+export function seek(fd: number, offset: number, whence: number, callback: (err: Error | null, currFilePos: number) => void): void;
 
 /**
-* Synchronous fcntl(2). Throws an exception on error.
-* @param fd File Descriptor
-* @param cmd The supported commands are: 'getfd' ( F_GETFD ) , 'setfd' ( F_SETFD )
-* Requiring this module adds FD_CLOEXEC to the constants module, for use with F_SETFD.
-* @param arg arg
-* @return Returns flags
-**/
-export declare function fcntlSync(fd: number, cmd: string, arg?: number): number;
+ * Synchronous lseek(2). Throws an exception on error. Returns current file position.
+ * @param fd File descriptor.
+ * @param offset Offset in bytes.
+ * @param whence Whence can be 0 (SEEK_SET) to set the new position in bytes to offset, 1 (SEEK_CUR)
+ *      to set the new position to the current position plus offset bytes (can be negative), or 2
+ *      (SEEK_END) to set to the end of the file plus offset bytes (usually negative or zero to seek
+ *      to the end of the file).
+ * @returns Returns current file position.
+ */
+export function seekSync(fd: number, offset: number, whence: number): number;
 
 /**
-* Asynchronous lseek(2).
-* @param fd File Descriptor
-* @param offset Offset
-* @param whence 
-* Whence can be 0 (SEEK_SET) to set the new position in bytes to offset, 1 (SEEK_CUR) to set the new 
-* position to the current position plus offset bytes (can be negative), or 2 (SEEK_END) to set to the end 
-* of the file plus offset bytes (usually negative or zero to seek to the end of the file).
-**/
-export declare function seek(fd: number, offset: number, whence: number, callback: (err: Error, currFilePos: number) => void): void;
+ * Asynchronous/synchronous statvfs(2).
+ * @param path Pathname of any file within the mounted file system. Default is `/`.
+ */
+export function statVFS(path: string, callback: (err: Error | null, stat: StatFVS) => void): void;
+export function statVFS(callback: (err: Error | null, stat: StatFVS) => void): void;
+export function statVFS(path?: string): StatFVS;
 
 /**
-* Synchronous lseek(2). Throws an exception on error. Returns current file position.
-* @param fd File Descriptor
-* @param offset Offset
-* @param whence 
-* Whence can be 0 (SEEK_SET) to set the new position in bytes to offset, 1 (SEEK_CUR) to set the new 
-* position to the current position plus offset bytes (can be negative), or 2 (SEEK_END) to set to the end 
-* of the file plus offset bytes (usually negative or zero to seek to the end of the file).
-* @returns Returns current file position.
-**/
-export declare function seekSync(fd: number, offset: number, whence: number): number;
+ * Filesystem statistics.
+ */
+export interface StatFVS {
+    /** File system block size. */
+    f_bsize: number;
+    /** Fragment size. */
+    f_frsize: number;
+    /** Size of fs in f_frsize units. */
+    f_blocks: number;
+    /** Number of free blocks. */
+    f_bfree: number;
+    /** Number of free blocks for unprivileged users. */
+    f_bavail: number;
+    /** Number of inodes. */
+    f_files: number;
+    /** Number of free inodes. */
+    f_ffree: number;
+    /** Number of free inodes for unprivileged users. */
+    f_favail: number;
+    /** Filesystem ID. */
+    f_fsid: number;
+    /** Mount flags. */
+    f_flag: number;
+    /** Maximum filename length. */
+    f_namemax: number;
+}
 
-/**
-* Asynchronous utime(2).
-* @param path File path
-* @param atime
-* Arguments atime and mtime are in seconds as for the system call.Note that the number value of Date() is in milliseconds,
-* so to use the 'now' value with fs.utime() you would have to divide by 1000 first, e.g. Date.now()/1000
-* Just like for utime(2), the absence of the atime and mtime means 'now'.
-* @param mtime
-* Arguments atime and mtime are in seconds as for the system call.Note that the number value of Date() is in milliseconds,
-* so to use the 'now' value with fs.utime() you would have to divide by 1000 first, e.g. Date.now()/1000
-* Just like for utime(2), the absence of the atime and mtime means 'now'.
-**/
-export declare function utime(path: string, atime: number, mtime: number, callback: (err: Error) => void): void;
+export namespace constants {
+    /**
+     * The file offset is set to offset bytes.
+     */
+    const SEEK_SET: number;
+    /**
+     * The file offset is set to its current location plus `offset` bytes.
+     */
+    const SEEK_CUR: number;
+    /**
+     * The file offset is set to the size of the file plus `offset` bytes.
+     */
+    const SEEK_END: number;
 
-/**
-* Synchronous version of utime(). Throws an exception on error.
-* @param path File path
-* @param atime
-* Arguments atime and mtime are in seconds as for the system call.Note that the number value of Date() is in milliseconds,
-* so to use the 'now' value with fs.utime() you would have to divide by 1000 first, e.g. Date.now()/1000
-* Just like for utime(2), the absence of the atime and mtime means 'now'.
-* @param mtime
-* Arguments atime and mtime are in seconds as for the system call.Note that the number value of Date() is in milliseconds,
-* so to use the 'now' value with fs.utime() you would have to divide by 1000 first, e.g. Date.now()/1000
-* Just like for utime(2), the absence of the atime and mtime means 'now'.
-**/
-export declare function utimeSync(path: string, atime: number, mtime: number): void;
+    /**
+     * Place a shared lock. More than one process may hold a shared lock for a given file at a given
+     * time.
+     */
+    const LOCK_SH: number;
+    /**
+     * Place an exclusive lock. Only one process may hold an exclusive lock for a given file at a
+     * given time.
+     */
+    const LOCK_EX: number;
+    /**
+     * Remove an existing lock held by this process.
+     */
+    const LOCK_UN : number;
+    /**
+     * A call to flock() may block if an incompatible lock is held by another process. To make a
+     * nonblocking request, include LOCK_NB (by ORing) with any of the above operations.
+     */
+    const LOCK_NB: number;
+
+    /**
+     * Return (as the function result) the file descriptor flags. `arg` is ignored.
+     */
+    const F_GETFD: number;
+    /**
+     * Set the file descriptor flags to the value specified by `arg`.
+     */
+    const F_SETFD: number;
+    /**
+     * The close-on-exec flag.
+     */
+    const FD_CLOEXEC: number;
+
+    /**
+     * A read lock on a file.
+     */
+    const F_RDLCK: number;
+    /**
+     * A write lock on a file.
+     */
+    const F_WRLCK: number;
+    /**
+     * Unlock a file.
+     */
+    const F_UNLCK: number;
+
+    /**
+     * Acquire a lock (when constants F_RDLCK or F_WRLCK are specified) or release a lock (when
+     * constant F_UNLCK is specified).
+     */
+    const F_SETLK: number;
+    /**
+     * As for F_SETLK, but if a conflicting lock is held on the file, then wait for that lock to be
+     * released.
+     */
+    const F_SETLKW: number;
+    /**
+     * Test for the existence locks.
+     */
+    const F_GETLK: number;
+}

--- a/types/fs-ext/tsconfig.json
+++ b/types/fs-ext/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
* Remove definitions for `utime()`, `utimeSync()`.
* Add constants definition.
* Add new values of `cmd` parameter to `fcntl()`, `fcntlSync()`.
* Add overrides for more accurate types of `flags` parameter in `flock()`, `flockSync()`.
* Add overrides for more accurate types of `cmd` parameter in `fcntl()`, `fcntlSync()`.
* Add statVFS() defintion.
* Rewrite tests.
* Enable `strictNullChecks` in `tsconfig.json`.

Refs https://github.com/baudehlo/node-fs-ext/pull/90

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/baudehlo/node-fs-ext#fs-ext
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
