### PR TITLE
[@types/node-fetch] Fix FetchError class definition

### DIFF
--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -148,9 +148,13 @@ export class Body {
     timeout: number;
 }
 
+interface SystemError extends Error {
+    code?: string;
+}
+
 export class FetchError extends Error {
     name: "FetchError";
-    constructor(message: string, type: string, systemError?: string);
+    constructor(message: string, type: string, systemError?: SystemError);
     type: string;
     code?: string;
     errno?: string;

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -9,6 +9,7 @@
 //                 Brandon Wilson <https://github.com/wilsonianb>
 //                 Steve Faulkner <https://github.com/southpolesteve>
 //                 ExE Boss <https://github.com/ExE-Boss>
+//                 Alex Savin <https://github.com/alexandrusavin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -158,7 +158,15 @@ function test_isRedirect() {
 }
 
 function test_FetchError() {
-    new FetchError("message", "type", "systemError");
+    new FetchError("message", "type", {
+        name: 'Error',
+        message: 'Error message',
+        code: "systemError",
+    });
+    new FetchError("message", "type", {
+        name: 'Error',
+        message: "Error without code",
+    });
     new FetchError("message", "type");
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/bitinn/node-fetch/blob/master/src/fetch-error.js#L24>> the way this function argument is used contradicts the documentation section and I assume the documentation was the source of this type 
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
