### PR TITLE
[node/module] (nodejs v12 and v13) Add missing types for custom require and require.cache

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -193,9 +193,13 @@ interface NodeRequireFunction {
     (id: string): any;
 }
 
+interface NodeRequireCache {
+    [path: string]: NodeModule;
+}
+
 interface NodeRequire extends NodeRequireFunction {
     resolve: RequireResolve;
-    cache: any;
+    cache: NodeRequireCache;
     /**
      * @deprecated
      */
@@ -1134,8 +1138,8 @@ declare namespace NodeJS {
         /**
          * @deprecated Deprecated since: v12.2.0. Please use createRequire() instead.
          */
-        static createRequireFromPath(path: string): NodeRequireFunction;
-        static createRequire(path: string): NodeRequireFunction;
+        static createRequireFromPath(path: string): NodeRequire;
+        static createRequire(path: string): NodeRequire;
         static builtinModules: string[];
 
         static Module: typeof Module;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -817,7 +817,23 @@ import moduleModule = require('module');
     let paths: string[] = module.paths;
     paths = m1.paths;
 
-    moduleModule.createRequireFromPath('./test')('test');
+    const customRequire1 = moduleModule.createRequireFromPath('./test');
+    const customRequire2 = moduleModule.createRequire('./test');
+
+    customRequire1('test');
+    customRequire2('test');
+
+    const resolved1: string = customRequire1.resolve('test');
+    const resolved2: string = customRequire2.resolve('test');
+
+    const paths1: string[] | null  = customRequire1.resolve.paths('test');
+    const paths2: string[] | null  = customRequire2.resolve.paths('test');
+
+    const cachedModule1: Module = customRequire1.cache['/path/to/module.js'];
+    const cachedModule2: Module = customRequire2.cache['/path/to/module.js'];
+
+    const main1: Module | undefined = customRequire1.main;
+    const main2: Module | undefined = customRequire2.main;
 }
 
 /////////////////////////////////////////////////////////


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  > https://nodejs.org/api/modules.html#modules_module_createrequire_filename
  > follow the link to the return value, see that it has the same API as the global require
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
