### PR TITLE
[PapaParse] Add delimitersToGuess to ParseConfig definition

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -36,10 +36,12 @@ export const unparse: (data: Array<Object> | Array<Array<any>> | UnparseObject, 
 export const BAD_DELIMETERS: Array<string>;
 
 // The true delimiter. Invisible. ASCII code 30. Should be doing the job we strangely rely upon commas and tabs for.
-export const RECORD_SEP: string;
+declare type RECORD_SEP_TYPE = '';
+export const RECORD_SEP = '';
 
 // Also sometimes used as a delimiting character. ASCII code 31.
-export const UNIT_SEP: string;
+declare type UNIT_SEP_TYPE = '';
+export const UNIT_SEP = '';
 
 // Whether or not the browser supports HTML5 Web Workers. If false, worker: true will have no effect.
 export const WORKERS_SUPPORTED: boolean;
@@ -51,6 +53,9 @@ export let SCRIPT_PATH: string;
 // When passed to Papa Parse a Readable stream is returned.
 declare type NODE_STREAM_INPUT_TYPE = 1;
 export const NODE_STREAM_INPUT = 1;
+
+// The possible values for the ParseConfig property delimitersToGuess
+declare type GuessableDelimiters = ',' | '\t' | '|' | ';' | RECORD_SEP_TYPE | UNIT_SEP_TYPE;
 
 /**
  * Configurable Properties
@@ -105,7 +110,7 @@ export interface ParseConfig {
     skipEmptyLines?: boolean | 'greedy'; // default: false
     fastMode?: boolean; // default: undefined
     withCredentials?: boolean; // default: undefined
-    delimitersToGuess?: string[]; // default: [',', '\t', '|', ';', Papa.RECORD_SEP, Papa.UNIT_SEP]
+    delimitersToGuess?: GuessableDelimiters[]; // default: [',', '\t', '|', ';', Papa.RECORD_SEP, Papa.UNIT_SEP]
 
     // Callbacks
     step?(results: ParseResult, parser: Parser): void; // default: undefined

--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -8,6 +8,7 @@
 //                 Behind The Math <https://github.com/BehindTheMath>
 //                 3af <https://github.com/3af>
 //                 Janne Liuhtonen <https://github.com/jliuhtonen>
+//                 Raphaël Barbazza <https://github.com/rbarbazz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -104,6 +105,7 @@ export interface ParseConfig {
     skipEmptyLines?: boolean | 'greedy'; // default: false
     fastMode?: boolean; // default: undefined
     withCredentials?: boolean; // default: undefined
+    delimitersToGuess?: string[]; // default: [',', '\t', '|', ';', Papa.RECORD_SEP, Papa.UNIT_SEP]
 
     // Callbacks
     step?(results: ParseResult, parser: Parser): void; // default: undefined

--- a/types/papaparse/papaparse-tests.ts
+++ b/types/papaparse/papaparse-tests.ts
@@ -41,6 +41,18 @@ Papa.parse('3,3,3', {
     dynamicTyping: { 5: true },
 });
 
+Papa.parse('4,4,4', {
+    delimitersToGuess: [';', ','],
+});
+
+Papa.parse('4,4,4', {
+    delimitersToGuess: [Papa.RECORD_SEP, '|', ',', ';'],
+});
+
+Papa.parse('4;4;4', {
+    delimitersToGuess: ['\t', Papa.UNIT_SEP],
+});
+
 var file = new File(null, null, null);
 
 Papa.parse(file, {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- Not sure what to test here, the property was just missing
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://www.papaparse.com/docs#config](url)
