### PR TITLE
[@types/express-session-static-core] Updated CookieOptions.sameSite to correctly reflect new change to @ty…

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -185,7 +185,7 @@ export interface CookieOptions {
     domain?: string;
     secure?: boolean;
     encode?: (val: string) => string;
-    sameSite?: boolean | string;
+    sameSite?: boolean | 'lax' | 'strict' | 'none';
 }
 
 export interface ByteRange { start: number; end: number; }


### PR DESCRIPTION
…pes/express-session

The change to express-session on Nov 18th (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40314) broke type checking for connect-redis and express-session. 

Specifically: 
Type 'string | boolean | undefined' is not assignable to type 'boolean | "lax" | "strict" | "none" | undefined'