### PR TITLE
[@types/jaeger-client] Update prometheus client version

### DIFF
--- a/types/jaeger-client/package.json
+++ b/types/jaeger-client/package.json
@@ -2,6 +2,6 @@
     "private": true,
     "dependencies": {
         "opentracing": "~0.14.3",
-        "prom-client": "~11.3.0"
+        "prom-client": "~11.5.3"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

As `jaeger-client` strictly depends on `prom-client` and `prom-client` type definition has been changed in `collectDefaultMetrics` from v11.4.0 [link](https://github.com/siimon/prom-client/compare/6d1f37e..210960e#diff-b52768974e6bc0faccb7d4b75b162c99R659)
