### PR TITLE
fix: incorrect signature cause ts2345

### DIFF
--- a/types/axios-curlirize/axios-curlirize-tests.ts
+++ b/types/axios-curlirize/axios-curlirize-tests.ts
@@ -1,5 +1,8 @@
 import curlirize from 'axios-curlirize';
 import axios from 'axios';
 
-curlirize(axios);
-curlirize(axios, (err, res) => { });
+const Axios = axios.create({});
+curlirize(Axios);
+curlirize(Axios, (res, _err) => {
+    const { command: string } = res;
+});

--- a/types/axios-curlirize/index.d.ts
+++ b/types/axios-curlirize/index.d.ts
@@ -5,12 +5,16 @@
 
 export = AxiosCurlirize;
 
-import { AxiosStatic } from 'axios';
+import { AxiosInstance } from 'axios';
 
-interface Callback {
-    (error: Error, result?: number): void;
+interface Result {
+    command: string;
 }
 
-declare function AxiosCurlirize(instance: AxiosStatic, callback?: Callback): void;
+interface Callback {
+    (result: Result, error: Error): void;
+}
+
+declare function AxiosCurlirize(instance: AxiosInstance, callback?: Callback): void;
 
 declare namespace AxiosCurlirize { }

--- a/types/axios-curlirize/index.d.ts
+++ b/types/axios-curlirize/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for axios-curlirize 1.3
 // Project: https://github.com/delirius325/axios-curlirize#readme
-// Definitions by: Steven Hankin <https://github.com/me>
+// Definitions by: Steven Hankin <https://github.com/stevenhankin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = AxiosCurlirize;


### PR DESCRIPTION
Test incorrectly used a static Axios config and needed to pass an Axios Instance
since the Axios module is updated to inject an interceptor

Please fill in this template.

- [y ] Use a meaningful title for the pull request. Include the name of the package modified.
- [y ] Test the change in your own code. (Compile and run.)
- [ y] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ y] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [y ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ y] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ n] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ n] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ n] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
