### PR TITLE
plotly.js: Add barnorm to Layout

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -277,9 +277,10 @@ export interface Layout {
 	legend: Partial<Legend>;
 	font: Partial<Font>;
 	scene: Partial<Scene>;
-	barmode: "stack" | "group" | "overlay" | "relative";
-	bargap: number;
-	bargroupgap: number;
+	barmode: 'stack' | 'group' | 'overlay' | 'relative';
+	barnorm: '' | 'fraction' | 'percent';
+	bargap: 0 | 1;
+	bargroupgap: 0 | 1;
 	selectdirection: 'h' | 'v' | 'd' | 'any';
 	hiddenlabels: string[];
 }

--- a/types/plotly.js/test/core-tests.ts
+++ b/types/plotly.js/test/core-tests.ts
@@ -1,5 +1,5 @@
 import * as Plotly from 'plotly.js/lib/core';
-import { Datum, ScatterData, Layout, PlotlyHTMLElement, newPlot } from 'plotly.js/lib/core';
+import { Datum, ScatterData, Layout, PlotlyHTMLElement, newPlot, PlotData } from 'plotly.js/lib/core';
 
 const graphDiv = '#test';
 
@@ -124,11 +124,11 @@ const graphDiv = '#test';
 // Plotly.relayout
 // update only values within nested objects
 (() => {
-	const update = {
+	const update: Partial<Layout> = {
 		title: 'some new title', // updates the title
 		'xaxis.range': [0, 5],   // updates the xaxis range
 		'yaxis.range[1]': 15	 // updates the end of the yaxis range
-	} as Layout;
+	};
 	Plotly.relayout(graphDiv, update);
 })();
 
@@ -146,11 +146,16 @@ const graphDiv = '#test';
 //////////////////////////////////////////////////////////////////////
 // Plotly.update
 (() => {
-	const data_update = {
-		marker: { color: 'red' }
+	const data_update: Partial<PlotData> = {
+		marker: { color: 'red' },
+		type: 'bar'
 	};
-	const layout_update = {
+	const layout_update: Partial<Layout> = {
 		title: 'some new title', // updates the title
+		barmode: 'stack',
+		barnorm: 'fraction',
+		bargap: 0,
+		bargroupgap: 0,
 	};
 	Plotly.update(graphDiv, data_update, layout_update);
 })();


### PR DESCRIPTION
Add barnorm to Plotly.Layout, and refine some parameters for bar.

https://plot.ly/javascript/reference/#layout-barnorm
https://github.com/plotly/plotly.js/blob/v1.44.0/src/traces/bar/layout_attributes.js#L31-L66

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/plotly/plotly.js/blob/v1.44.0/src/traces/bar/layout_attributes.js#L31-L66
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.