### PR TITLE
[@types/default-gateway] Gateway interface fixes

### DIFF
--- a/types/default-gateway/index.d.ts
+++ b/types/default-gateway/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for default-gateway 3.0
 // Project: https://github.com/silverwind/default-gateway#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
+//                 Michele Della Mea <https://github.com/ArcaneDiver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export const v4: DefaultGatewayFn;
@@ -13,5 +14,5 @@ export interface DefaultGatewayFn {
 
 export interface Gateway {
     gateway: string;
-    interface: string | null;
+    interface: string;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
	- The `interface` property of `Gateway` interface was setted to `string | null` but that's wrong because if there is no default gateway the function will throw an error than the property `interface` will be every time a `string`. 
		- [https://github.com/silverwind/default-gateway/blob/master/android.js#L23](https://github.com/silverwind/default-gateway/blob/master/android.js#L23)
		- [https://github.com/silverwind/default-gateway/blob/master/darwin.js#L32](https://github.com/silverwind/default-gateway/blob/master/darwin.js#L32)
		- [https://github.com/silverwind/default-gateway/blob/master/freebsd.js#L24](https://github.com/silverwind/default-gateway/blob/master/freebsd.js#L24)
		- [https://github.com/silverwind/default-gateway/blob/master/ibmi.js#L17](https://github.com/silverwind/default-gateway/blob/master/ibmi.js#L17)
		- [https://github.com/silverwind/default-gateway/blob/master/linux.js#L37](https://github.com/silverwind/default-gateway/blob/master/linux.js#L37)
		- [https://github.com/silverwind/default-gateway/blob/master/sunos.js#L27](https://github.com/silverwind/default-gateway/blob/master/sunos.js#L27)
		- [https://github.com/silverwind/default-gateway/blob/master/win32.js#L83](https://github.com/silverwind/default-gateway/blob/master/win32.js#L83)

