### PR TITLE
fix(ioredis): add length property to pipeline

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -562,6 +562,8 @@ declare namespace IORedis {
         readonly redis: Redis;
         readonly isCluster: boolean;
         readonly options: RedisOptions;
+        readonly length: number;
+
         bitcount(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
         bitcount(key: KeyType, start: number, end: number, callback?: (err: Error, res: number) => void): Pipeline;
 


### PR DESCRIPTION
the .length property is missing in the current type defintion,
see https://github.com/luin/ioredis/commit/a6060cb53653d315a20a08e5e89c7ce14e6c2ab5

regards
Simon

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/luin/ioredis/commit/a6060cb53653d315a20a08e5e89c7ce14e6c2ab5

