### PR TITLE
[@types/gremlin] Update translator type to be able to translate scripts to submit to Azure's Cosmos DB

### DIFF
--- a/types/gremlin/index.d.ts
+++ b/types/gremlin/index.d.ts
@@ -432,7 +432,7 @@ declare namespace process {
   class Translator {
     constructor(traversalSource: AnonymousTraversalSource | GraphTraversalSource);
     getTraversalSource(): Translator;
-    of(traversalSource: AnonymousTraversalSource | GraphTraversalSource): void;
+    of(traversalSource: AnonymousTraversalSource | GraphTraversalSource | string): void;
     translate(bytecode: Bytecode): string;
   }
 


### PR DESCRIPTION
Azure Cosmos DB with Gremlin API does not support fluent API yet, it was further postponed to first half of 2020.

As a workaround, we are using the translator to submit fluent api queries as 'script'.

However, we cannot initialize a translator that works with Azure's CosmosDB based based on an AnonymousTraversalSource or GraphTraversalSource, this type must allow for the 'string' possibility.

The correct usage with Azure's cosmos db is: 

```
const translator = new gremlin.process.Translator('g' as any);
``` 
Currently this works.

Related stackoverflow thread: 

https://stackoverflow.com/questions/58815569/azure-cosmos-gremlin-nodejs-how-to-submit-fluent-query-as-script-not-bytecod/59056304#59056304
