### PR TITLE
feat: Added axios-curlirize template

### DIFF
--- a/types/axios-curlirize/axios-curlirize-tests.ts
+++ b/types/axios-curlirize/axios-curlirize-tests.ts
@@ -1,0 +1,5 @@
+import curlirize from 'axios-curlirize'
+import axios from 'axios';
+
+curlirize(axios)
+curlirize(axios,(err,res)=>{})

--- a/types/axios-curlirize/axios-curlirize-tests.ts
+++ b/types/axios-curlirize/axios-curlirize-tests.ts
@@ -1,5 +1,5 @@
-import curlirize from 'axios-curlirize'
+import curlirize from 'axios-curlirize';
 import axios from 'axios';
 
-curlirize(axios)
-curlirize(axios,(err,res)=>{})
+curlirize(axios);
+curlirize(axios, (err, res) => { });

--- a/types/axios-curlirize/index.d.ts
+++ b/types/axios-curlirize/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for axios-curlirize 1.3
+// Project: https://github.com/delirius325/axios-curlirize#readme
+// Definitions by: Steven Hankin <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = AxiosCurlirize;
+
+import {AxiosStatic} from 'axios';
+
+interface ICallback {
+    (error: Error, result?: number): void;
+}
+
+declare function AxiosCurlirize(instance: AxiosStatic, callback?: ICallback): void;
+
+declare namespace AxiosCurlirize { }

--- a/types/axios-curlirize/index.d.ts
+++ b/types/axios-curlirize/index.d.ts
@@ -5,12 +5,12 @@
 
 export = AxiosCurlirize;
 
-import {AxiosStatic} from 'axios';
+import { AxiosStatic } from 'axios';
 
-interface ICallback {
+interface Callback {
     (error: Error, result?: number): void;
 }
 
-declare function AxiosCurlirize(instance: AxiosStatic, callback?: ICallback): void;
+declare function AxiosCurlirize(instance: AxiosStatic, callback?: Callback): void;
 
 declare namespace AxiosCurlirize { }

--- a/types/axios-curlirize/package.json
+++ b/types/axios-curlirize/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "axios": "^0.19.0"
+    }
+}

--- a/types/axios-curlirize/tsconfig.json
+++ b/types/axios-curlirize/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop":true
+    },
+    "files": [
+        "index.d.ts",
+        "axios-curlirize-tests.ts"
+    ]
+}

--- a/types/axios-curlirize/tslint.json
+++ b/types/axios-curlirize/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [Y] Use a meaningful title for the pull request. Include the name of the package modified.
- [Y ] Test the change in your own code. (Compile and run.)
- [Y ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [Y ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ Y] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ Y] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [Y ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ Y] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ Y] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ Y] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [Y ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ Y] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
