### PR TITLE
aws-lambda - removes the wrong assumption that headers are always set

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -125,7 +125,7 @@ strOrUndefined = apiGwEvtReqCtx.routeKey;
 
 /* API Gateway Event */
 strOrNull = apiGwEvt.body;
-str = apiGwEvt.headers['example'];
+str = apiGwEvt.headers!['example'];
 str = apiGwEvt.multiValueHeaders['example'][0];
 str = apiGwEvt.httpMethod;
 bool = apiGwEvt.isBase64Encoded;

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -79,7 +79,7 @@ export interface APIGatewayEventRequestContext {
 // API Gateway "event"
 export interface APIGatewayProxyEvent {
     body: string | null;
-    headers: { [name: string]: string };
+    headers?: { [name: string]: string };
     multiValueHeaders: { [name: string]: string[] };
     httpMethod: string;
     isBase64Encoded: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

Sorry, at the time, I can't find any good docs for this, better than https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html

which states that "the event structure varies by service.".

However, the reason fot the PR is by imperical/anecdotal evidence :) When testing a lambda in aws console without providing any headers, null was passed giving my typechecked code a NPE.