### PR TITLE
[@types/node] Add types for node.js worker.SHARE_ENV and Worker constructor env option

### DIFF
--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -5,6 +5,7 @@ declare module "worker_threads" {
 
     const isMainThread: boolean;
     const parentPort: null | MessagePort;
+    const SHARE_ENV: unique symbol;
     const threadId: number;
     const workerData: any;
 
@@ -54,12 +55,13 @@ declare module "worker_threads" {
     }
 
     interface WorkerOptions {
-        eval?: boolean;
-        workerData?: any;
+        stderr?: boolean;
         stdin?: boolean;
         stdout?: boolean;
-        stderr?: boolean;
+        env?: NodeJS.ProcessEnv | typeof SHARE_ENV;
+        eval?: boolean;
         execArgv?: string[];
+        workerData?: any;
     }
 
     class Worker extends EventEmitter {


### PR DESCRIPTION
`worker.SHARE_ENV` was added in `node.js v11.14.0`
`options.env` (seems to) exist since the introduction of `worker threads` in `node.js v10.5.0`

also took the liberty to order the properties of `WorkerOptions` alphabetically.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/dist/latest-v13.x/docs/api/worker_threads.html#worker_threads_worker_share_env>>
<<https://nodejs.org/dist/latest-v13.x/docs/api/worker_threads.html#worker_threads_new_worker_filename_options>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.