### PR TITLE
types/react-stripe-elements: add InjectedStripeProps.elements

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-stripe-elements 1.3
+// Type definitions for react-stripe-elements 6.0
 // Project: https://github.com/stripe/react-stripe-elements#readme
 // Definitions by: dan-j <https://github.com/dan-j>
 //                 Santiago Doldan <https://github.com/santiagodoldan>
@@ -9,6 +9,7 @@
 //                 Victor Irzak <https://github.com/virzak>
 //                 Alex Price <https://github.com/remotealex>
 //                 Maciej Dabek <https://github.com/bombek92>
+//                 Hiroshi Ioka <https://github.com/hirochachacha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -64,7 +65,8 @@ export namespace ReactStripeElements {
     }
 
     interface InjectedStripeProps {
-        stripe?: StripeProps;
+        stripe: StripeProps | null;
+        elements: stripe.elements.Elements | null;
     }
 
     interface ElementProps extends ElementsOptions {

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -139,6 +139,8 @@ class WrappedComponent extends React.Component<ComponentProps & InjectedStripePr
     }
 
     onSubmit = () => {
+        const elements = this.props.elements;
+
         this.props
             .stripe!.createToken({
                 name: '',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/stripe/react-stripe-elements/blob/a837941298e76f45d72a5b0150d0865332899b2d/src/components/inject.js#L31-L34
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
