### PR TITLE
[react] Add crossOrigin to SVGAttributes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2259,6 +2259,7 @@ declare namespace React {
         // Other HTML properties supported by SVG elements in browsers
         role?: string;
         tabIndex?: number;
+        crossOrigin?: "anonymous" | "use-credentials" | "";
 
         // SVG Specific attributes
         accentHeight?: number | string;

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -26,4 +26,5 @@ const testCases = [
     <span autoCorrect="on" />,
     <span translate="no" />,
     <span translate="yes" />,
+    <svg><image crossOrigin="anonymous"/></svg>,
 ];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

React supports SVG `<image>` elements with a `crossOrigin` prop. It even special-cases that prop so that it's rendered as an all-lowercase attribute in HTML (see https://github.com/facebook/react/pull/14832). 

This PR updates `@types/react` to reflect this, letting us write:

```tsx
<image crossOrigin="anonymous"/>
```

instead of workarounds like:

```tsx
<image {...{ crossOrigin: "anonymous" }}/>
```