### PR TITLE
bunyan-format: reverted back to old syntax

### DIFF
--- a/types/bunyan-format/bunyan-format-tests.ts
+++ b/types/bunyan-format/bunyan-format-tests.ts
@@ -1,9 +1,10 @@
 import BunyanFormatWritable = require('bunyan-format');
+import { Writable } from 'stream';
 
-const formatOut = new BunyanFormatWritable({ outputMode: 'short' });
+const formatOut: Writable = new BunyanFormatWritable({ outputMode: 'short' });
 
-const formatOut2 = new BunyanFormatWritable({ outputMode: 'bunyan', levelInString: true });
+const formatOut2: NodeJS.WritableStream = new BunyanFormatWritable({ outputMode: 'bunyan', levelInString: true });
 
-const formatOut3 = BunyanFormatWritable({ outputMode: 'short' });
+const formatOut3: Writable = BunyanFormatWritable({ outputMode: 'short' });
 
-const formatOut4 = BunyanFormatWritable({ outputMode: 'bunyan', levelInString: true });
+const formatOut4: NodeJS.WritableStream = BunyanFormatWritable({ outputMode: 'bunyan', levelInString: true });

--- a/types/bunyan-format/index.d.ts
+++ b/types/bunyan-format/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Piotr Roszatycki <https://github.com/dex4er>
 //                 Ashley Abbott <https://github.com/ashpabb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.6
+// TypeScript Version: 2.1
 
 /// <reference types="node" />
 
@@ -23,11 +23,13 @@ declare namespace BunyanFormatWritable {
     }
 }
 
-declare class BunyanFormatWritable extends Writable {
-    /** Creates a writable stream that formats bunyan records written to it. */
-    constructor(options: BunyanFormatWritable.Options, output?: Writable);
-}
+interface BunyanFormatWritable extends Writable {}
 
-declare function BunyanFormatWritable(options: BunyanFormatWritable.Options, output?: Writable): BunyanFormatWritable;
+declare var BunyanFormatWritable: {
+    /** Creates a writable stream that formats bunyan records written to it. */
+    (options: BunyanFormatWritable.Options, output?: Writable): BunyanFormatWritable;
+    /** Creates a writable stream that formats bunyan records written to it. */
+    new (options: BunyanFormatWritable.Options, output?: Writable): BunyanFormatWritable;
+};
 
 export = BunyanFormatWritable;

--- a/types/bunyan-format/index.d.ts
+++ b/types/bunyan-format/index.d.ts
@@ -23,6 +23,7 @@ declare namespace BunyanFormatWritable {
     }
 }
 
+// tslint:disable-next-line no-empty-interface
 interface BunyanFormatWritable extends Writable {}
 
 declare var BunyanFormatWritable: {

--- a/types/bunyan-format/tslint.json
+++ b/types/bunyan-format/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-empty-interface": false
+    }
+}

--- a/types/bunyan-format/tslint.json
+++ b/types/bunyan-format/tslint.json
@@ -1,6 +1,1 @@
-{
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-empty-interface": false
-    }
-}
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Previous #40257 is using new syntax from Typescript 3.6 and currently it broke compatibility with `bunyan` package:

```
Type 'BunyanFormatWritable' is missing the following properties from type 'Writable': writable, writableEnded, writableFinished, writableHighWaterMark, and 28 more.
```

or

```
Type 'BunyanFormatWritable' is missing the following properties from type 'WritableStream': writable, write, end, addListener, and 14 more.
```

I reverted to old syntax compatible with older Typescript 2.1.

It closes #40444
