### PR TITLE
fix: mask must accept Regex[] type - react-input-mask

### DIFF
--- a/types/react-input-mask/index.d.ts
+++ b/types/react-input-mask/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/sanniassin/react-input-mask
 // Definitions by: Alexandre Paré <https://github.com/apare>
 //                 Dima Danylyuk <https://github.com/dima7a14>
+//                 Lucas Rêgo <https://github.com/lucasraziel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -18,7 +19,7 @@ export interface InputState {
 }
 
 export interface MaskOptions {
-  mask: string;
+  mask: string | (string | RegExp)[];
   maskChar: string;
   alwaysShowMask: boolean;
   formatChars: Record<string, string>;
@@ -35,7 +36,7 @@ export interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
    * Any character can be escaped with backslash, which usually will appear as double backslash in JS strings.
    * For example, German phone mask with unremoveable prefix +49 will look like `mask="+4\\9 99 999 99"` or `mask={"+4\\\\9 99 999 99"}`
    */
-  mask: string;
+  mask: string | (string | RegExp)[];
   /**
    * Character to cover unfilled editable parts of mask. Default character is "_". If set to null, unfilled parts will be empty, like in ordinary input.
    */

--- a/types/react-input-mask/index.d.ts
+++ b/types/react-input-mask/index.d.ts
@@ -19,7 +19,7 @@ export interface InputState {
 }
 
 export interface MaskOptions {
-  mask: string | (string | RegExp)[];
+  mask: string | Array<(string | RegExp)>;
   maskChar: string;
   alwaysShowMask: boolean;
   formatChars: Record<string, string>;
@@ -36,7 +36,7 @@ export interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
    * Any character can be escaped with backslash, which usually will appear as double backslash in JS strings.
    * For example, German phone mask with unremoveable prefix +49 will look like `mask="+4\\9 99 999 99"` or `mask={"+4\\\\9 99 999 99"}`
    */
-  mask: string | (string | RegExp)[];
+  mask: string | Array<(string | RegExp)>;
   /**
    * Character to cover unfilled editable parts of mask. Default character is "_". If set to null, unfilled parts will be empty, like in ordinary input.
    */

--- a/types/react-input-mask/react-input-mask-tests.tsx
+++ b/types/react-input-mask/react-input-mask-tests.tsx
@@ -3,11 +3,17 @@ import * as React from 'react';
 
 let ref: HTMLInputElement | null = null;
 
+const firstLetter = /(?!.*[DFIOQU])[A-VXY]/i;
+const letter = /(?!.*[DFIOQU])[A-Z]/i;
+const digit = /[0-9]/;
+const mask = [firstLetter, digit, letter, " ", digit, letter, digit];
+
 <div>
   <ReactInputMask mask="+4\9 99 999 99" maskChar={null} />
   <ReactInputMask mask="+7 (999) 999-99-99" />
   <ReactInputMask mask="99-99-9999" defaultValue="13-00-2017" />
   <ReactInputMask mask="99/99/9999" placeholder="Enter birthdate" />
   <ReactInputMask mask="+7 (999) 999-99-99" />
+  <ReactInputMask mask={mask}/>
   <ReactInputMask mask="+7 (999) 999-99-99" inputRef={(node) => ref = node} />
 </div>;


### PR DESCRIPTION

Please fill in this template.

- fix: mask must accept Regex[] type - react-input-mask

mask was only accepting string, but according to the documentation of the package (link below), it also accepts a string with Regexp.


If changing an existing definition:
- <<https://github.com/sanniassin/react-input-mask>>

