### PR TITLE
@wordpress/components: Add hideLabelFromVision to BaseControl Props

### DIFF
--- a/types/wordpress__components/base-control/index.d.ts
+++ b/types/wordpress__components/base-control/index.d.ts
@@ -7,6 +7,12 @@ declare namespace BaseControl {
          * property as the content.
          */
         label?: ReactNode;
+
+        /**
+         * If true, the label will only be visible to screen readers.
+         */
+        hideLabelFromVision?: boolean;
+
         /**
          * If this property is added, a help text will be generated using help
          * property as the content.

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -65,7 +65,7 @@ interface MyCompleteOption {
 //
 // base-control
 //
-<C.BaseControl id="foo" label="hello world">
+<C.BaseControl id="foo" label="hello world" hideLabelFromVision>
     <C.BaseControl.VisualLabel>My Label</C.BaseControl.VisualLabel>
 </C.BaseControl>;
 
@@ -642,7 +642,13 @@ const kbshortcuts = {
 // text-control
 //
 <C.TextControl label="My text value" value={'foo'} onChange={value => console.log(value.toUpperCase())} />;
-<C.TextControl type="number" label="My numeric value" value={3} onChange={value => console.log(value.toUpperCase())} />;
+<C.TextControl
+    type="number"
+    label="My numeric value"
+    hideLabelFromVision
+    value={3}
+    onChange={value => console.log(value.toUpperCase())}
+/>;
 
 //
 // textarea-control


### PR DESCRIPTION
Add `hideLabelFromVision` prop to `BaseControl`.

It's documented in the [README](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/base-control/README.md#hidelabelfromvision).

Appears to be introduced in https://github.com/WordPress/gutenberg/commit/49124712753d8fbb424afc8fc184f013a12d67f1 

Released in [`8.1.0`](https://unpkg.com/browse/@wordpress/components@8.1.0/src/base-control/index.js) and not in previous [`8.0.0`](https://unpkg.com/browse/@wordpress/components@8.0.0/src/base-control/index.js).


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/master/packages/components/src/base-control/README.md#hidelabelfromvision
- [x] Updated to `8.1` If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. 
- **Does not apply** If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.