### PR TITLE
[chart.js] Add DoughnutModel interface

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -305,3 +305,46 @@ Chart.defaults.global.defaultFontFamily = 'Arial';
 Chart.defaults.global.tooltips.backgroundColor = '#0a2c54';
 Chart.defaults.global.tooltips.cornerRadius = 2;
 Chart.defaults.global.tooltips.displayColors = false;
+
+// Testing DoughnutModel
+const doughnutChart = new Chart(ctx, {
+    type: 'doughnut',
+    data: {
+        datasets: [
+            {
+                backgroundColor: '#ff0000',
+                borderColor: '#000000',
+                borderWidth: 3,
+                data: [1, 3, 5]
+            }
+        ]
+    }
+});
+
+if (doughnutChart.getDatasetMeta(0).data.length > 0) {
+    const doughnutChartModel = doughnutChart.getDatasetMeta(0).data[0]._model as Chart.DoughnutModel;
+    console.log(doughnutChartModel.backgroundColor);
+    console.log(doughnutChartModel.borderAlign);
+    console.log(doughnutChartModel.borderColor);
+    console.log(doughnutChartModel.borderWidth);
+    console.log(doughnutChartModel.circumference);
+    console.log(doughnutChartModel.endAngle);
+    console.log(doughnutChartModel.innerRadius);
+    console.log(doughnutChartModel.outerRadius);
+    console.log(doughnutChartModel.startAngle);
+    console.log(doughnutChartModel.x);
+    console.log(doughnutChartModel.y);
+
+    const doughnutChartView = doughnutChart.getDatasetMeta(0).data[0]._view as Chart.DoughnutModel;
+    console.log(doughnutChartView.backgroundColor);
+    console.log(doughnutChartView.borderAlign);
+    console.log(doughnutChartView.borderColor);
+    console.log(doughnutChartView.borderWidth);
+    console.log(doughnutChartView.circumference);
+    console.log(doughnutChartView.endAngle);
+    console.log(doughnutChartView.innerRadius);
+    console.log(doughnutChartView.outerRadius);
+    console.log(doughnutChartView.startAngle);
+    console.log(doughnutChartView.x);
+    console.log(doughnutChartView.y);
+}

--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -306,7 +306,6 @@ Chart.defaults.global.tooltips.backgroundColor = '#0a2c54';
 Chart.defaults.global.tooltips.cornerRadius = 2;
 Chart.defaults.global.tooltips.displayColors = false;
 
-// Testing DoughnutModel
 const doughnutChart = new Chart(ctx, {
     type: 'doughnut',
     data: {
@@ -321,6 +320,60 @@ const doughnutChart = new Chart(ctx, {
     }
 });
 
+// Testing Model properties
+if (doughnutChart.getDatasetMeta(0).data.length > 0) {
+    const doughnutChartModel = doughnutChart.getDatasetMeta(0).data[0]._model;
+    console.log(doughnutChartModel.backgroundColor);
+    console.log(doughnutChartModel.borderAlign);
+    console.log(doughnutChartModel.borderColor);
+    console.log(doughnutChartModel.borderWidth);
+    console.log(doughnutChartModel.circumference);
+    console.log(doughnutChartModel.controlPointNextX);
+    console.log(doughnutChartModel.controlPointNextY);
+    console.log(doughnutChartModel.controlPointPreviousX);
+    console.log(doughnutChartModel.controlPointPreviousY);
+    console.log(doughnutChartModel.endAngle);
+    console.log(doughnutChartModel.hitRadius);
+    console.log(doughnutChartModel.innerRadius);
+    console.log(doughnutChartModel.outerRadius);
+    console.log(doughnutChartModel.pointStyle);
+    console.log(doughnutChartModel.radius);
+    console.log(doughnutChartModel.skip);
+    console.log(doughnutChartModel.startAngle);
+    console.log(doughnutChartModel.steppedLine);
+    console.log(doughnutChartModel.tension);
+    console.log(doughnutChartModel.x);
+    console.log(doughnutChartModel.y);
+    console.log(doughnutChartModel.base);
+    console.log(doughnutChartModel.head);
+
+    const doughnutChartView = doughnutChart.getDatasetMeta(0).data[0]._view;
+    console.log(doughnutChartView.backgroundColor);
+    console.log(doughnutChartView.borderAlign);
+    console.log(doughnutChartView.borderColor);
+    console.log(doughnutChartView.borderWidth);
+    console.log(doughnutChartView.circumference);
+    console.log(doughnutChartView.controlPointNextX);
+    console.log(doughnutChartView.controlPointNextY);
+    console.log(doughnutChartView.controlPointPreviousX);
+    console.log(doughnutChartView.controlPointPreviousY);
+    console.log(doughnutChartView.endAngle);
+    console.log(doughnutChartView.hitRadius);
+    console.log(doughnutChartView.innerRadius);
+    console.log(doughnutChartView.outerRadius);
+    console.log(doughnutChartView.pointStyle);
+    console.log(doughnutChartView.radius);
+    console.log(doughnutChartView.skip);
+    console.log(doughnutChartView.startAngle);
+    console.log(doughnutChartView.steppedLine);
+    console.log(doughnutChartView.tension);
+    console.log(doughnutChartView.x);
+    console.log(doughnutChartView.y);
+    console.log(doughnutChartView.base);
+    console.log(doughnutChartView.head);
+}
+
+// Testing DoughnutModel properties
 if (doughnutChart.getDatasetMeta(0).data.length > 0) {
     const doughnutChartModel = doughnutChart.getDatasetMeta(0).data[0]._model as Chart.DoughnutModel;
     console.log(doughnutChartModel.backgroundColor);

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -97,26 +97,35 @@ interface MetaData {
     _chart: Chart;
     _datasetIndex: number;
     _index: number;
-    _model: Chart.ModelType;
+    _model: Model;
     _start?: any;
-    _view: Chart.ModelType;
+    _view: Model;
     _xScale: Chart.ChartScales;
     _yScale: Chart.ChartScales;
     hidden?: boolean;
 }
 
+// NOTE: This model is generic with a bunch of optional properties to represent all types of chart models.
+// Each chart type defines their own unique model structure so some of these optional properties
+// might always have values depending on the chart type.
 interface Model {
     backgroundColor: string;
+    borderAlign?: Chart.BorderAlignment;
     borderColor: string;
     borderWidth?: number;
+    circumference?: number;
     controlPointNextX: number;
     controlPointNextY: number;
     controlPointPreviousX: number;
     controlPointPreviousY: number;
+    endAngle?: number;
     hitRadius: number;
+    innerRadius?: number;
+    outerRadius?: number;
     pointStyle: string;
     radius: string;
     skip?: boolean;
+    startAngle?: number;
     steppedLine?: undefined;
     tension: number;
     x: number;
@@ -148,8 +157,6 @@ declare namespace Chart {
     type BorderAlignment = 'center' | 'inner';
 
     type BorderWidth = number | { [key in PositionType]?: number };
-
-    type ModelType = Model | DoughnutModel;
 
     interface ChartArea {
         top: number;
@@ -804,6 +811,7 @@ declare namespace Chart {
         easing?: Easing;
     }
 
+    // Model used with the doughnut chart
     interface DoughnutModel {
         backgroundColor: ChartColor;
         borderAlign: BorderAlignment;

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -97,9 +97,9 @@ interface MetaData {
     _chart: Chart;
     _datasetIndex: number;
     _index: number;
-    _model: Model;
+    _model: Chart.ModelType;
     _start?: any;
-    _view: Model;
+    _view: Chart.ModelType;
     _xScale: Chart.ChartScales;
     _yScale: Chart.ChartScales;
     hidden?: boolean;
@@ -148,6 +148,8 @@ declare namespace Chart {
     type BorderAlignment = 'center' | 'inner';
 
     type BorderWidth = number | { [key in PositionType]?: number };
+
+    type ModelType = Model | DoughnutModel;
 
     interface ChartArea {
         top: number;
@@ -800,6 +802,20 @@ declare namespace Chart {
         duration?: number;
         lazy?: boolean;
         easing?: Easing;
+    }
+
+    interface DoughnutModel {
+        backgroundColor: ChartColor;
+        borderAlign: BorderAlignment;
+        borderColor: string;
+        borderWidth: number;
+        circumference: number;
+        endAngle: number;
+        innerRadius: number;
+        outerRadius: number;
+        startAngle: number;
+        x: number;
+        y: number;
     }
 }
 


### PR DESCRIPTION
The existing `Model` interface didn't have most of the Doughnut chart model properties defined. I'm creating a new `DoughnutModel` interface that is specific to the Doughnut chart. I don't have time to create a new model interface for each chart type but hopefully that can be incrementally updated in future PRs.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * https://github.com/chartjs/Chart.js/blob/master/src/controllers/controller.doughnut.js#L242-L254
  * https://github.com/chartjs/Chart.js/blob/master/test/specs/controller.doughnut.tests.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
