### PR TITLE
[qrcode.react] Support imageSettings and passed-through props

### DIFF
--- a/types/qrcode.react/index.d.ts
+++ b/types/qrcode.react/index.d.ts
@@ -1,23 +1,42 @@
 // Type definitions for qrcode.react 0.9
 // Project: https://github.com/zpao/qrcode.react, http://zpao.github.io/qrcode.react
-// Definitions by: Mleko <https://github.com/mleko>, Yonas <https://github.com/yonasadiel>
+// Definitions by: Mleko <https://github.com/mleko>,
+//                 Yonas <https://github.com/yonasadiel>,
+//                 Bjoluc <https://github.com/bjoluc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 /// <reference types="react" />
 
 declare namespace qrcode {
-	interface QRCodeProps {
+	interface ImageSettings {
+		src: string;
+		x?: number;
+		y?: number;
+		height?: number;
+		width?: number;
+		excavate?: boolean;
+	}
+
+	interface BaseQRCodeProps {
 		value: string;
 		size?: number;
 		includeMargin?: boolean;
 		bgColor?: string;
 		fgColor?: string;
 		level?: "L"|"M"|"Q"|"H";
-		renderAs?: "svg" | "canvas";
+		imageSettings?: ImageSettings;
 	}
 
-	type QRCode = React.ComponentClass<QRCodeProps>;
+	type CanvasQRCodeProps = BaseQRCodeProps & {
+		renderAs?: "canvas"
+	} & React.CanvasHTMLAttributes<HTMLCanvasElement>;
+
+	type SvgQRCodeProps = BaseQRCodeProps & {
+		renderAs: "svg"
+	} & React.SVGProps<SVGSVGElement>;
+
+	type QRCode = React.ComponentClass<CanvasQRCodeProps | SvgQRCodeProps>;
 }
 
 declare const qrcode: qrcode.QRCode;

--- a/types/qrcode.react/index.d.ts
+++ b/types/qrcode.react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for qrcode.react 0.9
+// Type definitions for qrcode.react 1.0.0
 // Project: https://github.com/zpao/qrcode.react, http://zpao.github.io/qrcode.react
 // Definitions by: Mleko <https://github.com/mleko>,
 //                 Yonas <https://github.com/yonasadiel>,

--- a/types/qrcode.react/index.d.ts
+++ b/types/qrcode.react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for qrcode.react 1.0.0
+// Type definitions for qrcode.react 1.0
 // Project: https://github.com/zpao/qrcode.react, http://zpao.github.io/qrcode.react
 // Definitions by: Mleko <https://github.com/mleko>,
 //                 Yonas <https://github.com/yonasadiel>,

--- a/types/qrcode.react/qrcode.react-tests.tsx
+++ b/types/qrcode.react/qrcode.react-tests.tsx
@@ -10,5 +10,20 @@ const qrcodes = [
 	<QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" level="H"/>,
 	<QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" includeMargin={true}/>,
 	<QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" size={256} bgColor="pink" fgColor="red" level="Q"/>,
+	// Test imageSettings property:
+	<QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" imageSettings={{src: "./some-file.png"}}/>,
+	<QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" imageSettings={{
+		src: "./some-file.png",
+		x: 1,
+		y: 1,
+		height: 1,
+		width: 1,
+		excavate: true
+	}}/>,
+	// Test some passed-through props for svg and canvas elements:
 	<QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" renderAs="svg"/>,
+	<QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" renderAs="svg" amplitude={1}/>,
+	<QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" renderAs="canvas"/>,
+	<QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" renderAs="canvas" height={1} width={1}/>,
+	<QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" height={1} width={1}/>,
 ];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/zpao/qrcode.react#available-props>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

## Changes

* Add definitions for the [`imageSettings`](https://github.com/zpao/qrcode.react#imagesettings) property
* Support [passed-through](https://github.com/zpao/qrcode.react#custom-styles) props for the underlying `<svg>` and `<canvas>` elements, depending on the `renderAs` property