### PR TITLE
Added responseInterceptor swagger-ui-dist

### DIFF
--- a/types/swagger-ui-dist/index.d.ts
+++ b/types/swagger-ui-dist/index.d.ts
@@ -99,6 +99,12 @@ export interface SwaggerConfigs {
      */
     requestInterceptor?: ((request: SwaggerRequest) => SwaggerRequest);
 
+    /**
+     *  Function to intercept remote definition, "Try it out", and OAuth 2.0 responses.
+     *  Accepts one argument responseInterceptor(response) and must return the modified response, or a Promise that resolves to the modified response.
+     */
+    responseInterceptor?: ((request: SwaggerResponse) => SwaggerResponse);
+
     [k: string]: any;
 }
 
@@ -115,6 +121,10 @@ export const SwaggerUIBundle: SwaggerUIBundle;
 export interface SwaggerRequest {
   url: string;
   credentials: string;
+  [k: string]: any;
+}
+
+export interface SwaggerResponse {
   [k: string]: any;
 }
 

--- a/types/swagger-ui-dist/index.d.ts
+++ b/types/swagger-ui-dist/index.d.ts
@@ -103,7 +103,7 @@ export interface SwaggerConfigs {
      *  Function to intercept remote definition, "Try it out", and OAuth 2.0 responses.
      *  Accepts one argument responseInterceptor(response) and must return the modified response, or a Promise that resolves to the modified response.
      */
-    responseInterceptor?: ((request: SwaggerResponse) => SwaggerResponse);
+    responseInterceptor?: ((response: SwaggerResponse) => SwaggerResponse);
 
     [k: string]: any;
 }


### PR DESCRIPTION
`responseInterceptor` was missing so this PR fills it in.

We can see it should be included as per the documentation: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#responseInterceptor