### PR TITLE
Remove relative types="../react" reference in react-howler

### DIFF
--- a/types/react-howler/index.d.ts
+++ b/types/react-howler/index.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 
-/// <reference types="../react"/>
-/// <reference types="../howler"/>
+/// <reference types="react"/>
+/// <reference types="howler"/>
 
 import * as React from 'react';
 import { Howl } from 'howler';

--- a/types/react-howler/index.d.ts
+++ b/types/react-howler/index.d.ts
@@ -4,9 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 
-/// <reference types="react"/>
-/// <reference types="howler"/>
-
 import * as React from 'react';
 import { Howl } from 'howler';
 


### PR DESCRIPTION
CI doesn't checking `types` references, but will in an upcoming PR. I want Definitely Typed to be clean before merging it.