### PR TITLE
[ssh2-sftp-client] add the second param for list method

### DIFF
--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -7,6 +7,7 @@
 //                 Orblazer <https://github.com/orblazer>
 //                 Taylor Herron <https://github.com/gbhmt>
 //                 Lane Goldberg <https://github.com/builtbylane>
+//                 Lorenzo Adinolfi <https://github.com/loru88>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as ssh2 from 'ssh2';
@@ -17,7 +18,7 @@ export = sftp;
 declare class sftp {
     connect(options: ssh2.ConnectConfig): Promise<ssh2.SFTPWrapper>;
 
-    list(remoteFilePath: string): Promise<sftp.FileInfo[]>;
+    list(remoteFilePath: string, pattern?: string|RegExp): Promise<sftp.FileInfo[]>;
 
     exists(remotePath: string): Promise<false | "d" | "-" | "l">;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/theophilusx/ssh2-sftp-client#breaking-changes-in-version-4x
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
