### PR TITLE
[@types/jsesc] fix: bump patch number to republish type definitions

### DIFF
--- a/types/jsesc/index.d.ts
+++ b/types/jsesc/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jsesc 2.5.2
+// Type definitions for jsesc 2.5.3
 // Project: https://github.com/mathiasbynens/jsesc
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 //                 Lyanbin <https://github.com/Lyanbin>


### PR DESCRIPTION
This PR bumps the patch number of the type definitions to initiate another publish to the package registry. The [latest version](https://www.npmjs.com/package/@types/jsesc/v/2.5.0) on NPM failed to publish as expected.

If @typescript-bot publishes the package as expected, then this PR should fix #41069.


/cc @Lyanbin @Bartvds