### PR TITLE
[@types/node] Add worker.resourceLimits types

### DIFF
--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -5,6 +5,7 @@ declare module "worker_threads" {
 
     const isMainThread: boolean;
     const parentPort: null | MessagePort;
+    const resourceLimits: WorkerResourceLimits;
     const threadId: number;
     const workerData: any;
 
@@ -53,6 +54,12 @@ declare module "worker_threads" {
         off(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 
+    interface WorkerResourceLimits {
+        codeRangeSizeMb?: number;
+        maxOldGenerationSizeMb?: number;
+        maxYoungGenerationSizeMb?: number;
+    }
+
     interface WorkerOptions {
         eval?: boolean;
         workerData?: any;
@@ -63,6 +70,7 @@ declare module "worker_threads" {
     }
 
     class Worker extends EventEmitter {
+        readonly resourceLimits: WorkerResourceLimits;
         readonly stdin: Writable | null;
         readonly stdout: Readable;
         readonly stderr: Readable;


### PR DESCRIPTION
`worker.resourceLimits` was added in `node.js v13.2.0`

I didn't see anything about the naming conventions in the docs, is the name `WorkerResourceLimits` for the interface ok? or would it be better to name the interface `ResourceLimits`?

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/dist/latest-v13.x/docs/api/worker_threads.html#worker_threads_worker_resourcelimits>>
<<https://nodejs.org/dist/latest-v13.x/docs/api/worker_threads.html#worker_threads_worker_resourcelimits_1>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.