### PR TITLE
[@types/blessed] Allow additional properties for `IOptions` interface

### DIFF
--- a/types/blessed/blessed-tests.ts
+++ b/types/blessed/blessed-tests.ts
@@ -53,6 +53,12 @@ screen.key("q", () => screen.destroy());
 
 screen.render();
 
+// Allow for arbitrary extra properties to be stored in `options`
+const extraProps = blessed.box({
+  parent: box1,
+  id: 'box3'
+});
+
 // https://github.com/chjj/blessed/blob/master/test/widget-bigtext.js
 
 screen = blessed.screen({

--- a/types/blessed/index.d.ts
+++ b/types/blessed/index.d.ts
@@ -595,7 +595,9 @@ export namespace Widgets {
         destroy(): void;
     }
 
-    interface IOptions {}
+    interface IOptions {
+        [name: string]: any;
+    }
 
     interface IHasOptions<T extends IOptions> {
         options: T;

--- a/types/blessed/index.d.ts
+++ b/types/blessed/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Bryn Austin Bellomy <https://github.com/brynbellomy>
 //                 Steve Kellock <https://github.com/skellock>
 //                 Max Brauer <https://github.com/mamachanko>
+//                 Nathan Rajlich <https://github.com/TooTallNate>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 // TypeScript Version: 2.1
 


### PR DESCRIPTION
This change allows for arbitrary properties to be stored onto the options object of `Node` instances. This is useful for extra metadata to be stored onto a node and is accessible on the `node.options` property.

For example, the [`blessed-css`](https://github.com/TooTallNate/blessed-css) module utilizes the additional properties `id` and `className` for matching CSS selectors:

```typescript
const bg = blessed.box({
    parent: screen,
    id: 'bg'
});

console.log(bg.options.id);
// "bg"
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/TooTallNate/blessed-css#example