### PR TITLE
feat(react-lazylog): Add more fields for react-lazylog 4.4.1

### DIFF
--- a/types/react-lazylog/build/LazyLog.d.ts
+++ b/types/react-lazylog/build/LazyLog.d.ts
@@ -2,33 +2,33 @@ import { Component, ReactNode, CSSProperties } from "react";
 import { Range } from "immutable";
 
 export interface LazyLogProps {
-  url: string;
-  text: string;
-  fetchOptions?: RequestInit;
-  stream?: boolean;
-  height?: string | number;
-  width?: string | number;
-  follow?: boolean;
-  scrollToLine?: number;
-  highlight?: number | number[];
-  selectableLines?: boolean;
-  formatPart?: (text: string) => ReactNode;
-  onLoad?: () => any;
-  onError?: (error: any) => any;
-  onHighlight?: (range: Range) => any;
-  rowHeight?: number;
-  overscanRowCount?: number;
-  containerStyle?: CSSProperties;
-  style?: CSSProperties;
-  loadingComponent?: any;
-  lineClassName?: string;
-  highlightLineClassName?: string;
-  extraLines?: number;
-  caseInsensitive?: boolean;
+    url: string;
+    text: string;
+    fetchOptions?: RequestInit;
+    stream?: boolean;
+    height?: string | number;
+    width?: string | number;
+    follow?: boolean;
+    scrollToLine?: number;
+    highlight?: number | number[];
+    selectableLines?: boolean;
+    formatPart?: (text: string) => ReactNode;
+    onLoad?: () => any;
+    onError?: (error: any) => any;
+    onHighlight?: (range: Range) => any;
+    rowHeight?: number;
+    overscanRowCount?: number;
+    containerStyle?: CSSProperties;
+    style?: CSSProperties;
+    loadingComponent?: any;
+    lineClassName?: string;
+    highlightLineClassName?: string;
+    extraLines?: number;
+    caseInsensitive?: boolean;
 }
 
 export class LazyLog extends Component<LazyLogProps> {
-  static defaultProps: Partial<LazyLogProps>;
+    static defaultProps: Partial<LazyLogProps>;
 }
 
 export default LazyLog;

--- a/types/react-lazylog/build/LazyLog.d.ts
+++ b/types/react-lazylog/build/LazyLog.d.ts
@@ -3,7 +3,7 @@ import { Range } from "immutable";
 
 export interface LazyLogProps {
     url: string;
-    text: string;
+    text?: string;
     fetchOptions?: RequestInit;
     stream?: boolean;
     height?: string | number;

--- a/types/react-lazylog/build/LazyLog.d.ts
+++ b/types/react-lazylog/build/LazyLog.d.ts
@@ -2,27 +2,33 @@ import { Component, ReactNode, CSSProperties } from "react";
 import { Range } from "immutable";
 
 export interface LazyLogProps {
-    url: string;
-    fetchOptions?: RequestInit;
-    stream?: boolean;
-    height?: string | number;
-    width?: string | number;
-    follow?: boolean;
-    scrollToLine?: number;
-    highlight?: number | number[];
-    selectableLines?: boolean;
-    formatPart?: (text: string) => ReactNode;
-    onLoad?: () => any;
-    onError?: (error: any) => any;
-    onHighlight?: (range: Range) => any;
-    rowHeight?: number;
-    overscanRowCount?: number;
-    containerStyle?: CSSProperties;
-    style?: CSSProperties;
+  url: string;
+  text: string;
+  fetchOptions?: RequestInit;
+  stream?: boolean;
+  height?: string | number;
+  width?: string | number;
+  follow?: boolean;
+  scrollToLine?: number;
+  highlight?: number | number[];
+  selectableLines?: boolean;
+  formatPart?: (text: string) => ReactNode;
+  onLoad?: () => any;
+  onError?: (error: any) => any;
+  onHighlight?: (range: Range) => any;
+  rowHeight?: number;
+  overscanRowCount?: number;
+  containerStyle?: CSSProperties;
+  style?: CSSProperties;
+  loadingComponent?: any;
+  lineClassName?: string;
+  highlightLineClassName?: string;
+  extraLines?: number;
+  caseInsensitive?: boolean;
 }
 
 export class LazyLog extends Component<LazyLogProps> {
-    static defaultProps: Partial<LazyLogProps>;
+  static defaultProps: Partial<LazyLogProps>;
 }
 
 export default LazyLog;

--- a/types/react-lazylog/build/SearchBar.d.ts
+++ b/types/react-lazylog/build/SearchBar.d.ts
@@ -1,0 +1,14 @@
+import { Component, ReactNode, CSSProperties } from "react";
+
+export interface SearchBarProps {
+  onSearch?: (keyword: string) => void;
+  onClearSearch?: () => void;
+  onFilterLinesWithMatches?: (isFiltered: boolean) => void;
+  resultsCount?: number;
+  filterActive?: boolean;
+  disabled?: boolean;
+}
+
+export default class SearchBar extends Component<SearchBarProps> {
+  static defaultProps: Partial<SearchBarProps>;
+}

--- a/types/react-lazylog/index.d.ts
+++ b/types/react-lazylog/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-lazylog 4.4.1
+// Type definitions for react-lazylog 4.4
 // Project: https://github.com/mozilla-frontend-infra/react-lazylog
 // Definitions by: Benjamin Romano <https://github.com/benjaminRomano>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-lazylog/index.d.ts
+++ b/types/react-lazylog/index.d.ts
@@ -4,11 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-export * from './build/LazyLog';
-export * from './build/Line';
-export * from './build/LineContent';
-export * from './build/LineNumber';
-export * from './build/LinePart';
-export * from './build/Loading';
-export * from './build/ScrollFollow';
-export * from './build/SearchBar';
+export * from "./build/LazyLog";
+export * from "./build/Line";
+export * from "./build/LineContent";
+export * from "./build/LineNumber";
+export * from "./build/LinePart";
+export * from "./build/Loading";
+export * from "./build/ScrollFollow";
+export * from "./build/SearchBar";

--- a/types/react-lazylog/index.d.ts
+++ b/types/react-lazylog/index.d.ts
@@ -1,8 +1,14 @@
-// Type definitions for react-lazylog 3.1
+// Type definitions for react-lazylog 4.4.1
 // Project: https://github.com/mozilla-frontend-infra/react-lazylog
 // Definitions by: Benjamin Romano <https://github.com/benjaminRomano>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-export * from "./build/LazyLog";
-export * from "./build/ScrollFollow";
+export * from './LazyLog';
+export * from './Line';
+export * from './LineContent';
+export * from './LineNumber';
+export * from './LinePart';
+export * from './Loading';
+export * from './ScrollFollow';
+export * from './SearchBar';

--- a/types/react-lazylog/index.d.ts
+++ b/types/react-lazylog/index.d.ts
@@ -4,11 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-export * from './LazyLog';
-export * from './Line';
-export * from './LineContent';
-export * from './LineNumber';
-export * from './LinePart';
-export * from './Loading';
-export * from './ScrollFollow';
-export * from './SearchBar';
+export * from './build/LazyLog';
+export * from './build/Line';
+export * from './build/LineContent';
+export * from './build/LineNumber';
+export * from './build/LinePart';
+export * from './build/Loading';
+export * from './build/ScrollFollow';
+export * from './build/SearchBar';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
