### PR TITLE
fix: [react] Deleted unused type ReactComponentElement

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -111,7 +111,7 @@ declare namespace React {
     }
 
     interface ReactComponentElement<
-        T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
+        T extends string | JSXElementConstructor<any>,
         P = Pick<ComponentProps<T>, Exclude<keyof ComponentProps<T>, 'key' | 'ref'>>
     > extends ReactElement<P, T> { }
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -110,11 +110,6 @@ declare namespace React {
         key: Key | null;
     }
 
-    interface ReactComponentElement<
-        T extends string | JSXElementConstructor<any>,
-        P = Pick<ComponentProps<T>, Exclude<keyof ComponentProps<T>, 'key' | 'ref'>>
-    > extends ReactElement<P, T> { }
-
     /**
      * @deprecated Please use `FunctionComponentElement`
      */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:

N/A

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:

N/A

## Description

Deleted `ReactComponentElement` as it is not referred from anywhere and broken. In the latest TypeScript, `keyof X` cannot be applied to `string` (is resolved as `string | number`)

