### PR TITLE
[omit-empty] Fix typing to persist the type of processed object

### DIFF
--- a/types/omit-empty/index.d.ts
+++ b/types/omit-empty/index.d.ts
@@ -8,5 +8,5 @@ interface OmitOptions {
     omitZero?: boolean;
 }
 
-declare function omitEmpty(obj: object, options?: OmitOptions): object;
+declare function omitEmpty<T extends object>(obj: T, options?: OmitOptions): Pick<T>;
 export default omitEmpty;


### PR DESCRIPTION
Fix for `omit-empty` package to persist the type of processed object
