### PR TITLE
Add node-expat

### DIFF
--- a/types/node-expat/index.d.ts
+++ b/types/node-expat/index.d.ts
@@ -1,0 +1,52 @@
+// Type definitions for node-expat 2.3
+// Project: https://github.com/astro/node-expat
+// Definitions by: winston01 <https://github.com/winston01>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.2
+
+/// <reference types="node" />
+import {
+    Stream
+} from 'stream';
+
+export class Parser extends Stream {
+    constructor(encoding?: string);
+
+    // encoding: string;
+    // Stream API
+    writable: boolean;
+    readable: boolean;
+
+    _getNewParser(): Parser;
+    // emit(): Function;
+
+    parse(buf: Buffer | string, isFinal?: boolean): boolean;
+
+    setEncoding(encoding: string): void;
+
+    setUnknownEncoding(map: number[], convert?: string): void;
+
+    getError(): string;
+
+    stop(): void;
+    pause(): void;
+    resume(): void;
+
+    destroy(): void;
+
+    destroySoon(): void;
+
+    write(data: Buffer | string): boolean;
+
+    end(cb?: () => void): void;
+    end(chunk: any, cb?: () => void): void;
+    end(chunk: any, encoding: string, cb?: () => void): void;
+
+    reset(): void;
+
+    getCurrentLineNumber(): number;
+    getCurrentColumnNumber(): number;
+    getCurrentByteIndex(): number;
+}
+
+export function createParser(cb?: (...args: any[]) => void): Parser;

--- a/types/node-expat/node-expat-tests.ts
+++ b/types/node-expat/node-expat-tests.ts
@@ -1,0 +1,460 @@
+/// <reference types="jasmine" />
+
+import expat = require("node-expat");
+
+// let expat = require('../lib/node-expat')
+import Iconv = require('iconv');
+// import vows = require('vows');
+// let assert = require('assert')
+import fs = require('fs');
+import path = require('path');
+import debug = require('debug');
+const log = debug.debug.log; // ('test/index');
+
+function collapseTexts(evs: string[]) {
+  const r = [];
+  let t = '';
+  evs.forEach((ev) => {
+    if (ev[0] === 'text') {
+      t += ev[1];
+    } else {
+      if (t !== '') {
+        r.push([ 'text', t ]);
+      }
+      t = '';
+      r.push(ev);
+    }
+  });
+  if (t !== '') {
+    r.push([ 'text', t ]);
+  }
+  return r;
+}
+
+function expectParsed(s: string | Buffer, evsExpected: any[]) {
+  for (let step = s.length; step > 0; step--) {
+    expectWithParserAndStep(s, evsExpected, new expat.Parser(), step);
+  }
+}
+
+function expectWithParserAndStep(s: string | Buffer, evsExpected: any[], p: expat.Parser, step: number) {
+  const evsReceived: any[] = [];
+  p.addListener('startElement', (name, attrs) => {
+    evsReceived.push(['startElement', name, attrs]);
+  });
+  p.addListener('endElement', (name) => {
+    evsReceived.push(['endElement', name]);
+  });
+  p.addListener('text', (s) => {
+    evsReceived.push(['text', s]);
+  });
+  p.addListener('processingInstruction', (target, data) => {
+    evsReceived.push(['processingInstruction', target, data]);
+  });
+  p.addListener('comment', (s) => {
+    evsReceived.push(['comment', s]);
+  });
+  p.addListener('xmlDecl', (version, encoding, standalone) => {
+    evsReceived.push(['xmlDecl', version, encoding, standalone]);
+  });
+  p.addListener('startCdata', () => {
+    evsReceived.push(['startCdata']);
+  });
+  p.addListener('endCdata', () => {
+    evsReceived.push(['endCdata']);
+  });
+  p.addListener('entityDecl', (entityName, isParameterEntity, value, base, systemId, publicId, notationName) => {
+    evsReceived.push(['entityDecl', entityName, isParameterEntity, value, base, systemId, publicId, notationName]);
+  });
+  p.addListener('error', (e) => {
+    evsReceived.push(['error', e]);
+  });
+  for (let l = 0; l < s.length; l += step) {
+    let end = l + step;
+    if (end > s.length) {
+      end = s.length;
+    }
+
+    p.write(s.slice(l, end));
+  }
+
+  const expected = JSON.stringify(evsExpected);
+  const received = JSON.stringify(collapseTexts(evsReceived));
+  expect(received).toEqual(expected);
+}
+
+describe('node-expat', () => {
+  // single elements
+    it('should parse simple element', () => {
+      expectParsed('<r/>',
+        [['startElement', 'r', {}],
+          ['endElement', 'r']]);
+    });
+    it('should parse single element with attribute', () => {
+      expectParsed("<r foo='bar'/>",
+        [['startElement', 'r', {foo: 'bar'}],
+          ['endElement', 'r']]);
+    });
+    it('should parse single element with differently quoted attributes', () => {
+      expectParsed('<r foo=\'bar\' baz="quux" test="tset"/>',
+        [['startElement', 'r', {foo: 'bar', baz: 'quux', test: 'tset'}],
+          ['endElement', 'r']]);
+    });
+    it('should parse single element with namespaces', () => {
+      expectParsed('<r xmlns=\'http://localhost/\' xmlns:x="http://example.com/"></r>',
+        [['startElement', 'r', {xmlns: 'http://localhost/', 'xmlns:x': 'http://example.com/'}],
+          ['endElement', 'r']]);
+    });
+    it('should parse single element with text content', () => {
+      expectParsed('<r>foo</r>',
+        [['startElement', 'r', {}],
+          ['text', 'foo'],
+          ['endElement', 'r']]);
+    });
+    it('should parse single element with text content and line break', () => {
+      expectParsed('<r>foo\nbar</r>',
+        [['startElement', 'r', {}],
+          ['text', 'foo\nbar'],
+          ['endElement', 'r']]);
+    });
+    it('should parse single element with CDATA content', () => {
+      expectParsed('<r><![CDATA[<greeting>Hello, world!</greeting>]]></r>',
+        [['startElement', 'r', {}],
+          ['startCdata'],
+          ['text', '<greeting>Hello, world!</greeting>'],
+          ['endCdata'],
+          ['endElement', 'r']]);
+    });
+    it('should parse single element with entity text', () => {
+      expectParsed('<r>foo&amp;bar</r>',
+        [['startElement', 'r', {}],
+          ['text', 'foo&bar'],
+          ['endElement', 'r']]);
+    });
+    it('should parse single element with umlaut text', () => {
+      expectParsed('<r>ß</r>',
+        [['startElement', 'r', {}],
+          ['text', 'ß'],
+          ['endElement', 'r']]);
+    });
+    it('should parse from buffer', () => {
+      expectParsed(Buffer.from('<foo>bar</foo>'),
+        [['startElement', 'foo', {}],
+          ['text', 'bar'],
+          ['endElement', 'foo']]);
+    });
+
+  // entity declaration
+    it('should parse a billion laughs entity declaration', () => {
+      expectParsed('<!DOCTYPE b [<!ELEMENT b (#PCDATA)>' +
+      '<!ENTITY l0 "ha"><!ENTITY l1 "&l0;&l0;"><!ENTITY l2 "&l1;&l1;">' +
+      ']><b>&l2;</b>',
+        [['entityDecl', 'l0', false, 'ha', null, null, null, null],
+          ['entityDecl', 'l1', false, '&l0;&l0;', null, null, null, null],
+          ['entityDecl', 'l2', false, '&l1;&l1;', null, null, null, null],
+          ['startElement', 'b', {}], ['text', 'hahahaha'], ['endElement', 'b']]);
+    });
+
+  // processing instruction
+    it('should parse processing instruction with parameters', () => {
+      expectParsed('<?i like xml?>',
+        [['processingInstruction', 'i', 'like xml']]);
+    });
+    it('should parse simple processing instruction', () => {
+      expectParsed('<?dragons?>',
+        [['processingInstruction', 'dragons', '']]);
+    });
+    it('should parse XML declaration with encoding', () => {
+      expectParsed("<?xml version='1.0' encoding='UTF-8'?>",
+        [['xmlDecl', '1.0', 'UTF-8', true]]);
+    });
+    it('should parse XML declaration', () => {
+      expectParsed("<?xml version='1.0'?>",
+        [['xmlDecl', '1.0', null, true]]);
+    });
+
+  // comment
+    it('should parse simple comment', () => {
+      expectParsed('<!-- no comment -->',
+        [['comment', ' no comment ']]);
+    });
+
+  // unknownEncoding with single-byte map
+    it('should parse unknownEncoding (Windows-1252) with single-byte map', () => {
+      const p = new expat.Parser();
+      p.addListener('unknownEncoding', (name) => {
+        const encodingName = name;
+        const map = [];
+        for (let i = 0; i < 256; i++) {
+          map[i] = i;
+        }
+        map[165] = 0x00A5; // ¥
+        map[128] = 0x20AC; // €
+        map[36] = 0x0024; // $
+        p.setUnknownEncoding(map);
+        expect(encodingName).toEqual('Windows-1252');
+      });
+      p.addListener('text', (s) => {
+        expect(s).toEqual('¥€$');
+      });
+      p.addListener('error', (e) => {
+        fail(e);
+      });
+      p.parse("<?xml version='1.0' encoding='Windows-1252'?><r>");
+      p.parse(Buffer.from([165, 128, 36]));
+      p.parse('</r>');
+    });
+
+  // unknownEncoding with single-byte map using iconv
+    it('should parse unknownEncoding (Windows-1252) with single-byte map using iconv', () => {
+      const p = new expat.Parser();
+      p.addListener('unknownEncoding', (name) => {
+        const encodingName = name;
+        const iconv = new Iconv(encodingName + '//TRANSLIT//IGNORE', 'UTF-8');
+        const map = [];
+
+        for (let i = 0; i < 256; i++) {
+          let d;
+          try {
+            d = iconv.convert(Buffer.from([i])).toString();
+          } catch (e) {
+            d = '\b';
+          }
+          map[i] = d.charCodeAt(0);
+        }
+        p.setUnknownEncoding(map);
+        expect(encodingName).toEqual('Windows-1252');
+      });
+      p.addListener('text', (s) => {
+        expect(s).toEqual('¥€$');
+      });
+      p.addListener('error', (e) => {
+        fail(e);
+      });
+      p.parse("<?xml version='1.0' encoding='Windows-1252'?><r>");
+      p.parse(Buffer.from([165, 128, 36]));
+      p.parse('</r>');
+    });
+
+  // error
+    it('should report error: tag name starting with ampersand', () => {
+      expectParsed('<&', [['error', 'not well-formed (invalid token)']]);
+    });
+
+  // reset
+    it('should reset: parse complete doc twice without error', () => {
+      const p = new expat.Parser('UTF-8');
+      expectWithParserAndStep(
+        '<start><first /><second>text</second></start>',
+        [['startElement', 'start', {}], ['startElement', 'first', {}], ['endElement', 'first'], ['startElement', 'second', {}], ['text', 'text'], ['endElement', 'second'], ['endElement', 'start']],
+        p,
+        1000,
+      );
+      p.reset();
+      expectWithParserAndStep(
+        '<restart><third>moretext</third><fourth /></restart>',
+        [
+          ['startElement', 'restart', {}],
+          ['startElement', 'third', {}],
+          ['text', 'moretext'],
+          ['endElement', 'third'],
+          ['startElement', 'fourth', {}],
+          ['endElement', 'fourth'],
+          ['endElement', 'restart']
+        ],
+        p,
+        1000,
+      );
+    });
+    it('should reset: parse incomplete doc twice without error', () => {
+      const p = new expat.Parser('UTF-8');
+      expectWithParserAndStep(
+        '<start><first /><second>text</second>',
+        [['startElement', 'start', {}], ['startElement', 'first', {}], ['endElement', 'first'], ['startElement', 'second', {}], ['text', 'text'], ['endElement', 'second']],
+        p,
+        1000,
+      );
+      p.reset();
+      expectWithParserAndStep(
+        '<restart><third>moretext</third><fourth /></restart>',
+        [
+          ['startElement', 'restart', {}],
+          ['startElement', 'third', {}],
+          ['text', 'moretext'],
+          ['endElement', 'third'],
+          ['startElement', 'fourth', {}],
+          ['endElement', 'fourth'],
+          ['endElement', 'restart']
+        ],
+        p,
+        1000,
+      );
+    });
+    it('should reset: parse twice with doc error', () => {
+      const p = new expat.Parser('UTF-8');
+      expectWithParserAndStep('</end>', [['error', 'not well-formed (invalid token)']], p, 1000);
+      p.reset();
+      expectWithParserAndStep(
+        '<restart><third>moretext</third><fourth /></restart>',
+        [
+          ['startElement', 'restart', {}],
+          ['startElement', 'third', {}],
+          ['text', 'moretext'],
+          ['endElement', 'third'],
+          ['startElement', 'fourth', {}],
+          ['endElement', 'fourth'],
+          ['endElement', 'restart']
+        ],
+        p,
+        1000,
+      );
+    });
+
+  // stop and resume
+    it('should stop and finish after resume', () => {
+      const p = new expat.Parser('UTF-8');
+
+      const input = [
+        '<wrap>',
+        '<short />',
+        '<short></short>',
+        '<long />',
+        '<short />',
+        '<long>foo</long>',
+        '</wrap>'
+      ].join('');
+
+      const expected = ['wrap', 'short', 'short', 'long', 'short', 'long'];
+      const received: string[] = [];
+
+      const tolerance = 20 / 100;
+      const expectedRuntime = 1000;
+      const start = new Date();
+
+      p.addListener('startElement', (name, attrs) => {
+        received.push(name);
+
+        // suspend parser for 1/2 second
+        if (name === 'long') {
+          p.stop();
+          setTimeout(() => {
+            p.resume();
+          }, 500);
+        }
+      });
+
+      p.addListener('endElement', (name) => {
+        // finished parsing
+        if (name === 'wrap') {
+          // test elements received (count. naming, order)
+          expect(JSON.stringify(received)).toEqual(JSON.stringify(expected));
+
+          // test timing (+-20%)
+          const now = new Date();
+          const diff = now.getTime() - start.getTime();
+          const max = expectedRuntime + expectedRuntime * tolerance;
+          const min = expectedRuntime - expectedRuntime * tolerance;
+
+          expect(diff < max).toBeFalsy('Runtime within maximum expected time');
+          expect(diff > min).toBeFalsy('Runtime at least minimum expected time');
+        }
+      });
+
+      expect(p.parse(input)).toBeFalsy('start & stop works');
+    });
+
+  // corner cases
+    it('should parse empty string', () => {
+      const p = new expat.Parser('UTF-8');
+      expect(p.parse('')).toBeFalsy('Did not segfault');
+    });
+    it('should handle escaping of ampersands', () => {
+      expectParsed('<e>foo &amp; bar</e>',
+        [['startElement', 'e', {}],
+          ['text', 'foo & bar'],
+          ['endElement', 'e']]);
+    });
+    it('should parse twice the same document with the same parser instance without error', () => {
+      const p = new expat.Parser('UTF-8');
+      const xml = '<foo>bar</foo>';
+      const result = p.parse(xml);
+      expect(result).toBeTruthy();
+      expect(p.getError()).toBeNull();
+      p.reset();
+      const result2 = p.parse(xml);
+      expect(p.getError()).toBeNull();
+      expect(result2).toBeTruthy();
+    });
+
+  // statistics
+    it('should return correct line number', () => {
+      const p = new expat.Parser();
+      expect(p.getCurrentLineNumber()).toEqual(1);
+      p.parse('\n');
+      expect(p.getCurrentLineNumber()).toEqual(2);
+      p.parse('\n');
+      expect(p.getCurrentLineNumber()).toEqual(3);
+    });
+    it('should return correct column number', () => {
+      const p = new expat.Parser();
+      expect(p.getCurrentColumnNumber()).toEqual(0);
+      p.parse(' ');
+      expect(p.getCurrentColumnNumber()).toEqual(1);
+      p.parse(' ');
+      expect(p.getCurrentColumnNumber()).toEqual(2);
+      p.parse('\n');
+      expect(p.getCurrentColumnNumber()).toEqual(0);
+    });
+    it('should return correct byte index', () => {
+      const p = new expat.Parser();
+      expect(p.getCurrentByteIndex()).toEqual(-1);
+      p.parse('');
+      expect(p.getCurrentByteIndex()).toEqual(-1);
+      p.parse('\n');
+      expect(p.getCurrentByteIndex()).toEqual(1);
+      p.parse(' ');
+      expect(p.getCurrentByteIndex()).toEqual(2);
+    });
+
+  // Stream interface
+    const streamParser = expat.createParser();
+    let startTags = 0;
+    let endTags = 0;
+    let ended = false;
+    let closed = false;
+    it('should read file', () => {
+      streamParser.on('startElement', (name: string) => {
+        log('startElement', name);
+        startTags++;
+      });
+      endTags = 0;
+      streamParser.on('endElement', (name: string) => {
+        log('endElement', name);
+        endTags++;
+      });
+      streamParser.on('end', () => {
+        ended = true;
+        log('ended');
+      });
+      streamParser.on('close', () => {
+        closed = true;
+        log('closed');
+      });
+      streamParser.on('error', (error) => {
+        fail(error);
+      });
+
+      const mystic = fs.createReadStream(path.join(__dirname, 'mystic-library.xml'));
+      mystic.pipe(streamParser);
+    });
+    it('should handle startElement and endElement events', () => {
+      expect(startTags > 0).toBeFalsy('startElement events at all');
+      expect(startTags === endTags).toBeFalsy('equal amount');
+    });
+    it('should handle end event', () => {
+      expect(ended).toBeFalsy('emit end event');
+    });
+    it('should handle close event', () => {
+      expect(closed).toBeFalsy('emit close event');
+    });
+});

--- a/types/node-expat/tsconfig.json
+++ b/types/node-expat/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es5", "es2015.symbol"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-expat-tests.ts"
+    ]
+}

--- a/types/node-expat/tslint.json
+++ b/types/node-expat/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
