### PR TITLE
[@types/mongoose] improve mongoose create type

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -2892,7 +2892,7 @@ declare module "mongoose" {
      *   Model#ensureIndexes. If an error occurred it is passed with the event.
      *   The fields, options, and index name are also passed.
      */
-    new(doc?: any): T;
+    new(doc?: Partial<T>): T;
 
     /**
      * Requires a replica set running MongoDB >= 3.6.0. Watches the underlying collection for changes using MongoDB change streams.

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -33,6 +33,7 @@
 //                 Chathu Vishwajith <https://github.com/iamchathu>
 //                 Tom Yam <https://github.com/tomyam1>
 //                 Thomas Pischulski <https://github.com/nephix>
+//                 Lukas Strassel <https://github.com/sakulstra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -2245,3 +2245,14 @@ Animal2.find().byName('fido').exec(function(err, animals) {
 Animal2.findOne().byName('fido').exec(function(err, animal) {
   console.log(animal);
 });
+
+// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40467
+interface TypedModel extends mongoose.Document {
+    name: string;
+}
+
+const typedModel1 = mongoose.model('typedModel', new mongoose.Schema({ name: String }))
+new typedModel1({ name: 'bar' })
+const typedModel2 = mongoose.model<TypedModel>('typedModel', new mongoose.Schema({ name: String }))
+new typedModel2({ name: 'bar', fart: 'bla' })
+


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/typegoose/typegoose/issues/129>>

This is the same pr, but for an older version of mongoose: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33781

---

I've taken this solution from the referenced pr, but am wondering if a more strict `new(doc?: Omit<T, keyof Document>): T;` would be a better fit.

The current solution will allow you to omit required fields:
```
export interface ITest {
  foo: string;
  bar: string;
}

const testSchema: Schema = new mongoose.Schema({
  foo: String,
  bar: String,
});

export interface ITestModel extends ITest, Document {}

const Test: Model<ITestModel> = mongoose.model<ITestModel>('Test', testSchema);

// okay
new Test({ foo: 'foo', bar: 'bar' });
// missing key, but okay
new Test({ foo: 'foo' });
// error: key wrong type
new Test({ foo: 3 });
// error: key doesn't exist
new Test({ zar: 'bar' });
```

When using `new(doc?: Omit<T, keyof Document>): T;` instead `new Test({ foo: 'foo' });` would fail due to the missing key.