### PR TITLE
Fix a couple option types on Cesium classes ImageMaterialProperty and LabelGraphics

### DIFF
--- a/types/cesium/index.d.ts
+++ b/types/cesium/index.d.ts
@@ -2233,7 +2233,7 @@ declare namespace Cesium {
     class ImageMaterialProperty extends MaterialProperty {
         image: Property;
         repeat: Property;
-        constructor(options?: { image?: Property; repeat?: Property });
+        constructor(options?: { image?: Property; repeat?: Property, color?: Property, transparent?: Property });
     }
 
     class KmlDataSource extends DataSource {
@@ -2284,8 +2284,10 @@ declare namespace Cesium {
             eyeOffset?: Property;
             pixelOffset?: Property;
             translucencyByDistance?: Property;
-            pixelOffsetScaleByDistance?: Property
+            pixelOffsetScaleByDistance?: Property;
             heightReference?: Property;
+            scaleByDistance?: Property;
+            distanceDisplayCondition?: Property;
         });
         clone(result?: LabelGraphics): LabelGraphics;
         merge(source: LabelGraphics): LabelGraphics;

--- a/types/cesium/index.d.ts
+++ b/types/cesium/index.d.ts
@@ -2279,6 +2279,9 @@ declare namespace Cesium {
             outlineWidth?: number;
             show?: Property;
             scale?: Property;
+            showBackground?: Property;
+            backgroundColor?: Property;
+            backgroundPadding?: Property;
             horizontalOrigin?: Property;
             verticalOrigin?: Property;
             eyeOffset?: Property;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [ImageMaterialProperty](https://cesium.com/downloads/cesiumjs/releases/1.59/Build/Documentation/ImageMaterialProperty.html?classFilter=imageMater), [LabelGraphics](https://cesium.com/downloads/cesiumjs/releases/1.59/Build/Documentation/LabelGraphics.html?classFilter=labelgraph)