### PR TITLE
Add types for zfont

### DIFF
--- a/types/zfont/index.d.ts
+++ b/types/zfont/index.d.ts
@@ -1,0 +1,226 @@
+// Type definitions for zfont 1.2
+// Project: https://github.com/jaames/zfont
+// Definitions by: Dmitry Demensky <https://github.com/demensky>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.4
+
+import * as zdog from 'zdog';
+
+export as namespace Zfont;
+
+export function init(x: typeof zdog): typeof zdog;
+
+declare module 'zdog' {
+    /** @see {@link https://github.com/jaames/zfont#multiline-text Zfont API} */
+    type MultilineText = string | ReadonlyArray<string>;
+
+    /**
+     * Horizontal text alignment (equivalent to the CSS `text-align` property).
+     * @see {@link https://github.com/jaames/zfont#textalign Zfont API} (Text)
+     * @see {@link https://github.com/jaames/zfont#textalign-1 Zfont API} (TextGroup)
+     */
+    type TextAlign = 'left' | 'center' | 'right';
+
+    /**
+     * Vertical text alignment, equivalent to the HTML5 canvas' {@link CanvasRenderingContext2D.textBaseline textBaseline} property.
+     * @see {@link https://github.com/jaames/zfont#textbaseline Zfont API} (Text)
+     * @see {@link https://github.com/jaames/zfont#textbaseline-1 Zfont API} (TextGroup)
+     */
+    type TextBaseline = 'top' | 'middle' | 'bottom';
+
+    /**
+     * @see {@link Font}
+     * @see {@link https://github.com/jaames/zfont#options Zfont API}
+     */
+    interface FontOptions {
+        /** Font URL path. This can be a `.ttf` or `.otf` font, check out the {@link https://github.com/photopea/Typr.js Typr.js repo} for more details about font support. */
+        readonly src: string;
+    }
+
+    /**
+     * Represents a font that can be used by an instance of either {@link Text} or {@link TextGroup}.
+     * @see {@link https://github.com/jaames/zfont#zdogfont Zfont API}
+     */
+    class Font {
+        constructor(options: FontOptions);
+
+        /**
+         * Returns a Promise which resolves once this font has finished loading.
+         * @see {@link https://github.com/jaames/zfont#waitforload Zfont API}
+         */
+        waitForLoad(): Promise<void>;
+    }
+
+    /**
+     * @see {@link Text}
+     * @see {@link https://github.com/jaames/zfont#options-1 Zfont API}
+     */
+    interface TextOptions<T extends MultilineText> extends ShapeOptions {
+        /** @see {@link Text#font} */
+        readonly font: Font;
+
+        /**
+         * @default ''
+         * @see {@link Text#value}
+         */
+        readonly value?: T;
+
+        /**
+         * Measured in pixels.
+         * @default 64
+         * @see {@link Text#fontSize}
+         */
+        readonly fontSize?: number;
+
+        /**
+         * @default 'left'
+         * @see {@link Text#textAlign}
+         */
+        readonly textAlign?: TextAlign;
+
+        /**
+         * @default 'bottom'
+         * @see {@link Text#textBaseline}
+         */
+        readonly textBaseline?: TextBaseline;
+    }
+
+    /**
+     * An object used for rendering text.
+     * @see {@link https://github.com/jaames/zfont#zdogtext Zfont API}
+     */
+    class Text<T extends MultilineText = MultilineText> extends Shape {
+        /** @see {@link TextOptions#font} */
+        font: Font;
+
+        /** @see {@link TextOptions#value} */
+        value: MultilineText;
+
+        /** @see {@link TextOptions#fontSize} */
+        fontSize: number;
+
+        /** @see {@link TextOptions#textAlign} */
+        textAlign: TextAlign;
+
+        /** @see {@link TextOptions#textBaseline} */
+        textBaseline: TextBaseline;
+
+        constructor(options: TextOptions<T>);
+    }
+
+    /**
+     * @see {@link TextGroup}
+     * @see {@link https://github.com/jaames/zfont#options-2 Zfont API}
+     */
+    interface TextGroupOptions<T extends MultilineText> extends GroupOptions {
+        /** @see {@link TextGroup#font} */
+        readonly font: Font;
+
+        /**
+         * @default ''
+         * @see {@link TextGroup#value}
+         */
+        readonly value?: T;
+
+        /**
+         * Measured in pixels.
+         * @default 64
+         * @see {@link TextGroup#fontSize}
+         */
+        readonly fontSize?: number;
+
+        /**
+         * @default 'left'
+         * @see {@link TextGroup#textAlign}
+         */
+        readonly textAlign?: TextAlign;
+
+        /**
+         * @default 'bottom'
+         * @see {@link TextGroup#textBaseline}
+         */
+        readonly textBaseline?: TextBaseline;
+
+        /**
+         * @default '#333'
+         * @see {@link TextGroup#color}
+         */
+        readonly color?: string;
+
+        /**
+         * @default false
+         * @see {@link TextGroup#fill}
+         */
+        readonly fill?: boolean;
+
+        /**
+         * @default 1
+         * @see {@link TextGroup#stroke}
+         */
+        readonly stroke?: number | false;
+    }
+
+    /**
+     * This class is very similar to {@link Text}, except it acts as a {@link Group} instead, and each text glyph is rendered as its own shape.
+     * This is helpful for more advanced use-cases where you need control over each character.
+     * @see {@link https://github.com/jaames/zfont#zdogtextgroup Zfont API}
+     * @see {@link  Zfont API}
+     */
+    class TextGroup<T extends MultilineText = MultilineText> extends Group {
+        /**
+         * @see {@link TextGroupOptions#font}
+         * @see {@link https://github.com/jaames/zfont#font-1 Zfont API}
+         */
+        font: Font;
+
+        /**
+         * @see {@link TextGroupOptions#value}
+         * @see {@link https://github.com/jaames/zfont#value-1 Zfont API}
+         */
+        value: T;
+
+        /**
+         * @see {@link TextGroupOptions#fontSize}
+         * @see {@link https://github.com/jaames/zfont#fontsize-1 Zfont API}
+         */
+        fontSize: number;
+
+        /**
+         * @see {@link TextGroupOptions#textAlign}
+         * @see {@link https://github.com/jaames/zfont#textalign-1 Zfont API}
+         */
+        textAlign: TextAlign;
+
+        /**
+         * @see {@link TextGroupOptions#textBaseline}
+         * @see {@link https://github.com/jaames/zfont#textbaseline-1 Zfont API}
+         */
+        textBaseline: TextBaseline;
+
+        /**
+         * @see {@link TextGroupOptions#color}
+         * @see {@link https://github.com/jaames/zfont#color Zfont API}
+         */
+        color: string;
+
+        /**
+         * @see {@link TextGroupOptions#fill}
+         * @see {@link https://github.com/jaames/zfont#fill Zfont API}
+         */
+        fill: boolean;
+
+        /**
+         * @see {@link TextGroupOptions#stroke}
+         * @see {@link https://github.com/jaames/zfont#stroke Zfont API}
+         */
+        stroke: number | false;
+
+        constructor(options: TextGroupOptions<T>);
+    }
+
+    /**
+     * Returns a {@link Promise} which resolves as soon as all the fonts currently added to the scene are loaded and ready for use.
+     * @see {@link https://github.com/jaames/zfont#zdogtext Zfont API}
+     */
+    function waitForFonts(): Promise<undefined[]>;
+}

--- a/types/zfont/tsconfig.json
+++ b/types/zfont/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "zfont-tests.ts"
+    ]
+}

--- a/types/zfont/tslint.json
+++ b/types/zfont/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/zfont/zfont-tests.ts
+++ b/types/zfont/zfont-tests.ts
@@ -1,0 +1,53 @@
+import * as zdog from 'zdog';
+import { init } from 'zfont';
+
+init(zdog);
+
+new zdog.Font(); // $ExpectError
+new zdog.Font({}); // $ExpectError
+const font = new zdog.Font({ src: './path/to/font.ttf' });
+
+font.waitForLoad(); // $ExpectType Promise<void>
+
+new zdog.Text(); // $ExpectError
+new zdog.Text({}); // $ExpectError
+const text = new zdog.Text({ font });
+new zdog.Text({ font, value: 'a' });
+new zdog.Text({ font, value: ['a', 'b'] });
+new zdog.Text({ font, fontSize: 20 });
+new zdog.Text({ font, textAlign: 'left' });
+new zdog.Text({ font, textAlign: 'center' });
+new zdog.Text({ font, textAlign: 'right' });
+new zdog.Text({ font, textBaseline: 'top' });
+new zdog.Text({ font, textBaseline: 'middle' });
+new zdog.Text({ font, textBaseline: 'bottom' });
+
+text.font; // $ExpectType Font
+text.value; // $ExpectType MultilineText
+text.fontSize; // $ExpectType number
+text.textAlign; // $ExpectType TextAlign
+text.textBaseline; // $ExpectType TextBaseline
+
+new zdog.TextGroup(); // $ExpectError
+new zdog.TextGroup({}); // $ExpectError
+const textGroup = new zdog.TextGroup({ font });
+new zdog.TextGroup({ font, value: 'a' });
+new zdog.TextGroup({ font, value: ['a', 'b'] });
+new zdog.TextGroup({ font, fontSize: 20 });
+new zdog.TextGroup({ font, textAlign: 'left' });
+new zdog.TextGroup({ font, textAlign: 'center' });
+new zdog.TextGroup({ font, textAlign: 'right' });
+new zdog.TextGroup({ font, textBaseline: 'top' });
+new zdog.TextGroup({ font, textBaseline: 'middle' });
+new zdog.TextGroup({ font, textBaseline: 'bottom' });
+
+textGroup.font; // $ExpectType Font
+textGroup.value; // $ExpectType MultilineText
+textGroup.fontSize; // $ExpectType number
+textGroup.textAlign; // $ExpectType TextAlign
+textGroup.textBaseline; // $ExpectType TextBaseline
+textGroup.color; // $ExpectType string
+textGroup.fill; // $ExpectType boolean
+textGroup.stroke; // $ExpectType number | false
+
+zdog.waitForFonts(); // $ExpectType Promise<undefined[]>


### PR DESCRIPTION
Fixes jaames/zfont#6

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
