### PR TITLE
[webpack] Remove properties defination that has been removed in source

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -113,8 +113,6 @@ declare namespace webpack {
         /** Enter watch mode, which rebuilds on file change. */
         watch?: boolean;
         watchOptions?: Options.WatchOptions;
-        /** Switch loaders to debug mode. */
-        debug?: boolean;
         /** Include polyfills or mocks for various node stuff */
         node?: Node | false;
         /** Set the value of require.amd and define.amd. */
@@ -265,10 +263,6 @@ declare namespace webpack {
     }
 
     interface Module {
-        /** A array of applied pre loaders. */
-        preLoaders?: RuleSetRule[];
-        /** A array of applied post loaders. */
-        postLoaders?: RuleSetRule[];
         /** A RegExp or an array of RegExps. Don’t parse files matching. */
         noParse?: RegExp | RegExp[] | ((content: string) => boolean);
         unknownContextRequest?: string;


### PR DESCRIPTION
* remove Module.preLoaders, Module.postLoaders and Configuration.debug. These properties has been removed by webpack2.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/migrate/3/#modulepreloaders-and-modulepostloaders-were-removed
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
