### PR TITLE
[connect] Add missing property originalUrl to req parameter

### DIFF
--- a/types/connect/connect-tests.ts
+++ b/types/connect/connect-tests.ts
@@ -4,23 +4,23 @@ import connect = require("connect");
 const app = connect();
 
 // log all requests
-app.use((req: http.IncomingMessage, res: http.ServerResponse, next: connect.NextFunction) => {
+app.use((req: connect.IncomingMessage, res: http.ServerResponse, next: connect.NextFunction) => {
     console.log(req, res);
     next();
 });
 
 // "Throw" an Error
-app.use((req: http.IncomingMessage, res: http.ServerResponse, next: connect.NextFunction) => {
+app.use((req: connect.IncomingMessage, res: http.ServerResponse, next: connect.NextFunction) => {
     next(new Error("Something went wrong!"));
 });
 
 // "Throw" a number
-app.use((req: http.IncomingMessage, res: http.ServerResponse, next: connect.NextFunction) => {
+app.use((req: connect.IncomingMessage, res: http.ServerResponse, next: connect.NextFunction) => {
     next(404);
 });
 
 // Stop on errors
-app.use((err: any, req: http.IncomingMessage, res: http.ServerResponse, next: connect.NextFunction) => {
+app.use((err: any, req: connect.IncomingMessage, res: http.ServerResponse, next: connect.NextFunction) => {
     if (err) {
         return res.end(`Error: ${err}`);
     }
@@ -29,13 +29,19 @@ app.use((err: any, req: http.IncomingMessage, res: http.ServerResponse, next: co
 });
 
 // Use legacy `Function` for `next` parameter.
-app.use((req: http.IncomingMessage, res: http.ServerResponse, next: Function) => {
+app.use((req: connect.IncomingMessage, res: http.ServerResponse, next: Function) => {
     next();
 });
 
 // respond to all requests
-app.use((req: http.IncomingMessage, res: http.ServerResponse) => {
+app.use((req: connect.IncomingMessage, res: http.ServerResponse) => {
     res.end("Hello from Connect!\n");
+});
+
+// Allow http.IncomingMessage as the type for req
+app.use((req: http.IncomingMessage, res: http.ServerResponse) => {
+  console.log(req, res);
+  res.end();
 });
 
 //create node.js http server and listen on port

--- a/types/connect/index.d.ts
+++ b/types/connect/index.d.ts
@@ -18,11 +18,15 @@ declare function createServer(): createServer.Server;
 declare namespace createServer {
     export type ServerHandle = HandleFunction | http.Server;
 
+    export class IncomingMessage extends http.IncomingMessage {
+        originalUrl?: http.IncomingMessage["url"];
+    }
+
     type NextFunction = (err?: any) => void;
 
-    export type SimpleHandleFunction = (req: http.IncomingMessage, res: http.ServerResponse) => void;
-    export type NextHandleFunction = (req: http.IncomingMessage, res: http.ServerResponse, next: NextFunction) => void;
-    export type ErrorHandleFunction = (err: any, req: http.IncomingMessage, res: http.ServerResponse, next: NextFunction) => void;
+    export type SimpleHandleFunction = (req: IncomingMessage, res: http.ServerResponse) => void;
+    export type NextHandleFunction = (req: IncomingMessage, res: http.ServerResponse, next: NextFunction) => void;
+    export type ErrorHandleFunction = (err: any, req: IncomingMessage, res: http.ServerResponse, next: NextFunction) => void;
     export type HandleFunction = SimpleHandleFunction | NextHandleFunction | ErrorHandleFunction;
 
     export interface ServerStackItem {


### PR DESCRIPTION
This adds a new class IncomingMessage which extends from
http.IncomingMessage and adds the originalUrl property which was
previously missing. This new class is used for the req parameter in
HandleFunction.

The originalUrl property is added to req here:
https://github.com/senchalabs/connect/blob/3.4.0/index.js#L133

`originalUrl` is present in the version specified in these type definitions, so I didn't change the version.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/senchalabs/connect/blob/3.4.0/index.js#L133
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.