### PR TITLE
[react-geosuggest]: add missing `ignoreEnter` property

### DIFF
--- a/types/react-geosuggest/index.d.ts
+++ b/types/react-geosuggest/index.d.ts
@@ -34,6 +34,7 @@ export interface GeosuggestProps extends Omit<InputHTMLAttributes<HTMLInputEleme
     fixtures?: Fixture[];
     maxFixtures?: number;
     googleMaps?: typeof google.maps;
+    ignoreEnter?: boolean;
     ignoreTab?: boolean;
     queryDelay?: number;
     minLength?: number;

--- a/types/react-geosuggest/react-geosuggest-tests.tsx
+++ b/types/react-geosuggest/react-geosuggest-tests.tsx
@@ -42,6 +42,7 @@ class ReactGeosuggest extends React.Component {
                     fixtures={fixtures}
                     getSuggestLabel={getSuggestLabel}
                     highlightMatch={true}
+                    ignoreEnter={true}
                     ignoreTab={true}
                     initialValue="Hamburg"
                     inputClassName="inputClassName"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ubilabs/react-geosuggest

React Geosuggest docs and source describes `ignoreEnter` prop but is not included in the `GeosuggestProps` interface.