### PR TITLE
[react-syntax-highlighter] Fix lineProps and codeTagProps

### DIFF
--- a/types/react-syntax-highlighter/index.d.ts
+++ b/types/react-syntax-highlighter/index.d.ts
@@ -7,17 +7,15 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-type lineTagPropsFunction = (
-    lineNumber: number
-) => React.DOMAttributes<HTMLElement>;
+type lineTagPropsFunction = (lineNumber: number) => React.HTMLProps<HTMLElement>;
 
 declare module "react-syntax-highlighter" {
     export interface SyntaxHighlighterProps {
         language?: string;
         style?: any;
         customStyle?: any;
-        lineProps?: lineTagPropsFunction | React.DOMAttributes<HTMLElement>;
-        codeTagProps?: React.DOMAttributes<HTMLElement>;
+        lineProps?: lineTagPropsFunction | React.HTMLProps<HTMLElement>;
+        codeTagProps?: React.HTMLProps<HTMLElement>;
         useInlineStyles?: boolean;
         showLineNumbers?: boolean;
         startingLineNumber?: number;

--- a/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
+++ b/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
@@ -95,7 +95,7 @@ function codeTagProps() {
     }
     `;
 
-    const codeTagProps = {
+    const codeTagProps: SyntaxHighlighterProps["codeTagProps"] = {
         className: "some-classname",
         style: {
             opacity: 0
@@ -118,8 +118,7 @@ function linePropsObject() {
     }
     `;
 
-    const lineProps = {
-        otherProp: "otherProp",
+    const lineProps: SyntaxHighlighterProps["lineProps"] = {
         className: "some-classname",
         style: {
             opacity: 0
@@ -142,8 +141,7 @@ function lineTagPropsFunction() {
     }
     `;
 
-    const lineProps = (lineNumber: number) => ({
-        otherProp: "otherProp",
+    const lineProps: lineTagPropsFunction = (lineNumber: number) => ({
         className: "some-classname",
         style: {
             opacity: 0


### PR DESCRIPTION
Previously good code wouldn't compile because both `props` used
definitions without `React.HTMLProps` which is the correct definition for
the `props object` mentioned in https://github.com/conorhastings/react-syntax-highlighter#props.

All `lineProps` and `codeTagProps` tests have now explicitly defined
`prop` type.

Also code is now formatted with prettier.