### PR TITLE
Types for existing npm package `subleveldown` with tests

### DIFF
--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -5,12 +5,14 @@
 
 import { LevelUp } from 'levelup';
 import { AbstractLevelDOWN, AbstractIterator, ErrorCallback } from 'abstract-leveldown';
+import { CodecOptions } from 'level-codec';
 
 type SubDownOpenHook = (callback: ErrorCallback) => void;
 
-interface SubDownOptions {
+interface SubDownOptions extends CodecOptions {
     separator?: string;
     open?: SubDownOpenHook;
+    // TODO: Remove and inherit from constructor options from levelup package
     [key: string]: any;
 }
 

--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -19,7 +19,7 @@ declare namespace sub {
         ((options?: O) => Promise<V>);
 
     type InferDBClear<DB> =
-        DB extends { get: (options: infer O, callback: ErrorValueCallback<infer V>) => void } ?
+        DB extends { clear: (options: infer O, callback: ErrorValueCallback<infer V>) => void } ?
         LevelUpClear<V, O> :
         LevelUpClear<any, AbstractGetOptions>;
 

--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -13,8 +13,14 @@ declare namespace sub {
         // Any other options are passed along to the underlying levelup and encoding-down constructors.
         [key: string]: any;
     }
+
+    class SubIterator<K = any, V = any> extends AbstractIterator<K, V> {
+        iterator: AbstractIterator<K, V>;
+        prefix: string;
+        constructor(db: LevelUp<AbstractLevelDOWN<K, V>, AbstractIterator<K, V>>, ite: AbstractIterator<K, V>, prefix: string);
+    }
 }
 
-declare function sub<K = any, V = any>(db: LevelUp, prefix?: string, opts?: sub.Options | string): LevelUp<AbstractLevelDOWN<K, V>, AbstractIterator<K, V>>;
+declare function sub<K = any, V = any>(db: LevelUp, prefix?: string, opts?: sub.Options | string): LevelUp<AbstractLevelDOWN<K, V>, sub.SubIterator<K, V>>;
 
 export = sub;

--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -6,10 +6,11 @@
 import { LevelUp } from 'levelup';
 import { AbstractLevelDOWN, AbstractIterator, ErrorCallback } from 'abstract-leveldown';
 
+type SubDownOpenHook = (callback: ErrorCallback) => void;
+
 interface SubDownOptions {
     separator?: string;
-    open?: (callback: ErrorCallback) => void;
-    // Any other options are passed along to the underlying levelup and encoding-down constructors.
+    open?: SubDownOpenHook;
     [key: string]: any;
 }
 

--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for subleveldown 4.1
 // Project: https://github.com/level/subleveldown
 // Definitions by: Carson Farmer <https://github.com/carsonfarmer>
+//                 Dmitry Demensky <https://github.com/demensky>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { LevelUp } from 'levelup';

--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -6,21 +6,13 @@
 import { LevelUp } from 'levelup';
 import { AbstractLevelDOWN, AbstractIterator, ErrorCallback } from 'abstract-leveldown';
 
-declare namespace sub {
-    interface Options {
-        separator?: string;
-        open?: ((callback: ErrorCallback) => void);
-        // Any other options are passed along to the underlying levelup and encoding-down constructors.
-        [key: string]: any;
-    }
-
-    class SubIterator<K = any, V = any> extends AbstractIterator<K, V> {
-        iterator: AbstractIterator<K, V>;
-        prefix: string;
-        constructor(db: LevelUp<AbstractLevelDOWN<K, V>, AbstractIterator<K, V>>, ite: AbstractIterator<K, V>, prefix: string);
-    }
+interface SubDownOptions {
+    separator?: string;
+    open?: ((callback: ErrorCallback) => void);
+    // Any other options are passed along to the underlying levelup and encoding-down constructors.
+    [key: string]: any;
 }
 
-declare function sub<K = any, V = any>(db: LevelUp, prefix?: string, opts?: sub.Options | string): LevelUp<AbstractLevelDOWN<K, V>, sub.SubIterator<K, V>>;
-
+declare function sub<K = any, V = any>(db: LevelUp, prefix?: string, opts?: SubDownOptions | string): LevelUp<AbstractLevelDOWN<K, V>, AbstractIterator<K, V>>;
+declare namespace sub { }
 export = sub;

--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -3,31 +3,27 @@
 // Definitions by: Carson Farmer <https://github.com/carsonfarmer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'subleveldown' {
-    import { LevelUp } from 'levelup'
-    import { AbstractLevelDOWN, AbstractIteratorOptions, AbstractBatch, ErrorCallback, AbstractOptions, ErrorValueCallback, AbstractGetOptions, AbstractIterator } from 'abstract-leveldown';
+import { LevelUp } from 'levelup';
+import { ErrorValueCallback, ErrorCallback, AbstractGetOptions } from 'abstract-leveldown';
 
-    export interface Options {
-        separator?: string;
-        open?: Function;
-        [key: string]: any;
-    }
-
-    type LevelUpClear<V, O> =
-        ((callback: ErrorValueCallback<V>) => void) &
-        ((options: O, callback: ErrorValueCallback<V>) => void) &
-        ((options?: O) => Promise<V>);
-
-    type InferDBClear<DB> =
-        DB extends { get: (options: infer O, callback: ErrorValueCallback<infer V>) => void } ?
-        LevelUpClear<V, O> :
-        LevelUpClear<any, AbstractGetOptions>;
-
-    export interface SublevelDown<DB, Iterator> extends LevelUp<DB, Iterator>  {
-        clear: InferDBClear<DB>;
-
-    }
-
-    function sub<DB, Iterator>(db: LevelUp<DB, Iterator>, prefix?: string, options?: Options): SublevelDown<DB, Iterator>;
-    export default sub;
+export interface Options {
+    separator?: string;
+    open?: ((callback?: ErrorCallback) => any);
+    [key: string]: any;
 }
+
+type LevelUpClear<V, O> =
+    ((callback: ErrorValueCallback<V>) => void) &
+    ((options: O, callback: ErrorValueCallback<V>) => void) &
+    ((options?: O) => Promise<V>);
+
+type InferDBClear<DB> =
+    DB extends { get: (options: infer O, callback: ErrorValueCallback<infer V>) => void } ?
+    LevelUpClear<V, O> :
+    LevelUpClear<any, AbstractGetOptions>;
+
+export interface SublevelDown<DB, Iterator> extends LevelUp<DB, Iterator>  {
+    clear: InferDBClear<DB>;
+}
+
+export default function sub<DB, Iterator>(db: LevelUp<DB, Iterator>, prefix?: string, options?: Options): SublevelDown<DB, Iterator>;

--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -8,11 +8,15 @@ import { AbstractLevelDOWN, AbstractIterator, ErrorCallback } from 'abstract-lev
 
 interface SubDownOptions {
     separator?: string;
-    open?: ((callback: ErrorCallback) => void);
+    open?: (callback: ErrorCallback) => void;
     // Any other options are passed along to the underlying levelup and encoding-down constructors.
     [key: string]: any;
 }
 
-declare function sub<K = any, V = any>(db: LevelUp, prefix?: string, opts?: SubDownOptions | string): LevelUp<AbstractLevelDOWN<K, V>, AbstractIterator<K, V>>;
-declare namespace sub { }
+declare function sub<K = any, V = any>(
+    db: LevelUp,
+    prefix?: string,
+    opts?: SubDownOptions | string,
+): LevelUp<AbstractLevelDOWN<K, V>, AbstractIterator<K, V>>;
+declare namespace sub {}
 export = sub;

--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -4,27 +4,18 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { LevelUp } from 'levelup';
-import { ErrorValueCallback, ErrorCallback, AbstractGetOptions } from 'abstract-leveldown';
+import { ErrorCallback, AbstractOptions } from 'abstract-leveldown';
+import { KeyObject } from 'crypto';
 
 declare namespace sub {
     interface Options {
         separator?: string;
         open?: ((callback: ErrorCallback) => void);
+        // Any other options are passed along to the underlying levelup and encoding-down constructors.
+        [key: string]: any;
     }
 
-    type LevelUpClear<V, O> =
-        ((callback: ErrorValueCallback<V>) => void) &
-        ((options: O, callback: ErrorValueCallback<V>) => void) &
-        ((options?: O) => Promise<V>);
-
-    type InferDBClear<DB> =
-        DB extends { clear: (options: infer O, callback: ErrorValueCallback<infer V>) => void } ?
-        LevelUpClear<V, O> :
-        LevelUpClear<any, AbstractGetOptions>;
-
-    interface SubDown<DB, Iterator> extends LevelUp<DB, Iterator> {
-        clear: InferDBClear<DB>;
-    }
+    interface SubDown<DB, Iterator> extends LevelUp<DB, Iterator> {}
 }
 
 declare function sub<DB, Iterator>(db: LevelUp<DB, Iterator>, prefix?: string, opts?: sub.Options | string): sub.SubDown<DB, Iterator>;

--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -6,24 +6,28 @@
 import { LevelUp } from 'levelup';
 import { ErrorValueCallback, ErrorCallback, AbstractGetOptions } from 'abstract-leveldown';
 
-export interface Options {
-    separator?: string;
-    open?: ((callback?: ErrorCallback) => any);
-    [key: string]: any;
+declare namespace sub {
+    interface Options {
+        separator?: string;
+        open?: ((callback?: ErrorCallback) => any);
+        [key: string]: any;
+    }
+
+    type LevelUpClear<V, O> =
+        ((callback: ErrorValueCallback<V>) => void) &
+        ((options: O, callback: ErrorValueCallback<V>) => void) &
+        ((options?: O) => Promise<V>);
+
+    type InferDBClear<DB> =
+        DB extends { get: (options: infer O, callback: ErrorValueCallback<infer V>) => void } ?
+        LevelUpClear<V, O> :
+        LevelUpClear<any, AbstractGetOptions>;
+
+    interface SublevelDown<DB, Iterator> extends LevelUp<DB, Iterator> {
+        clear: InferDBClear<DB>;
+    }
 }
 
-type LevelUpClear<V, O> =
-    ((callback: ErrorValueCallback<V>) => void) &
-    ((options: O, callback: ErrorValueCallback<V>) => void) &
-    ((options?: O) => Promise<V>);
+declare function sub<DB, Iterator>(db: LevelUp < DB, Iterator >, prefix ?: string, options ?: sub.Options): sub.SublevelDown<DB, Iterator>;
 
-type InferDBClear<DB> =
-    DB extends { get: (options: infer O, callback: ErrorValueCallback<infer V>) => void } ?
-    LevelUpClear<V, O> :
-    LevelUpClear<any, AbstractGetOptions>;
-
-export interface SublevelDown<DB, Iterator> extends LevelUp<DB, Iterator>  {
-    clear: InferDBClear<DB>;
-}
-
-export default function sub<DB, Iterator>(db: LevelUp<DB, Iterator>, prefix?: string, options?: Options): SublevelDown<DB, Iterator>;
+export = sub;

--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -5,7 +5,6 @@
 
 import { LevelUp } from 'levelup';
 import { ErrorCallback, AbstractOptions } from 'abstract-leveldown';
-import { KeyObject } from 'crypto';
 
 declare namespace sub {
     interface Options {

--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -1,0 +1,33 @@
+// Type definitions for subleveldown 4.1
+// Project: https://github.com/level/subleveldown
+// Definitions by: Carson Farmer <https://github.com/carsonfarmer>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'subleveldown' {
+    import { LevelUp } from 'levelup'
+    import { AbstractLevelDOWN, AbstractIteratorOptions, AbstractBatch, ErrorCallback, AbstractOptions, ErrorValueCallback, AbstractGetOptions, AbstractIterator } from 'abstract-leveldown';
+
+    export interface Options {
+        separator?: string;
+        open?: Function;
+        [key: string]: any;
+    }
+
+    type LevelUpClear<V, O> =
+        ((callback: ErrorValueCallback<V>) => void) &
+        ((options: O, callback: ErrorValueCallback<V>) => void) &
+        ((options?: O) => Promise<V>);
+
+    type InferDBClear<DB> =
+        DB extends { get: (options: infer O, callback: ErrorValueCallback<infer V>) => void } ?
+        LevelUpClear<V, O> :
+        LevelUpClear<any, AbstractGetOptions>;
+
+    export interface SublevelDown<DB, Iterator> extends LevelUp<DB, Iterator>  {
+        clear: InferDBClear<DB>;
+
+    }
+
+    function sub<DB, Iterator>(db: LevelUp<DB, Iterator>, prefix?: string, options?: Options): SublevelDown<DB, Iterator>;
+    export default sub;
+}

--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { LevelUp } from 'levelup';
-import { ErrorCallback, AbstractOptions } from 'abstract-leveldown';
+import { AbstractLevelDOWN, AbstractIterator, ErrorCallback } from 'abstract-leveldown';
 
 declare namespace sub {
     interface Options {
@@ -13,10 +13,8 @@ declare namespace sub {
         // Any other options are passed along to the underlying levelup and encoding-down constructors.
         [key: string]: any;
     }
-
-    interface SubDown<DB, Iterator> extends LevelUp<DB, Iterator> {}
 }
 
-declare function sub<DB, Iterator>(db: LevelUp<DB, Iterator>, prefix?: string, opts?: sub.Options | string): sub.SubDown<DB, Iterator>;
+declare function sub<K = any, V = any>(db: LevelUp, prefix?: string, opts?: sub.Options | string): LevelUp<AbstractLevelDOWN<K, V>, AbstractIterator<K, V>>;
 
 export = sub;

--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -7,19 +7,44 @@ import { LevelUp } from 'levelup';
 import { AbstractLevelDOWN, AbstractIterator, ErrorCallback } from 'abstract-leveldown';
 import { CodecOptions } from 'level-codec';
 
+/** @see {@link SubDownOptions#open} */
 type SubDownOpenHook = (callback: ErrorCallback) => void;
 
+/**
+ * Any other options are passed along to the underlying `levelup` and `encoding-down` constructors.
+ * {@link https://github.com/Level/subleveldown#api See their documentation for further details}.
+ */
 interface SubDownOptions extends CodecOptions {
+    /**
+     * Character for separating sublevel prefixes from user keys and each other. Should be outside the character (or byte) range of user keys.
+     * @default '!'
+     */
     separator?: string;
+
+    /**
+     * Optional open hook called when the underlying `levelup` instance has been opened.
+     * The hook receives a callback which must be called to finish opening.
+     */
     open?: SubDownOpenHook;
+
     // TODO: Remove and inherit from constructor options from levelup package
     [key: string]: any;
 }
 
+/**
+ * Returns a `levelup` instance that uses subleveldown to prefix the keys of the underlying store of `db`.
+ * Any layers that this instance may have (like `encoding-down` or `subleveldown` itself) are peeled off to get to the innermost `abstract-leveldown` compliant store (like `leveldown`).
+ * This ensures there is no double encoding step.
+ * @param db
+ * @param prefix If omitted, the effective prefix is two separators, e.g. `'!!'`. If `db` is already a subleveldown-powered instance, the effective prefix is a combined prefix, e.g. `'!one!!two!'`.
+ * @param opts
+ * @see {@link https://github.com/Level/subleveldown#api subleveldown API}
+ */
 declare function sub<K = any, V = any>(
     db: LevelUp,
     prefix?: string,
     opts?: SubDownOptions | string,
 ): LevelUp<AbstractLevelDOWN<K, V>, AbstractIterator<K, V>>;
 declare namespace sub {}
+
 export = sub;

--- a/types/subleveldown/index.d.ts
+++ b/types/subleveldown/index.d.ts
@@ -9,8 +9,7 @@ import { ErrorValueCallback, ErrorCallback, AbstractGetOptions } from 'abstract-
 declare namespace sub {
     interface Options {
         separator?: string;
-        open?: ((callback?: ErrorCallback) => any);
-        [key: string]: any;
+        open?: ((callback: ErrorCallback) => void);
     }
 
     type LevelUpClear<V, O> =
@@ -23,11 +22,11 @@ declare namespace sub {
         LevelUpClear<V, O> :
         LevelUpClear<any, AbstractGetOptions>;
 
-    interface SublevelDown<DB, Iterator> extends LevelUp<DB, Iterator> {
+    interface SubDown<DB, Iterator> extends LevelUp<DB, Iterator> {
         clear: InferDBClear<DB>;
     }
 }
 
-declare function sub<DB, Iterator>(db: LevelUp < DB, Iterator >, prefix ?: string, options ?: sub.Options): sub.SublevelDown<DB, Iterator>;
+declare function sub<DB, Iterator>(db: LevelUp<DB, Iterator>, prefix?: string, opts?: sub.Options | string): sub.SubDown<DB, Iterator>;
 
 export = sub;

--- a/types/subleveldown/subleveldown-tests.ts
+++ b/types/subleveldown/subleveldown-tests.ts
@@ -1,5 +1,5 @@
 import levelup from 'levelup';
-import sub from 'subleveldown';
+import * as sub from 'subleveldown';
 import { AbstractLevelDOWN } from 'abstract-leveldown';
 
 interface StringEncoding {

--- a/types/subleveldown/subleveldown-tests.ts
+++ b/types/subleveldown/subleveldown-tests.ts
@@ -16,8 +16,8 @@ const db = levelup(new AbstractLevelDOWN('here'), {
     valueEncoding: stringEncoding
 });
 
-const example = sub(db, 'example');
-const nested = sub(example, 'nested');
+const example = sub<string>(db, 'example');
+const nested = sub<string, number>(example, 'nested');
 
 example.open();
 example.close();
@@ -32,7 +32,7 @@ example.put("key", {}, (error) => { });
 example.put("key", {}, { sync: true }, (error) => { });
 
 example.put('hello', 'world', () => {
-    nested.put('hi', 'welt', () => {
+    nested.put('hi', 1, () => {
         example.createReadStream().on('data', console.log);
     });
 });

--- a/types/subleveldown/subleveldown-tests.ts
+++ b/types/subleveldown/subleveldown-tests.ts
@@ -13,7 +13,7 @@ declare const stringEncoding: StringEncoding;
 
 const db = levelup(new AbstractLevelDOWN('here'), {
     keyEncoding: stringEncoding,
-    valueEncoding: stringEncoding
+    valueEncoding: stringEncoding,
 });
 
 const example = sub<string>(db, 'example', { separator: '!' });
@@ -21,15 +21,13 @@ const nested = sub<string, number>(example, 'nested');
 
 example.open();
 example.close();
-example.open((error) => {
-});
+example.open(error => {});
 
-example.close((error) => {
-});
+example.close(error => {});
 
-example.put("key", {});
-example.put("key", {}, (error) => { });
-example.put("key", {}, { sync: true }, (error) => { });
+example.put('key', {});
+example.put('key', {}, error => {});
+example.put('key', {}, { sync: true }, error => {});
 
 example.put('hello', 'world', () => {
     nested.put('hi', 1, () => {
@@ -37,35 +35,44 @@ example.put('hello', 'world', () => {
     });
 });
 
-example.get("key", { keyEncoding: "json" }, (error, val) => { });
-example.get("key", { fillCache: true }, (error, val) => { });
-example.get("key", (error, val) => { });
+example.get('key', { keyEncoding: 'json' }, (error, val) => {});
+example.get('key', { fillCache: true }, (error, val) => {});
+example.get('key', (error, val) => {});
 
-example.del("key");
-example.del("key", (error) => { });
-example.del("key", { keyEncoding: "json" }, (error) => { });
-example.del("key", { sync: true }, (error) => { });
+example.del('key');
+example.del('key', error => {});
+example.del('key', { keyEncoding: 'json' }, error => {});
+example.del('key', { sync: true }, error => {});
 
-example.batch([{
-    type: 'put'
-    , key: ([1, 2, 3])
-    , value: { some: 'json' }
-}], (error: Error | undefined) => { });
+example.batch(
+    [
+        {
+            type: 'put',
+            key: [1, 2, 3],
+            value: { some: 'json' },
+        },
+    ],
+    (error: Error | undefined) => {},
+);
 
-example.batch()
+example
+    .batch()
     .del('father')
     .put('name', 'Yuri Irsenovich Kim')
     .put('dob', '16 February 1941')
     .put('spouse', 'Kim Young-sook')
     .put('occupation', 'Clown')
-    .write(() => { console.log('Done!'); });
+    .write(() => {
+        console.log('Done!');
+    });
 
 // $ExpectType boolean
 example.isOpen();
 // $ExpectType boolean
 example.isClosed();
 
-example.createReadStream()
+example
+    .createReadStream()
     .on('data', (data: any) => {
         console.log(data.key, '=', data.value);
     })

--- a/types/subleveldown/subleveldown-tests.ts
+++ b/types/subleveldown/subleveldown-tests.ts
@@ -1,5 +1,5 @@
 import levelup from 'levelup';
-import * as sub from 'subleveldown';
+import sub from 'subleveldown';
 import { AbstractLevelDOWN } from 'abstract-leveldown';
 
 interface StringEncoding {
@@ -16,7 +16,7 @@ const db = levelup(new AbstractLevelDOWN('here'), {
     valueEncoding: stringEncoding
 });
 
-const example = sub<string>(db, 'example');
+const example = sub<string>(db, 'example', { separator: '!' });
 const nested = sub<string, number>(example, 'nested');
 
 example.open();

--- a/types/subleveldown/subleveldown-tests.ts
+++ b/types/subleveldown/subleveldown-tests.ts
@@ -1,5 +1,5 @@
 import levelup from 'levelup';
-import sub from 'subleveldown'
+import sub from 'subleveldown';
 import { AbstractLevelDOWN } from 'abstract-leveldown';
 
 interface StringEncoding {

--- a/types/subleveldown/subleveldown-tests.ts
+++ b/types/subleveldown/subleveldown-tests.ts
@@ -78,11 +78,3 @@ example.createReadStream()
     .on('end', () => {
         console.log('Stream closed');
     });
-
-example.clear((error) => {
-});
-
-example.clear({ gt: 'hello' }, (error) => {
-});
-
-example.clear().then(() => console.log('cleared'));

--- a/types/subleveldown/subleveldown-tests.ts
+++ b/types/subleveldown/subleveldown-tests.ts
@@ -1,0 +1,88 @@
+import levelup from 'levelup';
+import sub from 'subleveldown'
+import { AbstractLevelDOWN } from 'abstract-leveldown';
+
+interface StringEncoding {
+    encode(val: any): string;
+    decode(val: string): any;
+    buffer: boolean;
+    type: string;
+}
+
+declare const stringEncoding: StringEncoding;
+
+const db = levelup(new AbstractLevelDOWN('here'), {
+    keyEncoding: stringEncoding,
+    valueEncoding: stringEncoding
+});
+
+const example = sub(db, 'example');
+const nested = sub(example, 'nested');
+
+example.open();
+example.close();
+example.open((error) => {
+});
+
+example.close((error) => {
+});
+
+example.put("key", {});
+example.put("key", {}, (error) => { });
+example.put("key", {}, { sync: true }, (error) => { });
+
+example.put('hello', 'world', () => {
+    nested.put('hi', 'welt', () => {
+        example.createReadStream().on('data', console.log);
+    });
+});
+
+example.get("key", { keyEncoding: "json" }, (error, val) => { });
+example.get("key", { fillCache: true }, (error, val) => { });
+example.get("key", (error, val) => { });
+
+example.del("key");
+example.del("key", (error) => { });
+example.del("key", { keyEncoding: "json" }, (error) => { });
+example.del("key", { sync: true }, (error) => { });
+
+example.batch([{
+    type: 'put'
+    , key: ([1, 2, 3])
+    , value: { some: 'json' }
+}], (error: Error | undefined) => { });
+
+example.batch()
+    .del('father')
+    .put('name', 'Yuri Irsenovich Kim')
+    .put('dob', '16 February 1941')
+    .put('spouse', 'Kim Young-sook')
+    .put('occupation', 'Clown')
+    .write(() => { console.log('Done!'); });
+
+// $ExpectType boolean
+example.isOpen();
+// $ExpectType boolean
+example.isClosed();
+
+example.createReadStream()
+    .on('data', (data: any) => {
+        console.log(data.key, '=', data.value);
+    })
+    .on('error', (err: any) => {
+        console.log('Oh my!', err);
+    })
+    .on('close', () => {
+        console.log('Stream closed');
+    })
+    .on('end', () => {
+        console.log('Stream closed');
+    });
+
+example.clear((error) => {
+});
+
+example.clear({ gt: 'hello' }, (error) => {
+});
+
+example.clear().then(() => console.log('cleared'));

--- a/types/subleveldown/tsconfig.json
+++ b/types/subleveldown/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "subleveldown-tests.ts"
+    ]
+}

--- a/types/subleveldown/tsconfig.json
+++ b/types/subleveldown/tsconfig.json
@@ -8,6 +8,7 @@
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
+        "esModuleInterop": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/subleveldown/tslint.json
+++ b/types/subleveldown/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
