### PR TITLE
Fix circular dependency bug in @types/validator

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -1243,7 +1243,3 @@ export function whitelist(input: string, chars: string): string;
  * Converts to string.
  */
 export function toString(input: any): string;
-
-import * as Validator from './';
-
-export default Validator;


### PR DESCRIPTION
With these two lines, typescript errors with

`Circular definition of import alias 'Validator'`

Without them, the library works just fine.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).