### PR TITLE
feat: Add `@ungap/global‑this`

### DIFF
--- a/types/ungap__global-this/index.d.ts
+++ b/types/ungap__global-this/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for @ungap/global-this 0.3
+// Project: https://github.com/ungap/global-this
+// Definitions by: ExE Boss <https://github.com/ExE-Boss>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.4
+
+declare const global: typeof globalThis;
+export = global;

--- a/types/ungap__global-this/tsconfig.json
+++ b/types/ungap__global-this/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": ["es5"],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": ["../"],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"ungap__global-this-tests.ts",
+		"index.d.ts"
+	]
+}

--- a/types/ungap__global-this/tslint.json
+++ b/types/ungap__global-this/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/ungap__global-this/ungap__global-this-tests.ts
+++ b/types/ungap__global-this/ungap__global-this-tests.ts
@@ -1,0 +1,3 @@
+import global = require('ungap__global-this');
+
+global; // $ExpectType typeof globalThis


### PR DESCRIPTION
[The&nbsp;`@ungap/global‑this`&nbsp;polyfill](https://github.com/ungap/global-this) implements another&nbsp;cross‑platform compatible implementation of&nbsp;the&nbsp;[ES2020&nbsp;`globalThis`&nbsp;property](https://tc39.es/ecma262/#sec-globalthis). This&nbsp;one&nbsp;uses [a&nbsp;rather&nbsp;horrifying, but&nbsp;much&nbsp;more&nbsp;correct and&nbsp;universal&nbsp;approach](https://mathiasbynens.be/notes/globalthis).

Closes https://github.com/ungap/global-this/issues/3

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

review?(@amcasey, @WebReflection)