### PR TITLE
Added definitions for protoo-server

### DIFF
--- a/types/protoo-server/index.d.ts
+++ b/types/protoo-server/index.d.ts
@@ -1,0 +1,92 @@
+// Type definitions for protoo-server 4.0
+// Project: https://protoojs.org
+// Definitions by: Antonis Balasas <https://github.com/antoniom>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { Server as HttpServer, IncomingMessage } from 'http';
+import { Server as HttpsServer } from 'https';
+import { Socket } from 'net';
+import { IServerConfig } from 'websocket';
+
+export interface ConnectionRequestInfo {
+    request: IncomingMessage;
+    origin: string;
+    socket: Socket;
+}
+
+export interface ProtooRequest {
+    request: true;
+    id: number;
+    method: string;
+    data: any;
+}
+
+export interface ProotooResponse {
+    response: true;
+    id: number;
+    ok: boolean;
+    data?: any;
+    errorCode?: number;
+    errorReason?: string;
+}
+
+export interface ProtooNotification {
+    notification: true;
+    method: string;
+    data: any;
+}
+
+export type ConnectionRequestCb = (
+    info: ConnectionRequestInfo,
+    accept: ConnectionRequestAcceptFn,
+    reject: ConnectionRequestRejectFn,
+) => void;
+
+export type ConnectionRequestAcceptFn = () => WebSocketTransport;
+
+export type ConnectionRequestRejectFn = ((code: number, reason: string) => void) | ((error: Error) => void);
+
+export type RequestCb = (request: ProtooRequest, accept: AcceptFn, reject: RejectFn) => void;
+
+export type AcceptFn = (data: any) => void;
+
+export type RejectFn = ((errorCode?: Error) => void) | ((errorCode: number, errorReason: Error | string) => void);
+
+export type EmptyCb = () => void;
+
+export type NotificationCb = (notification: ProtooNotification) => void;
+
+export class WebSocketServer {
+    constructor(server: HttpServer | HttpsServer, options?: IServerConfig);
+    stop(): void;
+    on(eventType: 'connectionrequest', callback: ConnectionRequestCb): void;
+}
+
+export class WebSocketTransport {}
+
+export class Room {
+    peers: Peer[];
+    closed: boolean;
+    constructor();
+    createPeer(peerId: string, transport: WebSocketTransport): Promise<Peer>;
+    hasPeer(peerId: string): boolean;
+    getPeer(peerId: string): Peer;
+    close(): void;
+    on(eventType: 'close', callback: EmptyCb): void;
+}
+
+export class Peer {
+    readonly id: string;
+    data: any;
+    closed: boolean;
+    request(method: string, data?: any): Promise<ProotooResponse>;
+    notify(method: string, data?: any): Promise<void>;
+    close(): void;
+    on(eventType: 'request', callback: RequestCb): void;
+    on(eventType: 'notification', callback: NotificationCb): void;
+    on(eventType: 'close', callback: EmptyCb): void;
+}
+
+export const version: string;

--- a/types/protoo-server/index.d.ts
+++ b/types/protoo-server/index.d.ts
@@ -64,7 +64,7 @@ export class WebSocketServer {
     on(eventType: 'connectionrequest', callback: ConnectionRequestCb): void;
 }
 
-export class WebSocketTransport {}
+export interface WebSocketTransport {}
 
 export class Room {
     peers: Peer[];
@@ -77,7 +77,7 @@ export class Room {
     on(eventType: 'close', callback: EmptyCb): void;
 }
 
-export class Peer {
+export interface Peer {
     readonly id: string;
     data: any;
     closed: boolean;

--- a/types/protoo-server/index.d.ts
+++ b/types/protoo-server/index.d.ts
@@ -64,7 +64,12 @@ export class WebSocketServer {
     on(eventType: 'connectionrequest', callback: ConnectionRequestCb): void;
 }
 
-export interface WebSocketTransport {}
+export interface WebSocketTransport {
+    closed: boolean;
+    toString(): string;
+    close(): void;
+    send(message: any): Promise<void>;
+}
 
 export class Room {
     peers: Peer[];

--- a/types/protoo-server/protoo-server-tests.ts
+++ b/types/protoo-server/protoo-server-tests.ts
@@ -1,0 +1,19 @@
+import { createServer } from 'http';
+import { WebSocketServer, Peer, Room, version } from 'protoo-server';
+
+const server = createServer(() => {}).listen(5000);
+const room = new Room(); // $ExpectType Room
+room.closed; // $ExpectType boolean
+
+const wss = new WebSocketServer(server);
+wss.on('connectionrequest', async (info, accept, reject) => {
+    const transport = accept();
+
+    const peer: Peer = await room.createPeer('foo', transport);
+    peer.id; // $ExpectType string
+    peer.closed; // $ExpectType boolean
+    const res = room.hasPeer('foo'); // $ExpectType boolean
+    room.getPeer('foo'); // $ExpectType Peer
+});
+
+version; // $ExpectType string

--- a/types/protoo-server/tsconfig.json
+++ b/types/protoo-server/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "protoo-server-tests.ts"
+    ]
+}

--- a/types/protoo-server/tslint.json
+++ b/types/protoo-server/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

