### PR TITLE
@types/react: Mark booleanish HTML/SVG JSX attributes as such

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -45,6 +45,7 @@ type NativePointerEvent = PointerEvent;
 type NativeTransitionEvent = TransitionEvent;
 type NativeUIEvent = UIEvent;
 type NativeWheelEvent = WheelEvent;
+type Booleanish = boolean | 'true' | 'false';
 
 /**
  * defined in scheduler/tracing
@@ -1656,16 +1657,16 @@ declare namespace React {
         // Standard HTML Attributes
         accessKey?: string;
         className?: string;
-        contentEditable?: boolean;
+        contentEditable?: Booleanish;
         contextMenu?: string;
         dir?: string;
-        draggable?: boolean;
+        draggable?: Booleanish;
         hidden?: boolean;
         id?: string;
         lang?: string;
         placeholder?: string;
         slot?: string;
-        spellCheck?: boolean;
+        spellCheck?: Booleanish;
         style?: CSSProperties;
         tabIndex?: number;
         title?: string;
@@ -2272,7 +2273,7 @@ declare namespace React {
         ascent?: number | string;
         attributeName?: string;
         attributeType?: string;
-        autoReverse?: number | string;
+        autoReverse?: Booleanish;
         azimuth?: number | string;
         baseFrequency?: number | string;
         baselineShift?: number | string;
@@ -2312,7 +2313,7 @@ declare namespace React {
         enableBackground?: number | string;
         end?: number | string;
         exponent?: number | string;
-        externalResourcesRequired?: number | string;
+        externalResourcesRequired?: Booleanish;
         fill?: string;
         fillOpacity?: number | string;
         fillRule?: "nonzero" | "evenodd" | "inherit";
@@ -2321,7 +2322,7 @@ declare namespace React {
         filterUnits?: number | string;
         floodColor?: number | string;
         floodOpacity?: number | string;
-        focusable?: number | string;
+        focusable?: Booleanish;
         fontFamily?: string;
         fontSize?: number | string;
         fontSizeAdjust?: number | string;
@@ -2399,7 +2400,7 @@ declare namespace React {
         pointsAtX?: number | string;
         pointsAtY?: number | string;
         pointsAtZ?: number | string;
-        preserveAlpha?: number | string;
+        preserveAlpha?: Booleanish;
         preserveAspectRatio?: string;
         primitiveUnits?: number | string;
         r?: number | string;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1657,7 +1657,7 @@ declare namespace React {
         // Standard HTML Attributes
         accessKey?: string;
         className?: string;
-        contentEditable?: Booleanish;
+        contentEditable?: Booleanish | "inherit";
         contextMenu?: string;
         dir?: string;
         draggable?: Booleanish;
@@ -2322,7 +2322,7 @@ declare namespace React {
         filterUnits?: number | string;
         floodColor?: number | string;
         floodOpacity?: number | string;
-        focusable?: Booleanish;
+        focusable?: Booleanish | "auto";
         fontFamily?: string;
         fontSize?: number | string;
         fontSizeAdjust?: number | string;


### PR DESCRIPTION
These attributes are "booleanish" as described by React’s own code: https://github.com/facebook/react/blob/a7d07ff24d8d3d925ab45f5eb9be42a62a345dad/packages/react-dom/src/shared/DOMProperty.js#L257-L269

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/blob/a7d07ff24d8d3d925ab45f5eb9be42a62a345dad/packages/react-dom/src/shared/DOMProperty.js#L257-L269
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
