### PR TITLE
[rc-tooltip] Make `overlay` non-nullable

### DIFF
--- a/types/rc-tooltip/index.d.ts
+++ b/types/rc-tooltip/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: rhysd <https://github.com/rhysd>
 //                 ahstro <https://github.com/ahstro>
 //                 vsaarinen <https://github.com/vsaarinen>
+//                 aigoncharov <https://github.com/aigoncharov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -31,7 +32,7 @@ declare namespace RCTooltip {
 		placement?: Placement | Object;
 		align?: Object;
 		onPopupAlign?: (popupDomNode: Element, align: Object) => void;
-		overlay: React.ReactNode;
+		overlay: React.ReactChild | React.ReactFragment | React.ReactPortal;
 		arrowContent?: React.ReactNode;
 		getTooltipContainer?: () => Element;
 		destroyTooltipOnHide?: boolean;

--- a/types/rc-tooltip/index.d.ts
+++ b/types/rc-tooltip/index.d.ts
@@ -32,7 +32,7 @@ declare namespace RCTooltip {
 		placement?: Placement | Object;
 		align?: Object;
 		onPopupAlign?: (popupDomNode: Element, align: Object) => void;
-		overlay: React.ReactChild | React.ReactFragment | React.ReactPortal;
+		overlay: (() => React.ReactChild) | React.ReactChild | React.ReactFragment | React.ReactPortal;
 		arrowContent?: React.ReactNode;
 		getTooltipContainer?: () => Element;
 		destroyTooltipOnHide?: boolean;

--- a/types/rc-tooltip/rc-tooltip-tests.tsx
+++ b/types/rc-tooltip/rc-tooltip-tests.tsx
@@ -33,7 +33,7 @@ ReactDOM.render(
         defaultVisible
         onPopupAlign={(popup, align) => console.log('aligned:', popup, align)}
         arrowContent={<div className="arrow"/>}
-        getTooltipContainer={() => document.querySelector('.foo')}
+        getTooltipContainer={() => document.querySelector('.foo')!}
         destroyTooltipOnHide
         id="tooltip-id"
     >
@@ -58,3 +58,7 @@ const props: RCTooltip.Props = {
     trigger: ['click', 'focus'],
     overlay: () => <span>tooltip</span>,
 };
+
+// It should be a single-line definition because TS 2.9 and other TS versions throw an error on different lines
+// $ExpectError
+const falseProps: RCTooltip.Props = {overlay: undefined};

--- a/types/rc-tooltip/tsconfig.json
+++ b/types/rc-tooltip/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-component/tooltip/blob/3.7.3/src/Tooltip.jsx#L21 - it's required there
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
