### PR TITLE
js-cookie: better default generic and converter typing

### DIFF
--- a/types/js-cookie/index.d.ts
+++ b/types/js-cookie/index.d.ts
@@ -48,7 +48,7 @@ declare namespace Cookies {
         [property: string]: any;
     }
 
-    interface CookiesStatic<T extends object = object> {
+    interface CookiesStatic<T, U> {
         /**
          * Allows default cookie attributes to be accessed, changed, or reset
          */
@@ -57,17 +57,17 @@ declare namespace Cookies {
         /**
          * Create a cookie
          */
-        set(name: string, value: string | T, options?: CookieAttributes): void;
+        set(name: string, value: T, options?: CookieAttributes): void;
 
         /**
          * Read cookie
          */
-        get(name: string): string | undefined;
+        get(name: string): U | undefined;
 
         /**
          * Read all available cookies
          */
-        get(): {[key: string]: string};
+        get(): {[key: string]: U};
 
         /**
          * Returns the parsed representation of the string
@@ -94,7 +94,7 @@ declare namespace Cookies {
          * or SDK. Note: The noConflict method is not necessary when using
          * AMD or CommonJS, thus it is not exposed in those environments.
          */
-        noConflict?(): CookiesStatic<T>;
+        noConflict?(): CookiesStatic<T, U>;
 
         /**
          * Create a new instance of the api that overrides the default
@@ -103,14 +103,14 @@ declare namespace Cookies {
          * will run the converter first for each cookie. The returned
          * string will be used as the cookie value.
          */
-        withConverter<TConv extends object>(converter: CookieReadConverter | { write?: CookieWriteConverter<TConv>; read?: CookieReadConverter; }): CookiesStatic<TConv>;
+        withConverter<TConv>(converter: CookieReadConverter<TConv> | { write?: CookieWriteConverter<TConv>; read: CookieReadConverter<TConv>; }): CookiesStatic<TConv, TConv>;
     }
 
-    type CookieWriteConverter<T extends object> = (value: string | T, name: string) => string;
-    type CookieReadConverter = (value: string, name: string) => string;
+    type CookieWriteConverter<T> = (value: T, name: string) => string;
+    type CookieReadConverter<T> = (value: string, name: string) => T;
 }
 
-declare const Cookies: Cookies.CookiesStatic;
+declare const Cookies: Cookies.CookiesStatic<string | object | any[], string>;
 
 export = Cookies;
 export as namespace Cookies;

--- a/types/js-cookie/js-cookie-tests.ts
+++ b/types/js-cookie/js-cookie-tests.ts
@@ -22,7 +22,7 @@ Cookies.remove('name');
 Cookies.remove('name', { path: '' });
 
 const Cookies2 = Cookies.noConflict!();
-Cookies2; // $ExpectType CookiesStatic<object>
+Cookies2; // $ExpectType CookiesStatic<string | object | any[], string>
 
 Cookies.set('name', { foo: 'bar' });
 
@@ -42,10 +42,10 @@ cookies.get('escaped');
 Cookies.defaults.path = '';
 delete Cookies.defaults.path;
 
-const PHPCookies = Cookies.withConverter<object>({
+const PHPCookies = Cookies.withConverter<string>({
     write(value) {
-        value; // $ExpectType string | object
-        return encodeURIComponent(value as string)
+        value; // $ExpectType string
+        return encodeURIComponent(value)
             .replace(/%(23|24|26|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
     },
     read(value) {
@@ -64,6 +64,24 @@ const BlankConverterCookies = Cookies.withConverter({
         return value;
     }
 });
+
+class MyObject {
+    constructor(private readonly prop: string) { }
+    serialize(): string {
+        return this.prop;
+    }
+}
+const MyObjectPersister = Cookies.withConverter<MyObject>({
+    write(value) {
+        return value.serialize();
+    },
+    read(value) {
+        return new MyObject(value);
+    }
+});
+const object1 = new MyObject("value");
+MyObjectPersister.set("key", object1);
+const object2 = MyObjectPersister.get("key"); // $ExpectType MyObject | undefined
 
 document.cookie = 'hoge=hogehoge';
 BlankConverterCookies.get('hoge');


### PR DESCRIPTION
I made several changes to how generics are used:

- CookieStatic shouldn't extends `object` because you wan't to be able to pass `string`. The fact that it didn't accept `string` is why you were forced to use the union type `string | T`. 
- CookieStatic default generic value can't be `object`, the library only meant to accept arrays, object litterals or plain old string: https://github.com/js-cookie/js-cookie/tree/1698b1ae5fee119aa3d02f3be8e31260e02f1475#json
- CookieStatic now has two generics T for input and U for output (note that when branch 3.x, which drop Json support, leave beta this could be simplified back to a single generic)
- `get` returns `U` instead of hardcoded `string`
- `CookieReadConverter` use the same generic than `CookieWriteConverter`
- The `read` method isn't optional when using `withConverter` expanded syntax