### PR TITLE
[hls-parser] Create type definitions

### DIFF
--- a/types/hls-parser/hls-parser-tests.ts
+++ b/types/hls-parser/hls-parser-tests.ts
@@ -1,0 +1,24 @@
+import HLS = require('hls-parser');
+
+const playlist = HLS.parse('');
+
+if (playlist.isMasterPlaylist) {
+    // Master playlist
+} else {
+    // Media playlist
+}
+
+const { MediaPlaylist, Segment } = HLS.types;
+
+new MediaPlaylist({
+    targetDuration: 9,
+    playlistType: 'VOD',
+    segments: [
+        new Segment({
+            uri: 'low/1.m3u8',
+            duration: 9,
+            mediaSequenceNumber: 0,
+            discontinuitySequence: 0,
+        }),
+    ],
+});

--- a/types/hls-parser/index.d.ts
+++ b/types/hls-parser/index.d.ts
@@ -1,0 +1,284 @@
+// Type definitions for hls-parser 0.5
+// Project: https://github.com/kuu/hls-parser#readme
+// Definitions by: Christian Rackerseder <https://github.com/screendriver>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.4
+
+/// <reference types="node" />
+
+export interface Byterange {
+    length: number;
+    offset: number;
+}
+
+export interface Options {
+    strictMode: boolean;
+}
+
+export class Data {
+    type: 'playlist' | 'segment';
+}
+
+export namespace types {
+    class Playlist extends Data {
+        isMasterPlaylist: boolean;
+
+        uri?: string;
+
+        version?: number;
+
+        independentSegments: boolean;
+
+        start?: { offset: number; precise: boolean };
+
+        source?: string;
+
+        constructor(properties: {
+            isMasterPlaylist: boolean;
+            uri?: string;
+            version?: number;
+            independentSegments: boolean;
+            start?: { offset: number; precise: boolean };
+            source?: string;
+        });
+    }
+
+    class MasterPlaylist extends Playlist {
+        variants: readonly Variant[];
+
+        currentVariant?: number;
+
+        sessionDataList: readonly SessionData[];
+
+        sessionKeyList: readonly Key[];
+
+        constructor(properties: {
+            variants?: readonly Variant[];
+            currentVariant?: number;
+            sessionDataList?: readonly SessionData[];
+            sessionKeyList?: readonly Key[];
+            source?: string;
+        });
+    }
+
+    class MediaPlaylist extends Playlist {
+        targetDuration: number;
+
+        mediaSequenceBase?: number;
+
+        discontinuitySequenceBase?: number;
+
+        endlist: boolean;
+
+        playlistType?: 'EVENT' | 'VOD';
+
+        isIFrame: boolean;
+
+        segments: readonly Segment[];
+
+        constructor(properties: {
+            targetDuration: number;
+            mediaSequenceBase?: number;
+            discontinuitySequenceBase?: number;
+            endlist?: boolean;
+            playlistType?: 'EVENT' | 'VOD';
+            isIFrame?: boolean;
+            segments?: readonly Segment[];
+            source?: string;
+        });
+    }
+
+    class Variant {
+        uri: string;
+
+        isIFrameOnly?: boolean;
+
+        bandwidth: number;
+
+        averageBandwidth?: number;
+
+        codecs?: string;
+
+        resolution?: { width: number; height: number };
+
+        frameRate?: number;
+
+        hdcpLevel?: string;
+
+        audio: ReadonlyArray<Rendition<'AUDIO'>>;
+
+        video: ReadonlyArray<Rendition<'VIDEO'>>;
+
+        subtitles: ReadonlyArray<Rendition<'SUBTITLES'>>;
+
+        closedCaptions: ReadonlyArray<Rendition<'CLOSED-CAPTIONS'>>;
+
+        currentRenditions: { audio?: number; video?: number; subtitles?: number; closedCaptions?: number };
+
+        constructor(properties: {
+            uri: string;
+            isIFrameOnly?: boolean;
+            bandwidth: number;
+            averageBandwidth?: number;
+            codecs?: string;
+            resolution?: { width: number; height: number };
+            frameRate?: number;
+            hdcpLevel?: string;
+            audio?: ReadonlyArray<Rendition<'AUDIO'>>;
+            video?: ReadonlyArray<Rendition<'VIDEO'>>;
+            subtitles?: ReadonlyArray<Rendition<'SUBTITLES'>>;
+            closedCaptions?: ReadonlyArray<Rendition<'CLOSED-CAPTIONS'>>;
+            currentRenditions?: { audio?: number; video?: number; subtitles?: number; closedCaptions?: number };
+        });
+    }
+
+    class Rendition<T> {
+        type: T;
+
+        uri?: string;
+
+        groupId: string;
+
+        language?: string;
+
+        assocLanguage?: string;
+
+        name: string;
+
+        isDefault: boolean;
+
+        autoselect: boolean;
+
+        forced: boolean;
+
+        instreamId?: string;
+
+        characteristics?: string;
+
+        channels?: string;
+
+        constructor(properties: {
+            type: T;
+            uri?: string;
+            groupId: string;
+            language?: string;
+            assocLanguage?: string;
+            name: string;
+            isDefault?: boolean;
+            autoselect?: boolean;
+            forced?: boolean;
+            instreamId?: string;
+            characteristics?: string;
+            channels?: string;
+        });
+    }
+
+    class SessionData {
+        id: string;
+
+        value?: string;
+
+        uri?: string;
+
+        language?: string;
+
+        constructor(properties: { id: string; value?: string; uri?: string; language?: string });
+    }
+
+    class Segment extends Data {
+        uri: string;
+
+        duration: number;
+
+        title?: string;
+
+        byterange?: Byterange;
+
+        discontinuity?: boolean;
+
+        mediaSequenceNumber: number;
+
+        discontinuitySequence: number;
+
+        key?: Key;
+
+        map?: MediaInitializationSection;
+
+        programDateTime?: Date;
+
+        dateRange: DateRange;
+
+        constructor(properties: {
+            uri: string;
+            duration: number;
+            title?: string;
+            byterange?: Byterange;
+            discontinuity?: boolean;
+            mediaSequenceNumber: number;
+            discontinuitySequence: number;
+            key?: Key;
+            map?: MediaInitializationSection;
+            programDateTime?: Date;
+            dateRange?: DateRange;
+        });
+    }
+
+    class Key {
+        method: string;
+
+        uri?: string;
+
+        iv?: Buffer;
+
+        format?: string;
+
+        formatVersion?: string;
+
+        constructor(properties: { method: string; uri?: string; iv?: Buffer; format?: string; formatVersion?: string });
+    }
+
+    class MediaInitializationSection {
+        uri: string;
+
+        byterange?: Byterange;
+
+        constructor(properties: { uri: string; byterange?: Byterange });
+    }
+
+    class DateRange {
+        id: string;
+
+        classId?: string;
+
+        start: Date;
+
+        end?: Date;
+
+        duration?: number;
+
+        plannedDuration?: number;
+
+        endOnNext?: boolean;
+
+        attributes?: object;
+
+        constructor(properties: {
+            id: string;
+            classId?: string;
+            start: Date;
+            end?: Date;
+            duration?: number;
+            plannedDuration?: number;
+            endOnNext?: boolean;
+            attributes?: object;
+        });
+    }
+}
+
+export function parse(manifest: string): types.MasterPlaylist | types.MediaPlaylist;
+
+export function stringify(playlist: types.MasterPlaylist | types.MediaPlaylist): string;
+
+export function setOptions(overrides: Partial<Options>): void;
+
+export function getOptions(): Options;

--- a/types/hls-parser/tsconfig.json
+++ b/types/hls-parser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "hls-parser-tests.ts"
+    ]
+}

--- a/types/hls-parser/tslint.json
+++ b/types/hls-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.