### PR TITLE
@wordpress/block-editor: Add some settings to BlockEditorProvider

### DIFF
--- a/types/wordpress__block-editor/components/provider.d.ts
+++ b/types/wordpress__block-editor/components/provider.d.ts
@@ -1,7 +1,7 @@
 import { BlockInstance } from '@wordpress/blocks';
 import { ComponentType, ReactNode } from '@wordpress/element';
 
-import { EditorSettings } from '../';
+import { EditorSettings, EditorBlockListSettings } from '../';
 
 declare namespace BlockEditorProvider {
     interface Props {
@@ -35,7 +35,7 @@ declare namespace BlockEditorProvider {
          * except for the first.
          */
         onInput?(blocks: BlockInstance[]): void;
-        settings?: Partial<EditorSettings>;
+        settings?: Partial<EditorSettings & EditorBlockListSettings>;
         useSubRegistry?: boolean;
         /**
          * The current array of blocks.

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -65,6 +65,13 @@ const STYLES = [{ css: '.foo { color: red; }' }, { css: '.bar { color: blue; }',
 <be.BlockControls.Slot />;
 
 //
+// BlockEditorProvider
+//
+<be.BlockEditorProvider value={[]} settings={{ templateLock: 'all' }}>
+    <div />
+</be.BlockEditorProvider>;
+
+//
 // block-format-controls
 //
 <be.BlockFormatControls>Hello World</be.BlockFormatControls>;


### PR DESCRIPTION
Update `BlockEditorProvider` settings type. Includes `templateLock` setting which was found to be missing:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/134bb19cf822df209f89c6fb64dfabaa7e270984/types/wordpress__block-editor/index.d.ts#L29-L32

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Component fires `updateSettings` action with settings prop: https://github.com/WordPress/gutenberg/blob/70ad9f1286e4e7b243b51c42b35a7a8f06226555/packages/block-editor/src/components/provider/index.js#L36
  - This changes settings in state:
    - action: https://github.com/WordPress/gutenberg/blob/51fee9a045298a9c81e81675893c889e8df971cf/packages/block-editor/src/store/actions.js#L720-L725
    - reducer: https://github.com/WordPress/gutenberg/blob/51fee9a045298a9c81e81675893c889e8df971cf/packages/block-editor/src/store/reducer.js#L1162-L1172
  - `templateLock` selector reads from `settings.templateLock`: https://github.com/WordPress/gutenberg/blob/51fee9a045298a9c81e81675893c889e8df971cf/packages/block-editor/src/store/selectors.js#L1000-L1020
- **Does not apply** If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- **Does not apply** If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.