### PR TITLE
add missing option for case-sensitive-paths-webpack-plugin

### DIFF
--- a/types/case-sensitive-paths-webpack-plugin/index.d.ts
+++ b/types/case-sensitive-paths-webpack-plugin/index.d.ts
@@ -20,5 +20,9 @@ declare namespace CaseSensitivePathsWebpackPlugin {
          * Show more information
          */
         debug?: boolean;
+        /**
+         * Run before emit instead of after resolve for individual files
+         */
+        useBeforeEmitHook?: boolean;
     }
 }


### PR DESCRIPTION
When scrolling through the template I noticed this will be a lousy pull request. I thought I'd contribute something back, but it seems the investment is a bit bigger than the change and time I have available.

I would understand if this pull request was rejected, but maybe someone with a little more time can pick it up.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Urthen/case-sensitive-paths-webpack-plugin/blob/c821025cde4c98fe4043cddc045a46396f855e0f/index.js#L172
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - **version 2.2.0**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
