### PR TITLE
[chart.js] missing Chart.platform and Chart.global.tooltips static types

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -295,3 +295,13 @@ const customTooltipsPieChart = new Chart(ctx, {
         },
     },
 });
+
+// platform global values
+Chart.platform.disableCSSInjection = true;
+
+// default global static values
+Chart.defaults.global.defaultFontColor = '#544615';
+Chart.defaults.global.defaultFontFamily = 'Arial';
+Chart.defaults.global.tooltips.backgroundColor = '#0a2c54';
+Chart.defaults.global.tooltips.cornerRadius = 2;
+Chart.defaults.global.tooltips.displayColors = false;

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -55,7 +55,9 @@ declare class Chart {
     static plugins: PluginServiceStatic;
 
     static defaults: {
-        global: Chart.ChartOptions & Chart.ChartFontOptions;
+        global: Chart.ChartOptions & Chart.ChartFontOptions & {
+            tooltips: Chart.ChartTooltipOptions
+        };
         [key: string]: any;
     };
 
@@ -65,6 +67,10 @@ declare class Chart {
 
     static helpers: {
         [key: string]: any;
+    };
+
+    static platform: {
+        disableCSSInjection: boolean
     };
 
     // Tooltip Static Options


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: For platform update, see the code at the bottom of https://www.chartjs.org/docs/latest/getting-started/integration.html?h=platform. For the tooltips see https://www.chartjs.org/docs/latest/configuration/tooltip.html#tooltip-configuration.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.