### PR TITLE
remove qunit/v1 references in tests

### DIFF
--- a/types/jquery.bbq/jquery.bbq-tests.ts
+++ b/types/jquery.bbq/jquery.bbq-tests.ts
@@ -1,4 +1,4 @@
-/// <reference types="qunit/v1" />
+/// <reference types="qunit" />
 
 import $ = require('jquery');
 
@@ -30,9 +30,6 @@ $.param({ a: { b:1,c:2 }, d: [3,4,{ e:5 } as any] }) // "a=[object+Object]&d=3&d
 // >=1.4:
 $.param({ a: { b:1,c:2 }, d: [3,4,{ e:5 } as any] }) // "a[b]=1&a[c]=2&d[]=3&d[]=4&d[2][e]=5"
 // *************************************************************
-
-// Not sure why this isn't set by default in qunit.js..
-QUnit.jsDump.HTML = false;
 
 $(function(){ // START CLOSURE
 
@@ -86,7 +83,7 @@ function run_many_tests(...args: any[]) {
         setTimeout( loopy, delay );
       } else {
         func_done && func_done();
-        start();
+        QUnit.start();
       }
     })();
 
@@ -111,7 +108,7 @@ var params_obj = { a:['4','5','6'], b:{x:['7'], y:'8', z:['9','0','true','false'
   params_obj_bang = { "!a":['4'], a:['5','6'], b:{x:['7'], y:'8', z:['9','0','true','false','undefined','']}, c:'1' },
   params_obj_bang_coerce = { "!a":[4], a:[5,6] };//, b:{x:[7], y:8, z:[9,0,true,false,undefined,'']}, c:1 };
 
-test( 'jQuery.param.sorted', function() {
+QUnit.test( 'jQuery.param.sorted', function() {
   var tests: any[] = [
     {
       obj: {z:1,b:2,ab:3,bc:4,ba:5,aa:6,a1:7,x:8},
@@ -147,44 +144,44 @@ test( 'jQuery.param.sorted', function() {
     });
   }
 
-  expect( tests.length * 2 + 6 );
+  QUnit.assert.expect( tests.length * 2 + 6 );
 
   $.each( tests, function(i,test: any){
     var unsorted = $.param( test.obj, test.traditional ),
       sorted = $.param.sorted( test.obj, test.traditional );
 
-    equal( decodeURIComponent( sorted ), old_jquery && test.expected_old || test.expected, 'params should be sorted' );
-    deepEqual( $.deparam( unsorted, true ), $.deparam( sorted, true ), 'sorted params should deparam the same as unsorted params' )
+    QUnit.assert.equal( decodeURIComponent( sorted ), old_jquery && test.expected_old || test.expected, 'params should be sorted' );
+    QUnit.assert.deepEqual( $.deparam( unsorted, true ), $.deparam( sorted, true ), 'sorted params should deparam the same as unsorted params' )
   });
 
-  equal( $.param.fragment( 'foo', '#b=2&a=1' ), 'foo#a=1&b=2', 'params should be sorted' );
-  equal( $.param.fragment( 'foo', '#b=2&a=1', 1 ), 'foo#a=1&b=2', 'params should be sorted' );
-  equal( $.param.fragment( 'foo', '#b=2&a=1', 2 ), 'foo#b=2&a=1', 'params should NOT be sorted' );
-  equal( $.param.fragment( 'foo#c=3&a=4', '#b=2&a=1' ), 'foo#a=1&b=2&c=3', 'params should be sorted' );
-  equal( $.param.fragment( 'foo#c=3&a=4', '#b=2&a=1', 1 ), 'foo#a=4&b=2&c=3', 'params should be sorted' );
-  equal( $.param.fragment( 'foo#c=3&a=4', '#b=2&a=1', 2 ), 'foo#b=2&a=1', 'params should NOT be sorted' );
+  QUnit.assert.equal( $.param.fragment( 'foo', '#b=2&a=1' ), 'foo#a=1&b=2', 'params should be sorted' );
+  QUnit.assert.equal( $.param.fragment( 'foo', '#b=2&a=1', 1 ), 'foo#a=1&b=2', 'params should be sorted' );
+  QUnit.assert.equal( $.param.fragment( 'foo', '#b=2&a=1', 2 ), 'foo#b=2&a=1', 'params should NOT be sorted' );
+  QUnit.assert.equal( $.param.fragment( 'foo#c=3&a=4', '#b=2&a=1' ), 'foo#a=1&b=2&c=3', 'params should be sorted' );
+  QUnit.assert.equal( $.param.fragment( 'foo#c=3&a=4', '#b=2&a=1', 1 ), 'foo#a=4&b=2&c=3', 'params should be sorted' );
+  QUnit.assert.equal( $.param.fragment( 'foo#c=3&a=4', '#b=2&a=1', 2 ), 'foo#b=2&a=1', 'params should NOT be sorted' );
 
 });
 
-test( 'jQuery.param.querystring', function() {
-  expect( 11 );
+QUnit.test( 'jQuery.param.querystring', function() {
+  QUnit.assert.expect( 11 );
 
-  equal( $.param.querystring( 'http://example.com/' ), '', 'properly identifying params' );
-  equal( $.param.querystring( 'http://example.com/?foo' ),'foo', 'properly identifying params' );
-  equal( $.param.querystring( 'http://example.com/?foo#bar' ),'foo', 'properly identifying params' );
-  equal( $.param.querystring( 'http://example.com/?foo#bar?baz' ),'foo', 'properly identifying params' );
-  equal( $.param.querystring( 'http://example.com/#foo' ),'', 'properly identifying params' );
-  equal( $.param.querystring( 'http://example.com/#foo?bar' ),'', 'properly identifying params' );
+  QUnit.assert.equal( $.param.querystring( 'http://example.com/' ), '', 'properly identifying params' );
+  QUnit.assert.equal( $.param.querystring( 'http://example.com/?foo' ),'foo', 'properly identifying params' );
+  QUnit.assert.equal( $.param.querystring( 'http://example.com/?foo#bar' ),'foo', 'properly identifying params' );
+  QUnit.assert.equal( $.param.querystring( 'http://example.com/?foo#bar?baz' ),'foo', 'properly identifying params' );
+  QUnit.assert.equal( $.param.querystring( 'http://example.com/#foo' ),'', 'properly identifying params' );
+  QUnit.assert.equal( $.param.querystring( 'http://example.com/#foo?bar' ),'', 'properly identifying params' );
 
-  equal( $.param.querystring(), params_str, 'params string from window.location' );
-  equal( $.param.querystring( '?' + params_str ), params_str, 'params string from url' );
-  equal( $.param.querystring( 'foo.html?' + params_str ), params_str, 'params string from url' );
-  equal( $.param.querystring( 'http://a:b@example.com:1234/foo.html?' + params_str ), params_str, 'params string from url' );
-  equal( $.param.querystring( 'http://a:b@example.com:1234/foo.html?' + params_str + '#bippity-boppity-boo' ), params_str, 'params string from url' );
+  QUnit.assert.equal( $.param.querystring(), params_str, 'params string from window.location' );
+  QUnit.assert.equal( $.param.querystring( '?' + params_str ), params_str, 'params string from url' );
+  QUnit.assert.equal( $.param.querystring( 'foo.html?' + params_str ), params_str, 'params string from url' );
+  QUnit.assert.equal( $.param.querystring( 'http://a:b@example.com:1234/foo.html?' + params_str ), params_str, 'params string from url' );
+  QUnit.assert.equal( $.param.querystring( 'http://a:b@example.com:1234/foo.html?' + params_str + '#bippity-boppity-boo' ), params_str, 'params string from url' );
 });
 
-test( 'jQuery.param.querystring - build URL', function() {
-  expect( 10 );
+QUnit.test( 'jQuery.param.querystring - build URL', function() {
+  QUnit.assert.expect( 10 );
 
   function fake_encode( params_str ) {
     return '?' + $.map( params_str.split('&'), encodeURIComponent ).join('&').replace( /%3D/g, '=' ).replace( /%2B/g, '+' );
@@ -206,19 +203,19 @@ test( 'jQuery.param.querystring - build URL', function() {
     [ { a:'2' } ],
 
     function(result){
-      equal( current_url, pre + '?a=2' + post, '$.param.querystring( url, Object )' );
+      QUnit.assert.equal( current_url, pre + '?a=2' + post, '$.param.querystring( url, Object )' );
     },
 
     [ { b:'2' } ],
 
     function(result){
-      equal( current_url, pre + '?a=2&b=2' + post, '$.param.querystring( url, Object )' );
+      QUnit.assert.equal( current_url, pre + '?a=2&b=2' + post, '$.param.querystring( url, Object )' );
     },
 
     [ { c:true, d:false, e:'undefined', f:'' } ],
 
     function(result){
-      equal( current_url, pre + '?a=2&b=2&c=true&d=false&e=undefined&f=' + post, '$.param.querystring( url, Object )' );
+      QUnit.assert.equal( current_url, pre + '?a=2&b=2&c=true&d=false&e=undefined&f=' + post, '$.param.querystring( url, Object )' );
     },
 
     [ { a:[4,5,6]}],//, b:{x:[7], y:8, z:[9,0,<any>'true',<any>'false',<any>'undefined',<any>'']} }, 2 ],
@@ -228,7 +225,7 @@ test( 'jQuery.param.querystring - build URL', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=';
 
-      equal( current_url, pre + fake_encode( params ) + post, '$.param.querystring( url, Object, 2 )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ) + post, '$.param.querystring( url, Object, 2 )' );
     },
 
     [ { a:'1', c:'2' } as any, 1 ],
@@ -238,7 +235,7 @@ test( 'jQuery.param.querystring - build URL', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]&c=2'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&c=2';
 
-      equal( current_url, pre + fake_encode( params ) + post, '$.param.querystring( url, Object, 1 )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ) + post, '$.param.querystring( url, Object, 1 )' );
     },
 
     [ 'foo=1' ],
@@ -248,7 +245,7 @@ test( 'jQuery.param.querystring - build URL', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]&c=2&foo=1'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&c=2&foo=1';
 
-      equal( current_url, pre + fake_encode( params ) + post, '$.param.querystring( url, String )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ) + post, '$.param.querystring( url, String )' );
     },
 
     [ 'foo=2&bar=3' as any, 1 ],
@@ -258,76 +255,76 @@ test( 'jQuery.param.querystring - build URL', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]&bar=3&c=2&foo=1'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&bar=3&c=2&foo=1';
 
-      equal( current_url, pre + fake_encode( params ) + post, '$.param.querystring( url, String, 1 )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ) + post, '$.param.querystring( url, String, 1 )' );
     },
 
     [ 'http://example.com/test.html?/path/to/file.php#the-cow-goes-moo' as any, 2 ],
 
     function(result){
-      equal( current_url, pre + '?/path/to/file.php' + post, '$.param.querystring( url, String, 2 )' );
+      QUnit.assert.equal( current_url, pre + '?/path/to/file.php' + post, '$.param.querystring( url, String, 2 )' );
     },
 
     [ '?another-example' as any, 2 ],
 
     function(result){
-      equal( current_url, pre + '?another-example' + post, '$.param.querystring( url, String, 2 )' );
+      QUnit.assert.equal( current_url, pre + '?another-example' + post, '$.param.querystring( url, String, 2 )' );
     },
 
     [ 'i_am_out_of_witty_strings' as any, 2 ],
 
     function(result){
-      equal( current_url, pre + '?i_am_out_of_witty_strings' + post, '$.param.querystring( url, String, 2 )' );
+      QUnit.assert.equal( current_url, pre + '?i_am_out_of_witty_strings' + post, '$.param.querystring( url, String, 2 )' );
     }
 
   );
 
 });
 
-test( 'jQuery.param.fragment', function() {
-  expect( 29 );
+QUnit.test( 'jQuery.param.fragment', function() {
+  QUnit.assert.expect( 29 );
 
-  equal( $.param.fragment( 'http://example.com/' ), '', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/?foo' ),'', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/?foo#bar' ),'bar', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/?foo#bar?baz' ),'bar?baz', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/#foo' ),'foo', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/#foo?bar' ),'foo?bar', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/' ), '', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/?foo' ),'', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/?foo#bar' ),'bar', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/?foo#bar?baz' ),'bar?baz', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/#foo' ),'foo', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/#foo?bar' ),'foo?bar', 'properly identifying params' );
 
-  equal( $.param.fragment( 'http://example.com/' ), '', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/?foo' ),'', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/?foo#!bar' ),'!bar', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/?foo#!bar?baz' ),'!bar?baz', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/#!foo' ),'!foo', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/#!foo?bar' ),'!foo?bar', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/' ), '', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/?foo' ),'', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/?foo#!bar' ),'!bar', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/?foo#!bar?baz' ),'!bar?baz', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/#!foo' ),'!foo', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/#!foo?bar' ),'!foo?bar', 'properly identifying params' );
 
-  equal( $.param.fragment(), params_str, 'params string from window.location' );
-  equal( $.param.fragment( '#' + params_str ), params_str, 'params string from url' );
-  equal( $.param.fragment( 'foo.html#' + params_str ), params_str, 'params string from url' );
-  equal( $.param.fragment( 'http://a:b@example.com:1234/foo.html#' + params_str ), params_str, 'params string from url' );
-  equal( $.param.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#' + params_str ), params_str, 'params string from url' );
+  QUnit.assert.equal( $.param.fragment(), params_str, 'params string from window.location' );
+  QUnit.assert.equal( $.param.fragment( '#' + params_str ), params_str, 'params string from url' );
+  QUnit.assert.equal( $.param.fragment( 'foo.html#' + params_str ), params_str, 'params string from url' );
+  QUnit.assert.equal( $.param.fragment( 'http://a:b@example.com:1234/foo.html#' + params_str ), params_str, 'params string from url' );
+  QUnit.assert.equal( $.param.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#' + params_str ), params_str, 'params string from url' );
 
   $.param.fragment.ajaxCrawlable( true );
 
-  equal( $.param.fragment( 'http://example.com/' ), '', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/?foo' ),'', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/?foo#bar' ),'bar', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/?foo#bar?baz' ),'bar?baz', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/#foo' ),'foo', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/#foo?bar' ),'foo?bar', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/' ), '', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/?foo' ),'', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/?foo#bar' ),'bar', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/?foo#bar?baz' ),'bar?baz', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/#foo' ),'foo', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/#foo?bar' ),'foo?bar', 'properly identifying params' );
 
-  equal( $.param.fragment( 'http://example.com/' ), '', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/?foo' ),'', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/?foo#!bar' ),'bar', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/?foo#!bar?baz' ),'bar?baz', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/#!foo' ),'foo', 'properly identifying params' );
-  equal( $.param.fragment( 'http://example.com/#!foo?bar' ),'foo?bar', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/' ), '', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/?foo' ),'', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/?foo#!bar' ),'bar', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/?foo#!bar?baz' ),'bar?baz', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/#!foo' ),'foo', 'properly identifying params' );
+  QUnit.assert.equal( $.param.fragment( 'http://example.com/#!foo?bar' ),'foo?bar', 'properly identifying params' );
 
   $.param.fragment.ajaxCrawlable( false );
 
 });
 
-test( 'jQuery.param.fragment - build URL', function() {
-  expect( 40 );
+QUnit.test( 'jQuery.param.fragment - build URL', function() {
+  QUnit.assert.expect( 40 );
 
   function fake_encode( params_str ) {
     return '#' + $.map( params_str.split('&'), encodeURIComponent ).join('&').replace( /%3D/g, '=' ).replace( /%2B/g, '+' );
@@ -348,19 +345,19 @@ test( 'jQuery.param.fragment - build URL', function() {
     [ { a:'2' } ],
 
     function(result){
-      equal( current_url, pre + '#a=2', '$.param.fragment( url, Object )' );
+      QUnit.assert.equal( current_url, pre + '#a=2', '$.param.fragment( url, Object )' );
     },
 
     [ { b:'2' } ],
 
     function(result){
-      equal( current_url, pre + '#a=2&b=2', '$.param.fragment( url, Object )' );
+      QUnit.assert.equal( current_url, pre + '#a=2&b=2', '$.param.fragment( url, Object )' );
     },
 
     [ { c:true, d:false, e:'undefined', f:'' } ],
 
     function(result){
-      equal( current_url, pre + '#a=2&b=2&c=true&d=false&e=undefined&f=', '$.param.fragment( url, Object )' );
+      QUnit.assert.equal( current_url, pre + '#a=2&b=2&c=true&d=false&e=undefined&f=', '$.param.fragment( url, Object )' );
     },
 
     [ { a:[4,5,6]}],//, b:{x:[7], y:8, z:[9,0,'true','false','undefined','']} }, 2 ],
@@ -370,7 +367,7 @@ test( 'jQuery.param.fragment - build URL', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=';
 
-      equal( current_url, pre + fake_encode( params ), '$.param.fragment( url, Object, 2 )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ), '$.param.fragment( url, Object, 2 )' );
     },
 
     [ { a:'1', c:'2' } as any, 1 ],
@@ -380,7 +377,7 @@ test( 'jQuery.param.fragment - build URL', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]&c=2'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&c=2';
 
-      equal( current_url, pre + fake_encode( params ), '$.param.fragment( url, Object, 1 )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ), '$.param.fragment( url, Object, 1 )' );
     },
 
     [ 'foo=1' ],
@@ -390,7 +387,7 @@ test( 'jQuery.param.fragment - build URL', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]&c=2&foo=1'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&c=2&foo=1';
 
-      equal( current_url, pre + fake_encode( params ), '$.param.fragment( url, String )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ), '$.param.fragment( url, String )' );
     },
 
     [ 'foo=2&bar=3' as any, 1 ],
@@ -400,90 +397,90 @@ test( 'jQuery.param.fragment - build URL', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]&bar=3&c=2&foo=1'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&bar=3&c=2&foo=1';
 
-      equal( current_url, pre + fake_encode( params ), '$.param.fragment( url, String, 1 )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ), '$.param.fragment( url, String, 1 )' );
     },
 
     [ 'http://example.com/test.html?the-cow-goes-moo#/path/to/file.php' as any, 2 ],
 
     function(result){
-      equal( current_url, pre + '#/path/to/file.php', '$.param.fragment( url, String, 2 )' );
+      QUnit.assert.equal( current_url, pre + '#/path/to/file.php', '$.param.fragment( url, String, 2 )' );
     },
 
     [ '#another-example' as any, 2 ],
 
     function(result){
-      equal( current_url, pre + '#another-example', '$.param.fragment( url, String, 2 )' );
+      QUnit.assert.equal( current_url, pre + '#another-example', '$.param.fragment( url, String, 2 )' );
     },
 
     [ 'i_am_out_of_witty_strings' as any, 2 ],
 
     function(result){
-      equal( current_url, pre + '#i_am_out_of_witty_strings', '$.param.fragment( url, String, 2 )' );
+      QUnit.assert.equal( current_url, pre + '#i_am_out_of_witty_strings', '$.param.fragment( url, String, 2 )' );
     }
 
   );
 
   $.param.fragment.ajaxCrawlable( true );
 
-  equal( $.param.fragment( 'foo', {} ) , 'foo#!', '$.param.fragment( url, Object )' );
-  equal( $.param.fragment( 'foo', { b:2, a:1 } ) , 'foo#!a=1&b=2', '$.param.fragment( url, Object )' );
-  equal( $.param.fragment( 'foo#', { b:2, a:1 } ) , 'foo#!a=1&b=2', '$.param.fragment( url, Object )' );
-  equal( $.param.fragment( 'foo#!', { b:2, a:1 } ) , 'foo#!a=1&b=2', '$.param.fragment( url, Object )' );
-  equal( $.param.fragment( 'foo#c=3&a=4', { b:2, a:1 } ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, Object )' );
-  equal( $.param.fragment( 'foo#!c=3&a=4', { b:2, a:1 } ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, Object )' );
+  QUnit.assert.equal( $.param.fragment( 'foo', {} ) , 'foo#!', '$.param.fragment( url, Object )' );
+  QUnit.assert.equal( $.param.fragment( 'foo', { b:2, a:1 } ) , 'foo#!a=1&b=2', '$.param.fragment( url, Object )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#', { b:2, a:1 } ) , 'foo#!a=1&b=2', '$.param.fragment( url, Object )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#!', { b:2, a:1 } ) , 'foo#!a=1&b=2', '$.param.fragment( url, Object )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#c=3&a=4', { b:2, a:1 } ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, Object )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#!c=3&a=4', { b:2, a:1 } ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, Object )' );
 
-  equal( $.param.fragment( 'foo', '' ) , 'foo#!', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo', 'b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#', 'b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#!', 'b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#c=3&a=4', 'b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#!c=3&a=4', 'b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo', '' ) , 'foo#!', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo', 'b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#', 'b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#!', 'b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#c=3&a=4', 'b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#!c=3&a=4', 'b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, String )' );
 
-  equal( $.param.fragment( 'foo', '#' ) , 'foo#!', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo', '#b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#', '#b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#!', '#b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#c=3&a=4', '#b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#!c=3&a=4', '#b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo', '#' ) , 'foo#!', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo', '#b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#', '#b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#!', '#b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#c=3&a=4', '#b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#!c=3&a=4', '#b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, String )' );
 
-  equal( $.param.fragment( 'foo', '#!' ) , 'foo#!', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo', '#!b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#', '#!b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#!', '#!b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#c=3&a=4', '#!b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#!c=3&a=4', '#!b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo', '#!' ) , 'foo#!', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo', '#!b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#', '#!b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#!', '#!b=2&a=1' ) , 'foo#!a=1&b=2', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#c=3&a=4', '#!b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#!c=3&a=4', '#!b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.param.fragment( url, String )' );
 
   $.param.fragment.ajaxCrawlable( false );
 
   // If a params fragment starts with ! and BBQ is not in ajaxCrawlable mode,
   // things can get very ugly, very quickly.
-  equal( $.param.fragment( 'foo', '#!' ) , 'foo#!=', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo', '#!b=2&a=1' ) , 'foo#!b=2&a=1', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#', '#!b=2&a=1' ) , 'foo#!b=2&a=1', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#!', '#!b=2&a=1' ) , 'foo#!=&!b=2&a=1', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#c=3&a=4', '#!b=2&a=1' ) , 'foo#!b=2&a=1&c=3', '$.param.fragment( url, String )' );
-  equal( $.param.fragment( 'foo#!c=3&a=4', '#!b=2&a=1' ) , 'foo#!b=2&!c=3&a=1', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo', '#!' ) , 'foo#!=', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo', '#!b=2&a=1' ) , 'foo#!b=2&a=1', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#', '#!b=2&a=1' ) , 'foo#!b=2&a=1', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#!', '#!b=2&a=1' ) , 'foo#!=&!b=2&a=1', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#c=3&a=4', '#!b=2&a=1' ) , 'foo#!b=2&a=1&c=3', '$.param.fragment( url, String )' );
+  QUnit.assert.equal( $.param.fragment( 'foo#!c=3&a=4', '#!b=2&a=1' ) , 'foo#!b=2&!c=3&a=1', '$.param.fragment( url, String )' );
 
 });
 
-test( 'jQuery.param.fragment.ajaxCrawlable', function() {
-  expect( 5 );
+QUnit.test( 'jQuery.param.fragment.ajaxCrawlable', function() {
+  QUnit.assert.expect( 5 );
 
-  equal( ajaxcrawlable_init, false, 'ajaxCrawlable is disabled by default' );
-  equal( $.param.fragment.ajaxCrawlable( true ), true, 'enabling ajaxCrawlable should return true' );
-  equal( $.param.fragment.ajaxCrawlable(), true, 'ajaxCrawlable is now enabled' );
-  equal( $.param.fragment.ajaxCrawlable( false ), false, 'disabling ajaxCrawlable should return false' );
-  equal( $.param.fragment.ajaxCrawlable(), false, 'ajaxCrawlable is now disabled' );
+  QUnit.assert.equal( ajaxcrawlable_init, false, 'ajaxCrawlable is disabled by default' );
+  QUnit.assert.equal( $.param.fragment.ajaxCrawlable( true ), true, 'enabling ajaxCrawlable should return true' );
+  QUnit.assert.equal( $.param.fragment.ajaxCrawlable(), true, 'ajaxCrawlable is now enabled' );
+  QUnit.assert.equal( $.param.fragment.ajaxCrawlable( false ), false, 'disabling ajaxCrawlable should return false' );
+  QUnit.assert.equal( $.param.fragment.ajaxCrawlable(), false, 'ajaxCrawlable is now disabled' );
 });
 
-test( 'jQuery.param.fragment.noEscape', function() {
-  expect( 2 );
+QUnit.test( 'jQuery.param.fragment.noEscape', function() {
+  QUnit.assert.expect( 2 );
 
-  equal( $.param.fragment( '#', { foo: '/a,b@c$d+e&f=g h!' } ), '#foo=/a,b%40c%24d%2Be%26f%3Dg+h!', '/, should be unescaped, everything else but space (+) should be urlencoded' );
+  QUnit.assert.equal( $.param.fragment( '#', { foo: '/a,b@c$d+e&f=g h!' } ), '#foo=/a,b%40c%24d%2Be%26f%3Dg+h!', '/, should be unescaped, everything else but space (+) should be urlencoded' );
 
   $.param.fragment.ajaxCrawlable( true );
 
-  equal( $.param.fragment( '#', { foo: '/a,b@c$d+e&f=g h!' } ), '#!foo=/a,b%40c%24d%2Be%26f%3Dg+h!', '/, should be unescaped, everything else but ! and space (+) should be urlencoded' );
+  QUnit.assert.equal( $.param.fragment( '#', { foo: '/a,b@c$d+e&f=g h!' } ), '#!foo=/a,b%40c%24d%2Be%26f%3Dg+h!', '/, should be unescaped, everything else but ! and space (+) should be urlencoded' );
 
   $.param.fragment.ajaxCrawlable( false );
 });
@@ -495,86 +492,86 @@ test( 'jQuery.param.fragment.noEscape', function() {
 
 QUnit.module( 'jQuery.deparam' );
 
-test( 'jQuery.deparam - 1.4-style params', function() {
-  expect( 2 );
-  deepEqual( $.deparam( params_str ), params_obj, '$.deparam( String )' );
-  deepEqual( $.deparam( params_str, true ), params_obj_coerce, '$.deparam( String, true )' );
+QUnit.test( 'jQuery.deparam - 1.4-style params', function() {
+  QUnit.assert.expect( 2 );
+  QUnit.assert.deepEqual( $.deparam( params_str ), params_obj, '$.deparam( String )' );
+  QUnit.assert.deepEqual( $.deparam( params_str, true ), params_obj_coerce, '$.deparam( String, true )' );
 });
 
-test( 'jQuery.deparam - pre-1.4-style params', function() {
+QUnit.test( 'jQuery.deparam - pre-1.4-style params', function() {
   var params_str = 'a=1&a=2&a=3&b=4&c=5&c=6&c=true&c=false&c=undefined&c=&d=7',
     params_obj = { a:['1','2','3'], b:'4', c:['5','6','true','false','undefined',''], d:'7' },
     params_obj_coerce = { a:[1,2,3], b:4, c:[5,6,true,false,undefined,''], d:7 };
 
-  expect( 2 );
-  deepEqual( $.deparam( params_str ), params_obj, '$.deparam( String )' );
-  deepEqual( $.deparam( params_str, true ), params_obj_coerce, '$.deparam( String, true )' );
+  QUnit.assert.expect( 2 );
+  QUnit.assert.deepEqual( $.deparam( params_str ), params_obj, '$.deparam( String )' );
+  QUnit.assert.deepEqual( $.deparam( params_str, true ), params_obj_coerce, '$.deparam( String, true )' );
 });
 
-test( 'jQuery.deparam.querystring', function() {
-  expect( 12 );
+QUnit.test( 'jQuery.deparam.querystring', function() {
+  QUnit.assert.expect( 12 );
 
-  deepEqual( $.deparam.querystring(), params_obj, 'params obj from window.location' );
-  deepEqual( $.deparam.querystring( /*true*/ ), params_obj_coerce, 'params obj from window.location, coerced' );
-  deepEqual( $.deparam.querystring( params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.querystring( params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.querystring( '?' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.querystring( '?' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.querystring( 'foo.html?' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.querystring( 'foo.html?' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.querystring( 'http://a:b@example.com:1234/foo.html?' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.querystring( 'http://a:b@example.com:1234/foo.html?' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.querystring( 'http://a:b@example.com:1234/foo.html?' + params_str + '#bippity-boppity-boo' ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.querystring( 'http://a:b@example.com:1234/foo.html?' + params_str + '#bippity-boppity-boo', true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.querystring(), params_obj, 'params obj from window.location' );
+  QUnit.assert.deepEqual( $.deparam.querystring( /*true*/ ), params_obj_coerce, 'params obj from window.location, coerced' );
+  QUnit.assert.deepEqual( $.deparam.querystring( params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.querystring( params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.querystring( '?' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.querystring( '?' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.querystring( 'foo.html?' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.querystring( 'foo.html?' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.querystring( 'http://a:b@example.com:1234/foo.html?' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.querystring( 'http://a:b@example.com:1234/foo.html?' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.querystring( 'http://a:b@example.com:1234/foo.html?' + params_str + '#bippity-boppity-boo' ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.querystring( 'http://a:b@example.com:1234/foo.html?' + params_str + '#bippity-boppity-boo', true ), params_obj_coerce, 'params obj from string, coerced' );
 });
 
-test( 'jQuery.deparam.fragment', function() {
-  expect( 36 );
+QUnit.test( 'jQuery.deparam.fragment', function() {
+  QUnit.assert.expect( 36 );
 
-  deepEqual( $.deparam.fragment(), params_obj, 'params obj from window.location' );
-  deepEqual( $.deparam.fragment( /*true*/ ), params_obj_coerce, 'params obj from window.location, coerced' );
-  deepEqual( $.deparam.fragment( params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.fragment( params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment(), params_obj, 'params obj from window.location' );
+  QUnit.assert.deepEqual( $.deparam.fragment( /*true*/ ), params_obj_coerce, 'params obj from window.location, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
 
-  deepEqual( $.deparam.fragment( '#' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.fragment( '#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.fragment( 'foo.html#' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.fragment( 'foo.html#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( '#' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( '#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'foo.html#' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'foo.html#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
 
   // If a params fragment starts with ! and BBQ is not in ajaxCrawlable mode,
   // things can get very ugly, very quickly.
-  deepEqual( $.deparam.fragment( '#!' + params_str ), params_obj_bang, 'params obj from string' );
-  deepEqual( $.deparam.fragment( '#!' + params_str, true ), params_obj_bang_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.fragment( 'foo.html#!' + params_str ), params_obj_bang, 'params obj from string' );
-  deepEqual( $.deparam.fragment( 'foo.html#!' + params_str, true ), params_obj_bang_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#!' + params_str ), params_obj_bang, 'params obj from string' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#!' + params_str, true ), params_obj_bang_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#!' + params_str ), params_obj_bang, 'params obj from string' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#!' + params_str, true ), params_obj_bang_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( '#!' + params_str ), params_obj_bang, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( '#!' + params_str, true ), params_obj_bang_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'foo.html#!' + params_str ), params_obj_bang, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'foo.html#!' + params_str, true ), params_obj_bang_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#!' + params_str ), params_obj_bang, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#!' + params_str, true ), params_obj_bang_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#!' + params_str ), params_obj_bang, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#!' + params_str, true ), params_obj_bang_coerce, 'params obj from string, coerced' );
 
   $.param.fragment.ajaxCrawlable( true );
 
-  deepEqual( $.deparam.fragment( '#' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.fragment( '#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.fragment( 'foo.html#' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.fragment( 'foo.html#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( '#' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( '#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'foo.html#' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'foo.html#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
 
-  deepEqual( $.deparam.fragment( '#!' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.fragment( '#!' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.fragment( 'foo.html#!' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.fragment( 'foo.html#!' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#!' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#!' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#!' + params_str ), params_obj, 'params obj from string' );
-  deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#!' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( '#!' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( '#!' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'foo.html#!' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'foo.html#!' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#!' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html#!' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#!' + params_str ), params_obj, 'params obj from string' );
+  QUnit.assert.deepEqual( $.deparam.fragment( 'http://a:b@example.com:1234/foo.html?bippity-boppity-boo#!' + params_str, true ), params_obj_coerce, 'params obj from string, coerced' );
 
   $.param.fragment.ajaxCrawlable( false );
 });
@@ -612,8 +609,8 @@ function test_url_attr( container ) {
   return url;
 };
 
-test( 'jQuery.fn.querystring', function() {
-  expect( 60 );
+QUnit.test( 'jQuery.fn.querystring', function() {
+  QUnit.assert.expect( 60 );
 
   function fake_encode( params_str ) {
     return '?' + $.map( params_str.split('&'), encodeURIComponent ).join('&').replace( /%3D/g, '=' ).replace( /%2B/g, '+' );
@@ -632,17 +629,17 @@ test( 'jQuery.fn.querystring', function() {
 
       container = init_url_attr( container, current_url );
       elems = container.children('span');
-      equal( elems.length, 1, 'select the correct elements' );
-      equal( elems.querystring.apply( elems, [ 'arbitrary_attr' ].concat( aps.call( arguments ) ) ), elems, 'pass query string' );
+      QUnit.assert.equal( elems.length, 1, 'select the correct elements' );
+      QUnit.assert.equal( elems.querystring.apply( elems, [ 'arbitrary_attr' ].concat( aps.call( arguments ) ) ), elems, 'pass query string' );
 
       container = init_url_attr( container, current_url );
       elems = container.children('a, link');
-      equal( elems.length, 2, 'select the correct elements' );
-      equal( elems.querystring.apply( elems, [ 'href' ].concat( aps.call( arguments ) ) ), elems, 'pass query string' );
+      QUnit.assert.equal( elems.length, 2, 'select the correct elements' );
+      QUnit.assert.equal( elems.querystring.apply( elems, [ 'href' ].concat( aps.call( arguments ) ) ), elems, 'pass query string' );
 
       container = init_url_attr( container, current_url );
       elems = container.children();
-      equal( elems.querystring.apply( elems, aps.call( arguments ) ), elems, 'pass query string' );
+      QUnit.assert.equal( elems.querystring.apply( elems, aps.call( arguments ) ), elems, 'pass query string' );
 
       current_url = test_url_attr( container );
     },
@@ -652,19 +649,19 @@ test( 'jQuery.fn.querystring', function() {
     [ { a:'2' } ],
 
     function(result){
-      equal( current_url, pre + '?a=2' + post, '$.fn.querystring( url, Object )' );
+      QUnit.assert.equal( current_url, pre + '?a=2' + post, '$.fn.querystring( url, Object )' );
     },
 
     [ { b:'2' } ],
 
     function(result){
-      equal( current_url, pre + '?a=2&b=2' + post, '$.fn.querystring( url, Object )' );
+      QUnit.assert.equal( current_url, pre + '?a=2&b=2' + post, '$.fn.querystring( url, Object )' );
     },
 
     [ { c:true, d:false, e:'undefined', f:'' } ],
 
     function(result){
-      equal( current_url, pre + '?a=2&b=2&c=true&d=false&e=undefined&f=' + post, '$.fn.querystring( url, Object )' );
+      QUnit.assert.equal( current_url, pre + '?a=2&b=2&c=true&d=false&e=undefined&f=' + post, '$.fn.querystring( url, Object )' );
     },
 
     [ { a:[4,5,6]}],//, b:{x:[7], y:8, z:[9,0,'true','false','undefined','']} }, 2 ],
@@ -674,7 +671,7 @@ test( 'jQuery.fn.querystring', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=';
 
-      equal( current_url, pre + fake_encode( params ) + post, '$.fn.querystring( url, Object, 2 )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ) + post, '$.fn.querystring( url, Object, 2 )' );
     },
 
     [ { a:'1', c:'2' } as any, 1 ],
@@ -684,7 +681,7 @@ test( 'jQuery.fn.querystring', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]&c=2'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&c=2';
 
-      equal( current_url, pre + fake_encode( params ) + post, '$.fn.querystring( url, Object, 1 )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ) + post, '$.fn.querystring( url, Object, 1 )' );
     },
 
     [ 'foo=1' ],
@@ -694,7 +691,7 @@ test( 'jQuery.fn.querystring', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]&c=2&foo=1'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&c=2&foo=1';
 
-      equal( current_url, pre + fake_encode( params ) + post, '$.fn.querystring( url, String )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ) + post, '$.fn.querystring( url, String )' );
     },
 
     [ 'foo=2&bar=3' as any, 1 ],
@@ -704,33 +701,33 @@ test( 'jQuery.fn.querystring', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]&bar=3&c=2&foo=1'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&bar=3&c=2&foo=1';
 
-      equal( current_url, pre + fake_encode( params ) + post, '$.fn.querystring( url, String, 1 )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ) + post, '$.fn.querystring( url, String, 1 )' );
     },
 
     [ 'http://example.com/test.html?/path/to/file.php#the-cow-goes-moo' as any, 2 ],
 
     function(result){
-      equal( current_url, pre + '?/path/to/file.php' + post, '$.fn.querystring( url, String, 2 )' );
+      QUnit.assert.equal( current_url, pre + '?/path/to/file.php' + post, '$.fn.querystring( url, String, 2 )' );
     },
 
     [ '?another-example' as any, 2 ],
 
     function(result){
-      equal( current_url, pre + '?another-example' + post, '$.fn.querystring( url, String, 2 )' );
+      QUnit.assert.equal( current_url, pre + '?another-example' + post, '$.fn.querystring( url, String, 2 )' );
     },
 
     [ 'i_am_out_of_witty_strings' as any, 2 ],
 
     function(result){
-      equal( current_url, pre + '?i_am_out_of_witty_strings' + post, '$.fn.querystring( url, String, 2 )' );
+      QUnit.assert.equal( current_url, pre + '?i_am_out_of_witty_strings' + post, '$.fn.querystring( url, String, 2 )' );
     }
 
   );
 
 });
 
-test( 'jQuery.fn.fragment', function() {
-  expect( 240 );
+QUnit.test( 'jQuery.fn.fragment', function() {
+  QUnit.assert.expect( 240 );
 
   function fake_encode( params_str ) {
     return '#' + $.map( params_str.split('&'), encodeURIComponent ).join('&').replace( /%3D/g, '=' ).replace( /%2B/g, '+' );
@@ -751,19 +748,19 @@ test( 'jQuery.fn.fragment', function() {
     [ { a:'2' } ],
 
     function(result){
-      equal( current_url, pre + '#a=2', '$.fn.fragment( url, Object )' );
+      QUnit.assert.equal( current_url, pre + '#a=2', '$.fn.fragment( url, Object )' );
     },
 
     [ { b:'2' } ],
 
     function(result){
-      equal( current_url, pre + '#a=2&b=2', '$.fn.fragment( url, Object )' );
+      QUnit.assert.equal( current_url, pre + '#a=2&b=2', '$.fn.fragment( url, Object )' );
     },
 
     [ { c:true, d:false, e:'undefined', f:'' } ],
 
     function(result){
-      equal( current_url, pre + '#a=2&b=2&c=true&d=false&e=undefined&f=', '$.fn.fragment( url, Object )' );
+      QUnit.assert.equal( current_url, pre + '#a=2&b=2&c=true&d=false&e=undefined&f=', '$.fn.fragment( url, Object )' );
     },
 
     [ { a:[4,5,6]}],//, b:{x:[7], y:8, z:[9,0,'true','false','undefined','']} }, 2 ],
@@ -773,7 +770,7 @@ test( 'jQuery.fn.fragment', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=';
 
-      equal( current_url, pre + fake_encode( params ), '$.fn.fragment( url, Object, 2 )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ), '$.fn.fragment( url, Object, 2 )' );
     },
 
     [ { a:'1', c:'2' } as any, 1 ],
@@ -783,7 +780,7 @@ test( 'jQuery.fn.fragment', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]&c=2'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&c=2';
 
-      equal( current_url, pre + fake_encode( params ), '$.fn.fragment( url, Object, 1 )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ), '$.fn.fragment( url, Object, 1 )' );
     },
 
     [ 'foo=1' ],
@@ -793,7 +790,7 @@ test( 'jQuery.fn.fragment', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]&c=2&foo=1'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&c=2&foo=1';
 
-      equal( current_url, pre + fake_encode( params ), '$.fn.fragment( url, String )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ), '$.fn.fragment( url, String )' );
     },
 
     [ 'foo=2&bar=3' as any, 1 ],
@@ -803,25 +800,25 @@ test( 'jQuery.fn.fragment', function() {
         ? 'a=4&a=5&a=6&b=[object+Object]&bar=3&c=2&foo=1'
         : 'a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&bar=3&c=2&foo=1';
 
-      equal( current_url, pre + fake_encode( params ), '$.fn.fragment( url, String, 1 )' );
+      QUnit.assert.equal( current_url, pre + fake_encode( params ), '$.fn.fragment( url, String, 1 )' );
     },
 
     [ 'http://example.com/test.html?the-cow-goes-moo#/path/to/file.php' as any, 2 ],
 
     function(result){
-      equal( current_url, pre + '#/path/to/file.php', '$.fn.fragment( url, String, 2 )' );
+      QUnit.assert.equal( current_url, pre + '#/path/to/file.php', '$.fn.fragment( url, String, 2 )' );
     },
 
     [ '#another-example' as any, 2 ],
 
     function(result){
-      equal( current_url, pre + '#another-example', '$.fn.fragment( url, String, 2 )' );
+      QUnit.assert.equal( current_url, pre + '#another-example', '$.fn.fragment( url, String, 2 )' );
     },
 
     [ 'i_am_out_of_witty_strings' as any, 2 ],
 
     function(result){
-      equal( current_url, pre + '#i_am_out_of_witty_strings', '$.fn.fragment( url, String, 2 )' );
+      QUnit.assert.equal( current_url, pre + '#i_am_out_of_witty_strings', '$.fn.fragment( url, String, 2 )' );
     }
 
   );
@@ -834,59 +831,59 @@ test( 'jQuery.fn.fragment', function() {
 
     container = init_url_attr( container, url );
     elems = container.children('span');
-    equal( elems.length, 1, 'select the correct elements' );
-    equal( elems.fragment( 'arbitrary_attr', params, merge_mode ), elems, 'pass fragment' );
+    QUnit.assert.equal( elems.length, 1, 'select the correct elements' );
+    QUnit.assert.equal( elems.fragment( 'arbitrary_attr', params, merge_mode ), elems, 'pass fragment' );
 
     container = init_url_attr( container, url );
     elems = container.children('a, link');
-    equal( elems.length, 2, 'select the correct elements' );
-    equal( elems.fragment( params, merge_mode ), elems, 'pass fragment' );
+    QUnit.assert.equal( elems.length, 2, 'select the correct elements' );
+    QUnit.assert.equal( elems.fragment( params, merge_mode ), elems, 'pass fragment' );
 
     container = init_url_attr( container, url );
     elems = container.children();
-    equal( elems.fragment( params, merge_mode ), elems, 'pass fragment' );
+    QUnit.assert.equal( elems.fragment( params, merge_mode ), elems, 'pass fragment' );
 
     return test_url_attr( container );
   };
 
-  equal( test_fn_fragment( 'foo', {} ) , 'foo#!', '$.fn.fragment( url, Object )' );
-  equal( test_fn_fragment( 'foo', { b:2, a:1 } ) , 'foo#!a=1&b=2', '$.fn.fragment( url, Object )' );
-  equal( test_fn_fragment( 'foo#', { b:2, a:1 } ) , 'foo#!a=1&b=2', '$.fn.fragment( url, Object )' );
-  equal( test_fn_fragment( 'foo#!', { b:2, a:1 } ) , 'foo#!a=1&b=2', '$.fn.fragment( url, Object )' );
-  equal( test_fn_fragment( 'foo#c=3&a=4', { b:2, a:1 } ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, Object )' );
-  equal( test_fn_fragment( 'foo#!c=3&a=4', { b:2, a:1 } ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, Object )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo', {} ) , 'foo#!', '$.fn.fragment( url, Object )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo', { b:2, a:1 } ) , 'foo#!a=1&b=2', '$.fn.fragment( url, Object )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#', { b:2, a:1 } ) , 'foo#!a=1&b=2', '$.fn.fragment( url, Object )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#!', { b:2, a:1 } ) , 'foo#!a=1&b=2', '$.fn.fragment( url, Object )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#c=3&a=4', { b:2, a:1 } ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, Object )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#!c=3&a=4', { b:2, a:1 } ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, Object )' );
 
-  equal( test_fn_fragment( 'foo', '' ) , 'foo#!', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo', 'b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#', 'b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#!', 'b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#c=3&a=4', 'b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#!c=3&a=4', 'b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo', '' ) , 'foo#!', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo', 'b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#', 'b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#!', 'b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#c=3&a=4', 'b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#!c=3&a=4', 'b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, String )' );
 
-  equal( test_fn_fragment( 'foo', '#' ) , 'foo#!', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo', '#b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#', '#b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#!', '#b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#c=3&a=4', '#b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#!c=3&a=4', '#b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo', '#' ) , 'foo#!', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo', '#b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#', '#b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#!', '#b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#c=3&a=4', '#b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#!c=3&a=4', '#b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, String )' );
 
-  equal( test_fn_fragment( 'foo', '#!' ) , 'foo#!', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo', '#!b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#', '#!b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#!', '#!b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#c=3&a=4', '#!b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#!c=3&a=4', '#!b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo', '#!' ) , 'foo#!', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo', '#!b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#', '#!b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#!', '#!b=2&a=1' ) , 'foo#!a=1&b=2', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#c=3&a=4', '#!b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#!c=3&a=4', '#!b=2&a=1' ) , 'foo#!a=1&b=2&c=3', '$.fn.fragment( url, String )' );
 
   $.param.fragment.ajaxCrawlable( false );
 
   // If a params fragment starts with ! and BBQ is not in ajaxCrawlable mode,
   // things can get very ugly, very quickly.
-  equal( test_fn_fragment( 'foo', '#!' ) , 'foo#!=', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo', '#!b=2&a=1' ) , 'foo#!b=2&a=1', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#', '#!b=2&a=1' ) , 'foo#!b=2&a=1', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#!', '#!b=2&a=1' ) , 'foo#!=&!b=2&a=1', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#c=3&a=4', '#!b=2&a=1' ) , 'foo#!b=2&a=1&c=3', '$.fn.fragment( url, String )' );
-  equal( test_fn_fragment( 'foo#!c=3&a=4', '#!b=2&a=1' ) , 'foo#!b=2&!c=3&a=1', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo', '#!' ) , 'foo#!=', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo', '#!b=2&a=1' ) , 'foo#!b=2&a=1', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#', '#!b=2&a=1' ) , 'foo#!b=2&a=1', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#!', '#!b=2&a=1' ) , 'foo#!=&!b=2&a=1', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#c=3&a=4', '#!b=2&a=1' ) , 'foo#!b=2&a=1&c=3', '$.fn.fragment( url, String )' );
+  QUnit.assert.equal( test_fn_fragment( 'foo#!c=3&a=4', '#!b=2&a=1' ) , 'foo#!b=2&!c=3&a=1', '$.fn.fragment( url, String )' );
 
 });
 
@@ -895,16 +892,16 @@ test( 'jQuery.fn.fragment', function() {
 
 QUnit.module( 'jQuery.bbq' );
 
-test( 'jQuery.bbq.pushState(), jQuery.bbq.getState(), jQuery.bbq.removeState(), window.onhashchange', function() {
-  expect( old_jquery ? 95 : 167 );
+QUnit.test( 'jQuery.bbq.pushState(), jQuery.bbq.getState(), jQuery.bbq.removeState(), window.onhashchange', function() {
+  QUnit.assert.expect( old_jquery ? 95 : 167 );
 
   var a:{ str: string, coerce: boolean }, b:{ str: string, coerce: boolean }, c, d, e, f, x, y, hash, hash_actual, obj: { str: string, coerce: boolean }, event:JQueryBbq.EventObject, msg = 'Testing window.onhashchange and history';
 
   $.bbq.pushState();
-  equal( window.location.hash.replace( /^#/, ''), '', 'window.location hash should be empty' );
+  QUnit.assert.equal( window.location.hash.replace( /^#/, ''), '', 'window.location hash should be empty' );
 
   $.bbq.pushState({ a:'1', b:'1' });
-  deepEqual( $.deparam.fragment(), { a:'1', b:'1' }, 'hash should be set properly' );
+  QUnit.assert.deepEqual( $.deparam.fragment(), { a:'1', b:'1' }, 'hash should be set properly' );
 
   $(window).bind( 'hashchange', function(evt) {
     var hash_str = $.param.fragment(),
@@ -924,16 +921,16 @@ test( 'jQuery.bbq.pushState(), jQuery.bbq.getState(), jQuery.bbq.removeState(), 
 
   }).trigger( 'hashchange' );
 
-  deepEqual( obj.str, { a:'1', b:'1' }, 'hashchange triggered manually: $.bbq.getState()' );
-  deepEqual( obj.coerce, { a:1, b:1 },  'hashchange triggered manually: $.bbq.getState( true )' );
-  equal( a.str, '1', 'hashchange triggered manually: $.bbq.getState( "a" )' );
-  equal( a.coerce, 1, 'hashchange triggered manually: $.bbq.getState( "a", true )' );
+  QUnit.assert.deepEqual( obj.str, { a:'1', b:'1' } as any, 'hashchange triggered manually: $.bbq.getState()' );
+  QUnit.assert.deepEqual( obj.coerce, { a:1, b:1 } as any,  'hashchange triggered manually: $.bbq.getState( true )' );
+  QUnit.assert.equal( a.str, '1', 'hashchange triggered manually: $.bbq.getState( "a" )' );
+  QUnit.assert.equal( a.coerce, 1, 'hashchange triggered manually: $.bbq.getState( "a", true )' );
 
   if ( !old_jquery ) {
-    deepEqual( event.getState(), { a:'1', b:'1' }, 'hashchange triggered manually: event.getState()' );
-    deepEqual( event.getState('a'), { a:1, b:1 },  'hashchange triggered manually: event.getState( true )' );
-    equal( event.getState('a'), '1', 'hashchange triggered manually: event.getState( "a" )' );
-    equal( event.getState('a',true), 1, 'hashchange triggered manually: event.getState( "a", true )' );
+    QUnit.assert.deepEqual( event.getState(), { a:'1', b:'1' }, 'hashchange triggered manually: event.getState()' );
+    QUnit.assert.deepEqual( event.getState('a'), { a:1, b:1 },  'hashchange triggered manually: event.getState( true )' );
+    QUnit.assert.equal( event.getState('a'), '1', 'hashchange triggered manually: event.getState( "a" )' );
+    QUnit.assert.equal( event.getState('a',true), 1, 'hashchange triggered manually: event.getState( "a", true )' );
   }
 
   run_many_tests(
@@ -956,60 +953,60 @@ test( 'jQuery.bbq.pushState(), jQuery.bbq.getState(), jQuery.bbq.removeState(), 
     [ { a:'2' } ],
 
     function(result){
-      equal( hash_actual, '#' + hash, 'hash should begin with #!' );
-      deepEqual( obj.str, { a:'2', b:'1' }, '$.bbq.getState()' );
-      deepEqual( obj.coerce, { a:2, b:1 },  '$.bbq.getState( true )' );
-      equal( a.str, '2', '$.bbq.getState( "a" )' );
-      equal( a.coerce, 2, '$.bbq.getState( "a", true )' );
+      QUnit.assert.equal( hash_actual, '#' + hash, 'hash should begin with #!' );
+      QUnit.assert.deepEqual( obj.str, { a:'2', b:'1' } as any, '$.bbq.getState()' );
+      QUnit.assert.deepEqual( obj.coerce, { a:2, b:1 } as any,  '$.bbq.getState( true )' );
+      QUnit.assert.equal( a.str, '2', '$.bbq.getState( "a" )' );
+      QUnit.assert.equal( a.coerce, 2, '$.bbq.getState( "a", true )' );
       if ( !old_jquery ) {
-        deepEqual( event.getState(), { a:'2', b:'1' }, 'event.getState()' );
-        deepEqual( event.getState('a'), { a:2, b:1 },  'event.getState( true )' );
-        equal( event.getState('a'), '2', 'event.getState( "a" )' );
-        equal( event.getState('a',true), 2, 'event.getState( "a", true )' );
+        QUnit.assert.deepEqual( event.getState(), { a:'2', b:'1' }, 'event.getState()' );
+        QUnit.assert.deepEqual( event.getState('a'), { a:2, b:1 },  'event.getState( true )' );
+        QUnit.assert.equal( event.getState('a'), '2', 'event.getState( "a" )' );
+        QUnit.assert.equal( event.getState('a',true), 2, 'event.getState( "a", true )' );
       }
     },
 
     [ { b:'2' } ],
 
     function(result){
-      equal( hash_actual, '#' + hash, 'hash should begin with #!' );
-      deepEqual( obj.str, { a:'2', b:'2' }, '$.bbq.getState()' );
-      deepEqual( obj.coerce, { a:2, b:2 },  '$.bbq.getState( true )' );
-      equal( b.str, '2', '$.bbq.getState( "b" )' );
-      equal( b.coerce, 2, '$.bbq.getState( "b", true )' );
+      QUnit.assert.equal( hash_actual, '#' + hash, 'hash should begin with #!' );
+      QUnit.assert.deepEqual( obj.str, { a:'2', b:'2' } as any, '$.bbq.getState()' );
+      QUnit.assert.deepEqual( obj.coerce, { a:2, b:2 } as any,  '$.bbq.getState( true )' );
+      QUnit.assert.equal( b.str, '2', '$.bbq.getState( "b" )' );
+      QUnit.assert.equal( b.coerce, 2, '$.bbq.getState( "b", true )' );
       if ( !old_jquery ) {
-        deepEqual( event.getState(), { a:'2', b:'2' }, 'event.getState()' );
-        deepEqual( event.getState('a'), { a:2, b:2 },  'event.getState( true )' );
-        equal( event.getState('b'), '2', 'event.getState( "b" )' );
-        equal( event.getState('b',true), 2, 'event.getState( "b", true )' );
+        QUnit.assert.deepEqual( event.getState(), { a:'2', b:'2' }, 'event.getState()' );
+        QUnit.assert.deepEqual( event.getState('a'), { a:2, b:2 },  'event.getState( true )' );
+        QUnit.assert.equal( event.getState('b'), '2', 'event.getState( "b" )' );
+        QUnit.assert.equal( event.getState('b',true), 2, 'event.getState( "b", true )' );
       }
     },
 
     [ { c:true, d:false, e:'undefined', f:'' } ],
 
     function(result){
-      equal( hash_actual, '#' + hash, 'hash should begin with #!' );
-      deepEqual( obj.str, { a:'2', b:'2', c:'true', d:'false', e:'undefined', f:'' }, '$.bbq.getState()' );
-      deepEqual( obj.coerce, { a:2, b:2, c:true, d:false, e:undefined, f:'' },  '$.bbq.getState( true )' );
-      equal( c.str, 'true', '$.bbq.getState( "c" )' );
-      equal( c.coerce, true, '$.bbq.getState( "c", true )' );
-      equal( d.str, 'false', '$.bbq.getState( "d" )' );
-      equal( d.coerce, false, '$.bbq.getState( "d", true )' );
-      equal( e.str, 'undefined', '$.bbq.getState( "e" )' );
-      equal( e.coerce, undefined, '$.bbq.getState( "e", true )' );
-      equal( f.str, '', '$.bbq.getState( "f" )' );
-      equal( f.coerce, '', '$.bbq.getState( "f", true )' );
+      QUnit.assert.equal( hash_actual, '#' + hash, 'hash should begin with #!' );
+      QUnit.assert.deepEqual( obj.str, { a:'2', b:'2', c:'true', d:'false', e:'undefined', f:'' } as any, '$.bbq.getState()' );
+      QUnit.assert.deepEqual( obj.coerce, { a:2, b:2, c:true, d:false, e:undefined, f:'' } as any,  '$.bbq.getState( true )' );
+      QUnit.assert.equal( c.str, 'true', '$.bbq.getState( "c" )' );
+      QUnit.assert.equal( c.coerce, true, '$.bbq.getState( "c", true )' );
+      QUnit.assert.equal( d.str, 'false', '$.bbq.getState( "d" )' );
+      QUnit.assert.equal( d.coerce, false, '$.bbq.getState( "d", true )' );
+      QUnit.assert.equal( e.str, 'undefined', '$.bbq.getState( "e" )' );
+      QUnit.assert.equal( e.coerce, undefined, '$.bbq.getState( "e", true )' );
+      QUnit.assert.equal( f.str, '', '$.bbq.getState( "f" )' );
+      QUnit.assert.equal( f.coerce, '', '$.bbq.getState( "f", true )' );
       if ( !old_jquery ) {
-        deepEqual( event.getState(), { a:'2', b:'2', c:'true', d:'false', e:'undefined', f:'' }, 'event.getState()' );
-        deepEqual( event.getState('a'), { a:2, b:2, c:true, d:false, e:undefined, f:'' },  'event.getState( true )' );
-        equal( event.getState('c'), 'true', 'event.getState( "c" )' );
-        equal( event.getState('c',true), true, 'event.getState( "c", true )' );
-        equal( event.getState('d'), 'false', 'event.getState( "d" )' );
-        equal( event.getState('d',true), false, 'event.getState( "d", true )' );
-        equal( event.getState('e'), 'undefined', 'event.getState( "e" )' );
-        equal( event.getState('e',true), undefined, 'event.getState( "e", true )' );
-        equal( event.getState('f'), '', 'event.getState( "f" )' );
-        equal( event.getState('f',true), '', 'event.getState( "f", true )' );
+        QUnit.assert.deepEqual( event.getState(), { a:'2', b:'2', c:'true', d:'false', e:'undefined', f:'' }, 'event.getState()' );
+        QUnit.assert.deepEqual( event.getState('a'), { a:2, b:2, c:true, d:false, e:undefined, f:'' },  'event.getState( true )' );
+        QUnit.assert.equal( event.getState('c'), 'true', 'event.getState( "c" )' );
+        QUnit.assert.equal( event.getState('c',true), true, 'event.getState( "c", true )' );
+        QUnit.assert.equal( event.getState('d'), 'false', 'event.getState( "d" )' );
+        QUnit.assert.equal( event.getState('d',true), false, 'event.getState( "d", true )' );
+        QUnit.assert.equal( event.getState('e'), 'undefined', 'event.getState( "e" )' );
+        QUnit.assert.equal( event.getState('e',true), undefined, 'event.getState( "e", true )' );
+        QUnit.assert.equal( event.getState('f'), '', 'event.getState( "f" )' );
+        QUnit.assert.equal( event.getState('f',true), '', 'event.getState( "f", true )' );
       }
     },
 
@@ -1022,36 +1019,36 @@ test( 'jQuery.bbq.pushState(), jQuery.bbq.getState(), jQuery.bbq.removeState(), 
     },
 
     function(result){
-      equal( hash_actual, '#!' + hash, 'hash should begin with #!' );
-      deepEqual( obj.str, { a:'2', b:'2', d:'false', e:'undefined', f:'' }, '$.bbq.getState()' );
-      deepEqual( obj.coerce, { a:2, b:2, d:false, e:undefined, f:'' },  '$.bbq.getState( true )' );
-      equal( a.str, '2', '$.bbq.getState( "a" )' );
-      equal( a.coerce, 2, '$.bbq.getState( "a", true )' );
-      equal( b.str, '2', '$.bbq.getState( "b" )' );
-      equal( b.coerce, 2, '$.bbq.getState( "b", true )' );
-      equal( c.str, undefined, '$.bbq.getState( "c" )' );
-      equal( c.coerce, undefined, '$.bbq.getState( "c", true )' );
-      equal( d.str, 'false', '$.bbq.getState( "d" )' );
-      equal( d.coerce, false, '$.bbq.getState( "d", true )' );
-      equal( e.str, 'undefined', '$.bbq.getState( "e" )' );
-      equal( e.coerce, undefined, '$.bbq.getState( "e", true )' );
-      equal( f.str, '', '$.bbq.getState( "f" )' );
-      equal( f.coerce, '', '$.bbq.getState( "f", true )' );
+      QUnit.assert.equal( hash_actual, '#!' + hash, 'hash should begin with #!' );
+      QUnit.assert.deepEqual( obj.str, { a:'2', b:'2', d:'false', e:'undefined', f:'' } as any, '$.bbq.getState()' );
+      QUnit.assert.deepEqual( obj.coerce, { a:2, b:2, d:false, e:undefined, f:'' } as any,  '$.bbq.getState( true )' );
+      QUnit.assert.equal( a.str, '2', '$.bbq.getState( "a" )' );
+      QUnit.assert.equal( a.coerce, 2, '$.bbq.getState( "a", true )' );
+      QUnit.assert.equal( b.str, '2', '$.bbq.getState( "b" )' );
+      QUnit.assert.equal( b.coerce, 2, '$.bbq.getState( "b", true )' );
+      QUnit.assert.equal( c.str, undefined, '$.bbq.getState( "c" )' );
+      QUnit.assert.equal( c.coerce, undefined, '$.bbq.getState( "c", true )' );
+      QUnit.assert.equal( d.str, 'false', '$.bbq.getState( "d" )' );
+      QUnit.assert.equal( d.coerce, false, '$.bbq.getState( "d", true )' );
+      QUnit.assert.equal( e.str, 'undefined', '$.bbq.getState( "e" )' );
+      QUnit.assert.equal( e.coerce, undefined, '$.bbq.getState( "e", true )' );
+      QUnit.assert.equal( f.str, '', '$.bbq.getState( "f" )' );
+      QUnit.assert.equal( f.coerce, '', '$.bbq.getState( "f", true )' );
       if ( !old_jquery ) {
-        deepEqual( event.getState(), { a:'2', b:'2', d:'false', e:'undefined', f:'' }, 'event.getState()' );
-        deepEqual( event.getState('a'), { a:2, b:2, d:false, e:undefined, f:'' },  'event.getState( true )' );
-        equal( event.getState('a'), '2', 'event.getState( "a" )' );
-        equal( event.getState('a',true), 2, 'event.getState( "a", true )' );
-        equal( event.getState('b'), '2', 'event.getState( "b" )' );
-        equal( event.getState('b',true), 2, 'event.getState( "b", true )' );
-        equal( event.getState('c'), undefined, 'event.getState( "c" )' );
-        equal( event.getState('c',true), undefined, 'event.getState( "c", true )' );
-        equal( event.getState('d'), 'false', 'event.getState( "d" )' );
-        equal( event.getState('d',true), false, 'event.getState( "d", true )' );
-        equal( event.getState('e'), 'undefined', 'event.getState( "e" )' );
-        equal( event.getState('e',true), undefined, 'event.getState( "e", true )' );
-        equal( event.getState('f'), '', 'event.getState( "f" )' );
-        equal( event.getState('f',true), '', 'event.getState( "f", true )' );
+        QUnit.assert.deepEqual( event.getState(), { a:'2', b:'2', d:'false', e:'undefined', f:'' }, 'event.getState()' );
+        QUnit.assert.deepEqual( event.getState('a'), { a:2, b:2, d:false, e:undefined, f:'' },  'event.getState( true )' );
+        QUnit.assert.equal( event.getState('a'), '2', 'event.getState( "a" )' );
+        QUnit.assert.equal( event.getState('a',true), 2, 'event.getState( "a", true )' );
+        QUnit.assert.equal( event.getState('b'), '2', 'event.getState( "b" )' );
+        QUnit.assert.equal( event.getState('b',true), 2, 'event.getState( "b", true )' );
+        QUnit.assert.equal( event.getState('c'), undefined, 'event.getState( "c" )' );
+        QUnit.assert.equal( event.getState('c',true), undefined, 'event.getState( "c", true )' );
+        QUnit.assert.equal( event.getState('d'), 'false', 'event.getState( "d" )' );
+        QUnit.assert.equal( event.getState('d',true), false, 'event.getState( "d", true )' );
+        QUnit.assert.equal( event.getState('e'), 'undefined', 'event.getState( "e" )' );
+        QUnit.assert.equal( event.getState('e',true), undefined, 'event.getState( "e", true )' );
+        QUnit.assert.equal( event.getState('f'), '', 'event.getState( "f" )' );
+        QUnit.assert.equal( event.getState('f',true), '', 'event.getState( "f", true )' );
       }
     },
 
@@ -1060,36 +1057,36 @@ test( 'jQuery.bbq.pushState(), jQuery.bbq.getState(), jQuery.bbq.removeState(), 
     },
 
     function(result){
-      equal( hash_actual, '#!' + hash, 'hash should begin with #!' );
-      deepEqual( obj.str, { a:'2', b:'2' }, '$.bbq.getState()' );
-      deepEqual( obj.coerce, { a:2, b:2 },  '$.bbq.getState( true )' );
-      equal( a.str, '2', '$.bbq.getState( "a" )' );
-      equal( a.coerce, 2, '$.bbq.getState( "a", true )' );
-      equal( b.str, '2', '$.bbq.getState( "b" )' );
-      equal( b.coerce, 2, '$.bbq.getState( "b", true )' );
-      equal( c.str, undefined, '$.bbq.getState( "c" )' );
-      equal( c.coerce, undefined, '$.bbq.getState( "c", true )' );
-      equal( d.str, undefined, '$.bbq.getState( "d" )' );
-      equal( d.coerce, undefined, '$.bbq.getState( "d", true )' );
-      equal( e.str, undefined, '$.bbq.getState( "e" )' );
-      equal( e.coerce, undefined, '$.bbq.getState( "e", true )' );
-      equal( f.str, undefined, '$.bbq.getState( "f" )' );
-      equal( f.coerce, undefined, '$.bbq.getState( "f", true )' );
+      QUnit.assert.equal( hash_actual, '#!' + hash, 'hash should begin with #!' );
+      QUnit.assert.deepEqual( obj.str, { a:'2', b:'2' } as any, '$.bbq.getState()' );
+      QUnit.assert.deepEqual( obj.coerce, { a:2, b:2 } as any,  '$.bbq.getState( true )' );
+      QUnit.assert.equal( a.str, '2', '$.bbq.getState( "a" )' );
+      QUnit.assert.equal( a.coerce, 2, '$.bbq.getState( "a", true )' );
+      QUnit.assert.equal( b.str, '2', '$.bbq.getState( "b" )' );
+      QUnit.assert.equal( b.coerce, 2, '$.bbq.getState( "b", true )' );
+      QUnit.assert.equal( c.str, undefined, '$.bbq.getState( "c" )' );
+      QUnit.assert.equal( c.coerce, undefined, '$.bbq.getState( "c", true )' );
+      QUnit.assert.equal( d.str, undefined, '$.bbq.getState( "d" )' );
+      QUnit.assert.equal( d.coerce, undefined, '$.bbq.getState( "d", true )' );
+      QUnit.assert.equal( e.str, undefined, '$.bbq.getState( "e" )' );
+      QUnit.assert.equal( e.coerce, undefined, '$.bbq.getState( "e", true )' );
+      QUnit.assert.equal( f.str, undefined, '$.bbq.getState( "f" )' );
+      QUnit.assert.equal( f.coerce, undefined, '$.bbq.getState( "f", true )' );
       if ( !old_jquery ) {
-        deepEqual( event.getState(), { a:'2', b:'2' }, 'event.getState()' );
-        deepEqual( event.getState('a'), { a:2, b:2 },  'event.getState( true )' );
-        equal( event.getState('a'), '2', 'event.getState( "a" )' );
-        equal( event.getState('a',true), 2, 'event.getState( "a", true )' );
-        equal( event.getState('b'), '2', 'event.getState( "b" )' );
-        equal( event.getState('b',true), 2, 'event.getState( "b", true )' );
-        equal( event.getState('c'), undefined, 'event.getState( "c" )' );
-        equal( event.getState('c',true), undefined, 'event.getState( "c", true )' );
-        equal( event.getState('d'), undefined, 'event.getState( "d" )' );
-        equal( event.getState('d',true), undefined, 'event.getState( "d", true )' );
-        equal( event.getState('e'), undefined, 'event.getState( "e" )' );
-        equal( event.getState('e',true), undefined, 'event.getState( "e", true )' );
-        equal( event.getState('f'), undefined, 'event.getState( "f" )' );
-        equal( event.getState('f',true), undefined, 'event.getState( "f", true )' );
+        QUnit.assert.deepEqual( event.getState(), { a:'2', b:'2' }, 'event.getState()' );
+        QUnit.assert.deepEqual( event.getState('a'), { a:2, b:2 },  'event.getState( true )' );
+        QUnit.assert.equal( event.getState('a'), '2', 'event.getState( "a" )' );
+        QUnit.assert.equal( event.getState('a',true), 2, 'event.getState( "a", true )' );
+        QUnit.assert.equal( event.getState('b'), '2', 'event.getState( "b" )' );
+        QUnit.assert.equal( event.getState('b',true), 2, 'event.getState( "b", true )' );
+        QUnit.assert.equal( event.getState('c'), undefined, 'event.getState( "c" )' );
+        QUnit.assert.equal( event.getState('c',true), undefined, 'event.getState( "c", true )' );
+        QUnit.assert.equal( event.getState('d'), undefined, 'event.getState( "d" )' );
+        QUnit.assert.equal( event.getState('d',true), undefined, 'event.getState( "d", true )' );
+        QUnit.assert.equal( event.getState('e'), undefined, 'event.getState( "e" )' );
+        QUnit.assert.equal( event.getState('e',true), undefined, 'event.getState( "e", true )' );
+        QUnit.assert.equal( event.getState('f'), undefined, 'event.getState( "f" )' );
+        QUnit.assert.equal( event.getState('f',true), undefined, 'event.getState( "f", true )' );
       }
     },
 
@@ -1098,36 +1095,36 @@ test( 'jQuery.bbq.pushState(), jQuery.bbq.getState(), jQuery.bbq.removeState(), 
     },
 
     function(result){
-      equal( hash_actual, '#!', 'hash should just be #!' );
-      deepEqual( obj.str, {}, '$.bbq.getState()' );
-      deepEqual( obj.coerce, {},  '$.bbq.getState( true )' );
-      equal( a.str, undefined, '$.bbq.getState( "a" )' );
-      equal( a.coerce, undefined, '$.bbq.getState( "a", true )' );
-      equal( b.str, undefined, '$.bbq.getState( "b" )' );
-      equal( b.coerce, undefined, '$.bbq.getState( "b", true )' );
-      equal( c.str, undefined, '$.bbq.getState( "c" )' );
-      equal( c.coerce, undefined, '$.bbq.getState( "c", true )' );
-      equal( d.str, undefined, '$.bbq.getState( "d" )' );
-      equal( d.coerce, undefined, '$.bbq.getState( "d", true )' );
-      equal( e.str, undefined, '$.bbq.getState( "e" )' );
-      equal( e.coerce, undefined, '$.bbq.getState( "e", true )' );
-      equal( f.str, undefined, '$.bbq.getState( "f" )' );
-      equal( f.coerce, undefined, '$.bbq.getState( "f", true )' );
+      QUnit.assert.equal( hash_actual, '#!', 'hash should just be #!' );
+      QUnit.assert.deepEqual( obj.str, {} as any, '$.bbq.getState()' );
+      QUnit.assert.deepEqual( obj.coerce, {} as any,  '$.bbq.getState( true )' );
+      QUnit.assert.equal( a.str, undefined, '$.bbq.getState( "a" )' );
+      QUnit.assert.equal( a.coerce, undefined, '$.bbq.getState( "a", true )' );
+      QUnit.assert.equal( b.str, undefined, '$.bbq.getState( "b" )' );
+      QUnit.assert.equal( b.coerce, undefined, '$.bbq.getState( "b", true )' );
+      QUnit.assert.equal( c.str, undefined, '$.bbq.getState( "c" )' );
+      QUnit.assert.equal( c.coerce, undefined, '$.bbq.getState( "c", true )' );
+      QUnit.assert.equal( d.str, undefined, '$.bbq.getState( "d" )' );
+      QUnit.assert.equal( d.coerce, undefined, '$.bbq.getState( "d", true )' );
+      QUnit.assert.equal( e.str, undefined, '$.bbq.getState( "e" )' );
+      QUnit.assert.equal( e.coerce, undefined, '$.bbq.getState( "e", true )' );
+      QUnit.assert.equal( f.str, undefined, '$.bbq.getState( "f" )' );
+      QUnit.assert.equal( f.coerce, undefined, '$.bbq.getState( "f", true )' );
       if ( !old_jquery ) {
-        deepEqual( event.getState(), {}, 'event.getState()' );
-        deepEqual( event.getState('a'), {},  'event.getState( true )' );
-        equal( event.getState('a'), undefined, 'event.getState( "a" )' );
-        equal( event.getState('a',true), undefined, 'event.getState( "a", true )' );
-        equal( event.getState('b'), undefined, 'event.getState( "b" )' );
-        equal( event.getState('b',true), undefined, 'event.getState( "b", true )' );
-        equal( event.getState('c'), undefined, 'event.getState( "c" )' );
-        equal( event.getState('c',true), undefined, 'event.getState( "c", true )' );
-        equal( event.getState('d'), undefined, 'event.getState( "d" )' );
-        equal( event.getState('d',true), undefined, 'event.getState( "d", true )' );
-        equal( event.getState('e'), undefined, 'event.getState( "e" )' );
-        equal( event.getState('e',true), undefined, 'event.getState( "e", true )' );
-        equal( event.getState('f'), undefined, 'event.getState( "f" )' );
-        equal( event.getState('f',true), undefined, 'event.getState( "f", true )' );
+        QUnit.assert.deepEqual( event.getState(), {}, 'event.getState()' );
+        QUnit.assert.deepEqual( event.getState('a'), {},  'event.getState( true )' );
+        QUnit.assert.equal( event.getState('a'), undefined, 'event.getState( "a" )' );
+        QUnit.assert.equal( event.getState('a',true), undefined, 'event.getState( "a", true )' );
+        QUnit.assert.equal( event.getState('b'), undefined, 'event.getState( "b" )' );
+        QUnit.assert.equal( event.getState('b',true), undefined, 'event.getState( "b", true )' );
+        QUnit.assert.equal( event.getState('c'), undefined, 'event.getState( "c" )' );
+        QUnit.assert.equal( event.getState('c',true), undefined, 'event.getState( "c", true )' );
+        QUnit.assert.equal( event.getState('d'), undefined, 'event.getState( "d" )' );
+        QUnit.assert.equal( event.getState('d',true), undefined, 'event.getState( "d", true )' );
+        QUnit.assert.equal( event.getState('e'), undefined, 'event.getState( "e" )' );
+        QUnit.assert.equal( event.getState('e',true), undefined, 'event.getState( "e", true )' );
+        QUnit.assert.equal( event.getState('f'), undefined, 'event.getState( "f" )' );
+        QUnit.assert.equal( event.getState('f',true), undefined, 'event.getState( "f", true )' );
       }
     },
 
@@ -1143,16 +1140,16 @@ test( 'jQuery.bbq.pushState(), jQuery.bbq.getState(), jQuery.bbq.removeState(), 
           ? '[object Object]'
           : {x:[7], y:8} as any;//z:[9,0,true,false,undefined,'']};
 
-      equal( hash_actual, '#!' + hash, 'hash should begin with #!' );
-      deepEqual( obj.str, { a:['4','5','6'], b:b_str }, '$.bbq.getState()' );
-      deepEqual( obj.coerce, { a:[4,5,6], b:b_coerce },  '$.bbq.getState( true )' );
-      deepEqual( a.str, ['4','5','6'], '$.bbq.getState( "a" )' );
-      deepEqual( a.coerce, [4,5,6], '$.bbq.getState( "a", true )' );
+      QUnit.assert.equal( hash_actual, '#!' + hash, 'hash should begin with #!' );
+      QUnit.assert.deepEqual( obj.str, { a:['4','5','6'], b:b_str } as any, '$.bbq.getState()' );
+      QUnit.assert.deepEqual( obj.coerce, { a:[4,5,6], b:b_coerce } as any,  '$.bbq.getState( true )' );
+      QUnit.assert.deepEqual( a.str, ['4','5','6'] as any, '$.bbq.getState( "a" )' );
+      QUnit.assert.deepEqual( a.coerce, [4,5,6] as any, '$.bbq.getState( "a", true )' );
       if ( !old_jquery ) {
-        deepEqual( event.getState(), { a:['4','5','6'], b:b_str }, 'event.getState()' );
-        deepEqual( event.getState('a'), { a:[4,5,6], b:b_coerce },  'event.getState( true )' );
-        deepEqual( event.getState('a'), ['4','5','6'], 'event.getState( "a" )' );
-        deepEqual( event.getState('a',true), [4,5,6], 'event.getState( "a", true )' );
+        QUnit.assert.deepEqual( event.getState(), { a:['4','5','6'], b:b_str }, 'event.getState()' );
+        QUnit.assert.deepEqual( event.getState('a'), { a:[4,5,6], b:b_coerce },  'event.getState( true )' );
+        QUnit.assert.deepEqual( event.getState('a'), ['4','5','6'], 'event.getState( "a" )' );
+        QUnit.assert.deepEqual( event.getState('a',true), [4,5,6], 'event.getState( "a", true )' );
       }
     },
 
@@ -1166,32 +1163,32 @@ test( 'jQuery.bbq.pushState(), jQuery.bbq.getState(), jQuery.bbq.removeState(), 
           ? '[object Object]'
           : {x:[7], y:8} as any;//, z:[9,0,true,false,undefined,'']};
 
-      equal( hash_actual, '#!' + hash, 'hash should begin with #!' );
-      deepEqual( obj.str, { a:['4','5','6'], b:b_str, c:'2' }, '$.bbq.getState()' );
-      deepEqual( obj.coerce, { a:[4,5,6], b:b_coerce, c:2 },  '$.bbq.getState( true )' );
+      QUnit.assert.equal( hash_actual, '#!' + hash, 'hash should begin with #!' );
+      QUnit.assert.deepEqual( obj.str, { a:['4','5','6'], b:b_str, c:'2' } as any, '$.bbq.getState()' );
+      QUnit.assert.deepEqual( obj.coerce, { a:[4,5,6], b:b_coerce, c:2 } as any,  '$.bbq.getState( true )' );
       if ( !old_jquery ) {
-        deepEqual( event.getState(), { a:['4','5','6'], b:b_str, c:'2' }, 'event.getState()' );
-        deepEqual( event.getState('a'), { a:[4,5,6], b:b_coerce, c:2 },  'event.getState( true )' );
+        QUnit.assert.deepEqual( event.getState(), { a:['4','5','6'], b:b_str, c:'2' }, 'event.getState()' );
+        QUnit.assert.deepEqual( event.getState('a'), { a:[4,5,6], b:b_coerce, c:2 },  'event.getState( true )' );
       }
     },
 
     [ '#/path/to/file.php' as any, 2 ],
 
     function(result){
-      equal( hash_actual, '#!' + hash, 'hash should begin with #!' );
-      equal( hash, '/path/to/file.php', '$.param.fragment()' );
+      QUnit.assert.equal( hash_actual, '#!' + hash, 'hash should begin with #!' );
+      QUnit.assert.equal( hash, '/path/to/file.php', '$.param.fragment()' );
       if ( !old_jquery ) {
-        equal( event.fragment, '/path/to/file.php', 'event.fragment' );
+        QUnit.assert.equal( event.fragment, '/path/to/file.php', 'event.fragment' );
       }
     },
 
     [],
 
     function(result){
-      equal( hash_actual, '#!', 'hash should just be #!' );
-      equal( hash, '', '$.param.fragment()' );
+      QUnit.assert.equal( hash_actual, '#!', 'hash should just be #!' );
+      QUnit.assert.equal( hash, '', '$.param.fragment()' );
       if ( !old_jquery ) {
-        equal( event.fragment, '', 'event.fragment' );
+        QUnit.assert.equal( event.fragment, '', 'event.fragment' );
       }
     },
 
@@ -1204,18 +1201,18 @@ test( 'jQuery.bbq.pushState(), jQuery.bbq.getState(), jQuery.bbq.removeState(), 
     [ '#omg_ponies' as any, 2 ],
 
     function(result){
-      equal( hash, 'omg_ponies', 'event handler 1: $.param.fragment()' );
-      equal( x, 'omg_ponies', 'event handler 2: $.param.fragment()' );
+      QUnit.assert.equal( hash, 'omg_ponies', 'event handler 1: $.param.fragment()' );
+      QUnit.assert.equal( x, 'omg_ponies', 'event handler 2: $.param.fragment()' );
 
       hash = x = '';
-      equal( hash + x, '', 'vars reset' );
+      QUnit.assert.equal( hash + x, '', 'vars reset' );
 
       $(window).triggerHandler( 'hashchange' );
-      equal( hash, 'omg_ponies', 'event handler 1: $.param.fragment()' );
-      equal( x, 'omg_ponies', 'event handler 2: $.param.fragment()' );
+      QUnit.assert.equal( hash, 'omg_ponies', 'event handler 1: $.param.fragment()' );
+      QUnit.assert.equal( x, 'omg_ponies', 'event handler 2: $.param.fragment()' );
 
       hash = x = '';
-      equal( hash + x, '', 'vars reset' );
+      QUnit.assert.equal( hash + x, '', 'vars reset' );
 
       $(window).unbind( 'hashchange' );
     },
@@ -1223,11 +1220,11 @@ test( 'jQuery.bbq.pushState(), jQuery.bbq.getState(), jQuery.bbq.removeState(), 
     [ '#almost_done?not_search' as any, 2 ],
 
     function(result){
-      equal( hash, '', 'event handler 1: $.param.fragment()' );
-      equal( x, '', 'event handler 2: $.param.fragment()' );
+      QUnit.assert.equal( hash, '', 'event handler 1: $.param.fragment()' );
+      QUnit.assert.equal( x, '', 'event handler 2: $.param.fragment()' );
 
       var events:any;// = $.data( window, 'events' );
-      ok( !events || !events.hashchange, 'hashchange event unbound' );
+      QUnit.assert.ok( !events || !events.hashchange, 'hashchange event unbound' );
     },
 
     [ '#' ],
@@ -1258,14 +1255,14 @@ test( 'jQuery.bbq.pushState(), jQuery.bbq.getState(), jQuery.bbq.removeState(), 
     function(result){
       if ( is_chrome ) {
         // Read about this issue here: http://benalman.com/news/2009/09/chrome-browser-history-buggine/
-        ok( true, 'history is sporadically broken in chrome, this is a known bug, so this test is skipped in chrome' );
+        QUnit.assert.ok( true, 'history is sporadically broken in chrome, this is a known bug, so this test is skipped in chrome' );
       } else {
-        deepEqual( x, ['almost_done?not_search', 'omg_ponies', '', '/path/to/file.php'], 'back button and window.bbq.go(-1) should work' );
+        QUnit.assert.deepEqual( x, ['almost_done?not_search', 'omg_ponies', '', '/path/to/file.php'], 'back button and window.bbq.go(-1) should work' );
       }
 
       $(window).unbind( 'hashchange' );
       var events: any;// = $.data( window, 'events' );
-      ok( !events || !events.hashchange, 'hashchange event unbound' );
+      QUnit.assert.ok( !events || !events.hashchange, 'hashchange event unbound' );
     },
 
     function(result){

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -1,4 +1,4 @@
-/// <reference types="qunit/v1" />
+/// <reference types="qunit" />
 import * as ShareDB from 'sharedb';
 import * as http from 'http';
 import * as WebSocket from 'ws';


### PR DESCRIPTION
references to `v1` in the test files work on Definitely Typed but don't reflect real usage, which specifies versions using package.json.

The fix in this case is easy -- switch to current version of qunit. This required some test changes to jquery.bbq, but they were all renames, essentially.