### PR TITLE
[chart.js] Missing legend.align type

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -81,6 +81,7 @@ const chart: Chart = new Chart(ctx, {
             ],
         },
         legend: {
+            align: 'center',
             display: true,
             labels: {
                 usePointStyle: true,

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -285,11 +285,8 @@ declare namespace Chart {
         display?: boolean;
         position?: PositionType;
         fullWidth?: boolean;
-
         onClick?(event: MouseEvent, legendItem: ChartLegendLabelItem): void;
-
         onHover?(event: MouseEvent, legendItem: ChartLegendLabelItem): void;
-
         labels?: ChartLegendLabelOptions;
         reverse?: boolean;
     }

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -280,6 +280,7 @@ declare namespace Chart {
     }
 
     interface ChartLegendOptions {
+        align?: 'center' | 'end' | 'start';
         display?: boolean;
         position?: PositionType;
         fullWidth?: boolean;
@@ -288,7 +289,7 @@ declare namespace Chart {
         labels?: ChartLegendLabelOptions;
         reverse?: boolean;
     }
-
+    
     interface ChartLegendLabelOptions {
         boxWidth?: number;
         fontSize?: number;

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -20,6 +20,7 @@
 //                 Elian Cordoba <https://github.com/ElianCordoba>
 //                 Takuya Uehara <https://github.com/indigolain>
 //                 Ricardo Mello <https://github.com/ricardo-mello>
+//                 Ray Nicholus <https://github.com/rnicholus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -285,12 +285,15 @@ declare namespace Chart {
         display?: boolean;
         position?: PositionType;
         fullWidth?: boolean;
+
         onClick?(event: MouseEvent, legendItem: ChartLegendLabelItem): void;
+
         onHover?(event: MouseEvent, legendItem: ChartLegendLabelItem): void;
+
         labels?: ChartLegendLabelOptions;
         reverse?: boolean;
     }
-    
+
     interface ChartLegendLabelOptions {
         boxWidth?: number;
         fontSize?: number;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.chartjs.org/docs/latest/configuration/legend.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.