### PR TITLE
[@types/table-resolver] Typings for table-resolver lib

### DIFF
--- a/types/table-resolver/index.d.ts
+++ b/types/table-resolver/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for table-resolver 4.1
+// Project: https://github.com/reactabular/table-resolver#readme
+// Definitions by: Marcos Junior <https://github.com/junalmeida>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function headerRows<T>(args: { columns: T[] }): T[];
+export function nested<T>(args: { column: T }): T;
+export function resolve<T>(args: { columns: T[], method: (args: { column: T }) => T }): (data: any) => T[];
+export function columnChildren<T>(args: { columns: T[] }): T[];

--- a/types/table-resolver/table-resolver-tests.ts
+++ b/types/table-resolver/table-resolver-tests.ts
@@ -1,0 +1,14 @@
+import * as resolver from "table-resolver";
+
+const result = resolver.resolve({
+    columns: [{
+        id: "testid1",
+        title: "test title 1",
+    }, {
+        id: "testid2",
+        title: "test title 2"
+    }],
+    method: (item) => item.column
+});
+
+export default result;

--- a/types/table-resolver/tsconfig.json
+++ b/types/table-resolver/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "table-resolver-tests.ts"
+    ]
+}

--- a/types/table-resolver/tslint.json
+++ b/types/table-resolver/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
