### PR TITLE
[@keystonejs/adapter-mongoose] fix typo in adapter name

### DIFF
--- a/types/keystonejs__adapter-mongoose/index.d.ts
+++ b/types/keystonejs__adapter-mongoose/index.d.ts
@@ -16,7 +16,7 @@ declare module '@keystonejs/adapter-mongoose' {
         listAdapterClass?: any;
     }
 
-    class MoogooseAdapter extends BaseKeystoneAdapter {
+    class MongooseAdapter extends BaseKeystoneAdapter {
         constructor(options?: MongooseAdaptorOptions);
 
         disconnect(): void;

--- a/types/keystonejs__adapter-mongoose/keystonejs__adapter-mongoose-tests.ts
+++ b/types/keystonejs__adapter-mongoose/keystonejs__adapter-mongoose-tests.ts
@@ -1,3 +1,3 @@
 import { MoogooseAdapter } from '@keystonejs/adapter-mongoose';
 
-const adapter = new MoogooseAdapter();
+const adapter = new MongooseAdapter();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/keystonejs/keystone/blob/master/packages/adapter-mongoose/README.md
