### PR TITLE
[yup]: fix missing `notEqual` on `NumberLocale`

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -455,6 +455,7 @@ interface NumberLocale {
     max?: TestOptionsMessage<{ max: number }>;
     lessThan?: TestOptionsMessage<{ less: number }>;
     moreThan?: TestOptionsMessage<{ more: number }>;
+    notEqual?: TestOptionsMessage<{ more: number }>;
     positive?: TestOptionsMessage<{ more: number }>;
     negative?: TestOptionsMessage<{ less: number }>;
     integer?: TestOptionsMessage;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -512,6 +512,7 @@ const exhaustiveLocalObjectconst: LocaleObject = {
         max: '${path} must be less than or equal to ${max}',
         lessThan: '${path} must be less than ${less}',
         moreThan: '${path} must be greater than ${more}',
+        notEqual: '${path} must be not equal to ${notEqual}',
         positive: '${path} must be a positive number',
         negative: '${path} must be a negative number',
         integer: '${path} must be an integer',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://github.com/jquense/yup/blob/master/src/locale.js#L42

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I could not be able to find the change that add `notEqual`.