### PR TITLE
Add types for port-numbers

### DIFF
--- a/types/port-numbers/index.d.ts
+++ b/types/port-numbers/index.d.ts
@@ -4,14 +4,14 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface ServiceInfo {
-    name: string;
-    description: string;
+    readonly name: string;
+    readonly description: string;
 }
 
 export interface PortInfo {
-    port: number;
-    protocol: string;
-    description: string;
+    readonly port: number;
+    readonly protocol: string;
+    readonly description: string;
 }
 
 export function getService(port: number, protocol?: string): ServiceInfo | null;

--- a/types/port-numbers/index.d.ts
+++ b/types/port-numbers/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for port-numbers 5.0
+// Project: https://github.com/silverwind/port-numbers#readme
+// Definitions by: Alex Bradley <https://github.com/abradley>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface ServiceInfo {
+    name: string;
+    description: string;
+}
+
+export interface PortInfo {
+    port: number;
+    protocol: string;
+    description: string;
+}
+
+export function getService(port: number, protocol?: string): ServiceInfo | null;
+export function getPort(service: string, protocol?: string): PortInfo | null;

--- a/types/port-numbers/port-numbers-tests.ts
+++ b/types/port-numbers/port-numbers-tests.ts
@@ -1,0 +1,8 @@
+import { getPort, getService } from 'port-numbers';
+
+getPort('gopher');
+getPort('domain', 'udp');
+getPort('unknown-port');
+getService(80);
+getService(123, 'udp');
+getService(100000);

--- a/types/port-numbers/tsconfig.json
+++ b/types/port-numbers/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "port-numbers-tests.ts"
+    ]
+}

--- a/types/port-numbers/tslint.json
+++ b/types/port-numbers/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.