### PR TITLE
feat(css-mediaquery): Add types

### DIFF
--- a/types/css-mediaquery/css-mediaquery-tests.ts
+++ b/types/css-mediaquery/css-mediaquery-tests.ts
@@ -1,0 +1,25 @@
+import { match, parse, Expression } from 'css-mediaquery';
+
+// $ExpectError
+match('(min-width: 800)');
+// $ExpectType
+match('(min-width: 800)', {});
+match('(min-width: 800)', { width: 300 });
+match('(min-width: 800)', { width: '300px' });
+match('(min-width: 800)', { width: '300px', height: 100 });
+match('', { 'aspect-ratio': '16:10' });
+match('', { 'color-index': 2 });
+match('', { 'device-aspect-ratio': '4:3' });
+match('', { 'device-height': '500cm' });
+match('', { 'device-width': '1m' });
+match('', { color: 'blue' });
+match('', { grid: true });
+match('', { height: '300dpi' });
+match('', { monochrome: true });
+match('', { orientation: 'vertical' });
+match('', { resolution: '1440p' });
+match('', { scan: false });
+
+const [{ expressions }] = parse('screen and (min-width: 48em)');
+// $ExpectType Expression[]
+expressions;

--- a/types/css-mediaquery/index.d.ts
+++ b/types/css-mediaquery/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for css-mediaquery 0.1
 // Project: https://github.com/ericf/css-mediaquery
-// Definitions by: Sebastian Silbermann <https://github.com/me>
+// Definitions by: Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/css-mediaquery/index.d.ts
+++ b/types/css-mediaquery/index.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for css-mediaquery 0.1
+// Project: https://github.com/ericf/css-mediaquery
+// Definitions by: Sebastian Silbermann <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+export type MediaValues = Record<
+    | 'orientation'
+    | 'scan'
+    | 'width'
+    | 'height'
+    | 'device-width'
+    | 'device-height'
+    | 'resolution'
+    | 'aspect-ratio'
+    | 'device-aspect-ratio'
+    | 'grid'
+    | 'color'
+    | 'color-index'
+    | 'monochrome',
+    unknown
+>;
+
+export function match(query: string, values: Partial<MediaValues>): boolean;
+
+export type AST = QueryNode[];
+export interface QueryNode {
+    inverse: boolean;
+    type: string;
+    expressions: Expression[];
+}
+export interface Expression {
+    modifier: string;
+    feature: string;
+    value: string;
+}
+
+export function parse(query: string): AST;

--- a/types/css-mediaquery/tsconfig.json
+++ b/types/css-mediaquery/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "css-mediaquery-tests.ts"
+    ]
+}

--- a/types/css-mediaquery/tslint.json
+++ b/types/css-mediaquery/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Types for https://github.com/ericf/css-mediaquery/blob/v0.1.2/index.js

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

