### PR TITLE
Roarr: Make `MessageContextType' more permissive and include suggested properties.

### DIFF
--- a/types/roarr/index.d.ts
+++ b/types/roarr/index.d.ts
@@ -18,7 +18,13 @@ export interface RoarrGlobalStateType extends WriterType {
 
 export type SprintfArgumentType = string | number | boolean | null;
 
-export type MessageContextType = object;
+export interface MessageContextType {
+    application?: string;
+    logLevel?: number;
+    namespace?: string;
+    package?: string;
+    [k: string]: any;
+}
 
 export interface MessageType {
     context: MessageContextType;

--- a/types/roarr/roarr-tests.ts
+++ b/types/roarr/roarr-tests.ts
@@ -1,4 +1,4 @@
-import { default as Roarr, MessageType, MessageContextType } from "roarr";
+import { default as Roarr, MessageContextType, MessageType } from "roarr";
 
 const messageContextType = {
     foo: "bar",
@@ -42,7 +42,9 @@ alternativeLog.fatal('foo 2');
 
 const implicitLog = Roarr.child((message) => {
     message;                    // $Expect MessageType
-    message["message"] = message["message"].replace("foo", "bar");
+    message.message = message.message.replace("foo", "bar");
+    message.context["new key"] = "new value";
+    message.context.logLevel = "50"; // $ExpectError
 
     return message;
 });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gajus/roarr#context-property-names
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

`MessageContextType` as `object` was the wrong choice, since it doesn’t allow you to change any properties. This PR makes it more permissive and also includes the suggested conventions to aid in autocomplete. (It does mean, however, that code which goes against the conventions—for example, by setting `logLevel` to a `string`—will not compile. I’m not sure that’s a problem in practice.)