### PR TITLE
fix(final-form-focus): Pass FormValues to Decorator

### DIFF
--- a/types/final-form-focus/index.d.ts
+++ b/types/final-form-focus/index.d.ts
@@ -15,9 +15,11 @@ export type GetInputs = () => FocusableInput[];
 
 export type FindInput = (inputs: FocusableInput[], errors: object) => FocusableInput | undefined;
 
-export default function createDecorator(
+// tslint:disable:no-unnecessary-generics
+export default function createDecorator<FormValues = object>(
   getInputs?: GetInputs,
   findInput?: FindInput,
-): Decorator;
+): Decorator<FormValues>;
+// tslint:enable:no-unnecessary-generics
 
 export function getFormInputs(formName: string): GetInputs;

--- a/types/final-form-focus/tslint.json
+++ b/types/final-form-focus/tslint.json
@@ -1,1 +1,3 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Decorator expects a generic of `FormValues` to be passed in, otherwise it defaults to `object`


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/final-form/final-form/blob/master/src/index.d.ts#L286](source)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
