### PR TITLE
Update @types/mui-datatables to new release version

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mui-datatables 2.12
+// Type definitions for mui-datatables 2.13
 // Project: https://github.com/gregnb/mui-datatables
 // Definitions by: Jeroen "Favna" Claassens <https://github.com/favna>
 //                 Ankith Konda <https://github.com/ankithkonda>

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -123,6 +123,7 @@ export interface MUIDataTableColumnOptions {
     hint?: string;
     print?: boolean;
     searchable?: boolean;
+    setCellHeaderProps?: (columnMeta: MUIDataTableCustomHeadRenderer) => object;
     setCellProps?: (cellValue: string, rowIndex: number, columnIndex: number) => object;
     sort?: boolean;
     sortDirection?: 'asc' | 'desc';
@@ -170,6 +171,7 @@ export interface MUIDataTableOptions {
         displayData: Array<{ data: any[]; dataIndex: number }>,
         setSelectedRows: (rows: number[]) => void
     ) => React.ReactNode;
+    disableToolbarSelect?: boolean;
     download?: boolean;
     downloadOptions?: {
         filename: string;
@@ -228,6 +230,7 @@ export interface MUIDataTableOptions {
     selectableRows?: SelectableRows;
     selectableRowsHeader?: boolean;
     selectableRowsOnClick?: boolean;
+    setTableProps?: () => object;
     serverSide?: boolean;
     serverSideFilterList?: any[];
     setRowProps?: (row: any[], rowIndex: number) => object;


### PR DESCRIPTION
A new release has been pushed to mui-datatables.

Add the below properties to match the current mui-datatables version:
- Release: https://github.com/gregnb/mui-datatables/releases/tag/2.13.0

* Add 'setCellHeader' to mui-datatable MUIDataTableColumnOptions: [See mui-datatables PR](https://github.com/gregnb/mui-datatables/pull/889)
* Add 'disableToolbarSelect' to mui-datatables MUIDataTableOptions: [See mui-datatables PR](https://github.com/gregnb/mui-datatables/pull/874)
* Add 'setTableProps' to mui-datatables MUIDataTableOptions: [See mui-datatables PR](https://github.com/gregnb/mui-datatables/pull/670)




- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/gregnb/mui-datatables/releases/tag/2.13.0>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
