### PR TITLE
fix(ioredis): make types more accurate

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ioredis 4.0
+// Type definitions for ioredis 4.14
 // Project: https://github.com/luin/ioredis
 // Definitions by: York Yao <https://github.com/plantain-00>
 //                 Christopher Eck <https://github.com/chrisleck>
@@ -11,6 +11,7 @@
 //                 Oleg Repin <https://github.com/iamolegga>
 //                 Ting-Wai To <https://github.com/tingwai-to>
 //                 Alex Petty <https://github.com/pettyalex>
+//                 Simon Schick <https://github.com/SimonSchick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -21,8 +22,9 @@
 
 /// <reference types="node" />
 
-import tls = require('tls');
+import { ConnectionOptions } from 'tls';
 import { Readable } from 'stream';
+import { EventEmitter } from 'events';
 
 interface RedisStatic {
     new(port?: number, host?: string, options?: IORedis.RedisOptions): IORedis.Redis;
@@ -44,26 +46,30 @@ declare class Commander {
     defineCommand(name: string, definition: {
         numberOfKeys?: number;
         lua?: string;
-    }): any;
+    }): void;
     sendCommand(): void;
 }
 
 declare namespace IORedis {
     type KeyType = string | Buffer;
 
+    type BooleanResponse = 1 | 0;
+
+    type ValueType = string | Buffer | number | any[];
+
     interface Command {
-        setArgumentTransformer(name: string, fn: (args: any[]) => any[]): void;
+        setArgumentTransformer(name: string, fn: (args: ValueType[]) => ValueType[]): void;
         setReplyTransformer(name: string, fn: (result: any) => any): void;
     }
 
-    interface Redis extends NodeJS.EventEmitter, Commander {
+    interface Redis extends EventEmitter, Commander {
         Promise: typeof Promise;
         status: string;
-        connect(callback?: () => void): Promise<any>;
+        connect(callback?: () => void): Promise<void>;
         disconnect(): void;
         duplicate(): Redis;
 
-        send_command(command: string, ...args: any[]): any;
+        send_command(command: string, ...args: ValueType[]): Promise<any>;
 
         bitcount(key: KeyType, callback: (err: Error, res: number) => void): void;
         bitcount(key: KeyType, start: number, end: number, callback: (err: Error, res: number) => void): void;
@@ -76,31 +82,31 @@ declare namespace IORedis {
         getBuffer(key: KeyType, callback: (err: Error, res: Buffer) => void): void;
         getBuffer(key: KeyType): Promise<Buffer>;
 
-        set(key: KeyType, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<string>;
+        set(key: KeyType, value: ValueType, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<string>;
 
-        set(key: KeyType, value: any, callback: (err: Error, res: string) => void): void;
-        set(key: KeyType, value: any, setMode: string | any[], callback: (err: Error, res: string) => void): void;
-        set(key: KeyType, value: any, expiryMode: string, time: number | string, callback: (err: Error, res: string) => void): void;
-        set(key: KeyType, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: ValueType, callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: ValueType, setMode: string | any[], callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: ValueType, expiryMode: string, time: number | string, callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: ValueType, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: string) => void): void;
 
-        setBuffer(key: KeyType, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<Buffer>;
+        setBuffer(key: KeyType, value: ValueType, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<Buffer>;
 
-        setBuffer(key: KeyType, value: any, callback: (err: Error, res: Buffer) => void): void;
-        setBuffer(key: KeyType, value: any, setMode: string, callback: (err: Error, res: Buffer) => void): void;
-        setBuffer(key: KeyType, value: any, expiryMode: string, time: number, callback: (err: Error, res: Buffer) => void): void;
-        setBuffer(key: KeyType, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: ValueType, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: ValueType, setMode: string, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: ValueType, expiryMode: string, time: number, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: ValueType, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: Buffer) => void): void;
 
-        setnx(key: KeyType, value: any, callback: (err: Error, res: any) => void): void;
-        setnx(key: KeyType, value: any): Promise<any>;
+        setnx(key: KeyType, value: ValueType, callback: (err: Error, res: BooleanResponse) => void): void;
+        setnx(key: KeyType, value: ValueType): Promise<BooleanResponse>;
 
-        setex(key: KeyType, seconds: number, value: any, callback: (err: Error, res: any) => void): void;
-        setex(key: KeyType, seconds: number, value: any): Promise<any>;
+        setex(key: KeyType, seconds: number, value: ValueType, callback: (err: Error, res: Ok) => void): void;
+        setex(key: KeyType, seconds: number, value: ValueType): Promise<Ok>;
 
-        psetex(key: KeyType, milliseconds: number, value: any, callback: (err: Error, res: any) => void): void;
-        psetex(key: KeyType, milliseconds: number, value: any): Promise<any>;
+        psetex(key: KeyType, milliseconds: number, value: ValueType, callback: (err: Error, res: Ok) => void): void;
+        psetex(key: KeyType, milliseconds: number, value: ValueType): Promise<Ok>;
 
-        append(key: KeyType, value: any, callback: (err: Error, res: number) => void): void;
-        append(key: KeyType, value: any): Promise<number>;
+        append(key: KeyType, value: ValueType, callback: (err: Error, res: number) => void): void;
+        append(key: KeyType, value: ValueType): Promise<number>;
 
         strlen(key: KeyType, callback: (err: Error, res: number) => void): void;
         strlen(key: KeyType): Promise<number>;
@@ -112,14 +118,14 @@ declare namespace IORedis {
         exists(...keys: KeyType[]): Promise<number>;
         exists(key: KeyType, callback: (err: Error, res: number) => void): void;
 
-        setbit(key: KeyType, offset: number, value: any, callback: (err: Error, res: number) => void): void;
-        setbit(key: KeyType, offset: number, value: any): Promise<number>;
+        setbit(key: KeyType, offset: number, value: ValueType, callback: (err: Error, res: number) => void): void;
+        setbit(key: KeyType, offset: number, value: ValueType): Promise<number>;
 
         getbit(key: KeyType, offset: number, callback: (err: Error, res: number) => void): void;
         getbit(key: KeyType, offset: number): Promise<number>;
 
-        setrange(key: KeyType, offset: number, value: any, callback: (err: Error, res: number) => void): void;
-        setrange(key: KeyType, offset: number, value: any): Promise<number>;
+        setrange(key: KeyType, offset: number, value: ValueType, callback: (err: Error, res: number) => void): void;
+        setrange(key: KeyType, offset: number, value: ValueType): Promise<number>;
 
         getrange(key: KeyType, start: number, end: number, callback: (err: Error, res: string) => void): void;
         getrange(key: KeyType, start: number, end: number): Promise<string>;
@@ -133,22 +139,22 @@ declare namespace IORedis {
         decr(key: KeyType, callback: (err: Error, res: number) => void): void;
         decr(key: KeyType): Promise<number>;
 
-        mget(...keys: KeyType[]): any;
+        mget(...keys: KeyType[]): Promise<Array<string | null>>;
 
-        rpush(key: KeyType, ...values: any[]): any;
+        rpush(key: KeyType, ...values: ValueType[]): Promise<number>;
 
-        rpushBuffer(key: string, ...values: Buffer[]): any;
+        rpushBuffer(key: string, ...values: Buffer[]): Promise<number>;
 
-        lpush(key: KeyType, ...values: any[]): any;
+        lpush(key: KeyType, ...values: ValueType[]): Promise<number>;
 
-        rpushx(key: KeyType, value: any, callback: (err: Error, res: number) => void): void;
-        rpushx(key: KeyType, value: any): Promise<number>;
+        rpushx(key: KeyType, value: ValueType, callback: (err: Error, res: number) => void): void;
+        rpushx(key: KeyType, value: ValueType): Promise<number>;
 
-        lpushx(key: KeyType, value: any, callback: (err: Error, res: number) => void): void;
-        lpushx(key: KeyType, value: any): Promise<number>;
+        lpushx(key: KeyType, value: ValueType, callback: (err: Error, res: number) => void): void;
+        lpushx(key: KeyType, value: ValueType): Promise<number>;
 
-        linsert(key: KeyType, direction: "BEFORE" | "AFTER", pivot: string, value: any, callback: (err: Error, res: number) => void): void;
-        linsert(key: KeyType, direction: "BEFORE" | "AFTER", pivot: string, value: any): Promise<number>;
+        linsert(key: KeyType, direction: "BEFORE" | "AFTER", pivot: string, value: ValueType, callback: (err: Error, res: number) => void): void;
+        linsert(key: KeyType, direction: "BEFORE" | "AFTER", pivot: string, value: ValueType): Promise<number>;
 
         rpop(key: KeyType, callback: (err: Error, res: string) => void): void;
         rpop(key: KeyType): Promise<string>;
@@ -159,12 +165,12 @@ declare namespace IORedis {
         lpopBuffer(key: KeyType, callback: (err: Error, res: Buffer) => void): void;
         lpopBuffer(key: KeyType): Promise<Buffer>;
 
-        brpop(...keys: KeyType[]): any;
+        brpop(...keys: KeyType[]): Promise<[string, string]>;
 
-        blpop(...keys: KeyType[]): any;
+        blpop(...keys: KeyType[]): Promise<[string, string]>;
 
-        brpoplpush(source: string, destination: string, timeout: number, callback: (err: Error, res: any) => void): void;
-        brpoplpush(source: string, destination: string, timeout: number): Promise<any>;
+        brpoplpush(source: string, destination: string, timeout: number, callback: (err: Error, res: string) => void): void;
+        brpoplpush(source: string, destination: string, timeout: number): Promise<string>;
 
         llen(key: KeyType, callback: (err: Error, res: number) => void): void;
         llen(key: KeyType): Promise<number>;
@@ -172,20 +178,20 @@ declare namespace IORedis {
         lindex(key: KeyType, index: number, callback: (err: Error, res: string) => void): void;
         lindex(key: KeyType, index: number): Promise<string>;
 
-        lset(key: KeyType, index: number, value: any, callback: (err: Error, res: any) => void): void;
-        lset(key: KeyType, index: number, value: any): Promise<any>;
+        lset(key: KeyType, index: number, value: ValueType, callback: (err: Error, res: Ok) => void): void;
+        lset(key: KeyType, index: number, value: ValueType): Promise<Ok>;
 
-        lrange(key: KeyType, start: number, stop: number, callback: (err: Error, res: any) => void): void;
-        lrange(key: KeyType, start: number, stop: number): Promise<any>;
+        lrange(key: KeyType, start: number, stop: number, callback: (err: Error, res: string[]) => void): void;
+        lrange(key: KeyType, start: number, stop: number): Promise<string[]>;
 
         lrangeBuffer(key: KeyType, start: number, stop: number, callback: (err: Error, res: Buffer[]) => void): void;
         lrangeBuffer(key: KeyType, start: number, stop: number): Promise<Buffer[]>;
 
-        ltrim(key: KeyType, start: number, stop: number, callback: (err: Error, res: any) => void): void;
-        ltrim(key: KeyType, start: number, stop: number): Promise<any>;
+        ltrim(key: KeyType, start: number, stop: number, callback: (err: Error, res: Ok) => void): void;
+        ltrim(key: KeyType, start: number, stop: number): Promise<Ok>;
 
-        lrem(key: KeyType, count: number, value: any, callback: (err: Error, res: number) => void): void;
-        lrem(key: KeyType, count: number, value: any): Promise<number>;
+        lrem(key: KeyType, count: number, value: ValueType, callback: (err: Error, res: number) => void): void;
+        lrem(key: KeyType, count: number, value: ValueType): Promise<number>;
 
         rpoplpush(source: string, destination: string, callback: (err: Error, res: string) => void): void;
         rpoplpush(source: string, destination: string): Promise<string>;
@@ -193,72 +199,78 @@ declare namespace IORedis {
         rpoplpushBuffer(source: string, destination: string, callback: (err: Error, res: Buffer) => void): void;
         rpoplpushBuffer(source: string, destination: string): Promise<Buffer>;
 
-        sadd(key: KeyType, ...members: any[]): any;
+        sadd(key: KeyType, ...members: ValueType[]): Promise<number>;
 
-        srem(key: KeyType, ...members: any[]): any;
+        srem(key: KeyType, ...members: ValueType[]): Promise<number>;
 
-        smove(source: string, destination: string, member: string, callback: (err: Error, res: string) => void): void;
-        smove(source: string, destination: string, member: string): Promise<string>;
+        smove(source: string, destination: string, member: string, callback: (err: Error, res: BooleanResponse) => void): void;
+        smove(source: string, destination: string, member: string): Promise<BooleanResponse>;
 
-        sismember(key: KeyType, member: string, callback: (err: Error, res: 1 | 0) => void): void;
-        sismember(key: KeyType, member: string): Promise<1 | 0>;
+        sismember(key: KeyType, member: string, callback: (err: Error, res: BooleanResponse) => void): void;
+        sismember(key: KeyType, member: string): Promise<BooleanResponse>;
 
         scard(key: KeyType, callback: (err: Error, res: number) => void): void;
         scard(key: KeyType): Promise<number>;
 
-        spop(key: KeyType, callback: (err: Error, res: any) => void): void;
-        spop(key: KeyType, count: number, callback: (err: Error, res: any) => void): void;
-        spop(key: KeyType, count?: number): Promise<any>;
+        spop(key: KeyType, callback: (err: Error, res: string | null) => void): void;
+        spop(key: KeyType): Promise<string | null>;
+        spop(key: KeyType, count: number, callback: (err: Error, res: string[]) => void): void;
+        spop(key: KeyType, count: number): Promise<string[]>;
 
-        srandmember(key: KeyType, callback: (err: Error, res: any) => void): void;
-        srandmember(key: KeyType, count: number, callback: (err: Error, res: any) => void): void;
-        srandmember(key: KeyType, count?: number): Promise<any>;
+        srandmember(key: KeyType, callback: (err: Error, res: string | null) => void): void;
+        srandmember(key: KeyType): Promise<string | null>;
+        srandmember(key: KeyType, count: number, callback: (err: Error, res: string[]) => void): void;
+        srandmember(key: KeyType, count: number): Promise<string[]>;
 
-        sinter(...keys: KeyType[]): any;
+        sinter(...keys: KeyType[]): Promise<string[]>;
 
-        sinterstore(destination: string, ...keys: KeyType[]): any;
+        sinterstore(destination: string, ...keys: KeyType[]): Promise<number>;
 
-        sunion(...keys: KeyType[]): any;
+        sunion(...keys: KeyType[]): Promise<string[]>;
 
-        sunionstore(destination: string, ...keys: KeyType[]): any;
+        sunionstore(destination: string, ...keys: KeyType[]): Promise<number>;
 
-        sdiff(...keys: KeyType[]): any;
+        sdiff(...keys: KeyType[]): Promise<string[]>;
 
-        sdiffstore(destination: string, ...keys: KeyType[]): any;
+        sdiffstore(destination: string, ...keys: KeyType[]): Promise<number>;
 
-        smembers(key: KeyType, callback: (err: Error, res: any) => void): void;
-        smembers(key: KeyType): Promise<any>;
+        smembers(key: KeyType, callback: (err: Error, res: string[]) => void): void;
+        smembers(key: KeyType): Promise<string[]>;
 
         zadd(key: KeyType, ...args: string[]): Promise<number | string>;
 
         zaddBuffer(key: KeyType, score1: number, member1: Buffer): Promise<string | number>;
 
-        zincrby(key: KeyType, increment: number, member: string, callback: (err: Error, res: any) => void): void;
-        zincrby(key: KeyType, increment: number, member: string): Promise<any>;
+        zincrby(key: KeyType, increment: number, member: string, callback: (err: Error, res: string) => void): void;
+        zincrby(key: KeyType, increment: number, member: string): Promise<string>;
 
-        zrem(key: KeyType, ...members: any[]): any;
+        zrem(key: KeyType, ...members: ValueType[]): Promise<number>;
 
-        zremrangebyscore(key: KeyType, min: number | string, max: number | string, callback: (err: Error, res: any) => void): void;
-        zremrangebyscore(key: KeyType, min: number | string, max: number | string): Promise<any>;
+        zremrangebyscore(key: KeyType, min: number | string, max: number | string, callback: (err: Error, res: number) => void): void;
+        zremrangebyscore(key: KeyType, min: number | string, max: number | string): Promise<number>;
 
-        zremrangebyrank(key: KeyType, start: number, stop: number, callback: (err: Error, res: any) => void): void;
-        zremrangebyrank(key: KeyType, start: number, stop: number): Promise<any>;
+        zremrangebyrank(key: KeyType, start: number, stop: number, callback: (err: Error, res: number) => void): void;
+        zremrangebyrank(key: KeyType, start: number, stop: number): Promise<number>;
 
-        zunionstore(destination: string, numkeys: number, key: KeyType, ...args: string[]): any;
+        zunionstore(destination: string, numkeys: number, key: KeyType, ...args: string[]): Promise<number>;
 
-        zinterstore(destination: string, numkeys: number, key: KeyType, ...args: string[]): any;
+        zinterstore(destination: string, numkeys: number, key: KeyType, ...args: string[]): Promise<number>;
 
-        zrange(key: KeyType, start: number, stop: number, callback: (err: Error, res: any) => void): void;
-        zrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback: (err: Error, res: any) => void): void;
-        zrange(key: KeyType, start: number, stop: number, withScores?: "WITHSCORES"): Promise<any>;
+        zrange(key: KeyType, start: number, stop: number, callback: (err: Error, res: string[]) => void): void;
+        zrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback: (err: Error, res: string[]) => void): void;
+        zrange(key: KeyType, start: number, stop: number, withScores?: "WITHSCORES"): Promise<string[]>;
 
-        zrevrange(key: KeyType, start: number, stop: number, callback: (err: Error, res: any) => void): void;
-        zrevrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback: (err: Error, res: any) => void): void;
-        zrevrange(key: KeyType, start: number, stop: number, withScores?: "WITHSCORES"): Promise<any>;
+        zrevrange(key: KeyType, start: number, stop: number, callback: (err: Error, res: string[]) => void): void;
+        zrevrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback: (err: Error, res: string[]) => void): void;
+        zrevrange(key: KeyType, start: number, stop: number, withScores?: "WITHSCORES"): Promise<string[]>;
 
-        zrangebyscore(key: KeyType, min: number | string, max: number | string, ...args: string[]): any;
+        zrangebyscore(key: KeyType, min: number, max: number, withScores?: "WITHSCORES"): Promise<string[]>;
+        zrangebyscore(key: KeyType, min: number, max: number, withScores: "WITHSCORES", limit: "LIMIT", offset: number, count: number): Promise<string[]>;
+        zrangebyscore(key: KeyType, min: number, max: number, limit: "LIMIT", offset: number, count: number): Promise<string[]>;
 
-        zrevrangebyscore(key: KeyType, max: number | string, min: number | string, ...args: string[]): any;
+        zrevrangebyscore(key: KeyType, min: number, max: number, withScores?: "WITHSCORES"): Promise<string[]>;
+        zrevrangebyscore(key: KeyType, min: number, max: number, withScores: "WITHSCORES", limit: "LIMIT", offset: number, count: number): Promise<string[]>;
+        zrevrangebyscore(key: KeyType, min: number, max: number, limit: "LIMIT", offset: number, count: number): Promise<string[]>;
 
         zcount(key: KeyType, min: number | string, max: number | string, callback: (err: Error, res: number) => void): void;
         zcount(key: KeyType, min: number | string, max: number | string): Promise<number>;
@@ -275,24 +287,24 @@ declare namespace IORedis {
         zrevrank(key: KeyType, member: string, callback: (err: Error, res: number | null) => void): void;
         zrevrank(key: KeyType, member: string): Promise<number | null>;
 
-        hset(key: KeyType, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
-        hset(key: KeyType, field: string, value: any): Promise<0 | 1>;
-        hsetBuffer(key: KeyType, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
-        hsetBuffer(key: KeyType, field: string, value: any): Promise<Buffer>;
+        hset(key: KeyType, field: string, value: ValueType, callback: (err: Error, res: BooleanResponse) => void): void;
+        hset(key: KeyType, field: string, value: ValueType): Promise<BooleanResponse>;
+        hsetBuffer(key: KeyType, field: string, value: ValueType, callback: (err: Error, res: BooleanResponse) => void): void;
+        hsetBuffer(key: KeyType, field: string, value: ValueType): Promise<Buffer>;
 
-        hsetnx(key: KeyType, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
-        hsetnx(key: KeyType, field: string, value: any): Promise<0 | 1>;
+        hsetnx(key: KeyType, field: string, value: ValueType, callback: (err: Error, res: BooleanResponse) => void): void;
+        hsetnx(key: KeyType, field: string, value: ValueType): Promise<BooleanResponse>;
 
         hget(key: KeyType, field: string, callback: (err: Error, res: string | null) => void): void;
         hget(key: KeyType, field: string): Promise<string | null>;
         hgetBuffer(key: KeyType, field: string, callback: (err: Error, res: Buffer) => void): void;
         hgetBuffer(key: KeyType, field: string): Promise<Buffer>;
 
-        hmset(key: KeyType, ...args: any[]): Promise<0 | 1>;
-        hmset(key: KeyType, data: any, callback: (err: Error, res: 0 | 1) => void): void;
-        hmset(key: KeyType, data: any): Promise<0 | 1>;
+        hmset(key: KeyType, ...args: ValueType[]): Promise<BooleanResponse>;
+        hmset(key: KeyType, data: object | Map<string, ValueType>, callback: (err: Error, res: BooleanResponse) => void): void;
+        hmset(key: KeyType, data: object | Map<string, ValueType>): Promise<BooleanResponse>;
 
-        hmget(key: KeyType, ...fields: string[]): any;
+        hmget(key: KeyType, ...fields: string[]): Promise<Array<string | null>>;
 
         hincrby(key: KeyType, field: string, increment: number, callback: (err: Error, res: number) => void): void;
         hincrby(key: KeyType, field: string, increment: number): Promise<number>;
@@ -300,22 +312,22 @@ declare namespace IORedis {
         hincrbyfloat(key: KeyType, field: string, increment: number, callback: (err: Error, res: number) => void): void;
         hincrbyfloat(key: KeyType, field: string, increment: number): Promise<number>;
 
-        hdel(key: KeyType, ...fields: string[]): any;
+        hdel(key: KeyType, ...fields: string[]): Promise<number>;
 
         hlen(key: KeyType, callback: (err: Error, res: number) => void): void;
         hlen(key: KeyType): Promise<number>;
 
-        hkeys(key: KeyType, callback: (err: Error, res: any) => void): void;
-        hkeys(key: KeyType): Promise<any>;
+        hkeys(key: KeyType, callback: (err: Error, res: string[]) => void): void;
+        hkeys(key: KeyType): Promise<string[]>;
 
-        hvals(key: KeyType, callback: (err: Error, res: any) => void): void;
-        hvals(key: KeyType): Promise<any>;
+        hvals(key: KeyType, callback: (err: Error, res: string[]) => void): void;
+        hvals(key: KeyType): Promise<string[]>;
 
-        hgetall(key: KeyType, callback: (err: Error, res: any) => void): void;
-        hgetall(key: KeyType): Promise<any>;
+        hgetall(key: KeyType, callback: (err: Error, res: string[]) => void): void;
+        hgetall(key: KeyType): Promise<string[]>;
 
-        hexists(key: KeyType, field: string, callback: (err: Error, res: 0 | 1) => void): void;
-        hexists(key: KeyType, field: string): Promise<0 | 1>;
+        hexists(key: KeyType, field: string, callback: (err: Error, res: BooleanResponse) => void): void;
+        hexists(key: KeyType, field: string): Promise<BooleanResponse>;
 
         incrby(key: KeyType, increment: number, callback: (err: Error, res: number) => void): void;
         incrby(key: KeyType, increment: number): Promise<number>;
@@ -326,16 +338,16 @@ declare namespace IORedis {
         decrby(key: KeyType, decrement: number, callback: (err: Error, res: number) => void): void;
         decrby(key: KeyType, decrement: number): Promise<number>;
 
-        getset(key: KeyType, value: any, callback: (err: Error, res: string | null) => void): void;
-        getset(key: KeyType, value: any): Promise<string | null>;
+        getset(key: KeyType, value: ValueType, callback: (err: Error, res: string | null) => void): void;
+        getset(key: KeyType, value: ValueType): Promise<string | null>;
 
-        mset(...args: any[]): any;
-        mset(data: any, callback: (err: Error, res: string) => void): void;
-        mset(data: any): Promise<string>;
+        mset(...args: ValueType[]): Promise<Ok>;
+        mset(data: object | Map<string, ValueType>, callback: (err: Error, res: Ok) => void): void;
+        mset(data: object | Map<string, ValueType>): Promise<Ok>;
 
-        msetnx(...args: any[]): any;
-        msetnx(data: any, callback: (err: Error, res: 0 | 1) => void): void;
-        msetnx(data: any): Promise<0 | 1>;
+        msetnx(...args: ValueType[]): Promise<number>;
+        msetnx(data: object | Map<string, ValueType>, callback: (err: Error, res: BooleanResponse) => void): void;
+        msetnx(data: object | Map<string, ValueType>): Promise<BooleanResponse>;
 
         randomkey(callback: (err: Error, res: string) => void): void;
         randomkey(): Promise<string>;
@@ -343,26 +355,26 @@ declare namespace IORedis {
         select(index: number, callback: (err: Error, res: string) => void): void;
         select(index: number): Promise<string>;
 
-        move(key: KeyType, db: string, callback: (err: Error, res: 0 | 1) => void): void;
-        move(key: KeyType, db: string): Promise<0 | 1>;
+        move(key: KeyType, db: string, callback: (err: Error, res: BooleanResponse) => void): void;
+        move(key: KeyType, db: string): Promise<BooleanResponse>;
 
-        rename(key: KeyType, newkey: KeyType, callback: (err: Error, res: string) => void): void;
-        rename(key: KeyType, newkey: KeyType): Promise<string>;
+        rename(key: KeyType, newkey: KeyType, callback: (err: Error, res: Ok) => void): void;
+        rename(key: KeyType, newkey: KeyType): Promise<Ok>;
 
-        renamenx(key: KeyType, newkey: KeyType, callback: (err: Error, res: 0 | 1) => void): void;
-        renamenx(key: KeyType, newkey: KeyType): Promise<0 | 1>;
+        renamenx(key: KeyType, newkey: KeyType, callback: (err: Error, res: BooleanResponse) => void): void;
+        renamenx(key: KeyType, newkey: KeyType): Promise<BooleanResponse>;
 
-        expire(key: KeyType, seconds: number, callback: (err: Error, res: 0 | 1) => void): void;
-        expire(key: KeyType, seconds: number): Promise<0 | 1>;
+        expire(key: KeyType, seconds: number, callback: (err: Error, res: BooleanResponse) => void): void;
+        expire(key: KeyType, seconds: number): Promise<BooleanResponse>;
 
-        pexpire(key: KeyType, milliseconds: number, callback: (err: Error, res: 0 | 1) => void): void;
-        pexpire(key: KeyType, milliseconds: number): Promise<0 | 1>;
+        pexpire(key: KeyType, milliseconds: number, callback: (err: Error, res: BooleanResponse) => void): void;
+        pexpire(key: KeyType, milliseconds: number): Promise<BooleanResponse>;
 
-        expireat(key: KeyType, timestamp: number, callback: (err: Error, res: 0 | 1) => void): void;
-        expireat(key: KeyType, timestamp: number): Promise<0 | 1>;
+        expireat(key: KeyType, timestamp: number, callback: (err: Error, res: BooleanResponse) => void): void;
+        expireat(key: KeyType, timestamp: number): Promise<BooleanResponse>;
 
-        pexpireat(key: KeyType, millisecondsTimestamp: number, callback: (err: Error, res: 0 | 1) => void): void;
-        pexpireat(key: KeyType, millisecondsTimestamp: number): Promise<0 | 1>;
+        pexpireat(key: KeyType, millisecondsTimestamp: number, callback: (err: Error, res: BooleanResponse) => void): void;
+        pexpireat(key: KeyType, millisecondsTimestamp: number): Promise<BooleanResponse>;
 
         keys(pattern: string, callback: (err: Error, res: string[]) => void): void;
         keys(pattern: string): Promise<string[]>;
@@ -389,8 +401,8 @@ declare namespace IORedis {
         bgrewriteaof(callback: (err: Error, res: string) => void): void;
         bgrewriteaof(): Promise<string>;
 
-        shutdown(save: "SAVE" | "NOSAVE", callback: (err: Error, res: any) => void): void;
-        shutdown(save: "SAVE" | "NOSAVE"): Promise<any>;
+        shutdown(save: "SAVE" | "NOSAVE", callback: (err: Error, res: never) => void): void;
+        shutdown(save: "SAVE" | "NOSAVE"): Promise<never>;
 
         lastsave(callback: (err: Error, res: number) => void): void;
         lastsave(): Promise<number>;
@@ -401,11 +413,11 @@ declare namespace IORedis {
         multi(commands?: string[][], options?: MultiOptions): Pipeline;
         multi(options: { pipeline: false }): Promise<string>;
 
-        exec(callback: (err: Error, res: any) => void): void;
-        exec(): Promise<any>;
+        exec(callback: (err: Error, res: Array<[Error | null, string]>) => void): void;
+        exec(): Promise<Array<[Error | null, string]>>;
 
-        discard(callback: (err: Error, res: any) => void): void;
-        discard(): Promise<any>;
+        discard(callback: (err: Error, res: string) => void): void;
+        discard(): Promise<string>;
 
         sync(callback: (err: Error, res: any) => void): void;
         sync(): Promise<any>;
@@ -416,17 +428,17 @@ declare namespace IORedis {
         flushall(callback: (err: Error, res: string) => void): void;
         flushall(): Promise<string>;
 
-        sort(key: KeyType, ...args: string[]): any;
+        sort(key: KeyType, ...args: string[]): Promise<string[] | number>;
 
-        info(callback: (err: Error, res: any) => void): void;
-        info(section: string, callback: (err: Error, res: any) => void): void;
+        info(callback: (err: Error, res: string) => void): void;
+        info(section: string, callback: (err: Error, res: string) => void): void;
         info(section?: string): Promise<string>;
 
-        time(callback: (err: Error, res: any) => void): void;
-        time(): Promise<any>;
+        time(callback: (err: Error, res: [string, string]) => void): void;
+        time(): Promise<[string, string]>;
 
-        monitor(callback: (err: Error, res: NodeJS.EventEmitter) => void): void;
-        monitor(): Promise<NodeJS.EventEmitter>;
+        monitor(callback: (err: Error, res: EventEmitter) => void): void;
+        monitor(): Promise<EventEmitter>;
 
         ttl(key: KeyType, callback: (err: Error, res: number) => void): void;
         ttl(key: KeyType): Promise<number>;
@@ -434,52 +446,58 @@ declare namespace IORedis {
         pttl(key: KeyType, callback: (err: Error, res: number) => void): void;
         pttl(key: KeyType): Promise<number>;
 
-        persist(key: KeyType, callback: (err: Error, res: 0 | 1) => void): void;
-        persist(key: KeyType): Promise<0 | 1>;
+        persist(key: KeyType, callback: (err: Error, res: BooleanResponse) => void): void;
+        persist(key: KeyType): Promise<BooleanResponse>;
 
         slaveof(host: string, port: number, callback: (err: Error, res: string) => void): void;
         slaveof(host: string, port: number): Promise<string>;
 
-        debug(...args: any[]): any;
+        debug(...args: ValueType[]): Promise<any>;
 
-        config(...args: any[]): any;
+        config(op: 'GET', cfg: any[]): Promise<[string, string]>;
+        config(op: 'REWRITE'): Promise<Ok>;
+        config(op: 'SET', key: string, value: ValueType): Promise<Ok>;
 
-        subscribe(...channels: any[]): any;
+        subscribe(...channels: string[]): Promise<number>;
 
-        unsubscribe(...channels: string[]): any;
+        unsubscribe(...channels: string[]): Promise<number>;
 
-        psubscribe(...patterns: string[]): any;
+        psubscribe(...patterns: string[]): Promise<number>;
 
-        punsubscribe(...patterns: string[]): any;
+        punsubscribe(...patterns: string[]): Promise<number>;
 
         publish(channel: string, message: string, callback: (err: Error, res: number) => void): void;
         publish(channel: string, message: string): Promise<number>;
 
         publishBuffer(channel: string, message: Buffer): Promise<number>;
 
-        watch(...keys: KeyType[]): any;
+        watch(...keys: KeyType[]): Promise<Ok>;
 
         unwatch(callback: (err: Error, res: string) => void): void;
         unwatch(): Promise<string>;
 
-        cluster(...args: any[]): any;
+        cluster(...args: ValueType[]): any;
 
-        restore(...args: any[]): any;
+        restore(...args: ValueType[]): Promise<Ok>;
 
-        migrate(...args: any[]): any;
+        migrate(...args: ValueType[]): Promise<Ok | 'NOKEY'>;
 
         dump(key: KeyType, callback: (err: Error, res: string) => void): void;
         dump(key: KeyType): Promise<string>;
 
-        object(subcommand: string, ...args: any[]): any;
+        object(subcommand: string, ...args: ValueType[]): Promise<any>;
 
-        client(...args: any[]): any;
+        client(...args: ValueType[]): any;
 
-        eval(...args: any[]): any;
+        eval(script: string, numKeys: number, ...args: ValueType[]): any;
+        // This overload exists specifically to retain compatibility to `redlock`
+        // All arguments are by default flattened, declaring all possible permuatations
+        // would be unreasonable (and probably impossible)
+        eval(args: ValueType[], callback?: (err: Error | null, res: any) => void): any;
 
-        evalsha(...args: any[]): any;
+        evalsha(scriptSha: string, numKeys: string, ...args: ValueType[]): any;
 
-        script(...args: any[]): any;
+        script(...args: ValueType[]): any;
 
         quit(callback: (err: Error, res: string) => void): void;
         quit(): Promise<string>;
@@ -492,17 +510,17 @@ declare namespace IORedis {
         scan(cursor: number, matchOption: 'match' | 'MATCH', pattern: string, countOption: 'count' | 'COUNT', count: number): Promise<[string, string[]]>;
         scan(cursor: number, countOption: 'count' | 'COUNT', count: number, matchOption: 'match' | 'MATCH', pattern: string): Promise<[string, string[]]>;
 
-        sscan(key: KeyType, cursor: number, ...args: any[]): any;
+        sscan(key: KeyType, cursor: number, ...args: ValueType[]): Promise<[string, string[]]>;
 
-        hscan(key: KeyType, cursor: number, ...args: any[]): any;
+        hscan(key: KeyType, cursor: number, ...args: ValueType[]): Promise<[string, string[]]>;
 
-        zscan(key: KeyType, cursor: number, ...args: any[]): any;
+        zscan(key: KeyType, cursor: number, ...args: ValueType[]): Promise<[string, string[]]>;
 
-        pfmerge(destkey: KeyType, ...sourcekeys: KeyType[]): any;
+        pfmerge(destkey: KeyType, ...sourcekeys: KeyType[]): Promise<Ok>;
 
-        pfadd(key: KeyType, ...elements: string[]): any;
+        pfadd(key: KeyType, ...elements: string[]): Promise<number>;
 
-        pfcount(...keys: KeyType[]): any;
+        pfcount(...keys: KeyType[]): Promise<number>;
 
         pipeline(commands?: string[][]): Pipeline;
 
@@ -511,66 +529,62 @@ declare namespace IORedis {
         hscanStream(key: KeyType, options?: ScanStreamOption): Readable;
         zscanStream(key: KeyType, options?: ScanStreamOption): Readable;
 
-        xack(key: KeyType, group: string, ...ids: string[]): any;
+        xack(key: KeyType, group: string, ...ids: string[]): Promise<number>;
 
-        xadd(key: KeyType, id: string, ...args: string[]): any;
-        xadd(key: KeyType, maxLenOption: 'MAXLEN' | 'maxlen', count: number, ...args: string[]): any;
-        xadd(key: KeyType, maxLenOption: 'MAXLEN' | 'maxlen', approximate: '~', count: number, ...args: string[]): any;
+        xadd(key: KeyType, id: string, ...args: string[]): Promise<string>;
+        xadd(key: KeyType, maxLenOption: 'MAXLEN' | 'maxlen', count: number, ...args: string[]): Promise<string>;
+        xadd(key: KeyType, maxLenOption: 'MAXLEN' | 'maxlen', approximate: '~', count: number, ...args: string[]): Promise<string>;
 
-        xclaim(key: KeyType, group: string, consumer: string, minIdleTime: number, ...args: any[]): any;
+        xclaim(key: KeyType, group: string, consumer: string, minIdleTime: number, ...args: ValueType[]): Promise<Array<[string, string[]]>>;
 
-        xdel(key: KeyType, ...ids: string[]): any;
+        xdel(key: KeyType, ...ids: string[]): Promise<number>;
 
-        xgroup(...args: any[]): any;
+        xgroup(...args: ValueType[]): Promise<Ok>;
 
-        xinfo(...args: any[]): any;
+        xinfo(...args: ValueType[]): Promise<any>;
 
-        xlen(key: KeyType): any;
+        xlen(key: KeyType): Promise<number>;
 
-        xpending(key: KeyType, group: string, ...args: any[]): any;
+        xpending(key: KeyType, group: string, ...args: ValueType[]): Promise<any>;
 
-        xrange(key: KeyType, start: string, end: string, ...args: any[]): any;
+        xrange(key: KeyType, start: string, end: string, ...args: ValueType[]): Promise<Array<[string, string[]]>>;
 
-        xread(...args: any[]): any;
+        xread(...args: ValueType[]): Array<[string, string[]]>;
 
-        xreadgroup(groupOption: 'GROUP' | 'group', group: string, consumer: string,  ...args: any[]): any;
+        xreadgroup(groupOption: 'GROUP' | 'group', group: string, consumer: string,  ...args: ValueType[]): any;
 
-        xrevrange(key: KeyType, end: string, start: string, ...args: any[]): any;
+        xrevrange(key: KeyType, end: string, start: string, ...args: ValueType[]): Promise<Array<[string, string[]]>>;
 
-        xtrim(key: KeyType, maxLenOption: 'MAXLEN' | 'maxlen', ...args: any[]): any;
+        xtrim(key: KeyType, maxLenOption: 'MAXLEN' | 'maxlen', ...args: ValueType[]): Promise<number>;
     }
 
     interface Pipeline {
-        redis: Redis;
-        isCluster: boolean;
-        options: RedisOptions;
-        _queue: Command[];
-        _result: any[];
-        _transactions: number;
-        _shaToScript: {};
+        readonly redis: Redis;
+        readonly isCluster: boolean;
+        readonly options: RedisOptions;
         bitcount(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
         bitcount(key: KeyType, start: number, end: number, callback?: (err: Error, res: number) => void): Pipeline;
 
         get(key: KeyType, callback?: (err: Error, res: string) => void): Pipeline;
         getBuffer(key: KeyType, callback?: (err: Error, res: Buffer) => void): Pipeline;
 
-        set(key: KeyType, value: any, callback?: (err: Error, res: string) => void): Pipeline;
-        set(key: KeyType, value: any, setMode: string, callback?: (err: Error, res: string) => void): Pipeline;
-        set(key: KeyType, value: any, expiryMode: string, time: number, callback?: (err: Error, res: string) => void): Pipeline;
-        set(key: KeyType, value: any, expiryMode: string, time: number, setMode: string, callback?: (err: Error, res: string) => void): Pipeline;
+        set(key: KeyType, value: ValueType, callback?: (err: Error, res: string) => void): Pipeline;
+        set(key: KeyType, value: ValueType, setMode: string, callback?: (err: Error, res: string) => void): Pipeline;
+        set(key: KeyType, value: ValueType, expiryMode: string, time: number, callback?: (err: Error, res: string) => void): Pipeline;
+        set(key: KeyType, value: ValueType, expiryMode: string, time: number, setMode: string, callback?: (err: Error, res: string) => void): Pipeline;
 
-        setBuffer(key: KeyType, value: any, callback?: (err: Error, res: Buffer) => void): Pipeline;
-        setBuffer(key: KeyType, value: any, setMode: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
-        setBuffer(key: KeyType, value: any, expiryMode: string, time: number, callback?: (err: Error, res: Buffer) => void): Pipeline;
-        setBuffer(key: KeyType, value: any, expiryMode: string, time: number, setMode: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        setBuffer(key: KeyType, value: ValueType, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        setBuffer(key: KeyType, value: ValueType, setMode: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        setBuffer(key: KeyType, value: ValueType, expiryMode: string, time: number, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        setBuffer(key: KeyType, value: ValueType, expiryMode: string, time: number, setMode: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
 
-        setnx(key: KeyType, value: any, callback?: (err: Error, res: any) => void): Pipeline;
+        setnx(key: KeyType, value: ValueType, callback?: (err: Error, res: BooleanResponse) => void): Pipeline;
 
-        setex(key: KeyType, seconds: number, value: any, callback?: (err: Error, res: any) => void): Pipeline;
+        setex(key: KeyType, seconds: number, value: ValueType, callback?: (err: Error, res: Ok) => void): Pipeline;
 
-        psetex(key: KeyType, milliseconds: number, value: any, callback?: (err: Error, res: any) => void): Pipeline;
+        psetex(key: KeyType, milliseconds: number, value: ValueType, callback?: (err: Error, res: Ok) => void): Pipeline;
 
-        append(key: KeyType, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        append(key: KeyType, value: ValueType, callback?: (err: Error, res: number) => void): Pipeline;
 
         strlen(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
 
@@ -578,11 +592,11 @@ declare namespace IORedis {
 
         exists(...keys: KeyType[]): Pipeline;
 
-        setbit(key: KeyType, offset: number, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        setbit(key: KeyType, offset: number, value: ValueType, callback?: (err: Error, res: number) => void): Pipeline;
 
         getbit(key: KeyType, offset: number, callback?: (err: Error, res: number) => void): Pipeline;
 
-        setrange(key: KeyType, offset: number, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        setrange(key: KeyType, offset: number, value: ValueType, callback?: (err: Error, res: number) => void): Pipeline;
 
         getrange(key: KeyType, start: number, end: number, callback?: (err: Error, res: string) => void): Pipeline;
 
@@ -594,17 +608,17 @@ declare namespace IORedis {
 
         mget(...keys: KeyType[]): Pipeline;
 
-        rpush(key: KeyType, ...values: any[]): Pipeline;
+        rpush(key: KeyType, ...values: ValueType[]): Pipeline;
 
         rpushBuffer(key: string, ...values: Buffer[]): Pipeline;
 
-        lpush(key: KeyType, ...values: any[]): Pipeline;
+        lpush(key: KeyType, ...values: ValueType[]): Pipeline;
 
-        rpushx(key: KeyType, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        rpushx(key: KeyType, value: ValueType, callback?: (err: Error, res: number) => void): Pipeline;
 
-        lpushx(key: KeyType, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        lpushx(key: KeyType, value: ValueType, callback?: (err: Error, res: number) => void): Pipeline;
 
-        linsert(key: KeyType, direction: "BEFORE" | "AFTER", pivot: string, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        linsert(key: KeyType, direction: "BEFORE" | "AFTER", pivot: string, value: ValueType, callback?: (err: Error, res: number) => void): Pipeline;
 
         rpop(key: KeyType, callback?: (err: Error, res: string) => void): Pipeline;
 
@@ -616,39 +630,39 @@ declare namespace IORedis {
 
         blpop(...keys: KeyType[]): Pipeline;
 
-        brpoplpush(source: string, destination: string, timeout: number, callback?: (err: Error, res: any) => void): Pipeline;
+        brpoplpush(source: string, destination: string, timeout: number, callback?: (err: Error, res: string) => void): Pipeline;
 
         llen(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
 
         lindex(key: KeyType, index: number, callback?: (err: Error, res: string) => void): Pipeline;
 
-        lset(key: KeyType, index: number, value: any, callback?: (err: Error, res: any) => void): Pipeline;
+        lset(key: KeyType, index: number, value: ValueType, callback?: (err: Error, res: Ok) => void): Pipeline;
 
-        lrange(key: KeyType, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
+        lrange(key: KeyType, start: number, stop: number, callback?: (err: Error, res: string[]) => void): Pipeline;
 
         lrangeBuffer(key: KeyType, start: number, stop: number, callback?: (err: Error, res: Buffer[]) => void): Pipeline;
 
-        ltrim(key: KeyType, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
+        ltrim(key: KeyType, start: number, stop: number, callback?: (err: Error, res: Ok) => void): Pipeline;
 
-        lrem(key: KeyType, count: number, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        lrem(key: KeyType, count: number, value: ValueType, callback?: (err: Error, res: number) => void): Pipeline;
 
         rpoplpush(source: string, destination: string, callback?: (err: Error, res: string) => void): Pipeline;
 
-        sadd(key: KeyType, ...members: any[]): Pipeline;
+        sadd(key: KeyType, ...members: ValueType[]): Pipeline;
 
-        srem(key: KeyType, ...members: any[]): Pipeline;
+        srem(key: KeyType, ...members: ValueType[]): Pipeline;
 
         smove(source: string, destination: string, member: string, callback?: (err: Error, res: string) => void): Pipeline;
 
-        sismember(key: KeyType, member: string, callback?: (err: Error, res: 1 | 0) => void): Pipeline;
+        sismember(key: KeyType, member: string, callback?: (err: Error, res: BooleanResponse) => void): Pipeline;
 
         scard(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
 
-        spop(key: KeyType, callback?: (err: Error, res: any) => void): Pipeline;
-        spop(key: KeyType, count: number, callback?: (err: Error, res: any) => void): Pipeline;
+        spop(key: KeyType, callback?: (err: Error, res: string | null) => void): Pipeline;
+        spop(key: KeyType, count: number, callback?: (err: Error, res: string[]) => void): Pipeline;
 
-        srandmember(key: KeyType, callback?: (err: Error, res: any) => void): Pipeline;
-        srandmember(key: KeyType, count: number, callback?: (err: Error, res: any) => void): Pipeline;
+        srandmember(key: KeyType, callback?: (err: Error, res: string | null) => void): Pipeline;
+        srandmember(key: KeyType, count: number, callback?: (err: Error, res: string[]) => void): Pipeline;
 
         sinter(...keys: KeyType[]): Pipeline;
 
@@ -662,27 +676,27 @@ declare namespace IORedis {
 
         sdiffstore(destination: string, ...keys: KeyType[]): Pipeline;
 
-        smembers(key: KeyType, callback?: (err: Error, res: any) => void): Pipeline;
+        smembers(key: KeyType, callback?: (err: Error, res: string[]) => void): Pipeline;
 
         zadd(key: KeyType, ...args: string[]): Pipeline;
 
-        zincrby(key: KeyType, increment: number, member: string, callback?: (err: Error, res: any) => void): Pipeline;
+        zincrby(key: KeyType, increment: number, member: string, callback?: (err: Error, res: string) => void): Pipeline;
 
-        zrem(key: KeyType, ...members: any[]): Pipeline;
+        zrem(key: KeyType, ...members: ValueType[]): Pipeline;
 
-        zremrangebyscore(key: KeyType, min: number | string, max: number | string, callback?: (err: Error, res: any) => void): Pipeline;
+        zremrangebyscore(key: KeyType, min: number | string, max: number | string, callback?: (err: Error, res: number) => void): Pipeline;
 
-        zremrangebyrank(key: KeyType, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
+        zremrangebyrank(key: KeyType, start: number, stop: number, callback?: (err: Error, res: number) => void): Pipeline;
 
         zunionstore(destination: string, numkeys: number, key: KeyType, ...args: string[]): Pipeline;
 
         zinterstore(destination: string, numkeys: number, key: KeyType, ...args: string[]): Pipeline;
 
-        zrange(key: KeyType, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
-        zrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback?: (err: Error, res: any) => void): Pipeline;
+        zrange(key: KeyType, start: number, stop: number, callback?: (err: Error, res: string[]) => void): Pipeline;
+        zrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback?: (err: Error, res: string[]) => void): Pipeline;
 
-        zrevrange(key: KeyType, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
-        zrevrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback?: (err: Error, res: any) => void): Pipeline;
+        zrevrange(key: KeyType, start: number, stop: number, callback?: (err: Error, res: string[]) => void): Pipeline;
+        zrevrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback?: (err: Error, res: string[]) => void): Pipeline;
 
         zrangebyscore(key: KeyType, min: number | string, max: number | string, ...args: string[]): Pipeline;
 
@@ -698,16 +712,16 @@ declare namespace IORedis {
 
         zrevrank(key: KeyType, member: string, callback?: (err: Error, res: number) => void): Pipeline;
 
-        hset(key: KeyType, field: string, value: any, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
-        hsetBuffer(key: KeyType, field: string, value: any, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        hset(key: KeyType, field: string, value: ValueType, callback?: (err: Error, res: BooleanResponse) => void): Pipeline;
+        hsetBuffer(key: KeyType, field: string, value: ValueType, callback?: (err: Error, res: Buffer) => void): Pipeline;
 
-        hsetnx(key: KeyType, field: string, value: any, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        hsetnx(key: KeyType, field: string, value: ValueType, callback?: (err: Error, res: BooleanResponse) => void): Pipeline;
 
         hget(key: KeyType, field: string, callback?: (err: Error, res: string | string) => void): Pipeline;
         hgetBuffer(key: KeyType, field: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
 
-        hmset(key: KeyType, ...args: any[]): Pipeline;
-        hmset(key: KeyType, data: any, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        hmset(key: KeyType, ...args: ValueType[]): Pipeline;
+        hmset(key: KeyType, data: object | Map<string, any>, callback?: (err: Error, res: BooleanResponse) => void): Pipeline;
 
         hmget(key: KeyType, ...fields: string[]): Pipeline;
 
@@ -719,13 +733,13 @@ declare namespace IORedis {
 
         hlen(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
 
-        hkeys(key: KeyType, callback?: (err: Error, res: any) => void): Pipeline;
+        hkeys(key: KeyType, callback?: (err: Error, res: string[]) => void): Pipeline;
 
-        hvals(key: KeyType, callback?: (err: Error, res: any) => void): Pipeline;
+        hvals(key: KeyType, callback?: (err: Error, res: string[]) => void): Pipeline;
 
-        hgetall(key: KeyType, callback?: (err: Error, res: any) => void): Pipeline;
+        hgetall(key: KeyType, callback?: (err: Error, res: string[]) => void): Pipeline;
 
-        hexists(key: KeyType, field: string, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        hexists(key: KeyType, field: string, callback?: (err: Error, res: BooleanResponse) => void): Pipeline;
 
         incrby(key: KeyType, increment: number, callback?: (err: Error, res: number) => void): Pipeline;
 
@@ -733,31 +747,31 @@ declare namespace IORedis {
 
         decrby(key: KeyType, decrement: number, callback?: (err: Error, res: number) => void): Pipeline;
 
-        getset(key: KeyType, value: any, callback?: (err: Error, res: string) => void): Pipeline;
+        getset(key: KeyType, value: ValueType, callback?: (err: Error, res: string) => void): Pipeline;
 
-        mset(...args: any[]): Pipeline;
-        mset(data: any, callback?: (err: Error, res: string) => void): Pipeline;
+        mset(...args: ValueType[]): Pipeline;
+        mset(data: object | Map<string, any>, callback?: (err: Error, res: string) => void): Pipeline;
 
-        msetnx(...args: any[]): Pipeline;
-        msetnx(data: any, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        msetnx(...args: ValueType[]): Pipeline;
+        msetnx(data: object | Map<string, any>, callback?: (err: Error, res: BooleanResponse) => void): Pipeline;
 
         randomkey(callback?: (err: Error, res: string) => void): Pipeline;
 
         select(index: number, callback?: (err: Error, res: string) => void): Pipeline;
 
-        move(key: KeyType, db: string, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        move(key: KeyType, db: string, callback?: (err: Error, res: BooleanResponse) => void): Pipeline;
 
         rename(key: KeyType, newkey: KeyType, callback?: (err: Error, res: string) => void): Pipeline;
 
-        renamenx(key: KeyType, newkey: KeyType, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        renamenx(key: KeyType, newkey: KeyType, callback?: (err: Error, res: BooleanResponse) => void): Pipeline;
 
-        expire(key: KeyType, seconds: number, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        expire(key: KeyType, seconds: number, callback?: (err: Error, res: BooleanResponse) => void): Pipeline;
 
-        pexpire(key: KeyType, milliseconds: number, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        pexpire(key: KeyType, milliseconds: number, callback?: (err: Error, res: BooleanResponse) => void): Pipeline;
 
-        expireat(key: KeyType, timestamp: number, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        expireat(key: KeyType, timestamp: number, callback?: (err: Error, res: BooleanResponse) => void): Pipeline;
 
-        pexpireat(key: KeyType, millisecondsTimestamp: number, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        pexpireat(key: KeyType, millisecondsTimestamp: number, callback?: (err: Error, res: BooleanResponse) => void): Pipeline;
 
         keys(pattern: string, callback?: (err: Error, res: string[]) => void): Pipeline;
 
@@ -776,7 +790,7 @@ declare namespace IORedis {
 
         bgrewriteaof(callback?: (err: Error, res: string) => void): Pipeline;
 
-        shutdown(save: "SAVE" | "NOSAVE", callback?: (err: Error, res: any) => void): Pipeline;
+        shutdown(save: "SAVE" | "NOSAVE", callback?: (err: Error, res: never) => void): Pipeline;
 
         lastsave(callback?: (err: Error, res: number) => void): Pipeline;
 
@@ -784,7 +798,7 @@ declare namespace IORedis {
 
         multi(callback?: (err: Error, res: string) => void): Pipeline;
 
-        exec(callback?: (err: Error, res: any) => void): Promise<any>;
+        exec(callback?: (err: Error, res: Array<[Error | null, any]>) => void): Promise<Array<[Error | null, any]>>;
 
         discard(callback?: (err: Error, res: any) => void): Pipeline;
 
@@ -796,26 +810,26 @@ declare namespace IORedis {
 
         sort(key: KeyType, ...args: string[]): Pipeline;
 
-        info(callback?: (err: Error, res: any) => void): Pipeline;
-        info(section: string, callback?: (err: Error, res: any) => void): Pipeline;
+        info(callback?: (err: Error, res: string) => void): Pipeline;
+        info(section: string, callback?: (err: Error, res: string) => void): Pipeline;
 
-        time(callback?: (err: Error, res: any) => void): Pipeline;
+        time(callback?: (err: Error, res: [string, string]) => void): Pipeline;
 
-        monitor(callback?: (err: Error, res: NodeJS.EventEmitter) => void): Pipeline;
+        monitor(callback?: (err: Error, res: EventEmitter) => void): Pipeline;
 
         ttl(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
 
         pttl(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
 
-        persist(key: KeyType, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        persist(key: KeyType, callback?: (err: Error, res: BooleanResponse) => void): Pipeline;
 
         slaveof(host: string, port: number, callback?: (err: Error, res: string) => void): Pipeline;
 
-        debug(...args: any[]): Pipeline;
+        debug(...args: ValueType[]): Pipeline;
 
-        config(...args: any[]): Pipeline;
+        config(...args: ValueType[]): Pipeline;
 
-        subscribe(...channels: any[]): Pipeline;
+        subscribe(...channels: ValueType[]): Pipeline;
 
         unsubscribe(...channels: string[]): Pipeline;
 
@@ -829,23 +843,23 @@ declare namespace IORedis {
 
         unwatch(callback?: (err: Error, res: string) => void): Pipeline;
 
-        cluster(...args: any[]): Pipeline;
+        cluster(...args: ValueType[]): Pipeline;
 
-        restore(...args: any[]): Pipeline;
+        restore(...args: ValueType[]): Pipeline;
 
-        migrate(...args: any[]): Pipeline;
+        migrate(...args: ValueType[]): Pipeline;
 
         dump(key: KeyType, callback?: (err: Error, res: string) => void): Pipeline;
 
-        object(subcommand: string, ...args: any[]): Pipeline;
+        object(subcommand: string, ...args: ValueType[]): Pipeline;
 
-        client(...args: any[]): Pipeline;
+        client(...args: ValueType[]): Pipeline;
 
-        eval(...args: any[]): Pipeline;
+        eval(script: string, numKeys: number, ...args: ValueType[]): Pipeline;
 
-        evalsha(...args: any[]): Pipeline;
+        evalsha(scriptSha: string, numKeys: string, ...args: ValueType[]): Pipeline;
 
-        script(...args: any[]): Pipeline;
+        script(...args: ValueType[]): Pipeline;
 
         quit(callback?: (err: Error, res: string) => void): Pipeline;
 
@@ -856,11 +870,11 @@ declare namespace IORedis {
 
         scan(cursor: number, matchOption: 'match' | 'MATCH', pattern: string, countOption: 'count' | 'COUNT', count: number): Pipeline;
         scan(cursor: number, countOption: 'count' | 'COUNT', count: number, matchOption: 'match' | 'MATCH', pattern: string): Pipeline;
-        sscan(key: KeyType, cursor: number, ...args: any[]): Pipeline;
+        sscan(key: KeyType, cursor: number, ...args: ValueType[]): Pipeline;
 
-        hscan(key: KeyType, cursor: number, ...args: any[]): Pipeline;
+        hscan(key: KeyType, cursor: number, ...args: ValueType[]): Pipeline;
 
-        zscan(key: KeyType, cursor: number, ...args: any[]): Pipeline;
+        zscan(key: KeyType, cursor: number, ...args: ValueType[]): Pipeline;
 
         pfmerge(destkey: KeyType, ...sourcekeys: KeyType[]): Pipeline;
 
@@ -872,27 +886,27 @@ declare namespace IORedis {
 
         xadd(key: KeyType, id: string, ...args: string[]): Pipeline;
 
-        xclaim(key: KeyType, group: string, consumer: string, minIdleTime: number, id: string, ...args: any[]): Pipeline;
+        xclaim(key: KeyType, group: string, consumer: string, minIdleTime: number, id: string, ...args: ValueType[]): Pipeline;
 
         xdel(key: KeyType, ...ids: string[]): Pipeline;
 
-        xgroup(...args: any[]): Pipeline;
+        xgroup(...args: ValueType[]): Pipeline;
 
-        xinfo(...args: any[]): Pipeline;
+        xinfo(...args: ValueType[]): Pipeline;
 
         xlen(key: KeyType): Pipeline;
 
-        xpending(key: KeyType, group: string, ...args: any[]): Pipeline;
+        xpending(key: KeyType, group: string, ...args: ValueType[]): Pipeline;
 
-        xrange(key: KeyType, start: string, end: string, ...args: any[]): Pipeline;
+        xrange(key: KeyType, start: string, end: string, ...args: ValueType[]): Pipeline;
 
-        xread(...args: any[]): Pipeline;
+        xread(...args: ValueType[]): Pipeline;
 
-        xreadgroup(command: 'GROUP' | 'group', group: string, consumer: string,  ...args: any[]): Pipeline;
+        xreadgroup(command: 'GROUP' | 'group', group: string, consumer: string,  ...args: ValueType[]): Pipeline;
 
-        xrevrange(key: KeyType, end: string, start: string, ...args: any[]): Pipeline;
+        xrevrange(key: KeyType, end: string, start: string, ...args: ValueType[]): Pipeline;
 
-        xtrim(key: KeyType, strategy: 'MAXLEN' | 'maxlen', ...args: any[]): Pipeline;
+        xtrim(key: KeyType, strategy: 'MAXLEN' | 'maxlen', ...args: ValueType[]): Pipeline;
     }
 
     interface NodeConfiguration {
@@ -906,31 +920,33 @@ declare namespace IORedis {
 
     type CallbackFunction<T = any> = (err?: NodeJS.ErrnoException | null, result?: T) => void;
 
-    interface Cluster extends NodeJS.EventEmitter, Commander {
-        connect(callback: () => void): Promise<any>;
+    type Ok = 'OK';
+
+    interface Cluster extends EventEmitter, Commander {
+        connect(callback: () => void): Promise<void>;
         disconnect(): void;
         nodes(role?: NodeRole): Redis[];
-        quit(callback?: CallbackFunction<'OK'>): Promise<'OK'>;
+        quit(callback?: CallbackFunction<Ok>): Promise<Ok>;
         get(key: KeyType, callback: (err: Error, res: string | null) => void): void;
         get(key: KeyType): Promise<string | null>;
 
         getBuffer(key: KeyType, callback: (err: Error, res: Buffer) => void): void;
         getBuffer(key: KeyType): Promise<Buffer>;
 
-        set(key: KeyType, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<string>;
-        set(key: KeyType, value: any, callback: (err: Error, res: string) => void): void;
-        set(key: KeyType, value: any, setMode: string | any[], callback: (err: Error, res: string) => void): void;
-        set(key: KeyType, value: any, expiryMode: string, time: number | string, callback: (err: Error, res: string) => void): void;
-        set(key: KeyType, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: ValueType, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<string>;
+        set(key: KeyType, value: ValueType, callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: ValueType, setMode: string | any[], callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: ValueType, expiryMode: string, time: number | string, callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: ValueType, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: string) => void): void;
 
-        setBuffer(key: KeyType, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<Buffer>;
-        setBuffer(key: KeyType, value: any, callback: (err: Error, res: Buffer) => void): void;
-        setBuffer(key: KeyType, value: any, setMode: string, callback: (err: Error, res: Buffer) => void): void;
-        setBuffer(key: KeyType, value: any, expiryMode: string, time: number, callback: (err: Error, res: Buffer) => void): void;
-        setBuffer(key: KeyType, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: ValueType, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<Buffer>;
+        setBuffer(key: KeyType, value: ValueType, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: ValueType, setMode: string, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: ValueType, expiryMode: string, time: number, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: ValueType, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: Buffer) => void): void;
 
-        setnx(key: KeyType, value: any, callback: (err: Error, res: any) => void): void;
-        setnx(key: KeyType, value: any): Promise<any>;
+        setnx(key: KeyType, value: ValueType, callback: (err: Error, res: number) => void): void;
+        setnx(key: KeyType, value: ValueType): Promise<BooleanResponse>;
 
         del(...keys: KeyType[]): Promise<number>;
 
@@ -940,9 +956,9 @@ declare namespace IORedis {
         decr(key: KeyType, callback: (err: Error, res: number) => void): void;
         decr(key: KeyType): Promise<number>;
 
-        rpush(key: KeyType, ...values: any[]): any;
+        rpush(key: KeyType, ...values: ValueType[]): Promise<number>;
 
-        rpushBuffer(key: string, ...values: Buffer[]): any;
+        rpushBuffer(key: string, ...values: Buffer[]): Promise<number>;
 
         lpopBuffer(key: KeyType, callback: (err: Error, res: Buffer) => void): void;
         lpopBuffer(key: KeyType): Promise<Buffer>;
@@ -953,28 +969,28 @@ declare namespace IORedis {
         lrangeBuffer(key: KeyType, start: number, stop: number, callback: (err: Error, res: Buffer[]) => void): void;
         lrangeBuffer(key: KeyType, start: number, stop: number): Promise<Buffer[]>;
 
-        zadd(key: KeyType, ...args: string[]): Promise<number | string>;
+        zadd(key: KeyType, ...args: string[]): Promise<number>;
 
-        zrem(key: KeyType, ...members: any[]): any;
+        zrem(key: KeyType, ...members: ValueType[]): Promise<number>;
 
-        zrange(key: KeyType, start: number, stop: number, callback: (err: Error, res: any) => void): void;
-        zrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback: (err: Error, res: any) => void): void;
-        zrange(key: KeyType, start: number, stop: number, withScores?: "WITHSCORES"): Promise<any>;
+        zrange(key: KeyType, start: number, stop: number, callback: (err: Error, res: string[]) => void): void;
+        zrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback: (err: Error, res: string[]) => void): void;
+        zrange(key: KeyType, start: number, stop: number, withScores?: "WITHSCORES"): Promise<string[]>;
 
-        hset(key: KeyType, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
-        hset(key: KeyType, field: string, value: any): Promise<0 | 1>;
+        hset(key: KeyType, field: string, value: ValueType, callback: (err: Error, res: BooleanResponse) => void): void;
+        hset(key: KeyType, field: string, value: ValueType): Promise<BooleanResponse>;
 
         hget(key: KeyType, field: string, callback: (err: Error, res: string | null) => void): void;
         hget(key: KeyType, field: string): Promise<string | null>;
 
-        expire(key: KeyType, seconds: number, callback: (err: Error, res: 0 | 1) => void): void;
-        expire(key: KeyType, seconds: number): Promise<0 | 1>;
+        expire(key: KeyType, seconds: number, callback: (err: Error, res: BooleanResponse) => void): void;
+        expire(key: KeyType, seconds: number): Promise<BooleanResponse>;
 
         keys(pattern: string, callback: (err: Error, res: string[]) => void): void;
         keys(pattern: string): Promise<string[]>;
     }
 
-    interface ClusterStatic extends NodeJS.EventEmitter, Commander {
+    interface ClusterStatic extends EventEmitter, Commander {
         new (nodes: ClusterNode[], options?: ClusterOptions): Cluster;
     }
 
@@ -1055,7 +1071,7 @@ declare namespace IORedis {
          */
         autoResendUnfulfilledCommands?: boolean;
         lazyConnect?: boolean;
-        tls?: tls.ConnectionOptions;
+        tls?: ConnectionOptions;
         /**
          * default: "master".
          */

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -80,15 +80,8 @@ new Redis({
 });
 
 const pub = new Redis();
-redis.subscribe('news', 'music', (err: any, count: any) => {
-    // Now we are subscribed to both the 'news' and 'music' channels.
-    // `count` represents the number of channels we are currently subscribed to.
 
-    pub.publish('news', 'Hello world!');
-    pub.publishBuffer('music', Buffer.from('Hello again!'));
-});
-
-redis.on('message', (channel: any, message: any) => {
+pub.on('message', (channel: any, message: any) => {
     // Receive message Hello world! from channel news
     // Receive message Hello again! from channel music
     console.log('Receive message %s from channel %s', message, channel);
@@ -96,7 +89,7 @@ redis.on('message', (channel: any, message: any) => {
 
 // There's also an event called 'messageBuffer', which is the same as 'message' except
 // it returns buffers instead of strings.
-redis.on('messageBuffer', (channel: any, message: any) => {
+pub.on('messageBuffer', (channel: any, message: any) => {
     // Both `channel` and `message` are buffers.
 });
 
@@ -332,11 +325,10 @@ const getBuiltinCommandsResult = cluster.getBuiltinCommands();
 console.log(getBuiltinCommandsResult);
 const createBuiltinCommandResult = cluster.createBuiltinCommand('createBuiltinCommand');
 console.log(createBuiltinCommandResult);
-const defineCommandResult = cluster.defineCommand('defineCommand', {
+cluster.defineCommand('defineCommand', {
     numberOfKeys: 1,
     lua: 'lua'
 });
-console.log(defineCommandResult);
 cluster.sendCommand();
 
 redis.zaddBuffer('foo', 1, Buffer.from('bar')).then(() => {

--- a/types/redlock/index.d.ts
+++ b/types/redlock/index.d.ts
@@ -118,9 +118,10 @@ declare namespace Redlock {
         constructor(message?: string);
     }
 
+    type EvalArg = string | number;
+
     interface CompatibleRedisClient {
-        eval(args: any[], callback?: (err: Error | null, res: any) => void): any;
-        eval(...args: any[]): any;
+        eval(args: EvalArg[], callback?: (err: Error | null, res: any) => void): any;
     }
 }
 

--- a/types/redlock/v3/index.d.ts
+++ b/types/redlock/v3/index.d.ts
@@ -38,9 +38,10 @@ declare namespace Redlock {
         constructor(message?: string);
     }
 
+    type EvalArg = string | number;
+
     interface CompatibleRedisClient {
-        eval(args: any[], callback?: (err: Error | null, res: any) => void): any;
-        eval(...args: any[]): any;
+        eval(args: EvalArg[], callback?: (err: Error | null, res: any) => void): any;
     }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://redis.io/commands
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This is mostly narrowing almost all instances of `any` to something more useful.
There are still quite a few things missing (due to methods being autogenerated in the package) but this should help a few developers :)

Also remove some private members from interfaces.