### PR TITLE
(react-image-gallery):added renderThumbInner def to ReactImageGalleryProps

### DIFF
--- a/types/react-image-gallery/index.d.ts
+++ b/types/react-image-gallery/index.d.ts
@@ -81,6 +81,7 @@ export interface ReactImageGalleryProps {
     renderPlayPauseButton?: (onClick: React.MouseEventHandler<HTMLElement>, isPlaying: boolean) => React.ReactNode;
     renderFullscreenButton?: (onClick: React.MouseEventHandler<HTMLElement>, isFullscreen: boolean) => React.ReactNode;
     renderItem?: (item: ReactImageGalleryItem) => React.ReactNode;
+    renderThumbInner?(item?: ReactImageGalleryItem): React.ReactNode;
     stopPropagation?: boolean;
     additionalClass?: string;
     useTranslate3D?: boolean;

--- a/types/react-image-gallery/index.d.ts
+++ b/types/react-image-gallery/index.d.ts
@@ -81,7 +81,7 @@ export interface ReactImageGalleryProps {
     renderPlayPauseButton?: (onClick: React.MouseEventHandler<HTMLElement>, isPlaying: boolean) => React.ReactNode;
     renderFullscreenButton?: (onClick: React.MouseEventHandler<HTMLElement>, isFullscreen: boolean) => React.ReactNode;
     renderItem?: (item: ReactImageGalleryItem) => React.ReactNode;
-    renderThumbInner?(item?: ReactImageGalleryItem): React.ReactNode;
+    renderThumbInner?: (item: ReactImageGalleryItem) => React.ReactNode;
     stopPropagation?: boolean;
     additionalClass?: string;
     useTranslate3D?: boolean;

--- a/types/react-image-gallery/react-image-gallery-tests.tsx
+++ b/types/react-image-gallery/react-image-gallery-tests.tsx
@@ -10,6 +10,23 @@ class ImageGallery extends React.Component {
         }
     }
 
+    renderThumbInner(item: ReactImageGalleryItem) {
+        return (
+            <div className="image-gallery-thumbnail-inner">
+                <img
+                    src={item.thumbnail}
+                    alt={item.thumbnailAlt}
+                    title={item.thumbnailTitle}
+                />
+                {item.thumbnailLabel && (
+                    <div className="image-gallery-thumbnail-label">
+                        {item.thumbnailLabel}
+                    </div>
+                )}
+            </div>
+        );
+    }
+
     render() {
         const galleryItem: ReactImageGalleryItem = {
             original: 'http://localhost/logo.jpg',
@@ -20,7 +37,8 @@ class ImageGallery extends React.Component {
         const props: ReactImageGalleryProps = {
             items: [galleryItem],
             autoPlay: false,
-            showFullscreenButton: false
+            showFullscreenButton: false,
+            renderThumbInner: this.renderThumbInner
         };
 
         return <ReactImageGallery ref={(r) => this.gallery = r} {...props} />;

--- a/types/react-image-gallery/react-image-gallery-tests.tsx
+++ b/types/react-image-gallery/react-image-gallery-tests.tsx
@@ -10,7 +10,7 @@ class ImageGallery extends React.Component {
         }
     }
 
-    renderThumbInner(item: ReactImageGalleryItem) {
+    renderThumbInner(item: ReactImageGalleryItem): React.ReactNode {
         return (
             <div className="image-gallery-thumbnail-inner">
                 <img


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/xiaolin/react-image-gallery (see: `renderThumbInner`)
- [x] This is an old feature: https://github.com/xiaolin/react-image-gallery/commit/c9cc9c495ff28115d9229c5b12695ec881d45c68

Can't run `compile-scripts`, as getting the below errors:

```
> tsc -p scripts

error TS5055: Cannot write file '/Users/samhouse/Documents/Coding/open_source/DefinitelyTyped/scripts/not-needed.js' because it would overwrite input file.

error TS5055: Cannot write file '/Users/samhouse/Documents/Coding/open_source/DefinitelyTyped/scripts/update-codeowners.js' because it would overwrite input file.
```
