### PR TITLE
react-blessed: add missing reference

### DIFF
--- a/types/react-blessed/index.d.ts
+++ b/types/react-blessed/index.d.ts
@@ -4,6 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
+/// <reference path="./react.d.ts" />
+
 import * as React from 'react';
 import { Widgets, screen } from 'blessed';
 export type Callback = () => void | null | undefined;


### PR DESCRIPTION
The file, confusingly, is called react.d.ts, but isn't @types/react.