### PR TITLE
[estree] add `Directive`s to `Program`

### DIFF
--- a/types/estree/estree-tests.ts
+++ b/types/estree/estree-tests.ts
@@ -7,6 +7,7 @@ declare var statement: ESTree.Statement;
 declare var emptyStatement: ESTree.EmptyStatement;
 declare var blockStatement: ESTree.BlockStatement;
 declare var expressionStatement: ESTree.ExpressionStatement;
+declare var directive: ESTree.Directive;
 declare var ifStatement: ESTree.IfStatement;
 declare var labeledStatement: ESTree.LabeledStatement;
 declare var breakStatement: ESTree.BreakStatement;
@@ -119,6 +120,11 @@ statement = blockStatement.body[0];
 // ExpressionStatement
 var expressionStatement: ESTree.ExpressionStatement;
 expression = expressionStatement.expression;
+
+// Directive
+literal = directive.expression;
+// $ExpectType string
+directive.directive;
 
 // IfStatement
 var ifStatement: ESTree.IfStatement;

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -62,8 +62,14 @@ export interface Position {
 export interface Program extends BaseNode {
   type: "Program";
   sourceType: "script" | "module";
-  body: Array<Statement | ModuleDeclaration>;
+  body: Array<Directive | Statement | ModuleDeclaration>;
   comments?: Array<Comment>;
+}
+
+export interface Directive extends BaseNode {
+  type: "ExpressionStatement";
+  expression: Literal;
+  directive: string;
 }
 
 interface BaseFunction extends BaseNode {


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/estree/estree/blob/master/es5.md#directive
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

The ESTree documentation shows that `Program` nodes can also contain `Directive`s. This PR adds a `Directive` that can be detected using something like:

```typescript
if ("directive" in program.body[0]) {
  program.body[0].directive; // is a string
}

// or

function isDirective(stmt: Program["body"][0]): stmt is Directive {
  return "directive" in stmt;
}
```

Fixes #18204