### PR TITLE
[slonik] `memberType` in `sql.array` should be a string or another sq…

### DIFF
--- a/types/slonik/index.d.ts
+++ b/types/slonik/index.d.ts
@@ -300,7 +300,7 @@ export interface SqlTaggedTemplateType {
     <T = QueryResultRowType>(template: TemplateStringsArray, ...vals: ValueExpressionType[]): SqlSqlTokenType<T>;
     array: (
         values: PrimitiveValueExpressionType[],
-        memberType: string
+        memberType: TypeNameIdentifierType | SqlTokenType
     ) => ArraySqlTokenType;
     identifier: (
         names: string[]

--- a/types/slonik/slonik-tests.ts
+++ b/types/slonik/slonik-tests.ts
@@ -405,6 +405,10 @@ const samplesFromDocs = async () => {
     await connection.query(sql`
       SELECT (${sql.array([1, 2, 3], 'int4')})
     `);
+
+    await connection.query(sql`
+      SELECT (${sql.array([1, 2, 3], sql`int[]`)})
+    `);
   };
 
   const sample3 = async () => {


### PR DESCRIPTION
Per documentation, the example below is valid but I getting a TS error telling me that the memberType must be a `string`.

Example:
```js
const query = sql`SELECT (${sql.array([1, 2, 3], sql`int[]`)})`;
```

Error:
```
Argument of type 'TaggedTemplateLiteralInvocationType<QueryResultRowType<string>>' is not assignable to parameter of type 'string'
```

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/gajus/slonik/blame/master/README.md#L1193>>
