### PR TITLE
[react-native-vector-icons]: Add Nested class type for FontAwesome5 

### DIFF
--- a/types/react-native-vector-icons/FontAwesome5.d.ts
+++ b/types/react-native-vector-icons/FontAwesome5.d.ts
@@ -1,5 +1,5 @@
 import { Component } from "react";
-import { Icon, IconProps, ImageSource } from "./Icon";
+import { Icon, IconProps, ImageSource, ToolbarAndroidProps, TabBarItemIOSProps, IconButtonProps } from "./Icon";
 
 export const FA5Style: {
     regular: 0;
@@ -40,4 +40,8 @@ export default class FontAwesome5Icon extends Component<
     ): Promise<ImageSource>;
     static loadFont(file?: string): Promise<void>;
     static hasIcon(name: string): boolean;
+    static ToolbarAndroid: typeof Icon.ToolbarAndroid
+    static TabBarItem : typeof Icon.TabBarItem
+    static TabBarItemIOS: typeof Icon.TabBarItemIOS
+    static Button : typeof Icon.Button
 }

--- a/types/react-native-vector-icons/FontAwesome5.d.ts
+++ b/types/react-native-vector-icons/FontAwesome5.d.ts
@@ -1,5 +1,5 @@
 import { Component } from "react";
-import { Icon, IconProps, ImageSource, ToolbarAndroidProps, TabBarItemIOSProps, IconButtonProps } from "./Icon";
+import { Icon, IconProps, ImageSource } from "./Icon";
 
 export const FA5Style: {
     regular: 0;

--- a/types/react-native-vector-icons/FontAwesome5.d.ts
+++ b/types/react-native-vector-icons/FontAwesome5.d.ts
@@ -40,8 +40,8 @@ export default class FontAwesome5Icon extends Component<
     ): Promise<ImageSource>;
     static loadFont(file?: string): Promise<void>;
     static hasIcon(name: string): boolean;
-    static ToolbarAndroid: typeof Icon.ToolbarAndroid
-    static TabBarItem : typeof Icon.TabBarItem
-    static TabBarItemIOS: typeof Icon.TabBarItemIOS
-    static Button : typeof Icon.Button
+    static ToolbarAndroid: typeof Icon.ToolbarAndroid;
+    static TabBarItem: typeof Icon.TabBarItem;
+    static TabBarItemIOS: typeof Icon.TabBarItemIOS;
+    static Button: typeof Icon.Button;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #41000
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This addresses #41000, allows use of `Icon.Button` `Icon.ToolbarAndroid`, etc for FontAwesome5 and FontAwesome5Pro Icons.

