### PR TITLE
[@types/braintree-web]: optional hosted field styles; paypal promises

### DIFF
--- a/types/braintree-web/index.d.ts
+++ b/types/braintree-web/index.d.ts
@@ -685,8 +685,8 @@ declare namespace braintree {
      *   }
      * }, callback);
      */
-     create(options: { client: Client, fields: HostedFieldFieldOptions, styles: any }): Promise<HostedFields>;
-     create(options: { client: Client, fields: HostedFieldFieldOptions, styles: any }, callback: callback): void;
+     create(options: { client: Client, fields: HostedFieldFieldOptions, styles?: any }): Promise<HostedFields>;
+     create(options: { client: Client, fields: HostedFieldFieldOptions, styles?: any }, callback: callback): void;
 
 
     /**
@@ -1008,7 +1008,8 @@ declare namespace braintree {
      * });
      * @returns {void}
      */
-    create: (options: { client: Client }, callback: callback) => void;
+    create(options: { client: Client }): Promise<PayPal>;
+    create(options: { client: Client }, callback: callback): void;
 
     /**
      * @description The current version of the SDK, i.e. `3.0.2`.
@@ -1111,6 +1112,7 @@ declare namespace braintree {
      * });
      * @returns {PayPal~tokenizeReturn} A handle to close the PayPal checkout frame.
      */
+    tokenize(options: { flow: string, intent?: string, offerCredit?: boolean, useraction?: string, amount?: (string | number), currency?: string, displayName?: string, locale?: string, enableShippingAddress?: boolean, shippingAddressOverride?: PayPalShippingAddress, shippingAddressEditable?: boolean, billingAgreementDescription?: string }): Promise<PayPalTokenizeReturn>;
     tokenize(options: { flow: string, intent?: string, offerCredit?: boolean, useraction?: string, amount?: (string | number), currency?: string, displayName?: string, locale?: string, enableShippingAddress?: boolean, shippingAddressOverride?: PayPalShippingAddress, shippingAddressEditable?: boolean, billingAgreementDescription?: string }, callback: callback): PayPalTokenizeReturn;
 
     /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

   - [`styles` is an optional attribute for hosted fields](https://braintree.github.io/braintree-web/current/module-braintree-web_hosted-fields.html)  
   
   - [`PayPal` supports callbacks & promises](https://developers.braintreepayments.com/guides/paypal/client-side/javascript/v3#initialize-components) 

~~- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
~~- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
