### PR TITLE
[rdf-js] Add basic dataset interfaces

### DIFF
--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -10,8 +10,8 @@
 import * as stream from "stream";
 import { EventEmitter } from "events";
 
-/* Data Interfaces */
-/* https://github.com/rdfjs/representation-task-force/blob/master/interface-spec.md#data-interfaces */
+/* Data Model Interfaces */
+/* https://github.com/rdfjs/data-model-spec */
 
 /**
  * Contains an Iri, RDF blank Node, RDF literal, variable name, or a default graph
@@ -311,7 +311,7 @@ export interface DataFactory {
 }
 
 /* Stream Interfaces */
-/* https://github.com/rdfjs/representation-task-force/blob/master/interface-spec.md#stream-interfaces */
+/* https://github.com/rdfjs/stream-spec */
 
 /**
  * A quad stream.
@@ -422,4 +422,57 @@ export interface Store<Q extends BaseQuad = Quad> extends Source<Q>, Sink<Q> {
      * @return The resulting event emitter.
      */
     deleteGraph(graph: Q['graph'] | string): EventEmitter;
+}
+
+/* Dataset Interfaces */
+/* https://github.com/rdfjs/dataset-spec */
+
+export interface DatasetCore<Q extends BaseQuad = Quad> {
+    /**
+     * A non-negative integer that specifies the number of quads in the set.
+     */
+    readonly size: number;
+
+    /**
+     * Adds the specified quad to the dataset.
+     *
+     * Existing quads, as defined in `Quad.equals`, will be ignored.
+     */
+    add(quad: Q): this;
+
+    /**
+     * Removes the specified quad from the dataset.
+     */
+    delete(quad: Q): this;
+
+    /**
+     * Determines whether a dataset includes a certain quad.
+     */
+    has(quad: Q): boolean;
+
+    /**
+     * Returns a new dataset that is comprised of all quads in the current instance matching the given arguments.
+     *
+     * The logic described in {@link https://rdf.js.org/dataset-spec/#quad-matching|Quad Matching} is applied for each
+     * quad in this dataset to check if it should be included in the output dataset.
+     *
+     * This method always returns a new DatasetCore, even if that dataset contains no quads.
+     *
+     * Since a `DatasetCore` is an unordered set, the order of the quads within the returned sequence is arbitrary.
+     *
+     * @param subject   The optional exact subject to match.
+     * @param predicate The optional exact predicate to match.
+     * @param object    The optional exact object to match.
+     * @param graph     The optional exact graph to match.
+     */
+    match(subject?: Term, predicate?: Term, object?: Term, graph?: Term): DatasetCore<Q>;
+
+    [Symbol.iterator](): Iterator<Q>;
+}
+
+export interface DatasetCoreFactory<Q extends BaseQuad = Quad> {
+    /**
+     * Returns a new dataset and imports all quads, if given.
+     */
+    dataset(quads?: Q[]): DatasetCore<Q>;
 }

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -11,7 +11,7 @@ import * as stream from "stream";
 import { EventEmitter } from "events";
 
 /* Data Model Interfaces */
-/* https://github.com/rdfjs/data-model-spec */
+/* https://rdf.js.org/data-model-spec/ */
 
 /**
  * Contains an Iri, RDF blank Node, RDF literal, variable name, or a default graph
@@ -311,7 +311,7 @@ export interface DataFactory {
 }
 
 /* Stream Interfaces */
-/* https://github.com/rdfjs/stream-spec */
+/* https://rdf.js.org/stream-spec/ */
 
 /**
  * A quad stream.
@@ -425,7 +425,7 @@ export interface Store<Q extends BaseQuad = Quad> extends Source<Q>, Sink<Q> {
 }
 
 /* Dataset Interfaces */
-/* https://github.com/rdfjs/dataset-spec */
+/* https://rdf.js.org/dataset-spec/ */
 
 export interface DatasetCore<Q extends BaseQuad = Quad> {
     /**

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -146,6 +146,7 @@ function test_dataset() {
     const dataset2Match3: DatasetCore = dataset2.match(term, term);
     const dataset2Match4: DatasetCore = dataset2.match(term, term, term);
     const dataset2Match5: DatasetCore = dataset2.match(term, term, term, term);
+    const dataset2Iterable: Iterable<Quad> = dataset2;
 
     const dataset3Size: number = dataset3.size;
     const dataset3Add: DatasetCore<QuadBnode> = dataset3.add(quadBnode);
@@ -156,4 +157,5 @@ function test_dataset() {
     const dataset3Match3: DatasetCore<QuadBnode> = dataset3.match(term, term);
     const dataset3Match4: DatasetCore<QuadBnode> = dataset3.match(term, term, term);
     const dataset3Match5: DatasetCore<QuadBnode> = dataset3.match(term, term, term, term);
+    const dataset3Iterable: Iterable<QuadBnode> = dataset3;
 }

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -1,5 +1,5 @@
-import { BlankNode, DataFactory, DefaultGraph, Literal, NamedNode, Quad, BaseQuad, Sink, Source, Store, Stream, Triple, Term,
-  Variable, Quad_Graph } from "rdf-js";
+import { BlankNode, DataFactory, DatasetCore, DatasetCoreFactory, DefaultGraph, Literal, NamedNode, Quad, BaseQuad,
+  Sink, Source, Store, Stream, Triple, Term, Variable, Quad_Graph } from "rdf-js";
 import { EventEmitter } from "events";
 
 function test_terms() {
@@ -116,4 +116,44 @@ function test_stream() {
     const eventEmitter11: EventEmitter = store.removeMatches(term, term, term, /.*/);
     const eventEmitter12: EventEmitter = store.deleteGraph(graph);
     const eventEmitter13: EventEmitter = store.deleteGraph('http://example.org');
+}
+
+function test_dataset() {
+    interface QuadBnode extends BaseQuad {
+        subject: Term;
+        predicate: Term;
+        object: Term;
+        graph: Term;
+    }
+
+    const quad: Quad = <any> {};
+    const quadBnode: QuadBnode = <any> {};
+    const term: Term = <any> {};
+
+    const datasetCoreFactory1: DatasetCoreFactory = <any> {};
+    const datasetCoreFactory2: DatasetCoreFactory<QuadBnode> = <any> {};
+
+    const dataset1: DatasetCore = datasetCoreFactory1.dataset();
+    const dataset2: DatasetCore = datasetCoreFactory1.dataset([quad, quad]);
+    const dataset3: DatasetCore<QuadBnode> = datasetCoreFactory2.dataset([quadBnode, quad]);
+
+    const dataset2Size: number = dataset2.size;
+    const dataset2Add: DatasetCore = dataset2.add(quad);
+    const dataset2Delete: DatasetCore = dataset2.delete(quad);
+    const dataset2Has: boolean = dataset2.has(quad);
+    const dataset2Match1: DatasetCore = dataset2.match();
+    const dataset2Match2: DatasetCore = dataset2.match(term);
+    const dataset2Match3: DatasetCore = dataset2.match(term, term);
+    const dataset2Match4: DatasetCore = dataset2.match(term, term, term);
+    const dataset2Match5: DatasetCore = dataset2.match(term, term, term, term);
+
+    const dataset3Size: number = dataset3.size;
+    const dataset3Add: DatasetCore<QuadBnode> = dataset3.add(quadBnode);
+    const dataset3Delete: DatasetCore<QuadBnode> = dataset3.delete(quadBnode);
+    const dataset3Has: boolean = dataset3.has(quadBnode);
+    const dataset3Match1: DatasetCore<QuadBnode> = dataset3.match();
+    const dataset3Match2: DatasetCore<QuadBnode> = dataset3.match(term);
+    const dataset3Match3: DatasetCore<QuadBnode> = dataset3.match(term, term);
+    const dataset3Match4: DatasetCore<QuadBnode> = dataset3.match(term, term, term);
+    const dataset3Match5: DatasetCore<QuadBnode> = dataset3.match(term, term, term, term);
 }


### PR DESCRIPTION
Adds `DatasetCore` and `DatasetCoreFactory` from the [RDF/JS: Dataset specification 1.0](https://rdf.js.org/dataset-spec/).

I've not added the other interfaces due to the 'experimental' warning (though the 1.0 label suggests that it is now stable?).

Also fixed the links for the existing two specs.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://rdf.js.org/dataset-spec/
- ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~