### PR TITLE
Update types for amphtml-validator

### DIFF
--- a/types/amphtml-validator/amphtml-validator-tests.ts
+++ b/types/amphtml-validator/amphtml-validator-tests.ts
@@ -12,7 +12,6 @@ import * as ampHtmlValidator from "amphtml-validator";
                 col,
                 message,
                 specUrl,
-                category,
                 code,
                 params
             } = err;
@@ -23,6 +22,6 @@ import * as ampHtmlValidator from "amphtml-validator";
 
 (() => {
     const validator = ampHtmlValidator.newInstance("");
-    const result = validator.validateString("<html></html>");
+    const result = validator.validateString("<html></html>", "AMP4ADS");
     const { status, errors } = result;
 })();

--- a/types/amphtml-validator/index.d.ts
+++ b/types/amphtml-validator/index.d.ts
@@ -14,7 +14,6 @@ export interface ValidationError {
     col: number;
     message: string;
     specUrl: string | null;
-    category: ErrorCategoryCode;
     code: ValidationErrorCode;
     params: string[];
 }
@@ -26,7 +25,10 @@ export interface ValidationResult {
 
 export class Validator extends Script {
     sandbox: Context;
-    validateString(stringToValidate: string): ValidationResult;
+    validateString(
+        stringToValidate: string,
+        htmlFormat?: string
+    ): ValidationResult;
 }
 
 export function getInstance(
@@ -43,24 +45,12 @@ export type ValidationResultStatus = "UNKNOWN" | "PASS" | "FAIL";
 
 export type ValidationErrorSeverity = "UNKNOWN_SEVERITY" | "ERROR" | "WARNING";
 
-export type ErrorCategoryCode =
-    | "UNKNOWN"
-    | "GENERIC"
-    | "DISALLOWED_HTML_WITH_AMP_EQUIVALENT"
-    | "DISALLOWED_HTML"
-    | "AUTHOR_STYLESHEET_PROBLEM"
-    | "MANDATORY_AMP_TAG_MISSING_OR_INCORRECT"
-    | "AMP_TAG_PROBLEM"
-    | "CUSTOM_JAVASCRIPT_DISALLOWED"
-    | "AMP_LAYOUT_PROBLEM"
-    | "AMP_HTML_TEMPLATE_PROBLEM"
-    | "DEPRECATION";
-
 export type ValidationErrorCode =
     | "UNKNOWN_CODE"
     | "MANDATORY_TAG_MISSING"
     | "TAG_REQUIRED_BY_MISSING"
     | "WARNING_TAG_REQUIRED_BY_MISSING"
+    | "TAG_EXCLUDED_BY_TAG"
     | "WARNING_EXTENSION_UNUSED"
     | "EXTENSION_UNUSED"
     | "WARNING_EXTENSION_DEPRECATED_VERSION"
@@ -73,18 +63,23 @@ export type ValidationErrorCode =
     | "INVALID_ATTR_VALUE"
     | "DUPLICATE_ATTRIBUTE"
     | "ATTR_VALUE_REQUIRED_BY_LAYOUT"
+    | "MISSING_LAYOUT_ATTRIBUTES"
     | "IMPLIED_LAYOUT_INVALID"
     | "SPECIFIED_LAYOUT_INVALID"
     | "MANDATORY_ATTR_MISSING"
     | "MANDATORY_ONEOF_ATTR_MISSING"
+    | "MANDATORY_ANYOF_ATTR_MISSING"
     | "DUPLICATE_DIMENSION"
     | "DUPLICATE_UNIQUE_TAG"
     | "DUPLICATE_UNIQUE_TAG_WARNING"
     | "WRONG_PARENT_TAG"
     | "STYLESHEET_TOO_LONG"
+    | "STYLESHEET_AND_INLINE_STYLE_TOO_LONG"
+    | "INLINE_STYLE_TOO_LONG"
     | "MANDATORY_CDATA_MISSING_OR_INCORRECT"
     | "CDATA_VIOLATES_BLACKLIST"
     | "NON_WHITESPACE_CDATA_ENCOUNTERED"
+    | "INVALID_JSON_CDATA"
     | "DEPRECATED_ATTR"
     | "DEPRECATED_TAG"
     | "MANDATORY_PROPERTY_MISSING_FROM_ATTR_VALUE"
@@ -122,7 +117,9 @@ export type ValidationErrorCode =
     | "ATTR_MISSING_REQUIRED_EXTENSION"
     | "DOCUMENT_TOO_COMPLEX"
     | "INVALID_UTF8"
-    | "CSS_SYNTAX"
+    | "DOCUMENT_SIZE_LIMIT_EXCEEDED"
+    | "DEV_MODE_ONLY"
+    | "VALUE_SET_MISMATCH"
     | "CSS_SYNTAX_INVALID_AT_RULE"
     | "CSS_SYNTAX_STRAY_TRAILING_BACKSLASH"
     | "CSS_SYNTAX_UNTERMINATED_COMMENT"
@@ -150,6 +147,7 @@ export type ValidationErrorCode =
     | "CSS_SYNTAX_DISALLOWED_MEDIA_TYPE"
     | "CSS_SYNTAX_DISALLOWED_MEDIA_FEATURE"
     | "CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE"
+    | "CSS_EXCESSIVELY_NESTED"
     | "CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE_WITH_HINT"
     | "CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE"
     | "CSS_SYNTAX_PROPERTY_DISALLOWED_TOGETHER_WITH"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ampproject/amphtml/blob/a167d8e81ca42dc67ce4b823ae4cd94f52e32375/validator/validator.proto#L716-L829 and https://github.com/ampproject/amphtml/blob/a167d8e81ca42dc67ce4b823ae4cd94f52e32375/validator/nodejs/index.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
