### PR TITLE
fix(theme-ui): simplify SxStyleProp type

### DIFF
--- a/types/theme-ui/index.d.ts
+++ b/types/theme-ui/index.d.ts
@@ -123,17 +123,11 @@ export interface Theme extends StyledSystemTheme {
 export const jsx: typeof React.createElement;
 
 /**
- * The `SxStyleProp` extension `SystemStyleObject` and `Emotion` [style props](https://emotion.sh/docs/object-styles)
- * such that properties that are part of the `Theme` will be transformed to
- * their corresponding values. Other valid CSS properties are also allowed.
+ * The `sx` prop accepts a `SxStyleProp` object and properties that are part of
+ * the `Theme` will be transformed to their corresponding values. Other valid
+ * CSS properties are also allowed.
  */
-export type SxStyleProp = SystemStyleObject &
-    Record<
-        string,
-        | SystemStyleObject
-        | ResponsiveStyleValue<number | string>
-        | Record<string, SystemStyleObject | ResponsiveStyleValue<number | string>>
-    >;
+export type SxStyleProp = SystemStyleObject;
 
 export interface SxProps {
     /**

--- a/types/theme-ui/theme-ui-tests.tsx
+++ b/types/theme-ui/theme-ui-tests.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Flex, jsx, InitializeColorMode, ColorMode, Styled, Theme } from 'theme-ui';
+import { Flex, jsx, InitializeColorMode, ColorMode, Styled, SxStyleProp, Theme } from 'theme-ui';
 
 export const Component = () => {
     return (
@@ -112,3 +112,25 @@ const themeWithStyles: Theme = {
         },
     },
 };
+
+function SpreadingAndMergingInSxProp() {
+    const buttonStyles: SxStyleProp = {
+        font: 'inherit',
+        color: 'primary',
+        background: 'papayawhip',
+        border: 'none',
+        boxShadow: () => `0 0 4px black`,
+        ':hover': {
+            background: 'yellow',
+            width: ['80%', '40%', '20%'],
+        },
+        height: '2rem',
+        width: ['100%', '50%', '25%'],
+    };
+
+    return (
+        <button type="button" sx={{ ...buttonStyles, background: 'red' }}>
+            click me
+        </button>
+    );
+}


### PR DESCRIPTION
This allows for spreading an `SxStyleProp` object inside a new object and merging in other
properties before passing to `sx`, like so:

```
sx={{ ...someSxStylePropObj, background: 'red' }}
```

I believe this simplification is now possible due to changes made to the `SystemStyleObject` type
in `@styled-system/css` since these types were initially created.

Closes #40897

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/40897
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
