### PR TITLE
Fix bad types/v* references in tests

### DIFF
--- a/types/auth0.widget/auth0.widget-tests.ts
+++ b/types/auth0.widget/auth0.widget-tests.ts
@@ -1,10 +1,8 @@
-import 'auth0-js/v7';
+import 'auth0-js';
 
 var widget: Auth0WidgetStatic = new Auth0Widget({
     domain: 'mine.auth0.com',
     clientID: 'dsa7d77dsa7d7',
-    callbackURL: 'http://my-app.com/callback',
-    callbackOnLocationHash: true
 });
 
 widget.signin({

--- a/types/auth0.widget/index.d.ts
+++ b/types/auth0.widget/index.d.ts
@@ -8,15 +8,16 @@
 interface Auth0WidgetStatic {
     new(params: Auth0Constructor): Auth0WidgetStatic;
 
-    getClient(): Auth0Static;
-    getProfile(token: string, callback: Function): Auth0UserProfile;
-    parseHash(hash: string): Auth0DecodedHash;
+    getClient(): import("auth0-js").Authentication;
+    getProfile(token: string, callback: Function): import("auth0-js").Auth0UserProfile;
+    parseHash(hash: string): import("auth0-js").Auth0DecodedHash;
     reset(options: Auth0Options, callback?: Function): Auth0WidgetStatic;
     signin(options: Auth0Options, widgetLoadedCallback?: Function, popupCallback?: Function): Auth0WidgetStatic;
-    signup(options: Auth0Options, callback: (error?: Auth0Error, profile?: Auth0UserProfile, id_token?: string, access_token?: string, state?: string) => any): Auth0WidgetStatic;
+    signup(options: Auth0Options, callback: (error?: import("auth0-js").Auth0Error, profile?: import("auth0-js").Auth0UserProfile, id_token?: string, access_token?: string, state?: string) => any): Auth0WidgetStatic;
  }
 
-interface Auth0Constructor extends Auth0ClientOptions {
+type ClientOptions = import("auth0-js").AuthOptions;
+interface Auth0Constructor extends ClientOptions {
      assetsUrl?: string;
      cdn?: string;
      dict?: any;

--- a/types/auth0.widget/index.d.ts
+++ b/types/auth0.widget/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://auth0.com
 // Definitions by: Robert McLaws <https://github.com/advancedrei>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
 
 /// <reference types="auth0-js" />
 

--- a/types/gulp-connect/gulp-connect-tests.ts
+++ b/types/gulp-connect/gulp-connect-tests.ts
@@ -1,5 +1,5 @@
 // Copying examples from Readme which currently depend on gulp v3
-import * as gulp from 'gulp/v3';
+import * as gulp from 'gulp';
 import * as connect from 'gulp-connect';
 
 // Simple example
@@ -7,7 +7,7 @@ gulp.task('connect', () => {
   connect.server();
 });
 
-gulp.task('default', ['connect']);
+gulp.task('default', gulp.series(['connect']));
 
 // LiveReload
 gulp.task('connect', () => {
@@ -23,10 +23,10 @@ gulp.task('html', () => {
 });
 
 gulp.task('watch', () => {
-  gulp.watch(['./app/*.html'], ['html']);
+  gulp.watch(['./app/*.html'], gulp.series(['html']));
 });
 
-gulp.task('default', ['connect', 'watch']);
+gulp.task('default', gulp.series(['connect', 'watch']));
 
 // Start and stop server
 gulp.task('jenkins-tests', () => {
@@ -70,11 +70,11 @@ gulp.task('stylus', () => {
 });
 
 gulp.task('watch', () => {
-  gulp.watch(['./app/*.html'], ['html']);
-  gulp.watch(['./app/stylus/*.styl'], ['stylus']);
+  gulp.watch(['./app/*.html'], gulp.series(['html']));
+  gulp.watch(['./app/stylus/*.styl'], gulp.series(['stylus']));
 });
 
-gulp.task('default', ['connectDist', 'connectDev', 'watch']);
+gulp.task('default', gulp.series(['connectDist', 'connectDev', 'watch']));
 
 // Barebones middleware example from Readme
 gulp.task('connect', () => {


### PR DESCRIPTION
This also fixes the tests for incorrect `'package/v7`-style references, which I missed previously.

- gulp-connect *apparently* works with gulp 3 or 4, but the examples on
the homepage are written for gulp 3. I updated them minimally to work
with gulp 4 -- its types at least.

- auth0.widget depends on auth0-js which now uses modules. I switched to
import types and updated the type names.
