### PR TITLE
add types jsreport-chrome-pdf

### DIFF
--- a/types/jsreport-chrome-pdf/index.d.ts
+++ b/types/jsreport-chrome-pdf/index.d.ts
@@ -95,6 +95,7 @@ declare namespace JsReportChromePdf {
 		env: { [key: string]: string; };
 		devtools: boolean;
 		pipe: boolean;
+		extraPrefsFirefox: { [key: string]: any; };
 	}
 
 	// https://jsreport.net/learn/configuration

--- a/types/jsreport-chrome-pdf/index.d.ts
+++ b/types/jsreport-chrome-pdf/index.d.ts
@@ -1,0 +1,87 @@
+// Type definitions for jsreport-chrome-pdf 1.6
+// Project: https://github.com/jsreport/jsreport-chrome-pdf
+// Definitions by: taoqf <https://github.com/taoqf>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { ExtensionDefinition } from 'jsreport-core';
+
+declare module 'jsreport-core' {
+	interface Template {
+		chrome?: Partial<JsReportChromePdf.Chrome>;
+		chromeImage?: Partial<JsReportChromePdf.ChromeImage>;
+		recipe: 'chrome-pdf' | 'chrome-image' | string;
+	}
+}
+
+declare namespace JsReportChromePdf {
+	// https://jsreport.net/learn/chrome-pdf
+	// https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagepdfoptions
+	interface Chrome {
+		path: string;
+		scale: number;
+		displayHeaderFooter: boolean;
+		headerTemplate: string;
+		footerTemplate: string;
+		printBackground: boolean;
+		landscape: boolean;
+		pageRanges: string;	// 1-5, 8, 11-13
+		format: string;
+		width: string | number;
+		height: string | number;
+		margin: {
+			top?: string | number;
+			right?: string | number;
+			bottom?: string | number;
+			left?: string | number;
+		};
+		preferCSSPageSize: boolean;
+
+		// https://jsreport.net/learn/chrome-pdf
+		marginTop: string | number;
+		marginRight: string | number;
+		marginBottom: string | number;
+		marginLeft: string | number;
+		waitForJS: boolean;
+		waitForNetworkIddle: boolean;
+
+		// https://github.com/jsreport/jsreport-chrome-pdf/blob/master/test/chromeTest.js
+		header: string;
+		url: string;
+		pageNumber: number;
+		totalPages: number;
+		mediaType: 'screen' | 'print';
+	}
+
+	// https://jsreport.net/learn/chrome-image
+	// https://github.com/puppeteer/puppeteer/blob/v1.11.0/docs/api.md#pagescreenshotoptions
+	interface ChromeImage {
+		path: string;
+		type: 'jpeg' | 'png';
+		quality: number;	// 0-100
+		fullPage: boolean;
+		clip: {
+			x: number;
+			y: number;
+			width: number;
+			height: number;
+		};
+		omitBackground: boolean;
+		encoding: 'base64' | 'binary';
+	}
+
+	// https://jsreport.net/learn/configuration
+	interface Options {
+		allowLocalFilesAccess: boolean;
+		strategy: 'dedicated-process' | 'http-server' | 'in-process';
+		timeout: number;
+		numberOfWorkers: number;
+		host: string;
+		portLeftBoundary: number;
+		portRightBoundary: number;
+		allowedModules: string[];
+	}
+}
+
+declare function JsReportChromePdf(options?: Partial<JsReportChromePdf.Options>): ExtensionDefinition;
+
+export = JsReportChromePdf;

--- a/types/jsreport-chrome-pdf/index.d.ts
+++ b/types/jsreport-chrome-pdf/index.d.ts
@@ -69,6 +69,34 @@ declare namespace JsReportChromePdf {
 		encoding: 'base64' | 'binary';
 	}
 
+	// https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions
+	interface LaunchOptions {
+		product: 'chrome' | 'firefox';
+		ignoreHTTPSErrors: boolean;
+		headless: boolean;
+		executablePath: string;
+		slowMo: number;
+		defaultViewport: Partial<{
+			width: string;
+			height: string;
+			deviceScaleFactor: string;
+			isMobile: boolean;
+			hasTouch: boolean;
+			isLandscape: boolean;
+		}>;
+		args: string[];
+		ignoreDefaultArgs: boolean | string[];
+		handleSIGINT: boolean;
+		handleSIGTERM: boolean;
+		handleSIGHUP: boolean;
+		timeout: number;
+		dumpio: boolean;
+		userDataDir: string;
+		env: { [key: string]: string; };
+		devtools: boolean;
+		pipe: boolean;
+	}
+
 	// https://jsreport.net/learn/configuration
 	interface Options {
 		allowLocalFilesAccess: boolean;
@@ -79,6 +107,7 @@ declare namespace JsReportChromePdf {
 		portLeftBoundary: number;
 		portRightBoundary: number;
 		allowedModules: string[];
+		launchOptions: Partial<LaunchOptions>;
 	}
 }
 

--- a/types/jsreport-chrome-pdf/jsreport-chrome-pdf-tests.ts
+++ b/types/jsreport-chrome-pdf/jsreport-chrome-pdf-tests.ts
@@ -1,0 +1,47 @@
+import JsReport = require("jsreport-core");
+import JsReportChromePdf = require("jsreport-chrome-pdf");
+import JsRender = require("jsreport-jsrender");
+import fs = require('fs');
+
+const jsreport = JsReport({
+	tasks: {
+		strategy: "http-server"
+	}
+});
+
+jsreport.beforeRenderListeners.add('test', (req, res) => {
+	console.log('input', req.template.content);
+});
+
+jsreport.use(JsReportChromePdf());
+jsreport.use(JsRender());
+
+(async () => {
+	await jsreport.init();
+	const res = await jsreport.render({
+		template: {
+			content: 'content',
+			recipe: 'chrome-pdf',
+			engine: 'handlebars',
+			chrome: {
+				landscape: true,
+				scale: 2.0,
+				url: 'https://jsreport.net',
+				header: 'Foo',
+				mediaType: 'screen',
+				displayHeaderFooter: true,
+				margin: {
+					top: '80px',
+					bottom: '80px',
+				},
+				marginBottom: '80px',
+				headerTemplate: '{{printNumber 1}}<br/>',
+				footerTemplate: '{{printNumber 2}}<br/>'
+			},
+			helpers: `function printNumber (num) { return num  }`
+		},
+		data: { foo: "hello2" }
+	});
+	fs.writeFileSync('./types/test/test.pdf', res.content);
+	process.exit(0);
+})();

--- a/types/jsreport-chrome-pdf/tsconfig.json
+++ b/types/jsreport-chrome-pdf/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"strictFunctionTypes": true,
+		"lib": [
+			"es6"
+		],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": [
+			"../"
+		],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.d.ts",
+		"jsreport-chrome-pdf-tests.ts"
+	]
+}

--- a/types/jsreport-chrome-pdf/tslint.json
+++ b/types/jsreport-chrome-pdf/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
