### PR TITLE
[redux-state-sync] feat: pass complete action to predicate function

### DIFF
--- a/types/redux-state-sync/index.d.ts
+++ b/types/redux-state-sync/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for redux-state-sync 2.0
+// Type definitions for redux-state-sync 3.0
 // Project: https://github.com/AOHUA/redux-state-sync#readme
 // Definitions by: MU AOHUA <https://github.com/AOHUA>
 //                 AntonioMendez <https://github.com/AntonioMendez>
@@ -11,12 +11,13 @@ import BroadcastChannel from "broadcast-channel";
 export interface Stamp {
     $uuid: string;
     $wuid: string;
+    $isSync: boolean;
 }
 export type StampedAction = Stamp & AnyAction;
 
 export interface Config {
     channel?: string;
-    predicate?: (type?: string) => boolean | null;
+    predicate?: (action:AnyAction) => boolean | null;
     blacklist?: string[];
     whitelist?: string[];
     broadcastChannelOption?: object | null;
@@ -25,7 +26,7 @@ export interface Config {
 export interface MessageListenerConfig {
     channel: BroadcastChannel;
     dispatch: (action: AnyAction | StampedAction) => void;
-    allowed: (type?: string) => boolean;
+    allowed: (action:AnyAction) => boolean;
 }
 
 export function generateUuidForAction(action: AnyAction): StampedAction;

--- a/types/redux-state-sync/index.d.ts
+++ b/types/redux-state-sync/index.d.ts
@@ -17,7 +17,7 @@ export type StampedAction = Stamp & AnyAction;
 
 export interface Config {
     channel?: string;
-    predicate?: (action:AnyAction) => boolean | null;
+    predicate?: (action: AnyAction) => boolean | null;
     blacklist?: string[];
     whitelist?: string[];
     broadcastChannelOption?: object | null;
@@ -26,7 +26,7 @@ export interface Config {
 export interface MessageListenerConfig {
     channel: BroadcastChannel;
     dispatch: (action: AnyAction | StampedAction) => void;
-    allowed: (action:AnyAction) => boolean;
+    allowed: (action: AnyAction) => boolean;
 }
 
 export function generateUuidForAction(action: AnyAction): StampedAction;

--- a/types/redux-state-sync/redux-state-sync-tests.ts
+++ b/types/redux-state-sync/redux-state-sync-tests.ts
@@ -8,7 +8,7 @@ interface TestState {
 }
 const middleware = createStateSyncMiddleware({
         channel: 'test',
-        predicate: (type) => true,
+        predicate: (action) => true,
         blacklist: [],
         whitelist: [],
         broadcastChannelOption: {}


### PR DESCRIPTION
BREAKING: instead of only the type the complete action is now passed to the predicate function

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/AOHUA/redux-state-sync/pull/47
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
