### PR TITLE
feat(webidl‑conversions): Update to v5.0

### DIFF
--- a/types/webidl-conversions/index.d.ts
+++ b/types/webidl-conversions/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webidl-conversions 4.0
+// Type definitions for webidl-conversions 5.0
 // Project: https://github.com/jsdom/webidl-conversions#readme
 // Definitions by: ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -52,9 +52,7 @@ declare const WebIDLConversions: {
 	ByteString(V: any, opts?: WebIDLConversions.StringOptions): string;
 	USVString(V: any, opts?: WebIDLConversions.StringOptions): string;
 
-	object(V: any, opts?: WebIDLConversions.Options): object;
-	Error(V: any, opts?: WebIDLConversions.Options): Error;
-
+	object<V>(V: V, opts?: WebIDLConversions.Options): V extends object ? V : V & object;
 	ArrayBuffer(V: any, opts?: WebIDLConversions.Options): ArrayBuffer;
 	DataView(V: any, opts?: WebIDLConversions.Options): DataView;
 

--- a/types/webidl-conversions/webidl-conversions-tests.ts
+++ b/types/webidl-conversions/webidl-conversions-tests.ts
@@ -38,8 +38,10 @@ conversions.DOMString(any, options); // $ExpectType string
 conversions.ByteString(any, options); // $ExpectType string
 conversions.USVString(any, options); // $ExpectType string
 
-conversions.object(any, options); // $ExpectType object
-conversions.Error(any, options); // $ExpectType Error
+conversions.object(any, options); // $ExpectType any
+conversions.object(unknown, options); // $ExpectType object
+conversions.object('string', options); // $ExpectType never
+conversions.object({}, options); // $ExpectType {}
 
 conversions.ArrayBuffer(any, options); // $ExpectType ArrayBuffer
 conversions.DataView(any, options); // $ExpectType DataView

--- a/types/webidl-conversions/webidl-conversions-tests.ts
+++ b/types/webidl-conversions/webidl-conversions-tests.ts
@@ -7,6 +7,12 @@ const options: conversions.Options = ((): conversions.Options => {
 	return {};
 })();
 
+/**
+ * The `expectType` function from https://www.npmjs.com/package/tsd,
+ * except instead of returning `void`, it returns `T`.
+ */
+declare function expectType<T>(value: T): T;
+
 conversions.any(any); // $ExpectType any
 conversions.any(unknown); // $ExpectType unknown
 conversions.any(options); // $ExpectType Options
@@ -40,7 +46,7 @@ conversions.USVString(any, options); // $ExpectType string
 
 conversions.object(any, options); // $ExpectType any
 conversions.object(unknown, options); // $ExpectType object
-conversions.object('string', options); // $ExpectType never
+expectType<never>(conversions.object('string', options)); // $ExpectType never
 conversions.object({}, options); // $ExpectType {}
 
 conversions.ArrayBuffer(any, options); // $ExpectType ArrayBuffer

--- a/types/webidl-conversions/webidl-conversions-tests.ts
+++ b/types/webidl-conversions/webidl-conversions-tests.ts
@@ -46,7 +46,9 @@ conversions.USVString(any, options); // $ExpectType string
 
 conversions.object(any, options); // $ExpectType any
 conversions.object(unknown, options); // $ExpectType object
-expectType<never>(conversions.object('string', options)); // $ExpectType never
+expectType<null & object>(conversions.object(null, options));
+expectType<string & object>(conversions.object('string', options));
+expectType<number & object>(conversions.object(123, options));
 conversions.object({}, options); // $ExpectType {}
 
 conversions.ArrayBuffer(any, options); // $ExpectType ArrayBuffer


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/jsdom/webidl-conversions/releases/tag/v5.0.0>, <https://github.com/jsdom/webidl-conversions/pull/17>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

I’ve&nbsp;also&nbsp;improved the&nbsp;strictness of&nbsp;the&nbsp;`object(…)` conversion&nbsp;function.