### PR TITLE
[@types/carbon-components-react] add missing ReactAnchorAttr types to SwitcherItem

### DIFF
--- a/types/carbon-components-react/lib/components/UIShell/SwitcherItem.d.ts
+++ b/types/carbon-components-react/lib/components/UIShell/SwitcherItem.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ReactAttr, RequiresChildrenProps } from "../../../typings/shared";
+import { ReactAttr, ReactAnchorAttr, RequiresChildrenProps } from "../../../typings/shared";
 import { LinkProps } from "./Link";
 
 interface InheritedProps extends RequiresChildrenProps {
@@ -10,8 +10,8 @@ export interface SwitcherItemPropsBase extends InheritedProps {
     isSelected?: boolean,
 }
 
-export type SwitcherItemProps<E extends object = {}> = Omit<LinkProps<E>, "tabIndex"> & SwitcherItemPropsBase;
+export type SwitcherItemProps<E extends object = ReactAnchorAttr> = Omit<LinkProps<E>, "tabIndex"> & SwitcherItemPropsBase;
 
-declare function SwitcherItem<E extends object = {}>(props: React.PropsWithChildren<SwitcherItemProps<E>>, ref: React.Ref<HTMLElement>): React.ReactElement | null;
+declare function SwitcherItem<E extends object = ReactAnchorAttr>(props: React.PropsWithChildren<SwitcherItemProps<E>>, ref: React.Ref<HTMLElement>): React.ReactElement | null;
 
 export default SwitcherItem;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/UIShell/SwitcherItem.js
