### PR TITLE
sinon: strongly type accessors

### DIFF
--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -351,11 +351,16 @@ declare namespace Sinon {
          * The original method can be restored by calling object.method.restore().
          * The returned spy is the function object which replaced the original method. spy === object.method.
          */
-        <T, K extends keyof T>(obj: T, method: K, types?: string[]): T[K] extends (
+        <T, K extends keyof T>(obj: T, method: K): T[K] extends (
             ...args: infer TArgs
         ) => infer TReturnValue
             ? SinonSpy<TArgs, TReturnValue>
             : SinonSpy;
+
+        <T, K extends keyof T>(obj: T, method: K, types: Array<('get'|'set')>): PropertyDescriptor & {
+            get: SinonSpy<[], T[K]>;
+            set: SinonSpy<[T[K]], void>;
+        };
     }
 
     interface SinonStub<TArgs extends any[] = any[], TReturnValue = any>

--- a/types/sinon/ts3.1/sinon-tests.ts
+++ b/types/sinon/ts3.1/sinon-tests.ts
@@ -345,6 +345,10 @@ function testAssert() {
 
 function testTypedSpy() {
     const cls = class {
+        get accessorTest() { return 5; }
+        set accessorTest(v: number) { }
+        get getterTest() { return 5; }
+        set setterTest(v: number) { }
         foo(a: number, b: string): number {
             return 3;
         }
@@ -376,6 +380,16 @@ function testTypedSpy() {
 
     stub.withArgs(5, 'x').returns(3);
     stub.withArgs(sinon.match(5), 'x').returns(5);
+
+    const accessorSpy = sinon.spy(instance, 'accessorTest', ['get', 'set']);
+    accessorSpy.get.returned(5);
+    accessorSpy.set.calledWith(55);
+
+    const getterSpy = sinon.spy(instance, 'getterTest', ['get']);
+    getterSpy.get.returned(5);
+
+    const setterSpy = sinon.spy(instance, 'setterTest', ['set']);
+    setterSpy.set.calledWith(100);
 }
 
 function testSpy() {
@@ -392,18 +406,12 @@ function testSpy() {
     const spyTwo = sinon.spy().named('spyTwo');
 
     const methodSpy = sinon.spy(instance, 'foo'); // $ExpectType SinonSpy<[], void>
-    const methodSpy2 = sinon.spy(instance, 'bar', ['set', 'get']); // $ExpectType SinonSpy<any[], any>
-    const methodSpy3 = sinon.spy(instance, 'foobar'); // $ExpectType SinonSpy<[(string | undefined)?], string | undefined>
+    const methodSpy2 = sinon.spy(instance, 'foobar'); // $ExpectType SinonSpy<[(string | undefined)?], string | undefined>
 
     methodSpy.calledBefore(methodSpy2);
     methodSpy.calledAfter(methodSpy2);
     methodSpy.calledImmediatelyBefore(methodSpy2);
     methodSpy.calledImmediatelyAfter(methodSpy2);
-
-    methodSpy.calledBefore(methodSpy3);
-    methodSpy.calledAfter(methodSpy3);
-    methodSpy.calledImmediatelyBefore(methodSpy3);
-    methodSpy.calledImmediatelyAfter(methodSpy3);
 
     let count = 0;
     count = spy.callCount;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sinonjs/sinon/blob/a4724928a311ce66aa418b7ba835b4df81cca1f6/lib/sinon/spy.js#L184

a recent pr tried to sort this but got closed by the bot from inactivity and was slightly wrong. so here's my attempt

downside: the types are over-matching so you'll see a spied-on setter even if you don't spy the setter. but its better than what it is currently: broken.

to explain a little, the current types mean `spy(obj ,'prop', ['get'])` returns a spy. This is incorrect.

this change corrects that, so it now returns a descriptor instead which contains spies (e.g. `{get: Spy, set: Spy}`).