### PR TITLE
OpeningHours and UTC Offset Deprecation

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -3160,7 +3160,7 @@ declare namespace google.maps {
         }
 
         interface OpeningHours {
-            open_now: boolean;
+            isOpen(): boolean;
             periods: OpeningPeriod[];
             weekday_text: string[];
         }
@@ -3275,7 +3275,7 @@ declare namespace google.maps {
             reviews?: PlaceReview[];
             types?: string[];
             url?: string;
-            utc_offset?: number;
+            utc_offset_minutes?: number;
             vicinity?: string;
             website?: string;
         }


### PR DESCRIPTION
Changes on November 20, 2020
Refer [place_field_js_migration](https://developers.google.com/maps/documentation/javascript/place_field_js_migration)

Previously, the Maps JavaScript API’s Places Library exposes two properties in its PlaceResult objects:
- utc_offset, which is returned by Place Details requests and
- opening_hours.open_now, which is returned by Place Details, Find Place, Nearby Search, Text Search requests.

These properties have been replaced as follows:
- utc_offset, by utc_offset_minutes
- opening_hours.open_now, by the isOpen() method in Place Details requests only.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
