### PR TITLE
Fix type error in stream-json FilterBase.d.ts

### DIFF
--- a/types/stream-json/filters/FilterBase.d.ts
+++ b/types/stream-json/filters/FilterBase.d.ts
@@ -11,7 +11,7 @@ declare namespace FilterBase {
 
     interface Token {
         readonly name: string;
-        readonly value?: ReadonlyArray<string | null | true | false>;
+        readonly value?: string | null | boolean;
     }
 
     type FilterFunction = (stack: Stack, token: Token) => boolean;

--- a/types/stream-json/stream-json-tests.ts
+++ b/types/stream-json/stream-json-tests.ts
@@ -134,6 +134,17 @@ const used = (array: any[]) => array.forEach(value => console.log(!!value));
 
     parser
         .pipe(new Replace({ filter: 'total', replacement: [{ name: 'trueValue' }] }))
+        .pipe(
+            new Replace({
+                filter: 'sum',
+                replacement: [
+                    { name: 'startNumber' },
+                    { name: 'numberChunk', value: '0' },
+                    { name: 'endNumber' },
+                    { name: 'numberValue', value: '0' },
+                ]
+            })
+        )
         .pipe(Replace.make({ filter: /\b_\w*\b/i, allowEmptyReplacement: true }))
         .pipe(
             Replace.replace({


### PR DESCRIPTION
Remove an extraneous `ReadonlyArray<...>` from the Token value.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/uhop/stream-json/wiki/FilterBase
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.