### PR TITLE
Add types for react-mathquill

### DIFF
--- a/types/edtr-io__mathquill/edtr-io__mathquill-tests.ts
+++ b/types/edtr-io__mathquill/edtr-io__mathquill-tests.ts
@@ -1,4 +1,4 @@
-import { MQ, Config } from 'edtr-io__mathquill';
+import { MQ, Config } from '@edtr-io/mathquill';
 
 const Test = () => {
     const config: Config = {

--- a/types/edtr-io__mathquill/edtr-io__mathquill-tests.ts
+++ b/types/edtr-io__mathquill/edtr-io__mathquill-tests.ts
@@ -1,19 +1,13 @@
-import * as React from 'react';
-import MathQuill, { addStyles } from 'react-mathquill';
-import { Config, MQ } from 'edtr-io__mathquill';
-
-addStyles();
+import { MQ, Config } from 'edtr-io__mathquill';
 
 const Test = () => {
-    const [latex, setLatex] = React.useState<string>('');
-
     const config: Config = {
         spaceBehavesLikeTab: true,
         leftRightIntoCmdGoes: 'up',
         autoSubscriptNumerals: true,
         maxDepth: 10,
         substituteTextarea() {
-            return '';
+            return document.createElement('textarea');
         },
         restrictMismatchedBrackets: true,
         sumStartsWithNEquals: true,
@@ -42,13 +36,4 @@ const Test = () => {
             },
         },
     };
-
-    return (
-        <MathQuill
-            latex={latex}
-            onChange={(MQ: MQ) => setLatex(MQ.latex())}
-            config={config}
-            mathquillDidMount={(MQ: MQ) => MQ.latex('\\sqrt{}')}
-        />
-    );
 };

--- a/types/edtr-io__mathquill/index.d.ts
+++ b/types/edtr-io__mathquill/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @edtr-io/mathquill 0.11.0
+// Type definitions for @edtr-io/mathquill 0.11
 // Project: https://github.com/edtr-io/mathquill#readme
 // Definitions by: Marco Gonzalez <https://github.com/magonzalez9>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/edtr-io__mathquill/index.d.ts
+++ b/types/edtr-io__mathquill/index.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for @edtr-io/mathquill 0.11.0
+// Project: https://github.com/edtr-io/mathquill#readme
+// Definitions by: Marco Gonzalez <https://github.com/magonzalez9>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+export interface MathField {
+    focus(): MQ;
+    blur(): MQ;
+    write(latex: string): MQ;
+    cmd(latex: string): MQ;
+    select(): MQ;
+    clearSelection(): MQ;
+    moveToLeftEnd(): MQ;
+    moveToRightEnd(): MQ;
+    moveToDirEnd(direction: number): MQ;
+    keystroke(keys: string): MQ;
+    typedText(text: string): MQ;
+    config(config: Config): MQ;
+}
+
+export interface MQ extends MathField {
+    L: number;
+    R: number;
+    revert(): MQ;
+    reflow(): MQ;
+    el(): HTMLElement;
+    latex(): string;
+    latex(latex: string): MQ;
+}
+
+export interface Config {
+    spaceBehavesLikeTab?: boolean;
+    leftRightIntoCmdGoes?: string;
+    restrictMismatchedBrackets?: boolean;
+    sumStartsWithNEquals?: boolean;
+    supSubsRequireOperand?: boolean;
+    charsThatBreakOutOfSupSub?: string;
+    autoSubscriptNumerals?: boolean;
+    autoCommands?: string;
+    autoOperatorNames?: string;
+    maxDepth?: number;
+    substituteTextarea?(): HTMLTextAreaElement;
+    handlers?: {
+        enter?(mathField: MQ): any;
+        edit?(mathField: MQ): any;
+        upOutOf?(mathField: MQ): any;
+        moveOutOf?(direction: number, mathField: MQ): any;
+    };
+}

--- a/types/edtr-io__mathquill/tsconfig.json
+++ b/types/edtr-io__mathquill/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "edtr-io__mathquill-tests.ts"
+    ]
+}

--- a/types/edtr-io__mathquill/tsconfig.json
+++ b/types/edtr-io__mathquill/tsconfig.json
@@ -15,7 +15,10 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@edtr-io/mathquill": ["edtr-io__mathquill"]
+        }
     },
     "files": [
         "index.d.ts",

--- a/types/edtr-io__mathquill/tslint.json
+++ b/types/edtr-io__mathquill/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/react-mathquill/index.d.ts
+++ b/types/react-mathquill/index.d.ts
@@ -10,7 +10,7 @@ import { MQ, Config } from '@edtr-io/mathquill';
 export interface Props extends Omit<ComponentProps<'span'>, 'onChange'> {
     latex: string;
     config?: Config;
-    onChange?(mathField: MQ): any;
+    onChange?(mathField: MQ): void;
     mathquillDidMount?(mathField: MQ): void;
 }
 

--- a/types/react-mathquill/index.d.ts
+++ b/types/react-mathquill/index.d.ts
@@ -2,8 +2,9 @@
 // Project: https://github.com/viktorstrate/react-mathquill#readme
 // Definitions by: Marco Gonzalez <https://github.com/magonzalez9>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5' just under the header.
 
-import { ComponentProps, ReactNode, Component } from "react";
+import { ComponentProps, ReactNode, Component } from 'react';
 
 export interface MathField {
     focus(): MathQuill;
@@ -50,7 +51,7 @@ export interface Config {
     };
 }
 
-export interface Props extends Omit<ComponentProps<"span">, 'onChange'> {
+export interface Props extends Omit<ComponentProps<'span'>, 'onChange'> {
     latex: string;
     config?: Config;
     onChange?(mathField: MathQuill): any;
@@ -59,7 +60,6 @@ export interface Props extends Omit<ComponentProps<"span">, 'onChange'> {
 
 export function addStyles(): any;
 
-declare class Mathquill extends Component<Props>  {
-}
+declare class Mathquill extends Component<Props> {}
 
 export default Mathquill;

--- a/types/react-mathquill/index.d.ts
+++ b/types/react-mathquill/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.5
 
-import { ComponentProps, ReactNode, Component } from 'react';
+import { ComponentProps, Component } from 'react';
 import { MQ, Config } from '@edtr-io/mathquill';
 
 export interface Props extends Omit<ComponentProps<'span'>, 'onChange'> {

--- a/types/react-mathquill/index.d.ts
+++ b/types/react-mathquill/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/viktorstrate/react-mathquill#readme
 // Definitions by: Marco Gonzalez <https://github.com/magonzalez9>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5'
+// TypeScript Version: 3.5
 
 import { ComponentProps, ReactNode, Component } from 'react';
 

--- a/types/react-mathquill/index.d.ts
+++ b/types/react-mathquill/index.d.ts
@@ -11,7 +11,7 @@ export interface Props extends Omit<ComponentProps<'span'>, 'onChange'> {
     latex: string;
     config?: Config;
     onChange?(mathField: MQ): any;
-    mathquillDidMount?(mathField: MQ): any;
+    mathquillDidMount?(mathField: MQ): void;
 }
 
 export function addStyles(): void;

--- a/types/react-mathquill/index.d.ts
+++ b/types/react-mathquill/index.d.ts
@@ -58,7 +58,7 @@ export interface Props extends Omit<ComponentProps<'span'>, 'onChange'> {
     mathquillDidMount?(mathField: MathQuill): any;
 }
 
-export function addStyles(): any;
+export function addStyles(): void;
 
 declare class Mathquill extends Component<Props> {}
 

--- a/types/react-mathquill/index.d.ts
+++ b/types/react-mathquill/index.d.ts
@@ -8,7 +8,7 @@ import { ComponentProps, Component } from 'react';
 import { MQ, Config } from '@edtr-io/mathquill';
 
 export interface Props extends Omit<ComponentProps<'span'>, 'onChange'> {
-    latex: string;
+    latex?: string;
     config?: Config;
     onChange?(mathField: MQ): void;
     mathquillDidMount?(mathField: MQ): void;

--- a/types/react-mathquill/index.d.ts
+++ b/types/react-mathquill/index.d.ts
@@ -5,61 +5,17 @@
 // TypeScript Version: 3.5
 
 import { ComponentProps, ReactNode, Component } from 'react';
-
-export interface MathField {
-    focus(): MathQuill;
-    blur(): MathQuill;
-    write(latex: string): MathQuill;
-    cmd(latex: string): MathQuill;
-    select(): MathQuill;
-    clearSelection(): MathQuill;
-    moveToLeftEnd(): MathQuill;
-    moveToRightEnd(): MathQuill;
-    moveToDirEnd(direction: number): MathQuill;
-    keystroke(keys: string): MathQuill;
-    typedText(text: string): MathQuill;
-    config(config: Config): MathQuill;
-}
-
-export interface MathQuill extends MathField {
-    L: number;
-    R: number;
-    revert(): MathQuill;
-    reflow(): MathQuill;
-    el(): HTMLElement;
-    latex(): string;
-    latex(latex: string): MathQuill;
-}
-
-export interface Config {
-    spaceBehavesLikeTab?: boolean;
-    leftRightIntoCmdGoes?: string;
-    restrictMismatchedBrackets?: boolean;
-    sumStartsWithNEquals?: boolean;
-    supSubsRequireOperand?: boolean;
-    charsThatBreakOutOfSupSub?: string;
-    autoSubscriptNumerals?: boolean;
-    autoCommands?: string;
-    autoOperatorNames?: string;
-    maxDepth?: number;
-    substituteTextarea?(): HTMLTextAreaElement;
-    handlers?: {
-        enter?(mathField: MathQuill): any;
-        edit?(mathField: MathQuill): any;
-        upOutOf?(mathField: MathQuill): any;
-        moveOutOf?(direction: number, mathField: MathQuill): any;
-    };
-}
+import { MQ, Config } from 'edtr-io__mathquill';
 
 export interface Props extends Omit<ComponentProps<'span'>, 'onChange'> {
     latex: string;
     config?: Config;
-    onChange?(mathField: MathQuill): any;
-    mathquillDidMount?(mathField: MathQuill): any;
+    onChange?(mathField: MQ): any;
+    mathquillDidMount?(mathField: MQ): any;
 }
 
 export function addStyles(): void;
 
-declare class Mathquill extends Component<Props> {}
+declare class MathQuill extends Component<Props> {}
 
-export default Mathquill;
+export default MathQuill;

--- a/types/react-mathquill/index.d.ts
+++ b/types/react-mathquill/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 3.5
 
 import { ComponentProps, ReactNode, Component } from 'react';
-import { MQ, Config } from 'edtr-io__mathquill';
+import { MQ, Config } from '@edtr-io/mathquill';
 
 export interface Props extends Omit<ComponentProps<'span'>, 'onChange'> {
     latex: string;

--- a/types/react-mathquill/index.d.ts
+++ b/types/react-mathquill/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/viktorstrate/react-mathquill#readme
 // Definitions by: Marco Gonzalez <https://github.com/magonzalez9>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5' just under the header.
+// TypeScript Version: 3.5'
 
 import { ComponentProps, ReactNode, Component } from 'react';
 

--- a/types/react-mathquill/index.d.ts
+++ b/types/react-mathquill/index.d.ts
@@ -1,0 +1,65 @@
+// Type definitions for react-mathquill 0.1
+// Project: https://github.com/viktorstrate/react-mathquill#readme
+// Definitions by: Marco Gonzalez <https://github.com/magonzalez9>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { ComponentProps, ReactNode, Component } from "react";
+
+export interface MathField {
+    focus(): MathQuill;
+    blur(): MathQuill;
+    write(latex: string): MathQuill;
+    cmd(latex: string): MathQuill;
+    select(): MathQuill;
+    clearSelection(): MathQuill;
+    moveToLeftEnd(): MathQuill;
+    moveToRightEnd(): MathQuill;
+    moveToDirEnd(direction: number): MathQuill;
+    keystroke(keys: string): MathQuill;
+    typedText(text: string): MathQuill;
+    config(config: Config): MathQuill;
+}
+
+export interface MathQuill extends MathField {
+    L: number;
+    R: number;
+    revert(): MathQuill;
+    reflow(): MathQuill;
+    el(): HTMLElement;
+    latex(): string;
+    latex(latex: string): MathQuill;
+}
+
+export interface Config {
+    spaceBehavesLikeTab?: boolean;
+    leftRightIntoCmdGoes?: string;
+    restrictMismatchedBrackets?: boolean;
+    sumStartsWithNEquals?: boolean;
+    supSubsRequireOperand?: boolean;
+    charsThatBreakOutOfSupSub?: string;
+    autoSubscriptNumerals?: boolean;
+    autoCommands?: string;
+    autoOperatorNames?: string;
+    maxDepth?: number;
+    substituteTextarea?(): HTMLTextAreaElement;
+    handlers?: {
+        enter?(mathField: MathQuill): any;
+        edit?(mathField: MathQuill): any;
+        upOutOf?(mathField: MathQuill): any;
+        moveOutOf?(direction: number, mathField: MathQuill): any;
+    };
+}
+
+export interface Props extends Omit<ComponentProps<"span">, 'onChange'> {
+    latex: string;
+    config?: Config;
+    onChange?(mathField: MathQuill): any;
+    mathquillDidMount?(mathField: MathQuill): any;
+}
+
+export function addStyles(): any;
+
+declare class Mathquill extends Component<Props>  {
+}
+
+export default Mathquill;

--- a/types/react-mathquill/react-mathquill-tests.tsx
+++ b/types/react-mathquill/react-mathquill-tests.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import Mathquill, {addStyles, Config, MathQuill} from 'react-mathquill';
+
+addStyles();
+
+function Test() {
+    const [latex, setLatex] = React.useState<string>('');
+
+    const config: Config = {
+        spaceBehavesLikeTab: true,
+        leftRightIntoCmdGoes: 'up',
+        autoSubscriptNumerals: true,
+        maxDepth: 10,
+        substituteTextarea: function() {
+            return '';
+        },
+        restrictMismatchedBrackets: true,
+        sumStartsWithNEquals: true,
+        supSubsRequireOperand: true,
+        charsThatBreakOutOfSupSub: '+-=<>',
+        autoCommands: 'pi theta sqrt',
+        autoOperatorNames: 'sin cos tan log',
+        handlers: {
+            edit: function(mathField: MathQuill) { return mathField; },
+            enter: function(mathField: MathQuill)  {
+                mathField.blur(); 
+                mathField.focus();
+                mathField.keystroke('Tab')
+                mathField.typedText('test');
+                mathField.moveToLeftEnd();
+                mathField.moveToRightEnd();
+                mathField.moveToDirEnd(1); 
+            },
+            upOutOf: function(mathField: MathQuill) { mathField.keystroke('Enter') },
+            moveOutOf: function(dir: number, mathField: MathQuill) { if (dir === 1) mathField.clearSelection() }
+        }   
+    }
+
+    return (
+        <Mathquill
+            latex={latex}
+            onChange={ (MQ: MathQuill) => setLatex(MQ.latex())}
+            config={config}
+            mathquillDidMount={ (MQ: MathQuill) => MQ.latex('\\sqrt{}')}
+        />
+    );
+}

--- a/types/react-mathquill/react-mathquill-tests.tsx
+++ b/types/react-mathquill/react-mathquill-tests.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import Mathquill, {addStyles, Config, MathQuill} from 'react-mathquill';
+import Mathquill, { addStyles, Config, MathQuill } from 'react-mathquill';
 
 addStyles();
 
-function Test() {
+const Test = () => {
     const [latex, setLatex] = React.useState<string>('');
 
     const config: Config = {
@@ -11,7 +11,7 @@ function Test() {
         leftRightIntoCmdGoes: 'up',
         autoSubscriptNumerals: true,
         maxDepth: 10,
-        substituteTextarea: function() {
+        substituteTextarea() {
             return '';
         },
         restrictMismatchedBrackets: true,
@@ -21,27 +21,33 @@ function Test() {
         autoCommands: 'pi theta sqrt',
         autoOperatorNames: 'sin cos tan log',
         handlers: {
-            edit: function(mathField: MathQuill) { return mathField; },
-            enter: function(mathField: MathQuill)  {
-                mathField.blur(); 
+            edit(mathField: MathQuill) {
+                return mathField;
+            },
+            enter(mathField: MathQuill) {
+                mathField.blur();
                 mathField.focus();
-                mathField.keystroke('Tab')
+                mathField.keystroke('Tab');
                 mathField.typedText('test');
                 mathField.moveToLeftEnd();
                 mathField.moveToRightEnd();
-                mathField.moveToDirEnd(1); 
+                mathField.moveToDirEnd(1);
             },
-            upOutOf: function(mathField: MathQuill) { mathField.keystroke('Enter') },
-            moveOutOf: function(dir: number, mathField: MathQuill) { if (dir === 1) mathField.clearSelection() }
-        }   
-    }
+            upOutOf(mathField: MathQuill) {
+                mathField.keystroke('Enter');
+            },
+            moveOutOf(dir: number, mathField: MathQuill) {
+                if (dir === 1) mathField.clearSelection();
+            },
+        },
+    };
 
     return (
         <Mathquill
             latex={latex}
-            onChange={ (MQ: MathQuill) => setLatex(MQ.latex())}
+            onChange={(MQ: MathQuill) => setLatex(MQ.latex())}
             config={config}
-            mathquillDidMount={ (MQ: MathQuill) => MQ.latex('\\sqrt{}')}
+            mathquillDidMount={(MQ: MathQuill) => MQ.latex('\\sqrt{}')}
         />
     );
-}
+};

--- a/types/react-mathquill/react-mathquill-tests.tsx
+++ b/types/react-mathquill/react-mathquill-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MathQuill, { addStyles } from 'react-mathquill';
-import { Config, MQ } from 'edtr-io__mathquill';
+import { Config, MQ } from '@edtr-io/mathquill';
 
 addStyles();
 

--- a/types/react-mathquill/tsconfig.json
+++ b/types/react-mathquill/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "jsx": "react",
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-mathquill-tests.tsx"
+    ]
+}

--- a/types/react-mathquill/tsconfig.json
+++ b/types/react-mathquill/tsconfig.json
@@ -15,7 +15,10 @@
         "jsx": "react",
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@edtr-io/mathquill": ["edtr-io__mathquill"]
+        }
     },
     "files": [
         "index.d.ts",

--- a/types/react-mathquill/tslint.json
+++ b/types/react-mathquill/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
