### PR TITLE
react-map-gl - Added missing types

### DIFF
--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -221,7 +221,7 @@ export interface FlyToInterpolatorProps {
     speed?: number;
     screenSpeed?: number;
     maxDuraiton?: number;
-};
+}
 
 export class FlyToInterpolator extends TransitionInterpolator {
     constructor(props?: FlyToInterpolatorProps);

--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -80,10 +80,7 @@ export interface QueryRenderedFeaturesParams {
 
 export class StaticMap extends React.PureComponent<StaticMapProps> {
     getMap(): MapboxGL.Map;
-    queryRenderedFeatures(
-        geometry?: MapboxGL.PointLike | MapboxGL.PointLike[],
-        parameters?: QueryRenderedFeaturesParams,
-    ): Array<GeoJSON.Feature<GeoJSON.GeometryObject>>;
+    queryRenderedFeatures(geometry?: MapboxGL.PointLike | MapboxGL.PointLike[], parameters?: QueryRenderedFeaturesParams): Array<GeoJSON.Feature<GeoJSON.GeometryObject>>;
 }
 
 export interface ExtraState {
@@ -101,11 +98,7 @@ export interface PositionInput {
 
 export type ViewportChangeHandler = (viewState: ViewportProps) => void;
 
-export type ContextViewportChangeHandler = (
-    viewState: ViewportProps,
-    interactionState: ExtraState,
-    oldViewState: ViewportProps,
-) => void;
+export type ContextViewportChangeHandler = (viewState: ViewportProps, interactionState: ExtraState, oldViewState: ViewportProps) => void;
 
 export interface MapControllerOptions {
     onViewportChange?: ContextViewportChangeHandler;
@@ -214,7 +207,7 @@ export enum TRANSITION_EVENTS {
     BREAK = 1,
     SNAP_TO_END = 2,
     IGNORE = 3,
-    UPDATE = 4,
+    UPDATE = 4
 }
 
 export class TransitionInterpolator {}
@@ -223,7 +216,7 @@ export class LinearInterpolator extends TransitionInterpolator {
     constructor(transitionProps?: string[]);
 }
 
-export type FlyToInterpolatorProps = {
+export interface FlyToInterpolatorProps {
     curve?: number;
     speed?: number;
     screenSpeed?: number;
@@ -294,10 +287,7 @@ export interface InteractiveMapProps extends StaticMapProps {
 
 export class InteractiveMap extends React.PureComponent<InteractiveMapProps> {
     getMap(): MapboxGL.Map;
-    queryRenderedFeatures(
-        geometry?: MapboxGL.PointLike | MapboxGL.PointLike[],
-        parameters?: QueryRenderedFeaturesParams,
-    ): Array<GeoJSON.Feature<GeoJSON.GeometryObject>>;
+    queryRenderedFeatures(geometry?: MapboxGL.PointLike | MapboxGL.PointLike[], parameters?: QueryRenderedFeaturesParams): Array<GeoJSON.Feature<GeoJSON.GeometryObject>>;
 }
 
 export default InteractiveMap;

--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -4,6 +4,7 @@
 //                 Fabio Berta <https://github.com/fnberta>
 //                 Sander Siim <https://github.com/sandersiim>
 //                 Otto Urpelainen <https://github.com/oturpe>
+//                 Arman Safikhani <https://github.com/Arman92>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -126,7 +126,7 @@ export interface ViewportProps {
     minZoom: number;
     maxPitch: number;
     minPitch: number;
-    transitionDuration?: number;
+    transitionDuration?: number | 'auto';
     transitionInterpolator?: TransitionInterpolator;
     transitionInterruption?: TRANSITION_EVENTS;
     transitionEasing?: EasingFunction;
@@ -215,7 +215,16 @@ export class LinearInterpolator extends TransitionInterpolator {
     constructor(transitionProps?: string[]);
 }
 
-export class FlyToInterpolator extends TransitionInterpolator {}
+export type FlyToInterpolatorProps = {
+  curve?: number,
+  speed?: number,
+  screenSpeed?: number,
+  maxDuraiton?: number
+};
+
+export class FlyToInterpolator extends TransitionInterpolator {
+    constructor(props: FlyToInterpolatorProps = {})
+}
 
 export interface ViewStateChangeInfo {
     viewState: ViewportProps;
@@ -239,7 +248,7 @@ export interface InteractiveMapProps extends StaticMapProps {
     onViewStateChange?: ContextViewStateChangeHandler;
     onViewportChange?: ContextViewportChangeHandler;
     onInteractionStateChange?: (state: ExtraState) => void;
-    transitionDuration?: number;
+    transitionDuration?: number | 'auto';
     transitionInterpolator?: TransitionInterpolator;
     transitionInterruption?: TRANSITION_EVENTS;
     transitionEasing?: EasingFunction;

--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -79,7 +79,10 @@ export interface QueryRenderedFeaturesParams {
 
 export class StaticMap extends React.PureComponent<StaticMapProps> {
     getMap(): MapboxGL.Map;
-    queryRenderedFeatures(geometry?: MapboxGL.PointLike | MapboxGL.PointLike[], parameters?: QueryRenderedFeaturesParams): Array<GeoJSON.Feature<GeoJSON.GeometryObject>>;
+    queryRenderedFeatures(
+        geometry?: MapboxGL.PointLike | MapboxGL.PointLike[],
+        parameters?: QueryRenderedFeaturesParams,
+    ): Array<GeoJSON.Feature<GeoJSON.GeometryObject>>;
 }
 
 export interface ExtraState {
@@ -97,7 +100,11 @@ export interface PositionInput {
 
 export type ViewportChangeHandler = (viewState: ViewportProps) => void;
 
-export type ContextViewportChangeHandler = (viewState: ViewportProps, interactionState: ExtraState, oldViewState: ViewportProps) => void;
+export type ContextViewportChangeHandler = (
+    viewState: ViewportProps,
+    interactionState: ExtraState,
+    oldViewState: ViewportProps,
+) => void;
 
 export interface MapControllerOptions {
     onViewportChange?: ContextViewportChangeHandler;
@@ -206,7 +213,7 @@ export enum TRANSITION_EVENTS {
     BREAK = 1,
     SNAP_TO_END = 2,
     IGNORE = 3,
-    UPDATE = 4
+    UPDATE = 4,
 }
 
 export class TransitionInterpolator {}
@@ -216,14 +223,14 @@ export class LinearInterpolator extends TransitionInterpolator {
 }
 
 export type FlyToInterpolatorProps = {
-  curve?: number,
-  speed?: number,
-  screenSpeed?: number,
-  maxDuraiton?: number
+    curve?: number;
+    speed?: number;
+    screenSpeed?: number;
+    maxDuraiton?: number;
 };
 
 export class FlyToInterpolator extends TransitionInterpolator {
-    constructor(props: FlyToInterpolatorProps = {})
+    constructor(props?: FlyToInterpolatorProps);
 }
 
 export interface ViewStateChangeInfo {
@@ -286,7 +293,10 @@ export interface InteractiveMapProps extends StaticMapProps {
 
 export class InteractiveMap extends React.PureComponent<InteractiveMapProps> {
     getMap(): MapboxGL.Map;
-    queryRenderedFeatures(geometry?: MapboxGL.PointLike | MapboxGL.PointLike[], parameters?: QueryRenderedFeaturesParams): Array<GeoJSON.Feature<GeoJSON.GeometryObject>>;
+    queryRenderedFeatures(
+        geometry?: MapboxGL.PointLike | MapboxGL.PointLike[],
+        parameters?: QueryRenderedFeaturesParams,
+    ): Array<GeoJSON.Feature<GeoJSON.GeometryObject>>;
 }
 
 export default InteractiveMap;

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import * as React from "react";
 import {
     InteractiveMap,
     CanvasOverlay,
@@ -6,11 +6,13 @@ import {
     HTMLOverlay,
     FullscreenControl,
     GeolocateControl,
+    CanvasRedrawOptions,
+    HTMLRedrawOptions,
+    SVGRedrawOptions,
     StaticMap,
-    ViewportProps,
-    FlyToInterpolator,
+    ViewportProps
 } from 'react-map-gl';
-import * as MapboxGL from 'mapbox-gl';
+import * as MapboxGL from "mapbox-gl";
 
 interface State {
     viewport: ViewportProps;
@@ -44,14 +46,18 @@ class MyMap extends React.Component<{}, State> {
                     ref={this.setRefInteractive}
                     onViewportChange={viewport => this.setState({ viewport })}
                     onViewStateChange={({ viewState }) => this.setState({ viewport: viewState })}
-                    transitionInterpolator={new FlyToInterpolator({ speed: 2 })}
-                    transitionDuration="auto"
                 >
                     <FullscreenControl className="test-class" container={document.querySelector('body')} />
-                    <GeolocateControl className="test-class" style={{ marginTop: '8px' }} />
+                    <GeolocateControl className="test-class" style={{ marginTop: "8px" }} />
                     <CanvasOverlay
                         redraw={opts => {
-                            const { ctx, height, project, unproject, width } = opts;
+                            const {
+                                ctx,
+                                height,
+                                project,
+                                unproject,
+                                width,
+                            } = opts;
                             const xy: number[] = unproject(project([20, 20]));
                             ctx.clearRect(0, 0, width, height);
                         }}
@@ -63,10 +69,17 @@ class MyMap extends React.Component<{}, State> {
                         captureClick={true}
                         captureDoubleClick={true}
                     />
-                    <SVGOverlay redraw={() => {}} />
+                    <SVGOverlay
+                        redraw={() => {}}
+                    />
                     <SVGOverlay
                         redraw={opts => {
-                            const { height, project, unproject, width } = opts;
+                            const {
+                                height,
+                                project,
+                                unproject,
+                                width,
+                            } = opts;
                             const xy: number[] = unproject(project([20, 20]));
                         }}
                         captureScroll={true}
@@ -74,14 +87,21 @@ class MyMap extends React.Component<{}, State> {
                         captureClick={true}
                         captureDoubleClick={true}
                     />
-                    <HTMLOverlay redraw={() => {}} />
+                    <HTMLOverlay
+                        redraw={() => {}}
+                    />
                     <HTMLOverlay
                         redraw={opts => {
-                            const { height, project, unproject, width } = opts;
+                            const {
+                                height,
+                                project,
+                                unproject,
+                                width,
+                            } = opts;
                             const xy: number[] = unproject(project([20, 20]));
                         }}
                         style={{
-                            border: '2px solid black',
+                            border: "2px solid black"
                         }}
                         captureScroll={true}
                         captureDrag={true}

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -102,9 +102,9 @@ class MyMap extends React.Component<{}, State> {
 
     private readonly setRefInteractive = (el: InteractiveMap) => {
         this.map = el.getMap();
-    };
+    }
 
     private readonly setRefStatic = (el: StaticMap) => {
         this.map = el.getMap();
-    };
+    }
 }

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from 'react';
 import {
     InteractiveMap,
     CanvasOverlay,
@@ -6,13 +6,11 @@ import {
     HTMLOverlay,
     FullscreenControl,
     GeolocateControl,
-    CanvasRedrawOptions,
-    HTMLRedrawOptions,
-    SVGRedrawOptions,
     StaticMap,
-    ViewportProps
+    ViewportProps,
+    FlyToInterpolator,
 } from 'react-map-gl';
-import * as MapboxGL from "mapbox-gl";
+import * as MapboxGL from 'mapbox-gl';
 
 interface State {
     viewport: ViewportProps;
@@ -46,18 +44,14 @@ class MyMap extends React.Component<{}, State> {
                     ref={this.setRefInteractive}
                     onViewportChange={viewport => this.setState({ viewport })}
                     onViewStateChange={({ viewState }) => this.setState({ viewport: viewState })}
+                    transitionInterpolator={new FlyToInterpolator({ speed: 2 })}
+                    transitionDuration="auto"
                 >
                     <FullscreenControl className="test-class" container={document.querySelector('body')} />
-                    <GeolocateControl className="test-class" style={{ marginTop: "8px" }} />
+                    <GeolocateControl className="test-class" style={{ marginTop: '8px' }} />
                     <CanvasOverlay
                         redraw={opts => {
-                            const {
-                                ctx,
-                                height,
-                                project,
-                                unproject,
-                                width,
-                            } = opts;
+                            const { ctx, height, project, unproject, width } = opts;
                             const xy: number[] = unproject(project([20, 20]));
                             ctx.clearRect(0, 0, width, height);
                         }}
@@ -69,17 +63,10 @@ class MyMap extends React.Component<{}, State> {
                         captureClick={true}
                         captureDoubleClick={true}
                     />
-                    <SVGOverlay
-                        redraw={() => {}}
-                    />
+                    <SVGOverlay redraw={() => {}} />
                     <SVGOverlay
                         redraw={opts => {
-                            const {
-                                height,
-                                project,
-                                unproject,
-                                width,
-                            } = opts;
+                            const { height, project, unproject, width } = opts;
                             const xy: number[] = unproject(project([20, 20]));
                         }}
                         captureScroll={true}
@@ -87,21 +74,14 @@ class MyMap extends React.Component<{}, State> {
                         captureClick={true}
                         captureDoubleClick={true}
                     />
-                    <HTMLOverlay
-                        redraw={() => {}}
-                    />
+                    <HTMLOverlay redraw={() => {}} />
                     <HTMLOverlay
                         redraw={opts => {
-                            const {
-                                height,
-                                project,
-                                unproject,
-                                width,
-                            } = opts;
+                            const { height, project, unproject, width } = opts;
                             const xy: number[] = unproject(project([20, 20]));
                         }}
                         style={{
-                            border: "2px solid black"
+                            border: '2px solid black',
                         }}
                         captureScroll={true}
                         captureDrag={true}
@@ -122,9 +102,9 @@ class MyMap extends React.Component<{}, State> {
 
     private readonly setRefInteractive = (el: InteractiveMap) => {
         this.map = el.getMap();
-    }
+    };
 
     private readonly setRefStatic = (el: StaticMap) => {
         this.map = el.getMap();
-    }
+    };
 }


### PR DESCRIPTION
Fixed missing types according to: https://github.com/uber/react-map-gl/blob/5.1-release/examples/viewport-animation/src/app.js
FlyToInterpolator class was missing it's constructor props and transitionDuration property couldn't have 'auto' value

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/uber/react-map-gl/blob/3e35c9b78430cdc19f1072806ff2545966ac4542/examples/viewport-animation/src/app.js#L30

