### PR TITLE
fix: align callback functions of dataset with spec

### DIFF
--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -23,6 +23,8 @@ import { EventEmitter } from "events";
  */
 export type Term = NamedNode | BlankNode | Literal | Variable | DefaultGraph;
 
+type PropType<TObj, TProp extends keyof TObj> = TObj[TProp];
+
 /**
  * Contains an IRI.
  */
@@ -529,21 +531,21 @@ export interface Dataset<Q extends BaseQuad = Quad> extends DatasetCore<Q> {
      *
      * This method is aligned with `Array.prototype.every()` in ECMAScript-262.
      */
-    every(iteratee: QuadFilterIteratee<Q>): boolean;
+    every(iteratee: PropType<QuadFilterIteratee<Q>, 'test'>): boolean;
 
     /**
      * Creates a new dataset with all the quads that pass the test implemented by the provided `iteratee`.
      *
      * This method is aligned with Array.prototype.filter() in ECMAScript-262.
      */
-    filter(iteratee: QuadFilterIteratee<Q>): this;
+    filter(iteratee: PropType<QuadFilterIteratee<Q>, 'test'>): this;
 
     /**
      * Executes the provided `iteratee` once on each quad in the dataset.
      *
      * This method is aligned with `Array.prototype.forEach()` in ECMAScript-262.
      */
-    forEach(iteratee: QuadRunIteratee<Q>): void;
+    forEach(iteratee: PropType<QuadRunIteratee<Q>, 'run'>): void;
 
     /**
      * Imports all quads from the given stream into the dataset.
@@ -560,7 +562,7 @@ export interface Dataset<Q extends BaseQuad = Quad> extends DatasetCore<Q> {
     /**
      * Returns a new dataset containing all quads returned by applying `iteratee` to each quad in the current dataset.
      */
-    map(iteratee: QuadMapIteratee<Q>): this;
+    map(iteratee: PropType<QuadMapIteratee<Q>, 'map'>): this;
 
     /**
      * This method calls the `iteratee` on each `quad` of the `Dataset`. The first time the `iteratee` is called, the
@@ -571,7 +573,7 @@ export interface Dataset<Q extends BaseQuad = Quad> extends DatasetCore<Q> {
      *
      * This method is aligned with `Array.prototype.reduce()` in ECMAScript-262.
      */
-    reduce<A = any>(iteratee: QuadReduceIteratee<A, Q>, initialValue?: A): A;
+    reduce<A = any>(iteratee: PropType<QuadReduceIteratee<A, Q>, 'run'>, initialValue?: A): A;
 
     /**
      * Existential quantification method, tests whether some quads in the dataset pass the test implemented by the
@@ -581,7 +583,7 @@ export interface Dataset<Q extends BaseQuad = Quad> extends DatasetCore<Q> {
      *
      * This method is aligned with `Array.prototype.some()` in ECMAScript-262.
      */
-    some(iteratee: QuadFilterIteratee<Q>): boolean;
+    some(iteratee: PropType<QuadFilterIteratee<Q>, 'test'>): boolean;
 
     /**
      * Returns the set of quads within the dataset as a host language native sequence, for example an `Array` in
@@ -652,3 +654,5 @@ export interface QuadRunIteratee<Q extends BaseQuad = Quad> {
      */
     run(quad: Q, dataset: Dataset<Q>): void;
 }
+
+export {};

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -177,27 +177,11 @@ function test_dataset() {
     const stream1: Stream = <any> {};
     const stream2: Stream<QuadBnode> = <any> {};
 
-    const quadFilterIteratee = (quad: Quad, dataset: Dataset): boolean => {
-        return dataset.has(quad);
-    };
-    const quadMapIteratee = (quad: Quad, dataset: Dataset): Quad => {
-        if (dataset.has(quad))
-            return quad;
-
-        return factory.quad(quad.subject, quad.predicate, quad.object, quad.graph);
-    };
-    const quadReduceToStringIteratee = (reduced: string, quad: Quad): string => {
-        return reduced + quad.subject.termType;
-    };
-    const quadReduceToArrayIteratee = (arr: boolean[], quad: Quad, dataset: Dataset): boolean[] => {
-        return [
-            ...arr,
-            dataset.has(quad)
-        ];
-    };
-    const quadForEachIteratee = (quad: Quad, dataset: Dataset): void => {
-        console.log(dataset.has(quad) ? 'it really has it' : 'what?');
-    };
+    const quadFilterIteratee: (quad: Quad, dataset: Dataset) => boolean = <any> {};
+    const quadMapIteratee: (quad: Quad, dataset: Dataset) => Quad = <any> {};
+    const quadReduceToStringIteratee: (reduced: string, quad: Quad) => string = <any> {};
+    const quadReduceToArrayIteratee: (arr: boolean[], quad: Quad, dataset: Dataset) => boolean[] = <any> {};
+    const quadForEachIteratee: (quad: Quad, dataset: Dataset) => void = <any> {};
 
     const datasetFactory1: DatasetFactory = <any> {};
     const datasetFactory2: DatasetFactory<QuadBnode> = <any> {};

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -1,7 +1,8 @@
 import { BlankNode, DataFactory, Dataset, DatasetCore, DatasetCoreFactory, DatasetFactory, DefaultGraph, Literal,
-  NamedNode, Quad, BaseQuad, Sink, Source, Store, Stream, Triple, Term, Variable, Quad_Graph, QuadFilterIteratee,
-  QuadMapIteratee, QuadReduceIteratee, QuadRunIteratee } from "rdf-js";
+  NamedNode, Quad, BaseQuad, Sink, Source, Store, Stream, Triple, Term, Variable, Quad_Graph } from "rdf-js";
 import { EventEmitter } from "events";
+
+const factory: DataFactory = <any> {};
 
 function test_terms() {
     // Only types are checked in this tests,
@@ -176,19 +177,27 @@ function test_dataset() {
     const stream1: Stream = <any> {};
     const stream2: Stream<QuadBnode> = <any> {};
 
-    const quadFilterIteratee1: QuadFilterIteratee = <any> {};
-    const quadFilterIteratee2: QuadFilterIteratee<QuadBnode> = <any> {};
+    const quadFilterIteratee = (quad: Quad, dataset: Dataset): boolean => {
+        return dataset.has(quad);
+    };
+    const quadMapIteratee = (quad: Quad, dataset: Dataset): Quad => {
+        if (dataset.has(quad))
+            return quad;
 
-    const quadMapIteratee1: QuadMapIteratee = <any> {};
-    const quadMapIteratee2: QuadMapIteratee<QuadBnode> = <any> {};
-
-    const quadReduceIteratee1: QuadReduceIteratee = <any> {};
-    const quadReduceIteratee2: QuadReduceIteratee<string> = <any> {};
-    const quadReduceIteratee3: QuadReduceIteratee<any, QuadBnode> = <any> {};
-    const quadReduceIteratee4: QuadReduceIteratee<string, QuadBnode> = <any> {};
-
-    const quadRunIteratee1: QuadRunIteratee = <any> {};
-    const quadRunIteratee2: QuadRunIteratee<QuadBnode> = <any> {};
+        return factory.quad(quad.subject, quad.predicate, quad.object, quad.graph);
+    };
+    const quadReduceToStringIteratee = (reduced: string, quad: Quad): string => {
+        return reduced + quad.subject.termType;
+    };
+    const quadReduceToArrayIteratee = (arr: boolean[], quad: Quad, dataset: Dataset): boolean[] => {
+        return [
+            ...arr,
+            dataset.has(quad)
+        ];
+    };
+    const quadForEachIteratee = (quad: Quad, dataset: Dataset): void => {
+        console.log(dataset.has(quad) ? 'it really has it' : 'what?');
+    };
 
     const datasetFactory1: DatasetFactory = <any> {};
     const datasetFactory2: DatasetFactory<QuadBnode> = <any> {};
@@ -214,25 +223,22 @@ function test_dataset() {
     const dataset2DeleteMatches5: Dataset = dataset2.deleteMatches(term, term, term, term);
     const dataset2Difference: Dataset = dataset2.difference(dataset1);
     const dataset2Equals: boolean = dataset2.equals(dataset1);
-    const dataset2Every: boolean = dataset2.every(quadFilterIteratee1);
-    const dataset2Filter: Dataset = dataset2.filter(quadFilterIteratee1);
-    // tslint:disable-next-line:no-void-expression void-return
-    const dataset2Foreach: void = dataset2.forEach(quadRunIteratee1);
+    const dataset2Every: boolean = dataset2.every(quadFilterIteratee);
+    const dataset2Filter: Dataset = dataset2.filter(quadFilterIteratee);
+    dataset2.forEach(quadForEachIteratee);
     const dataset2Has: boolean = dataset2.has(quad);
     const dataset2Import: Promise<Dataset> = dataset2.import(stream1);
     const dataset2Intersection: Dataset = dataset2.intersection(dataset1);
-    const dataset2Map: Dataset = dataset2.map(quadMapIteratee1);
+    const dataset2Map: Dataset = dataset2.map(quadMapIteratee);
     const dataset2Match1: Dataset = dataset2.match();
     const dataset2Match2: Dataset = dataset2.match(term);
     const dataset2Match3: Dataset = dataset2.match(term, term);
     const dataset2Match4: Dataset = dataset2.match(term, term, term);
     const dataset2Match5: Dataset = dataset2.match(term, term, term, term);
-    const dataset2Reduce1: object = dataset2.reduce(quadReduceIteratee1);
-    const dataset2Reduce2: object = dataset2.reduce(quadReduceIteratee1, []);
-    const dataset2Reduce3: object = dataset2.reduce(quadReduceIteratee1, '');
-    const dataset2Reduce4: string = dataset2.reduce(quadReduceIteratee2);
-    const dataset2Reduce5: string = dataset2.reduce(quadReduceIteratee2, '');
-    const dataset2Some: boolean = dataset2.some(quadFilterIteratee1);
+    const dataset2Reduce1: string = dataset2.reduce(quadReduceToStringIteratee);
+    const dataset2Reduce2: boolean[] = dataset2.reduce(quadReduceToArrayIteratee, []);
+    const dataset2Reduce3: string = dataset2.reduce(quadReduceToStringIteratee, '');
+    const dataset2Some: boolean = dataset2.some(quadFilterIteratee);
     const dataset2ToArray: Quad[] = dataset2.toArray();
     const dataset2ToCanonical: string = dataset2.toCanonical();
     const dataset2ToStream: Stream = dataset2.toStream();
@@ -254,25 +260,24 @@ function test_dataset() {
     const dataset4DeleteMatches5: Dataset<QuadBnode> = dataset4.deleteMatches(term, term, term, term);
     const dataset4Difference: Dataset<QuadBnode> = dataset4.difference(dataset3);
     const dataset4Equals: boolean = dataset4.equals(dataset3);
-    const dataset4Every: boolean = dataset4.every(quadFilterIteratee2);
-    const dataset4Filter: Dataset<QuadBnode> = dataset4.filter(quadFilterIteratee2);
-    // tslint:disable-next-line:no-void-expression void-return
-    const dataset4Foreach: void = dataset4.forEach(quadRunIteratee2);
+    const dataset4Every: boolean = dataset4.every(quadFilterIteratee);
+    const dataset4Filter: Dataset<QuadBnode> = dataset4.filter(quadFilterIteratee);
+    dataset4.forEach(quadForEachIteratee);
     const dataset4Has: boolean = dataset4.has(quadBnode);
     const dataset4Import: Promise<Dataset<QuadBnode>> = dataset4.import(stream2);
     const dataset4Intersection: Dataset<QuadBnode> = dataset4.intersection(dataset3);
-    const dataset4Map: Dataset<QuadBnode> = dataset4.map(quadMapIteratee2);
+    const dataset4Map: Dataset<QuadBnode> = dataset4.map(quadMapIteratee);
     const dataset4Match1: Dataset<QuadBnode> = dataset4.match();
     const dataset4Match2: Dataset<QuadBnode> = dataset4.match(term);
     const dataset4Match3: Dataset<QuadBnode> = dataset4.match(term, term);
     const dataset4Match4: Dataset<QuadBnode> = dataset4.match(term, term, term);
     const dataset4Match5: Dataset<QuadBnode> = dataset4.match(term, term, term, term);
-    const dataset4Reduce1: object = dataset4.reduce(quadReduceIteratee3);
-    const dataset4Reduce2: object = dataset4.reduce(quadReduceIteratee3, []);
-    const dataset4Reduce3: object = dataset4.reduce(quadReduceIteratee3, '');
-    const dataset4Reduce4: string = dataset4.reduce(quadReduceIteratee4);
-    const dataset4Reduce5: string = dataset4.reduce(quadReduceIteratee4, '');
-    const dataset4Some: boolean = dataset4.some(quadFilterIteratee1);
+    const dataset4Reduce1: string = dataset4.reduce(quadReduceToStringIteratee);
+    const dataset4Reduce2: boolean[] = dataset4.reduce(quadReduceToArrayIteratee, []);
+    const dataset4Reduce3: string = dataset4.reduce(quadReduceToStringIteratee, '');
+    const dataset4Reduce4: string = dataset4.reduce(quadReduceToStringIteratee);
+    const dataset4Reduce5: string = dataset4.reduce(quadReduceToStringIteratee, '');
+    const dataset4Some: boolean = dataset4.some(quadFilterIteratee);
     const dataset4ToArray: QuadBnode[] = dataset4.toArray();
     const dataset4ToCanonical: string = dataset4.toCanonical();
     const dataset4ToStream: Stream<QuadBnode> = dataset4.toStream();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation: https://rdf.js.org/dataset-spec/#quadmapiteratee-interface
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.