### PR TITLE
[pg] Updated Client and Pool config types according to docs

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pg 7.11
+// Type definitions for pg 7.14
 // Project: http://github.com/brianc/node-postgres
 // Definitions by: Phips Peter <https://github.com/pspeter3>, Ravi van Rooijen <https://github.com/HoldYourWaffle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -10,7 +10,9 @@ import events = require("events");
 import stream = require("stream");
 import pgTypes = require("pg-types");
 
-export interface ConnectionConfig {
+import { ConnectionOptions } from "tls";
+
+export interface ClientConfig {
     user?: string;
     database?: string;
     password?: string;
@@ -20,22 +22,17 @@ export interface ConnectionConfig {
     keepAlive?: boolean;
     stream?: stream.Duplex;
     statement_timeout?: false | number;
-    connectionTimeoutMillis?: number;
+    ssl?: boolean | ConnectionOptions;
+    query_timeout?: number;
     keepAliveInitialDelayMillis?: number;
 }
 
-export interface Defaults extends ConnectionConfig {
+export interface Defaults extends ClientConfig {
     poolSize?: number;
     poolIdleTimeout?: number;
     reapIntervalMillis?: number;
     binary?: boolean;
     parseInt8?: boolean;
-}
-
-import { ConnectionOptions } from "tls";
-
-export interface ClientConfig extends ConnectionConfig {
-    ssl?: boolean | ConnectionOptions;
 }
 
 export interface PoolConfig extends ClientConfig {

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -27,6 +27,8 @@ export interface ClientConfig {
     keepAliveInitialDelayMillis?: number;
 }
 
+export type ConnectionConfig = ClientConfig;
+
 export interface Defaults extends ClientConfig {
     poolSize?: number;
     poolIdleTimeout?: number;


### PR DESCRIPTION
I found that typings are incorrect according to the documentation.
query_timeout option is missing, but connectionTimeoutMillis is present for Client config, which is not right and doesn't work.

https://node-postgres.com/api/client
https://node-postgres.com/api/pool
