### PR TITLE
Adjust polymer attributeChangedCallback to spec.

### DIFF
--- a/types/polymer/index.d.ts
+++ b/types/polymer/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/Polymer/polymer
 // Definitions by: Louis Grignon <https://github.com/lgrignon>, Suguru Inatomi <https://github.com/laco0416>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.1
 
 import { CustomElementConstructor } from "webcomponents.js";
 

--- a/types/polymer/index.d.ts
+++ b/types/polymer/index.d.ts
@@ -195,7 +195,7 @@ declare global {
 
       detachedCallback?():void;
 
-      attributeChangedCallback?(name: string):void;
+      attributeChangedCallback?(attributeName: string, oldValue: string|null, newValue: string|null, namespace: string|null): void;
 
       extend?(prototype: Object, api: Object):Object;
 

--- a/types/webcomponents.js/index.d.ts
+++ b/types/webcomponents.js/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/webcomponents/webcomponentsjs, http://webcomponents.org
 // Definitions by: Adi Dahiya <https://github.com/adidahiya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.1
 
 export interface CustomElementInit {
     prototype: HTMLElement;


### PR DESCRIPTION
According to the specification at:
    https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-reactions

`attributeChangedCallback` is called "given the attribute's local name,
old value, new value, and namespace as arguments". This also matches
browser implementations and understanding of how things work from
discussion with Polymer engineers (CC @rictic).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- ~~[ ] Add or edit tests to reflect the change. (Run with `npm test`.)~~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-reactions
