### PR TITLE
[sortablejs] adds 5 missing properties in interfaces

### DIFF
--- a/types/sortablejs/index.d.ts
+++ b/types/sortablejs/index.d.ts
@@ -95,6 +95,10 @@ declare namespace Sortable {
             OnSpillOptions,
             SwapOptions {}
 
+    /**
+     * A class that all plugins inherit from for the sake of types
+     */
+    export class Plugin extends SortablePlugin {}
     export class MultiDrag extends MultiDragPlugin {}
     export class AutoScroll extends AutoScrollPlugin {}
     export class Swap extends SwapPlugin {}

--- a/types/sortablejs/index.d.ts
+++ b/types/sortablejs/index.d.ts
@@ -36,9 +36,9 @@ declare class Sortable {
     /**
      * Mounts a plugin to Sortable
      * @param sortablePlugin a sortable plugin.
-     * 
+     *
      * @example
-     * 
+     *
      * Sortable.mount(new MultiDrag(), new AutoScroll())
      */
     static mount(...sortablePlugins: SortablePlugin[]): void;
@@ -164,6 +164,7 @@ declare namespace Sortable {
         /**
          * whether elements can be added from other lists, or an array of group names from which elements can be taken.
          */
+        put?: PutResult | ((to: Sortable, from: Sortable) => PullResult);
         /**
          * a canonical version of pull, created by Sortable
          */

--- a/types/sortablejs/index.d.ts
+++ b/types/sortablejs/index.d.ts
@@ -164,7 +164,7 @@ declare namespace Sortable {
         /**
          * whether elements can be added from other lists, or an array of group names from which elements can be taken.
          */
-        put?: PutResult | ((to: Sortable, from: Sortable) => PullResult);
+        put?: PutResult | ((to: Sortable) => PullResult);
         /**
          * a canonical version of pull, created by Sortable
          */

--- a/types/sortablejs/index.d.ts
+++ b/types/sortablejs/index.d.ts
@@ -152,7 +152,24 @@ declare namespace Sortable {
         /**
          * whether elements can be added from other lists, or an array of group names from which elements can be taken.
          */
-        put?: ((to: Sortable) => PutResult) | PutResult;
+        /**
+         * a canonical version of pull, created by Sortable
+         */
+        checkPull?: (
+            sortable: Sortable,
+            activeSortable: Sortable,
+            dragEl: HTMLElement,
+            event: SortableEvent,
+        ) => boolean | string | Array<string>;
+        /**
+         * a canonical version of put, created by Sortable
+         */
+        checkPut?: (
+            sortable: Sortable,
+            activeSortable: Sortable,
+            dragEl: HTMLElement,
+            event: SortableEvent,
+        ) => boolean | string | 'clone' | Array<string>;
         /**
          * revert cloned element to initial position after moving to a another list.
          */

--- a/types/sortablejs/index.d.ts
+++ b/types/sortablejs/index.d.ts
@@ -123,6 +123,18 @@ declare namespace Sortable {
          * list, in which moved element.
          */
         to: HTMLElement;
+        /**
+         * Old index within parent, only counting draggable elements
+         */
+        oldDraggableIndex: number | undefined;
+        /**
+         * New index within parent, only counting draggable elements
+         */
+        newDraggableIndex: number | undefined;
+        /**
+         * Pull mode if dragging into another sortable
+         */
+        pullMode: 'clone' | boolean | undefined;
     }
 
     export interface MoveEvent extends Event {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
 
 - `checkPull` and `CheckPut`:
<https://github.com/SortableJS/Sortable/blob/118828dc12f7debabf4e4d3068c499207ef5d823/src/Sortable.js#L280-L281>
- `oldDragableIndex`, `newDraggableIndex` and `pullMode`:
<https://github.com/SortableJS/Sortable#event-object-demo>
