### PR TITLE
@wordpress/components: Add Popover.Slot type

### DIFF
--- a/types/wordpress__components/index.d.ts
+++ b/types/wordpress__components/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for @wordpress/components 7.4
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/components/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
+//                 Jon Surrell <https://github.com/sirreal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 

--- a/types/wordpress__components/popover/index.d.ts
+++ b/types/wordpress__components/popover/index.d.ts
@@ -1,4 +1,5 @@
-import { ComponentType, HTMLProps, ReactNode } from '@wordpress/element';
+import { ComponentType, HTMLProps, ReactNode, ReactElement } from '@wordpress/element';
+import { Slot } from '@wordpress/components';
 
 declare namespace Popover {
     interface Props extends HTMLProps<HTMLDivElement> {
@@ -85,6 +86,29 @@ declare namespace Popover {
         | 'bottom right'
         | 'bottom center';
 }
-declare const Popover: ComponentType<Popover.Props>;
+
+declare const Popover: ComponentType<Popover.Props> & {
+    /**
+     * Use Popover.Slot to render the Popover to a specific location on the page.
+     *
+     * This is useful to allow style cascade to take effect.
+     *
+     * @example
+     *
+     * import { render } from '@wordpress/element';
+     * import { Popover } from '@wordpress/components';
+     * import Content from './Content';
+     *
+     * const app = document.getElementById( 'app' );
+     * render(
+     *   <div>
+     *       <Content />
+     *       <Popover.Slot />
+     *   </div>,
+     *   app
+     * );
+     */
+    Slot(): ReactElement<Slot.Props, typeof Slot>;
+};
 
 export default Popover;

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -458,6 +458,8 @@ const kbshortcuts = {
     Hello World
 </C.Popover>;
 
+<C.Popover.Slot />;
+
 //
 // query-controls
 //
@@ -900,7 +902,7 @@ const MySlotFillProvider = () => {
             render() {
                 return <div>{this.props.foo}</div>;
             }
-        }
+        },
     );
     <EnhancedComponentClassExpression foo="hello world" />;
 


### PR DESCRIPTION
Add `Popover.Slot` to the `Popover` component.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/tree/master/packages/components/src/popover
- **Does not apply** If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- **Does not apply** If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

