### PR TITLE
react-dom tests: Add missing import of 'experimental'

### DIFF
--- a/types/react-dom/test/experimental-tests.tsx
+++ b/types/react-dom/test/experimental-tests.tsx
@@ -1,5 +1,6 @@
 import React = require('react');
 import ReactDOM = require('react-dom');
+import 'react-dom/experimental';
 
 function createRoot() {
     const root = ReactDOM.createRoot(document);


### PR DESCRIPTION
This worked by mistake because experimental.d.ts is in tsconfig.json, but consumers of `@types/react-dom` will need `import 'react-dom/experimental'` so the test should reflect that.