### PR TITLE
Improve types of highland sequence/series/flatten

### DIFF
--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -74,6 +74,7 @@ var barStream: Highland.Stream<Bar>;
 
 var fooStreamStream: Highland.Stream<Highland.Stream<Foo>>;
 var barStreamStream: Highland.Stream<Highland.Stream<Bar>>;
+var barStreamArrStream: Highland.Stream<Highland.Stream<Bar>[]>;
 
 var fooArrStream: Highland.Stream<Foo[]>;
 var barArrStream: Highland.Stream<Bar[]>;
@@ -301,7 +302,13 @@ barStream = fooStream.flatMap((x: Foo) => {
   return bar;
 });
 
-barStream = fooStream.flatten<Bar>();
+barStream = barArrStream.flatten<Bar>();
+barStream = barArrStream.flatten();
+barStream = barStreamStream.flatten();
+barStream = barStreamArrStream.flatten();
+
+// $ExpectError
+barArrStream.flatten<Foo>();
 
 fooStream = fooStream.fork();
 
@@ -315,7 +322,14 @@ fooStream = fooStreamStream.parallel(num);
 
 barStream = barStreamStream.sequence();
 
-barStream = fooStream.series<Bar>();
+barStream = barStreamStream.series<Bar>();
+
+// $ExpectError
+fooStream.sequence();
+// $ExpectError
+barStream.series();
+// $ExpectError
+fooStreamStream.sequence<Bar>();
 
 bar = fooStream.through(x => bar);
 barStream = fooStream.through(readwritable);


### PR DESCRIPTION
The sequence and series methods now work on streams-of-arrays as well.
Flatten now has an accurate return type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://highlandjs.org/#sequence
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
