### PR TITLE
Added wrap prop for the TabsProps interface (gestalt)

### DIFF
--- a/types/gestalt/index.d.ts
+++ b/types/gestalt/index.d.ts
@@ -738,6 +738,7 @@ export interface TabsProps {
         }
     ) => void;
     tabs: ReadonlyArray<{ text: any; href: string }>;
+    wrap?: boolean:
 }
 
 /*

--- a/types/gestalt/index.d.ts
+++ b/types/gestalt/index.d.ts
@@ -738,7 +738,7 @@ export interface TabsProps {
         }
     ) => void;
     tabs: ReadonlyArray<{ text: any; href: string }>;
-    wrap?: boolean:
+    wrap?: boolean;
 }
 
 /*


### PR DESCRIPTION
For the gestalt library.
Added the missing wrap prop for the TabsProps interface.

If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: [https://pinterest.github.io/gestalt/#/Tabs](https://pinterest.github.io/gestalt/#/Tabs)

