### PR TITLE
[@types/deline] Fix export

### DIFF
--- a/types/deline/deline-tests.ts
+++ b/types/deline/deline-tests.ts
@@ -1,12 +1,12 @@
-import * as dl from "deline";
+import deline = require("deline");
 
 const moduleName = "deline";
 
-dl.deline(`deline`); // $ExpectType string
-dl.deline(`module name: ${moduleName}`); // $ExpectType string
-dl.deline`deline`; // $ExpectType string
-dl.deline`tagged template: ${moduleName}`; // $ExpectType string
-dl.deline`
+deline(`deline`); // $ExpectType string
+deline(`module name: ${moduleName}`); // $ExpectType string
+deline`deline`; // $ExpectType string
+deline`tagged template: ${moduleName}`; // $ExpectType string
+deline`
 tagged template:
 
 ${moduleName}

--- a/types/deline/index.d.ts
+++ b/types/deline/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for deline 1.0
 // Project: https://github.com/airbnb/deline#readme
 // Definitions by: Inaki Arroyo <https://github.com/iarroyo5>
+//                 Tim van der Horst <https://github.com/vdh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function deline(strings: string | TemplateStringsArray, ...values: any[]): string;
+declare function deline(strings: string | TemplateStringsArray, ...values: any[]): string;
+export = deline;


### PR DESCRIPTION
The export was using a named export instead of the CommonJS style of export that [`deline`](https://github.com/airbnb/deline) uses.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/airbnb/deline/blob/master/deline.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
