### PR TITLE
[inputmask] Add definitions property to Options

### DIFF
--- a/types/inputmask/index.d.ts
+++ b/types/inputmask/index.d.ts
@@ -513,6 +513,13 @@ declare namespace Inputmask {
          * Format of the unmasked value. This is only effective when used with the datetime alias.
          */
         outputFormat?: string;
+
+        /**
+         * Add new definitions to this inputmask.
+         */
+        definitions?: {
+            [key: string]: Definition;
+        };
     }
 
     interface Instance {
@@ -658,7 +665,7 @@ declare namespace Inputmask {
          */
         extendDefaults(opts: Options): void;
         /**
-         * Add new definitions to this inputmask.
+         * Extends the set of available definitions.
          */
         extendDefinitions(definitions: {
             [key: string]: Definition,

--- a/types/inputmask/test/inputmask-global-tests.ts
+++ b/types/inputmask/test/inputmask-global-tests.ts
@@ -70,6 +70,12 @@ Inputmask({
     unmaskAsNumber: false,
     inputType: "text",
     inputmode: "numeric",
+    definitions: {
+        X: {
+            validator: "[xX]",
+            casing: "upper"
+        }
+    }
 }).mask("selector");
 
 Inputmask("9-a{1,3}9{1,3}").mask("selector");
@@ -89,50 +95,50 @@ function testMask() {
 }
 
 Inputmask.extendDefaults({
-	autoUnmask: true
+    autoUnmask: true
 });
 Inputmask.extendDefinitions({
-	A: {
-		validator: "[A-Za-z\u0410-\u044F\u0401\u0451\u00C0-\u00FF\u00B5]",
-		casing: "upper"
-	},
-	'+': {
-		validator: "[0-9A-Za-z\u0410-\u044F\u0401\u0451\u00C0-\u00FF\u00B5]",
-		casing: "upper"
-	}
+    A: {
+        validator: "[A-Za-z\u0410-\u044F\u0401\u0451\u00C0-\u00FF\u00B5]",
+        casing: "upper"
+    },
+    '+': {
+        validator: "[0-9A-Za-z\u0410-\u044F\u0401\u0451\u00C0-\u00FF\u00B5]",
+        casing: "upper"
+    }
 });
 Inputmask.extendAliases({
-	numeric: {
-		mask: "r",
-		greedy: false
-	}
+    numeric: {
+        mask: "r",
+        greedy: false
+    }
 });
 
 Inputmask.extendDefinitions({
-	f: {
-	  	validator: "[0-9\(\)\.\+/ ]"
-	},
-	j: {
-	  	validator: "(19|20)\\d{2}"
-	},
-	x: {
-		validator: "[0-2]",
-		definitionSymbol: "i"
-	},
-	y: {
-		validator: (chrs: string, buffer: string[], pos: number) => {
-			const valExp2 = new RegExp("2[0-5]|[01][0-9]");
-			return valExp2.test(buffer[pos - 1] + chrs);
-		},
-		definitionSymbol: "i"
-	},
-	z: {
-		validator: (chrs: string, buffer: string[], pos: number) => {
-			const valExp3 = new RegExp("25[0-5]|2[0-4][0-9]|[01][0-9][0-9]");
-			return valExp3.test(buffer[pos - 2] + buffer[pos - 1] + chrs);
-		},
-		definitionSymbol: "i"
-	}
+    f: {
+        validator: "[0-9\(\)\.\+/ ]"
+    },
+    j: {
+        validator: "(19|20)\\d{2}"
+    },
+    x: {
+        validator: "[0-2]",
+        definitionSymbol: "i"
+    },
+    y: {
+        validator: (chrs: string, buffer: string[], pos: number) => {
+            const valExp2 = new RegExp("2[0-5]|[01][0-9]");
+            return valExp2.test(buffer[pos - 1] + chrs);
+        },
+        definitionSymbol: "i"
+    },
+    z: {
+        validator: (chrs: string, buffer: string[], pos: number) => {
+            const valExp3 = new RegExp("25[0-5]|2[0-4][0-9]|[01][0-9][0-9]");
+            return valExp3.test(buffer[pos - 2] + buffer[pos - 1] + chrs);
+        },
+        definitionSymbol: "i"
+    }
 });
 
 function testElement(el: HTMLElement) {

--- a/types/inputmask/test/inputmask-jquery-tests.ts
+++ b/types/inputmask/test/inputmask-jquery-tests.ts
@@ -78,4 +78,10 @@ $("#testmask").inputmask({
     unmaskAsNumber: false,
     inputType: "text",
     inputmode: "numeric",
+    definitions: {
+        X: {
+            validator: "[xX]",
+            casing: "upper"
+        }
+    }
 });

--- a/types/inputmask/test/inputmask-module-tests.ts
+++ b/types/inputmask/test/inputmask-module-tests.ts
@@ -72,6 +72,12 @@ Inputmask({
     unmaskAsNumber: false,
     inputType: "text",
     inputmode: "numeric",
+    definitions: {
+        X: {
+            validator: "[xX]",
+            casing: "upper"
+        }
+    }
 }).mask("selector");
 
 Inputmask("9-a{1,3}9{1,3}").mask("selector");


### PR DESCRIPTION
The `inputmask` API allows developers to add definitions either globally using `Inputmask.extendDefinitions`  or on a per instance basis by defining the definitions in the mask instance options. This PR adds the typings to allow developers to add definitions on a per instance basis.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - Usage example: https://github.com/RobinHerbots/Inputmask#dynamic-masks
    - Source Code: https://github.com/RobinHerbots/Inputmask/blob/4.x/js/inputmask.js#L358
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
