### PR TITLE
[@types/koa-views] Add missing autoRender flag to opts

### DIFF
--- a/types/koa-views/index.d.ts
+++ b/types/koa-views/index.d.ts
@@ -28,6 +28,10 @@ import * as Koa from "koa";
 
 declare function views(dir: string, opts?: {
     /*
+    * autoRender the result into ctx.body, defaults to true
+    */
+    autoRender?: boolean,
+    /*
     * default extension for your views
     */
     extension?: string,

--- a/types/koa-views/koa-views-tests.ts
+++ b/types/koa-views/koa-views-tests.ts
@@ -4,6 +4,7 @@ import views = require("koa-views");
 const app = new Koa();
 
 app.use(views('/views', {
+    autoRender: true,
     map: {
         html: 'underscore'
     },


### PR DESCRIPTION
[Documentation of autoRender](https://www.npmjs.com/package/koa-views#viewsroot-opts)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ n/a ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ n/a ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
