### PR TITLE
Add logform dependency to datadog-winston

### DIFF
--- a/types/datadog-winston/package.json
+++ b/types/datadog-winston/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "winston-transport": "^4.3.0"
+        "winston-transport": "^4.3.0",
+        "logform": "^1.4.0"
     }
 }


### PR DESCRIPTION
winston-transport depends on logform, but only has it as a devDependency. I opened a PR to change this, but I don't know when it will be merged; the bug has been open since May. In the meantime, datadog-winston will do what all other clients have had to: add logform as a dependency itself.

Fixes dtslint-runner failure.