### PR TITLE
[newman] Adding missing fields to NewmanRunFailure.

### DIFF
--- a/types/newman/index.d.ts
+++ b/types/newman/index.d.ts
@@ -178,9 +178,9 @@ export interface NewmanRunFailure {
     error: NewmanRunExecutionAssertionError;
     /** The event where the failure occurred */
     at: string;
-    source: any;
+    source: NewmanRunExecutionItem | undefined;
     parent: any;
-    cursor: any;
+    cursor: { ref: string } | {};
 }
 export function run(
     options: NewmanRunOptions,

--- a/types/newman/index.d.ts
+++ b/types/newman/index.d.ts
@@ -173,10 +173,14 @@ export interface NewmanRunExecutionAssertionError {
     test: string;
     message: string;
     stack: string;
-}export interface NewmanRunFailure {
+}
+export interface NewmanRunFailure {
     error: NewmanRunExecutionAssertionError;
     /** The event where the failure occurred */
     at: string;
+    source: any;
+    parent: any;
+    cursor: any;
 }
 export function run(
     options: NewmanRunOptions,

--- a/types/newman/newman-tests.ts
+++ b/types/newman/newman-tests.ts
@@ -29,5 +29,6 @@ run(
         summary.run; // $ExpectType NewmanRun
         summary.run.executions; // $ExpectType NewmanRunExecution[]
         summary.run.failures; // $ExpectType NewmanRunFailure[]
+        summary.run.failures[0].source; // $ExpectType any
     }
 );

--- a/types/newman/newman-tests.ts
+++ b/types/newman/newman-tests.ts
@@ -29,6 +29,6 @@ run(
         summary.run; // $ExpectType NewmanRun
         summary.run.executions; // $ExpectType NewmanRunExecution[]
         summary.run.failures; // $ExpectType NewmanRunFailure[]
-        summary.run.failures[0].source; // $ExpectType any
+        summary.run.failures[0].source; // $ExpectType NewmanRunExecutionItem | undefined
     }
 );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

There are 3 fields missing from the NewmanRunFailure type: source, parent, cursor.  See link below.  These fields are present from newman 3.1.1 to the present version. Not being familiar with the newman or postman code base, I don't know the shapes of these fields, but I think they should at least be included with a type of 'any'

[location in code where they add failures](https://github.com/postmanlabs/newman/blob/b2208685bde2152546975a1e07ab21d9726eadb3/lib/run/summary.js#L319) 
