### PR TITLE
Cheerio / adding undefined to return type of attr method of Cheerio interface

### DIFF
--- a/types/cheerio/cheerio-tests.ts
+++ b/types/cheerio/cheerio-tests.ts
@@ -46,6 +46,7 @@ $ = cheerio.load(html, {
  */
 var $el = $('.class');
 var $multiEl = $('selector', 'selector', 'selector');
+var $emptyEl = $('.not-existing-class');
 
 $el.cheerio;
 
@@ -60,6 +61,8 @@ $el.attr('id', 'favorite').html();
 $el.attr('id', (el, i, attr) => el.tagName + i * 2 + attr).html();
 $el.attr('id', el => el.tagName).html();
 $el.attr({ id: 'uniq', class: 'big' }).html();
+
+$emptyEl.attr('id') === undefined;
 
 // props
 $el.prop('style');

--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -27,7 +27,7 @@ interface Cheerio {
     // Attributes
 
     attr(): { [attr: string]: string };
-    attr(name: string): string;
+    attr(name: string): string | undefined;
     attr(name: string, value: AttrFunction): Cheerio;
     // `value` *can* be `any` here but:
     // 1. That makes type-checking the function-type useless


### PR DESCRIPTION
attr method of empty selection returns undefined

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: (no mention in documentation)

