### PR TITLE
Types for winston-loggly-bulk

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
             "_comment": "This will remove husky from when we started migrating to use prettier",
             "pre-commit": "npm uninstall husky"
         }
-    },
+    }
 }

--- a/package.json
+++ b/package.json
@@ -31,5 +31,6 @@
             "_comment": "This will remove husky from when we started migrating to use prettier",
             "pre-commit": "npm uninstall husky"
         }
-    }
+    },
+    "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -32,5 +32,4 @@
             "pre-commit": "npm uninstall husky"
         }
     },
-    "dependencies": {}
 }

--- a/types/winston-loggly-bulk/index.d.ts
+++ b/types/winston-loggly-bulk/index.d.ts
@@ -1,0 +1,72 @@
+// Type definitions for winston-loggly-bulk 3.0
+// Project: https://github.com/hongyiweiwu/winston-loggly-bulk
+// Definitions by: Yi Hong <https://github.com/hongyiweiwu>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import TransportStream = require("winston-transport");
+
+declare module 'winston/lib/winston/transports' {
+    interface Transports {
+        Loggly: typeof Loggly;
+        flushLogsAndExit: typeof flushLogsAndExit;
+    }
+}
+
+export namespace Loggly {
+    interface LogglyBulkTransportOptions extends TransportStream.TransportStreamOptions {
+        /**
+         * The subdomain of your Loggly account.
+         */
+        subdomain: string;
+
+        /**
+         * The authentication information for your Loggly account.
+         */
+        auth?: string;
+
+        /**
+         * The name of the input this instance should log to.
+         */
+        inputName?: string;
+        /**
+         * The input token of the input this instance should log to.
+         */
+        inputToken?: string;
+        /**
+         * If true, messages will be sent to Loggly as JSON.
+         */
+        json?: boolean;
+        /**
+         * An array  of tags to send to loggly.
+         */
+        tags?: string[];
+        /**
+         * If true, sends messages using bulk url.
+         */
+        isBulk?: boolean;
+        /**
+         * Strip color codes from the logs before sending.
+         */
+        stripColors?: boolean;
+        bufferOptions?: {
+            /**
+             * Number of logs to be buffered.
+             */
+            size?: number;
+            /**
+             * Time in milliseconds to retry sending buffered logs.
+             */
+            retriesInMilliSeconds?: number;
+        };
+        /**
+         * If false, library will not include timestamp in log events.
+         */
+        timestamp?: boolean;
+    }
+}
+
+export function flushLogsAndExit(): void;
+
+export class Loggly extends TransportStream {
+    constructor(options: Loggly.LogglyBulkTransportOptions);
+}

--- a/types/winston-loggly-bulk/package.json
+++ b/types/winston-loggly-bulk/package.json
@@ -1,0 +1,7 @@
+{
+    "dependencies": {
+        "logform": "^2.1.2",
+        "winston-transport": "^4.3.0"
+    },
+    "private": true
+}

--- a/types/winston-loggly-bulk/tsconfig.json
+++ b/types/winston-loggly-bulk/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "winston-loggly-bulk-tests.ts"
+    ]
+}

--- a/types/winston-loggly-bulk/tslint.json
+++ b/types/winston-loggly-bulk/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/winston-loggly-bulk/winston-loggly-bulk-tests.ts
+++ b/types/winston-loggly-bulk/winston-loggly-bulk-tests.ts
@@ -1,0 +1,3 @@
+// To be added.
+
+let a = 2;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.