### PR TITLE
Types for @edtr-io/mathquill

### DIFF
--- a/types/mathquill/index.d.ts
+++ b/types/mathquill/index.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for mathquill 0.10
+// Project: https://github.com/edtr-io/mathquill#readme
+// Definitions by: Marco Gonzalez <https://github.com/magonzalez9>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+export interface MathField {
+    focus(): MQ;
+    blur(): MQ;
+    write(latex: string): MQ;
+    cmd(latex: string): MQ;
+    select(): MQ;
+    clearSelection(): MQ;
+    moveToLeftEnd(): MQ;
+    moveToRightEnd(): MQ;
+    moveToDirEnd(direction: number): MQ;
+    keystroke(keys: string): MQ;
+    typedText(text: string): MQ;
+    config(config: Config): MQ;
+}
+
+export interface MQ extends MathField {
+    L: number;
+    R: number;
+    revert(): MQ;
+    reflow(): MQ;
+    el(): HTMLElement;
+    latex(): string;
+    latex(latex: string): MQ;
+}
+
+export interface Config {
+    spaceBehavesLikeTab?: boolean;
+    leftRightIntoCmdGoes?: string;
+    restrictMismatchedBrackets?: boolean;
+    sumStartsWithNEquals?: boolean;
+    supSubsRequireOperand?: boolean;
+    charsThatBreakOutOfSupSub?: string;
+    autoSubscriptNumerals?: boolean;
+    autoCommands?: string;
+    autoOperatorNames?: string;
+    maxDepth?: number;
+    substituteTextarea?(): HTMLTextAreaElement;
+    handlers?: {
+        enter?(mathField: MQ): any;
+        edit?(mathField: MQ): any;
+        upOutOf?(mathField: MQ): any;
+        moveOutOf?(direction: number, mathField: MQ): any;
+    };
+}

--- a/types/mathquill/mathquill-tests.ts
+++ b/types/mathquill/mathquill-tests.ts
@@ -1,0 +1,39 @@
+import { MQ, Config } from 'mathquill';
+
+const Test = () => {
+    const config: Config = {
+        spaceBehavesLikeTab: true,
+        leftRightIntoCmdGoes: 'up',
+        autoSubscriptNumerals: true,
+        maxDepth: 10,
+        substituteTextarea() {
+            return document.createElement('textarea');
+        },
+        restrictMismatchedBrackets: true,
+        sumStartsWithNEquals: true,
+        supSubsRequireOperand: true,
+        charsThatBreakOutOfSupSub: '+-=<>',
+        autoCommands: 'pi theta sqrt',
+        autoOperatorNames: 'sin cos tan log',
+        handlers: {
+            edit(mathField: MQ) {
+                return mathField;
+            },
+            enter(mathField: MQ) {
+                mathField.blur();
+                mathField.focus();
+                mathField.keystroke('Tab');
+                mathField.typedText('test');
+                mathField.moveToLeftEnd();
+                mathField.moveToRightEnd();
+                mathField.moveToDirEnd(1);
+            },
+            upOutOf(mathField: MQ) {
+                mathField.keystroke('Enter');
+            },
+            moveOutOf(dir: number, mathField: MQ) {
+                if (dir === 1) mathField.clearSelection();
+            },
+        },
+    };
+};

--- a/types/mathquill/tsconfig.json
+++ b/types/mathquill/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mathquill-tests.ts"
+    ]
+}

--- a/types/mathquill/tslint.json
+++ b/types/mathquill/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.