### PR TITLE
Revert "aws-lambda - removes the wrong assumption that headers are always set"

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -125,7 +125,7 @@ strOrUndefined = apiGwEvtReqCtx.routeKey;
 
 /* API Gateway Event */
 strOrNull = apiGwEvt.body;
-str = apiGwEvt.headers!['example'];
+str = apiGwEvt.headers['example'];
 str = apiGwEvt.multiValueHeaders['example'][0];
 str = apiGwEvt.httpMethod;
 bool = apiGwEvt.isBase64Encoded;

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -79,7 +79,7 @@ export interface APIGatewayEventRequestContext {
 // API Gateway "event"
 export interface APIGatewayProxyEvent {
     body: string | null;
-    headers?: { [name: string]: string };
+    headers: { [name: string]: string };
     multiValueHeaders: { [name: string]: string[] };
     httpMethod: string;
     isBase64Encoded: boolean;


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#40876 due to breaking change complaints.

I happen to think this is the right thing to do, but I'm happy to hear this out.