### PR TITLE
Update ioredis sentinel retry strategy

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1014,7 +1014,7 @@ declare namespace IORedis {
          * When the return value isn't a number, ioredis will stop trying to reconnect.
          * Fixed in: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15858
          */
-        retryStrategy?(times: number): number | false;
+        retryStrategy?(times: number): number | void | null;
         /**
          * By default, all pending commands will be flushed with an error every
          * 20 retry attempts. That makes sure commands won't wait forever when
@@ -1070,7 +1070,7 @@ declare namespace IORedis {
          * If `sentinelRetryStrategy` returns a valid delay time, ioredis will try to reconnect from scratch.
          * default: function(times) { return Math.min(times * 10, 1000); }
          */
-        sentinelRetryStrategy?(times: number): number | false;
+        sentinelRetryStrategy?(times: number): number | void | null;
         /**
          * Can be used to prefer a particular slave or set of slaves based on priority.
          */

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1070,7 +1070,7 @@ declare namespace IORedis {
          * If `sentinelRetryStrategy` returns a valid delay time, ioredis will try to reconnect from scratch.
          * default: function(times) { return Math.min(times * 10, 1000); }
          */
-        sentinelRetryStrategy?: (retryAttempts: number) => number | void | null;
+        sentinelRetryStrategy?(times: number): number | false;
         /**
          * Can be used to prefer a particular slave or set of slaves based on priority.
          */

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1070,7 +1070,7 @@ declare namespace IORedis {
          * If `sentinelRetryStrategy` returns a valid delay time, ioredis will try to reconnect from scratch.
          * default: function(times) { return Math.min(times * 10, 1000); }
          */
-        sentinelRetryStrategy?: (retryAttempts: number) => number;
+        sentinelRetryStrategy?: (retryAttempts: number) => number | void | null;
         /**
          * Can be used to prefer a particular slave or set of slaves based on priority.
          */

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -71,7 +71,7 @@ new Redis({
     family: 4,           // 4 (IPv4) or 6 (IPv6)
     password: 'auth',
     db: 0,
-    retryStrategy() { return false; },
+    retryStrategy() { return null; },
     maxRetriesPerRequest: 20,
     showFriendlyErrorStack: true,
     tls: {


### PR DESCRIPTION
The new declaration of the `sentinelRetryStrategy` option is:
```ts
(retryAttempts: number) => number | void | null;
```

~But for consistency with `retryStrategy`, I decided to use:~
```ts
(times: number) => number | false;
```

Instead of ☝️ it has been decided to change `retryStrategy`'s declaration to `(times: number) => number | void | null;` in order to stay consistent with the original implementation. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40726#issuecomment-559893144.



---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - https://github.com/luin/ioredis/compare/v4.14.4...v4.15.0
   - https://github.com/luin/ioredis/blob/06b28e1c0a7d9ce163037d4c569b6b94970d99d5/lib/connectors/SentinelConnector/index.ts#L40
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
