### PR TITLE
Adding HeaderLines type for mailparser

### DIFF
--- a/types/mailparser/index.d.ts
+++ b/types/mailparser/index.d.ts
@@ -42,7 +42,13 @@ export type HeaderValue = string | string[] | AddressObject | Date | StructuredH
  * A Map object with lowercase header keys.
  */
 export type Headers = Map<string, HeaderValue>;
-
+/**
+ * An array of raw header lines
+ */
+export type HeaderLines = Array<{
+    key: string;
+    line: string
+}>;
 /**
  * Address details.
  */
@@ -108,6 +114,10 @@ interface AttachmentCommon {
 	 * A Map value that holds MIME headers for the attachment node.
 	 */
 	headers: Headers;
+    /**
+	 * An array of raw header lines for the attachment node.
+	 */
+	headerLines: HeaderLines;
 	/**
 	 * A MD5 hash of the message content.
 	 */
@@ -177,6 +187,10 @@ interface ParsedMail {
 	 * - `date` value is a Date object.
 	 */
 	headers: Headers;
+    /**
+	 * An array of raw header lines
+	 */
+	headerLines: HeaderLines;
 	/**
 	 * The HTML body of the message.
 	 *

--- a/types/mailparser/index.d.ts
+++ b/types/mailparser/index.d.ts
@@ -45,7 +45,7 @@ export type Headers = Map<string, HeaderValue>;
 /**
  * An array of raw header lines
  */
-export type HeaderLines = Array<{
+export type HeaderLines = ReadonlyArray<{
     key: string;
     line: string;
 }>;

--- a/types/mailparser/index.d.ts
+++ b/types/mailparser/index.d.ts
@@ -47,7 +47,7 @@ export type Headers = Map<string, HeaderValue>;
  */
 export type HeaderLines = Array<{
     key: string;
-    line: string
+    line: string;
 }>;
 /**
  * Address details.

--- a/types/mailparser/index.d.ts
+++ b/types/mailparser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mailparser 2.4
+// Type definitions for mailparser 2.7
 // Project: https://github.com/nodemailer/mailparser
 // Definitions by: Peter Snider <https://github.com/psnider>
 //                 Andrey Volynkin <https://github.com/Avol-V>


### PR DESCRIPTION
Typing recently introduced `headerLines`; see this commit: nodemailer/mailparser@56ea813

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodemailer/mailparser/commit/56ea81366ba045aa7dd12d5847794f75fb54d71a
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.