### PR TITLE
Added negotiateLocale(key) to angular-translate

### DIFF
--- a/types/angular-translate/index.d.ts
+++ b/types/angular-translate/index.d.ts
@@ -69,8 +69,8 @@ declare module 'angular' {
              *
              * If no or a falsy key is given, returns undefined.
              *
-             * @param {string} [key] Language key
-             * @return {string|undefined} Language key or undefined if no language key is found.
+             * @param [key] Language key
+             * @return Language key or undefined if no language key is found.
              */
             negotiateLocale(key?: string): string | undefined;
             preferredLanguage(langKey?: string): string;

--- a/types/angular-translate/index.d.ts
+++ b/types/angular-translate/index.d.ts
@@ -58,9 +58,19 @@ declare module 'angular' {
             instant(translationId: string, interpolateParams?: any, interpolationId?: string, forceLanguage?: string, sanitizeStrategy?: string): string;
             instant(translationId: string[], interpolateParams?: any, interpolationId?: string, forceLanguage?: string, sanitizeStrategy?: string): { [key: string]: string };
             isPostCompilingEnabled(): boolean;
-            /** Returns a language key based on available languages and language aliases. If a language key cannot be resolved, returns undefined.
+            /**
+             * @ngdoc function
+             * @name pascalprecht.translate.$translate#negotiateLocale
+             * @methodOf pascalprecht.translate.$translate
+             *
+             * @description
+             * Returns a language key based on available languages and language aliases. If a
+             * language key cannot be resolved, returns undefined.
+             *
              * If no or a falsy key is given, returns undefined.
-             * @returns Language key or undefined if no language key is found.
+             *
+             * @param {string} [key] Language key
+             * @return {string|undefined} Language key or undefined if no language key is found.
              */
             negotiateLocale(key?: string): string | undefined;
             preferredLanguage(langKey?: string): string;

--- a/types/angular-translate/index.d.ts
+++ b/types/angular-translate/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for Angular Translate (pascalprecht.translate module) 2.16
 // Project: https://github.com/PascalPrecht/angular-translate
-// Definitions by: Michel Salib <https://github.com/michelsalib>, Gabriel Gil <https://github.com/GabrielGil>
+// Definitions by: Michel Salib <https://github.com/michelsalib>,
+//                 Gabriel Gil <https://github.com/GabrielGil>,
+//                 Dmitry Gurovich <https://github.com/yrtimiD>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -56,6 +58,11 @@ declare module 'angular' {
             instant(translationId: string, interpolateParams?: any, interpolationId?: string, forceLanguage?: string, sanitizeStrategy?: string): string;
             instant(translationId: string[], interpolateParams?: any, interpolationId?: string, forceLanguage?: string, sanitizeStrategy?: string): { [key: string]: string };
             isPostCompilingEnabled(): boolean;
+            /** Returns a language key based on available languages and language aliases. If a language key cannot be resolved, returns undefined.
+             * If no or a falsy key is given, returns undefined.
+             * @returns Language key or undefined if no language key is found.
+             */
+            negotiateLocale(key?: string): string | undefined;
             preferredLanguage(langKey?: string): string;
             proposedLanguage(): string;
             refresh(langKey?: string): angular.IPromise<void>;

--- a/types/angular-translate/index.d.ts
+++ b/types/angular-translate/index.d.ts
@@ -69,7 +69,7 @@ declare module 'angular' {
              *
              * If no or a falsy key is given, returns undefined.
              *
-             * @param [key] Language key
+             * @param key Language key
              * @return Language key or undefined if no language key is found.
              */
             negotiateLocale(key?: string): string | undefined;


### PR DESCRIPTION
Adds missing method.
From [official documentation](https://angular-translate.github.io/docs/#/api/pascalprecht.translate.$translate) scroll to negotiateLocale([key])
or [source code](https://github.com/angular-translate/angular-translate/blob/aafbc39/src/service/translate.js#L1883)
JSDocs are from original lib code
Exists in 2.16 (no need to change version)
