### PR TITLE
[promise.allsettled] Added option to provide a type for PromiseRejection when using the allSettled function

### DIFF
--- a/types/promise.allsettled/implementation.d.ts
+++ b/types/promise.allsettled/implementation.d.ts
@@ -5,6 +5,7 @@ type PromiseResultTuple<T extends [unknown, ...unknown[]]> = {[P in keyof T]: Pr
 
 declare function allSettled(): Promise<[]>;
 declare function allSettled<T extends [unknown, ...unknown[]]>(iterable: PromiseTuple<T>): Promise<PromiseResultTuple<T>>;
+// tslint:disable-next-line no-unnecessary-generics
 declare function allSettled<T, E>(iterable: Iterable<Promise<T> | T>): Promise<Array<PromiseResult<T, E>>>;
 
 export = allSettled;

--- a/types/promise.allsettled/implementation.d.ts
+++ b/types/promise.allsettled/implementation.d.ts
@@ -5,6 +5,6 @@ type PromiseResultTuple<T extends [unknown, ...unknown[]]> = {[P in keyof T]: Pr
 
 declare function allSettled(): Promise<[]>;
 declare function allSettled<T extends [unknown, ...unknown[]]>(iterable: PromiseTuple<T>): Promise<PromiseResultTuple<T>>;
-declare function allSettled<T>(iterable: Iterable<Promise<T> | T>): Promise<Array<PromiseResult<T>>>;
+declare function allSettled<T, E>(iterable: Iterable<Promise<T> | T>): Promise<Array<PromiseResult<T, E>>>;
 
 export = allSettled;

--- a/types/promise.allsettled/index.d.ts
+++ b/types/promise.allsettled/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ljharb/promise.allsettled#readme
 // Definitions by: Martin Jurča <https://github.com/jurca>
 //                 Elizabeth Lorenz <https://github.com/kisaraofpern>
-//		   Nikhil Mashettiwar <https://github.com/nikmash>
+//                 Nikhil Mashettiwar <https://github.com/nikmash>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 

--- a/types/promise.allsettled/index.d.ts
+++ b/types/promise.allsettled/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/ljharb/promise.allsettled#readme
 // Definitions by: Martin Jurča <https://github.com/jurca>
 //                 Elizabeth Lorenz <https://github.com/kisaraofpern>
+//		   Nikhil Mashettiwar <https://github.com/nikmash>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
