### PR TITLE
[leaflet.js] fix typings for Polyline.addLatLng()

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -6,6 +6,7 @@
 //                 Roni Karilkar <https://github.com/ronikar>
 //                 Sandra Frischmuth <https://github.com/sanfrisc>
 //                 Vladimir Dashukevich <https://github.com/life777>
+//                 Henry Thasler <https://github.com/henrythasler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -986,7 +987,7 @@ export class Polyline<T extends geojson.GeometryObject = geojson.LineString | ge
     isEmpty(): boolean;
     getCenter(): LatLng;
     getBounds(): LatLngBounds;
-    addLatLng(latlng: LatLngExpression | LatLngExpression[]): this;
+    addLatLng(latlng: LatLngExpression | LatLngExpression[], latlngs?: LatLng[]): this;
     closestLayerPoint(p: Point): Point;
 
     feature?: geojson.Feature<T, P>;

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -592,6 +592,7 @@ const simplePolylineLatLngs: L.LatLngExpression[] = [[45.51, -122.68], [37.77, -
 polyline = L.polyline(simplePolylineLatLngs);
 polyline = new L.Polyline(simplePolylineLatLngs);
 polyline.setLatLngs(simplePolylineLatLngs);
+polyline.addLatLng([45.51, -122.68]);
 const simplePolylineLatLngs2: L.LatLng[] = polyline.getLatLngs() as L.LatLng[];
 
 // multi polyline
@@ -602,6 +603,8 @@ const multiPolylineLatLngs: L.LatLngExpression[][] = [
 polyline = L.polyline(multiPolylineLatLngs);
 polyline = new L.Polyline(multiPolylineLatLngs);
 polyline.setLatLngs(multiPolylineLatLngs);
+const segment = polyline.getLatLngs() as L.LatLng[][];	// this only works because we *know* it is a 2D-Array
+polyline.addLatLng([40.78, -73.91], segment[1]);
 const multiPolylineLatLngs2: L.LatLng[][] = polyline.getLatLngs() as L.LatLng[][];
 
 const obj1 = {


### PR DESCRIPTION
This patch updates the [typings for leaflet.js](https://www.npmjs.com/package/@types/leaflet). The method [Polyline.addLatLng()](https://github.com/Leaflet/Leaflet/blob/587eb48163f2b7d840c4f2ecc9bc4dfc7f3932c8/src/layer/vector/Polyline.js#L163) is defined as `@method addLatLng(latlng: LatLng, latlngs? LatLng[]): this`. The current typings do not match that definition. This is fixed with this PR.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Leaflet/Leaflet/blob/587eb48163f2b7d840c4f2ecc9bc4dfc7f3932c8/src/layer/vector/Polyline.js#L163
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.