### PR TITLE
[@types/react-query] Fix pagination option

### DIFF
--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -38,7 +38,7 @@ export interface QueryOptions<TResult> {
 
 export interface QueryOptionsPaginated<TResult> extends QueryOptions<TResult> {
     paginated: true;
-    getCanFetchMore: (lastPage: number, allPages: number) => boolean;
+    getCanFetchMore: (lastPage: TResult, allPages: TResult[]) => boolean;
 }
 
 export interface QueryResult<TResult, TVariables> {

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -37,12 +37,12 @@ const queryNested = useQuery(['key', {
 queryNested.data; // $ExpectType number | null
 
 // Paginated mode
-const queryPaginated = useQuery('key', () => Promise.resolve([1, 2, 3]), {
+const queryPaginated = useQuery('key', () => Promise.resolve({data: [1, 2, 3], next: true}), {
     paginated: true,
-    getCanFetchMore: (lastPage, allPages) => true
+    getCanFetchMore: (lastPage, allPages) => lastPage.next
 });
-queryPaginated.data; // $ExpectType number[][] | null
-queryPaginated.fetchMore; // $ExpectType (variables?: {} | undefined) => Promise<number[]> || (variables?: object | undefined) => Promise<number[]>
+queryPaginated.data; // $ExpectType { data: number[]; next: boolean; }[] | null
+queryPaginated.fetchMore; // $ExpectType (variables?: {} | undefined) => Promise<{ data: number[]; next: boolean; }> || (variables?: object | undefined) => Promise<{ data: number[]; next: boolean; }>
 queryPaginated.canFetchMore; // $ExpectType boolean
 queryPaginated.isFetchingMore; // $ExpectType boolean
 


### PR DESCRIPTION
The getCanFetchMore function takes in the actual paged data, not a number.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tannerlinsley/react-query#load-more--infinite-scroll-pagination
