### PR TITLE
[@types/reactabular-sticky] First version of reactabular-sticky typings

### DIFF
--- a/types/reactabular-sticky/index.d.ts
+++ b/types/reactabular-sticky/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for reactabular-sticky 8.14
+// Project: http://reactabular.js.org/
+// Definitions by: Marcos Junior <https://github.com/junalmeida>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import * as Table from "reactabular-table";
+import * as React from "react";
+
+export interface StickyHeaderProps {
+    tableBody: HTMLElement | null;
+    onScroll?: (e: Partial<UIEvent>) => void;
+}
+
+export class Header extends React.Component<StickyHeaderProps & Table.HeaderProps> {
+    ref: HTMLElement;
+    container: HTMLElement;
+}
+
+export interface StickyBodyProps {
+    tableHeader: HTMLElement | null;
+    onScroll?: (e: Partial<UIEvent>) => void;
+}
+
+export class Body extends React.Component<StickyBodyProps & Table.BodyProps> {
+    ref: HTMLElement;
+}

--- a/types/reactabular-sticky/reactabular-sticky-tests.tsx
+++ b/types/reactabular-sticky/reactabular-sticky-tests.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import * as Sticky from "reactabular-sticky";
+import * as Table from "reactabular-table";
+
+export interface Props {
+    columns: Table.Column[];
+    rows: any[];
+}
+
+class ReactabularStickyTestComponent extends React.Component<Props> {
+    constructor(props: Props) {
+        super(props);
+    }
+
+    renderers: Table.Renderers = {
+        header: {
+            cell: undefined,
+        },
+        body: {
+            row: (props: any) => <tr {...props} />,
+        },
+    };
+
+    private tableHeader: HTMLElement | null;
+    private tableBody: HTMLElement | null;
+
+    render() {
+        return <div>
+            <Table.Provider
+                columns={ this.props.columns }
+                renderers={this.renderers}
+            >
+                <Sticky.Header
+                    ref={(obj) => this.tableHeader = obj && obj.container}
+                    tableBody={this.tableBody}
+                />
+                <Sticky.Body
+                    ref={(obj) => this.tableBody = obj && obj.ref}
+                    tableHeader={this.tableHeader}
+                    rows={this.props.rows}
+                    rowKey="id"
+                />
+            </Table.Provider>
+        </div>;
+    }
+}
+export default ReactabularStickyTestComponent;

--- a/types/reactabular-sticky/tsconfig.json
+++ b/types/reactabular-sticky/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "jsx": "react",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "reactabular-sticky-tests.tsx"
+    ]
+}

--- a/types/reactabular-sticky/tslint.json
+++ b/types/reactabular-sticky/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
