### PR TITLE
[@types/slate-plain-serializer] Add delimiter option

### DIFF
--- a/types/slate-plain-serializer/index.d.ts
+++ b/types/slate-plain-serializer/index.d.ts
@@ -11,7 +11,7 @@ export interface DeserializeOptions {
     toJson?: boolean;
     defaultBlock?: BlockProperties;
     defaultMarks?: MarkProperties[] | Set<MarkProperties>;
-    delimiter?: string,
+    delimiter?: string;
 }
 
 export interface SerializeOptions {

--- a/types/slate-plain-serializer/index.d.ts
+++ b/types/slate-plain-serializer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for slate-plain-serializer 0.7.11
+// Type definitions for slate-plain-serializer 0.7
 // Project: https://github.com/ianstormtaylor/slate
 // Definitions by: Brandon Shelton <https://github.com/YangusKhan>
 //                 Martin Kiefel <https://github.com/mkiefel>

--- a/types/slate-plain-serializer/index.d.ts
+++ b/types/slate-plain-serializer/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for slate-plain-serializer 0.6
+// Type definitions for slate-plain-serializer 0.7.11
 // Project: https://github.com/ianstormtaylor/slate
 // Definitions by: Brandon Shelton <https://github.com/YangusKhan>
 //                 Martin Kiefel <https://github.com/mkiefel>
+//                 Alex Nault <https://github.com/anault>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import { BlockProperties, MarkProperties, Value } from 'slate';
@@ -10,11 +11,16 @@ export interface DeserializeOptions {
     toJson?: boolean;
     defaultBlock?: BlockProperties;
     defaultMarks?: MarkProperties[] | Set<MarkProperties>;
+    delimiter?: string,
+}
+
+export interface SerializeOptions {
+    delimiter?: string;
 }
 
 declare namespace Plain {
-  function deserialize(string: string, options?: DeserializeOptions): Value;
-  function serialize(value: Value): string;
+    function deserialize(string: string, options?: DeserializeOptions): Value;
+    function serialize(value: Value, options?: SerializeOptions): string;
 }
 
 export default Plain;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ianstormtaylor/slate/blob/v0.47/packages/slate-plain-serializer/src/index.js 
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
