### PR TITLE
[fastbitset] Add types for fastbitset

### DIFF
--- a/types/fastbitset/fastbitset-tests.ts
+++ b/types/fastbitset/fastbitset-tests.ts
@@ -1,0 +1,27 @@
+import FastBitSet = require('fastbitset');
+
+const bitSet = new FastBitSet();
+
+bitSet.add(1);
+bitSet.has(1);
+bitSet.add(2);
+
+bitSet.add(10);
+bitSet.array();
+
+let otherBitSet = new FastBitSet([1, 2, 3, 10]);
+
+otherBitSet.difference(bitSet);
+otherBitSet.union_size(bitSet);
+otherBitSet.union(bitSet);
+otherBitSet.new_union(bitSet);
+otherBitSet.new_intersection(bitSet);
+otherBitSet.intersection_size(bitSet);
+otherBitSet.difference_size(bitSet);
+otherBitSet.intersects(bitSet);
+otherBitSet.intersection(bitSet);
+
+otherBitSet = bitSet.clone();
+otherBitSet.equals(bitSet);
+otherBitSet.forEach(value => value);
+otherBitSet.trim();

--- a/types/fastbitset/index.d.ts
+++ b/types/fastbitset/index.d.ts
@@ -1,0 +1,114 @@
+// Type definitions for fastbitset 0.2
+// Project: https://github.com/lemire/FastBitSet.js
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare class FastBitSet {
+    constructor(iterable?: Iterable<number>);
+
+    /** Add the value (Set the bit at `index` to `true`) */
+    add(index: number): void;
+
+    /** Return an array with the set bit locations (values) */
+    array(): number[];
+
+    /**
+     * Tries to add the value (Set the bit at `index` to `true`), returns `1` if the
+     * value was added, returns `0` if the value was already present
+     */
+    checkedAdd(index: number): 1 | 0;
+
+    /** Remove all values, reset memory usage */
+    clear(): void;
+
+    /** Creates a copy of this bitmap */
+    clone(): FastBitSet;
+
+    /**
+     * Computes the difference between this bitset and another one,
+     * the current bitset is modified (and returned by the function)
+     */
+    difference(otherbitmap: FastBitSet): FastBitSet;
+
+    /** Computes the size of the difference between this bitset and another one */
+    difference_size(otherbitmap: FastBitSet): number;
+
+    /**
+     * Computes the intersection between this bitset and another one,
+     * the current bitmap is modified
+     */
+    equals(otherbitmap: FastBitSet): boolean;
+
+    /** If the value was not in the set, add it, otherwise remove it (flip bit at `index`) */
+    flip(index: number): void;
+
+    /** Return an array with the set bit locations (values) */
+    forEach(fnc: (index: number) => void): void;
+
+    /** fast function to compute the Hamming weight of a 32-bit unsigned integer */
+    hammingWeight(v: number): number;
+
+    /** fast function to compute the Hamming weight of four 32-bit unsigned integers */
+    hammingWeight4(v1: number, v2: number, v3: number, v4: number): number;
+
+    /** Is the value contained in the set? Is the bit at `index` `true` or `false`? */
+    has(index: number): boolean;
+
+    /**
+     * Check if this bitset intersects with another one,
+     * no bitmap is modified
+     */
+    intersects(otherbitmap: FastBitSet): boolean;
+
+    /**
+     * Computes the intersection between this bitset and another one,
+     * the current bitmap is modified  (and returned by the function)
+     */
+    intersection(otherbitmap: FastBitSet): FastBitSet;
+
+    /** Computes the size of the intersection between this bitset and another one */
+    intersection_size(otherbitmap: FastBitSet): number;
+
+    /** Return `true` if no bit is set */
+    isEmpty(index: number): boolean;
+
+    /**
+     * Computes the intersection between this bitset and another one,
+     * a new bitmap is generated
+     */
+    new_intersection(otherbitmap: FastBitSet): FastBitSet;
+
+    /**
+     * Computes the difference between this bitset and another one,
+     * a new bitmap is generated
+     */
+    new_difference(otherbitmap: FastBitSet): FastBitSet;
+
+    new_union(otherbitmap: FastBitSet): FastBitSet;
+
+    /** Set the bit at `index` to `false` */
+    remove(index: number): void;
+
+    /** Resize the bitset so that we can write a value at `index` */
+    resize(index: number): void;
+
+    /** How many values stored in the set? How many set bits? */
+    size(): number;
+
+    /** Returns a string representation */
+    toString(): string;
+
+    /** Reduce the memory usage to a minimum */
+    trim(): void;
+
+    /**
+     * Computes the union between this bitset and another one,
+     * the current bitset is modified (and returned by the function)
+     */
+    union(otherbitmap: FastBitSet): FastBitSet;
+
+    /** Computes the size union between this bitset and another one */
+    union_size(otherbitmap: FastBitSet): number;
+}
+
+export = FastBitSet;

--- a/types/fastbitset/tsconfig.json
+++ b/types/fastbitset/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "fastbitset-tests.ts"
+    ]
+}

--- a/types/fastbitset/tslint.json
+++ b/types/fastbitset/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
