### PR TITLE
Add "compact" option to Globalize's CommonNumberFormatterOptions.

### DIFF
--- a/types/globalize/dist/globalize.d.ts
+++ b/types/globalize/dist/globalize.d.ts
@@ -41,7 +41,11 @@ declare namespace Globalize {
 		/**
 		 * Boolean (default is true) value indicating whether a grouping separator should be used.
 		 */
-		useGrouping?: boolean;
+        useGrouping?: boolean;
+        /**
+         * String `short` or `long` indicating which compact number format should be used to represent the number.
+         */
+        compact?: "short" | "long";
 	}
 
 	interface Shared {

--- a/types/globalize/dist/globalize.d.ts
+++ b/types/globalize/dist/globalize.d.ts
@@ -41,11 +41,11 @@ declare namespace Globalize {
 		/**
 		 * Boolean (default is true) value indicating whether a grouping separator should be used.
 		 */
-        useGrouping?: boolean;
-        /**
-         * String `short` or `long` indicating which compact number format should be used to represent the number.
-         */
-        compact?: "short" | "long";
+		useGrouping?: boolean;
+		/**
+		 * String `short` or `long` indicating which compact number format should be used to represent the number.
+		 */
+		compact?: "short" | "long";
 	}
 
 	interface Shared {

--- a/types/globalize/globalize-tests.ts
+++ b/types/globalize/globalize-tests.ts
@@ -71,6 +71,9 @@ strOutput = numberFormatter(20);
 numberFormatter = Globalize.numberFormatter({ style: "decimal" });
 strOutput = numberFormatter(20.2);
 
+numberFormatter = Globalize.numberFormatter({ compact: "short" });
+strOutput = numberFormatter(27588910);
+
 let numberParser = en.numberParser();
 let numOutput = numberParser("20");
 


### PR DESCRIPTION
This option was introduced with Globalize 1.4.0

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/globalizejs/globalize/blob/master/doc/api/number/number-formatter.md#formatting-compact-numbers (also https://github.com/globalizejs/globalize/pull/759)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
