### PR TITLE
[@types/stripe]: SetupIntentPaymentMethodType allow 'sepa_debit'

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -6268,7 +6268,7 @@ declare namespace Stripe {
         }
 
         /** Payment methods supported by Payment Intents. This is a subsetset of all Payment Method types. See https://stripe.com/docs/api/payment_methods/create#create_payment_method-type */
-        type SetupIntentPaymentMethodType = 'card' | 'card_present';
+        type SetupIntentPaymentMethodType = 'card' | 'card_present' | 'sepa_debit';
 
         interface ISetupIntent extends IResourceObject {
             /**


### PR DESCRIPTION
As shown in https://stripe.com/docs/payments/sepa-debit-setup-intents 'sepa_debit' is a valid SetupIntentPaymentMethodType.
Additionally the example code shown here https://stripe.com/docs/api/setup_intents/create?lang=node does not compile if you use 'sepa_debit' as part of `payment_method_types`.

---

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://stripe.com/docs/payments/sepa-debit-setup-intents>>
