### PR TITLE
[lang.js] add definitions for lang.js

### DIFF
--- a/types/lang.js/index.d.ts
+++ b/types/lang.js/index.d.ts
@@ -1,0 +1,124 @@
+// Type definitions for lang.js 1.1
+// Project: https://github.com/rmariuzzo/Lang.js#readme
+// Definitions by: Krzysztof Gutkowski <https://github.com/LiquidPL>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace Lang;
+
+export = Lang;
+
+declare class Lang {
+    constructor(options: Lang.Options);
+
+    /**
+     * Set messages source.
+     *
+     * @param messages The messages source.
+     */
+    setMessages(messages: Lang.Messages): void;
+
+    /**
+     * Get the current locale.
+     *
+     * @return The current locale.
+     */
+    getLocale(): string;
+
+    /**
+     * Set the current locale.
+     *
+     * @return void
+     */
+    setLocale(locale: string): void;
+
+    /**
+     * Get the fallback locale being used.
+     *
+     * @return The fallback locale.
+     */
+    getFallback(): string;
+
+    /**
+     * Set the fallback locale being used.
+     *
+     * @param fallback The fallback locale.
+     */
+    setFallback(fallback: string): void;
+
+    /**
+     * Checks whether a given key exists in the messages source.
+     *
+     * @param key The key of the message.
+     * @param locale The locale of the message.
+     *
+     * @return true if the given key is defined on the messages source, otherwise false.
+     */
+    has(key: string, locale?: string): boolean;
+
+    /**
+     * Gets a translation message.
+     *
+     * @param key The key of the message.
+     * @param replacements The replacements to be done in the message.
+     * @param locale The locale to use, if not passed use the default locale.
+     *
+     * @return The translation message, if not found the given key.
+     */
+    get(key: string, replacements?: Lang.Replacements, locale?: string): string;
+
+    /**
+     * Gets a translation message.
+     *
+     * This method act as an alias to get() method, just without the locale parameter.
+     *
+     * @param key The key of the message.
+     * @param replacements The replacements to be done in the message.
+     *
+     * @return The translation message, if not found the given key.
+     */
+
+    trans(key: string, replacements?: Lang.Replacements): string;
+
+    /**
+     * Gets the plural or singular form of the message specified based on an integer value.
+     *
+     * @param key The key of the message.
+     * @param count The number of elements.
+     * @param replacements The replacements to be done in the message.
+     * @param locale The locale to use, if not passed use the default locale.
+     *
+     * @return The translation message according to an integer value.
+     */
+    choice(key: string, count: number, replacements?: Lang.Replacements, locale?: string): string;
+
+    /**
+     * Gets the plural or singular form of the message specified based on an integer value.
+     *
+     * This method act as an alias to choice() method, just without the locale parameter.
+     *
+     * @param key The key of the message.
+     * @param count The number of elements.
+     * @param replacements The replacements to be done in the message.
+     *
+     * @return The translation message according to an integer value.
+     */
+    transChoice(key: string, count: number, replacements?: Lang.Replacements): string;
+}
+
+declare namespace Lang {
+    interface Messages {
+        [index: string]: {
+            [key: string]: string;
+        };
+    }
+
+    interface Replacements {
+        [key: string]: string;
+    }
+
+    interface Options {
+        locale: string;
+        fallback: string;
+        messages: Messages;
+    }
+}

--- a/types/lang.js/lang.js-tests.ts
+++ b/types/lang.js/lang.js-tests.ts
@@ -1,0 +1,50 @@
+import * as Lang from 'lang.js';
+
+const messages: Lang.Messages = {
+    en: {
+        'test-key': 'test',
+    }
+};
+
+const lang = new Lang({
+    locale: 'en',
+    fallback: 'en',
+    messages
+});
+
+lang.setMessages(messages);
+
+lang.setLocale('en');
+lang.getLocale();
+
+lang.setFallback('en');
+lang.getFallback();
+
+lang.has('test-key');
+lang.has('test-key', 'en');
+
+lang.get('test-key');
+lang.get('test-key', {
+    param: 'value',
+});
+lang.get('test-key', {
+    param: 'value',
+}, 'en');
+
+lang.trans('test-key');
+lang.trans('test-key', {
+    param: 'value',
+});
+
+lang.choice('test.key', 2);
+lang.choice('test.key', 2, {
+    param: 'value',
+});
+lang.choice('test.key', 2, {
+    param: 'value',
+}, 'en');
+
+lang.transChoice('test.key', 2);
+lang.transChoice('test.key', 2, {
+    param: 'value',
+});

--- a/types/lang.js/tsconfig.json
+++ b/types/lang.js/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "lang.js-tests.ts"
+    ]
+}

--- a/types/lang.js/tslint.json
+++ b/types/lang.js/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.