### PR TITLE
node: update dgram module to Node 12.x API

### DIFF
--- a/types/node/dgram.d.ts
+++ b/types/node/dgram.d.ts
@@ -11,9 +11,10 @@ declare module "dgram" {
     }
 
     interface BindOptions {
-        port: number;
+        port?: number;
         address?: string;
         exclusive?: boolean;
+        fd?: number;
     }
 
     type SocketType = "udp4" | "udp6";
@@ -34,67 +35,82 @@ declare module "dgram" {
     function createSocket(options: SocketOptions, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;
 
     class Socket extends events.EventEmitter {
-        send(msg: string | Uint8Array | any[], port: number, address?: string, callback?: (error: Error | null, bytes: number) => void): void;
-        send(msg: string | Uint8Array, offset: number, length: number, port: number, address?: string, callback?: (error: Error | null, bytes: number) => void): void;
+        addMembership(multicastAddress: string, multicastInterface?: string): void;
+        address(): AddressInfo;
         bind(port?: number, address?: string, callback?: () => void): void;
         bind(port?: number, callback?: () => void): void;
         bind(callback?: () => void): void;
         bind(options: BindOptions, callback?: () => void): void;
         close(callback?: () => void): void;
-        address(): AddressInfo | string;
-        setBroadcast(flag: boolean): void;
-        setTTL(ttl: number): void;
-        setMulticastTTL(ttl: number): void;
-        setMulticastInterface(multicastInterface: string): void;
-        setMulticastLoopback(flag: boolean): void;
-        addMembership(multicastAddress: string, multicastInterface?: string): void;
+        connect(port: number, address?: string, callback?: () => void): void;
+        connect(port: number, callback: () => void): void;
+        disconnect(): void;
         dropMembership(multicastAddress: string, multicastInterface?: string): void;
-        ref(): this;
-        unref(): this;
-        setRecvBufferSize(size: number): void;
-        setSendBufferSize(size: number): void;
         getRecvBufferSize(): number;
         getSendBufferSize(): number;
+        ref(): this;
+        remoteAddress(): AddressInfo;
+        send(msg: string | Uint8Array | any[], port?: number, address?: string, callback?: (error: Error | null, bytes: number) => void): void;
+        send(msg: string | Uint8Array | any[], port?: number, callback?: (error: Error | null, bytes: number) => void): void;
+        send(msg: string | Uint8Array | any[], callback?: (error: Error | null, bytes: number) => void): void;
+        send(msg: string | Uint8Array, offset: number, length: number, port?: number, address?: string, callback?: (error: Error | null, bytes: number) => void): void;
+        send(msg: string | Uint8Array, offset: number, length: number, port?: number, callback?: (error: Error | null, bytes: number) => void): void;
+        send(msg: string | Uint8Array, offset: number, length: number, callback?: (error: Error | null, bytes: number) => void): void;
+        setBroadcast(flag: boolean): void;
+        setMulticastInterface(multicastInterface: string): void;
+        setMulticastLoopback(flag: boolean): void;
+        setMulticastTTL(ttl: number): void;
+        setRecvBufferSize(size: number): void;
+        setSendBufferSize(size: number): void;
+        setTTL(ttl: number): void;
+        unref(): this;
 
         /**
          * events.EventEmitter
          * 1. close
-         * 2. error
-         * 3. listening
-         * 4. message
+         * 2. connect
+         * 3. error
+         * 4. listening
+         * 5. message
          */
         addListener(event: string, listener: (...args: any[]) => void): this;
         addListener(event: "close", listener: () => void): this;
+        addListener(event: "connect", listener: () => void): this;
         addListener(event: "error", listener: (err: Error) => void): this;
         addListener(event: "listening", listener: () => void): this;
         addListener(event: "message", listener: (msg: Buffer, rinfo: RemoteInfo) => void): this;
 
         emit(event: string | symbol, ...args: any[]): boolean;
         emit(event: "close"): boolean;
+        emit(event: "connect"): boolean;
         emit(event: "error", err: Error): boolean;
         emit(event: "listening"): boolean;
         emit(event: "message", msg: Buffer, rinfo: RemoteInfo): boolean;
 
         on(event: string, listener: (...args: any[]) => void): this;
         on(event: "close", listener: () => void): this;
+        on(event: "connect", listener: () => void): this;
         on(event: "error", listener: (err: Error) => void): this;
         on(event: "listening", listener: () => void): this;
         on(event: "message", listener: (msg: Buffer, rinfo: RemoteInfo) => void): this;
 
         once(event: string, listener: (...args: any[]) => void): this;
         once(event: "close", listener: () => void): this;
+        once(event: "connect", listener: () => void): this;
         once(event: "error", listener: (err: Error) => void): this;
         once(event: "listening", listener: () => void): this;
         once(event: "message", listener: (msg: Buffer, rinfo: RemoteInfo) => void): this;
 
         prependListener(event: string, listener: (...args: any[]) => void): this;
         prependListener(event: "close", listener: () => void): this;
+        prependListener(event: "connect", listener: () => void): this;
         prependListener(event: "error", listener: (err: Error) => void): this;
         prependListener(event: "listening", listener: () => void): this;
         prependListener(event: "message", listener: (msg: Buffer, rinfo: RemoteInfo) => void): this;
 
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
         prependOnceListener(event: "close", listener: () => void): this;
+        prependOnceListener(event: "connect", listener: () => void): this;
         prependOnceListener(event: "error", listener: (err: Error) => void): this;
         prependOnceListener(event: "listening", listener: () => void): this;
         prependOnceListener(event: "message", listener: (msg: Buffer, rinfo: RemoteInfo) => void): this;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -39,6 +39,7 @@
 //                 Marcin Kopacz <https://github.com/chyzwar>
 //                 Trivikram Kamat <https://github.com/trivikr>
 //                 Minh Son Nguyen <https://github.com/nguymin4>
+//                 Junxiao Shi <https://github.com/yoursunny>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // NOTE: These definitions support NodeJS and TypeScript 3.2.

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -10,6 +10,7 @@ import * as dns from "dns";
 import * as async_hooks from "async_hooks";
 import * as inspector from "inspector";
 import * as trace_events from "trace_events";
+import * as dgram from "dgram";
 import Module = require("module");
 
 ////////////////////////////////////////////////////
@@ -837,6 +838,88 @@ import tty = require('tty');
     const stdin: tty.ReadStream = process.stdin;
     const stdout: tty.WriteStream = process.stdout;
     const stderr: tty.WriteStream = process.stderr;
+}
+
+/////////////////////////////////////////////////////////
+/// dgram tests : https://nodejs.org/api/dgram.html ///
+/////////////////////////////////////////////////////////
+{
+    let sock: dgram.Socket = dgram.createSocket("udp4");
+    sock = dgram.createSocket({ type: "udp4" });
+    sock = dgram.createSocket({
+        type: "udp4",
+        reuseAddr: true,
+        ipv6Only: false,
+        recvBufferSize: 4096,
+        sendBufferSize: 4096,
+        lookup: dns.lookup,
+    });
+    sock = dgram.createSocket("udp6", (msg, rinfo) => {
+        msg; // $ExpectType Buffer
+        rinfo; // $ExpectType RemoteInfo
+    });
+    sock.addMembership("233.252.0.0");
+    sock.addMembership("233.252.0.0", "192.0.2.1");
+    sock.address().address; // $ExpectType string
+    sock.address().family; // $ExpectType string
+    sock.address().port; // $ExpectType number
+    sock.bind();
+    sock.bind(() => undefined);
+    sock.bind(8000);
+    sock.bind(8000, () => undefined);
+    sock.bind(8000, "192.0.2.1");
+    sock.bind(8000, "192.0.2.1", () => undefined);
+    sock.bind({}, () => undefined);
+    sock.bind({ port: 8000, address: "192.0.2.1", exclusive: true });
+    sock.bind({ fd: 7, exclusive: true });
+    sock.close();
+    sock.close(() => undefined);
+    sock.connect(8000);
+    sock.connect(8000, "192.0.2.1");
+    sock.connect(8000, () => undefined);
+    sock.connect(8000, "192.0.2.1", () => undefined);
+    sock.disconnect();
+    sock.dropMembership("233.252.0.0");
+    sock.dropMembership("233.252.0.0", "192.0.2.1");
+    sock.getRecvBufferSize(); // $ExpectType number
+    sock.getSendBufferSize(); // $ExpectType number
+    sock = sock.ref();
+    sock.remoteAddress().address; // $ExpectType string
+    sock.remoteAddress().family; // $ExpectType string
+    sock.remoteAddress().port; // $ExpectType number
+    sock.send("datagram");
+    sock.send(new Uint8Array(256), 8000, (err) => {
+        err; // $ExpectType Error | null
+    });
+    sock.send(Buffer.alloc(256), 8000, "192.0.2.1");
+    sock.send(new Uint8Array(256), 128, 64);
+    sock.send("datagram", 128, 64, (err) => undefined);
+    sock.send(new Uint8Array(256), 128, 64, 8000);
+    sock.send(new Uint8Array(256), 128, 64, 8000, (err) => undefined);
+    sock.send(Buffer.alloc(256), 128, 64, 8000, "192.0.2.1");
+    sock.send("datagram", 128, 64, 8000, "192.0.2.1", (err) => undefined);
+    sock.setBroadcast(true);
+    sock.setMulticastInterface("192.0.2.1");
+    sock.setMulticastLoopback(false);
+    sock.setMulticastTTL(128);
+    sock.setRecvBufferSize(4096);
+    sock.setSendBufferSize(4096);
+    sock.setTTL(128);
+    sock = sock.unref();
+
+    sock.on("close", () => undefined);
+    sock.on("connect", () => undefined);
+    sock.on("error", (exception) => {
+        exception; // $ExpectType Error
+    });
+    sock.on("listening", () => undefined);
+    sock.on("message", (msg, rinfo) => {
+        msg; // $ExpectType Buffer
+        rinfo.address; // $ExpectType string
+        rinfo.family; // $ExpectType "IPv4" | "IPv6"
+        rinfo.port; // $ExpectType number
+        rinfo.size; // $ExpectType number
+    });
 }
 
 ////////////////////////////////////////////////////


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/dgram.html
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

## List of Changes

In `socket.address()`, change return type to `AddressInfo` only, instead of `AddressInfo|string`. From docs:

> Returns an object containing the address information for a socket.

In `socket.bind(options)`, set `port` as optional. From docs:

> If port is not specified or is 0, the operating system will attempt to bind to a random port.

Add `socket.connect(..)` and `socket.disconnect()` functions, and `"connect"` event.
Add `socket.send(..)` overloads where `port` and `address` are omitted.
These are new APIs introduced in Node 12.x.

## Notes

This is same as #40263 that was erroneously closed by @typescript-bot .

I did not include `socket.addSourceSpecificMembership` and `socket.dropSourceSpecificMembership` because these are introduced in Node 13.x, not Node 12.x.

The declarations are now in alphabetical order, so that I (and future maintainers) can easily compare them against Node docs.
I also added test cases for all existing and new functions in "dgram" module.

#11244 #11245 #13307 can be closed.