### PR TITLE
Add login_hint typing to gapi.auth2

### DIFF
--- a/types/gapi.auth2/gapi.auth2-tests.ts
+++ b/types/gapi.auth2/gapi.auth2-tests.ts
@@ -24,7 +24,8 @@ function test_getAuthInstance() {
 function test_signIn() {
   gapi.auth2.getAuthInstance().signIn({
     scope: 'email profile',
-    prompt: 'content'
+    prompt: 'content',
+    login_hint: 'example@example.com'
   });
 }
 
@@ -34,6 +35,7 @@ function test_signInOptionsBuild() {
   options.setFetchBasicProfile(true);
   options.setPrompt('select_account');
   options.setScope('profile').setScope('email');
+  options.setLoginHint('example@example.com');
   gapi.auth2.getAuthInstance().signIn(options);
 }
 

--- a/types/gapi.auth2/index.d.ts
+++ b/types/gapi.auth2/index.d.ts
@@ -111,6 +111,14 @@ declare namespace gapi.auth2 {
      * The default redirect_uri is the current URL stripped of query parameters and hash fragment.
      */
     redirect_uri?: string;
+    /**
+     * When your app knows which user it is trying to authenticate, it can provide this parameter as a hint to the authentication server.
+     * Passing this hint suppresses the account chooser and either pre-fill the email box on the sign-in form, or select the proper session (if the user is using multiple sign-in),
+     * which can help you avoid problems that occur if your app logs in the wrong user account. The value can be either an email address or the sub string,
+     * which is equivalent to the user's Google ID.
+     * https://developers.google.com/identity/protocols/OpenIDConnect?hl=en#authenticationuriparameters
+     */
+    login_hint?: string;
   }
 
   /**
@@ -181,6 +189,7 @@ declare namespace gapi.auth2 {
     setFetchBasicProfile(fetch: boolean): any;
     setPrompt(prompt: string): any;
     setScope(scope: string): any;
+    setLoginHint(hint: string): any;
   }
 
   interface BasicProfile {


### PR DESCRIPTION
Context Docs:
- https://developers.google.com/identity/protocols/OpenIDConnect?hl=en#authenticationuriparameters
- https://stackoverflow.com/questions/52490476/which-methods-of-google-oauth2-api-accept-login-hint-as-a-parameter

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: See context docs above. E.g.:  https://developers.google.com/identity/protocols/OpenIDConnect?hl=en#authenticationuriparameters
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. N/A
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. N/A