### PR TITLE
Stripe: Add Type for FileLinks

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -4035,7 +4035,7 @@ declare namespace Stripe {
              * Only return links for the given file.
              */
             file?: string;
-            
+
             /**
              * Filter links by their expiration status. By default, all links are returned.
              */

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -3977,30 +3977,37 @@ declare namespace Stripe {
              * Value is 'file_link'
              */
             object: 'file_link';
+
             /**
              * Time at which the object was created. Measured in seconds since the Unix epoch.
              */
             created: number;
+
             /**
              * Whether this link is already expired.
              */
             expired: boolean;
+
             /**
              * Time at which the link expires.
              */
             expires_at: number;
+
             /**
              * The file object this link points to
              */
             file: string;
+
             /**
              * Has the value true if the object exists in live mode or the value false if the object exists in test mode.
              */
             livemode: boolean;
+
             /**
              * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
              */
             metadata: IMetadata;
+
             /**
              * The publicly accessible URL to download the file.
              */
@@ -4012,6 +4019,7 @@ declare namespace Stripe {
              * The ID of the file
              */
             file: string;
+
             /**
              * A future timestamp after which the link will no longer be usable.
              */
@@ -4027,6 +4035,7 @@ declare namespace Stripe {
              * Only return links for the given file.
              */
             file?: string;
+            
             /**
              * Filter links by their expiration status. By default, all links are returned.
              */

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -4026,11 +4026,11 @@ declare namespace Stripe {
             /**
              * Only return links for the given file.
              */
-            file: string;
+            file?: string;
             /**
              * Filter links by their expiration status. By default, all links are returned.
              */
-            expired: boolean;
+            expired?: boolean;
         }
     }
 

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -33,6 +33,7 @@
 //                 Claus Stilborg <https://github.com/stilborg>
 //                 Jorgen Vik <https://github.com/jvik>
 //                 Richard Ward <https://github.com/richardwardza>
+//                 Aseel Al Dallal <https://github.com/Aseelaldallal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -4019,7 +4019,7 @@ declare namespace Stripe {
         }
 
         interface IFileLinksUpdateOptions extends IDataOptionsWithMetadata {
-            expires_at?: number;
+            expires_at?: number | 'now';
         }
 
         interface IFileLinksListOptions extends IListOptionsCreated {

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -3972,7 +3972,6 @@ declare namespace Stripe {
     }
 
     namespace fileLinks {
-
         interface IFileLink extends IResourceObject {
             /**
              * Value is 'file_link'
@@ -3987,7 +3986,7 @@ declare namespace Stripe {
              */
             expired: boolean;
             /**
-             * Time at which the link expires. 
+             * Time at which the link expires.
              */
             expires_at: number;
             /**
@@ -3995,22 +3994,22 @@ declare namespace Stripe {
              */
             file: string;
             /**
-             * Has the value true if the object exists in live mode or the value false if the object exists in test mode. 
+             * Has the value true if the object exists in live mode or the value false if the object exists in test mode.
              */
             livemode: boolean;
             /**
              * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
              */
             metadata: IMetadata;
-            /** 
-             * The publicly accessible URL to download the file. 
+            /**
+             * The publicly accessible URL to download the file.
              */
             url: string;
         }
 
         interface IFileLinksCreationOptions extends IDataOptionsWithMetadata {
-            /** 
-             * The ID of the file 
+            /**
+             * The ID of the file
              */
             file: string;
             /**
@@ -12784,7 +12783,7 @@ declare namespace Stripe {
             retrieve(id: string, response?: IResponseFn<fileLinks.IFileLink>): Promise<fileLinks.IFileLink>;
 
             /**
-             * Updates an existing file link object. Expired links can no longer be updated. Returns the file link object if successful, 
+             * Updates an existing file link object. Expired links can no longer be updated. Returns the file link object if successful,
              * and throws an error otherwise.
              */
             update(

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -107,12 +107,10 @@ declare class Stripe {
      * @deprecated
      */
     recipientCards: Stripe.resources.RecipientCards;
-
     /**
      * @deprecated
      */
     recipients: Stripe.resources.Recipients;
-
     subscriptions: Stripe.resources.Subscriptions;
     subscriptionItems: Stripe.resources.SubscriptionItems;
     tokens: Stripe.resources.Tokens;

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -107,16 +107,19 @@ declare class Stripe {
      * @deprecated
      */
     recipientCards: Stripe.resources.RecipientCards;
+
     /**
      * @deprecated
      */
     recipients: Stripe.resources.Recipients;
+
     subscriptions: Stripe.resources.Subscriptions;
     subscriptionItems: Stripe.resources.SubscriptionItems;
     tokens: Stripe.resources.Tokens;
     transfers: Stripe.resources.Transfers;
     applicationFees: Stripe.resources.ApplicationFees;
     files: Stripe.resources.Files;
+    fileLinks: Stripe.resources.FileLinks;
     bitcoinReceivers: Stripe.resources.BitcoinReceivers;
     refunds: Stripe.resources.Refunds;
     countrySpecs: Stripe.resources.CountrySpecs;
@@ -3968,6 +3971,70 @@ declare namespace Stripe {
             | 'identity_document'
             | 'incorporation_article'
             | 'incorporation_document';
+    }
+
+    namespace fileLinks {
+
+        interface IFileLink extends IResourceObject {
+            /**
+             * Value is 'file_link'
+             */
+            object: 'file_link';
+            /**
+             * Time at which the object was created. Measured in seconds since the Unix epoch.
+             */
+            created: number;
+            /**
+             * Whether this link is already expired.
+             */
+            expired: boolean;
+            /**
+             * Time at which the link expires. 
+             */
+            expires_at: number;
+            /**
+             * The file object this link points to
+             */
+            file: string;
+            /**
+             * Has the value true if the object exists in live mode or the value false if the object exists in test mode. 
+             */
+            livemode: boolean;
+            /**
+             * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+             */
+            metadata: IMetadata;
+            /** 
+             * The publicly accessible URL to download the file. 
+             */
+            url: string;
+        }
+
+        interface IFileLinksCreationOptions extends IDataOptionsWithMetadata {
+            /** 
+             * The ID of the file 
+             */
+            file: string;
+            /**
+             * A future timestamp after which the link will no longer be usable.
+             */
+            expires_at?: number;
+        }
+
+        interface IFileLinksUpdateOptions extends IDataOptionsWithMetadata {
+            expires_at?: number;
+        }
+
+        interface IFileLinksListOptions extends IListOptionsCreated {
+            /**
+             * Only return links for the given file.
+             */
+            file: string;
+            /**
+             * Filter links by their expiration status. By default, all links are returned.
+             */
+            expired: boolean;
+        }
     }
 
     namespace invoices {
@@ -12681,6 +12748,76 @@ declare namespace Stripe {
                 response?: IResponseFn<IList<files.IFileUpdate>>,
             ): IListPromise<files.IFileUpdate>;
             list(response?: IResponseFn<IList<files.IFileUpdate>>): IListPromise<files.IFileUpdate>;
+        }
+
+        class FileLinks extends StripeResource {
+            /**
+             * Creates a new file link object.
+             */
+            create(
+                data: fileLinks.IFileLinksCreationOptions,
+                options: HeaderOptions,
+                response?: IResponseFn<fileLinks.IFileLink>,
+            ): Promise<fileLinks.IFileLink>;
+            create(
+                data: fileLinks.IFileLinksCreationOptions,
+                response?: IResponseFn<fileLinks.IFileLink>,
+            ): Promise<fileLinks.IFileLink>;
+
+            /**
+             * Returns a file link object if a valid identifier was provided, and throws an error otherwise.
+             */
+            retrieve(
+                id: string,
+                data: IDataOptions,
+                options: HeaderOptions,
+                response?: IResponseFn<fileLinks.IFileLink>,
+            ): Promise<fileLinks.IFileLink>;
+            retrieve(
+                id: string,
+                data: IDataOptions,
+                response?: IResponseFn<fileLinks.IFileLink>,
+            ): Promise<fileLinks.IFileLink>;
+            retrieve(
+                id: string,
+                options: HeaderOptions,
+                response?: IResponseFn<fileLinks.IFileLink>,
+            ): Promise<fileLinks.IFileLink>;
+            retrieve(id: string, response?: IResponseFn<fileLinks.IFileLink>): Promise<fileLinks.IFileLink>;
+
+            /**
+             * Updates an existing file link object. Expired links can no longer be updated. Returns the file link object if successful, 
+             * and throws an error otherwise.
+             */
+            update(
+                id: string,
+                data: fileLinks.IFileLinksUpdateOptions,
+                options: HeaderOptions,
+                response?: IResponseFn<fileLinks.IFileLink>,
+            ): Promise<fileLinks.IFileLink>;
+            update(
+                id: string,
+                data: fileLinks.IFileLinksUpdateOptions,
+                response?: IResponseFn<fileLinks.IFileLink>,
+            ): Promise<fileLinks.IFileLink>;
+
+            /**
+             * Returns a list of file links
+             */
+            list(
+                data: fileLinks.IFileLinksListOptions,
+                options: HeaderOptions,
+                response?: IResponseFn<IList<fileLinks.IFileLink>>,
+            ): IListPromise<fileLinks.IFileLink>;
+            list(
+                data: fileLinks.IFileLinksListOptions,
+                response?: IResponseFn<IList<fileLinks.IFileLink>>,
+            ): IListPromise<fileLinks.IFileLink>;
+            list(
+                options: HeaderOptions,
+                response?: IResponseFn<IList<fileLinks.IFileLink>>,
+            ): IListPromise<fileLinks.IFileLink>;
+            list(response?: IResponseFn<IList<fileLinks.IFileLink>>): IListPromise<fileLinks.IFileLink>;
         }
 
         class Invoices extends StripeResource {

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1661,6 +1661,8 @@ stripe.coupons.list({ limit: 3 }).then(coupons => {
 // ##################################################################################
 
 stripe.fileLinks.create({ file: 'file_1FgxGXBZBR5SQORg4FkgjG2O' }, (err, fileLink) => {
+    console.log('Err', err);
+    console.log('FileLink', fileLink);
     // asynchronously called
 });
 

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1678,7 +1678,31 @@ stripe.fileLinks.retrieve('link_1FhJXrBZBR5SQORg2hZCYnZ7', (err, fileLink) => {
 });
 
 stripe.fileLinks.retrieve('link_1FhJXrBZBR5SQORg2hZCYnZ7').then(fileLink => {
-    fileLink; // $ExpectType void
+    fileLink; // $ExpectType IFileLink
+});
+
+stripe.fileLinks.update(
+    'link_1FhJXrBZBR5SQORg2hZCYnZ7',
+    { expires_at: 'now', metadata: { order_id: '6735' } },
+    (err, fileLink) => {
+        fileLink; // $ExpectType IFileLink
+    },
+);
+
+stripe.fileLinks.update('link_1FhJXrBZBR5SQORg2hZCYnZ7', { expires_at: 1542822417 }, (err, fileLink) => {
+    fileLink; // $ExpectType IFileLink
+});
+
+stripe.fileLinks.update('link_1FhJXrBZBR5SQORg2hZCYnZ7', {}).then(fileLink => {
+    fileLink; // $ExpectType IFileLink
+});
+
+stripe.fileLinks.list({ limit: 3 }, (err, fileLinks) => {
+    // asynchronously called
+});
+
+stripe.fileLinks.list({ limit: 3 }).then(fileLinks => {
+    // asynchronously called
 });
 
 //#endregion

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1673,6 +1673,14 @@ stripe.fileLinks
         fileLink; // $ExpectType IFileLink
     });
 
+stripe.fileLinks.retrieve('link_1FhJXrBZBR5SQORg2hZCYnZ7', (err, fileLink) => {
+    // asynchronously called
+});
+
+stripe.fileLinks.retrieve('link_1FhJXrBZBR5SQORg2hZCYnZ7').then(fileLink => {
+    // asynchronously called
+});
+
 //#endregion
 
 //#region Discounts tests

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1660,11 +1660,18 @@ stripe.coupons.list({ limit: 3 }).then(coupons => {
 //#region FileLinks tests
 // ##################################################################################
 
-stripe.fileLinks.create({ file: 'file_1FgxGXBZBR5SQORg4FkgjG2O' }, (err, fileLink) => {
-    console.log('Err', err);
-    console.log('FileLink', fileLink);
-    // asynchronously called
-});
+stripe.fileLinks.create(
+    { file: 'file_1FgxGXBZBR5SQORg4FkgjG2O', expires_at: 1542822417, metadata: { any: 'any' } },
+    (err, fileLink) => {
+        fileLink; // $ExpectType IFileLink
+    },
+);
+
+stripe.fileLinks
+    .create({ file: 'file_1FgxGXBZBR5SQORg4FkgjG2O', expires_at: 1542822417, metadata: { any: 'any' } })
+    .then(fileLink => {
+        fileLink; // $ExpectType IFileLink
+    });
 
 //#endregion
 

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1674,11 +1674,11 @@ stripe.fileLinks
     });
 
 stripe.fileLinks.retrieve('link_1FhJXrBZBR5SQORg2hZCYnZ7', (err, fileLink) => {
-    // asynchronously called
+    fileLink; // $ExpectType IFileLink
 });
 
 stripe.fileLinks.retrieve('link_1FhJXrBZBR5SQORg2hZCYnZ7').then(fileLink => {
-    // asynchronously called
+    fileLink; // $ExpectType void
 });
 
 //#endregion

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1657,6 +1657,15 @@ stripe.coupons.list({ limit: 3 }).then(coupons => {
 
 //#endregion
 
+//#region FileLinks tests
+// ##################################################################################
+
+stripe.fileLinks.create({ file: 'file_1FgxGXBZBR5SQORg4FkgjG2O' }, (err, fileLink) => {
+    // asynchronously called
+});
+
+//#endregion
+
 //#region Discounts tests
 // ##################################################################################
 


### PR DESCRIPTION
Add Type for FileLinks
https://stripe.com/docs/api/file_links

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.


