### PR TITLE
Fix missing module export for grecaptcha

### DIFF
--- a/types/grecaptcha/index.d.ts
+++ b/types/grecaptcha/index.d.ts
@@ -8,6 +8,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var grecaptcha: ReCaptchaV2.ReCaptcha;
+export = grecaptcha;
 
 declare namespace ReCaptchaV2 {
   interface ReCaptcha {


### PR DESCRIPTION
With this minor fix, one would now be able to properly use ES6 style imports to access the grecaptcha typings.

Previously:

`import grecaptcha from 'grecaptcha';`
The ES6 style import statement would throw a compile-time error stating the the module did not exist in `@types/grecaptcha/index.d.ts`

After the fix:

`import grecaptcha from 'grecaptcha';`
The ES6 style import statement _no longer_ presents developers with a compile-time error and can properly use the typings provided by the `index.d.ts`.

