### PR TITLE
fix(airtable): return types for Table.create

### DIFF
--- a/types/airtable/airtable-tests.ts
+++ b/types/airtable/airtable-tests.ts
@@ -74,4 +74,27 @@ async () => {
             }
         }
     }
+
+    {
+        const newRowData: Row = {
+            field1: 'string',
+            attachments: [],
+            booleanField: false,
+            numberField: 0,
+            singleCollaborator: { email: '', id: '', name: '' },
+            multiCollaborators: [],
+        };
+
+        const newRecord = await table.create(newRowData);
+
+        newRecord.id;
+        newRecord.fields;
+
+        const newRecords = await table.create([newRowData, newRowData]);
+
+        newRecords.forEach(r => {
+            r.id;
+            r.fields;
+        });
+    }
 };

--- a/types/airtable/index.d.ts
+++ b/types/airtable/index.d.ts
@@ -42,8 +42,8 @@ declare global {
         interface Table<TFields extends FieldSet> {
             select(opt?: SelectOptions): Query<TFields>;
             find(id: string): Promise<Response<TFields>>;
-            create(record: TFields, opts?: { typecast: boolean }): Promise<Response<TFields>>;
-            create(records: TFields[], opts?: { typecast: boolean }): Promise<Array<Response<TFields>>>;
+            create(record: TFields, opts?: { typecast: boolean }): Promise<ResponseSingle<TFields>>;
+            create(records: TFields[], opts?: { typecast: boolean }): Promise<Response<TFields>>;
             update(...args: any[]): Promise<any>;
             replace(...args: any[]): Promise<any>;
             destroy(...args: any[]): Promise<any>;
@@ -73,6 +73,7 @@ declare global {
         }
 
         type Response<TFields> = ReadonlyArray<Row<TFields>>;
+        type ResponseSingle<TFields> = Readonly<Row<TFields>>;
 
         interface Row<TFields> {
             id: string;

--- a/types/airtable/index.d.ts
+++ b/types/airtable/index.d.ts
@@ -41,9 +41,9 @@ declare global {
 
         interface Table<TFields extends FieldSet> {
             select(opt?: SelectOptions): Query<TFields>;
-            find(id: string): Promise<Response<TFields>>;
-            create(record: TFields, opts?: { typecast: boolean }): Promise<ResponseSingle<TFields>>;
-            create(records: TFields[], opts?: { typecast: boolean }): Promise<Response<TFields>>;
+            find(id: string): Promise<Record<TFields>>;
+            create(record: TFields, opts?: { typecast: boolean }): Promise<Record<TFields>>;
+            create(records: TFields[], opts?: { typecast: boolean }): Promise<Records<TFields>>;
             update(...args: any[]): Promise<any>;
             replace(...args: any[]): Promise<any>;
             destroy(...args: any[]): Promise<any>;
@@ -67,18 +67,17 @@ declare global {
         }
 
         interface Query<TFields extends object> {
-            all(): Promise<Response<TFields>>;
-            firstPage(): Promise<Response<TFields>>;
-            eachPage(pageCallback: (records: Response<TFields>, next: () => void) => void): Promise<void>;
+            all(): Promise<Records<TFields>>;
+            firstPage(): Promise<Records<TFields>>;
+            eachPage(pageCallback: (records: Records<TFields>, next: () => void) => void): Promise<void>;
         }
 
-        type Response<TFields> = ReadonlyArray<Row<TFields>>;
-        type ResponseSingle<TFields> = Readonly<Row<TFields>>;
-
-        interface Row<TFields> {
+        interface Record<TFields> {
             id: string;
             fields: TFields;
         }
+
+        type Records<TFields> = ReadonlyArray<Record<TFields>>;
 
         interface Attachment {
             id: string;


### PR DESCRIPTION
When `create` is called with a single object to create, the return type is not an array, but a single object. `Response<TFields>` is defined as `ReadonlyArray<Row<TFields>>` (note: `Array`), which isn't correct for a single object. Likewise, `Promise<Array<Response<TFields>>>` implies a multidimensional array, which again isn't correct.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
