### PR TITLE
auth0.widget: fix reference to auth0-js

### DIFF
--- a/types/auth0.widget/index.d.ts
+++ b/types/auth0.widget/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Robert McLaws <https://github.com/advancedrei>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="auth0-js/v7" />
+/// <reference types="auth0-js" />
 
 interface Auth0WidgetStatic {
     new(params: Auth0Constructor): Auth0WidgetStatic;


### PR DESCRIPTION
It would like to reference v7, but it does so with a triple-slash reference:

```ts
/// <reference types="auth0-js/v7" />
```

This reference doesn't work in the shipped version of auth0.widget.
The full fix for this is to all package.json references to `@types/auth0-js@7`, but this isn't needed to fix this particular problem because just referring to the current version works fine:

```ts
/// <reference types="auth0-js" />
```