### PR TITLE
feat(react-swipeable-views-utils): Add types

### DIFF
--- a/types/react-swipeable-views-utils/index.d.ts
+++ b/types/react-swipeable-views-utils/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for react-swipeable-views-utils 0.13
+// Project: https://github.com/oliviertassinari/react-swipeable-views#react-swipeable-views
+// Definitions by: Sebastian Silbermann <https://github.com/eps1lon>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import * as React from 'react';
+import { ConsistentWith, Omit, PropInjector } from '@material-ui/types';
+import { OnChangeIndexCallback, OnSwitchingCallback } from 'react-swipeable-views';
+
+export interface WithAutoPlay {
+    index: number;
+    onChangeIndex: OnChangeIndexCallback;
+    onSwitching?: OnSwitchingCallback;
+}
+export interface WithAutoPlayProps {
+    autoplay?: boolean;
+    direction?: 'incremental' | 'decremental';
+    index: number;
+    interval?: number;
+    onChangeIndex: OnChangeIndexCallback;
+    slideCount?: number;
+}
+
+export const autoPlay: PropInjector<WithAutoPlay, WithAutoPlayProps>;

--- a/types/react-swipeable-views-utils/package.json
+++ b/types/react-swipeable-views-utils/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@material-ui/types": "^4.0.0"
+    }
+}

--- a/types/react-swipeable-views-utils/react-swipeable-views-utils-tests.tsx
+++ b/types/react-swipeable-views-utils/react-swipeable-views-utils-tests.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import SwipeableViews from 'react-swipeable-views';
+import { autoPlay } from 'react-swipeable-views-utils';
+
+const AutoPlaySwipeableViews = autoPlay(SwipeableViews);
+
+function autoPlayTest() {
+    // $ExpectError
+    <AutoPlaySwipeableViews />;
+    <AutoPlaySwipeableViews
+        index={1}
+        onChangeIndex={index => {
+            // $ExpectType number
+            index;
+        }}
+    />;
+}

--- a/types/react-swipeable-views-utils/tsconfig.json
+++ b/types/react-swipeable-views-utils/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "jsx": "react",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-swipeable-views-utils-tests.tsx"
+    ]
+}

--- a/types/react-swipeable-views-utils/tslint.json
+++ b/types/react-swipeable-views-utils/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Types for https://github.com/oliviertassinari/react-swipeable-views/blob/v0.13.3/packages/react-swipeable-views-utils/src/autoPlay.js

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
