### PR TITLE
Updates Prettier API for version 1.19

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -344,6 +344,7 @@ export interface FileInfoOptions {
     ignorePath?: string;
     withNodeModules?: boolean;
     plugins?: string[];
+    resolveConfig?: boolean
 }
 
 export interface FileInfoResult {

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -130,7 +130,6 @@ export interface RequiredOptions extends doc.printer.Options {
      * Change when properties in objects are quoted.
      */
     quoteProps: 'as-needed' | 'consistent' | 'preserve';
-
     /**
      * Whether or not to indent the code inside <script> and <style> tags in Vue files. 
      */

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -349,7 +349,7 @@ export interface FileInfoOptions {
     ignorePath?: string;
     withNodeModules?: boolean;
     plugins?: string[];
-    resolveConfig?: boolean
+    resolveConfig?: boolean;
 }
 
 export interface FileInfoResult {

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -130,6 +130,11 @@ export interface RequiredOptions extends doc.printer.Options {
      * Change when properties in objects are quoted.
      */
     quoteProps: 'as-needed' | 'consistent' | 'preserve';
+
+    /**
+     * Whether or not to indent the code inside <script> and <style> tags in Vue files. 
+     */
+    vueIndentScriptAndStyle: boolean;
 }
 
 export interface ParserOptions extends RequiredOptions {

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -131,7 +131,7 @@ export interface RequiredOptions extends doc.printer.Options {
      */
     quoteProps: 'as-needed' | 'consistent' | 'preserve';
     /**
-     * Whether or not to indent the code inside <script> and <style> tags in Vue files. 
+     * Whether or not to indent the code inside <script> and <style> tags in Vue files.
      */
     vueIndentScriptAndStyle: boolean;
 }


### PR DESCRIPTION
See https://prettier.io/blog/2019/11/09/1.19.0.html#api

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
