### PR TITLE
[react-redux] Configurable RootState with module augmentation

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -46,7 +46,7 @@ import hoistNonReactStatics = require('hoist-non-react-statics');
 export interface ConfigurableRootState {}
 
 export type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
-export type SafeRoofState = AnyIfEmpty<ConfigurableRootState>;
+export type SafeRootState = AnyIfEmpty<ConfigurableRootState>;
 
 // Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
@@ -188,7 +188,7 @@ export interface Connect {
     // tslint:disable:no-unnecessary-generics
     (): InferableComponentEnhancer<DispatchProp>;
 
-    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = SafeRoofState>(
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = SafeRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>
     ): InferableComponentEnhancerWithProps<TStateProps & DispatchProp, TOwnProps>;
 
@@ -205,12 +205,12 @@ export interface Connect {
         TOwnProps
     >;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRoofState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>
     ): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRoofState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     ): InferableComponentEnhancerWithProps<
@@ -224,7 +224,7 @@ export interface Connect {
         mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>,
     ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
 
-    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}, State = SafeRoofState>(
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}, State = SafeRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: null | undefined,
         mergeProps: MergeProps<TStateProps, undefined, TOwnProps, TMergedProps>,
@@ -236,7 +236,7 @@ export interface Connect {
         mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>,
     ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
 
-    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = SafeRoofState>(
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = SafeRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: null | undefined,
         mergeProps: null | undefined,
@@ -260,14 +260,14 @@ export interface Connect {
         TOwnProps
     >;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRoofState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>,
         mergeProps: null | undefined,
         options: Options<State, TStateProps, TOwnProps>
     ): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRoofState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
         mergeProps: null | undefined,
@@ -277,7 +277,7 @@ export interface Connect {
         TOwnProps
     >;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}, State = SafeRoofState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}, State = SafeRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
         mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
@@ -299,13 +299,13 @@ export type ConnectedProps<TConnector> =
  */
 export const connect: Connect;
 
-export type MapStateToProps<TStateProps, TOwnProps, State = SafeRoofState> =
+export type MapStateToProps<TStateProps, TOwnProps, State = SafeRootState> =
     (state: State, ownProps: TOwnProps) => TStateProps;
 
-export type MapStateToPropsFactory<TStateProps, TOwnProps, State = SafeRoofState> =
+export type MapStateToPropsFactory<TStateProps, TOwnProps, State = SafeRootState> =
     (initialState: State, ownProps: TOwnProps) => MapStateToProps<TStateProps, TOwnProps, State>;
 
-export type MapStateToPropsParam<TStateProps, TOwnProps, State = SafeRoofState> =
+export type MapStateToPropsParam<TStateProps, TOwnProps, State = SafeRootState> =
     MapStateToPropsFactory<TStateProps, TOwnProps, State> | MapStateToProps<TStateProps, TOwnProps, State> | null | undefined;
 
 export type MapDispatchToPropsFunction<TDispatchProps, TOwnProps> =
@@ -324,7 +324,7 @@ export type MapDispatchToPropsNonObject<TDispatchProps, TOwnProps> = MapDispatch
 export type MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps> =
     (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps) => TMergedProps;
 
-export interface Options<State = SafeRoofState, TStateProps = {}, TOwnProps = {}, TMergedProps = {}> extends ConnectOptions {
+export interface Options<State = SafeRootState, TStateProps = {}, TOwnProps = {}, TMergedProps = {}> extends ConnectOptions {
     /**
      * If true, implements shouldComponentUpdate and shallowly compares the result of mergeProps,
      * preventing unnecessary updates, assuming that the component is a “pure” component
@@ -376,7 +376,7 @@ export interface Options<State = SafeRoofState, TStateProps = {}, TOwnProps = {}
  * @param connectOptions If specified, further customizes the behavior of the connector. Additionally, any extra
  *     options will be passed through to your <code>selectorFactory</code> in the <code>factoryOptions</code> argument.
  */
-export function connectAdvanced<S = SafeRoofState, TProps = {}, TOwnProps = {}, TFactoryOptions = {}>(
+export function connectAdvanced<S = SafeRootState, TProps = {}, TOwnProps = {}, TFactoryOptions = {}>(
     // tslint:disable-next-line no-unnecessary-generics
     selectorFactory: SelectorFactory<S, TProps, TOwnProps, TFactoryOptions>,
     connectOptions?: ConnectOptions & TFactoryOptions
@@ -390,10 +390,10 @@ export function connectAdvanced<S = SafeRoofState, TProps = {}, TOwnProps = {}, 
  * call, the component will not be re-rendered. It's the responsibility of <code>selector</code> to return that
  * previous object when appropriate.
  */
-export type SelectorFactory<S = SafeRoofState, TProps = {}, TOwnProps = {}, TFactoryOptions = {}> =
+export type SelectorFactory<S = SafeRootState, TProps = {}, TOwnProps = {}, TFactoryOptions = {}> =
     (dispatch: Dispatch<Action>, factoryOptions: TFactoryOptions) => Selector<S, TProps, TOwnProps>;
 
-export type Selector<S = SafeRoofState, TProps = {}, TOwnProps = null> = TOwnProps extends null | undefined
+export type Selector<S = SafeRootState, TProps = {}, TOwnProps = null> = TOwnProps extends null | undefined
     ? (state: S) => TProps
     : (state: S, ownProps: TOwnProps) => TProps;
 
@@ -448,7 +448,7 @@ export interface ConnectOptions {
     context?: Context<ReactReduxContextValue>;
 }
 
-export interface ReactReduxContextValue<SS = SafeRoofState, A extends Action = AnyAction> {
+export interface ReactReduxContextValue<SS = SafeRootState, A extends Action = AnyAction> {
     store: Store<SS, A>;
     storeState: SS;
 }
@@ -551,7 +551,7 @@ export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
  *   return <div>{counter}</div>
  * }
  */
-export function useSelector<TState = SafeRoofState, TSelected = any>(
+export function useSelector<TState = SafeRootState, TSelected = any>(
     selector: (state: TState) => TSelected,
     equalityFn?: (left: TSelected, right: TSelected) => boolean
 ): TSelected;
@@ -569,7 +569,7 @@ export function useSelector<TState = SafeRoofState, TSelected = any>(
  * const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector;
  *
  */
-export interface TypedUseSelectorHook<TState = SafeRoofState> {
+export interface TypedUseSelectorHook<TState = SafeRootState> {
     <TSelected>(
         selector: (state: TState) => TSelected,
         equalityFn?: (left: TSelected, right: TSelected) => boolean
@@ -591,7 +591,7 @@ export interface TypedUseSelectorHook<TState = SafeRoofState> {
  *   return <div>{store.getState()}</div>
  * }
  */
-export function useStore<S = SafeRoofState, A extends Action = AnyAction>(): Store<S, A>;
+export function useStore<S = SafeRootState, A extends Action = AnyAction>(): Store<S, A>;
 
 /**
  * Hook factory, which creates a `useSelector` hook bound to a given context.

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -376,7 +376,7 @@ export interface Options<State = SafeRootState, TStateProps = {}, TOwnProps = {}
  * @param connectOptions If specified, further customizes the behavior of the connector. Additionally, any extra
  *     options will be passed through to your <code>selectorFactory</code> in the <code>factoryOptions</code> argument.
  */
-export function connectAdvanced<S, TProps, TOwnProps, TFactoryOptions>(
+export function connectAdvanced<S, TProps, TOwnProps, TFactoryOptions = {}>(
     // tslint:disable-next-line no-unnecessary-generics
     selectorFactory: SelectorFactory<S, TProps, TOwnProps, TFactoryOptions>,
     connectOptions?: ConnectOptions & TFactoryOptions

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -43,7 +43,10 @@ import hoistNonReactStatics = require('hoist-non-react-statics');
  * https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  */
 // tslint:disable-next-line:no-empty-interface
-export interface RootState {}
+export interface ConfigurableRootState {}
+
+export type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
+export type SafeRoofState = AnyIfEmpty<ConfigurableRootState>;
 
 // Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
@@ -185,7 +188,7 @@ export interface Connect {
     // tslint:disable:no-unnecessary-generics
     (): InferableComponentEnhancer<DispatchProp>;
 
-    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = RootState>(
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = SafeRoofState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>
     ): InferableComponentEnhancerWithProps<TStateProps & DispatchProp, TOwnProps>;
 
@@ -202,12 +205,12 @@ export interface Connect {
         TOwnProps
     >;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = RootState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRoofState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>
     ): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = RootState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRoofState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     ): InferableComponentEnhancerWithProps<
@@ -221,7 +224,7 @@ export interface Connect {
         mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>,
     ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
 
-    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}, State = RootState>(
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}, State = SafeRoofState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: null | undefined,
         mergeProps: MergeProps<TStateProps, undefined, TOwnProps, TMergedProps>,
@@ -233,7 +236,7 @@ export interface Connect {
         mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>,
     ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
 
-    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = RootState>(
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = SafeRoofState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: null | undefined,
         mergeProps: null | undefined,
@@ -257,14 +260,14 @@ export interface Connect {
         TOwnProps
     >;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = RootState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRoofState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>,
         mergeProps: null | undefined,
         options: Options<State, TStateProps, TOwnProps>
     ): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = RootState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRoofState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
         mergeProps: null | undefined,
@@ -274,7 +277,7 @@ export interface Connect {
         TOwnProps
     >;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}, State = RootState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}, State = SafeRoofState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
         mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
@@ -296,13 +299,14 @@ export type ConnectedProps<TConnector> =
  */
 export const connect: Connect;
 
-export type MapStateToProps<TStateProps, TOwnProps, State = RootState> =
+export type MapStateToProps<TStateProps, TOwnProps, State = SafeRoofState> =
     (state: State, ownProps: TOwnProps) => TStateProps;
 
-export type MapStateToPropsFactory<TStateProps, TOwnProps, State = RootState> =
+export type MapStateToPropsFactory<TStateProps, TOwnProps, State = SafeRoofState> =
     (initialState: State, ownProps: TOwnProps) => MapStateToProps<TStateProps, TOwnProps, State>;
 
-export type MapStateToPropsParam<TStateProps, TOwnProps, State = RootState> = MapStateToPropsFactory<TStateProps, TOwnProps, State> | MapStateToProps<TStateProps, TOwnProps, State> | null | undefined;
+export type MapStateToPropsParam<TStateProps, TOwnProps, State = SafeRoofState> =
+    MapStateToPropsFactory<TStateProps, TOwnProps, State> | MapStateToProps<TStateProps, TOwnProps, State> | null | undefined;
 
 export type MapDispatchToPropsFunction<TDispatchProps, TOwnProps> =
     (dispatch: Dispatch<Action>, ownProps: TOwnProps) => TDispatchProps;
@@ -320,7 +324,7 @@ export type MapDispatchToPropsNonObject<TDispatchProps, TOwnProps> = MapDispatch
 export type MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps> =
     (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps) => TMergedProps;
 
-export interface Options<State = RootState, TStateProps = {}, TOwnProps = {}, TMergedProps = {}> extends ConnectOptions {
+export interface Options<State = SafeRoofState, TStateProps = {}, TOwnProps = {}, TMergedProps = {}> extends ConnectOptions {
     /**
      * If true, implements shouldComponentUpdate and shallowly compares the result of mergeProps,
      * preventing unnecessary updates, assuming that the component is a “pure” component
@@ -372,7 +376,7 @@ export interface Options<State = RootState, TStateProps = {}, TOwnProps = {}, TM
  * @param connectOptions If specified, further customizes the behavior of the connector. Additionally, any extra
  *     options will be passed through to your <code>selectorFactory</code> in the <code>factoryOptions</code> argument.
  */
-export function connectAdvanced<S = RootState, TProps = {}, TOwnProps = {}, TFactoryOptions = {}>(
+export function connectAdvanced<S = SafeRoofState, TProps = {}, TOwnProps = {}, TFactoryOptions = {}>(
     // tslint:disable-next-line no-unnecessary-generics
     selectorFactory: SelectorFactory<S, TProps, TOwnProps, TFactoryOptions>,
     connectOptions?: ConnectOptions & TFactoryOptions
@@ -386,10 +390,10 @@ export function connectAdvanced<S = RootState, TProps = {}, TOwnProps = {}, TFac
  * call, the component will not be re-rendered. It's the responsibility of <code>selector</code> to return that
  * previous object when appropriate.
  */
-export type SelectorFactory<S = RootState, TProps = {}, TOwnProps = {}, TFactoryOptions = {}> =
+export type SelectorFactory<S = SafeRoofState, TProps = {}, TOwnProps = {}, TFactoryOptions = {}> =
     (dispatch: Dispatch<Action>, factoryOptions: TFactoryOptions) => Selector<S, TProps, TOwnProps>;
 
-export type Selector<S = RootState, TProps = {}, TOwnProps = null> = TOwnProps extends null | undefined
+export type Selector<S = SafeRoofState, TProps = {}, TOwnProps = null> = TOwnProps extends null | undefined
     ? (state: S) => TProps
     : (state: S, ownProps: TOwnProps) => TProps;
 
@@ -444,7 +448,7 @@ export interface ConnectOptions {
     context?: Context<ReactReduxContextValue>;
 }
 
-export interface ReactReduxContextValue<SS = RootState, A extends Action = AnyAction> {
+export interface ReactReduxContextValue<SS = SafeRoofState, A extends Action = AnyAction> {
     store: Store<SS, A>;
     storeState: SS;
 }
@@ -547,7 +551,7 @@ export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
  *   return <div>{counter}</div>
  * }
  */
-export function useSelector<TState = RootState, TSelected = any>(
+export function useSelector<TState = SafeRoofState, TSelected = any>(
     selector: (state: TState) => TSelected,
     equalityFn?: (left: TSelected, right: TSelected) => boolean
 ): TSelected;
@@ -565,7 +569,7 @@ export function useSelector<TState = RootState, TSelected = any>(
  * const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector;
  *
  */
-export interface TypedUseSelectorHook<TState = RootState> {
+export interface TypedUseSelectorHook<TState = SafeRoofState> {
     <TSelected>(
         selector: (state: TState) => TSelected,
         equalityFn?: (left: TSelected, right: TSelected) => boolean
@@ -587,7 +591,7 @@ export interface TypedUseSelectorHook<TState = RootState> {
  *   return <div>{store.getState()}</div>
  * }
  */
-export function useStore<S = RootState, A extends Action = AnyAction>(): Store<S, A>;
+export function useStore<S = SafeRoofState, A extends Action = AnyAction>(): Store<S, A>;
 
 /**
  * Hook factory, which creates a `useSelector` hook bound to a given context.

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -14,6 +14,7 @@
 //                 Søren Bruus Frank <https://github.com/soerenbf>
 //                 Jonathan Ziller <https://github.com/mrwolfz>
 //                 Dylan Vann <https://github.com/dylanvann>
+//                 Yuki Ito <https://github.com/Lazyuki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -34,6 +35,15 @@ import {
 } from 'redux';
 
 import hoistNonReactStatics = require('hoist-non-react-statics');
+
+/**
+ * This interface can be augmented by users to add default types for the root state when
+ * using `react-redux`.
+ * Use module augmentation to append your own type definition in a your_custom_type.d.ts file.
+ * https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
+ */
+// tslint:disable-next-line:no-empty-interface
+export interface RootState {}
 
 // Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
@@ -175,7 +185,7 @@ export interface Connect {
     // tslint:disable:no-unnecessary-generics
     (): InferableComponentEnhancer<DispatchProp>;
 
-    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = {}>(
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = RootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>
     ): InferableComponentEnhancerWithProps<TStateProps & DispatchProp, TOwnProps>;
 
@@ -192,12 +202,12 @@ export interface Connect {
         TOwnProps
     >;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = {}>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = RootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>
     ): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = {}>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = RootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     ): InferableComponentEnhancerWithProps<
@@ -211,7 +221,7 @@ export interface Connect {
         mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>,
     ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
 
-    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}, State = {}>(
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}, State = RootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: null | undefined,
         mergeProps: MergeProps<TStateProps, undefined, TOwnProps, TMergedProps>,
@@ -223,7 +233,7 @@ export interface Connect {
         mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>,
     ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
 
-    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = {}>(
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = RootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: null | undefined,
         mergeProps: null | undefined,
@@ -247,14 +257,14 @@ export interface Connect {
         TOwnProps
     >;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = {}>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = RootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>,
         mergeProps: null | undefined,
         options: Options<State, TStateProps, TOwnProps>
     ): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = {}>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = RootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
         mergeProps: null | undefined,
@@ -264,7 +274,7 @@ export interface Connect {
         TOwnProps
     >;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}, State = {}>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}, State = RootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
         mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
@@ -286,13 +296,13 @@ export type ConnectedProps<TConnector> =
  */
 export const connect: Connect;
 
-export type MapStateToProps<TStateProps, TOwnProps, State> =
+export type MapStateToProps<TStateProps, TOwnProps, State = RootState> =
     (state: State, ownProps: TOwnProps) => TStateProps;
 
-export type MapStateToPropsFactory<TStateProps, TOwnProps, State> =
+export type MapStateToPropsFactory<TStateProps, TOwnProps, State = RootState> =
     (initialState: State, ownProps: TOwnProps) => MapStateToProps<TStateProps, TOwnProps, State>;
 
-export type MapStateToPropsParam<TStateProps, TOwnProps, State> = MapStateToPropsFactory<TStateProps, TOwnProps, State> | MapStateToProps<TStateProps, TOwnProps, State> | null | undefined;
+export type MapStateToPropsParam<TStateProps, TOwnProps, State = RootState> = MapStateToPropsFactory<TStateProps, TOwnProps, State> | MapStateToProps<TStateProps, TOwnProps, State> | null | undefined;
 
 export type MapDispatchToPropsFunction<TDispatchProps, TOwnProps> =
     (dispatch: Dispatch<Action>, ownProps: TOwnProps) => TDispatchProps;
@@ -310,7 +320,7 @@ export type MapDispatchToPropsNonObject<TDispatchProps, TOwnProps> = MapDispatch
 export type MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps> =
     (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps) => TMergedProps;
 
-export interface Options<State = {}, TStateProps = {}, TOwnProps = {}, TMergedProps = {}> extends ConnectOptions {
+export interface Options<State = RootState, TStateProps = {}, TOwnProps = {}, TMergedProps = {}> extends ConnectOptions {
     /**
      * If true, implements shouldComponentUpdate and shallowly compares the result of mergeProps,
      * preventing unnecessary updates, assuming that the component is a “pure” component
@@ -362,7 +372,7 @@ export interface Options<State = {}, TStateProps = {}, TOwnProps = {}, TMergedPr
  * @param connectOptions If specified, further customizes the behavior of the connector. Additionally, any extra
  *     options will be passed through to your <code>selectorFactory</code> in the <code>factoryOptions</code> argument.
  */
-export function connectAdvanced<S, TProps, TOwnProps, TFactoryOptions = {}>(
+export function connectAdvanced<S = RootState, TProps = {}, TOwnProps = {}, TFactoryOptions = {}>(
     // tslint:disable-next-line no-unnecessary-generics
     selectorFactory: SelectorFactory<S, TProps, TOwnProps, TFactoryOptions>,
     connectOptions?: ConnectOptions & TFactoryOptions
@@ -376,10 +386,10 @@ export function connectAdvanced<S, TProps, TOwnProps, TFactoryOptions = {}>(
  * call, the component will not be re-rendered. It's the responsibility of <code>selector</code> to return that
  * previous object when appropriate.
  */
-export type SelectorFactory<S, TProps, TOwnProps, TFactoryOptions> =
+export type SelectorFactory<S = RootState, TProps = {}, TOwnProps = {}, TFactoryOptions = {}> =
     (dispatch: Dispatch<Action>, factoryOptions: TFactoryOptions) => Selector<S, TProps, TOwnProps>;
 
-export type Selector<S, TProps, TOwnProps = null> = TOwnProps extends null | undefined
+export type Selector<S = RootState, TProps = {}, TOwnProps = null> = TOwnProps extends null | undefined
     ? (state: S) => TProps
     : (state: S, ownProps: TOwnProps) => TProps;
 
@@ -434,7 +444,7 @@ export interface ConnectOptions {
     context?: Context<ReactReduxContextValue>;
 }
 
-export interface ReactReduxContextValue<SS = any, A extends Action = AnyAction> {
+export interface ReactReduxContextValue<SS = RootState, A extends Action = AnyAction> {
     store: Store<SS, A>;
     storeState: SS;
 }
@@ -537,7 +547,7 @@ export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
  *   return <div>{counter}</div>
  * }
  */
-export function useSelector<TState, TSelected>(
+export function useSelector<TState = RootState, TSelected = any>(
     selector: (state: TState) => TSelected,
     equalityFn?: (left: TSelected, right: TSelected) => boolean
 ): TSelected;
@@ -555,7 +565,7 @@ export function useSelector<TState, TSelected>(
  * const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector;
  *
  */
-export interface TypedUseSelectorHook<TState> {
+export interface TypedUseSelectorHook<TState = RootState> {
     <TSelected>(
         selector: (state: TState) => TSelected,
         equalityFn?: (left: TSelected, right: TSelected) => boolean
@@ -577,7 +587,7 @@ export interface TypedUseSelectorHook<TState> {
  *   return <div>{store.getState()}</div>
  * }
  */
-export function useStore<S = any, A extends Action = AnyAction>(): Store<S, A>;
+export function useStore<S = RootState, A extends Action = AnyAction>(): Store<S, A>;
 
 /**
  * Hook factory, which creates a `useSelector` hook bound to a given context.

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -376,7 +376,7 @@ export interface Options<State = SafeRootState, TStateProps = {}, TOwnProps = {}
  * @param connectOptions If specified, further customizes the behavior of the connector. Additionally, any extra
  *     options will be passed through to your <code>selectorFactory</code> in the <code>factoryOptions</code> argument.
  */
-export function connectAdvanced<S = SafeRootState, TProps = {}, TOwnProps = {}, TFactoryOptions = {}>(
+export function connectAdvanced<S, TProps, TOwnProps, TFactoryOptions>(
     // tslint:disable-next-line no-unnecessary-generics
     selectorFactory: SelectorFactory<S, TProps, TOwnProps, TFactoryOptions>,
     connectOptions?: ConnectOptions & TFactoryOptions
@@ -390,10 +390,10 @@ export function connectAdvanced<S = SafeRootState, TProps = {}, TOwnProps = {}, 
  * call, the component will not be re-rendered. It's the responsibility of <code>selector</code> to return that
  * previous object when appropriate.
  */
-export type SelectorFactory<S = SafeRootState, TProps = {}, TOwnProps = {}, TFactoryOptions = {}> =
+export type SelectorFactory<S, TProps, TOwnProps, TFactoryOptions> =
     (dispatch: Dispatch<Action>, factoryOptions: TFactoryOptions) => Selector<S, TProps, TOwnProps>;
 
-export type Selector<S = SafeRootState, TProps = {}, TOwnProps = null> = TOwnProps extends null | undefined
+export type Selector<S, TProps, TOwnProps = null> = TOwnProps extends null | undefined
     ? (state: S) => TProps
     : (state: S, ownProps: TOwnProps) => TProps;
 
@@ -448,7 +448,7 @@ export interface ConnectOptions {
     context?: Context<ReactReduxContextValue>;
 }
 
-export interface ReactReduxContextValue<SS = SafeRootState, A extends Action = AnyAction> {
+export interface ReactReduxContextValue<SS = any, A extends Action = AnyAction> {
     store: Store<SS, A>;
     storeState: SS;
 }
@@ -569,7 +569,7 @@ export function useSelector<TState = SafeRootState, TSelected = unknown>(
  * const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector;
  *
  */
-export interface TypedUseSelectorHook<TState = SafeRootState> {
+export interface TypedUseSelectorHook<TState> {
     <TSelected>(
         selector: (state: TState) => TSelected,
         equalityFn?: (left: TSelected, right: TSelected) => boolean

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -43,10 +43,10 @@ import hoistNonReactStatics = require('hoist-non-react-statics');
  * https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  */
 // tslint:disable-next-line:no-empty-interface
-export interface ConfigurableRootState {}
+export interface DefaultRootState {}
 
-export type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
-export type SafeRootState = AnyIfEmpty<ConfigurableRootState>;
+export type ObjectIfEmpty<T extends object> = keyof T extends never ? {} : T;
+export type SafeRootState = ObjectIfEmpty<DefaultRootState>;
 
 // Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
@@ -551,7 +551,7 @@ export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
  *   return <div>{counter}</div>
  * }
  */
-export function useSelector<TState = SafeRootState, TSelected = any>(
+export function useSelector<TState = SafeRootState, TSelected = unknown>(
     selector: (state: TState) => TSelected,
     equalityFn?: (left: TSelected, right: TSelected) => boolean
 ): TSelected;

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -45,8 +45,8 @@ import hoistNonReactStatics = require('hoist-non-react-statics');
 // tslint:disable-next-line:no-empty-interface
 export interface DefaultRootState {}
 
-export type ObjectIfEmpty<T extends object> = keyof T extends never ? {} : T;
-export type SafeRootState = ObjectIfEmpty<DefaultRootState>;
+export type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
+export type RootStateOrAny = AnyIfEmpty<DefaultRootState>;
 
 // Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
@@ -188,7 +188,7 @@ export interface Connect {
     // tslint:disable:no-unnecessary-generics
     (): InferableComponentEnhancer<DispatchProp>;
 
-    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = SafeRootState>(
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = DefaultRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>
     ): InferableComponentEnhancerWithProps<TStateProps & DispatchProp, TOwnProps>;
 
@@ -205,12 +205,12 @@ export interface Connect {
         TOwnProps
     >;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRootState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>
     ): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRootState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     ): InferableComponentEnhancerWithProps<
@@ -224,7 +224,7 @@ export interface Connect {
         mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>,
     ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
 
-    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}, State = SafeRootState>(
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}, State = DefaultRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: null | undefined,
         mergeProps: MergeProps<TStateProps, undefined, TOwnProps, TMergedProps>,
@@ -236,7 +236,7 @@ export interface Connect {
         mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>,
     ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
 
-    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = SafeRootState>(
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = DefaultRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: null | undefined,
         mergeProps: null | undefined,
@@ -260,14 +260,14 @@ export interface Connect {
         TOwnProps
     >;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRootState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>,
         mergeProps: null | undefined,
         options: Options<State, TStateProps, TOwnProps>
     ): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = SafeRootState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
         mergeProps: null | undefined,
@@ -277,7 +277,7 @@ export interface Connect {
         TOwnProps
     >;
 
-    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}, State = SafeRootState>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}, State = DefaultRootState>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
         mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
@@ -299,13 +299,13 @@ export type ConnectedProps<TConnector> =
  */
 export const connect: Connect;
 
-export type MapStateToProps<TStateProps, TOwnProps, State = SafeRootState> =
+export type MapStateToProps<TStateProps, TOwnProps, State = DefaultRootState> =
     (state: State, ownProps: TOwnProps) => TStateProps;
 
-export type MapStateToPropsFactory<TStateProps, TOwnProps, State = SafeRootState> =
+export type MapStateToPropsFactory<TStateProps, TOwnProps, State = DefaultRootState> =
     (initialState: State, ownProps: TOwnProps) => MapStateToProps<TStateProps, TOwnProps, State>;
 
-export type MapStateToPropsParam<TStateProps, TOwnProps, State = SafeRootState> =
+export type MapStateToPropsParam<TStateProps, TOwnProps, State = DefaultRootState> =
     MapStateToPropsFactory<TStateProps, TOwnProps, State> | MapStateToProps<TStateProps, TOwnProps, State> | null | undefined;
 
 export type MapDispatchToPropsFunction<TDispatchProps, TOwnProps> =
@@ -324,7 +324,7 @@ export type MapDispatchToPropsNonObject<TDispatchProps, TOwnProps> = MapDispatch
 export type MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps> =
     (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps) => TMergedProps;
 
-export interface Options<State = SafeRootState, TStateProps = {}, TOwnProps = {}, TMergedProps = {}> extends ConnectOptions {
+export interface Options<State = DefaultRootState, TStateProps = {}, TOwnProps = {}, TMergedProps = {}> extends ConnectOptions {
     /**
      * If true, implements shouldComponentUpdate and shallowly compares the result of mergeProps,
      * preventing unnecessary updates, assuming that the component is a “pure” component
@@ -551,7 +551,7 @@ export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
  *   return <div>{counter}</div>
  * }
  */
-export function useSelector<TState = SafeRootState, TSelected = unknown>(
+export function useSelector<TState = DefaultRootState, TSelected = unknown>(
     selector: (state: TState) => TSelected,
     equalityFn?: (left: TSelected, right: TSelected) => boolean
 ): TSelected;
@@ -591,7 +591,7 @@ export interface TypedUseSelectorHook<TState> {
  *   return <div>{store.getState()}</div>
  * }
  */
-export function useStore<S = SafeRootState, A extends Action = AnyAction>(): Store<S, A>;
+export function useStore<S = RootStateOrAny, A extends Action = AnyAction>(): Store<S, A>;
 
 /**
  * Hook factory, which creates a `useSelector` hook bound to a given context.

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1400,7 +1400,7 @@ function testUseStore() {
 function testCreateHookFunctions() {
     // $ExpectType { <TDispatch = Dispatch<any>>(): TDispatch; <A extends Action<any> = AnyAction>(): Dispatch<A>; }
     createDispatchHook();
-    // $ExpectType <TState, TSelected>(selector: (state: TState) => TSelected, equalityFn?: ((left: TSelected, right: TSelected) => boolean) | undefined) => TSelected
+    // $ExpectType <TState = any, TSelected = any>(selector: (state: TState) => TSelected, equalityFn?: ((left: TSelected, right: TSelected) => boolean) | undefined) => TSelected
     createSelectorHook();
     interface RootState {
         property: string;

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1388,7 +1388,8 @@ function testUseStore() {
 
     const untypedStore = useStore();
     const state = untypedStore.getState();
-    state.things.stuff.anything; // any by default
+    // untyped store has {} as the state by default
+    state.things; // $ExpectError
 
     const typedStore = useStore<TypedState, TypedAction>();
     const typedState = typedStore.getState();
@@ -1400,7 +1401,7 @@ function testUseStore() {
 function testCreateHookFunctions() {
     // $ExpectType { <TDispatch = Dispatch<any>>(): TDispatch; <A extends Action<any> = AnyAction>(): Dispatch<A>; }
     createDispatchHook();
-    // $ExpectType <TState = {}, TSelected = unknown>(selector: (state: TState) => TSel ected, equalityFn?: ((left: TSelected, right: TSelected) => boolean) | undefined) => TSelected
+    // $ExpectType <TState = {}, TSelected = unknown>(selector: (state: TState) => TSelected, equalityFn?: ((left: TSelected, right: TSelected) => boolean) | undefined) => TSelected
     createSelectorHook();
     interface RootState {
         property: string;

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1400,7 +1400,7 @@ function testUseStore() {
 function testCreateHookFunctions() {
     // $ExpectType { <TDispatch = Dispatch<any>>(): TDispatch; <A extends Action<any> = AnyAction>(): Dispatch<A>; }
     createDispatchHook();
-    // $ExpectType <TState = any, TSelected = any>(selector: (state: TState) => TSelected, equalityFn?: ((left: TSelected, right: TSelected) => boolean) | undefined) => TSelected
+    // $ExpectType <TState = {}, TSelected = unknown>(selector: (state: TState) => TSel ected, equalityFn?: ((left: TSelected, right: TSelected) => boolean) | undefined) => TSelected
     createSelectorHook();
     interface RootState {
         property: string;

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1408,7 +1408,7 @@ function testCreateHookFunctions() {
     }
     // Should be able to create a version typed for a specific root state.
     const useTypedSelector: TypedUseSelectorHook<RootState> = createSelectorHook();
-    // $ExpectType <S = any, A extends Action<any> = AnyAction>() => Store<S, A>
+    // $ExpectType <S = {}, A extends Action<any> = AnyAction>() => Store<S, A>
     createStoreHook();
 }
 

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1388,8 +1388,7 @@ function testUseStore() {
 
     const untypedStore = useStore();
     const state = untypedStore.getState();
-    // untyped store has {} as the state by default
-    state.things; // $ExpectError
+    state.things.stuff.anything; // any by default
 
     const typedStore = useStore<TypedState, TypedAction>();
     const typedState = typedStore.getState();

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1400,14 +1400,14 @@ function testUseStore() {
 function testCreateHookFunctions() {
     // $ExpectType { <TDispatch = Dispatch<any>>(): TDispatch; <A extends Action<any> = AnyAction>(): Dispatch<A>; }
     createDispatchHook();
-    // $ExpectType <TState = {}, TSelected = unknown>(selector: (state: TState) => TSelected, equalityFn?: ((left: TSelected, right: TSelected) => boolean) | undefined) => TSelected
+    // $ExpectType <TState = DefaultRootState, TSelected = unknown>(selector: (state: TState) => TSelected, equalityFn?: ((left: TSelected, right: TSelected) => boolean) | undefined) => TSelected
     createSelectorHook();
     interface RootState {
         property: string;
     }
     // Should be able to create a version typed for a specific root state.
     const useTypedSelector: TypedUseSelectorHook<RootState> = createSelectorHook();
-    // $ExpectType <S = {}, A extends Action<any> = AnyAction>() => Store<S, A>
+    // $ExpectType <S = any, A extends Action<any> = AnyAction>() => Store<S, A>
     createStoreHook();
 }
 


### PR DESCRIPTION
With this PR, users can use Typescript's [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) to specify the type of `RootState` in which all the `react-redux` functions can infer from. (I got this idea from how `styled-components` does `DefaultTheme` ) https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7cb38cbc6d4f3092270331f90c16d29d1fc43cc2/types/styled-components/index.d.ts#L410-L417
All users need to do is create a `d.ts` file that extends this `RootState` with their own state. This works particularly well with redux since you are supposed to create only one "root state" and all the components share this state
e.g.
```tsx
// my-redux.d.ts
import 'react-redux';
type UserState = { name: string };
type CacheState = { favorites: string[] };

type MyState = { user: UserState, cache: CacheState };

declare module 'react-redux' {
  export interface ConfigurableRootState extends MyState {}
}
```

Then, anywhere in their code, they could simply do 
```tsx
connect(
    ({ user, cache }) => (
        { 
            username: user.name,
            favorites: cache.favorites,
        }
    ))(Component);
```
without manually specifying types.
The root state type would be automatically inferred in other functions like
```tsx
const username = useSelector(state => state.user.name);
```
as well. 

I've tested this in my own project and it works great, but I may have overlooked unintended side effects. Let me know if this is something that you guys tried but decided against it. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.) **Can't test module augmentation in those test files**
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <see styled-components link>