### PR TITLE
[BSON] Remove deprecation annotation for DBRef

### DIFF
--- a/types/bson/index.d.ts
+++ b/types/bson/index.d.ts
@@ -162,7 +162,6 @@ export class Code {
 
 /**
  * A class representation of the BSON DBRef type.
- * @deprecated
  */
 export class DBRef {
     /**


### PR DESCRIPTION
DBRef is currently not deprecated http://mongodb.github.io/node-mongodb-native/3.2/api/DBRef.html
