### PR TITLE
Add missing type information for v3.2 of react-hooks-testing-library 

### DIFF
--- a/types/testing-library__react-hooks/index.d.ts
+++ b/types/testing-library__react-hooks/index.d.ts
@@ -35,7 +35,7 @@ export interface RenderHookResult<P, R, S> {
 /**
  * Renders a test component that will call the provided `callback`, including any hooks it calls, every time it renders.
  */
-export function renderHook<P, R>(callback: (props: P) => R, options?: RenderHookOptions<P>): RenderHookResult<P, R>;
+export function renderHook<P, R, S>(callback: (props: P) => R, options?: RenderHookOptions<P>): RenderHookResult<P, R, S>;
 
 /**
  * Unmounts any rendered hooks rendered with `renderHook`, ensuring all effects have been flushed.

--- a/types/testing-library__react-hooks/index.d.ts
+++ b/types/testing-library__react-hooks/index.d.ts
@@ -17,9 +17,15 @@ export interface HookResult<R> {
     readonly error: Error;
 }
 
+export interface WaitOptions {
+    timeout?: number;
+    suppressErrors?: boolean;
+}
+
 export interface RenderHookResult<P, R> {
     readonly result: HookResult<R>;
     readonly waitForNextUpdate: () => Promise<void>;
+    readonly waitForValueToChange: (selector: () => S, options?: WaitOptions) => Promise<void>;
     readonly unmount: () => boolean;
     readonly rerender: (newProps?: P) => void;
 }

--- a/types/testing-library__react-hooks/index.d.ts
+++ b/types/testing-library__react-hooks/index.d.ts
@@ -25,7 +25,7 @@ export interface WaitOptions {
 
 export interface RenderHookResult<P, R> {
     readonly result: HookResult<R>;
-    readonly waitForNextUpdate: () => Promise<void>;
+    readonly waitForNextUpdate: (options?: WaitOptions) => Promise<void>;
     readonly waitForValueToChange: (selector: () => any, options?: WaitOptions) => Promise<void>;
     readonly wait: (callback: () => boolean|void, options?: WaitOptions) => Promise<void>;
     readonly unmount: () => boolean;

--- a/types/testing-library__react-hooks/index.d.ts
+++ b/types/testing-library__react-hooks/index.d.ts
@@ -27,6 +27,7 @@ export interface RenderHookResult<P, R> {
     readonly result: HookResult<R>;
     readonly waitForNextUpdate: () => Promise<void>;
     readonly waitForValueToChange: (selector: () => S, options?: WaitOptions) => Promise<void>;
+    readonly wait: (callback: () => boolean|void, options?: WaitOptions) => Promise<void>;
     readonly unmount: () => boolean;
     readonly rerender: (newProps?: P) => void;
 }

--- a/types/testing-library__react-hooks/index.d.ts
+++ b/types/testing-library__react-hooks/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @testing-library/react-hooks 3.2.1
+// Type definitions for @testing-library/react-hooks 3.2
 // Project: https://github.com/testing-library/react-hooks-testing-library
 // Definitions by: Michael Peyper <https://github.com/mpeyper>
 //                 Sarah Dayan <https://github.com/sarahdayan>

--- a/types/testing-library__react-hooks/index.d.ts
+++ b/types/testing-library__react-hooks/index.d.ts
@@ -23,10 +23,10 @@ export interface WaitOptions {
     suppressErrors?: boolean;
 }
 
-export interface RenderHookResult<P, R, S> {
+export interface RenderHookResult<P, R> {
     readonly result: HookResult<R>;
     readonly waitForNextUpdate: () => Promise<void>;
-    readonly waitForValueToChange: (selector: () => S, options?: WaitOptions) => Promise<void>;
+    readonly waitForValueToChange: (selector: () => any, options?: WaitOptions) => Promise<void>;
     readonly wait: (callback: () => boolean|void, options?: WaitOptions) => Promise<void>;
     readonly unmount: () => boolean;
     readonly rerender: (newProps?: P) => void;
@@ -35,7 +35,7 @@ export interface RenderHookResult<P, R, S> {
 /**
  * Renders a test component that will call the provided `callback`, including any hooks it calls, every time it renders.
  */
-export function renderHook<P, R, S>(callback: (props: P) => R, options?: RenderHookOptions<P>): RenderHookResult<P, R, S>;
+export function renderHook<P, R>(callback: (props: P) => R, options?: RenderHookOptions<P>): RenderHookResult<P, R>;
 
 /**
  * Unmounts any rendered hooks rendered with `renderHook`, ensuring all effects have been flushed.

--- a/types/testing-library__react-hooks/index.d.ts
+++ b/types/testing-library__react-hooks/index.d.ts
@@ -23,7 +23,7 @@ export interface WaitOptions {
     suppressErrors?: boolean;
 }
 
-export interface RenderHookResult<P, R> {
+export interface RenderHookResult<P, R, S> {
     readonly result: HookResult<R>;
     readonly waitForNextUpdate: () => Promise<void>;
     readonly waitForValueToChange: (selector: () => S, options?: WaitOptions) => Promise<void>;

--- a/types/testing-library__react-hooks/index.d.ts
+++ b/types/testing-library__react-hooks/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for @testing-library/react-hooks 3.1
+// Type definitions for @testing-library/react-hooks 3.2.1
 // Project: https://github.com/testing-library/react-hooks-testing-library
 // Definitions by: Michael Peyper <https://github.com/mpeyper>
+//                 Sarah Dayan <https://github.com/sarahdayan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 


### PR DESCRIPTION
fixes https://github.com/testing-library/react-hooks-testing-library/issues/246

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-hooks-testing-library.com/reference/api#waitforvaluetochange
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.