### PR TITLE
Add types for purifycss-webpack

### DIFF
--- a/types/purifycss-webpack/index.d.ts
+++ b/types/purifycss-webpack/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/webpack-contrib/purifycss-webpack
 // Definitions by: Geoff Garbers <https://github.com/garbetjie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-/// <reference types="webpack"/>
 
 import * as webpack from 'webpack';
 

--- a/types/purifycss-webpack/index.d.ts
+++ b/types/purifycss-webpack/index.d.ts
@@ -2,27 +2,27 @@
 // Project: https://github.com/webpack-contrib/purifycss-webpack
 // Definitions by: Geoff Garbers <https://github.com/garbetjie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-///<reference types="webpack"/>
+/// <reference types="webpack"/>
 
-import {Plugin} from "webpack";
+import * as webpack from 'webpack';
 
-declare class PurifyPlugin extends Plugin {
+declare class PurifyPlugin extends webpack.Plugin {
     constructor(options?: PurifyOptions);
 }
 
-declare type PurifyOptions = {
-    styleExtensions?: string[],
-    moduleExtensions?: string[],
-    minimize?: boolean,
-    paths?: object|string[]
+interface PurifyOptions {
+    styleExtensions?: string[];
+    moduleExtensions?: string[];
+    minimize?: boolean;
+    paths?: object | string[];
     purifyOptions?: {
         minify?: boolean,
         output?: string | boolean,
         info?: boolean,
         rejected?: boolean,
         whitelist?: string[]
-    },
-    verbose?: boolean
+    };
+    verbose?: boolean;
 }
 
 export = PurifyPlugin;

--- a/types/purifycss-webpack/index.d.ts
+++ b/types/purifycss-webpack/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for purifycss-webpack 0.7
+// Project: https://github.com/webpack-contrib/purifycss-webpack
+// Definitions by: Geoff Garbers <https://github.com/garbetjie>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+///<reference types="webpack"/>
+
+import {Plugin} from "webpack";
+
+declare class PurifyPlugin extends Plugin {
+    constructor(options?: PurifyOptions);
+}
+
+declare type PurifyOptions = {
+    styleExtensions?: string[],
+    moduleExtensions?: string[],
+    minimize?: boolean,
+    paths?: object|string[]
+    purifyOptions?: {
+        minify?: boolean,
+        output?: string | boolean,
+        info?: boolean,
+        rejected?: boolean,
+        whitelist?: string[]
+    },
+    verbose?: boolean
+}
+
+export = PurifyPlugin;

--- a/types/purifycss-webpack/purifycss-webpack-tests.ts
+++ b/types/purifycss-webpack/purifycss-webpack-tests.ts
@@ -1,3 +1,16 @@
 import PurifyPlugin from 'purifycss-webpack';
 
-new PurifyPlugin({ styleExtensions: ['.css'] });
+new PurifyPlugin({
+    styleExtensions: ['.css'],
+    minimize: true,
+    moduleExtensions: ['.js'],
+    paths: [''],
+    verbose: true,
+    purifyOptions: {
+        minify: false,
+        output: '',
+        info: false,
+        rejected: false,
+        whitelist: [''],
+    },
+});

--- a/types/purifycss-webpack/purifycss-webpack-tests.ts
+++ b/types/purifycss-webpack/purifycss-webpack-tests.ts
@@ -1,0 +1,3 @@
+import PurifyPlugin from 'purifycss-webpack';
+
+new PurifyPlugin({ styleExtensions: ['.css'] });

--- a/types/purifycss-webpack/tsconfig.json
+++ b/types/purifycss-webpack/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "esModuleInterop": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "purifycss-webpack-tests.ts"
+    ]
+}

--- a/types/purifycss-webpack/tslint.json
+++ b/types/purifycss-webpack/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

Hi there. This is my first attempt at using TypeScript properly, and at providing a type definition. Please let me know what needs to change in order to improve it.

I have tried to follow all the instructions to the best of my ability.