### PR TITLE
fix(rdf-js): match should allow null on optional parameters

### DIFF
--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -465,7 +465,7 @@ export interface DatasetCore<Q extends BaseQuad = Quad> {
      * @param object    The optional exact object to match.
      * @param graph     The optional exact graph to match.
      */
-    match(subject?: Term, predicate?: Term, object?: Term, graph?: Term): this;
+    match(subject?: Term | null, predicate?: Term | null, object?: Term | null, graph?: Term | null): this;
 
     [Symbol.iterator](): Iterator<Q>;
 }

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -147,6 +147,10 @@ function test_datasetcore() {
     const dataset2Match3: DatasetCore = dataset2.match(term, term);
     const dataset2Match4: DatasetCore = dataset2.match(term, term, term);
     const dataset2Match5: DatasetCore = dataset2.match(term, term, term, term);
+    const dataset2MatchWithNull1: DatasetCore = dataset2.match(term);
+    const dataset2MatchWithNull2: DatasetCore = dataset2.match(null, term);
+    const dataset2MatchWithNull3: DatasetCore = dataset2.match(term, null, term);
+    const dataset2MatchWithNull4: DatasetCore = dataset2.match(term, term, null, term);
     const dataset2Iterable: Iterable<Quad> = dataset2;
 
     const dataset3Size: number = dataset3.size;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [example test case](https://github.com/rdfjs-base/dataset/blob/master/test/DatasetCore.js#L167-L176)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.