### PR TITLE
fix(ember-data): improve belongsTo and hasMany relationship typing

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -25,18 +25,6 @@ type ModelKeys<Model extends DS.Model> = Exclude<keyof Model, keyof DS.Model>;
 type AttributesFor<Model extends DS.Model> = ModelKeys<Model>; // TODO: filter to attr properties only (TS 2.8)
 type RelationshipsFor<Model extends DS.Model> = ModelKeys<Model>; // TODO: filter to hasMany/belongsTo properties only (TS 2.8)
 
-// infer the generic type of hasMany when used as computed or decorator
-type UnpackManyArray<T> =
-    T extends DS.ManyArray<infer X> ? X :
-    T extends DS.PromiseManyArray<infer Y> ? Y :
-    T extends Ember.ComputedProperty<DS.PromiseManyArray<infer Z>, any> ? Z :
-    T;
-
-// used to infer the generic type of belongsTo when used as computed or decorator
-type UnpackComputedProperty<T> =
-    T extends Ember.ComputedProperty<infer Y> ? Y:
-    T;
-
 export interface ChangedAttributes {
     [key: string]: [any, any] | undefined;
 }
@@ -558,11 +546,11 @@ export namespace DS {
         /**
          * Get the reference for the specified belongsTo relationship.
          */
-        belongsTo<T extends keyof this = RelationshipsFor<this>>(name: T): BelongsToReference<UnpackComputedProperty<this[T]>>;
+        belongsTo(name: RelationshipsFor<this>): BelongsToReference<any>;
         /**
          * Get the reference for the specified hasMany relationship.
          */
-        hasMany<T extends keyof this = RelationshipsFor<this>>(name: T): HasManyReference<UnpackManyArray<this[T]>>;
+        hasMany(name: RelationshipsFor<this>): HasManyReference<any>;
         /**
          * Given a callback, iterates over each of the relationships in the model,
          * invoking the callback with the name of each relationship and its relationship

--- a/types/ember-data/test/belongs-to.ts
+++ b/types/ember-data/test/belongs-to.ts
@@ -8,16 +8,16 @@ class Folder extends DS.Model {
     children = DS.hasMany('folder', { inverse: 'parent' });
     parent = DS.belongsTo('folder', { inverse: 'children' });
 
-    @DS.belongsTo('owner') owner!: Owner;
+    @DS.belongsTo('icon') icon!: Icon;
 }
 
-class Owner extends DS.Model {
+class Icon extends DS.Model {
 }
 
 declare module 'ember-data/types/registries/model' {
     export default interface ModelRegistry {
         folder: Folder;
-        owner: Owner;
+        icon: Icon;
     }
 }
 
@@ -39,8 +39,8 @@ folder.set('parent', store.findRecord('folder', 3));
 folder.belongsTo('parent').value();
 
 // when used as decorator
-// $ExpectType Owner | null
-folder.belongsTo('owner').value();
+// $ExpectType Icon | null
+folder.belongsTo('icon').value();
 
 // $ExpectType "id" | "link"
 folder.belongsTo('parent').remoteType();

--- a/types/ember-data/test/belongs-to.ts
+++ b/types/ember-data/test/belongs-to.ts
@@ -7,11 +7,17 @@ class Folder extends DS.Model {
     name = DS.attr('string');
     children = DS.hasMany('folder', { inverse: 'parent' });
     parent = DS.belongsTo('folder', { inverse: 'children' });
+
+    @DS.belongsTo('owner') owner!: Owner;
+}
+
+class Owner extends DS.Model {
 }
 
 declare module 'ember-data/types/registries/model' {
     export default interface ModelRegistry {
         folder: Folder;
+        owner: Owner;
     }
 }
 
@@ -28,5 +34,13 @@ folder.set('parent', folder);
 folder.set('parent', folder.get('parent'));
 folder.set('parent', store.findRecord('folder', 3));
 
-// $ExpectType Model | null
+// when used as cp
+// $ExpectType Folder | null
 folder.belongsTo('parent').value();
+
+// when used as decorator
+// $ExpectType Owner | null
+folder.belongsTo('owner').value();
+
+// $ExpectType "id" | "link"
+folder.belongsTo('parent').remoteType();

--- a/types/ember-data/test/belongs-to.ts
+++ b/types/ember-data/test/belongs-to.ts
@@ -35,11 +35,14 @@ folder.set('parent', folder.get('parent'));
 folder.set('parent', store.findRecord('folder', 3));
 
 // when used as cp
-// $ExpectType Folder | null
+// $ExpectType any
 folder.belongsTo('parent').value();
 
+// $ExpectType Folder | null
+(folder.belongsTo('parent') as DS.BelongsToReference<Folder>).value();
+
 // when used as decorator
-// $ExpectType Icon | null
+// $ExpectType any
 folder.belongsTo('icon').value();
 
 // $ExpectType "id" | "link"

--- a/types/ember-data/test/has-many.ts
+++ b/types/ember-data/test/has-many.ts
@@ -16,6 +16,8 @@ class BlogPost extends DS.Model {
     title = DS.attr('string');
     commentsAsync = DS.hasMany('blog-comment');
     commentsSync = DS.hasMany('blog-comment', { async: false });
+
+    @DS.hasMany('blog-comment') archivedComments: DS.ManyArray<BlogComment>;
 }
 
 const blogPost = BlogPost.create();
@@ -59,6 +61,13 @@ declare module 'ember-data/types/registries/model' {
 class Polymorphic extends DS.Model {
     paymentMethods = DS.hasMany('payment-method', { polymorphic: true });
 }
-
-// $ExpectType ManyArray<any> | null
+// when used as cp
+// $ExpectType ManyArray<BlogComment> | null
 blogPost.hasMany('commentsAsync').value();
+
+// when used as decorator
+// $ExpectType ManyArray<BlogComment> | null
+blogPost.hasMany('archivedComments').value();
+
+// $ExpectType "ids" | "link"
+blogPost.hasMany('commentsAsync').remoteType();

--- a/types/ember-data/test/has-many.ts
+++ b/types/ember-data/test/has-many.ts
@@ -62,11 +62,11 @@ class Polymorphic extends DS.Model {
     paymentMethods = DS.hasMany('payment-method', { polymorphic: true });
 }
 // when used as cp
-// $ExpectType ManyArray<BlogComment> | null
+// $ExpectType ManyArray<any> | null
 blogPost.hasMany('commentsAsync').value();
 
 // when used as decorator
-// $ExpectType ManyArray<BlogComment> | null
+// $ExpectType ManyArray<any> | null
 blogPost.hasMany('archivedComments').value();
 
 // $ExpectType "ids" | "link"

--- a/types/ember-data/tsconfig.json
+++ b/types/ember-data/tsconfig.json
@@ -5,6 +5,7 @@
             "es6",
             "dom"
         ],
+        "experimentalDecorators": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

  * `remoteType` return type: [hasMany](https://github.com/emberjs/data/blob/v3.14.0/packages/store/addon/-private/system/references/has-many.js#L76-L81), [belongsTo](https://github.com/emberjs/data/blob/v3.14.0/packages/store/addon/-private/system/references/reference.ts#L76-L82) (Note the ember-data type also declares `identity` but it doesn't seem to be used)
  * I made BelongsToReference and HasManyReference generic (HasManyReference had some generic parts already). We might be able to narrow the generic type further by asserting that `T extends Model` but I'm not sure if it's too strict.
  * `hasMany` and `belongsTo` now extracts the type by extracting it from the instance. This can create false-positives as it can't decide if a field is an attribute or a relationship. This drawback [already existed previously](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/ember-data/index.d.ts#L26).
  * __Note__: this also adjusts the tsconfig to enable checking of `belongsTo` and `hasMany` when used as a decorator

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
