### PR TITLE
react-widgets: fix busySpinner missing from DropdownList typing

### DIFF
--- a/types/react-widgets/index.d.ts
+++ b/types/react-widgets/index.d.ts
@@ -8,6 +8,8 @@
 //                 Georg Steinmetz <https://github.com/georg94>
 //                 Troy Zarger <https://github.com/tzarger>
 //                 Siya Mzam  <https://github.com/vegtelenseg>
+//                 Cale Bergh <https://github.com/calebergh>
+//                 Ryan McKeel <https://github.com/rmckeel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-widgets/index.d.ts
+++ b/types/react-widgets/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-widgets 4.3
+// Type definitions for react-widgets 4.4
 // Project: https://github.com/jquense/react-widgets, http://jquense.github.io/react-widgets/docs
 // Definitions by: Rogier Schouten <https://github.com/rogierschouten>
 //                 Balázs Sándor <https://github.com/sanyatuning>

--- a/types/react-widgets/lib/DropdownList.d.ts
+++ b/types/react-widgets/lib/DropdownList.d.ts
@@ -143,6 +143,11 @@ interface DropdownListProps extends ReactWidgetsCommonDropdownProps<DropdownList
      */
     busy?: boolean;
     /**
+     * An optional ReactNode to override the spinner gif element when the busy property
+     * is set to true.
+     */
+    busySpinner?: React.ReactNode;
+    /**
      * The speed, in milliseconds, of the dropdown animation.
      * @default 250
      */


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://jquense.github.io/react-widgets/api/DropdownList/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
