### PR TITLE
[chart.js] Added missing property `z` to GridLineOptions.

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -162,7 +162,8 @@ const scaleOptions: Chart.RadialLinearScale = {
         zeroLineColor: 'rgba(0, 0, 0, 0.25)',
         zeroLineBorderDash: [],
         zeroLineBorderDashOffset: 0.0,
-        offsetGridLines: false
+        offsetGridLines: false,
+        z: 9
     }
 };
 const radarChartOptions: Chart.RadialChartOptions = {

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -510,6 +510,7 @@ declare namespace Chart {
         zeroLineBorderDash?: number[];
         zeroLineBorderDashOffset?: number;
         offsetGridLines?: boolean;
+        z?: number;
     }
 
     interface ScaleTitleOptions {


### PR DESCRIPTION
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.chartjs.org/docs/latest/axes/styling.html>>

Details:
z | number | 0 | z-index of gridline layer. Values <= 0 are drawn under datasets, > 0 on top.
