### PR TITLE
pdfjs-dist: Added PDFPageProxy.pageIndex

### DIFF
--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -62,10 +62,10 @@ declare class PDFDataRangeTransport {
     addProgressiveDoneListener(listener: PDFDataRangeTransportListener): void
     onDataRange(begin: number, chunk: unknown): void
     onDataProgress(loaded: number, total: number): void
-    onDataProgressiveRead(chunk: unknown): void    
+    onDataProgressiveRead(chunk: unknown): void
     onDataProgressiveDone(): void
-    transportReady() : void    
-    requestDataRange(begin: number, end: number): void    
+    transportReady() : void
+    requestDataRange(begin: number, end: number): void
     abort(): void
 }
 
@@ -77,11 +77,11 @@ interface PDFWorkerParameters {
 
 declare class PDFWorker {
     constructor(params?: PDFWorkerParameters)
-    readonly promise: Promise<unknown>    
+    readonly promise: Promise<unknown>
     readonly port: any |null
     readonly messageHandler: unknown | null
     destroy(): void
-    static fromPort(params?: PDFWorkerParameters): PDFWorker  
+    static fromPort(params?: PDFWorkerParameters): PDFWorker
     static getWorkerSrc(): string
 }
 declare enum  CMapCompressionType {
@@ -105,7 +105,7 @@ interface PDFSource {
      * Binary PDF data. Use typed arrays
      * (Uint8Array) to improve the memory usage. If PDF data is BASE64-encoded,
      * use atob() to convert it to a binary string first.
-     */    
+     */
     data?: Uint8Array | BufferSource | string;
     /**
      * Basic authentication headers.
@@ -115,7 +115,7 @@ interface PDFSource {
     };
     /**
      * For decrypting password-protected PDFs.
-     */    
+     */
     password?: string;
     /**
     * Indicates whether or not cross-site
@@ -145,7 +145,7 @@ interface PDFSource {
      * the loading and parsing of the PDF data.
      */
     worker?: PDFWorker;
-    /** 
+    /**
      * Controls the logging level; the
      * constants from {VerbosityLevel} should be used.
      */
@@ -169,7 +169,7 @@ interface PDFSource {
     nativeImageDecoderSupport?: "decode"|"display"|"none"
     /**
      * The URL where the predefined
-     * Adobe CMaps are located. Include trailing slash. */    
+     * Adobe CMaps are located. Include trailing slash. */
     cMapUrl?: string
     /**
      * Specifies if the Adobe CMaps are
@@ -180,46 +180,46 @@ interface PDFSource {
      * used when reading built-in CMap files. Providing a custom factory is useful
      * for environments without `XMLHttpRequest` support, such as e.g. Node.js.
      * The default value is {DOMCMapReaderFactory}.
-     */    
+     */
     CMapReaderFactory?: any
     /**
      * Reject certain promises, e.g.
      * `getOperatorList`, `getTextContent`, and `RenderTask`, when the associated
      * PDF data cannot be successfully parsed, instead of attempting to recover
      * whatever possible of the data. The default value is `false`.
-     */    
+     */
     stopAtErrors?: boolean
     /**
      * The maximum allowed image size
      * in total pixels, i.e. width * height. Images above this value will not be
      * rendered. Use -1 for no limit, which is also the default value.
-     */    
+     */
     maxImageSize?: number
     /**
      * Determines if we can eval
      * strings as JS. Primarily used to improve performance of font rendering,
      * and when parsing PDF functions. The default value is `true`.
-     */    
+     */
     isEvalSupported?: boolean
     /**
      * By default fonts are
      *   converted to OpenType fonts and loaded via font face rules. If disabled,
      *   fonts will be rendered using a built-in font renderer that constructs the
      *   glyphs with primitive path commands. The default value is `false`.
-     */    
+     */
     disableFontFace?: boolean
     /**
      * Disable range request loading
      *   of PDF files. When enabled, and if the server supports partial content
      *   requests, then the PDF will be fetched in chunks.
      *   The default value is `false`.
-     */    
+     */
     disableRange?: boolean
     /**
      * Disable streaming of PDF file
      *   data. By default PDF.js attempts to load PDFs in chunks.
      *   The default value is `false`.
-     */    
+     */
     disableStream?: boolean
     /**
      * Disable pre-fetching of PDF
@@ -228,18 +228,18 @@ interface PDFSource {
      *   The default value is `false`.
      *   NOTE: It is also necessary to disable streaming, see above,
      *         in order for disabling of pre-fetching to work correctly.
-     */    
+     */
     disableAutoFetch?: boolean
     /**
      * Disable the use of
      *   `URL.createObjectURL`, for compatibility with older browsers.
      *   The default value is `false`.
-     */    
+     */
     disableCreateObjectURL?: boolean
     /**
      * Enables special hooks for debugging
      * PDF.js (see `web/debugger.js`). The default value is `false`.
-     */    
+     */
     pdfBug?: boolean
 }
 
@@ -402,6 +402,11 @@ interface PDFRenderTask extends PDFLoadingTask<PDFPageProxy> {
 }
 
 interface PDFPageProxy {
+
+    /**
+     * Page index of the page.  First page is 0.
+     */
+    pageIndex: number;
 
     /**
      * Page number of the page.  First page is 1.


### PR DESCRIPTION
I added `PDFPageProxy.pageIndex`. I didn't test it because it was a trivial changes, adding one of many properties for that object.

The property is specified here: https://github.com/mozilla/pdf.js/blob/16778118f66f1c8971349cafe19938e4a40bde86/src/display/api.js#L908

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/mozilla/pdf.js/blob/16778118f66f1c8971349cafe19938e4a40bde86/src/display/api.js#L908>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

