### PR TITLE
Fix missing argument defintion in nuxtjs__auth

### DIFF
--- a/types/nuxtjs__auth/index.d.ts
+++ b/types/nuxtjs__auth/index.d.ts
@@ -47,7 +47,7 @@ export interface Auth<T = any> {
   strategy(): string;
   registerStrategy(strategyName: string, strategy: object): void;
   setStrategy(strategyName: string): void;
-  setUserToken(): Promise<never>;
+  setUserToken(token: string): Promise<never>;
   getRefreshToken(strategyName: string): string;
   setRefreshToken(strategyName: string, token?: string): string;
   syncRefreshToken(strategyName: string): string;

--- a/types/nuxtjs__auth/index.d.ts
+++ b/types/nuxtjs__auth/index.d.ts
@@ -47,7 +47,7 @@ export interface Auth<T = any> {
   strategy(): string;
   registerStrategy(strategyName: string, strategy: object): void;
   setStrategy(strategyName: string): void;
-  setUserToken(token: string): Promise<never>;
+  setUserToken(token: string): Promise<void>;
   getRefreshToken(strategyName: string): string;
   setRefreshToken(strategyName: string, token?: string): string;
   syncRefreshToken(strategyName: string): string;


### PR DESCRIPTION
The `setUserToken` function requires `token` argument. But there is no definition in this code. I fixed this problem.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/nuxt-community/auth-module/blob/ea08d39b849b882ea32da7a9db9c338bef210db5/lib/core/auth.js#L162>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.