### PR TITLE
[jws] Allow JOSE header parameter types other than string, as defined in RFC

### DIFF
--- a/types/jws/index.d.ts
+++ b/types/jws/index.d.ts
@@ -150,5 +150,5 @@ export type Algorithm = 'HS256' | 'HS384' | 'HS512' | 'RS256' |
 
 export interface Header {
     alg: Algorithm;
-    [name: string]: string | string[] | number | undefined;
+    [name: string]: string | ReadonlyArray<string> | number | undefined;
 }

--- a/types/jws/index.d.ts
+++ b/types/jws/index.d.ts
@@ -150,5 +150,5 @@ export type Algorithm = 'HS256' | 'HS384' | 'HS512' | 'RS256' |
 
 export interface Header {
     alg: Algorithm;
-    [name: string]: string;
+    [name: string]: string | string[] | number | undefined;
 }

--- a/types/jws/index.d.ts
+++ b/types/jws/index.d.ts
@@ -172,5 +172,5 @@ export interface CertificateProperties extends PrivateProperties {
 }
 
 export interface PrivateProperties {
-    [name: string]: any
+    [name: string]: any;
 }

--- a/types/jws/index.d.ts
+++ b/types/jws/index.d.ts
@@ -148,27 +148,29 @@ export type Algorithm = 'HS256' | 'HS384' | 'HS512' | 'RS256' |
                         'ES512' | 'PS256' | 'PS384' | 'PS512' |
                         'none';
 
-export type Header = {
+export interface Header extends CertificateProperties {
     alg: Algorithm;
     jwk?: JWK;
     typ?: string;
     cty?: string;
     crit?: ReadonlyArray<string>;
-} & CertificateProperties & {
-    [name: string]: any
-};
+}
 
-export type JWK = {
+export interface JWK extends CertificateProperties {
     alg?: Algorithm;
     kty: string;
     use?: string;
     key_ops?: ReadonlyArray<string>;
-} & CertificateProperties;
+}
 
-export interface CertificateProperties {
+export interface CertificateProperties extends PrivateProperties {
     kid?: string;
     x5u?: string;
     x5c?: ReadonlyArray<string>;
     x5t?: string;
     'x5t#S256'?: string;
+}
+
+export interface PrivateProperties {
+    [name: string]: any
 }

--- a/types/jws/index.d.ts
+++ b/types/jws/index.d.ts
@@ -153,7 +153,7 @@ export type Header = {
     jwk?: JWK;
     typ?: string;
     cty?: string;
-    crit?: string[];
+    crit?: ReadonlyArray<string>;
 } & CertificateProperties & {
     [name: string]: any
 };
@@ -168,7 +168,7 @@ export type JWK = {
 export interface CertificateProperties {
     kid?: string;
     x5u?: string;
-    x5c?: string[];
+    x5c?: ReadonlyArray<string>;
     x5t?: string;
     'x5t#S256'?: string;
 }

--- a/types/jws/index.d.ts
+++ b/types/jws/index.d.ts
@@ -148,7 +148,27 @@ export type Algorithm = 'HS256' | 'HS384' | 'HS512' | 'RS256' |
                         'ES512' | 'PS256' | 'PS384' | 'PS512' |
                         'none';
 
-export interface Header {
+export type Header = {
     alg: Algorithm;
-    [name: string]: string | ReadonlyArray<string> | number | undefined;
+    jwk?: JWK;
+    typ?: string;
+    cty?: string;
+    crit?: string[];
+} & CertificateProperties & {
+    [name: string]: any
+}
+
+export type JWK = {
+    alg?: Algorithm;
+    kty: string;
+    use?: string;
+    key_ops?: ReadonlyArray<string>;
+} & CertificateProperties;
+
+export type CertificateProperties = {
+    kid?: string;
+    x5u?: string;
+    x5c?: string[];
+    x5t?: string;
+    'x5t#S256'?: string;
 }

--- a/types/jws/index.d.ts
+++ b/types/jws/index.d.ts
@@ -156,7 +156,7 @@ export type Header = {
     crit?: string[];
 } & CertificateProperties & {
     [name: string]: any
-}
+};
 
 export type JWK = {
     alg?: Algorithm;
@@ -165,7 +165,7 @@ export type JWK = {
     key_ops?: ReadonlyArray<string>;
 } & CertificateProperties;
 
-export type CertificateProperties = {
+export interface CertificateProperties {
     kid?: string;
     x5u?: string;
     x5c?: string[];


### PR DESCRIPTION
- According to [RFC7515 4.1.11](https://tools.ietf.org/html/rfc7515#section-4.1.11) JOSE headers in JWS can be an array of strings (for `crit` property)
- The same point, as well as [RFC7519 4.1.4](https://tools.ietf.org/html/rfc7519#section-4.1.4) shows that using a number as header value for `exp` is possible
- To allow more dynamic structures and better code, allowing undefined, as it does not result in the resulting signature and/or JOSE header (after decoding back to JSON) to be different. Consider this:
```ts
type JsonWebSignatureHeader = {
    alg: JsonWebSignatureAlgorithm;
    jku?: string;
};

const header: JsonWebSignatureHeader = {
    alg: 'RS256'
};

createSign({
    header
}).on('done', (signature: string) => {
    console.log(signature);
});
```
this would result in an error `Type 'string | undefined' is not assignable to type 'string'.` because `jku` is optional property of `JsonWebSignatureHeader`, while still being correct header object for JWS.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianloveswords/node-jws
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~ Fixes existing version types
- [x] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~ no substantial changes