### PR TITLE
[request-promise] Fix: allow to specify return types

### DIFF
--- a/types/request-promise/index.d.ts
+++ b/types/request-promise/index.d.ts
@@ -4,6 +4,7 @@
 //                 Joe Skeen <https://github.com/joeskeen>
 //                 Aya Morisawa <https://github.com/AyaMorisawa>
 //                 Matt R. Wilson <https://github.com/mastermatt>
+//                 Sergey Bakulin <https://github.com/vansergen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 
@@ -13,12 +14,12 @@ import errors = require('./errors');
 import Promise = require('bluebird');
 
 declare namespace requestPromise {
-    interface RequestPromise extends request.Request {
-        then: Promise<any>["then"];
-        catch: Promise<any>["catch"];
-        finally: Promise<any>["finally"];
-        cancel: Promise<any>["cancel"];
-        promise(): Promise<any>;
+    interface RequestPromise<T = any> extends request.Request {
+        then: Promise<T>['then'];
+        catch: Promise<T>['catch'];
+        finally: Promise<T>['finally'];
+        cancel: Promise<T>['cancel'];
+        promise(): Promise<T>;
     }
 
     interface RequestPromiseOptions extends request.CoreOptions {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cdf01cf33d2db0f25558413ce3ba98b472c4dd07/types/bluebird/index.d.ts#L43

Additional context:
Now one can specify return types in the following way:
```typescript
import * as rp from "request-promise";
function myFunc(): rp.RequestPromise<object> {
  return rp.get({ uri: "http://worldtimeapi.org/api/ip", json: true });
}
myFunc().then(data => console.log(data)); // (parameter) data: object
```

