### PR TITLE
swagger-ui-dist: Change `layout` field to accept any string

### DIFF
--- a/types/swagger-ui-dist/index.d.ts
+++ b/types/swagger-ui-dist/index.d.ts
@@ -74,7 +74,7 @@ export interface SwaggerConfigs {
     /**
      * The name of a component available via the plugin system to use as the top-level layout for Swagger UI.
      */
-    layout?: 'BaseLayout';
+    layout?: string;
 
     /**
      * Controls the default expansion setting for the operations and tags. It can be 'list' (expands only the tags), 'full' (expands the tags and operations) or 'none' (expands nothing).


### PR DESCRIPTION
Since you can extend Swagger UI with your own layouts, `layout` field should be able to accept any string (e.g. see [`AugmentingLayout` at "Creating a custom layout" page](https://github.com/swagger-api/swagger-ui/blob/94e101924b84435585896f4ea7c4092182a91f23/docs/customization/custom-layout.md#augmenting-the-default-layout)).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/swagger-api/swagger-ui/blob/94e101924b84435585896f4ea7c4092182a91f23/docs/customization/custom-layout.md