### PR TITLE
[@types/node] Remove `readonly` from `http.ClientRequest`

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -178,7 +178,7 @@ declare module "http" {
 
         constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
 
-        readonly path: string;
+        path: string;
         abort(): void;
         onSocket(socket: Socket): void;
         setTimeout(timeout: number, callback?: () => void): this;

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -120,6 +120,7 @@ import * as net from 'net';
 
     // path
     const path: string = req.path;
+    req.path = '/';
 }
 
 {

--- a/types/node/v10/http.d.ts
+++ b/types/node/v10/http.d.ts
@@ -165,6 +165,8 @@ declare module "http" {
 
         constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
 
+        method: string;
+
         readonly path: string;
         abort(): void;
         onSocket(socket: net.Socket): void;

--- a/types/node/v10/http.d.ts
+++ b/types/node/v10/http.d.ts
@@ -165,9 +165,7 @@ declare module "http" {
 
         constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
 
-        method: string;
-
-        readonly path: string;
+        path: string;
         abort(): void;
         onSocket(socket: net.Socket): void;
         setTimeout(timeout: number, callback?: () => void): this;


### PR DESCRIPTION
There is nothing in the source code that prevents this property from being overwritten, and user code and/or modules may change this property before flushing the HTTP header.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/2f45ad8060e13d5ac912335096d21526f2f9602b/lib/_http_client.js#L167