### PR TITLE
[workerpool] Make exec and proxy methods typed.

### DIFF
--- a/types/workerpool/index.d.ts
+++ b/types/workerpool/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Alorel <https://github.com/Alorel>
 //                 Seulgi Kim <https://github.com/sgkim126>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.1
 
 /// <reference types="node" />
 
@@ -17,6 +17,10 @@ export interface WorkerPoolStats {
     activeTasks: number;
 }
 
+export type Proxy<T extends {[k: string]: (...args: any[]) => any}> = {
+    [M in keyof T]: (...args: Parameters<T[M]>) => Promise<ReturnType<T[M]>>;
+};
+
 export interface WorkerPool {
     /**
      * Execute a function on a worker with given arguments.
@@ -27,14 +31,15 @@ export interface WorkerPool {
      * and executed there with the provided parameters. The provided function must be static,
      * it must not depend on variables in a surrounding scope.
      */
-    exec(method: ((...args: any[]) => any) | string, params: any[] | null): Promise<any>;
+    exec<T extends (...args: any[]) => any>(method: T | string, params: Parameters<T> | null): Promise<ReturnType<T>>;
 
     /**
      * Create a proxy for the worker pool.
      * The proxy contains a proxy for all methods available on the worker.
      * All methods return promises resolving the methods result.
      */
-    proxy(): Promise<any>;
+    // tslint:disable-next-line: no-unnecessary-generics
+    proxy<T extends {[k: string]: (...args: any[]) => any}>(): Promise<Proxy<T>>;
 
     /** Retrieve statistics on workers, and active and pending tasks. */
     stats(): WorkerPoolStats;

--- a/types/workerpool/workerpool-tests.ts
+++ b/types/workerpool/workerpool-tests.ts
@@ -37,6 +37,33 @@ pool.exec('foo', null)
     .then(() => pool.exec('foo', []))
     .then(() => pool.exec(() => {}, null));
 
+function add(a: number, b: number): number {
+    return a + b;
+}
+
+function hello(): string {
+    return 'hello';
+}
+
+pool.exec(add, [1, 2])
+    .then((c: number) => c);
+pool.exec<typeof add>('add', [1, 2])
+    .then((c: number) => c);
+pool.exec(hello, [])
+    .then((s: string) => s);
+
+const workers = {add, hello};
+type IWorkers = typeof workers;
+pool.proxy<IWorkers>().then((proxy) => {
+    proxy.add(1, 2);
+    proxy.hello();
+});
+
+pool.proxy().then((proxy) => {
+    proxy.add(1, 2);
+    proxy.hello();
+});
+
 new wp.Promise.CancellationError();
 new wp.Promise.TimeoutError();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/josdejong/workerpool>>
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

### Overview

This PR makes `WorkerPool.prototype.exec` and `WorkerPool.prototype.proxy` typed using `ReturnType` and `Parameters`. 

- The type of `params` in the arguments of `exec` must have the same type as `method`.
- To make the return type of `proxy` typed, I have introduced the `Proxy` type and use it. We can see a typical usage in the test.