### PR TITLE
Allow overriding styled component prop names

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -67,8 +67,8 @@ export type StyledComponentProps<
     // Distribute O if O is a union type
     O extends object
     ? WithOptionalTheme<
-          Omit<ReactDefaultizedProps<C, React.ComponentPropsWithRef<C>> & O, A> &
-              Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,
+          LooseOmit<Merge<ReactDefaultizedProps<C, React.ComponentPropsWithRef<C>>, O>, A> &
+              Partial<LoosePick<Merge<React.ComponentPropsWithRef<C>, O>, A>>,
           T
       > &
           WithChildrenIfReactComponentClass<C>
@@ -347,6 +347,11 @@ export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<
 
 // Helper type operators
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type Merge<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
+type LooseOmit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+type LoosePick<T, K extends keyof any> = {
+    [P in Extract<K, keyof T>]: T[P];
+};
 type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, "theme"> & {
     theme?: T;
 };


### PR DESCRIPTION
Fixes #37413, as requested by @tpict

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.) -- @tpict - could you help here?
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #37413
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - N/A
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. - N/A
