### PR TITLE
fast-text-encoding: Fix global name collisions

### DIFF
--- a/types/fast-text-encoding/fast-text-encoding-tests.ts
+++ b/types/fast-text-encoding/fast-text-encoding-tests.ts
@@ -1,4 +1,6 @@
-import 'fast-text-encoding';
+// Declare globals in non-DOM environment
+declare let TextDecoder: fastTextEncoding.TextDecoder;
+declare let TextEncoder: fastTextEncoding.TextEncoder;
 
 const encoder1 = new TextEncoder();
 const _encoder2 = new TextEncoder('utf-8');

--- a/types/fast-text-encoding/index.d.ts
+++ b/types/fast-text-encoding/index.d.ts
@@ -1,28 +1,66 @@
 // Type definitions for fast-text-encoding 1.0
-// Project: https://github.com/samthor/fast-text-encoder#readme
+// Project: https://github.com/samthor/fast-text-encoding#readme
 // Definitions by: Ciarán Ingle <https://github.com/inglec-arista>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
-declare namespace fastTextEncoder {
-    interface Options {
+/**
+ * fast-text-encoding does not export any members, but defines the global classes
+ * 1) TextDecoder (https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder)
+ * 2) TextEncoder (https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder)
+ * if they are not already defined.
+ *
+ * We do not declare these globals here since they are already declared in "lib.dom.d.ts" and would
+ * result in name collisions. Instead, we export the types so that `TextDecoder` and `TextEncoder`
+ * can be manually declared in a non-DOM environment (see tests).
+ */
+
+declare namespace fastTextEncoding {
+    /**
+     * Options for `TextDecoder.decode` and `TextEncoder.encode`.
+     */
+    interface TextEncodingOptions {
         stream: boolean;
     }
-}
 
-declare class TextEncoder {
-    encoding: string;
+    /**
+     * Options for TextDecoder constructor.
+     */
+    interface TextDecoderOptions {
+        fatal: boolean;
+    }
 
-    constructor(label?: string);
+    /**
+     * TextDecoder instance.
+     */
+    class TextDecoderClass {
+        encoding: string;
+        fatal: boolean;
+        ignoreBOM: boolean;
 
-    encode(string: string, options?: fastTextEncoder.Options): Uint8Array;
-}
+        constructor(utfLabel?: string, options?: TextDecoderOptions);
 
-declare class TextDecoder {
-    encoding: string;
-    fatal: boolean;
-    ignoreBOM: boolean;
+        decode(buffer: Uint8Array, options?: TextEncodingOptions): string;
+    }
 
-    constructor(utfLabel?: string, options?: { fatal: boolean });
+    /**
+     * TextEncoder instance.
+     */
+    class TextEncoderClass {
+        encoding: string;
 
-    decode(buffer: Uint8Array, options?: fastTextEncoder.Options): string;
+        constructor(label?: string);
+
+        encode(string: string, options?: TextEncodingOptions): Uint8Array;
+    }
+
+    /**
+     * TextDecoder class.
+     */
+    type TextDecoder = typeof TextDecoderClass;
+
+    /**
+     * TextEncoder class.
+     */
+    type TextEncoder = typeof TextEncoderClass;
 }


### PR DESCRIPTION
Global var definitions for TextDecoder and TextEncoder collide with the
globals defined by "lib.dom.d.ts". Ideally we would be able to
conditionally define TextDecoder and TextEncoder if they are not
already defined in the current context. Since we cannot do conditional
definitions in an ambient context, we export these types so the user
can do this themselves (see tests).

- Move global type definitions to namespace to prevent collisions with
  "lib.dom.d.ts" TextDecoder and TextEncoder.
- Update name of namespace from "fastTextEncoder" to "fastTextEncoding"
  to match package name.
- Update tests to manually define global vars TextDecoder and
  TextEncoder.