### PR TITLE
Add RouterService `off` method definition to compliment `on` definition

### DIFF
--- a/types/ember__routing/router-service.d.ts
+++ b/types/ember__routing/router-service.d.ts
@@ -220,7 +220,8 @@ export default class RouterService extends Service {
         options?: { queryParams: object }
     ): string;
 
-    // https://api.emberjs.com/ember/3.6/classes/RouterService/events/routeDidChange?anchor=routeDidChange
+    // https://api.emberjs.com/ember/3.12/classes/RouterService/events/routeDidChange?anchor=routeDidChange
+    // http://api.emberjs.com/ember/3.12/classes/Evented/methods/on?anchor=on
     /**
      * Register a callback for an event.
      *
@@ -237,5 +238,21 @@ export default class RouterService extends Service {
     on(
         name: 'routeDidChange' | 'routeWillChange',
         callback: (transition: Transition) => void
+    ): RouterService;
+
+    // https://api.emberjs.com/ember/3.12/classes/RouterService/events/routeDidChange?anchor=routeDidChange
+    // http://api.emberjs.com/ember/3.12/classes/Evented/methods/off?anchor=off
+    /**
+     * Remove a registered callback for an event.
+     *
+     * To remove the registered callback, the function you pass must be the
+     * same function as the original callback that was registered.
+     *
+     * @param name     the name of the event
+     * @param callback the same function of the original callback
+     */
+    off(
+      name: 'routeDidChange' | 'routeWillChange',
+      callback: (transition: Transition) => void
     ): RouterService;
 }

--- a/types/ember__routing/test/router.ts
+++ b/types/ember__routing/test/router.ts
@@ -80,4 +80,32 @@ const RouterServiceConsumer = Service.extend({
                 }
             });
     },
+    offAndRouteInfo() {
+        const router = get(this, 'router');
+        router
+            .off('routeWillChange', transition => {
+                const to = transition.to;
+                to.child; // $ExpectType RouteInfo | null
+                to.localName; // $ExpectType string
+                to.name; // $ExpectType string
+                to.paramNames; // $ExpectType string[]
+                to.params.foo; // $ExpectType string | undefined
+                to.parent; // $ExpectType RouteInfo | null
+                to.queryParams.foo; // $ExpectType string | undefined
+                to.find(info => info.name === 'foo'); // $ExpectType RouteInfo | undefined
+            })
+            .off('routeDidChange', transition => {
+                const from = transition.from;
+                if (from) {
+                    from.child; // $ExpectType RouteInfo | null
+                    from.localName; // $ExpectType string
+                    from.name; // $ExpectType string
+                    from.paramNames; // $ExpectType string[]
+                    from.params.foo; // $ExpectType string | undefined
+                    from.parent; // $ExpectType RouteInfo | null
+                    from.queryParams.foo; // $ExpectType string | undefined
+                    from.find(info => info.name === 'foo'); // $ExpectType RouteInfo | undefined
+                }
+            });
+    },
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - **RouterService** extends the `Evented` mixin, which implements the `on` and `off` methods for the two `routeWillChange` and `routeDidChange` events. While `on` has been defined on the RouterService class, `off` is missing.
  - https://github.com/emberjs/ember.js/blob/v3.14.1/packages/%40ember/-internals/routing/lib/services/router.ts#L410
  - http://api.emberjs.com/ember/3.12/classes/Evented/methods/off?anchor=off
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
