### PR TITLE
[styled-components] Allow static properties to be passed through

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -22,6 +22,7 @@ declare global {
 
 import * as CSS from "csstype";
 import * as React from "react";
+import hoistNonReactStatics = require('hoist-non-react-statics');
 
 export type CSSProperties = CSS.Properties<string | number>;
 
@@ -160,7 +161,7 @@ export type StyledComponent<
     A extends keyof any = never
 > = // the "string" allows this to be used as an object key
     // I really want to avoid this if possible but it's the only way to use nesting with object styles...
-    string & StyledComponentBase<C, T, O, A> & { [K in keyof C]: C[K] };
+    string & StyledComponentBase<C, T, O, A> & hoistNonReactStatics.NonReactStatics<C extends React.ComponentType<any> ? C : never>;
 
 export interface StyledComponentBase<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -22,7 +22,7 @@ declare global {
 
 import * as CSS from "csstype";
 import * as React from "react";
-import hoistNonReactStatics = require('hoist-non-react-statics');
+import * as hoistNonReactStatics from 'hoist-non-react-statics';
 
 export type CSSProperties = CSS.Properties<string | number>;
 

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -8,6 +8,7 @@
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 David Ruisinger <https://github.com/flavordaaave>
 //                 Matthew Wagerfield <https://github.com/wagerfield>
+//                 Yuki Ito <https://github.com/Lazyuki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -159,7 +160,7 @@ export type StyledComponent<
     A extends keyof any = never
 > = // the "string" allows this to be used as an object key
     // I really want to avoid this if possible but it's the only way to use nesting with object styles...
-    string & StyledComponentBase<C, T, O, A>;
+    string & StyledComponentBase<C, T, O, A> & { [K in keyof C]: C[K] };
 
 export interface StyledComponentBase<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,

--- a/types/styled-components/package.json
+++ b/types/styled-components/package.json
@@ -2,7 +2,6 @@
     "private": true,
     "dependencies": {
         "csstype": "^2.2.0",
-        "@types/hoist-non-react-statics": "^3.3.1"
     },
     "types": "index",
     "typesVersions": {

--- a/types/styled-components/package.json
+++ b/types/styled-components/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "csstype": "^2.2.0",
+        "csstype": "^2.2.0"
     },
     "types": "index",
     "typesVersions": {

--- a/types/styled-components/package.json
+++ b/types/styled-components/package.json
@@ -1,7 +1,8 @@
 {
     "private": true,
     "dependencies": {
-        "csstype": "^2.2.0"
+        "csstype": "^2.2.0",
+        "@types/hoist-non-react-statics": "^3.3.1"
     },
     "types": "index",
     "typesVersions": {

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1033,25 +1033,16 @@ function staticPropertyPassthrough() {
     class A extends React.Component<AProps> {}
     class B extends React.Component {
         static A = A;
-        private readonly PRIVATE = 'PR';
-        PUBLIC = 'PUB';
+        PUBLIC = 'PUBIC_VAL';
         static F = () => {};
     }
-    const C: React.FC & { A: typeof A; F: () => void } = () => <div></div>;
-    C.A = A; // Typescript Version 3.1
-    C.F = () => {};
-
     const StyledB = styled(B)``;
-    const StyledC = styled(C)``;
     <StyledB.A />; // $ExpectError
     <StyledB.A a='a' />; // $ExpectError
     <StyledB.A a={0} />;
-    StyledB.PRIVATE; // $ExpectError
     StyledB.PUBLIC; // $ExpectError
     StyledB.componentDidMount(); // $ExpectError
     StyledB.F();
-    <StyledC.A a={0} />;
-    StyledC.F();
 }
 
 function unionTest() {

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1029,17 +1029,16 @@ const wrapperFunc = <StyledWrapperFunc>Text</StyledWrapperFunc>; // $ExpectError
 
 // Test if static properties added to the underlying component is passed through.
 function staticPropertyPassthrough() {
-    interface AProps { a: number };
+    interface AProps { a: number; }
     class A extends React.Component<AProps> {}
     class B extends React.Component {
         static A = A;
-        private PRV = 'PR';
-        public PUB = 'PUB';
+        private readonly PRIVATE = 'PR';
+        PUBLIC = 'PUB';
         static F = () => {};
-        D = () => {}
     }
     const C: React.FC & { A: typeof A; F: () => void } = () => <div></div>;
-    C.A = A;
+    C.A = A; // Typescript Version 3.1
     C.F = () => {};
 
     const StyledB = styled(B)``;
@@ -1047,8 +1046,8 @@ function staticPropertyPassthrough() {
     <StyledB.A />; // $ExpectError
     <StyledB.A a='a' />; // $ExpectError
     <StyledB.A a={0} />;
-    StyledB.PRV; // $ExpectError
-    StyledB.PUB; // $ExpectError
+    StyledB.PRIVATE; // $ExpectError
+    StyledB.PUBLIC; // $ExpectError
     StyledB.componentDidMount(); // $ExpectError
     StyledB.F();
     <StyledC.A a={0} />;

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1030,11 +1030,16 @@ const wrapperFunc = <StyledWrapperFunc>Text</StyledWrapperFunc>; // $ExpectError
 // Test if static properties added to the underlying component is passed through.
 function staticPropertyPassthrough() {
     interface AProps { a: number; }
+    interface BProps {}
+    interface BState {}
     class A extends React.Component<AProps> {}
-    class B extends React.Component {
+    class B extends React.Component<BProps, BState> {
         static A = A;
         PUBLIC = 'PUBIC_VAL';
-        static F = () => {};
+        static F = (props: BProps, state: BState) => props && state;
+        static getDerivedStateFromProps(props: BProps, state: BState) {
+            return state;
+        }
     }
     const StyledB = styled(B)``;
     <StyledB.A />; // $ExpectError
@@ -1042,7 +1047,8 @@ function staticPropertyPassthrough() {
     <StyledB.A a={0} />;
     StyledB.PUBLIC; // $ExpectError
     StyledB.componentDidMount(); // $ExpectError
-    StyledB.F();
+    StyledB.F({} , {});
+    StyledB.getDerivedStateFromProps({} , {}); // $ExpectError
 }
 
 function unionTest() {

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1030,8 +1030,8 @@ const wrapperFunc = <StyledWrapperFunc>Text</StyledWrapperFunc>; // $ExpectError
 // Test if static properties added to the underlying component is passed through.
 function staticPropertyPassthrough() {
     interface AProps { a: number; }
-    interface BProps {}
-    interface BState {}
+    interface BProps { b: string; }
+    interface BState { b: string; }
     class A extends React.Component<AProps> {}
     class B extends React.Component<BProps, BState> {
         static A = A;
@@ -1047,8 +1047,8 @@ function staticPropertyPassthrough() {
     <StyledB.A a={0} />;
     StyledB.PUBLIC; // $ExpectError
     StyledB.componentDidMount(); // $ExpectError
-    StyledB.F({} , {});
-    StyledB.getDerivedStateFromProps({} , {}); // $ExpectError
+    StyledB.F({ b: 'b' } , { b: 'b' });
+    StyledB.getDerivedStateFromProps({ b: 'b' } , { b: 'b' }); // $ExpectError
 }
 
 function unionTest() {

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1027,6 +1027,34 @@ const StyledWrapperFunc = styled(WrapperFunc)``;
 // No `children` in props, so this should generate an error
 const wrapperFunc = <StyledWrapperFunc>Text</StyledWrapperFunc>; // $ExpectError
 
+// Test if static properties added to the underlying component is passed through.
+function staticPropertyPassthrough() {
+    interface AProps { a: number };
+    class A extends React.Component<AProps> {}
+    class B extends React.Component {
+        static A = A;
+        private PRV = 'PR';
+        public PUB = 'PUB';
+        static F = () => {};
+        D = () => {}
+    }
+    const C: React.FC & { A: typeof A; F: () => void } = () => <div></div>;
+    C.A = A;
+    C.F = () => {};
+
+    const StyledB = styled(B)``;
+    const StyledC = styled(C)``;
+    <StyledB.A />; // $ExpectError
+    <StyledB.A a='a' />; // $ExpectError
+    <StyledB.A a={0} />;
+    StyledB.PRV; // $ExpectError
+    StyledB.PUB; // $ExpectError
+    StyledB.componentDidMount(); // $ExpectError
+    StyledB.F();
+    <StyledC.A a={0} />;
+    StyledC.F();
+}
+
 function unionTest() {
     interface Book {
         kind: 'book';

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1030,8 +1030,8 @@ const wrapperFunc = <StyledWrapperFunc>Text</StyledWrapperFunc>; // $ExpectError
 // Test if static properties added to the underlying component is passed through.
 function staticPropertyPassthrough() {
     interface AProps { a: number; }
-    interface BProps { b: string; }
-    interface BState { b: string; }
+    interface BProps { b?: string; }
+    interface BState { b?: string; }
     class A extends React.Component<AProps> {}
     class B extends React.Component<BProps, BState> {
         static A = A;

--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -8,6 +8,7 @@ declare global {
 
 import * as CSS from "csstype";
 import * as React from "react";
+import hoistNonReactStatics = require('hoist-non-react-statics');
 
 export type CSSProperties = CSS.Properties<string | number>;
 
@@ -144,7 +145,7 @@ export type StyledComponent<
     A extends keyof any = never
 > = // the "string" allows this to be used as an object key
     // I really want to avoid this if possible but it's the only way to use nesting with object styles...
-    string & StyledComponentBase<C, T, O, A> & { [K in keyof C]: C[K] };
+    string & StyledComponentBase<C, T, O, A> & hoistNonReactStatics.NonReactStatics<C extends React.ComponentType<any> ? C : never>;
 
 export interface StyledComponentBase<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,

--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -144,7 +144,7 @@ export type StyledComponent<
     A extends keyof any = never
 > = // the "string" allows this to be used as an object key
     // I really want to avoid this if possible but it's the only way to use nesting with object styles...
-    string & StyledComponentBase<C, T, O, A>;
+    string & StyledComponentBase<C, T, O, A> & { [K in keyof C]: C[K] };
 
 export interface StyledComponentBase<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,

--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -8,7 +8,7 @@ declare global {
 
 import * as CSS from "csstype";
 import * as React from "react";
-import hoistNonReactStatics = require('hoist-non-react-statics');
+import * as hoistNonReactStatics from 'hoist-non-react-statics';
 
 export type CSSProperties = CSS.Properties<string | number>;
 

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -1043,11 +1043,16 @@ const wrapperFunc = <StyledWrapperFunc>Text</StyledWrapperFunc>; // $ExpectError
 // Test if static properties added to the underlying component is passed through.
 function staticPropertyPassthrough() {
     interface AProps { a: number; }
+    interface BProps {}
+    interface BState {}
     class A extends React.Component<AProps> {}
     class B extends React.Component {
         static A = A;
         PUBLIC = 'PUBIC_VAL';
-        static F = () => {};
+        static F = (props: BProps, state: BState) => props && state;
+        static getDerivedStateFromProps(props: BProps, state: BState) {
+            return state;
+        }
     }
     // Test FunctionComponent as well which can't be tested in <= TS 3.0
     const C: React.FC & { A: typeof A; F: () => void } = () => <div></div>;
@@ -1060,7 +1065,8 @@ function staticPropertyPassthrough() {
     <StyledB.A a={0} />;
     StyledB.PUBLIC; // $ExpectError
     StyledB.componentDidMount(); // $ExpectError
-    StyledB.F();
+    StyledB.F({} , {});
+    StyledB.getDerivedStateFromProps({} , {}); // $ExpectError
     <StyledC.A a={0} />;
     StyledC.F();
 }

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -1043,8 +1043,8 @@ const wrapperFunc = <StyledWrapperFunc>Text</StyledWrapperFunc>; // $ExpectError
 // Test if static properties added to the underlying component is passed through.
 function staticPropertyPassthrough() {
     interface AProps { a: number; }
-    interface BProps {}
-    interface BState {}
+    interface BProps { b: string; }
+    interface BState { b: string; }
     class A extends React.Component<AProps> {}
     class B extends React.Component {
         static A = A;
@@ -1065,8 +1065,8 @@ function staticPropertyPassthrough() {
     <StyledB.A a={0} />;
     StyledB.PUBLIC; // $ExpectError
     StyledB.componentDidMount(); // $ExpectError
-    StyledB.F({} , {});
-    StyledB.getDerivedStateFromProps({} , {}); // $ExpectError
+    StyledB.F({ b: 'b' } , {  b: 'b' });
+    StyledB.getDerivedStateFromProps({ b: 'b' } , { b: 'b' }); // $ExpectError
     <StyledC.A a={0} />;
     StyledC.F();
 }

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -1043,8 +1043,8 @@ const wrapperFunc = <StyledWrapperFunc>Text</StyledWrapperFunc>; // $ExpectError
 // Test if static properties added to the underlying component is passed through.
 function staticPropertyPassthrough() {
     interface AProps { a: number; }
-    interface BProps { b: string; }
-    interface BState { b: string; }
+    interface BProps { b?: string; }
+    interface BState { b?: string; }
     class A extends React.Component<AProps> {}
     class B extends React.Component {
         static A = A;

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -1042,26 +1042,23 @@ const wrapperFunc = <StyledWrapperFunc>Text</StyledWrapperFunc>; // $ExpectError
 
 // Test if static properties added to the underlying component is passed through.
 function staticPropertyPassthrough() {
-    interface AProps { a: number };
+    interface AProps { a: number; }
     class A extends React.Component<AProps> {}
     class B extends React.Component {
         static A = A;
-        private PRV = 'PR';
-        public PUB = 'PUB';
+        PUBLIC = 'PUBIC_VAL';
         static F = () => {};
-        D = () => {}
     }
+    // Test FunctionComponent as well which can't be tested in <= TS 3.0
     const C: React.FC & { A: typeof A; F: () => void } = () => <div></div>;
     C.A = A;
     C.F = () => {};
-
     const StyledB = styled(B)``;
     const StyledC = styled(C)``;
     <StyledB.A />; // $ExpectError
     <StyledB.A a='a' />; // $ExpectError
     <StyledB.A a={0} />;
-    StyledB.PRV; // $ExpectError
-    StyledB.PUB; // $ExpectError
+    StyledB.PUBLIC; // $ExpectError
     StyledB.componentDidMount(); // $ExpectError
     StyledB.F();
     <StyledC.A a={0} />;

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -1040,6 +1040,34 @@ const StyledWrapperFunc = styled(WrapperFunc)``;
 // No `children` in props, so this should generate an error
 const wrapperFunc = <StyledWrapperFunc>Text</StyledWrapperFunc>; // $ExpectError
 
+// Test if static properties added to the underlying component is passed through.
+function staticPropertyPassthrough() {
+    interface AProps { a: number };
+    class A extends React.Component<AProps> {}
+    class B extends React.Component {
+        static A = A;
+        private PRV = 'PR';
+        public PUB = 'PUB';
+        static F = () => {};
+        D = () => {}
+    }
+    const C: React.FC & { A: typeof A; F: () => void } = () => <div></div>;
+    C.A = A;
+    C.F = () => {};
+
+    const StyledB = styled(B)``;
+    const StyledC = styled(C)``;
+    <StyledB.A />; // $ExpectError
+    <StyledB.A a='a' />; // $ExpectError
+    <StyledB.A a={0} />;
+    StyledB.PRV; // $ExpectError
+    StyledB.PUB; // $ExpectError
+    StyledB.componentDidMount(); // $ExpectError
+    StyledB.F();
+    <StyledC.A a={0} />;
+    StyledC.F();
+}
+
 function unionTest() {
     interface Book {
         kind: 'book';


### PR DESCRIPTION
Allows styled components to retain static fields of the original component, which fixes #32048
Right now 
```jsx
class A extends React.Component {}
class B extends React.Component {
    static A = A;
}
const StyledB = styled(B)``;
<StyledB.A />
```
raises an error that says `Property 'A' does not exist on type 'StyledComponent<typeof B, DefaultTheme, {}, never>'` but if this was plain JS it works as intended. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #32048