### PR TITLE
react-router: Add array option to params while generating path

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -20,6 +20,7 @@
 //                 Wesley Tsai <https://github.com/wezleytsai>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 Nicholas Hehr <https://github.com/HipsterBrown>
+//                 Mehmet Sarıoğlu <https://github.com/sarioglu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -136,7 +137,9 @@ export function matchPath<Params extends { [K in keyof Params]?: string }>(
 
 export function generatePath(
     pattern: string,
-    params?: { [paramName: string]: string | number | boolean | undefined },
+    params?: {
+        [paramName: string]: string | number | boolean | undefined | Array<string | number | boolean | undefined>;
+    },
 ): string;
 
 export type WithRouterProps<C extends React.ComponentType<any>> = C extends React.ComponentClass


### PR DESCRIPTION
Add array option to params while generating path

This PR provides ability to use array type params since it is possible to define paths using modifiers like * and +

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pillarjs/path-to-regexp#zero-or-more
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
