### PR TITLE
feat: Add `@ungap/weakmap`

### DIFF
--- a/types/ungap__weakmap/index.d.ts
+++ b/types/ungap__weakmap/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for @ungap/weakmap 0.1
+// Project: https://github.com/ungap/weakmap#readme
+// Definitions by: ExE Boss <https://github.com/ExE-Boss>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Based on definitions from `lib.es2015.collection` and `lib.es2015.iterable`.
+ */
+declare class WeakMap<K extends object = object, V = any> {
+	constructor(entries?: ReadonlyArray<[K, V]> | null);
+	constructor(iterable: Iterable<[K, V]> | null | undefined);
+
+	delete(key: K): boolean;
+	get(key: K): V | undefined;
+	has(key: K): boolean;
+	set(key: K, value: V): this;
+}
+
+export = WeakMap;
+export as namespace WeakMap;

--- a/types/ungap__weakmap/test/weakmap.cjs.test.ts
+++ b/types/ungap__weakmap/test/weakmap.cjs.test.ts
@@ -1,0 +1,22 @@
+import WeakMap = require('ungap__weakmap');
+
+WeakMap; // $ExpectType typeof WeakMap
+
+// $ExpectType WeakMap<object, any>
+const weakMap = new WeakMap();
+
+weakMap.delete; // $ExpectType (key: object) => boolean
+weakMap.has; // $ExpectType (key: object) => boolean
+weakMap.get; // $ExpectType (key: object) => any
+weakMap.set; // $ExpectType (key: object, value: any) => WeakMap<object, any>
+
+function foo<K extends object, V>(...args: Array<[K, V]>): WeakMap<K, V> {
+	const weakMap = new WeakMap(arguments as Iterable<[K, V]>);
+
+	weakMap.delete; // $ExpectType (key: K) => boolean
+	weakMap.has; // $ExpectType (key: K) => boolean
+	weakMap.get; // $ExpectType (key: K) => V | undefined
+	weakMap.set; // $ExpectType (key: K, value: V) => WeakMap<K, V>
+
+	return weakMap;
+}

--- a/types/ungap__weakmap/tsconfig.json
+++ b/types/ungap__weakmap/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": ["es5", "es2015.iterable"],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": ["../"],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.d.ts",
+		"test/weakmap.cjs.test.ts"
+	]
+}

--- a/types/ungap__weakmap/tslint.json
+++ b/types/ungap__weakmap/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
I&nbsp;originally tried&nbsp;adding **UMD**&nbsp;global&nbsp;tests as&nbsp;well, but&nbsp;that has&nbsp;conflicts with&nbsp;the&nbsp;empty `WeakMap`&nbsp;interface defined&nbsp;in&nbsp;`lib.es2015.iterable`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

review?(@amcasey, @WebReflection)