### PR TITLE
Adds types for existing npm module datastore-level

### DIFF
--- a/types/datastore-level/datastore-level-tests.ts
+++ b/types/datastore-level/datastore-level-tests.ts
@@ -1,12 +1,12 @@
 import leveldown from 'leveldown';
 import levelup from 'levelup';
 import { Key, Result, Query, Batch, Datastore } from 'interface-datastore';
-import LevelDatastore from 'datastore-level';
+import LevelDatastore, { LevelDatastore as Interface } from 'datastore-level';
 
 const levelStore: Datastore = new LevelDatastore('init-default');
 levelStore.open();
 
-const store = new LevelDatastore('path', { db: (path, opts) => levelup(leveldown(path), opts) });
+const store: Interface = new LevelDatastore('path', { db: (path, opts) => levelup(leveldown(path), opts) });
 store.open();
 
 const k = new Key('/z/one');
@@ -48,7 +48,7 @@ store.put(k, Buffer.from('hello')).then(() => {
     });
 });
 
-const b: Batch<Buffer> = store.batch();
+const b: Batch = store.batch();
 
 store.put(new Key('/z/old'), Buffer.from('old')).then(() => {
     b.put(new Key('/a/one'), Buffer.from('1'));
@@ -68,10 +68,10 @@ const hello = { key: new Key('/q/1hello'), value: Buffer.from('1') };
 const world = { key: new Key('/z/2world'), value: Buffer.from('2') };
 const hello2 = { key: new Key('/z/3hello2'), value: Buffer.from('3') };
 
-const filter1: Query.Filter<Buffer> = (entry: Result<Buffer>) => !entry.key.toString().endsWith('hello');
-const filter2 = (entry: Result<Buffer>) => entry.key.toString().endsWith('hello2');
+const filter1: Query.Filter = (entry: Result) => !entry.key.toString().endsWith('hello');
+const filter2 = (entry: Result) => entry.key.toString().endsWith('hello2');
 
-const order: Query.Order<Buffer> = (res: Array<Result<Buffer>>) => {
+const order: Query.Order = (res: Result[]) => {
     return res.sort((a, b) => {
         if (a.value.toString() < b.value.toString()) {
             return -1;
@@ -90,7 +90,7 @@ batch.commit();
 
 // Do some waiting...
 
-const query: Query<Buffer> = {
+const query: Query = {
     prefix: '/z',
     keysOnly: false,
     filters: [filter1, filter2],
@@ -100,7 +100,7 @@ const query: Query<Buffer> = {
 };
 
 const test = async () => {
-    const res: Array<Result<Buffer>> = [];
+    const res: Result[] = [];
     for await (const item of store.query(query)) {
         res.push(item);
         const key = item.key.toString();

--- a/types/datastore-level/datastore-level-tests.ts
+++ b/types/datastore-level/datastore-level-tests.ts
@@ -1,0 +1,111 @@
+import leveldown from 'leveldown';
+import levelup from 'levelup';
+import { Key, Result, Query, Batch, Datastore } from 'interface-datastore';
+import LevelDatastore from 'datastore-level';
+
+const levelStore: Datastore = new LevelDatastore('init-default');
+levelStore.open();
+
+const store = new LevelDatastore('path', { db: (path, opts) => levelup(leveldown(path), opts) });
+store.open();
+
+const k = new Key('/z/one');
+store.put(k, Buffer.from('one'));
+
+const data: Array<[Key, Buffer]> = [];
+for (let i = 0; i < 100; i++) {
+    data.push([new Key(`/z/key${i}`), Buffer.from(`data${i}`)]);
+}
+
+Promise.all(data.map(d => store.put(d[0], d[1]))).then(() => {
+    Promise.all(data.map(d => store.get(d[0]))).then(res => {
+        console.log(res);
+    });
+});
+
+store.put(k, Buffer.from('hello')).then(() => {
+    store.get(k).then(res => {
+        console.log(res);
+    });
+});
+
+const invalid = new Key('/does/not/exist');
+
+try {
+    store.get(invalid);
+} catch (err) {
+    console.log(err); // ErrCode
+}
+
+store.put(k, Buffer.from('hello')).then(() => {
+    store.get(k).then(() => {
+        store.delete(k).then(() => {
+            store.has(k).then(exists => {
+                console.log(exists);
+                // true
+            });
+        });
+    });
+});
+
+const b: Batch<Buffer> = store.batch();
+
+store.put(new Key('/z/old'), Buffer.from('old')).then(() => {
+    b.put(new Key('/a/one'), Buffer.from('1'));
+    b.put(new Key('/q/two'), Buffer.from('2'));
+    b.put(new Key('/q/three'), Buffer.from('3'));
+    b.delete(new Key('/z/old'));
+    b.commit().then(() => {
+        const keys = ['/a/one', '/q/two', '/q/three', '/z/old'];
+        Promise.all(keys.map(k => store.has(new Key(k)))).then(res => {
+            console.log(res);
+            // [true, true, true, false]
+        });
+    });
+});
+
+const hello = { key: new Key('/q/1hello'), value: Buffer.from('1') };
+const world = { key: new Key('/z/2world'), value: Buffer.from('2') };
+const hello2 = { key: new Key('/z/3hello2'), value: Buffer.from('3') };
+
+const filter1: Query.Filter<Buffer> = (entry: Result<Buffer>) => !entry.key.toString().endsWith('hello');
+const filter2 = (entry: Result<Buffer>) => entry.key.toString().endsWith('hello2');
+
+const order: Query.Order<Buffer> = (res: Array<Result<Buffer>>) => {
+    return res.sort((a, b) => {
+        if (a.value.toString() < b.value.toString()) {
+            return -1;
+        }
+        return 1;
+    });
+};
+
+const batch = store.batch();
+
+batch.put(hello.key, hello.value);
+batch.put(world.key, world.value);
+batch.put(hello2.key, hello2.value);
+
+batch.commit();
+
+// Do some waiting...
+
+const query: Query<Buffer> = {
+    prefix: '/z',
+    keysOnly: false,
+    filters: [filter1, filter2],
+    orders: [order],
+    offset: 1,
+    limit: 1
+};
+
+const test = async () => {
+    const res: Array<Result<Buffer>> = [];
+    for await (const item of store.query(query)) {
+        res.push(item);
+        const key = item.key.toString();
+        const value = item.value.buffer;
+        console.log(`${key}: ${value}`);
+    }
+};
+test();

--- a/types/datastore-level/index.d.ts
+++ b/types/datastore-level/index.d.ts
@@ -7,11 +7,14 @@
 
 import { LevelUp } from 'levelup';
 import { Datastore } from 'interface-datastore';
+import { AbstractLevelDOWN, AbstractIterator } from 'abstract-leveldown'
 
 /**
  * A datastore backed by leveldb.
  */
-export interface LevelDatastore<Value = Buffer> extends Datastore<Value> {}
+export interface LevelDatastore<Value = Buffer> extends Datastore<Value> {
+    db: LevelUp<AbstractLevelDOWN<string, Value>, AbstractIterator<string, Value>>
+}
 
 export interface LevelDatastoreOptions {
     db: (location: string, options?: any) => LevelUp;
@@ -19,8 +22,8 @@ export interface LevelDatastoreOptions {
 }
 
 export interface LevelDatastoreConstructor<Value = Buffer> {
-    new(path: string, options?: LevelDatastoreOptions): LevelDatastore<Value>;
-    (path: string, options?: LevelDatastoreOptions): LevelDatastore<Value>;
+    new <Value>(path: string, options?: LevelDatastoreOptions): LevelDatastore<Value>;
+    <Value>(path: string, options?: LevelDatastoreOptions): LevelDatastore<Value>;
 }
 
 declare const LevelDatastore: LevelDatastoreConstructor;

--- a/types/datastore-level/index.d.ts
+++ b/types/datastore-level/index.d.ts
@@ -7,18 +7,18 @@
 
 import { LevelUp } from 'levelup';
 import { Datastore, Batch } from 'interface-datastore';
-import { AbstractLevelDOWN, AbstractIterator, AbstractBatch } from 'abstract-leveldown'
+import { AbstractLevelDOWN, AbstractIterator, AbstractBatch } from 'abstract-leveldown';
 
 export interface LevelDatastoreBatch<Value = Buffer> extends Batch<Value> {
-    ops: AbstractBatch<string, Value>[]
+    ops: Array<AbstractBatch<string, Value>>;
 }
 
 /**
  * A datastore backed by leveldb.
  */
 export interface LevelDatastore<Value = Buffer> extends Datastore<Value> {
-    db: LevelUp<AbstractLevelDOWN<string, Value>, AbstractIterator<string, Value>>
-    batch(): LevelDatastoreBatch<Value>
+    db: LevelUp<AbstractLevelDOWN<string, Value>, AbstractIterator<string, Value>>;
+    batch(): LevelDatastoreBatch<Value>;
 }
 
 export interface LevelDatastoreOptions {
@@ -26,9 +26,9 @@ export interface LevelDatastoreOptions {
     [key: string]: any;
 }
 
-export interface LevelDatastoreConstructor<Value = Buffer> {
-    new <Value>(path: string, options?: LevelDatastoreOptions): LevelDatastore<Value>;
-    <Value>(path: string, options?: LevelDatastoreOptions): LevelDatastore<Value>;
+export interface LevelDatastoreConstructor {
+    new (path: string, options?: LevelDatastoreOptions): LevelDatastore;
+    (path: string, options?: LevelDatastoreOptions): LevelDatastore;
 }
 
 declare const LevelDatastore: LevelDatastoreConstructor;

--- a/types/datastore-level/index.d.ts
+++ b/types/datastore-level/index.d.ts
@@ -6,25 +6,15 @@
 // TypeScript Version: 3.6
 
 import { LevelUp } from 'levelup';
-import { Key, Datastore, Batch, Query, Result } from 'interface-datastore';
-import { ErrorCallback } from 'abstract-leveldown';
+import { Datastore } from 'interface-datastore';
 
 /**
  * A datastore backed by leveldb.
  */
-export interface LevelDatastore<Value = Buffer> extends Datastore<Value> {
-    open(): Promise<void>;
-    put(key: Key, val: Value): Promise<void>;
-    get(key: Key): Promise<Value>;
-    has(key: Key): Promise<boolean>;
-    delete(key: Key): Promise<void>;
-    batch(): Batch<Value>;
-    query(q: Query<Value>): AsyncIterable<Result<Value>>;
-    close(): Promise<void>;
-}
+export interface LevelDatastore<Value = Buffer> extends Datastore<Value> {}
 
 export interface LevelDatastoreOptions {
-    db: (location: string, options?: any, cb?: ErrorCallback) => LevelUp;
+    db: (location: string, options?: any) => LevelUp;
     [key: string]: any;
 }
 

--- a/types/datastore-level/index.d.ts
+++ b/types/datastore-level/index.d.ts
@@ -17,7 +17,7 @@ export interface LevelDatastore<Value = Buffer> extends Datastore<Value> {
 }
 
 export interface LevelDatastoreOptions {
-    db: (location: string, options?: any) => LevelUp;
+    db?: (location: string, options?: any) => LevelUp;
     [key: string]: any;
 }
 

--- a/types/datastore-level/index.d.ts
+++ b/types/datastore-level/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for datastore-level 0.14
+// Project: https://github.com/ipfs/js-datastore-level#readme
+// Definitions by: Carson Farmer <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node" />
+// TypeScript Version: 3.6
+
+import { LevelUp } from 'levelup';
+import { Key, Datastore, Batch, Query, Result } from 'interface-datastore';
+import { ErrorCallback } from 'abstract-leveldown';
+
+/**
+ * A datastore backed by leveldb.
+ */
+export interface LevelDatastore<Value = Buffer> extends Datastore<Value> {
+    open(): Promise<void>;
+    put(key: Key, val: Value): Promise<void>;
+    get(key: Key): Promise<Value>;
+    has(key: Key): Promise<boolean>;
+    delete(key: Key): Promise<void>;
+    batch(): Batch<Value>;
+    query(q: Query<Value>): AsyncIterable<Result<Value>>;
+    close(): Promise<void>;
+}
+
+export interface LevelDatastoreOptions {
+    db: (location: string, options?: any, cb?: ErrorCallback) => LevelUp;
+    [key: string]: any;
+}
+
+export interface LevelDatastoreConstructor<Value = Buffer> {
+    new(path: string, options?: LevelDatastoreOptions): LevelDatastore<Value>;
+    (path: string, options?: LevelDatastoreOptions): LevelDatastore<Value>;
+}
+
+declare const LevelDatastore: LevelDatastoreConstructor;
+export default LevelDatastore;

--- a/types/datastore-level/index.d.ts
+++ b/types/datastore-level/index.d.ts
@@ -6,14 +6,19 @@
 // TypeScript Version: 3.6
 
 import { LevelUp } from 'levelup';
-import { Datastore } from 'interface-datastore';
-import { AbstractLevelDOWN, AbstractIterator } from 'abstract-leveldown'
+import { Datastore, Batch } from 'interface-datastore';
+import { AbstractLevelDOWN, AbstractIterator, AbstractBatch } from 'abstract-leveldown'
+
+export interface LevelDatastoreBatch<Value = Buffer> extends Batch<Value> {
+    ops: AbstractBatch<string, Value>[]
+}
 
 /**
  * A datastore backed by leveldb.
  */
 export interface LevelDatastore<Value = Buffer> extends Datastore<Value> {
     db: LevelUp<AbstractLevelDOWN<string, Value>, AbstractIterator<string, Value>>
+    batch(): LevelDatastoreBatch<Value>
 }
 
 export interface LevelDatastoreOptions {

--- a/types/datastore-level/tsconfig.json
+++ b/types/datastore-level/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "esnext",
+            "esnext.asynciterable"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "datastore-level-tests.ts"
+    ]
+}

--- a/types/datastore-level/tslint.json
+++ b/types/datastore-level/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/interface-datastore/index.d.ts
+++ b/types/interface-datastore/index.d.ts
@@ -40,13 +40,13 @@ export class MemoryDatastore<Value = Buffer> implements Datastore<Value> {
     close(): Promise<void>;
 }
 
-export interface Batch<Value> {
+export interface Batch<Value = Buffer> {
     put(key: Key, value: Value): void;
     delete(key: Key): void;
     commit(): Promise<void>;
 }
 
-export interface Result<Value> {
+export interface Result<Value = Buffer> {
     key: Key;
     value: Value;
 }
@@ -56,7 +56,7 @@ export namespace Query {
     type Order<T> = (items: Array<Result<T>>) => Array<Result<T>>;
 }
 
-export interface Query<Value> {
+export interface Query<Value = Buffer> {
     prefix?: string;
     filters?: Array<Query.Filter<Value>>;
     orders?: Array<Query.Order<Value>>;

--- a/types/interface-datastore/index.d.ts
+++ b/types/interface-datastore/index.d.ts
@@ -1,0 +1,254 @@
+// Type definitions for interface-datastore 0.8
+// Project: https://github.com/ipfs/interface-datastore#readme
+// Definitions by: Carson Farmer <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node" />
+// TypeScript Version: 3.6
+
+// From https://github.com/IndigoUnited/js-err-code
+// Used here specifically for string-based error codes only
+export interface ErrCode extends Error {
+    code: string; // any | undefined
+    // [key: string]: any
+}
+
+export namespace Errors {
+    function dbOpenFailedError(error: Error): ErrCode;
+    function dbDeleteFailedError(error: Error): ErrCode;
+    function dbWriteFailedError(error: Error): ErrCode;
+    function notFoundError(error: Error): ErrCode;
+}
+
+export namespace utils {
+    function filter<T>(iterable: AsyncIterable<T>, filterer: (item: T) => boolean): AsyncGenerator<T>;
+    function sortAll<T>(iterable: AsyncIterable<T>, sorter: (items: T[]) => T[]): AsyncGenerator<T>;
+    function take<T>(iterable: AsyncIterable<T>, n: number): AsyncGenerator<T>;
+    function map<T, O>(iterable: AsyncIterable<T>, mapper: (item: T) => O): AsyncGenerator<O>;
+    function replaceStartWith(s: string, r: RegExp): string;
+    function tmpdir(): string;
+}
+
+export class MemoryDatastore<Value = Buffer> implements Datastore<Value> {
+    constructor();
+    open(): Promise<void>;
+    put(key: Key, val: Value): Promise<void>;
+    get(key: Key): Promise<Value>;
+    has(key: Key): Promise<boolean>;
+    delete(key: Key): Promise<void>;
+    batch(): Batch<Value>;
+    query(q: Query<Value>): AsyncIterable<Result<Value>>;
+    close(): Promise<void>;
+}
+
+export interface Batch<Value> {
+    put(key: Key, value: Value): void;
+    delete(key: Key): void;
+    commit(): Promise<void>;
+}
+
+export interface Result<Value> {
+    key: Key;
+    value: Value;
+}
+
+export namespace Query {
+    type Filter<T> = (item: Result<T>) => boolean;
+    type Order<T> = (items: Array<Result<T>>) => Array<Result<T>>;
+}
+
+export interface Query<Value> {
+    prefix?: string;
+    filters?: Array<Query.Filter<Value>>;
+    orders?: Array<Query.Order<Value>>;
+    limit?: number;
+    offset?: number;
+    keysOnly?: boolean;
+}
+
+/**
+ * A Key represents the unique identifier of an object.
+ * Our Key scheme is inspired by file systems and Google App Engine key model.
+ * Keys are meant to be unique across a system. Keys are hierarchical,
+ * incorporating more and more specific namespaces. Thus keys can be deemed
+ * 'children' or 'ancestors' of other keys:
+ * - `new Key('/Comedy')`
+ * - `new Key('/Comedy/MontyPython')`
+ * Also, every namespace can be parametrized to embed relevant object
+ * information. For example, the Key `name` (most specific namespace) could
+ * include the object type:
+ * - `new Key('/Comedy/MontyPython/Actor:JohnCleese')`
+ * - `new Key('/Comedy/MontyPython/Sketch:CheeseShop')`
+ * - `new Key('/Comedy/MontyPython/Sketch:CheeseShop/Character:Mousebender')`
+ *
+ */
+export class Key {
+    constructor(s: Buffer | string, clean?: boolean);
+    /**
+     * Convert to the string representation
+     *
+     * @param encoding The encoding to use. Should default to 'utf8'.
+     */
+    toString(encoding?: string): string;
+    /**
+     * Return the buffer representation of the key
+     */
+    toBuffer(): Buffer;
+    /**
+     * Return string representation of the key
+     */
+    get [Symbol.toStringTag](): string;
+    /**
+     * Constructs a key out of a namespace array.
+     *
+     * @param list The array of namespaces
+     *
+     * @example
+     * Key.withNamespaces(['one', 'two'])
+     * // => Key('/one/two')
+     */
+    static withNamespaces(list: string[]): Key;
+    /**
+     * Returns a randomly (uuid) generated key.
+     *
+     * @example
+     * Key.random()
+     * // => Key('/f98719ea086343f7b71f32ea9d9d521d')
+     *
+     */
+    static random(): Key;
+    /**
+     * Cleanup the current key
+     */
+    clean(): void;
+    /**
+     * Check if the given key is sorted lower than ourself.
+     *
+     * @param key The other Key to check against
+     */
+    less(key: Key): boolean;
+    /**
+     * Returns the key with all parts in reversed order.
+     *
+     * @example
+     * new Key('/Comedy/MontyPython/Actor:JohnCleese').reverse()
+     * // => Key('/Actor:JohnCleese/MontyPython/Comedy')
+     */
+    reverse(): Key;
+    /**
+     * Returns the `namespaces` making up this Key.
+     */
+    namespaces(): string[];
+    /**
+     * Returns the "base" namespace of this key.
+     *
+     * @example
+     * new Key('/Comedy/MontyPython/Actor:JohnCleese').baseNamespace()
+     * // => 'Actor:JohnCleese'
+     */
+    baseNamespace(): string;
+    /**
+     * Returns the `list` representation of this key.
+     *
+     * @example
+     * new Key('/Comedy/MontyPython/Actor:JohnCleese').list()
+     * // => ['Comedy', 'MontyPythong', 'Actor:JohnCleese']
+     */
+    list(): string[];
+    /**
+     * Returns the "type" of this key (value of last namespace).
+     *
+     * @example
+     * new Key('/Comedy/MontyPython/Actor:JohnCleese').type()
+     * // => 'Actor'
+     */
+    type(): string;
+    /**
+     * Returns the "name" of this key (field of last namespace).
+     *
+     * @example
+     * new Key('/Comedy/MontyPython/Actor:JohnCleese').name()
+     * // => 'JohnCleese'
+     */
+    name(): string;
+    /**
+     * Returns an "instance" of this type key (appends value to namespace).
+     *
+     * @param str The string to append
+     *
+     * @example
+     * new Key('/Comedy/MontyPython/Actor').instance('JohnClesse')
+     * // => Key('/Comedy/MontyPython/Actor:JohnCleese')
+     */
+    instance(str: string): Key;
+    /**
+     * Returns the "path" of this key (parent + type).
+     *
+     * @example
+     * new Key('/Comedy/MontyPython/Actor:JohnCleese').path()
+     * // => Key('/Comedy/MontyPython/Actor')
+     */
+    path(): Key;
+    /**
+     * Returns the `parent` Key of this Key.
+     *
+     * @example
+     * new Key("/Comedy/MontyPython/Actor:JohnCleese").parent()
+     * // => Key("/Comedy/MontyPython")
+     */
+    parent(): Key;
+    /**
+     * Returns the `child` Key of this Key.
+     *
+     * @param key The child Key to add
+     *
+     * @example
+     * new Key('/Comedy/MontyPython').child(new Key('Actor:JohnCleese'))
+     * // => Key('/Comedy/MontyPython/Actor:JohnCleese')
+     */
+    child(key: Key): Key;
+    /**
+     * Returns whether this key is a prefix of `other`
+     *
+     * @param other The other key to test against
+     *
+     * @example
+     * new Key('/Comedy').isAncestorOf('/Comedy/MontyPython')
+     * // => true
+     */
+    isAncestorOf(other: Key): boolean;
+    /**
+     * Returns whether this key is a contains another as prefix.
+     *
+     * @param other The other Key to test against
+     *
+     * @example
+     * new Key('/Comedy/MontyPython').isDecendantOf('/Comedy')
+     * // => true
+     */
+    isDecendantOf(other: Key): boolean;
+    /**
+     * Returns wether this key has only one namespace.
+     */
+    isTopLevel(): boolean;
+    /**
+     * Concats one or more Keys into one new Key.
+     *
+     * @param keys The array of keys to concatenate
+     */
+    concat(...keys: Key[]): Key;
+    /**
+     * Returns whether the input is a valid Key.
+     */
+    static isKey(key: any): boolean;
+}
+
+export interface Datastore<Value = Buffer> {
+    open(): Promise<void>;
+    put(key: Key, val: Value): Promise<void>;
+    get(key: Key): Promise<Value>;
+    has(key: Key): Promise<boolean>;
+    delete(key: Key): Promise<void>;
+    batch(): Batch<Value>;
+    query(q: Query<Value>): AsyncIterable<Result<Value>>;
+    close(): Promise<void>;
+}

--- a/types/interface-datastore/index.d.ts
+++ b/types/interface-datastore/index.d.ts
@@ -52,8 +52,8 @@ export interface Result<Value = Buffer> {
 }
 
 export namespace Query {
-    type Filter<T> = (item: Result<T>) => boolean;
-    type Order<T> = (items: Array<Result<T>>) => Array<Result<T>>;
+    type Filter<T = Buffer> = (item: Result<T>) => boolean;
+    type Order<T = Buffer> = (items: Array<Result<T>>) => Array<Result<T>>;
 }
 
 export interface Query<Value = Buffer> {

--- a/types/interface-datastore/interface-datastore-tests.ts
+++ b/types/interface-datastore/interface-datastore-tests.ts
@@ -41,7 +41,7 @@ store.put(k, Buffer.from('hello')).then(() => {
     });
 });
 
-const b: Batch<Buffer> = store.batch();
+const b: Batch = store.batch();
 
 store.put(new Key('/z/old'), Buffer.from('old')).then(() => {
     b.put(new Key('/a/one'), Buffer.from('1'));
@@ -64,7 +64,7 @@ const hello2 = { key: new Key('/z/3hello2'), value: Buffer.from('3') };
 const filter1: Query.Filter = (entry: Result) => !entry.key.toString().endsWith('hello');
 const filter2 = (entry: Result) => entry.key.toString().endsWith('hello2');
 
-const order: Query.Order = (res: Array<Result>) => {
+const order: Query.Order = (res: Result[]) => {
     return res.sort((a, b) => {
         if (a.value.toString() < b.value.toString()) {
             return -1;
@@ -93,7 +93,7 @@ const query: Query = {
 };
 
 const test = async () => {
-    const res: Array<Result> = [];
+    const res: Result[] = [];
     for await (const item of store.query(query)) {
         res.push(item);
         const key = item.key.toString();

--- a/types/interface-datastore/interface-datastore-tests.ts
+++ b/types/interface-datastore/interface-datastore-tests.ts
@@ -61,10 +61,10 @@ const hello = { key: new Key('/q/1hello'), value: Buffer.from('1') };
 const world = { key: new Key('/z/2world'), value: Buffer.from('2') };
 const hello2 = { key: new Key('/z/3hello2'), value: Buffer.from('3') };
 
-const filter1: Query.Filter<Buffer> = (entry: Result<Buffer>) => !entry.key.toString().endsWith('hello');
-const filter2 = (entry: Result<Buffer>) => entry.key.toString().endsWith('hello2');
+const filter1: Query.Filter = (entry: Result) => !entry.key.toString().endsWith('hello');
+const filter2 = (entry: Result) => entry.key.toString().endsWith('hello2');
 
-const order: Query.Order<Buffer> = (res: Array<Result<Buffer>>) => {
+const order: Query.Order = (res: Array<Result>) => {
     return res.sort((a, b) => {
         if (a.value.toString() < b.value.toString()) {
             return -1;
@@ -83,7 +83,7 @@ batch.commit();
 
 // Do some waiting...
 
-const query: Query<Buffer> = {
+const query: Query = {
     prefix: '/z',
     keysOnly: false,
     filters: [filter1, filter2],
@@ -93,7 +93,7 @@ const query: Query<Buffer> = {
 };
 
 const test = async () => {
-    const res: Array<Result<Buffer>> = [];
+    const res: Array<Result> = [];
     for await (const item of store.query(query)) {
         res.push(item);
         const key = item.key.toString();

--- a/types/interface-datastore/interface-datastore-tests.ts
+++ b/types/interface-datastore/interface-datastore-tests.ts
@@ -1,0 +1,104 @@
+import { Key, MemoryDatastore, Result, Query, Batch, Errors, utils, Datastore } from 'interface-datastore';
+
+const store: Datastore = new MemoryDatastore();
+
+const k = new Key('/z/one');
+store.put(k, Buffer.from('one'));
+
+const data: Array<[Key, Buffer]> = [];
+for (let i = 0; i < 100; i++) {
+    data.push([new Key(`/z/key${i}`), Buffer.from(`data${i}`)]);
+}
+
+Promise.all(data.map(d => store.put(d[0], d[1]))).then(() => {
+    Promise.all(data.map(d => store.get(d[0]))).then(res => {
+        console.log(res);
+    });
+});
+
+store.put(k, Buffer.from('hello')).then(() => {
+    store.get(k).then(res => {
+        console.log(res);
+    });
+});
+
+const invalid = new Key('/does/not/exist');
+
+try {
+    store.get(invalid);
+} catch (err) {
+    console.log(err); // ErrCode
+}
+
+store.put(k, Buffer.from('hello')).then(() => {
+    store.get(k).then(() => {
+        store.delete(k).then(() => {
+            store.has(k).then(exists => {
+                console.log(exists);
+                // true
+            });
+        });
+    });
+});
+
+const b: Batch<Buffer> = store.batch();
+
+store.put(new Key('/z/old'), Buffer.from('old')).then(() => {
+    b.put(new Key('/a/one'), Buffer.from('1'));
+    b.put(new Key('/q/two'), Buffer.from('2'));
+    b.put(new Key('/q/three'), Buffer.from('3'));
+    b.delete(new Key('/z/old'));
+    b.commit().then(() => {
+        const keys = ['/a/one', '/q/two', '/q/three', '/z/old'];
+        Promise.all(keys.map(k => store.has(new Key(k)))).then(res => {
+            console.log(res);
+            // [true, true, true, false]
+        });
+    });
+});
+
+const hello = { key: new Key('/q/1hello'), value: Buffer.from('1') };
+const world = { key: new Key('/z/2world'), value: Buffer.from('2') };
+const hello2 = { key: new Key('/z/3hello2'), value: Buffer.from('3') };
+
+const filter1: Query.Filter<Buffer> = (entry: Result<Buffer>) => !entry.key.toString().endsWith('hello');
+const filter2 = (entry: Result<Buffer>) => entry.key.toString().endsWith('hello2');
+
+const order: Query.Order<Buffer> = (res: Array<Result<Buffer>>) => {
+    return res.sort((a, b) => {
+        if (a.value.toString() < b.value.toString()) {
+            return -1;
+        }
+        return 1;
+    });
+};
+
+const batch = store.batch();
+
+batch.put(hello.key, hello.value);
+batch.put(world.key, world.value);
+batch.put(hello2.key, hello2.value);
+
+batch.commit();
+
+// Do some waiting...
+
+const query: Query<Buffer> = {
+    prefix: '/z',
+    keysOnly: false,
+    filters: [filter1, filter2],
+    orders: [order],
+    offset: 1,
+    limit: 1
+};
+
+const test = async () => {
+    const res: Array<Result<Buffer>> = [];
+    for await (const item of store.query(query)) {
+        res.push(item);
+        const key = item.key.toString();
+        const value = item.value.buffer;
+        console.log(`${key}: ${value}`);
+    }
+};
+test();

--- a/types/interface-datastore/tsconfig.json
+++ b/types/interface-datastore/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "esnext",
+            "esnext.asynciterable"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "interface-datastore-tests.ts"
+    ]
+}

--- a/types/interface-datastore/tslint.json
+++ b/types/interface-datastore/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR depends on (is branched from): https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40842. That PR should be merged **first**.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.