### PR TITLE
Create separate versions for different react-native versions

### DIFF
--- a/types/react-native/v0.60/BatchedBridge.d.ts
+++ b/types/react-native/v0.60/BatchedBridge.d.ts
@@ -1,0 +1,23 @@
+interface SpyData {
+    type: number;
+    module?: string;
+    method: string | number;
+    args: any[];
+}
+
+declare class MessageQueue {
+    static spy(spyOrToggle: boolean | ((data: SpyData) => void)): void;
+
+    getCallableModule(name: string): Object;
+    registerCallableModule(name: string, module: Object): void;
+    registerLazyCallableModule(name: string, factory: () => Object): void;
+}
+
+declare module 'react-native/Libraries/BatchedBridge/BatchedBridge' {
+    const BatchedBridge: MessageQueue;
+    export default BatchedBridge;
+}
+
+declare module 'react-native/Libraries/BatchedBridge/MessageQueue' {
+    export default MessageQueue;
+}

--- a/types/react-native/v0.60/Devtools.d.ts
+++ b/types/react-native/v0.60/Devtools.d.ts
@@ -1,0 +1,20 @@
+declare module 'react-native/Libraries/Core/Devtools/parseErrorStack' {
+    export type StackFrame = {
+        file: string;
+        methodName: string;
+        lineNumber: number;
+        column: number | null;
+    };
+
+    export interface ExtendedError extends Error {
+        framesToPop?: number;
+    }
+
+    export default function parseErrorStack(error: ExtendedError): StackFrame[];
+}
+
+declare module 'react-native/Libraries/Core/Devtools/symbolicateStackTrace' {
+    import { StackFrame } from 'react-native/Libraries/Core/Devtools/parseErrorStack';
+
+    export default function symbolicateStackTrace(stack: ReadonlyArray<StackFrame>): Promise<StackFrame[]>;
+}

--- a/types/react-native/v0.60/LaunchScreen.d.ts
+++ b/types/react-native/v0.60/LaunchScreen.d.ts
@@ -1,0 +1,9 @@
+// Adds the JSX elements used in the launch screen.
+
+declare module 'react-native/Libraries/NewAppScreen' {
+    export const Header: any;
+    export const LearnMoreLinks: any;
+    export const Colors: any;
+    export const DebugInstructions: any;
+    export const ReloadInstructions: any;
+}

--- a/types/react-native/v0.60/globals.d.ts
+++ b/types/react-native/v0.60/globals.d.ts
@@ -1,0 +1,274 @@
+/*
+ * This file is necessary to declare global functions that might also be included by `--lib dom`.
+ * Due to a TypeScript bug, these cannot be placed inside a `declare global` block in index.d.ts.
+ * https://github.com/Microsoft/TypeScript/issues/16430
+ */
+
+//
+// Timer Functions
+//
+declare function clearInterval(handle: number): void;
+declare function clearTimeout(handle: number): void;
+declare function setInterval(handler: (...args: any[]) => void, timeout: number): number;
+declare function setInterval(handler: any, timeout?: any, ...args: any[]): number;
+declare function setTimeout(handler: (...args: any[]) => void, timeout: number): number;
+declare function setTimeout(handler: any, timeout?: any, ...args: any[]): number;
+declare function clearImmediate(handle: number): void;
+declare function setImmediate(handler: (...args: any[]) => void): number;
+
+declare function cancelAnimationFrame(handle: number): void;
+declare function requestAnimationFrame(callback: (time: number) => void): number;
+
+declare function fetchBundle(bundleId: number, callback: (error?: Error | null) => void): void;
+
+//
+// Fetch API
+//
+
+declare interface GlobalFetch {
+    fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+}
+
+declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+
+declare interface WindowOrWorkerGlobalScope {
+    fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+}
+
+interface Blob {}
+
+declare class FormData {
+    append(name: string, value: any): void;
+}
+
+declare interface Body {
+    readonly bodyUsed: boolean;
+    arrayBuffer(): Promise<ArrayBuffer>;
+    blob(): Promise<Blob>;
+    json(): Promise<any>;
+    text(): Promise<string>;
+    formData(): Promise<FormData>;
+}
+
+declare interface Headers {
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    forEach(callback: Function, thisArg?: any): void;
+    get(name: string): string | null;
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+}
+
+declare var Headers: {
+    prototype: Headers;
+    new (init?: HeadersInit_): Headers;
+};
+
+type BodyInit_ =
+    | Blob
+    | Int8Array
+    | Int16Array
+    | Int32Array
+    | Uint8Array
+    | Uint16Array
+    | Uint32Array
+    | Uint8ClampedArray
+    | Float32Array
+    | Float64Array
+    | DataView
+    | ArrayBuffer
+    | FormData
+    | string
+    | null;
+
+declare interface RequestInit {
+    body?: BodyInit_;
+    credentials?: RequestCredentials_;
+    headers?: HeadersInit_;
+    integrity?: string;
+    keepalive?: boolean;
+    method?: string;
+    mode?: RequestMode_;
+    referrer?: string;
+    window?: any;
+}
+
+declare interface Request extends Object, Body {
+    readonly credentials: RequestCredentials_;
+    readonly headers: Headers;
+    readonly method: string;
+    readonly mode: RequestMode_;
+    readonly referrer: string;
+    readonly url: string;
+    clone(): Request;
+}
+
+declare var Request: {
+    prototype: Request;
+    new (input: Request | string, init?: RequestInit): Request;
+};
+
+declare type RequestInfo = Request | string;
+
+declare interface ResponseInit {
+    headers?: HeadersInit_;
+    status?: number;
+    statusText?: string;
+}
+
+declare interface Response extends Object, Body {
+    readonly headers: Headers;
+    readonly ok: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly type: ResponseType_;
+    readonly url: string;
+    readonly redirected: boolean;
+    clone(): Response;
+}
+
+declare var Response: {
+    prototype: Response;
+    new (body?: BodyInit_, init?: ResponseInit): Response;
+    error: () => Response;
+    redirect: (url: string, status?: number) => Response;
+};
+
+type HeadersInit_ = Headers | string[][] | { [key: string]: string };
+type RequestCredentials_ = 'omit' | 'same-origin' | 'include';
+type RequestMode_ = 'navigate' | 'same-origin' | 'no-cors' | 'cors';
+type ResponseType_ = 'basic' | 'cors' | 'default' | 'error' | 'opaque' | 'opaqueredirect';
+
+//
+// XMLHttpRequest
+//
+
+declare interface ProgressEvent extends Event {
+    readonly lengthComputable: boolean;
+    readonly loaded: number;
+    readonly total: number;
+}
+
+interface XMLHttpRequestEventMap extends XMLHttpRequestEventTargetEventMap {
+    readystatechange: Event;
+}
+
+interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
+    //  msCaching: string;
+    onreadystatechange: ((this: XMLHttpRequest, ev: Event) => any) | null;
+    readonly readyState: number;
+    readonly response: any;
+    readonly responseText: string;
+    responseType: XMLHttpRequestResponseType;
+    readonly responseURL: string;
+    readonly responseXML: Document | null;
+    readonly status: number;
+    readonly statusText: string;
+    timeout: number;
+    readonly upload: XMLHttpRequestUpload;
+    withCredentials: boolean;
+    abort(): void;
+    getAllResponseHeaders(): string;
+    getResponseHeader(header: string): string | null;
+    //  msCachingEnabled(): boolean;
+    open(method: string, url: string, async?: boolean, user?: string | null, password?: string | null): void;
+    overrideMimeType(mime: string): void;
+    send(data?: any): void;
+    setRequestHeader(header: string, value: string): void;
+    readonly DONE: number;
+    readonly HEADERS_RECEIVED: number;
+    readonly LOADING: number;
+    readonly OPENED: number;
+    readonly UNSENT: number;
+    addEventListener<K extends keyof XMLHttpRequestEventMap>(
+        type: K,
+        listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any,
+    ): void;
+    //  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+    removeEventListener<K extends keyof XMLHttpRequestEventMap>(
+        type: K,
+        listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any,
+    ): void;
+    //  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+}
+
+declare var XMLHttpRequest: {
+    prototype: XMLHttpRequest;
+    new (): XMLHttpRequest;
+    readonly DONE: number;
+    readonly HEADERS_RECEIVED: number;
+    readonly LOADING: number;
+    readonly OPENED: number;
+    readonly UNSENT: number;
+};
+
+interface XMLHttpRequestEventTargetEventMap {
+    abort: ProgressEvent;
+    error: ProgressEvent;
+    load: ProgressEvent;
+    loadend: ProgressEvent;
+    loadstart: ProgressEvent;
+    progress: ProgressEvent;
+    timeout: ProgressEvent;
+}
+
+interface XMLHttpRequestEventTarget {
+    onabort: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+    onerror: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+    onload: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+    onloadend: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+    onloadstart: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+    onprogress: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+    ontimeout: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+    addEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(
+        type: K,
+        listener: (this: XMLHttpRequestEventTarget, ev: XMLHttpRequestEventTargetEventMap[K]) => any,
+    ): void;
+    //  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+    removeEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(
+        type: K,
+        listener: (this: XMLHttpRequestEventTarget, ev: XMLHttpRequestEventTargetEventMap[K]) => any,
+    ): void;
+    //  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+}
+
+interface XMLHttpRequestUpload extends EventTarget, XMLHttpRequestEventTarget {
+    addEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(
+        type: K,
+        listener: (this: XMLHttpRequestUpload, ev: XMLHttpRequestEventTargetEventMap[K]) => any,
+    ): void;
+    //  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+    removeEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(
+        type: K,
+        listener: (this: XMLHttpRequestUpload, ev: XMLHttpRequestEventTargetEventMap[K]) => any,
+    ): void;
+    //  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+}
+
+declare var XMLHttpRequestUpload: {
+    prototype: XMLHttpRequestUpload;
+    new (): XMLHttpRequestUpload;
+};
+
+declare type XMLHttpRequestResponseType = '' | 'arraybuffer' | 'blob' | 'document' | 'json' | 'text';
+
+/**
+ * Based on definitions of lib.dom and  lib.dom.iteralbe
+ */
+declare class URLSearchParams {
+    constructor(init?: string[][] | Record<string, string> | string | URLSearchParams);
+
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string | null;
+    getAll(name: string): string[];
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+    sort(): void;
+    forEach(callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any): void;
+    [Symbol.iterator](): IterableIterator<[string, string]>;
+
+    entries(): IterableIterator<[string, string]>;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<string>;
+}

--- a/types/react-native/v0.60/index.d.ts
+++ b/types/react-native/v0.60/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-native 0.62
+// Type definitions for react-native 0.60
 // Project: https://github.com/facebook/react-native
 // Definitions by: Eloy Durán <https://github.com/alloy>
 //                 HuHuanming <https://github.com/huhuanming>

--- a/types/react-native/v0.60/legacy-properties.d.ts
+++ b/types/react-native/v0.60/legacy-properties.d.ts
@@ -1,0 +1,266 @@
+import {
+    TextProps,
+    TextPropsIOS,
+    TextPropsAndroid,
+    AccessibilityProps,
+    AccessibilityPropsIOS,
+    AccessibilityPropsAndroid,
+    TextInputProps,
+    TextInputIOSProps,
+    TextInputAndroidProps,
+    ViewProps,
+    ViewPropsIOS,
+    ViewPropsAndroid,
+    ToolbarAndroidProps,
+    ViewPagerAndroidProps,
+    SegmentedControlIOSProps,
+    ScrollViewProps,
+    ScrollViewPropsIOS,
+    ScrollViewPropsAndroid,
+    InputAccessoryViewProps,
+    NavigatorIOSProps,
+    ActivityIndicatorProps,
+    ActivityIndicatorIOSProps,
+    DatePickerIOSProps,
+    DrawerLayoutAndroidProps,
+    PickerItemProps,
+    PickerIOSItemProps,
+    PickerProps,
+    PickerPropsIOS,
+    PickerPropsAndroid,
+    PickerIOSProps,
+    ProgressBarAndroidProps,
+    ProgressViewIOSProps,
+    RefreshControlProps,
+    RefreshControlPropsIOS,
+    RefreshControlPropsAndroid,
+    RecyclerViewBackedScrollViewProps,
+    SliderProps,
+    SliderPropsIOS,
+    SliderPropsAndroid,
+    SwitchIOSProps,
+    ImageSourcePropType,
+    ImageProps,
+    ImagePropsIOS,
+    ImagePropsAndroid,
+    ImageBackgroundProps,
+    FlatListProps,
+    VirtualizedListProps,
+    SectionListProps,
+    ListViewProps,
+    MaskedViewIOSProps,
+    ModalProps,
+    TouchableWithoutFeedbackProps,
+    TouchableHighlightProps,
+    TouchableOpacityProps,
+    TouchableNativeFeedbackProps,
+    TabBarIOSItemProps,
+    TabBarIOSProps,
+    SnapshotViewIOSProps,
+    ButtonProps,
+    StatusBarProps,
+    StatusBarPropsIOS,
+    StatusBarPropsAndroid,
+    SwitchProps,
+    SwitchPropsIOS,
+} from 'react-native';
+
+declare module 'react-native' {
+    /*
+     * Previously, props interfaces where named *Properties
+     * They have been renamed to *Props to match React Native documentation
+     * The following lines ensure compatibility with *Properties and should be removed in the future
+     */
+
+    /** @deprecated Use TextProps */
+    export type TextProperties = TextProps;
+
+    /** @deprecated Use TextPropsIOS */
+    export type TextPropertiesIOS = TextPropsIOS;
+
+    /** @deprecated Use TextPropsAndroid */
+    export type TextPropertiesAndroid = TextPropsAndroid;
+
+    /** @deprecated Use AccessibilityProps */
+    export type AccessibilityProperties = AccessibilityProps;
+
+    /** @deprecated Use AccessibilityPropsIOS */
+    export type AccessibilityPropertiesIOS = AccessibilityPropsIOS;
+
+    /** @deprecated Use AccessibilityPropsAndroid */
+    export type AccessibilityPropertiesAndroid = AccessibilityPropsAndroid;
+
+    /** @deprecated Use TextInputProps */
+    export type TextInputProperties = TextInputProps;
+
+    /** @deprecated Use TextInputIOSProps */
+    export type TextInputIOSProperties = TextInputIOSProps;
+
+    /** @deprecated Use TextInputAndroidProps */
+    export type TextInputAndroidProperties = TextInputAndroidProps;
+
+    /** @deprecated Use ViewProps */
+    export type ViewProperties = ViewProps;
+
+    /** @deprecated Use ViewPropsIOS */
+    export type ViewPropertiesIOS = ViewPropsIOS;
+
+    /** @deprecated Use ViewPropsAndroid */
+    export type ViewPropertiesAndroid = ViewPropsAndroid;
+
+    /** @deprecated Use ToolbarAndroidProps */
+    export type ToolbarAndroidProperties = ToolbarAndroidProps;
+
+    /** @deprecated Use ViewPagerAndroidProps */
+    export type ViewPagerAndroidProperties = ViewPagerAndroidProps;
+
+    /** @deprecated Use SegmentedControlIOSProps */
+    export type SegmentedControlIOSProperties = SegmentedControlIOSProps;
+
+    /** @deprecated Use ScrollViewProps */
+    export type ScrollViewProperties = ScrollViewProps;
+
+    /** @deprecated Use ScrollViewPropsIOS */
+    export type ScrollViewPropertiesIOS = ScrollViewPropsIOS;
+
+    /** @deprecated Use ScrollViewPropsAndroid */
+    export type ScrollViewPropertiesAndroid = ScrollViewPropsAndroid;
+
+    /** @deprecated Use InputAccessoryViewProps */
+    export type InputAccessoryViewProperties = InputAccessoryViewProps;
+
+    /** @deprecated Use NavigatorIOSProps */
+    export type NavigatorIOSProperties = NavigatorIOSProps;
+
+    /** @deprecated Use ActivityIndicatorProps */
+    export type ActivityIndicatorProperties = ActivityIndicatorProps;
+
+    /** @deprecated Use ActivityIndicatorIOSProps */
+    export type ActivityIndicatorIOSProperties = ActivityIndicatorIOSProps;
+
+    /** @deprecated Use DatePickerIOSProps */
+    export type DatePickerIOSProperties = DatePickerIOSProps;
+
+    /** @deprecated Use DrawerLayoutAndroidProps */
+    export type DrawerLayoutAndroidProperties = DrawerLayoutAndroidProps;
+
+    /** @deprecated Use PickerItemProps */
+    export type PickerItemProperties = PickerItemProps;
+
+    /** @deprecated Use PickerIOSItemProps */
+    export type PickerIOSItemProperties = PickerIOSItemProps;
+
+    /** @deprecated Use PickerProps */
+    export type PickerProperties = PickerProps;
+
+    /** @deprecated Use PickerPropsIOS */
+    export type PickerPropertiesIOS = PickerPropsIOS;
+
+    /** @deprecated Use PickerPropsAndroid */
+    export type PickerPropertiesAndroid = PickerPropsAndroid;
+
+    /** @deprecated Use PickerIOSProps */
+    export type PickerIOSProperties = PickerIOSProps;
+
+    /** @deprecated Use ProgressBarAndroidProps */
+    export type ProgressBarAndroidProperties = ProgressBarAndroidProps;
+
+    /** @deprecated Use ProgressViewIOSProps */
+    export type ProgressViewIOSProperties = ProgressViewIOSProps;
+
+    /** @deprecated Use RefreshControlProps */
+    export type RefreshControlProperties = RefreshControlProps;
+
+    /** @deprecated Use RefreshControlPropsIOS */
+    export type RefreshControlPropertiesIOS = RefreshControlPropsIOS;
+
+    /** @deprecated Use RefreshControlPropsAndroid */
+    export type RefreshControlPropertiesAndroid = RefreshControlPropsAndroid;
+
+    /** @deprecated Use RecyclerViewBackedScrollViewProps */
+    export type RecyclerViewBackedScrollViewProperties = RecyclerViewBackedScrollViewProps;
+
+    /** @deprecated Use SliderProps */
+    export type SliderProperties = SliderProps;
+
+    /** @deprecated Use SliderPropsIOS */
+    export type SliderPropertiesIOS = SliderPropsIOS;
+
+    /** @deprecated Use SliderPropsAndroid */
+    export type SliderPropertiesAndroid = SliderPropsAndroid;
+
+    /** @deprecated Use SwitchIOSProps */
+    export type SwitchIOSProperties = SwitchIOSProps;
+
+    /** @deprecated Use ImageSourcePropType */
+    export type ImagePropertiesSourceOptions = ImageSourcePropType;
+
+    /** @deprecated Use ImageProps */
+    export type ImageProperties = ImageProps;
+
+    /** @deprecated Use ImagePropsIOS */
+    export type ImagePropertiesIOS = ImagePropsIOS;
+
+    /** @deprecated Use ImagePropsAndroid */
+    export type ImagePropertiesAndroid = ImagePropsAndroid;
+
+    /** @deprecated Use ImageBackgroundProps */
+    export type ImageBackgroundProperties = ImageBackgroundProps;
+
+    /** @deprecated Use FlatListProps */
+    export type FlatListProperties<ItemT> = FlatListProps<ItemT>;
+
+    /** @deprecated Use VirtualizedListProps */
+    export type VirtualizedListProperties<ItemT> = VirtualizedListProps<ItemT>;
+
+    /** @deprecated Use SectionListProps */
+    export type SectionListProperties<ItemT> = SectionListProps<ItemT>;
+
+    /** @deprecated Use ListViewProps */
+    export type ListViewProperties = ListViewProps;
+
+    /** @deprecated Use MaskedViewIOSProps */
+    export type MaskedViewIOSProperties = MaskedViewIOSProps;
+
+    /** @deprecated Use ModalProps */
+    export type ModalProperties = ModalProps;
+
+    /** @deprecated Use TouchableWithoutFeedbackProps */
+    export type TouchableWithoutFeedbackProperties = TouchableWithoutFeedbackProps;
+
+    /** @deprecated Use TouchableHighlightProps */
+    export type TouchableHighlightProperties = TouchableHighlightProps;
+
+    /** @deprecated Use TouchableOpacityProps */
+    export type TouchableOpacityProperties = TouchableOpacityProps;
+
+    /** @deprecated Use TouchableNativeFeedbackProps */
+    export type TouchableNativeFeedbackProperties = TouchableNativeFeedbackProps;
+
+    /** @deprecated Use TabBarIOSItemProps */
+    export type TabBarIOSItemProperties = TabBarIOSItemProps;
+
+    /** @deprecated Use TabBarIOSProps */
+    export type TabBarIOSProperties = TabBarIOSProps;
+
+    /** @deprecated Use SnapshotViewIOSProps */
+    export type SnapshotViewIOSProperties = SnapshotViewIOSProps;
+
+    /** @deprecated Use ButtonProps */
+    export type ButtonProperties = ButtonProps;
+
+    /** @deprecated Use StatusBarProps */
+    export type StatusBarProperties = StatusBarProps;
+
+    /** @deprecated Use StatusBarPropsIOS */
+    export type StatusBarPropertiesIOS = StatusBarPropsIOS;
+
+    /** @deprecated Use StatusBarPropsAndroid */
+    export type StatusBarPropertiesAndroid = StatusBarPropsAndroid;
+
+    /** @deprecated Use SwitchProps */
+    export type SwitchProperties = SwitchProps;
+
+    /** @deprecated Use SwitchPropsIOS */
+    export type SwitchPropertiesIOS = SwitchPropsIOS;
+}

--- a/types/react-native/v0.60/tsconfig.json
+++ b/types/react-native/v0.60/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "jsx": "react",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "test/index.tsx",
+        "test/globals.tsx",
+        "test/animated.tsx",
+        "test/init-example.tsx",
+        "test/ART.tsx",
+        "test/legacy-properties.tsx",
+        "test/stylesheet-create.tsx"
+    ]
+}

--- a/types/react-native/v0.60/tslint.json
+++ b/types/react-native/v0.60/tslint.json
@@ -1,0 +1,31 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        // Lowercase `object` is available in TypeScript 2.2 only.
+        "ban-types": false,
+        // Below are all TODO
+        "align": false,
+        "array-type": false,
+        "comment-format": false,
+        "interface-over-type-literal": false,
+        "jsdoc-format": false,
+        "max-line-length": false,
+        "no-declare-current-package": false,
+        "no-misused-new": false,
+        "no-consecutive-blank-lines": false,
+        "no-duplicate-imports": false,
+        "no-empty-interface": false,
+        "no-padding": false,
+        "no-self-import": false,
+        "no-var": false,
+        "no-var-keyword": false,
+        "prefer-declare-function": false,
+        "prefer-method-signature": false,
+        "semicolon": false,
+        "space-within-parens": false,
+        "strict-export-declare-modifiers": false,
+        "use-default-type-parameter": false,
+        "no-unnecessary-generics": false,
+        "no-single-declare-module": false
+    }
+}

--- a/types/react-native/v0.61/BatchedBridge.d.ts
+++ b/types/react-native/v0.61/BatchedBridge.d.ts
@@ -1,0 +1,23 @@
+interface SpyData {
+    type: number;
+    module?: string;
+    method: string | number;
+    args: any[];
+}
+
+declare class MessageQueue {
+    static spy(spyOrToggle: boolean | ((data: SpyData) => void)): void;
+
+    getCallableModule(name: string): Object;
+    registerCallableModule(name: string, module: Object): void;
+    registerLazyCallableModule(name: string, factory: () => Object): void;
+}
+
+declare module 'react-native/Libraries/BatchedBridge/BatchedBridge' {
+    const BatchedBridge: MessageQueue;
+    export default BatchedBridge;
+}
+
+declare module 'react-native/Libraries/BatchedBridge/MessageQueue' {
+    export default MessageQueue;
+}

--- a/types/react-native/v0.61/Devtools.d.ts
+++ b/types/react-native/v0.61/Devtools.d.ts
@@ -1,0 +1,20 @@
+declare module 'react-native/Libraries/Core/Devtools/parseErrorStack' {
+    export type StackFrame = {
+        file: string;
+        methodName: string;
+        lineNumber: number;
+        column: number | null;
+    };
+
+    export interface ExtendedError extends Error {
+        framesToPop?: number;
+    }
+
+    export default function parseErrorStack(error: ExtendedError): StackFrame[];
+}
+
+declare module 'react-native/Libraries/Core/Devtools/symbolicateStackTrace' {
+    import { StackFrame } from 'react-native/Libraries/Core/Devtools/parseErrorStack';
+
+    export default function symbolicateStackTrace(stack: ReadonlyArray<StackFrame>): Promise<StackFrame[]>;
+}

--- a/types/react-native/v0.61/LaunchScreen.d.ts
+++ b/types/react-native/v0.61/LaunchScreen.d.ts
@@ -1,0 +1,9 @@
+// Adds the JSX elements used in the launch screen.
+
+declare module 'react-native/Libraries/NewAppScreen' {
+    export const Header: any;
+    export const LearnMoreLinks: any;
+    export const Colors: any;
+    export const DebugInstructions: any;
+    export const ReloadInstructions: any;
+}

--- a/types/react-native/v0.61/globals.d.ts
+++ b/types/react-native/v0.61/globals.d.ts
@@ -1,0 +1,274 @@
+/*
+ * This file is necessary to declare global functions that might also be included by `--lib dom`.
+ * Due to a TypeScript bug, these cannot be placed inside a `declare global` block in index.d.ts.
+ * https://github.com/Microsoft/TypeScript/issues/16430
+ */
+
+//
+// Timer Functions
+//
+declare function clearInterval(handle: number): void;
+declare function clearTimeout(handle: number): void;
+declare function setInterval(handler: (...args: any[]) => void, timeout: number): number;
+declare function setInterval(handler: any, timeout?: any, ...args: any[]): number;
+declare function setTimeout(handler: (...args: any[]) => void, timeout: number): number;
+declare function setTimeout(handler: any, timeout?: any, ...args: any[]): number;
+declare function clearImmediate(handle: number): void;
+declare function setImmediate(handler: (...args: any[]) => void): number;
+
+declare function cancelAnimationFrame(handle: number): void;
+declare function requestAnimationFrame(callback: (time: number) => void): number;
+
+declare function fetchBundle(bundleId: number, callback: (error?: Error | null) => void): void;
+
+//
+// Fetch API
+//
+
+declare interface GlobalFetch {
+    fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+}
+
+declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+
+declare interface WindowOrWorkerGlobalScope {
+    fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+}
+
+interface Blob {}
+
+declare class FormData {
+    append(name: string, value: any): void;
+}
+
+declare interface Body {
+    readonly bodyUsed: boolean;
+    arrayBuffer(): Promise<ArrayBuffer>;
+    blob(): Promise<Blob>;
+    json(): Promise<any>;
+    text(): Promise<string>;
+    formData(): Promise<FormData>;
+}
+
+declare interface Headers {
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    forEach(callback: Function, thisArg?: any): void;
+    get(name: string): string | null;
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+}
+
+declare var Headers: {
+    prototype: Headers;
+    new (init?: HeadersInit_): Headers;
+};
+
+type BodyInit_ =
+    | Blob
+    | Int8Array
+    | Int16Array
+    | Int32Array
+    | Uint8Array
+    | Uint16Array
+    | Uint32Array
+    | Uint8ClampedArray
+    | Float32Array
+    | Float64Array
+    | DataView
+    | ArrayBuffer
+    | FormData
+    | string
+    | null;
+
+declare interface RequestInit {
+    body?: BodyInit_;
+    credentials?: RequestCredentials_;
+    headers?: HeadersInit_;
+    integrity?: string;
+    keepalive?: boolean;
+    method?: string;
+    mode?: RequestMode_;
+    referrer?: string;
+    window?: any;
+}
+
+declare interface Request extends Object, Body {
+    readonly credentials: RequestCredentials_;
+    readonly headers: Headers;
+    readonly method: string;
+    readonly mode: RequestMode_;
+    readonly referrer: string;
+    readonly url: string;
+    clone(): Request;
+}
+
+declare var Request: {
+    prototype: Request;
+    new (input: Request | string, init?: RequestInit): Request;
+};
+
+declare type RequestInfo = Request | string;
+
+declare interface ResponseInit {
+    headers?: HeadersInit_;
+    status?: number;
+    statusText?: string;
+}
+
+declare interface Response extends Object, Body {
+    readonly headers: Headers;
+    readonly ok: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly type: ResponseType_;
+    readonly url: string;
+    readonly redirected: boolean;
+    clone(): Response;
+}
+
+declare var Response: {
+    prototype: Response;
+    new (body?: BodyInit_, init?: ResponseInit): Response;
+    error: () => Response;
+    redirect: (url: string, status?: number) => Response;
+};
+
+type HeadersInit_ = Headers | string[][] | { [key: string]: string };
+type RequestCredentials_ = 'omit' | 'same-origin' | 'include';
+type RequestMode_ = 'navigate' | 'same-origin' | 'no-cors' | 'cors';
+type ResponseType_ = 'basic' | 'cors' | 'default' | 'error' | 'opaque' | 'opaqueredirect';
+
+//
+// XMLHttpRequest
+//
+
+declare interface ProgressEvent extends Event {
+    readonly lengthComputable: boolean;
+    readonly loaded: number;
+    readonly total: number;
+}
+
+interface XMLHttpRequestEventMap extends XMLHttpRequestEventTargetEventMap {
+    readystatechange: Event;
+}
+
+interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
+    //  msCaching: string;
+    onreadystatechange: ((this: XMLHttpRequest, ev: Event) => any) | null;
+    readonly readyState: number;
+    readonly response: any;
+    readonly responseText: string;
+    responseType: XMLHttpRequestResponseType;
+    readonly responseURL: string;
+    readonly responseXML: Document | null;
+    readonly status: number;
+    readonly statusText: string;
+    timeout: number;
+    readonly upload: XMLHttpRequestUpload;
+    withCredentials: boolean;
+    abort(): void;
+    getAllResponseHeaders(): string;
+    getResponseHeader(header: string): string | null;
+    //  msCachingEnabled(): boolean;
+    open(method: string, url: string, async?: boolean, user?: string | null, password?: string | null): void;
+    overrideMimeType(mime: string): void;
+    send(data?: any): void;
+    setRequestHeader(header: string, value: string): void;
+    readonly DONE: number;
+    readonly HEADERS_RECEIVED: number;
+    readonly LOADING: number;
+    readonly OPENED: number;
+    readonly UNSENT: number;
+    addEventListener<K extends keyof XMLHttpRequestEventMap>(
+        type: K,
+        listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any,
+    ): void;
+    //  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+    removeEventListener<K extends keyof XMLHttpRequestEventMap>(
+        type: K,
+        listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any,
+    ): void;
+    //  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+}
+
+declare var XMLHttpRequest: {
+    prototype: XMLHttpRequest;
+    new (): XMLHttpRequest;
+    readonly DONE: number;
+    readonly HEADERS_RECEIVED: number;
+    readonly LOADING: number;
+    readonly OPENED: number;
+    readonly UNSENT: number;
+};
+
+interface XMLHttpRequestEventTargetEventMap {
+    abort: ProgressEvent;
+    error: ProgressEvent;
+    load: ProgressEvent;
+    loadend: ProgressEvent;
+    loadstart: ProgressEvent;
+    progress: ProgressEvent;
+    timeout: ProgressEvent;
+}
+
+interface XMLHttpRequestEventTarget {
+    onabort: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+    onerror: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+    onload: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+    onloadend: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+    onloadstart: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+    onprogress: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+    ontimeout: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+    addEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(
+        type: K,
+        listener: (this: XMLHttpRequestEventTarget, ev: XMLHttpRequestEventTargetEventMap[K]) => any,
+    ): void;
+    //  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+    removeEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(
+        type: K,
+        listener: (this: XMLHttpRequestEventTarget, ev: XMLHttpRequestEventTargetEventMap[K]) => any,
+    ): void;
+    //  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+}
+
+interface XMLHttpRequestUpload extends EventTarget, XMLHttpRequestEventTarget {
+    addEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(
+        type: K,
+        listener: (this: XMLHttpRequestUpload, ev: XMLHttpRequestEventTargetEventMap[K]) => any,
+    ): void;
+    //  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+    removeEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(
+        type: K,
+        listener: (this: XMLHttpRequestUpload, ev: XMLHttpRequestEventTargetEventMap[K]) => any,
+    ): void;
+    //  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+}
+
+declare var XMLHttpRequestUpload: {
+    prototype: XMLHttpRequestUpload;
+    new (): XMLHttpRequestUpload;
+};
+
+declare type XMLHttpRequestResponseType = '' | 'arraybuffer' | 'blob' | 'document' | 'json' | 'text';
+
+/**
+ * Based on definitions of lib.dom and  lib.dom.iteralbe
+ */
+declare class URLSearchParams {
+    constructor(init?: string[][] | Record<string, string> | string | URLSearchParams);
+
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string | null;
+    getAll(name: string): string[];
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+    sort(): void;
+    forEach(callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any): void;
+    [Symbol.iterator](): IterableIterator<[string, string]>;
+
+    entries(): IterableIterator<[string, string]>;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<string>;
+}

--- a/types/react-native/v0.61/index.d.ts
+++ b/types/react-native/v0.61/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-native 0.62
+// Type definitions for react-native 0.61
 // Project: https://github.com/facebook/react-native
 // Definitions by: Eloy Durán <https://github.com/alloy>
 //                 HuHuanming <https://github.com/huhuanming>

--- a/types/react-native/v0.61/legacy-properties.d.ts
+++ b/types/react-native/v0.61/legacy-properties.d.ts
@@ -1,0 +1,266 @@
+import {
+    TextProps,
+    TextPropsIOS,
+    TextPropsAndroid,
+    AccessibilityProps,
+    AccessibilityPropsIOS,
+    AccessibilityPropsAndroid,
+    TextInputProps,
+    TextInputIOSProps,
+    TextInputAndroidProps,
+    ViewProps,
+    ViewPropsIOS,
+    ViewPropsAndroid,
+    ToolbarAndroidProps,
+    ViewPagerAndroidProps,
+    SegmentedControlIOSProps,
+    ScrollViewProps,
+    ScrollViewPropsIOS,
+    ScrollViewPropsAndroid,
+    InputAccessoryViewProps,
+    NavigatorIOSProps,
+    ActivityIndicatorProps,
+    ActivityIndicatorIOSProps,
+    DatePickerIOSProps,
+    DrawerLayoutAndroidProps,
+    PickerItemProps,
+    PickerIOSItemProps,
+    PickerProps,
+    PickerPropsIOS,
+    PickerPropsAndroid,
+    PickerIOSProps,
+    ProgressBarAndroidProps,
+    ProgressViewIOSProps,
+    RefreshControlProps,
+    RefreshControlPropsIOS,
+    RefreshControlPropsAndroid,
+    RecyclerViewBackedScrollViewProps,
+    SliderProps,
+    SliderPropsIOS,
+    SliderPropsAndroid,
+    SwitchIOSProps,
+    ImageSourcePropType,
+    ImageProps,
+    ImagePropsIOS,
+    ImagePropsAndroid,
+    ImageBackgroundProps,
+    FlatListProps,
+    VirtualizedListProps,
+    SectionListProps,
+    ListViewProps,
+    MaskedViewIOSProps,
+    ModalProps,
+    TouchableWithoutFeedbackProps,
+    TouchableHighlightProps,
+    TouchableOpacityProps,
+    TouchableNativeFeedbackProps,
+    TabBarIOSItemProps,
+    TabBarIOSProps,
+    SnapshotViewIOSProps,
+    ButtonProps,
+    StatusBarProps,
+    StatusBarPropsIOS,
+    StatusBarPropsAndroid,
+    SwitchProps,
+    SwitchPropsIOS,
+} from 'react-native';
+
+declare module 'react-native' {
+    /*
+     * Previously, props interfaces where named *Properties
+     * They have been renamed to *Props to match React Native documentation
+     * The following lines ensure compatibility with *Properties and should be removed in the future
+     */
+
+    /** @deprecated Use TextProps */
+    export type TextProperties = TextProps;
+
+    /** @deprecated Use TextPropsIOS */
+    export type TextPropertiesIOS = TextPropsIOS;
+
+    /** @deprecated Use TextPropsAndroid */
+    export type TextPropertiesAndroid = TextPropsAndroid;
+
+    /** @deprecated Use AccessibilityProps */
+    export type AccessibilityProperties = AccessibilityProps;
+
+    /** @deprecated Use AccessibilityPropsIOS */
+    export type AccessibilityPropertiesIOS = AccessibilityPropsIOS;
+
+    /** @deprecated Use AccessibilityPropsAndroid */
+    export type AccessibilityPropertiesAndroid = AccessibilityPropsAndroid;
+
+    /** @deprecated Use TextInputProps */
+    export type TextInputProperties = TextInputProps;
+
+    /** @deprecated Use TextInputIOSProps */
+    export type TextInputIOSProperties = TextInputIOSProps;
+
+    /** @deprecated Use TextInputAndroidProps */
+    export type TextInputAndroidProperties = TextInputAndroidProps;
+
+    /** @deprecated Use ViewProps */
+    export type ViewProperties = ViewProps;
+
+    /** @deprecated Use ViewPropsIOS */
+    export type ViewPropertiesIOS = ViewPropsIOS;
+
+    /** @deprecated Use ViewPropsAndroid */
+    export type ViewPropertiesAndroid = ViewPropsAndroid;
+
+    /** @deprecated Use ToolbarAndroidProps */
+    export type ToolbarAndroidProperties = ToolbarAndroidProps;
+
+    /** @deprecated Use ViewPagerAndroidProps */
+    export type ViewPagerAndroidProperties = ViewPagerAndroidProps;
+
+    /** @deprecated Use SegmentedControlIOSProps */
+    export type SegmentedControlIOSProperties = SegmentedControlIOSProps;
+
+    /** @deprecated Use ScrollViewProps */
+    export type ScrollViewProperties = ScrollViewProps;
+
+    /** @deprecated Use ScrollViewPropsIOS */
+    export type ScrollViewPropertiesIOS = ScrollViewPropsIOS;
+
+    /** @deprecated Use ScrollViewPropsAndroid */
+    export type ScrollViewPropertiesAndroid = ScrollViewPropsAndroid;
+
+    /** @deprecated Use InputAccessoryViewProps */
+    export type InputAccessoryViewProperties = InputAccessoryViewProps;
+
+    /** @deprecated Use NavigatorIOSProps */
+    export type NavigatorIOSProperties = NavigatorIOSProps;
+
+    /** @deprecated Use ActivityIndicatorProps */
+    export type ActivityIndicatorProperties = ActivityIndicatorProps;
+
+    /** @deprecated Use ActivityIndicatorIOSProps */
+    export type ActivityIndicatorIOSProperties = ActivityIndicatorIOSProps;
+
+    /** @deprecated Use DatePickerIOSProps */
+    export type DatePickerIOSProperties = DatePickerIOSProps;
+
+    /** @deprecated Use DrawerLayoutAndroidProps */
+    export type DrawerLayoutAndroidProperties = DrawerLayoutAndroidProps;
+
+    /** @deprecated Use PickerItemProps */
+    export type PickerItemProperties = PickerItemProps;
+
+    /** @deprecated Use PickerIOSItemProps */
+    export type PickerIOSItemProperties = PickerIOSItemProps;
+
+    /** @deprecated Use PickerProps */
+    export type PickerProperties = PickerProps;
+
+    /** @deprecated Use PickerPropsIOS */
+    export type PickerPropertiesIOS = PickerPropsIOS;
+
+    /** @deprecated Use PickerPropsAndroid */
+    export type PickerPropertiesAndroid = PickerPropsAndroid;
+
+    /** @deprecated Use PickerIOSProps */
+    export type PickerIOSProperties = PickerIOSProps;
+
+    /** @deprecated Use ProgressBarAndroidProps */
+    export type ProgressBarAndroidProperties = ProgressBarAndroidProps;
+
+    /** @deprecated Use ProgressViewIOSProps */
+    export type ProgressViewIOSProperties = ProgressViewIOSProps;
+
+    /** @deprecated Use RefreshControlProps */
+    export type RefreshControlProperties = RefreshControlProps;
+
+    /** @deprecated Use RefreshControlPropsIOS */
+    export type RefreshControlPropertiesIOS = RefreshControlPropsIOS;
+
+    /** @deprecated Use RefreshControlPropsAndroid */
+    export type RefreshControlPropertiesAndroid = RefreshControlPropsAndroid;
+
+    /** @deprecated Use RecyclerViewBackedScrollViewProps */
+    export type RecyclerViewBackedScrollViewProperties = RecyclerViewBackedScrollViewProps;
+
+    /** @deprecated Use SliderProps */
+    export type SliderProperties = SliderProps;
+
+    /** @deprecated Use SliderPropsIOS */
+    export type SliderPropertiesIOS = SliderPropsIOS;
+
+    /** @deprecated Use SliderPropsAndroid */
+    export type SliderPropertiesAndroid = SliderPropsAndroid;
+
+    /** @deprecated Use SwitchIOSProps */
+    export type SwitchIOSProperties = SwitchIOSProps;
+
+    /** @deprecated Use ImageSourcePropType */
+    export type ImagePropertiesSourceOptions = ImageSourcePropType;
+
+    /** @deprecated Use ImageProps */
+    export type ImageProperties = ImageProps;
+
+    /** @deprecated Use ImagePropsIOS */
+    export type ImagePropertiesIOS = ImagePropsIOS;
+
+    /** @deprecated Use ImagePropsAndroid */
+    export type ImagePropertiesAndroid = ImagePropsAndroid;
+
+    /** @deprecated Use ImageBackgroundProps */
+    export type ImageBackgroundProperties = ImageBackgroundProps;
+
+    /** @deprecated Use FlatListProps */
+    export type FlatListProperties<ItemT> = FlatListProps<ItemT>;
+
+    /** @deprecated Use VirtualizedListProps */
+    export type VirtualizedListProperties<ItemT> = VirtualizedListProps<ItemT>;
+
+    /** @deprecated Use SectionListProps */
+    export type SectionListProperties<ItemT> = SectionListProps<ItemT>;
+
+    /** @deprecated Use ListViewProps */
+    export type ListViewProperties = ListViewProps;
+
+    /** @deprecated Use MaskedViewIOSProps */
+    export type MaskedViewIOSProperties = MaskedViewIOSProps;
+
+    /** @deprecated Use ModalProps */
+    export type ModalProperties = ModalProps;
+
+    /** @deprecated Use TouchableWithoutFeedbackProps */
+    export type TouchableWithoutFeedbackProperties = TouchableWithoutFeedbackProps;
+
+    /** @deprecated Use TouchableHighlightProps */
+    export type TouchableHighlightProperties = TouchableHighlightProps;
+
+    /** @deprecated Use TouchableOpacityProps */
+    export type TouchableOpacityProperties = TouchableOpacityProps;
+
+    /** @deprecated Use TouchableNativeFeedbackProps */
+    export type TouchableNativeFeedbackProperties = TouchableNativeFeedbackProps;
+
+    /** @deprecated Use TabBarIOSItemProps */
+    export type TabBarIOSItemProperties = TabBarIOSItemProps;
+
+    /** @deprecated Use TabBarIOSProps */
+    export type TabBarIOSProperties = TabBarIOSProps;
+
+    /** @deprecated Use SnapshotViewIOSProps */
+    export type SnapshotViewIOSProperties = SnapshotViewIOSProps;
+
+    /** @deprecated Use ButtonProps */
+    export type ButtonProperties = ButtonProps;
+
+    /** @deprecated Use StatusBarProps */
+    export type StatusBarProperties = StatusBarProps;
+
+    /** @deprecated Use StatusBarPropsIOS */
+    export type StatusBarPropertiesIOS = StatusBarPropsIOS;
+
+    /** @deprecated Use StatusBarPropsAndroid */
+    export type StatusBarPropertiesAndroid = StatusBarPropsAndroid;
+
+    /** @deprecated Use SwitchProps */
+    export type SwitchProperties = SwitchProps;
+
+    /** @deprecated Use SwitchPropsIOS */
+    export type SwitchPropertiesIOS = SwitchPropsIOS;
+}

--- a/types/react-native/v0.61/tsconfig.json
+++ b/types/react-native/v0.61/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "jsx": "react",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "test/index.tsx",
+        "test/globals.tsx",
+        "test/animated.tsx",
+        "test/init-example.tsx",
+        "test/ART.tsx",
+        "test/legacy-properties.tsx",
+        "test/stylesheet-create.tsx"
+    ]
+}

--- a/types/react-native/v0.61/tslint.json
+++ b/types/react-native/v0.61/tslint.json
@@ -1,0 +1,31 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        // Lowercase `object` is available in TypeScript 2.2 only.
+        "ban-types": false,
+        // Below are all TODO
+        "align": false,
+        "array-type": false,
+        "comment-format": false,
+        "interface-over-type-literal": false,
+        "jsdoc-format": false,
+        "max-line-length": false,
+        "no-declare-current-package": false,
+        "no-misused-new": false,
+        "no-consecutive-blank-lines": false,
+        "no-duplicate-imports": false,
+        "no-empty-interface": false,
+        "no-padding": false,
+        "no-self-import": false,
+        "no-var": false,
+        "no-var-keyword": false,
+        "prefer-declare-function": false,
+        "prefer-method-signature": false,
+        "semicolon": false,
+        "space-within-parens": false,
+        "strict-export-declare-modifiers": false,
+        "use-default-type-parameter": false,
+        "no-unnecessary-generics": false,
+        "no-single-declare-module": false
+    }
+}


### PR DESCRIPTION
Moving to the structure that allows us to have separate type definitions for multiple versions.  This will allow us to update the root types for the next version when changes are made to react-native master.  Rather than having to wait until the next release of react-native, when type changes have been forgotten.

Other than copying files, the only changes I've made is to the version numbers in index.d.ts in the various folders.  (0.61 in the v0.61 folder, and 0.62 in the v0.62)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). - Already fails prior to change

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
