### PR TITLE
[@types/stripe] Added config param to constructor

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -64,9 +64,9 @@ interface ResponseEvent {
 }
 
 interface StripeConfig {
-    apiVersion?: string;
+    apiVersion?: string | null;
     maxNetworkRetries?: number;
-    httpAgent?: Agent;
+    httpAgent?: Agent | null;
     timeout?: number;
     host?: string;
     port?: number;

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -64,13 +64,13 @@ interface ResponseEvent {
 }
 
 interface StripeConfig {
-    apiVersion: string;
-    maxNetworkRetries: number;
-    httpAgent: Agent;
-    timeout: number;
-    host: string;
-    port: number;
-    telemetry: boolean;
+    apiVersion?: string;
+    maxNetworkRetries?: number;
+    httpAgent?: Agent;
+    timeout?: number;
+    host?: string;
+    port?: number;
+    telemetry?: boolean;
 }
 
 declare class Stripe {

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -63,6 +63,16 @@ interface ResponseEvent {
     request_end_time: number;
 }
 
+interface StripeConfig {
+    apiVersion: string;
+    maxNetworkRetries: number;
+    httpAgent: Agent;
+    timeout: number;
+    host: string;
+    port: number;
+    telemetry: boolean;
+}
+
 declare class Stripe {
     DEFAULT_HOST: string;
     DEFAULT_PORT: string;
@@ -84,6 +94,7 @@ declare class Stripe {
     StripeResource: typeof Stripe.StripeResource;
 
     constructor(apiKey: string, version?: string);
+    constructor(apiKey: string, config?: StripeConfig);
 
     accounts: Stripe.resources.Accounts;
     balance: Stripe.resources.Balance;

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -17,6 +17,8 @@ stripe = new Stripe('sk_test_BF573NobVn98OiIsPAv7A04K', {
     telemetry: true
 });
 
+stripe = new Stripe('sk_test_BF573NobVn98OiIsPAv7A04K', {});
+
 stripe.setHttpAgent(new HttpAgent());
 stripe.setHttpAgent(new HttpsAgent());
 

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -1,10 +1,21 @@
 import Stripe = require('stripe');
 import { customers } from 'stripe';
 
-const stripe = new Stripe('sk_test_BF573NobVn98OiIsPAv7A04K');
+let stripe = new Stripe('sk_test_BF573NobVn98OiIsPAv7A04K');
+stripe = new Stripe('sk_test_BF573NobVn98OiIsPAv7A04K', 'latest');
 
 import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
+
+stripe = new Stripe('sk_test_BF573NobVn98OiIsPAv7A04K', {
+    apiVersion: 'latest',
+    maxNetworkRetries: 1,
+    httpAgent: new HttpAgent(),
+    timeout: 1000,
+    host: 'api.example.com',
+    port: 123,
+    telemetry: true
+});
 
 stripe.setHttpAgent(new HttpAgent());
 stripe.setHttpAgent(new HttpsAgent());


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

~^ Running `npm run lint stripe` gives back an error like:~
```
The 'no-unnecessary-generics' rule threw an error in '/usr/src/js/DefinitelyTyped/types/stripe/index.d.ts':
TypeError: sig.parameters is not iterable
```

~:thinking: It doesn't seem like this is related to this change - but I'm not sure how to fix it :|~

Looks like it passes on CI :relaxed: 

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/stripe/stripe-node#initialize-with-config-object
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~