### PR TITLE
Lodash: fix return types for `overSome` and `overEvery`

### DIFF
--- a/types/lodash/common/util.d.ts
+++ b/types/lodash/common/util.d.ts
@@ -971,7 +971,7 @@ declare module "../index" {
         overEvery<T, Result1 extends T, Result2 extends T>(
             a: (arg: T) => arg is Result1,
             b: (arg: T) => arg is Result2
-        ): (arg: T) => Result1 & Result2;
+        ): (arg: T) => arg is Result1 & Result2;
         overEvery<T>(...predicates: Array<Many<(...args: T[]) => boolean>>): (...args: T[]) => boolean;
     }
 
@@ -1002,7 +1002,7 @@ declare module "../index" {
         overSome<T, Result1 extends T, Result2 extends T>(
             a: (arg: T) => arg is Result1,
             b: (arg: T) => arg is Result2
-        ): (arg: T) => Result1 | Result2;
+        ): (arg: T) => arg is Result1 | Result2;
         overSome<T>(...predicates: Array<Many<(...args: T[]) => boolean>>): (...args: T[]) => boolean;
     }
 

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -6844,7 +6844,7 @@ fp.now(); // $ExpectType number
     const userDefinedTypeGuard1: (item: object) => item is { a: 1 } = anything;
     const userDefinedTypeGuard2: (item: object) => item is { b: 1 } = anything;
 
-    _.overEvery(userDefinedTypeGuard1, userDefinedTypeGuard2); // $ExpectType (arg: object) => { a: 1; } & { b: 1; }
+    _.overEvery(userDefinedTypeGuard1, userDefinedTypeGuard2); // $ExpectType (arg: object) => arg is { a: 1; } & { b: 1; }
 
     _.overEvery((number: number) => true); // $ExpectType (...args: number[]) => boolean
     _.overEvery((number: number) => true, (number: number) => true); // $ExpectType (...args: number[]) => boolean
@@ -6862,7 +6862,7 @@ fp.now(); // $ExpectType number
     fp.overEvery((number: number) => true); // $ExpectType (...args: number[]) => boolean
     fp.overEvery([(number: number) => true, (number: number) => true]); // $ExpectType (...args: number[]) => boolean
 
-    _.overSome(userDefinedTypeGuard1, userDefinedTypeGuard2); // $ExpectType (arg: object) => { a: 1; } | { b: 1; }
+    _.overSome(userDefinedTypeGuard1, userDefinedTypeGuard2); // $ExpectType (arg: object) => arg is { a: 1; } | { b: 1; }
 
     _.overSome((number: number) => true); // $ExpectType (...args: number[]) => boolean
     _.overSome((number: number) => true, (number: number) => true); // $ExpectType (...args: number[]) => boolean

--- a/types/lodash/ts3.1/common/util.d.ts
+++ b/types/lodash/ts3.1/common/util.d.ts
@@ -755,7 +755,7 @@ declare module "../index" {
         overEvery<T, Result1 extends T, Result2 extends T>(...predicates: [
             (arg: T) => arg is Result1,
             (arg: T) => arg is Result2
-        ]): (arg: T) => Result1 & Result2;
+        ]): (arg: T) => arg is Result1 & Result2;
         overEvery<T>(...predicates: Array<Many<(...args: T[]) => boolean>>): (...args: T[]) => boolean;
     }
     interface Collection<T> {
@@ -794,7 +794,7 @@ declare module "../index" {
         overSome<T, Result1 extends T, Result2 extends T>(...predicates: [
             (arg: T) => arg is Result1,
             (arg: T) => arg is Result2
-        ]): (arg: T) => Result1 | Result2;
+        ]): (arg: T) => arg is Result1 | Result2;
         overSome<T>(...predicates: Array<Many<(...args: T[]) => boolean>>): (...args: T[]) => boolean;
     }
     interface Collection<T> {


### PR DESCRIPTION
In #40247 I accidentally used the wrong return type.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.