### PR TITLE
@wordpress/components Popover: Add onFocusOutside

### DIFF
--- a/types/wordpress__components/index.d.ts
+++ b/types/wordpress__components/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/components 7.4
+// Type definitions for @wordpress/components 8.2
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/components/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 //                 Jon Surrell <https://github.com/sirreal>

--- a/types/wordpress__components/popover/index.d.ts
+++ b/types/wordpress__components/popover/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType, HTMLProps, ReactNode, ReactElement } from '@wordpress/element';
+import { ComponentType, HTMLProps, ReactNode, ReactElement, FocusEvent } from '@wordpress/element';
 import { Slot } from '@wordpress/components';
 
 declare namespace Popover {
@@ -81,7 +81,7 @@ declare namespace Popover {
          *
          * Defaults to `onClose` when not provided.
          */
-        onFocusOutside?(): void;
+        onFocusOutside?(event: FocusEvent): void;
     }
     /**
      * The direction in which the popover should open relative to its parent

--- a/types/wordpress__components/popover/index.d.ts
+++ b/types/wordpress__components/popover/index.d.ts
@@ -67,9 +67,21 @@ declare namespace Popover {
          * A callback invoked when the user clicks outside the opened popover,
          * passing the click event. The popover should be closed in response to
          * this interaction.
-         * @defaultValue Props.onClose
+         *
+         * @deprecated  use `onFocusOutside`
          */
         onClickOutside?(): void;
+
+        /**
+         * A callback invoked when the focus leaves the opened popover. This
+         * should only be provided in advanced use-cases when a Popover should
+         * close under specific circumstances; for example, if the new
+         * `document.activeElement` is content of or otherwise controlling
+         * Popover visibility.
+         *
+         * Defaults to `onClose` when not provided.
+         */
+        onFocusOutside?(): void;
     }
     /**
      * The direction in which the popover should open relative to its parent

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -454,6 +454,9 @@ const kbshortcuts = {
             return anchorEl.parentElement.getBoundingClientRect();
         }
     }}
+    onClose={() => {}}
+    onClickOutside={() => {}}
+    onFocusOutside={() => {}}
 >
     Hello World
 </C.Popover>;
@@ -499,14 +502,20 @@ const kbshortcuts = {
     label="User type"
     help="The type of the current user"
     selected="a"
-    options={[{ label: 'Author', value: 'a' }, { label: 'Editor', value: 'e' }]}
+    options={[
+        { label: 'Author', value: 'a' },
+        { label: 'Editor', value: 'e' },
+    ]}
     onChange={value => value && console.log(value.toUpperCase())}
 />;
 <C.RadioControl
     label="User type"
     help="The type of the current user"
     selected={{ foo: 'bar' }}
-    options={[{ label: 'Author', value: { foo: 'bar' } }, { label: 'Editor', value: { foo: 'baz' } }]}
+    options={[
+        { label: 'Author', value: { foo: 'bar' } },
+        { label: 'Editor', value: { foo: 'baz' } },
+    ]}
     onChange={value => value && console.log(value.foo)}
 />;
 
@@ -560,14 +569,22 @@ const kbshortcuts = {
 <C.SelectControl
     label="Size"
     value="50%"
-    options={[{ label: 'Big', value: '100%' }, { label: 'Medium', value: '50%' }, { label: 'Small', value: '25%' }]}
+    options={[
+        { label: 'Big', value: '100%' },
+        { label: 'Medium', value: '50%' },
+        { label: 'Small', value: '25%' },
+    ]}
     onChange={size => console.log(size)}
 />;
 <C.SelectControl
     label="Size"
     value={['50%']}
     multiple
-    options={[{ label: 'Big', value: '100%' }, { label: 'Medium', value: '50%' }, { label: 'Small', value: '25%' }]}
+    options={[
+        { label: 'Big', value: '100%' },
+        { label: 'Medium', value: '50%' },
+        { label: 'Small', value: '25%' },
+    ]}
     onChange={size => console.log(size)}
 />;
 

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -456,7 +456,9 @@ const kbshortcuts = {
     }}
     onClose={() => {}}
     onClickOutside={() => {}}
-    onFocusOutside={() => {}}
+    onFocusOutside={e => {
+        if (e.relatedTarget && e.relatedTarget === document.querySelector('#my-element')) return;
+    }}
 >
     Hello World
 </C.Popover>;

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -502,20 +502,14 @@ const kbshortcuts = {
     label="User type"
     help="The type of the current user"
     selected="a"
-    options={[
-        { label: 'Author', value: 'a' },
-        { label: 'Editor', value: 'e' },
-    ]}
+    options={[{ label: 'Author', value: 'a' }, { label: 'Editor', value: 'e' }]}
     onChange={value => value && console.log(value.toUpperCase())}
 />;
 <C.RadioControl
     label="User type"
     help="The type of the current user"
     selected={{ foo: 'bar' }}
-    options={[
-        { label: 'Author', value: { foo: 'bar' } },
-        { label: 'Editor', value: { foo: 'baz' } },
-    ]}
+    options={[{ label: 'Author', value: { foo: 'bar' } }, { label: 'Editor', value: { foo: 'baz' } }]}
     onChange={value => value && console.log(value.foo)}
 />;
 
@@ -569,22 +563,14 @@ const kbshortcuts = {
 <C.SelectControl
     label="Size"
     value="50%"
-    options={[
-        { label: 'Big', value: '100%' },
-        { label: 'Medium', value: '50%' },
-        { label: 'Small', value: '25%' },
-    ]}
+    options={[{ label: 'Big', value: '100%' }, { label: 'Medium', value: '50%' }, { label: 'Small', value: '25%' }]}
     onChange={size => console.log(size)}
 />;
 <C.SelectControl
     label="Size"
     value={['50%']}
     multiple
-    options={[
-        { label: 'Big', value: '100%' },
-        { label: 'Medium', value: '50%' },
-        { label: 'Small', value: '25%' },
-    ]}
+    options={[{ label: 'Big', value: '100%' }, { label: 'Medium', value: '50%' }, { label: 'Small', value: '25%' }]}
     onChange={size => console.log(size)}
 />;
 

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -457,7 +457,7 @@ const kbshortcuts = {
     onClose={() => {}}
     onClickOutside={() => {}}
     onFocusOutside={e => {
-        if (e.relatedTarget && e.relatedTarget === document.querySelector('#my-element')) return;
+        if (e.relatedTarget === document.querySelector('#my-element')) return;
     }}
 >
     Hello World


### PR DESCRIPTION
- Package version [8.2](https://unpkg.com/browse/@wordpress/components@8.2.0/src/popover/index.js) (not present in previous [8.1](https://unpkg.com/browse/@wordpress/components@8.1.0/src/popover/index.js)).
- [Deprecate `onClickOutside`](https://github.com/WordPress/gutenberg/blob/74551b5b6203ca4131f23951364d71b827bee657/packages/components/src/popover/index.js#L314-L315)
- Add [`onFocusOutside`](https://github.com/WordPress/gutenberg/tree/74551b5b6203ca4131f23951364d71b827bee657/packages/components/src/popover#onfocusoutside).
- Add a few props type tests.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/tree/74551b5b6203ca4131f23951364d71b827bee657/packages/components/src/popover#onfocusoutside
- [x] **8.2** If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
