### PR TITLE
fix(parse/File): substitute Blob type in constructor

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -125,7 +125,7 @@ declare namespace Parse {
         progress?: Function;
     }
 
-    interface SuccessFailureOptions extends SuccessOption, ErrorOption {}
+    interface SuccessFailureOptions extends SuccessOption, ErrorOption { }
 
     interface SignUpOptions {
         useMasterKey?: boolean;
@@ -151,7 +151,7 @@ declare namespace Parse {
         useMasterKey?: boolean;
     }
 
-    interface ScopeOptions extends SessionTokenOption, UseMasterKeyOption {}
+    interface ScopeOptions extends SessionTokenOption, UseMasterKeyOption { }
 
     interface SilentOption {
         /**
@@ -238,7 +238,7 @@ declare namespace Parse {
      *     extension.
      */
     class File {
-        constructor(name: string, data: number[] | { base64: string } | Blob | { uri: string }, type?: string);
+        constructor(name: string, data: number[] | { base64: string } | { size: number; type: string; } | { uri: string }, type?: string);
         /**
          * Return the data for the file, downloading it if not already present.
          * Data is present if initialized with Byte Array, Base64 or Saved with Uri.
@@ -447,28 +447,28 @@ declare namespace Parse {
         unPinAllWithName(name: string, objects: Object[]): Promise<void>;
     }
     interface ObjectConstructor extends ObjectStatic {
-        new<T extends Attributes>(className: string, attributes: T, options?: any): Object<T>;
+        new <T extends Attributes>(className: string, attributes: T, options?: any): Object<T>;
         new(className?: string, attributes?: Attributes, options?: any): Object;
     }
     const Object: ObjectConstructor;
 
     namespace Object {
-        interface DestroyOptions extends SuccessFailureOptions, WaitOption, ScopeOptions {}
+        interface DestroyOptions extends SuccessFailureOptions, WaitOption, ScopeOptions { }
 
-        interface DestroyAllOptions extends BatchSizeOption, ScopeOptions {}
+        interface DestroyAllOptions extends BatchSizeOption, ScopeOptions { }
 
-        interface FetchAllOptions extends SuccessFailureOptions, ScopeOptions {}
+        interface FetchAllOptions extends SuccessFailureOptions, ScopeOptions { }
 
-        interface FetchOptions extends SuccessFailureOptions, ScopeOptions {}
+        interface FetchOptions extends SuccessFailureOptions, ScopeOptions { }
 
         interface SaveOptions
             extends CascadeSaveOption,
-                SuccessFailureOptions,
-                SilentOption,
-                ScopeOptions,
-                WaitOption {}
+            SuccessFailureOptions,
+            SilentOption,
+            ScopeOptions,
+            WaitOption { }
 
-        interface SaveAllOptions extends BatchSizeOption, ScopeOptions {}
+        interface SaveAllOptions extends BatchSizeOption, ScopeOptions { }
 
         interface SetOptions extends ErrorOption, SilentOption {
             promise?: any;
@@ -501,7 +501,7 @@ declare namespace Parse {
         appIdentifier: string;
     }
     interface InstallationConstructor extends ObjectStatic {
-        new<T extends Attributes>(attributes: T): Installation<T>;
+        new <T extends Attributes>(attributes: T): Installation<T>;
         new(): Installation;
     }
     const Installation: InstallationConstructor;
@@ -627,11 +627,11 @@ declare namespace Parse {
     }
 
     namespace Query {
-        interface EachOptions extends SuccessFailureOptions, ScopeOptions {}
-        interface CountOptions extends SuccessFailureOptions, ScopeOptions {}
-        interface FindOptions extends SuccessFailureOptions, ScopeOptions {}
-        interface FirstOptions extends SuccessFailureOptions, ScopeOptions {}
-        interface GetOptions extends SuccessFailureOptions, ScopeOptions {}
+        interface EachOptions extends SuccessFailureOptions, ScopeOptions { }
+        interface CountOptions extends SuccessFailureOptions, ScopeOptions { }
+        interface FindOptions extends SuccessFailureOptions, ScopeOptions { }
+        interface FirstOptions extends SuccessFailureOptions, ScopeOptions { }
+        interface GetOptions extends SuccessFailureOptions, ScopeOptions { }
 
         // According to http://docs.parseplatform.org/rest/guide/#aggregate-queries
         interface AggregationOptions {
@@ -755,7 +755,7 @@ declare namespace Parse {
         setName(name: string, options?: SuccessFailureOptions): any;
     }
     interface RoleConstructor extends ObjectStatic {
-        new<T extends Attributes>(name: string, acl: ACL): Role<Partial<T>>;
+        new <T extends Attributes>(name: string, acl: ACL): Role<Partial<T>>;
         new(name: string, acl: ACL): Role;
     }
     const Role: RoleConstructor;
@@ -773,8 +773,8 @@ declare namespace Parse {
         getSessionToken(): string;
         isCurrentSessionRevocable(): boolean;
     }
-    interface SessionConstructor  extends ObjectStatic {
-        new<T extends Attributes>(attributes: T): Session<T>;
+    interface SessionConstructor extends ObjectStatic {
+        new <T extends Attributes>(attributes: T): Session<T>;
         new(): Session;
 
         current(): Promise<Session>;
@@ -808,7 +808,7 @@ declare namespace Parse {
         _linkWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions): Promise<User>;
     }
     interface UserConstructor extends ObjectStatic {
-        new<T extends Attributes>(attributes: T): User<T>;
+        new <T extends Attributes>(attributes: T): User<T>;
         new(): User;
 
         allowCustomUserClass(isAllowed: boolean): void;
@@ -1023,8 +1023,8 @@ declare namespace Parse {
         interface AfterSaveRequest extends TriggerRequest {
             context: object;
         }
-        interface AfterDeleteRequest extends TriggerRequest {}      // tslint:disable-line no-empty-interface
-        interface BeforeDeleteRequest extends TriggerRequest {}     // tslint:disable-line no-empty-interface
+        interface AfterDeleteRequest extends TriggerRequest { }      // tslint:disable-line no-empty-interface
+        interface BeforeDeleteRequest extends TriggerRequest { }     // tslint:disable-line no-empty-interface
         interface BeforeSaveRequest extends TriggerRequest {
             context: object;
         }
@@ -1083,7 +1083,7 @@ declare namespace Parse {
         function startJob(jobName: string, data: any): Promise<string>;
         function useMasterKey(): void;
 
-        interface RunOptions extends SuccessFailureOptions, ScopeOptions {}
+        interface RunOptions extends SuccessFailureOptions, ScopeOptions { }
 
         /**
          * To use this Cloud Module in Cloud Code, you must require 'buffer' in your JavaScript file.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/parse-community/Parse-SDK-JS/blob/9bacf0821eaf5b7bbee0d897086601c8e7be69ea/src/ParseFile.js#L25
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
