### PR TITLE
s3rver: make error optional in callback signature

### DIFF
--- a/types/s3rver/index.d.ts
+++ b/types/s3rver/index.d.ts
@@ -18,7 +18,7 @@ declare class S3rver {
     setSilent(silent: boolean): S3rver;
     setIndexDocument(indexDocument: string): S3rver;
     setErrorDocument(errorDocument: string): S3rver;
-    run(callback: (error: Error, hostname: string, port: number, directory: string) => void): http.Server;
+    run(callback: (error: Error | null, hostname: string, port: number, directory: string) => void): http.Server;
     run(): Promise<string>;
 }
 

--- a/types/s3rver/index.d.ts
+++ b/types/s3rver/index.d.ts
@@ -17,6 +17,10 @@ declare class S3rver {
     setErrorDocument(errorDocument: string): S3rver;
     run(callback: (error: Error | null, hostname: string, port: number, directory: string) => void): S3rver;
     run(): Promise<string>;
+    close(): Promise<void>;
+    // Should return S3rver, but doesn't in all cases, currently
+    // See https://github.com/jamhall/s3rver/pull/571
+    close(callback: (error: Error | null) => void): void;
 }
 
 interface S3rverOptions {

--- a/types/s3rver/index.d.ts
+++ b/types/s3rver/index.d.ts
@@ -7,9 +7,6 @@
 
 /// <reference types="node" />
 
-
-import * as http from "http";
-
 declare class S3rver {
     constructor(options: S3rverOptions)
     setPort(port: number): S3rver;
@@ -18,7 +15,7 @@ declare class S3rver {
     setSilent(silent: boolean): S3rver;
     setIndexDocument(indexDocument: string): S3rver;
     setErrorDocument(errorDocument: string): S3rver;
-    run(callback: (error: Error | null, hostname: string, port: number, directory: string) => void): http.Server;
+    run(callback: (error: Error | null, hostname: string, port: number, directory: string) => void): S3rver;
     run(): Promise<string>;
 }
 

--- a/types/s3rver/s3rver-tests.ts
+++ b/types/s3rver/s3rver-tests.ts
@@ -10,6 +10,7 @@ var s3rver = new S3rver({
 }).run((err, hostname, port, directory) => {});
 
 s3rver.close();
+s3rver.close(e => console.log(e));
 
 // using new options
 import fs = require('fs');


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: See below.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Context for changes:
* Making `error` nullable in the callback for `.run`: [it's a standard node callback](https://github.com/jamhall/s3rver/blob/master/lib/s3rver.js#L152).
* Making `.run` return `S3rver` not `http.Server`: [source code here](https://github.com/jamhall/s3rver/blob/master/lib/s3rver.js#L152).
* Adding signature for close method: [source code here](https://github.com/jamhall/s3rver/blob/master/lib/s3rver.js#L189)
