### PR TITLE
[expect-puppeteer]: Added "default options" functions

### DIFF
--- a/types/expect-puppeteer/expect-puppeteer-tests.ts
+++ b/types/expect-puppeteer/expect-puppeteer-tests.ts
@@ -29,7 +29,15 @@ const testGlobal = async (instance: ElementHandle | Page) => {
 };
 
 const testImported = async (instance: ElementHandle | Page) => {
-    const expectPuppeteer = await import("expect-puppeteer");
+    const {default: expectPuppeteer, defaultOptions, setDefaultOptions, getDefaultOptions} = await import("expect-puppeteer");
+
+    setDefaultOptions({
+        ...getDefaultOptions(),
+        timeout: 555,
+        polling: "mutation",
+    });
+
+    const newOptions = defaultOptions({timeout: 600});
 
     await expectPuppeteer(instance).toClick("selector");
     await expect(instance).toClick("selector", { polling: "mutation", text: "text" });

--- a/types/expect-puppeteer/index.d.ts
+++ b/types/expect-puppeteer/index.d.ts
@@ -67,4 +67,11 @@ declare global {
 }
 
 declare function expectPuppeteer(instance: ElementHandle | Page): ExpectPuppeteer;
-export = expectPuppeteer;
+
+interface ExpectDefaultOptions extends ExpectToClickOptions, ExpectTimingActions {}
+declare function defaultOptions(options: ExpectDefaultOptions): ExpectDefaultOptions;
+declare function setDefaultOptions(options: ExpectDefaultOptions): void;
+declare function getDefaultOptions(): ExpectDefaultOptions;
+
+export default expectPuppeteer;
+export { defaultOptions, setDefaultOptions, getDefaultOptions };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer#configure-default-options
  - https://github.com/smooth-code/jest-puppeteer/blob/master/packages/expect-puppeteer/src/options.js
  - https://github.com/smooth-code/jest-puppeteer/commits/master/packages/expect-puppeteer/src/options.js

---

This PR adds missing definitions for [`expect-puppeteer`](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer#configure-default-options)'s default options configuration functions.