### PR TITLE
Add missing references to adone.d.ts

### DIFF
--- a/types/adone/adone.d.ts
+++ b/types/adone/adone.d.ts
@@ -2,6 +2,8 @@
 /// <reference types="lodash" />
 /// <reference types="benchmark" />
 /// <reference types="async" />
+/// <reference path="./async.d.ts" />
+/// <reference path="./benchmark.d.ts" />
 
 declare namespace adone {
     const _null: symbol;


### PR DESCRIPTION
It relies on async.d.ts and benchmark.d.ts, but forgets to reference them.