### PR TITLE
fast-text-encoding: Add v1 types

### DIFF
--- a/types/fast-text-encoding/fast-text-encoding-tests.ts
+++ b/types/fast-text-encoding/fast-text-encoding-tests.ts
@@ -1,0 +1,20 @@
+import 'fast-text-encoding';
+
+const encoder1 = new TextEncoder();
+const _encoder2 = new TextEncoder('utf-8');
+
+const _encoderEncoding = encoder1.encoding;
+
+const _encoded1 = encoder1.encode('foo');
+const _encoded2 = encoder1.encode('foo', { stream: false });
+
+const decoder1 = new TextDecoder();
+const _decoder2 = new TextDecoder('utf-8');
+const _decoder3 = new TextDecoder('utf-8', { fatal: false });
+
+const _decoderEncoding = decoder1.encoding;
+const _decoderFatal = decoder1.fatal;
+const _decoderIgnoreBOM = decoder1.ignoreBOM;
+
+const _decoded1 = decoder1.decode(new Uint8Array(16));
+const _decoded2 = decoder1.decode(new Uint8Array(16), { stream: false });

--- a/types/fast-text-encoding/index.d.ts
+++ b/types/fast-text-encoding/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for fast-text-encoding 1.0
+// Project: https://github.com/samthor/fast-text-encoder#readme
+// Definitions by: Ciarán Ingle <https://github.com/inglec-arista>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace fastTextEncoder {
+    interface Options {
+        stream: boolean;
+    }
+}
+
+declare class TextEncoder {
+    encoding: string;
+
+    constructor(label?: string);
+
+    encode(string: string, options?: fastTextEncoder.Options): Uint8Array;
+}
+
+declare class TextDecoder {
+    encoding: string;
+    fatal: boolean;
+    ignoreBOM: boolean;
+
+    constructor(utfLabel?: string, options?: { fatal: boolean });
+
+    decode(buffer: Uint8Array, options?: fastTextEncoder.Options): string;
+}

--- a/types/fast-text-encoding/tsconfig.json
+++ b/types/fast-text-encoding/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+      "fast-text-encoding-tests.ts",
+      "index.d.ts"
+    ]
+}

--- a/types/fast-text-encoding/tslint.json
+++ b/types/fast-text-encoding/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
fast-text-encoding updates browser globals, hence no types are exported and no tests are provided.