### PR TITLE
Add rfdc (Really Fast Deep Clone) types

### DIFF
--- a/types/rfdc/index.d.ts
+++ b/types/rfdc/index.d.ts
@@ -1,0 +1,86 @@
+// Type definitions for rfdc 1.1
+// Project: https://github.com/davidmarkclements/rfdc#readme
+// Definitions by: Emily Marigold Klassen <https://github.com/forivall>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = rfdc;
+
+/**
+ * Really Fast Deep Clone
+ *
+ * ### Types
+ *
+ * `rdfc` clones all JSON types:
+ *
+ * * `Object`
+ * * `Array`
+ * * `Number`
+ * * `String`
+ * * `null`
+ *
+ * With additional support for:
+ *
+ * * `Date` (copied)
+ * * `undefined` (copied)
+ * * `Function` (referenced)
+ * * `AsyncFunction` (referenced)
+ * * `GeneratorFunction` (referenced)
+ * * `arguments` (copied to a normal object)
+ *
+ * All other types have output values that match the output
+ * of `JSON.parse(JSON.stringify(o))`.
+ *
+ * For instance:
+ *
+ * ```js
+ * const rdfc = require('rdfc')()
+ * const err = Error()
+ * err.code = 1
+ * JSON.parse(JSON.stringify(e)) // {code: 1}
+ * rdfc(e) // {code: 1}
+ *
+ * JSON.parse(JSON.stringify(new Uint8Array([1, 2, 3]))) //  {'0': 1, '1': 2, '2': 3 }
+ * rdfc(new Uint8Array([1, 2, 3])) //  {'0': 1, '1': 2, '2': 3 }
+ *
+ * JSON.parse(JSON.stringify({rx: /foo/})) // {rx: {}}
+ * rdfc({rx: /foo/}) // {rx: {}}
+ * ```
+ */
+declare function rfdc(opts?: rfdc.Options): <T>(obj: T) => T;
+
+declare namespace rfdc {
+    interface Options {
+        /**
+         * Copy prototype properties as well as own properties into the new
+         * object.
+         *
+         * It's marginally faster to allow enumerable properties on the
+         * prototype to be copied into the cloned object (not onto it's
+         * prototype, directly onto the object).
+         *
+         * To explain by way of code:
+         *
+         * ```js
+         * require('rfdc')({ proto: false })(Object.create({a: 1})) // => {}
+         * require('rfdc')({ proto: true })(Object.create({a: 1})) // => {a: 1}
+         * ```
+         *
+         * Setting `proto` to `true` will provide an additional 2% performance
+         * boost.
+         */
+        proto?: boolean;
+        /**
+         * Keeping track of circular references will slow down performance with
+         * an additional 25% overhead. Even if an object doesn't have any
+         * circular references, the tracking overhead is the cost. By default if
+         * an object with a circular reference is passed to `rfdc`, it will
+         * throw (similar to how `JSON.stringify` would throw).
+         *
+         * Use the `circles` option to detect and preserve circular references
+         * in the object. If performance is important, try removing the circular
+         * reference from the object (set to `undefined`) and then add it back
+         * manually after cloning instead of using this option.
+         */
+        circles?: boolean;
+    }
+}

--- a/types/rfdc/rfdc-tests.ts
+++ b/types/rfdc/rfdc-tests.ts
@@ -1,0 +1,24 @@
+import rfdc = require('rfdc');
+interface Obj {
+    foo?: 'bar';
+}
+const obj: Obj = {};
+const clone = rfdc({ proto: false, circles: false });
+// $ExpectType Obj
+clone(obj);
+
+// Note: we can't replicate the actual behaviour in the type system
+// as typescript doesn't expose prototypes in any special way.
+const err: Error & {code?: number} = Error();
+err.code = 1;
+JSON.parse(JSON.stringify(err)); // {code: 1}
+// $ExpectType Error & { code?: number | undefined; }
+clone(err); // Actual type: {code: 1}
+
+JSON.parse(JSON.stringify(new Uint8Array([1, 2, 3]))); //  {'0': 1, '1': 2, '2': 3 }
+// $ExpectType Uint8Array
+clone(new Uint8Array([1, 2, 3])); // Actual type: {'0': 1, '1': 2, '2': 3 }
+
+JSON.parse(JSON.stringify({rx: /foo/})); // {rx: {}}
+// $ExpectType { rx: RegExp; }
+clone({rx: /foo/}); // {rx: {}}

--- a/types/rfdc/tsconfig.json
+++ b/types/rfdc/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rfdc-tests.ts"
+    ]
+}

--- a/types/rfdc/tslint.json
+++ b/types/rfdc/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
