### PR TITLE
feat: add @babel/standalone

### DIFF
--- a/types/babel__standalone/babel__standalone-tests.ts
+++ b/types/babel__standalone/babel__standalone-tests.ts
@@ -1,0 +1,44 @@
+import * as babel from '@babel/standalone';
+
+const options = {
+    ast: true,
+    sourceMaps: true
+};
+
+babel.transform('code()', options);
+
+const ast = {
+    type: "Program",
+    start: 0,
+    end: 2,
+    directives: [],
+    body: [
+      {
+        type: "ExpressionStatement",
+        start: 0,
+        end: 1,
+        expression: {
+          type: "NumericLiteral",
+          start: 0,
+          end: 2,
+          value: 42,
+          raw: "42",
+        },
+      },
+    ],
+    sourceType: "script",
+};
+
+babel.transformFromAst(ast, "42", { presets: ['es2015'] });
+
+const lolizer = () => ({
+    visitor: {
+      Identifier(path: { node: { name: string}}) {
+        path.node.name = "LOL";
+      },
+    },
+});
+
+babel.registerPlugin("lolizer", lolizer);
+
+babel.registerPreset("lulz", { plugins: [lolizer] });

--- a/types/babel__standalone/babel__standalone-tests.ts
+++ b/types/babel__standalone/babel__standalone-tests.ts
@@ -7,30 +7,6 @@ const options = {
 
 babel.transform('code()', options);
 
-const ast = {
-    type: "Program",
-    start: 0,
-    end: 2,
-    directives: [],
-    body: [
-      {
-        type: "ExpressionStatement",
-        start: 0,
-        end: 1,
-        expression: {
-          type: "NumericLiteral",
-          start: 0,
-          end: 2,
-          value: 42,
-          raw: "42",
-        },
-      },
-    ],
-    sourceType: "script",
-};
-
-babel.transformFromAst(ast, "42", { presets: ['es2015'] });
-
 const lolizer = () => ({
     visitor: {
       Identifier(path: { node: { name: string}}) {

--- a/types/babel__standalone/index.d.ts
+++ b/types/babel__standalone/index.d.ts
@@ -24,7 +24,7 @@ export function registerPresets(newPresets: {
 export const availablePlugins: Record<string, object | (() => void)>;
 export const availablePresets: Record<string, object | (() => void)>;
 
-export function transformScriptTags(scriptTags?: any[]): void;
+export function transformScriptTags(scriptTags?: HTMLCollection): void;
 
 export function disableScriptTags(): void;
 

--- a/types/babel__standalone/index.d.ts
+++ b/types/babel__standalone/index.d.ts
@@ -19,7 +19,7 @@ export function registerPlugins(newPlugins: {
 export function registerPreset(name: string, preset: object | (() => void)): void;
 export function registerPresets(newPresets: {
     [key: string]: object | (() => void),
-}): void
+}): void;
 
 export const availablePlugins: Record<string, object | (() => void)>;
 export const availablePresets: Record<string, object | (() => void)>;

--- a/types/babel__standalone/index.d.ts
+++ b/types/babel__standalone/index.d.ts
@@ -1,0 +1,30 @@
+// Type definitions for @babel/standalone 7.7.4
+// Project: https://github.com/babel/babel/tree/master/packages/babel-standalone
+// Definitions by: Matheus Goncalves da Silva <https://github.com/PlayMa256>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { TransformOptions, types, FileResultCallback } from '@babel/core';
+
+export function transform(code: string, options: TransformOptions): string;
+
+export function transformFromAst(ast: types.Node, code: string | undefined, opts: TransformOptions | undefined, callback?: FileResultCallback): void;
+
+export function registerPlugin(name: string, plugin: Object | Function): void;
+
+export function registerPlugins(newPlugins: {
+    [key: string]: Object | Function
+}): void;
+
+export function registerPreset(name: string, preset: Object | Function): void;
+export function registerPresets(newPresets: {
+    [key: string]: Object | Function,
+}): void
+
+export const availablePlugins: Record<string, Object | Function>;
+export const availablePresets: Record<string, Object | Function>;
+
+export function transformScriptTags(scriptTags?: Array<any>): void;
+
+export function disableScriptTags(): void;
+
+export as namespace babel;

--- a/types/babel__standalone/index.d.ts
+++ b/types/babel__standalone/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/babel/babel/tree/master/packages/babel-standalone
 // Definitions by: Matheus Goncalves da Silva <https://github.com/PlayMa256>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
 
 import { TransformOptions, types, FileResultCallback } from '@babel/core';
 

--- a/types/babel__standalone/index.d.ts
+++ b/types/babel__standalone/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @babel/standalone 7.7.4
+// Type definitions for @babel/standalone 7.1
 // Project: https://github.com/babel/babel/tree/master/packages/babel-standalone
 // Definitions by: Matheus Goncalves da Silva <https://github.com/PlayMa256>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/babel__standalone/index.d.ts
+++ b/types/babel__standalone/index.d.ts
@@ -10,21 +10,21 @@ export function transform(code: string, options: TransformOptions): string;
 
 export function transformFromAst(ast: types.Node, code: string | undefined, opts: TransformOptions | undefined, callback?: FileResultCallback): void;
 
-export function registerPlugin(name: string, plugin: Object | Function): void;
+export function registerPlugin(name: string, plugin: object | (() => void)): void;
 
 export function registerPlugins(newPlugins: {
-    [key: string]: Object | Function
+    [key: string]: object | (() => void)
 }): void;
 
-export function registerPreset(name: string, preset: Object | Function): void;
+export function registerPreset(name: string, preset: object | (() => void)): void;
 export function registerPresets(newPresets: {
-    [key: string]: Object | Function,
+    [key: string]: object | (() => void),
 }): void
 
-export const availablePlugins: Record<string, Object | Function>;
-export const availablePresets: Record<string, Object | Function>;
+export const availablePlugins: Record<string, object | (() => void)>;
+export const availablePresets: Record<string, object | (() => void)>;
 
-export function transformScriptTags(scriptTags?: Array<any>): void;
+export function transformScriptTags(scriptTags?: any[]): void;
 
 export function disableScriptTags(): void;
 

--- a/types/babel__standalone/package.json
+++ b/types/babel__standalone/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@babel/core": "^7.1.0"
+    }
+}

--- a/types/babel__standalone/tsconfig.json
+++ b/types/babel__standalone/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/babel__standalone/tsconfig.json
+++ b/types/babel__standalone/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@babel/standalone": [
+                "babel__standalone"
+            ],
+            "@babel/core": [
+                "babel__core"
+            ],
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "babel__standalone-tests.ts"
+    ]
+}

--- a/types/babel__standalone/tsconfig.json
+++ b/types/babel__standalone/tsconfig.json
@@ -18,7 +18,7 @@
             ],
             "@babel/core": [
                 "babel__core"
-            ],
+            ]
         },
         "types": [],
         "noEmit": true,

--- a/types/babel__standalone/tsconfig.json
+++ b/types/babel__standalone/tsconfig.json
@@ -18,6 +18,15 @@
             ],
             "@babel/core": [
                 "babel__core"
+            ],
+            "@babel/generator": [
+                "babel__generator"
+            ],
+            "@babel/template": [
+                "babel__template"
+            ],
+            "@babel/traverse": [
+                "babel__traverse"
             ]
         },
         "types": [],

--- a/types/babel__standalone/tslint.json
+++ b/types/babel__standalone/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

