### PR TITLE
[parquetjs] optional/repeated are always usable

### DIFF
--- a/types/parquetjs/lib/schema.interface.d.ts
+++ b/types/parquetjs/lib/schema.interface.d.ts
@@ -1,5 +1,7 @@
+export type SchemaInterfaceField = SingleFieldInterface | NestedFieldsInterface;
+
 export interface SchemaInterface {
-    [key: string]: SingleFieldInterface | NestedFieldsInterface;
+    [key: string]: SchemaInterfaceField;
 }
 
 export interface SingleFieldInterface {
@@ -7,9 +9,11 @@ export interface SingleFieldInterface {
     encoding?: string;
     bitWidth?: number;
     optional?: boolean;
+    repeated?: boolean;
 }
 
 export interface NestedFieldsInterface {
-    repeated: boolean;
+    optional?: boolean;
+    repeated?: boolean;
     fields: SchemaInterface;
 }


### PR DESCRIPTION
The library will accept optional on a struct (with fields) and
repeated on a normal field (without fields).

For example, a struct could be optional, or you can have an array
of integers.
