### PR TITLE
[react-relay] Improve nullability handling of pagination hooks

### DIFF
--- a/types/react-relay/lib/relay-experimental/useBlockingPaginationFragment.d.ts
+++ b/types/react-relay/lib/relay-experimental/useBlockingPaginationFragment.d.ts
@@ -14,23 +14,30 @@ export interface ReturnType<TQuery extends OperationType, TKey, TFragmentData> {
 
 export type $Call<Fn extends (...args: any[]) => any> = Fn extends (arg: any) => infer RT ? RT : never;
 
-export type NonNullableReturnType<T extends { readonly ' $data'?: unknown }> = (arg: T) => NonNullable<T[' $data']>;
-export type NullableReturnType<T extends { readonly ' $data'?: unknown | null }> = (arg: T) => T[' $data'] | null;
+interface KeyType {
+    readonly ' $data'?: unknown;
+}
+
+type KeyReturnType<T extends KeyType> = (arg: T) => NonNullable<T[' $data']>;
 
 export function useBlockingPaginationFragment<
     TQuery extends OperationType,
-    TKey extends { readonly ' $data'?: unknown | null }
+    TKey extends KeyType
 >(
     fragmentInput: GraphQLTaggedNode,
     parentFragmentRef: TKey,
     componentDisplayName?: string,
-): ReturnType<
-    // tslint:disable-next-line:no-unnecessary-generics
-    TQuery,
-    TKey,
-    // NOTE: This $Call ensures that the type of the returned data is either:
-    //   - nullable if the provided ref type is nullable
-    //   - non-nullable if the provided ref type is non-nullable
-    // prettier-ignore
-    $Call<NonNullableReturnType<TKey> & NullableReturnType<TKey>>
->;
+): // tslint:disable-next-line no-unnecessary-generics
+ReturnType<TQuery, TKey, $Call<KeyReturnType<TKey>>>;
+
+export function useBlockingPaginationFragment<
+    TQuery extends OperationType,
+    TKey extends KeyType
+>(
+    fragmentInput: GraphQLTaggedNode,
+    parentFragmentRef: TKey | null,
+    componentDisplayName?: string,
+): // tslint:disable-next-line no-unnecessary-generics
+ReturnType<TQuery, TKey | null, $Call<KeyReturnType<TKey>> | null>;
+
+export { };

--- a/types/react-relay/lib/relay-experimental/useLegacyPaginationFragment.d.ts
+++ b/types/react-relay/lib/relay-experimental/useLegacyPaginationFragment.d.ts
@@ -15,14 +15,28 @@ export interface ReturnType<TQuery extends OperationType, TKey, TFragmentData> {
 
 export type $Call<Fn extends (...args: any[]) => any> = Fn extends (arg: any) => infer RT ? RT : never;
 
-export type NonNullableReturnType<T extends { readonly ' $data'?: unknown }> = (arg: T) => NonNullable<T[' $data']>;
-export type NullableReturnType<T extends { readonly ' $data'?: unknown | null }> = (arg: T) => T[' $data'] | null;
+interface KeyType {
+    readonly ' $data'?: unknown;
+}
+
+type KeyReturnType<T extends KeyType> = (arg: T) => NonNullable<T[' $data']>;
 
 export function useLegacyPaginationFragment<
     TQuery extends OperationType,
-    TKey extends { readonly ' $data'?: unknown | null }
+    TKey extends KeyType
 >(
     fragmentInput: GraphQLTaggedNode,
     parentFragmentRef: TKey,
 ): // tslint:disable-next-line no-unnecessary-generics
-ReturnType<TQuery, TKey, $Call<NonNullableReturnType<TKey> & NullableReturnType<TKey>>>;
+ReturnType<TQuery, TKey, $Call<KeyReturnType<TKey>>>;
+
+export function useLegacyPaginationFragment<
+    TQuery extends OperationType,
+    TKey extends KeyType
+>(
+    fragmentInput: GraphQLTaggedNode,
+    parentFragmentRef: TKey | null,
+): // tslint:disable-next-line no-unnecessary-generics
+ReturnType<TQuery, TKey | null, $Call<KeyReturnType<TKey>> | null>;
+
+export {};

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -431,7 +431,7 @@ function PaginationFragment() {
     }
 
     interface Props {
-        user: FriendsListComponent_user$key;
+        user: FriendsListComponent_user$key | null;
     }
 
     return function FriendsList(props: Props) {

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -12,6 +12,7 @@ import {
     useFragment,
     useRefetchableFragment,
     usePaginationFragment,
+    useBlockingPaginationFragment,
 } from 'react-relay/hooks';
 
 const source = new RecordSource();
@@ -527,6 +528,170 @@ function PaginationFragment_WithNonNullUserProp() {
             isLoadingPrevious,
             refetch, // For refetching connection
         } = usePaginationFragment<FriendsListPaginationQuery, FriendsListComponent_user$key>(
+            graphql`
+                fragment FriendsListComponent_user on User @refetchable(queryName: "FriendsListPaginationQuery") {
+                    name
+                    friends(first: $count, after: $cursor) @connection(key: "FriendsList_user_friends") {
+                        edges {
+                            node {
+                                name
+                                age
+                            }
+                        }
+                    }
+                }
+            `,
+            props.user,
+        );
+
+        return (
+            <>
+                <h1>Friends of {data.name}:</h1>
+
+                {data.friends.edges.map(({ node }) => (
+                    <div>
+                        {node.name} - {node.age}
+                    </div>
+                ))}
+
+                <button onClick={() => loadNext(10)}>Load more friends</button>
+            </>
+        );
+    };
+}
+
+/**
+ * Tests for useBlockingPaginationFragment
+ * see https://relay.dev/docs/en/experimental/api-reference#useblockingpaginationfragment
+ */
+function BlockingPaginationFragment() {
+    interface FriendsListPaginationQueryVariables {
+        count?: number;
+        cursor?: string;
+        id: string;
+    }
+    interface FriendsListPaginationQueryResponse {
+        readonly node: {
+            readonly ' $fragmentRefs': FragmentRefs<'FriendsListComponent_user'>;
+        };
+    }
+    interface FriendsListPaginationQuery {
+        readonly response: FriendsListPaginationQueryResponse;
+        readonly variables: FriendsListPaginationQueryVariables;
+    }
+
+    interface FriendsListComponent_user {
+        readonly name: string;
+        readonly friends: {
+            readonly edges: ReadonlyArray<{
+                readonly node: {
+                    readonly name: string;
+                    readonly age: number;
+                };
+            }>;
+        };
+        readonly id: string;
+        readonly ' $refType': 'FriendsListComponent_user';
+    }
+    type FriendsListComponent_user$data = FriendsListComponent_user;
+    interface FriendsListComponent_user$key {
+        readonly ' $data'?: FriendsListComponent_user$data;
+        readonly ' $fragmentRefs': FragmentRefs<'FriendsListComponent_user'>;
+    }
+
+    interface Props {
+        user: FriendsListComponent_user$key | null;
+    }
+
+    return function FriendsList(props: Props) {
+        const {
+            data,
+            loadNext,
+            loadPrevious,
+            hasNext,
+            hasPrevious,
+            refetch, // For refetching connection
+        } = useBlockingPaginationFragment<FriendsListPaginationQuery, FriendsListComponent_user$key>(
+            graphql`
+                fragment FriendsListComponent_user on User @refetchable(queryName: "FriendsListPaginationQuery") {
+                    name
+                    friends(first: $count, after: $cursor) @connection(key: "FriendsList_user_friends") {
+                        edges {
+                            node {
+                                name
+                                age
+                            }
+                        }
+                    }
+                }
+            `,
+            props.user,
+        );
+
+        return (
+            <>
+                <h1>Friends of {data!.name}:</h1>
+
+                {data!.friends.edges.map(({ node }) => (
+                    <div>
+                        {node.name} - {node.age}
+                    </div>
+                ))}
+
+                <button onClick={() => loadNext(10)}>Load more friends</button>
+            </>
+        );
+    };
+}
+
+function BlockingPaginationFragment_WithNonNullUserProp() {
+    interface FriendsListPaginationQueryVariables {
+        count?: number;
+        cursor?: string;
+        id: string;
+    }
+    interface FriendsListPaginationQueryResponse {
+        readonly node: {
+            readonly ' $fragmentRefs': FragmentRefs<'FriendsListComponent_user'>;
+        };
+    }
+    interface FriendsListPaginationQuery {
+        readonly response: FriendsListPaginationQueryResponse;
+        readonly variables: FriendsListPaginationQueryVariables;
+    }
+
+    interface FriendsListComponent_user {
+        readonly name: string;
+        readonly friends: {
+            readonly edges: ReadonlyArray<{
+                readonly node: {
+                    readonly name: string;
+                    readonly age: number;
+                };
+            }>;
+        };
+        readonly id: string;
+        readonly ' $refType': 'FriendsListComponent_user';
+    }
+    type FriendsListComponent_user$data = FriendsListComponent_user;
+    interface FriendsListComponent_user$key {
+        readonly ' $data'?: FriendsListComponent_user$data;
+        readonly ' $fragmentRefs': FragmentRefs<'FriendsListComponent_user'>;
+    }
+
+    interface Props {
+        user: FriendsListComponent_user$key;
+    }
+
+    return function FriendsList(props: Props) {
+        const {
+            data,
+            loadNext,
+            loadPrevious,
+            hasNext,
+            hasPrevious,
+            refetch, // For refetching connection
+        } = useBlockingPaginationFragment<FriendsListPaginationQuery, FriendsListComponent_user$key>(
             graphql`
                 fragment FriendsListComponent_user on User @refetchable(queryName: "FriendsListPaginationQuery") {
                     name

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -476,3 +476,85 @@ function PaginationFragment() {
         );
     };
 }
+
+function PaginationFragment_WithNonNullUserProp() {
+    interface FriendsListPaginationQueryVariables {
+        count?: number;
+        cursor?: string;
+        id: string;
+    }
+    interface FriendsListPaginationQueryResponse {
+        readonly node: {
+            readonly ' $fragmentRefs': FragmentRefs<'FriendsListComponent_user'>;
+        };
+    }
+    interface FriendsListPaginationQuery {
+        readonly response: FriendsListPaginationQueryResponse;
+        readonly variables: FriendsListPaginationQueryVariables;
+    }
+
+    interface FriendsListComponent_user {
+        readonly name: string;
+        readonly friends: {
+            readonly edges: ReadonlyArray<{
+                readonly node: {
+                    readonly name: string;
+                    readonly age: number;
+                };
+            }>;
+        };
+        readonly id: string;
+        readonly ' $refType': 'FriendsListComponent_user';
+    }
+    type FriendsListComponent_user$data = FriendsListComponent_user;
+    interface FriendsListComponent_user$key {
+        readonly ' $data'?: FriendsListComponent_user$data;
+        readonly ' $fragmentRefs': FragmentRefs<'FriendsListComponent_user'>;
+    }
+
+    interface Props {
+        user: FriendsListComponent_user$key;
+    }
+
+    return function FriendsList(props: Props) {
+        const {
+            data,
+            loadNext,
+            loadPrevious,
+            hasNext,
+            hasPrevious,
+            isLoadingNext,
+            isLoadingPrevious,
+            refetch, // For refetching connection
+        } = usePaginationFragment<FriendsListPaginationQuery, FriendsListComponent_user$key>(
+            graphql`
+                fragment FriendsListComponent_user on User @refetchable(queryName: "FriendsListPaginationQuery") {
+                    name
+                    friends(first: $count, after: $cursor) @connection(key: "FriendsList_user_friends") {
+                        edges {
+                            node {
+                                name
+                                age
+                            }
+                        }
+                    }
+                }
+            `,
+            props.user,
+        );
+
+        return (
+            <>
+                <h1>Friends of {data.name}:</h1>
+
+                {data.friends.edges.map(({ node }) => (
+                    <div>
+                        {node.name} - {node.age}
+                    </div>
+                ))}
+
+                <button onClick={() => loadNext(10)}>Load more friends</button>
+            </>
+        );
+    };
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://relay.dev/docs/en/experimental/api-reference#usepaginationfragment>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This is basically a follow-up to #40167, which improved the nullability handling for the `useFragment` hook.

This PR adopts the improvements made in #40167, and applies them to the `usePaginationFragment` and `useBlockingPaginationFragment` hooks.