### PR TITLE
Added Const namespace to argparse

### DIFF
--- a/types/argparse/argparse-tests.ts
+++ b/types/argparse/argparse-tests.ts
@@ -6,6 +6,7 @@ import {
     Action,
     ActionConstructorOptions,
     Namespace,
+    Const,
 } from 'argparse';
 let args: any;
 
@@ -305,3 +306,46 @@ customActionExample.addArgument('--abc', {
 customActionExample.addArgument('--def', {
     action: CustomAction2,
 });
+
+const constExample = new ArgumentParser();
+constExample.addArgument(
+    ['-f', '--foo'],
+    {
+        help: 'foo bar',
+        nargs: Const.ONE_OR_MORE
+    }
+);
+constExample.addArgument(
+    ['-b', '--bar'],
+    {
+        help: 'bar foo',
+        nargs: Const.ZERO_OR_MORE
+    }
+);
+constExample.addArgument(
+    '--baz',
+    {
+        help: 'baz',
+        nargs: Const.OPTIONAL
+    }
+);
+constExample.addArgument(
+    '--qux',
+    {
+        help: Const.SUPPRESS
+    }
+);
+constExample.addArgument(
+    'quux',
+    {
+        help: 'quux',
+        nargs: Const.REMAINDER
+    }
+);
+
+constExample.printHelp();
+console.log('-----------');
+
+args = constExample.parseArgs('--foo x --bar --baz y --qux z a b c d e'.split(' '));
+console.dir(args);
+console.log('-----------');

--- a/types/argparse/index.d.ts
+++ b/types/argparse/index.d.ts
@@ -4,6 +4,7 @@
 //                 Tomasz Łaziuk <https://github.com/tlaziuk>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 Kannan Goundan <https://github.com/cakoose>
+//                 Halvor Holsten Strand <https://github.com/ondkloss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -109,4 +110,12 @@ export interface ArgumentOptions {
     required?: boolean;
     help?: string;
     metavar?: string;
+}
+
+export namespace Const {
+    const SUPPRESS: string;
+    const OPTIONAL: string;
+    const ZERO_OR_MORE: string;
+    const ONE_OR_MORE: string;
+    const REMAINDER: string;
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/nodeca/argparse/blob/master/lib/const.js>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.