### PR TITLE
[@types/elasticsearch] hits.total is now an object in the search response

### DIFF
--- a/types/elasticsearch/elasticsearch-tests.ts
+++ b/types/elasticsearch/elasticsearch-tests.ts
@@ -299,7 +299,7 @@ client.search({
     allTitles.push(hit.fields.title);
   });
 
-  if (response.hits.total !== allTitles.length) {
+  if (response.hits.total.value !== allTitles.length) {
     // now we can call scroll over and over
     client.scroll({
       scrollId: response._scroll_id!,

--- a/types/elasticsearch/elasticsearch-tests.ts
+++ b/types/elasticsearch/elasticsearch-tests.ts
@@ -299,7 +299,11 @@ client.search({
     allTitles.push(hit.fields.title);
   });
 
-  if (response.hits.total.value !== allTitles.length) {
+  const hitsTotal = typeof response.hits.total === 'object'
+    ? response.hits.total.value
+    : response.hits.total;
+
+  if (hitsTotal !== allTitles.length) {
     // now we can call scroll over and over
     client.scroll({
       scrollId: response._scroll_id!,

--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for elasticsearch 5.0
+// Type definitions for elasticsearch 16.5
 // Project: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/16.x/index.html
 // Definitions by: Casper Skydt <https://github.com/CasperSkydt>
 //                 Blake Smith <https://github.com/bfsmith>
@@ -11,6 +11,7 @@
 //                 Budi Irawan <https://github.com/deerawan>
 //                 Yonatan Kiron <https://github.com/YonatanKiron>
 //                 Jani Šumak <https://github.com/dasdachs>
+//                 Viet Bui <https://github.com/vietbui>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -609,7 +610,10 @@ export interface SearchResponse<T> {
     _scroll_id?: string;
     _shards: ShardsResponse;
     hits: {
-        total: number;
+        total: {
+            value: number;
+            relation: "eq" | "gte";
+        };
         max_score: number;
         hits: Array<{
             _index: string;

--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -470,6 +470,7 @@ export interface MGetResponse<T> {
 export interface MSearchParams extends GenericParams {
     search_type?: "query_then_fetch" | "query_and_fetch" | "dfs_query_then_fetch" | "dfs_query_and_fetch";
     maxConcurrentSearches?: number;
+    restTotalHitsAsInt?: boolean;
     index?: NameList;
     type?: NameList;
 }
@@ -480,6 +481,7 @@ export interface MSearchResponse<T> {
 
 export interface MSearchTemplateParams extends GenericParams {
     search_type?: "query_then_fetch" | "query_and_fetch" | "dfs_query_then_fetch" | "dfs_query_and_fetch";
+    restTotalHitsAsInt?: boolean;
     index?: NameList;
     type?: NameList;
 }
@@ -561,6 +563,7 @@ export interface RenderSearchTemplateParams extends GenericParams {
 }
 
 export interface ScrollParams extends GenericParams {
+    restTotalHitsAsInt?: boolean;
     scroll: TimeSpan;
     scrollId: string;
 }
@@ -582,6 +585,7 @@ export interface SearchParams extends GenericParams {
     lowercaseExpandedTerms?: boolean;
     preference?: string;
     q?: string;
+    restTotalHitsAsInt?: boolean;
     routing?: NameList;
     scroll?: TimeSpan;
     searchType?: "query_then_fetch" | "dfs_query_then_fetch";
@@ -610,7 +614,7 @@ export interface SearchResponse<T> {
     _scroll_id?: string;
     _shards: ShardsResponse;
     hits: {
-        total: {
+        total: number | {
             value: number;
             relation: "eq" | "gte";
         };
@@ -666,6 +670,7 @@ export interface SearchTemplateParams extends GenericParams {
     allowNoIndices?: boolean;
     expandWildcards?: ExpandWildcards;
     preference?: string;
+    restTotalHitsAsInt?: boolean;
     routing?: NameList;
     scroll?: TimeSpan;
     searchType?: "query_then_fetch" | "query_and_fetch" | "dfs_query_then_fetch" | "dfs_query_and_fetch";


### PR DESCRIPTION
Breaking change introduced by Elasticsearch 7.0: https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#hits-total-now-object-search-response

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#hits-total-now-object-search-response
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
