### PR TITLE
[js-cookie] Remove getJson method

### DIFF
--- a/types/js-cookie/index.d.ts
+++ b/types/js-cookie/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for js-cookie 2.2
+// Type definitions for js-cookie 3.0
 // Project: https://github.com/js-cookie/js-cookie
 // Definitions by: Theodore Brown <https://github.com/theodorejb>
 //                 BendingBender <https://github.com/BendingBender>
@@ -68,18 +68,6 @@ declare namespace Cookies {
          * Read all available cookies
          */
         get(): {[key: string]: string};
-
-        /**
-         * Returns the parsed representation of the string
-         * stored in the cookie according to JSON.parse
-         */
-        getJSON(name: string): any;
-
-        /**
-         * Returns the parsed representation of
-         * all cookies according to JSON.parse
-         */
-        getJSON(): {[key: string]: any};
 
         /**
          * Delete cookie

--- a/types/js-cookie/js-cookie-tests.ts
+++ b/types/js-cookie/js-cookie-tests.ts
@@ -26,12 +26,6 @@ Cookies2; // $ExpectType CookiesStatic<object>
 
 Cookies.set('name', { foo: 'bar' });
 
-// $ExpectType any
-Cookies.getJSON('name');
-
-// $ExpectType { [key: string]: any; }
-Cookies.getJSON();
-
 document.cookie = 'escaped=%u5317';
 document.cookie = 'default=%E5%8C%97';
 const cookies = Cookies.withConverter((value, name) =>


### PR DESCRIPTION
The `getJson` method has been dropped from the library.

https://github.com/js-cookie/js-cookie/commit/4b79290b98d7fbf1ab493a7f9e1619418ac01e45