### PR TITLE
ink-spinner: replace `Component` imported from `ink` with `Component` imported from `react`

### DIFF
--- a/types/ink-spinner/index.d.ts
+++ b/types/ink-spinner/index.d.ts
@@ -6,7 +6,7 @@
 
 import { Chalk } from 'chalk';
 import * as cliSpinners from 'cli-spinners';
-import { Component } from 'ink';
+import { Component } from 'react';
 
 type StringifyPartial<T> = {
     [P in keyof T]?: string;
@@ -34,6 +34,6 @@ type ChalkProps = BooleansPartial<ChalkCommons>
     & StringifyPartial<ChalkKeywordsAndHexes>
     & TupleOfNumbersPartial<ChalkColorModels>;
 
-declare class Spinner extends Component<SpinnerProps & ChalkProps> { }
+declare class Spinner extends Component<SpinnerProps & ChalkProps> {}
 
 export = Spinner;

--- a/types/ink-spinner/index.d.ts
+++ b/types/ink-spinner/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for ink-spinner 2.0
 // Project: https://github.com/vadimdemedes/ink-spinner#readme
-// Definitions by: Łukasz Ostrowski <https://github.com/lukostry>
+// Definitions by: Łukasz Ostrowski <https://github.com/lukostry>, Justin Anastos <https://github.com/justinanastos>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ink-spinner/ink-spinner-tests.tsx
+++ b/types/ink-spinner/ink-spinner-tests.tsx
@@ -1,5 +1,4 @@
-/** @jsx h */
-import { h } from 'ink';
+import React from 'react';
 import Spinner from 'ink-spinner';
 // NOTE: `import Spinner = require('ink-spinner');` will work as well.
 // If importing using ES6 default import as above,


### PR DESCRIPTION
Please fill in this template.

@lukostry

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

# Reasoning

`ink` doesn't export `Component`. Use the `React` export instead.