### PR TITLE
Import Boom type only.

### DIFF
--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types='node' />
 
-import * as Boom from '@hapi/boom';
+import { Boom } from '@hapi/boom';
 import * as http from 'http';
 import * as https from 'https';
 import * as Shot from '@hapi/shot';


### PR DESCRIPTION
When I try to build my project locally with `@types/hapi__hapi` included as a dependency, I get the following error:
`Cannot use namespace 'Boom' as a type.` lines 514 & 4057

I'm also running TypeScript 3.7.2 on that project. I think this error is only visible on this version of TypeScript.

![image](https://user-images.githubusercontent.com/161976/69645814-c5bc0980-1034-11ea-97e4-910966fe55de.png)
