### PR TITLE
fix: add missing typing for auth0-js lib

### DIFF
--- a/types/auth0-js/auth0-js-tests.ts
+++ b/types/auth0-js/auth0-js-tests.ts
@@ -139,7 +139,8 @@ webAuth.passwordlessStart({
 webAuth.passwordlessLogin({
     connection: 'the_connection',
     phoneNumber: '123',
-    verificationCode: '456'
+    verificationCode: '456',
+    state: '12313eqwasdadaasd'
 }, (err, data) => {});
 
 webAuth.signupAndAuthorize({

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -618,23 +618,40 @@ export interface ChangePasswordOptions {
     email: string;
 }
 
+export interface BaseAuthOptions {
+    clientID?: string;
+    responseType?: string;
+    redirectUri?: string;
+    scope?: string;
+    audience?: string;
+    state?: string;
+    nonce?: string;
+    _csrf?: string;
+    __instate?: string;
+}
+
+export interface PasswordlessStartAuthParams extends BaseAuthOptions {
+    responseMode?: string;
+}
+
 export interface PasswordlessStartOptions {
     connection: string;
     send: string;
     phoneNumber?: string;
     email?: string;
-    authParams?: any;
+    authParams?: PasswordlessStartAuthParams;
 }
 
-export interface PasswordlessVerifyOptions {
+export interface PasswordlessVerifyOptions extends BaseAuthOptions {
     connection: string;
     verificationCode: string;
     phoneNumber?: string;
     email?: string;
     send?: string;
+    responseMode?: string;
 }
 
-export interface PasswordlessLoginOptions {
+export interface PasswordlessLoginOptions extends BaseAuthOptions {
     connection: string;
     verificationCode: string;
     phoneNumber?: string;


### PR DESCRIPTION
This PR adds missing typing for auth0-js library.

It extends typing for WebAuth api:
- `passwordlessStart` method - typing for baseOptions (Reference: https://github.com/auth0/auth0.js/blob/master/src/web-auth/index.js#L603-L611)
- `passwrodlessVerify` method - typing for baseOptions (Reference: https://github.com/auth0/auth0.js/blob/master/src/web-auth/index.js#L869-L878)
- `passwordlessLogin` methods - typing for baseOptions (Reference: https://github.com/auth0/auth0.js/blob/master/src/web-auth/index.js#L779-L787)
 

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

