### PR TITLE
webpack: add MultiStats.hasErrors method

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1196,6 +1196,8 @@ declare namespace webpack {
         interface MultiStats {
             stats: Stats[];
             hash: string;
+            /** Returns true if there were errors while compiling. */
+            hasErrors(): boolean;
         }
 
         interface MultiCompilerHooks {


### PR DESCRIPTION
`MultiStats` [exposes](https://github.com/webpack/webpack/blob/master/lib/MultiStats.js#L29) `hasErrors` method.