### PR TITLE
[sharp] update typings to 0.23.3 and fix #40640

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sharp 0.23.3
+// Type definitions for sharp 0.23
 // Project: https://github.com/lovell/sharp
 // Definitions by: François Nguyen <https://github.com/lith-light-g>
 //                 Wooseop Kim <https://github.com/wooseopkim>

--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sharp 0.23
+// Type definitions for sharp 0.23.3
 // Project: https://github.com/lovell/sharp
 // Definitions by: François Nguyen <https://github.com/lith-light-g>
 //                 Wooseop Kim <https://github.com/wooseopkim>
@@ -586,6 +586,15 @@ declare namespace sharp {
         resize(width?: number | null, height?: number | null, options?: ResizeOptions): Sharp;
 
         /**
+         * Shorthand for resize(null, null, options);
+         *
+         * @param options resize options
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        resize(options: ResizeOptions): Sharp;
+
+        /**
          * Extends/pads the edges of the image with the provided background colour.
          * This operation will always occur after resizing and extraction, if any.
          * @param extend single pixel count to add to all edges or an Object with per-edge counts
@@ -929,6 +938,8 @@ declare namespace sharp {
         overlap?: number;
         /** Tile angle of rotation, must be a multiple of 90. (optional, default 0) */
         angle?: number;
+        /** background colour, parsed by the color module, defaults to white without transparency. (optional, default {r:255,g:255,b:255,alpha:1}) */
+        background?: string | RGBA;
         /** How deep to make the pyramid, possible values are "onepixel", "onetile" or "one" (default based on layout) */
         depth?: string;
         /** Threshold to skip tile generation, a value 0 - 255 for 8-bit images or 0 - 65535 for 16-bit images */

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -46,6 +46,10 @@ sharp('input.jpg')
         // containing a scaled and cropped version of input.jpg
     });
 
+sharp('input.jpg')
+    .resize({width: 300})
+    .toFile('output.jpg');
+
 sharp({
     create: {
         width: 300,


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - Add `background` parameter to `tile()`: https://github.com/lovell/sharp/pull/1924
   - Add shorthand overload for `resize()`: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/40640
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
