### PR TITLE
Avoid error when dynamically generating routes

### DIFF
--- a/types/hookrouter/index.d.ts
+++ b/types/hookrouter/index.d.ts
@@ -8,7 +8,7 @@ export namespace HookRouter {
 	type InterceptedPath = string | null;
 	interface AProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> { href: string; }
 	interface QueryParams { [key: string]: any; }
-	interface RouteObject { [key: string]: (params: QueryParams) => any; }
+	interface RouteObject { [key: string]: (params: QueryParams & string) => any; }
 }
 export function setLinkProps(props: HookRouter.AProps): HookRouter.AProps;
 export function A(props: HookRouter.AProps): React.ReactHTMLElement<HTMLAnchorElement>;


### PR DESCRIPTION
This is supposed to avoid throwing an error when the routes object is the return value of a function passing additional params, rather than creating it as an object.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<<https://github.com/Paratron/hookrouter>>