### PR TITLE
feat: 🎸 add types for express-healthcheck

### DIFF
--- a/types/express-healthcheck/express-healthcheck-tests.ts
+++ b/types/express-healthcheck/express-healthcheck-tests.ts
@@ -1,0 +1,6 @@
+import { Router } from 'express';
+import health from 'express-healthcheck';
+
+const router = Router();
+
+router.use('/health', health());

--- a/types/express-healthcheck/index.d.ts
+++ b/types/express-healthcheck/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for express-healthcheck 0.1
+// Project: https://github.com/lennym/express-healthcheck/
+// Definitions by: Ollie Tribe <https://github.com/o8e>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { RequestHandlerParams } from 'express-serve-static-core';
+
+export interface Options {
+    test?: () => any;
+    healthy?: () => any;
+}
+
+export default function fn(options?: Options): RequestHandlerParams;

--- a/types/express-healthcheck/tsconfig.json
+++ b/types/express-healthcheck/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-healthcheck-tests.ts"
+    ]
+}

--- a/types/express-healthcheck/tslint.json
+++ b/types/express-healthcheck/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
## [express-healthcheck](https://github.com/lennym/express-healthcheck)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x]  Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

### New definition

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.