### PR TITLE
[trashable] Add types for trashable

### DIFF
--- a/types/trashable/index.d.ts
+++ b/types/trashable/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for trashable 1.0
+// Project: https://github.com/hjylewis/trashable#readme
+// Definitions by: James Lismore <https://github.com/jlismore>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type TrashablePromise<T> = Promise<T> & { trash: () => void };
+
+declare function makeTrashable<T>(promise: Promise<T>): TrashablePromise<T>;
+
+export = makeTrashable;

--- a/types/trashable/trashable-tests.ts
+++ b/types/trashable/trashable-tests.ts
@@ -1,0 +1,13 @@
+import makeTrashable = require('trashable');
+
+const booleanPromise = new Promise<boolean>(resolve => {
+    resolve(true);
+});
+const trashableBooleanPromise = makeTrashable(booleanPromise); // $ExpectType TrashablePromise<boolean>
+trashableBooleanPromise.trash(); // $ExpectType void
+
+const complexPromise = new Promise<{ a: number; b: string }>(resolve => {
+    resolve({ a: 1, b: '1' });
+});
+const trashableComplexPromise = makeTrashable(complexPromise); // $ExpectType TrashablePromise<{ a: number; b: string; }>
+trashableComplexPromise.trash(); // $ExpectType void

--- a/types/trashable/tsconfig.json
+++ b/types/trashable/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "trashable-tests.ts"
+    ]
+}

--- a/types/trashable/tslint.json
+++ b/types/trashable/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
