### PR TITLE
[Enzyme] Allow .find() with class component type parameter

### DIFF
--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -67,7 +67,12 @@ class AnotherComponent extends Component<AnotherComponentProps> {
     setState(...args: any[]) {
         console.log(args);
     }
+
+    handleAnotherEcho(value: string) {
+      return value;
+    }
 }
+
 interface OptionalFunctionProp {
     functionProp?(): void;
     requiredFunctionProp(): void;
@@ -647,6 +652,11 @@ function ReactWrapperTest() {
         anotherComponentWrapper = reactWrapper.find(AnotherComponent);
         anotherStatelessWrapper = reactWrapper.find(AnotherStatelessComponent);
         reactWrapper = reactWrapper.find({ prop: 'myprop' });
+    }
+
+    function test_findWithType() {
+      const anotherComponentTypedWrapper = reactWrapper.find<AnotherComponent>(AnotherComponent);
+      anotherComponentTypedWrapper.instance().handleAnotherEcho('it works');
     }
 
     function test_findWhere() {

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -408,6 +408,9 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
      */
     find<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
     find<P2>(component: ComponentType<P2>): ShallowWrapper<P2, any>;
+    find<C2 extends Component>(
+      componentClass: ComponentClass<C2['props']>,
+    ): ShallowWrapper<C2['props'], C2['state'], C2>;
     find(props: EnzymePropSelector): ShallowWrapper<any, any>;
     find(selector: string): ShallowWrapper<HTMLAttributes, any>;
 
@@ -541,6 +544,9 @@ export class ReactWrapper<P = {}, S = {}, C = Component> {
      */
     find<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
     find<P2>(component: ComponentType<P2>): ReactWrapper<P2, any>;
+    find<C2 extends Component>(
+      componentClass: ComponentClass<C2['props']>,
+    ): ReactWrapper<C2['props'], C2['state'], C2>;
     find(props: EnzymePropSelector): ReactWrapper<any, any>;
     find(selector: string): ReactWrapper<HTMLAttributes, any>;
 


### PR DESCRIPTION
Currently, using `.find` on a ShallowWrapper/ReactWrapper with a class component means you have to cast the result manually, e.g:

`const child = wrapper.find(MyClassComponent).instance() as MyClassComponent`

This PR lets you pass a type argument (similar to the one on `shallow()`/`mount()`) to make this slightly less painful:

`wrapper.find<MyClassComponent>(MyClassComponent)`

The two existing overloads take the prop type as a type argument, which makes sense with a SFC, but not a class component. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see the description at top for a short example.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.