### PR TITLE
[@types/node] Use ExecException for child_process.execFile()

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -320,25 +320,25 @@ declare module "child_process" {
     function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): ChildProcess;
 
     // no `options` definitely means stdout/stderr are `string`.
-    function execFile(file: string, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
-    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, callback: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, callback: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
 
     // `options` with `"buffer"` or `null` for `encoding` means stdout/stderr are definitely `Buffer`.
-    function execFile(file: string, options: ExecFileOptionsWithBufferEncoding, callback: (error: Error | null, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
+    function execFile(file: string, options: ExecFileOptionsWithBufferEncoding, callback: (error: ExecException | null, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
         options: ExecFileOptionsWithBufferEncoding,
-        callback: (error: Error | null, stdout: Buffer, stderr: Buffer) => void,
+        callback: (error: ExecException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
 
     // `options` with well known `encoding` means stdout/stderr are definitely `string`.
-    function execFile(file: string, options: ExecFileOptionsWithStringEncoding, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, options: ExecFileOptionsWithStringEncoding, callback: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
         options: ExecFileOptionsWithStringEncoding,
-        callback: (error: Error | null, stdout: string, stderr: string) => void,
+        callback: (error: ExecException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
 
     // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`.
@@ -346,30 +346,35 @@ declare module "child_process" {
     function execFile(
         file: string,
         options: ExecFileOptionsWithOtherEncoding,
-        callback: (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void,
+        callback: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
         options: ExecFileOptionsWithOtherEncoding,
-        callback: (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void,
+        callback: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
     ): ChildProcess;
 
     // `options` without an `encoding` means stdout/stderr are definitely `string`.
-    function execFile(file: string, options: ExecFileOptions, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
-    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ExecFileOptions, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, options: ExecFileOptions, callback: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(
+        file: string,
+        args: ReadonlyArray<string> | undefined | null,
+        options: ExecFileOptions,
+        callback: (error: ExecException | null, stdout: string, stderr: string) => void
+    ): ChildProcess;
 
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function execFile(
         file: string,
         options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null,
-        callback: ((error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
+        callback: ((error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
     ): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
         options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null,
-        callback: ((error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
+        callback: ((error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
     ): ChildProcess;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.

--- a/types/node/v10/child_process.d.ts
+++ b/types/node/v10/child_process.d.ts
@@ -181,25 +181,25 @@ declare module "child_process" {
     function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): ChildProcess;
 
     // no `options` definitely means stdout/stderr are `string`.
-    function execFile(file: string, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
-    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, callback: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, callback: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
 
     // `options` with `"buffer"` or `null` for `encoding` means stdout/stderr are definitely `Buffer`.
-    function execFile(file: string, options: ExecFileOptionsWithBufferEncoding, callback: (error: Error | null, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
+    function execFile(file: string, options: ExecFileOptionsWithBufferEncoding, callback: (error: ExecException | null, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
         options: ExecFileOptionsWithBufferEncoding,
-        callback: (error: Error | null, stdout: Buffer, stderr: Buffer) => void,
+        callback: (error: ExecException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
 
     // `options` with well known `encoding` means stdout/stderr are definitely `string`.
-    function execFile(file: string, options: ExecFileOptionsWithStringEncoding, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, options: ExecFileOptionsWithStringEncoding, callback: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
         options: ExecFileOptionsWithStringEncoding,
-        callback: (error: Error | null, stdout: string, stderr: string) => void,
+        callback: (error: ExecException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
 
     // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`.
@@ -207,30 +207,35 @@ declare module "child_process" {
     function execFile(
         file: string,
         options: ExecFileOptionsWithOtherEncoding,
-        callback: (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void,
+        callback: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
         options: ExecFileOptionsWithOtherEncoding,
-        callback: (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void,
+        callback: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
     ): ChildProcess;
 
     // `options` without an `encoding` means stdout/stderr are definitely `string`.
-    function execFile(file: string, options: ExecFileOptions, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
-    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ExecFileOptions, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, options: ExecFileOptions, callback: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(
+        file: string,
+        args: ReadonlyArray<string> | undefined | null,
+        options: ExecFileOptions,
+        callback: (error: ExecException | null, stdout: string, stderr: string) => void
+    ): ChildProcess;
 
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function execFile(
         file: string,
         options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null,
-        callback: ((error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
+        callback: ((error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
     ): ChildProcess;
     function execFile(
         file: string,
         args: ReadonlyArray<string> | undefined | null,
         options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null,
-        callback: ((error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
+        callback: ((error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
     ): ChildProcess;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<following>>

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/27708 changed type of error in `child_process.exec`, but `child_process.execFile` should be also change.
[`exec` just calls `execFile`](https://github.com/nodejs/node/blob/147317f60c41acdd934c6da3868f442e05226e37/lib/child_process.js#L149-L154).  They have same callbacks.