### PR TITLE
[@types/matter-js] Fix types for Runner.create() and IRunnerOptions

### DIFF
--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -1671,7 +1671,7 @@ declare namespace Matter {
         stiffness?: number;
 
         /**
-         * A `Number` that specifies the damping of the constraint, 
+         * A `Number` that specifies the damping of the constraint,
          * i.e. the amount of resistance applied to each body based on their velocities to limit the amount of oscillation.
          * Damping will only be apparent when the constraint also has a very low `stiffness`.
          * A value of `0.1` means the constraint will apply heavy damping, resulting in little to no oscillation.
@@ -1827,7 +1827,7 @@ declare namespace Matter {
         stiffness: number;
 
         /**
-         * A `Number` that specifies the damping of the constraint, 
+         * A `Number` that specifies the damping of the constraint,
          * i.e. the amount of resistance applied to each body based on their velocities to limit the amount of oscillation.
          * Damping will only be apparent when the constraint also has a very low `stiffness`.
          * A value of `0.1` means the constraint will apply heavy damping, resulting in little to no oscillation.
@@ -2429,10 +2429,10 @@ declare namespace Matter {
         /**
          * Render wireframes only
          * @type boolean
-         * @default true 
+         * @default true
          */
         wireframes?: boolean;
-        
+
         /**
          * Sets scene background
          * @type string
@@ -2570,6 +2570,14 @@ declare namespace Matter {
         * @default 1000 / 60
         */
         delta?: number;
+
+        /**
+         * A flag that specifies whether the runner is running or not.
+         * @property enabled
+         * @type boolean
+         * @default true
+         */
+        enabled?: boolean;
     }
 
     /**
@@ -2590,7 +2598,7 @@ declare namespace Matter {
          * @method create
          * @param {} options
          */
-        static create(options:IRunnerOptions): Runner;
+        static create(options?: IRunnerOptions): Runner;
         /**
          * Continuously ticks a `Matter.Engine` by calling `Runner.tick` on the `requestAnimationFrame` event.
          * @method run
@@ -3400,7 +3408,7 @@ declare namespace Matter {
         static trigger(object: any, eventNames: string, event?: (e: any) => void): void;
 
     }
-    
+
     type Dependency = {name: string, range: string}
                     | {name: string, version: string}
                     | string;
@@ -3410,7 +3418,7 @@ declare namespace Matter {
         version: string;
         install: () => void;
         for?: string;
-        
+
         /**
          * Registers a plugin object so it can be resolved later by name.
          * @method register
@@ -3418,16 +3426,16 @@ declare namespace Matter {
          * @return {object} The plugin.
          */
         static register(plugin: Plugin): Plugin;
-      
+
         /**
-         * Resolves a dependency to a plugin object from the registry if it exists. 
+         * Resolves a dependency to a plugin object from the registry if it exists.
          * The `dependency` may contain a version, but only the name matters when resolving.
          * @method resolve
          * @param dependency {string} The dependency.
          * @return {object} The plugin if resolved, otherwise `undefined`.
          */
         static resolve(dependency: string): Plugin | undefined;
-        
+
         /**
          * Returns `true` if the object meets the minimum standard to be considered a plugin.
          * This means it must define the following properties:
@@ -3501,7 +3509,7 @@ declare namespace Matter {
          * @return {object} The dependency parsed into its components.
          */
         static dependencyParse(dependency: Dependency) : {name: string, range: string};
-        
+
         /**
          * Parses a version string into its components.
          * Versions are strictly of the format `x.y.z` (as in [semver](http://semver.org/)).

--- a/types/matter-js/matter-js-tests.ts
+++ b/types/matter-js/matter-js-tests.ts
@@ -1,5 +1,5 @@
 import Matter = require("matter-js");
-var Engine = Matter.Engine, 
+var Engine = Matter.Engine,
 	World = Matter.World,
 	Body = Matter.Body,
 	Bodies = Matter.Bodies,
@@ -9,7 +9,7 @@ var Engine = Matter.Engine,
 	Query = Matter.Query,
     Plugin = Matter.Plugin,
     Render = Matter.Render;
-    
+
 
 Matter.use('matter-attractors');
 Plugin.use(Matter, ["matter-wrap"]);
@@ -51,9 +51,9 @@ World.add(engine.world, [box2, circle1]);
 var stack = Composites.stack(0, 100, 5, 1, 20, 0, function(x:number, y:number, column:number, row:number) {
             return Bodies.circle(x, y, 75, { restitution: 0.9 });
         });
-        
+
 World.add(engine.world, stack);
- 
+
 //Constraints
 var constraint1 = Constraint.create({
 	bodyA: box1,
@@ -62,7 +62,7 @@ var constraint1 = Constraint.create({
 	damping: 0.01
 });
 
-//Query 
+//Query
 var collisions = Query.ray([box1, box2, circle1], {x:1, y:2}, {x:3, y:4});
 
 World.addConstraint(engine.world, constraint1);
@@ -90,3 +90,12 @@ var render = Render.create({
 		}
 	}
 })
+
+// Runner
+const runner1 = Matter.Runner.create({
+    delta: 1000 / 60,
+    isFixed: false,
+    enabled: true
+});
+const runner2 = Matter.Runner.create({});
+const runner3 = Matter.Runner.create();


### PR DESCRIPTION
Definition for Runner.create() should allow no-arguments call, as can be seen
in the official examples, e.g. https://github.com/liabru/matter-js/blob/master/examples/gravity.js#L33

Also current definition for IRunnerOptions is missing 'enabled' property.

Whitespace changes are the effect of applying `.editorconfig` settings.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint matter-js` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/liabru/matter-js/blob/master/examples/gravity.js#L33
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
