### PR TITLE
feat: Add `domtagger`

### DIFF
--- a/types/domtagger/index.d.ts
+++ b/types/domtagger/index.d.ts
@@ -1,0 +1,88 @@
+// Type definitions for domtagger 0.5
+// Project: https://github.com/WebReflection/domtagger
+// Definitions by: ExE Boss <https://github.com/ExE-Boss>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace domtagger;
+
+declare namespace domtagger {
+	interface Options {
+		/**
+		 * The type of content to create.
+		 *
+		 * When `'svg'`, the generated template function returns `SVGElement` instances.
+		 *
+		 * @default 'html'
+		 */
+		type?: string;
+
+		/**
+		 * Used to provide a custom algorithm for converting a template
+		 * to a valid HTML text.
+		 */
+		convert?(template: TemplateStringsArray): string;
+
+		/**
+		 * Used to postprocess the result of `convert`.
+		 *
+		 * @param transform The default transformation.
+		 */
+		transform?(markup: string): string;
+
+		/**
+		 * Called when the parsed result is an attribute node.
+		 *
+		 * @param element The element whose attribute to set.
+		 * @param name The raw attribute name.
+		 * @param attribute The attribute node.
+		 *
+		 * @example
+		 * ```ts
+		 * (node, name, attribute) => value => {
+		 * 	const type = typeof value;
+		 * 	if (type === 'boolean' || type === 'function') {
+		 * 		node[name] = value;
+		 * 	} else if (value == null) {
+		 * 		node.removeAttribute(name);
+		 * 	} else {
+		 * 		node.setAttribute(name, value);
+		 * 	}
+		 * }
+		 * ```
+		 */
+		attribute(element: Element, name: string, attribute: Attr): (value: any) => void;
+
+		/**
+		 * How to handle cases where content can only be some text.
+		 *
+		 * The node is one that can only have text.
+		 *
+		 * @param node The node whose text content to set
+		 *
+		 * @example
+		 * ```ts
+		 * node => textContent => {
+		 * 	node.textContent = textContent;
+		 * }
+		 * ```
+		 */
+		text(node: Node): (textContent: any) => void;
+
+		/**
+		 * Called when no other node type satisfies the parsed result.
+		 *
+		 * @param node The node
+		 * @param childNodes
+		 */
+		any(node: Node, childNodes: ChildNode[]): (markup: any) => void;
+	}
+
+	interface SVGOptions extends Options {
+		type: 'svg';
+	}
+}
+
+declare function domtagger(opts: domtagger.SVGOptions): (template: TemplateStringsArray, ...args: any[]) => SVGElement;
+declare function domtagger(opts: domtagger.Options): (template: TemplateStringsArray, ...args: any[]) => HTMLElement;
+
+export = domtagger;

--- a/types/domtagger/test/domtagger.cjs.test.ts
+++ b/types/domtagger/test/domtagger.cjs.test.ts
@@ -1,0 +1,54 @@
+import domtagger = require('domtagger');
+
+const options: domtagger.Options = {
+	attribute(node, name) {
+		return value => {
+			const type = typeof value;
+			if (type === 'boolean' || type === 'function') {
+				(node as any)[name] = value;
+			} else if (value == null) {
+				node.removeAttribute(name);
+			} else {
+				node.setAttribute(name, value);
+			}
+		};
+	},
+
+	text(node) {
+		return textContent => {
+			node.textContent = textContent;
+		};
+	},
+
+	any(node, childNodes) {
+		return markup => {
+			switch (node.nodeType) {
+				case Node.ELEMENT_NODE:
+					(node as Element).innerHTML = markup;
+					break;
+			}
+		};
+	},
+};
+
+function createOptions<T extends string>(type: T): domtagger.Options & { type: T } {
+	return Object.create(options, {
+		type: { value: type, enumerable: true, configurable: true, writable: true },
+	});
+}
+
+// $ExpectType (template: TemplateStringsArray, ...args: any[]) => HTMLElement
+const html = domtagger(createOptions('html'));
+
+// $ExpectType (template: TemplateStringsArray, ...args: any[]) => SVGElement
+const svg = domtagger(createOptions('svg'));
+
+// $ExpectType HTMLElement
+html`
+	<div class="${'foo'}" />
+`;
+
+// $ExpectType SVGElement
+svg`
+	<g class="${'foo'}" />
+`;

--- a/types/domtagger/test/domtagger.umd.test.ts
+++ b/types/domtagger/test/domtagger.umd.test.ts
@@ -1,0 +1,52 @@
+const options: domtagger.Options = {
+	attribute(node, name) {
+		return value => {
+			const type = typeof value;
+			if (type === 'boolean' || type === 'function') {
+				(node as any)[name] = value;
+			} else if (value == null) {
+				node.removeAttribute(name);
+			} else {
+				node.setAttribute(name, value);
+			}
+		};
+	},
+
+	text(node) {
+		return textContent => {
+			node.textContent = textContent;
+		};
+	},
+
+	any(node, childNodes) {
+		return markup => {
+			switch (node.nodeType) {
+				case Node.ELEMENT_NODE:
+					(node as Element).innerHTML = markup;
+					break;
+			}
+		};
+	},
+};
+
+function createOptions<T extends string>(type: T): domtagger.Options & { type: T } {
+	return Object.create(options, {
+		type: { value: type, enumerable: true, configurable: true, writable: true },
+	});
+}
+
+// $ExpectType (template: TemplateStringsArray, ...args: any[]) => HTMLElement
+const html = domtagger(createOptions('html'));
+
+// $ExpectType (template: TemplateStringsArray, ...args: any[]) => SVGElement
+const svg = domtagger(createOptions('svg'));
+
+// $ExpectType HTMLElement
+html`
+	<div class="${'foo'}" />
+`;
+
+// $ExpectType SVGElement
+svg`
+	<g class="${'foo'}" />
+`;

--- a/types/domtagger/tsconfig.json
+++ b/types/domtagger/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": [
+			"es5",
+			"dom"
+		],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": ["../"],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.d.ts",
+		"test/domtagger.cjs.test.ts",
+		"test/domtagger.umd.test.ts"
+	]
+}

--- a/types/domtagger/tslint.json
+++ b/types/domtagger/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

review?(@amcasey, @sandersn, @WebReflection)