### PR TITLE
@wordpress/components Popover: Remove anchorRect prop

### DIFF
--- a/types/wordpress__components/popover/index.d.ts
+++ b/types/wordpress__components/popover/index.d.ts
@@ -4,10 +4,6 @@ import { Slot } from '@wordpress/components';
 declare namespace Popover {
     interface Props extends HTMLProps<HTMLDivElement> {
         /**
-         * A custom `DOMRect` object at which to position the popover.
-         */
-        anchorRect?: DOMRect | ClientRect;
-        /**
          * Should the popover have an animation?
          * @defaultValue true
          */


### PR DESCRIPTION
`anchorRect` prop does not seem to exist on the [`Popover` component](https://github.com/WordPress/gutenberg/blob/c7d00c64a4c74236a4aab528b3987811ab928deb/packages/components/src/popover/index.js). Remove it.

Props @ockham: https://github.com/Automattic/wp-calypso/pull/37740#discussion_r348400504

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/c7d00c64a4c74236a4aab528b3987811ab928deb/packages/components/src/popover/index.js
- **Does not apply** If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- **Does not apply** If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
