### PR TITLE
cache-manager/Remove the need for cast

### DIFF
--- a/types/cache-manager/index.d.ts
+++ b/types/cache-manager/index.d.ts
@@ -52,11 +52,11 @@ export type CallbackFunc<T> = (error: any, result: T) => void;
 export type WrapArgsType<T> = string | ((callback: CallbackFunc<T>) => void) | CachingConfig | CallbackFunc<T>;
 
 export interface Cache {
-    set<T>(key: string, value: T, options: CachingConfig, callback?: (error: any) => void): void;
-    set<T>(key: string, value: T, ttl: number, callback?: (error: any) => void): void;
     set<T>(key: string, value: T, options: CachingConfig): Promise<any>;
     set<T>(key: string, value: T, ttl: number): Promise<any>;
-
+    set<T>(key: string, value: T, options: CachingConfig, callback: (error: any) => void): void;
+    set<T>(key: string, value: T, ttl: number, callback: (error: any) => void): void;
+    
     // Because the library accepts multiple keys as arguments but not as an array and rather as individual parameters
     // of the function, the type definition had to be changed to this rather than specific ones
     // actual definitions would looks like this (impossible in typescript):


### PR DESCRIPTION
With the current order, I have to cast to unknown and then to `Promise<any>`
```
  public set<T>(key: string, value: T, options: CacheManager.CachingConfig): Promise<any> {
    return (this.client.set(key, value, options) as unknown) as Promise<any>;
  }
```

With the new order I can just do:
```
  public set<T>(key: string, value: T, options: CacheManager.CachingConfig) { // returns type is Promise<any>
    return (this.client.set(key, value, options);
  }
```

and
```
  public set<T>(key: string, value: T, options: CacheManager.CachingConfig) { // returns type is void
    return (this.client.set(key, value, options, ()=> {});
  }
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: this is just an order issue
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.