### PR TITLE
Fixing a property does not exist on type 'UploadedFile[]' for EXPRESS-FILEUPLOAD

### DIFF
--- a/types/express-fileupload/index.d.ts
+++ b/types/express-fileupload/index.d.ts
@@ -22,7 +22,7 @@ declare function fileUpload(options?: fileUpload.Options): express.RequestHandle
 
 declare namespace fileUpload {
     class FileArray {
-        [index: string]: UploadedFile | UploadedFile[]
+        [index: string]: UploadedFile
     }
 
     interface UploadedFile {


### PR DESCRIPTION
This is the URL of the package -   https://github.com/richardgirges/express-fileupload

Any of this properties 
**name**: A name of the file for upload
**mv**: A function to move the file elsewhere on your server
**mimetype**: The mimetype of your file
**data**: A buffer representation of your file, returns empty buffer in case useTempFiles option was set to true

Does not exist on UploadedFile. Type script throws back an error of something like this, 
Property 'mimetype' does not exist on type 'UploadedFile | UploadedFile[]'.

Here's a link to a sample issue
https://github.com/richardgirges/express-fileupload/issues/175.

Removing | UploadedFile[] fixes the issue.



