### PR TITLE
Add missing isVisible prop  to renderMonthElement

### DIFF
--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -75,6 +75,7 @@ declare namespace ReactDates {
                 month: momentPropTypes.momentObj;
                 onMonthSelect: (currentMonth: momentPropTypes.momentObj, newMonthVal: string) => void;
                 onYearSelect: (currentMonth: momentPropTypes.momentObj, newYearVal: string) => void;
+                isVisible: boolean;
             }
         ) => string | JSX.Element;
         orientation?: OrientationShape;
@@ -179,6 +180,7 @@ declare namespace ReactDates {
                 month: momentPropTypes.momentObj;
                 onMonthSelect: (currentMonth: momentPropTypes.momentObj, newMonthVal: string) => void;
                 onYearSelect: (currentMonth: momentPropTypes.momentObj, newYearVal: string) => void;
+                isVisible: boolean;
             }
         ) => string | JSX.Element;
         orientation?: OrientationShape;
@@ -420,6 +422,7 @@ declare namespace ReactDates {
                 month: momentPropTypes.momentObj;
                 onMonthSelect: (currentMonth: momentPropTypes.momentObj, newMonthVal: string) => void;
                 onYearSelect: (currentMonth: momentPropTypes.momentObj, newYearVal: string) => void;
+                isVisible: boolean;
             }
         ) => string | JSX.Element;
         enableOutsideDays?: boolean;


### PR DESCRIPTION
The react-dates docs (https://github.com/airbnb/react-dates) state that `isVisible` is a prop available with the optional `renderMonthElement` prop:

![image](https://user-images.githubusercontent.com/13546265/70356597-bdd54400-1842-11ea-9c3b-637aed8e3ed9.png)

However, `isVisible` is not currently listed as a prop for `renderMonthElement` and a typescript error is thrown.
