### PR TITLE
Node: `querystring`: restrict input type

### DIFF
--- a/types/node/querystring.d.ts
+++ b/types/node/querystring.d.ts
@@ -11,7 +11,7 @@ declare module "querystring" {
     interface ParsedUrlQuery { [key: string]: string | string[]; }
 
     interface ParsedUrlQueryInput {
-        [key: string]: NodeJS.PoorMansUnknown;
+        [key: string]: string | number | boolean | string[] | number[] | boolean[];
     }
 
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;

--- a/types/node/test/querystring.ts
+++ b/types/node/test/querystring.ts
@@ -16,6 +16,18 @@ interface SampleObject { [key: string]: string; }
     result = querystring.stringify(obj, sep, eq);
     result = querystring.stringify(obj, sep, eq);
     result = querystring.stringify(obj, sep, eq, options);
+
+    querystring.stringify({ foo: () => {} }); // $ExpectError
+    querystring.stringify({ foo: { bar: 1 } }); // $ExpectError
+
+    querystring.stringify({
+        foo: 'foo',
+        bar: 1,
+        baz: true,
+        foo2: ['a', 'b'],
+        bar2: [1, 2],
+        baz2: [true, false]
+    });
 }
 
 {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://devdocs.io/node/querystring#querystring_querystring_stringify_obj_sep_eq_options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
