### PR TITLE
[materialize-css] Updated materialize-css autocomplete typing

### DIFF
--- a/types/materialize-css/autocomplete.d.ts
+++ b/types/materialize-css/autocomplete.d.ts
@@ -1,7 +1,7 @@
 /// <reference path="./common.d.ts" />
 
 declare namespace M {
-    class Autocomplete extends Component<AutocompleteOptions> {
+    class Autocomplete extends Component<AutocompleteOptions> implements Openable {
         /**
          * Get Instance
          */
@@ -16,6 +16,16 @@ declare namespace M {
          * Init autocompletes
          */
         static init(els: MElements, options?: Partial<AutocompleteOptions>): Autocomplete[];
+
+        /**
+         * Show autocomplete.
+         */
+        open(): void;
+
+        /**
+         * Hide autocomplete.
+         */
+        close(): void;
 
         /**
          * Select a specific autocomplete options.
@@ -81,7 +91,7 @@ declare namespace M {
 
 interface JQuery {
     // Pick<T,K> to check methods exist.
-    autocomplete(method: keyof Pick<M.Autocomplete, "destroy">): JQuery;
+    autocomplete(method: keyof Pick<M.Autocomplete, "open" | "close" | "destroy">): JQuery;
     autocomplete(method: keyof Pick<M.Autocomplete, "selectOption">, el: Element): JQuery;
     autocomplete(method: keyof Pick<M.Autocomplete, "updateData">, data: M.AutocompleteData): JQuery;
     autocomplete(options?: Partial<M.AutocompleteOptions>): JQuery;

--- a/types/materialize-css/index.d.ts
+++ b/types/materialize-css/index.d.ts
@@ -4,6 +4,7 @@
 //                  Maxim Balaganskiy <https://github.com/MaximBalaganskiy>
 //                  David Moniz <https://github.com/MonizDave>
 //                  Daniel Hoenes <https://github.com/broccoliarchy>
+//                  Rick Lucassen <https://github.com/SnowyLeopard>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 

--- a/types/materialize-css/test/autocomplete.test.ts
+++ b/types/materialize-css/test/autocomplete.test.ts
@@ -38,6 +38,10 @@ const autocomplete = new materialize.Autocomplete(elem, {
 // $ExpectType void
 autocomplete.updateData({ Microsoft: null });
 // $ExpectType void
+autocomplete.open();
+// $ExpectType void
+autocomplete.close();
+// $ExpectType void
 autocomplete.destroy();
 // $ExpectType AutocompleteOptions
 autocomplete.options;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://materializecss.com/autocomplete.html and https://github.com/Dogfalo/materialize/blob/v1-dev/js/autocomplete.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


Noticed that the autocomplete type was not complete and was missing the `open` and `close` methods. So I added them. 😄 