### PR TITLE
Add roxy option to the rox-* packages

### DIFF
--- a/types/rox-browser/index.d.ts
+++ b/types/rox-browser/index.d.ts
@@ -49,6 +49,12 @@ export interface RoxSetupOptions {
   freeze?: RoxFlagFreezeLevel;
   disableNetworkFetch?: boolean;
   devModeSecret?: string;
+  /**
+   * Set Roxy's URL for automated tests or local development.
+   *
+   * https://support.rollout.io/docs/microservices-automated-testing-and-local-development
+   */
+  roxy?: string;
 }
 
 export enum RoxFetcherStatus {

--- a/types/rox-node/index.d.ts
+++ b/types/rox-node/index.d.ts
@@ -49,6 +49,12 @@ export interface RoxSetupOptions {
   fetchIntervalInSec?: number;
   disableNetworkFetch?: boolean;
   devModeSecret?: string;
+  /**
+   * Set Roxy's URL for automated tests or local development.
+   *
+   * https://support.rollout.io/docs/microservices-automated-testing-and-local-development
+   */
+  roxy?: string;
 }
 
 export enum RoxFetcherStatus {

--- a/types/rox-react-native/index.d.ts
+++ b/types/rox-react-native/index.d.ts
@@ -46,6 +46,12 @@ export interface RoxSetupOptions {
     freeze?: FreezeOptions;
     disableNetworkFetch?: boolean;
     devModeSecret?: string;
+    /**
+     * Set Roxy's URL for automated tests or local development.
+     *
+     * https://support.rollout.io/docs/microservices-automated-testing-and-local-development
+     */
+    roxy?: string;
     // https://support.rollout.io/docs/reactnative#section--asyncstorage-
     AsyncStorage?: any; // AsyncStorage from 'react-native' package
 }


### PR DESCRIPTION
One option supported by Rollout.io and described in https://support.rollout.io/docs/microservices-automated-testing-and-local-development#section-redirecting-rollout-sdk-to-roxy is missing from the three rox packages.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://support.rollout.io/docs/microservices-automated-testing-and-local-development#section-redirecting-rollout-sdk-to-roxy