### PR TITLE
@wordpress/data: Add persist to registerStore

### DIFF
--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for @wordpress/data 4.6
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/data/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
+//                 Jon Surrell <https://github.com/sirreal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 

--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -48,7 +48,26 @@ export interface StoreConfig<S> {
         [k: string]: (action: Action) => any;
     };
     initialState?: S;
-    persist?: Array<keyof S>;
+
+    /**
+     * Use persist with the persistence plugin to persist state.
+     *
+     * The registry must use the `persistence` plugin.
+     *
+     * Set to `true` to persist all state, or pass an array of state keys to persist.
+     *
+     * @example
+     *
+     * import { plugins, registerStore, use } from '@wordpress/data';
+     *
+     * use( plugins.persistence, { storageKey: 'example' } );
+     *
+     * registerStore( 'my-plugin', {
+     *   // …
+     *   persist: [ 'state-key-to-persist' ],
+     * } );
+     */
+    persist?: true | Array<keyof S>;
 }
 
 export interface Store<S, A extends Action = Action> {

--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -47,7 +47,7 @@ export interface StoreConfig<S> {
         [k: string]: (action: Action) => any;
     };
     initialState?: S;
-    persist?: (keyof S)[];
+    persist?: Array<keyof S>;
 }
 
 export interface Store<S, A extends Action = Action> {

--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -31,6 +31,7 @@ export interface GenericStoreConfig {
     getSelectors(): SelectorMap;
     subscribe: Subscriber;
 }
+
 export interface StoreConfig<S> {
     reducer: Reducer<S>;
     actions?: {
@@ -46,7 +47,9 @@ export interface StoreConfig<S> {
         [k: string]: (action: Action) => any;
     };
     initialState?: S;
+    persist?: (keyof S)[];
 }
+
 export interface Store<S, A extends Action = Action> {
     getState(): S;
     subscribe: Subscriber;

--- a/types/wordpress__data/wordpress__data-tests.tsx
+++ b/types/wordpress__data/wordpress__data-tests.tsx
@@ -20,8 +20,14 @@ data.registerStore<FooBar>('foo', {
         getSomething: (state, thing: keyof FooBar) => state[thing],
     },
     actions: {
-        setFoo: (text: 'foo') => ({ type: 'SET_FOO', text }),
+        setFoo: (text: string) => ({ type: 'SET_FOO', text }),
     },
+    persist: ['foo'],
+});
+
+data.registerStore<{ key: string }>('bad-persist', {
+    reducer: (state = { key: 'value' }) => state,
+    persist: ['invalid-persist-key'], // $ExpectError
 });
 
 const HookComponent = () => {


### PR DESCRIPTION
- Add type for `registerStore` [`persist`](https://github.com/WordPress/gutenberg/tree/master/packages/data/src/plugins/persistence)
- Add tests

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/tree/master/packages/data/src/plugins/persistence
- **Does not apply** If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- **Does not apply** If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
