### PR TITLE
sqlite3: add interrupt method

### DIFF
--- a/types/sqlite3/index.d.ts
+++ b/types/sqlite3/index.d.ts
@@ -89,6 +89,7 @@ export class Database extends events.EventEmitter {
     on(event: string, listener: (...args: any[]) => void): this;
 
     configure(option: "busyTimeout", value: number): void;
+    interrupt(): void;
 }
 
 export function verbose(): sqlite3;

--- a/types/sqlite3/sqlite3-tests.ts
+++ b/types/sqlite3/sqlite3-tests.ts
@@ -109,4 +109,8 @@ db.run("UPDATE tbl SET name = ?5 WHERE id = ?", {
   5: "bar"
 });
 
+db.each("select 1", err => {
+  db.interrupt();
+});
+
 db.close();


### PR DESCRIPTION
Add interrupt to type definition. This function is released since v3.1.5 (5 Oct 2016).

https://github.com/mapbox/node-sqlite3/pull/518
https://github.com/mapbox/node-sqlite3/blob/4f61a03c60cb827b7cad7f624f34e607779b85d9/CHANGELOG.md#315

P.S. API document of node-sqlite3 doesn't have interrupt now.
https://github.com/mapbox/node-sqlite3/issues/1205#issuecomment-559983976

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mapbox/node-sqlite3/pull/518
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.