### PR TITLE
[@types/carbon-components-react] add missing types for SideNavLink and SideNavMenuItem

### DIFF
--- a/types/carbon-components-react/lib/components/UIShell/SideNavLink.d.ts
+++ b/types/carbon-components-react/lib/components/UIShell/SideNavLink.d.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {
     ReactAttr,
+    ReactAnchorAttr,
     RenderIconProps,
     RequiresChildrenProps,
     SideNavSharedProps,
@@ -19,13 +20,13 @@ interface InheritedProps extends
 
 export interface SideNavLinkPropsBase extends InheritedProps { }
 
-export type SideNavLinkProps<E extends object = {}> = LinkProps<E> & SideNavLinkPropsBase;
+export type SideNavLinkProps<E extends object = ReactAnchorAttr> = LinkProps<E> & SideNavLinkPropsBase;
 
 declare interface SideNavLinkFC<E extends object = {}> extends React.FC<SideNavLinkProps<E>> { }
 export declare function createCustomSideNavLink<E extends object = {}>(
     element: SideNavLinkProps['element']
 ): SideNavLinkFC<Omit<E, 'element'>>;
 
-declare function SideNavLink<E extends object = {}>(props: React.PropsWithChildren<SideNavLinkProps<E>>): React.ReactElement | null;
+declare function SideNavLink<E extends object = ReactAnchorAttr>(props: React.PropsWithChildren<SideNavLinkProps<E>>): React.ReactElement | null;
 
 export default SideNavLink;

--- a/types/carbon-components-react/lib/components/UIShell/SideNavMenuItem.d.ts
+++ b/types/carbon-components-react/lib/components/UIShell/SideNavMenuItem.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ReactAttr } from "../../../typings/shared";
+import { ReactAttr, ReactAnchorAttr } from "../../../typings/shared";
 import { LinkProps } from "./Link";
 
 interface InheritedProps {
@@ -11,8 +11,8 @@ export interface SideNavMenuItemPropsBase extends InheritedProps {
     isActive?: boolean,
 }
 
-export type SideNavMenuItemProps<E extends object = {}> = LinkProps<E> & SideNavMenuItemPropsBase;
+export type SideNavMenuItemProps<E extends object = ReactAnchorAttr> = LinkProps<E> & SideNavMenuItemPropsBase;
 
-declare function SideNavMenuItem<E extends object = {}>(props: React.PropsWithChildren<SideNavMenuItemProps<E>>, ref: React.Ref<HTMLElement>): React.ReactElement | null;
+declare function SideNavMenuItem<E extends object = ReactAnchorAttr>(props: React.PropsWithChildren<SideNavMenuItemProps<E>>, ref: React.Ref<HTMLElement>): React.ReactElement | null;
 
 export default SideNavMenuItem;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  [SideNavLink](https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/UIShell/SideNavLink.js)
 [SideNavMenuItem](https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/UIShell/SideNavMenuItem.js)
