### PR TITLE
Add rdf-dataset-ext

### DIFF
--- a/types/rdf-dataset-ext/addAll.d.ts
+++ b/types/rdf-dataset-ext/addAll.d.ts
@@ -1,0 +1,3 @@
+import { addAll } from '.';
+
+export = addAll;

--- a/types/rdf-dataset-ext/deleteMatch.d.ts
+++ b/types/rdf-dataset-ext/deleteMatch.d.ts
@@ -1,0 +1,3 @@
+import { deleteMatch } from '.';
+
+export = deleteMatch;

--- a/types/rdf-dataset-ext/equals.d.ts
+++ b/types/rdf-dataset-ext/equals.d.ts
@@ -1,0 +1,3 @@
+import { equals } from '.';
+
+export = equals;

--- a/types/rdf-dataset-ext/fromStream.d.ts
+++ b/types/rdf-dataset-ext/fromStream.d.ts
@@ -1,0 +1,3 @@
+import { fromStream} from '.';
+
+export = fromStream;

--- a/types/rdf-dataset-ext/fromStream.d.ts
+++ b/types/rdf-dataset-ext/fromStream.d.ts
@@ -1,3 +1,3 @@
-import { fromStream} from '.';
+import { fromStream } from '.';
 
 export = fromStream;

--- a/types/rdf-dataset-ext/index.d.ts
+++ b/types/rdf-dataset-ext/index.d.ts
@@ -1,3 +1,8 @@
+// Type definitions for rdf-dataset-ext 1.0
+// Project: https://github.com/rdf-ext/rdf-dataset-ext
+// Definitions by: Chris Wilkinson <https://github.com/thewilkybarkid>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
 import { EventEmitter } from 'events';
 import { BaseQuad, DatasetCore, Quad, Stream, Term } from 'rdf-js';
 

--- a/types/rdf-dataset-ext/index.d.ts
+++ b/types/rdf-dataset-ext/index.d.ts
@@ -1,48 +1,42 @@
 import { EventEmitter } from 'events';
 import { BaseQuad, DatasetCore, Quad, Stream, Term } from 'rdf-js';
 
-declare namespace ext {
+/**
+ * Iterates over iterable and adds all quads to dataset by calling `.add` for each quad.
+ *
+ * Returns the given dataset.
+ */
+export function addAll<Q extends BaseQuad = Quad, D extends DatasetCore<Q> = DatasetCore<Q>>(dataset: D, iterable: Iterable<Q>): D;
 
-    /**
-     * Iterates over iterable and adds all quads to dataset by calling `.add` for each quad.
-     *
-     * Returns the given dataset.
-     */
-    function addAll<Q extends BaseQuad = Quad, D extends DatasetCore<Q> = DatasetCore<Q>>(dataset: D, iterable: Iterable<Q>): D;
+/**
+ * Deletes all quads in the given dataset which match the given subject, predicate, object, graph pattern.
+ *
+ * `.match` of dataset is used to find the matches and .delete to delete all matches. Returns the given dataset.
+ */
+export function deleteMatch<D extends DatasetCore<BaseQuad> = DatasetCore>(dataset: D, subject?: Term, predicate?: Term, object?: Term, graph?: Term): D;
 
-    /**
-     * Deletes all quads in the given dataset which match the given subject, predicate, object, graph pattern.
-     *
-     * `.match` of dataset is used to find the matches and .delete to delete all matches. Returns the given dataset.
-     */
-    function deleteMatch<D extends DatasetCore<BaseQuad> = DatasetCore>(dataset: D, subject?: Term, predicate?: Term, object?: Term, graph?: Term): D;
+/**
+ * Tests if the datasets a and b contain the same quads without doing a normalization step beforehand.
+ *
+ * That means Blank Node labels must also match. The comparison is done by testing `.size` of both dataset for
+ * equality and by looping over all quads of a and check if b contains it using the `.has` method. Returns `true` if
+ * both datasets are equal. Otherwise `false `is returned.
+ */
+export function equals(a: DatasetCore<BaseQuad>, b: DatasetCore<BaseQuad>): boolean;
 
-    /**
-     * Tests if the datasets a and b contain the same quads without doing a normalization step beforehand.
-     *
-     * That means Blank Node labels must also match. The comparison is done by testing `.size` of both dataset for
-     * equality and by looping over all quads of a and check if b contains it using the `.has` method. Returns `true` if
-     * both datasets are equal. Otherwise `false `is returned.
-     */
-    function equals(a: DatasetCore<BaseQuad>, b: DatasetCore<BaseQuad>): boolean;
+/**
+ * Adds all quads from stream till the stream is finished.
+ *
+ * Errors emitted by the stream are forwarded as Promise rejects. Returns the given dataset.
+ */
+export function fromStream<D extends DatasetCore<BaseQuad> = DatasetCore>(dataset: D, stream: EventEmitter): Promise<D>;
 
-    /**
-     * Adds all quads from stream till the stream is finished.
-     *
-     * Errors emitted by the stream are forwarded as Promise rejects. Returns the given dataset.
-     */
-    function fromStream<D extends DatasetCore<BaseQuad> = DatasetCore>(dataset: D, stream: EventEmitter): Promise<D>;
+/**
+ * Returns the canonical representation of the dataset as string.
+ */
+export function toCanonical(dataset: DatasetCore<BaseQuad>): string;
 
-    /**
-     * Returns the canonical representation of the dataset as string.
-     */
-    function toCanonical(dataset: DatasetCore<BaseQuad>): string;
-
-    /**
-     * Creates a `Stream` which emits all quads of the given dataset. Returns the created stream.
-     */
-    function toStream<Q extends BaseQuad = Quad>(dataset: DatasetCore<Q>): Stream<Q>;
-
-}
-
-export = ext;
+/**
+ * Creates a `Stream` which emits all quads of the given dataset. Returns the created stream.
+ */
+export function toStream<Q extends BaseQuad = Quad>(dataset: DatasetCore<Q>): Stream<Q>;

--- a/types/rdf-dataset-ext/index.d.ts
+++ b/types/rdf-dataset-ext/index.d.ts
@@ -1,0 +1,48 @@
+import { EventEmitter } from 'events';
+import { BaseQuad, DatasetCore, Quad, Stream, Term } from 'rdf-js';
+
+declare namespace ext {
+
+    /**
+     * Iterates over iterable and adds all quads to dataset by calling `.add` for each quad.
+     *
+     * Returns the given dataset.
+     */
+    function addAll<Q extends BaseQuad = Quad, D extends DatasetCore<Q> = DatasetCore<Q>>(dataset: D, iterable: Iterable<Q>): D;
+
+    /**
+     * Deletes all quads in the given dataset which match the given subject, predicate, object, graph pattern.
+     *
+     * `.match` of dataset is used to find the matches and .delete to delete all matches. Returns the given dataset.
+     */
+    function deleteMatch<D extends DatasetCore<BaseQuad> = DatasetCore>(dataset: D, subject?: Term, predicate?: Term, object?: Term, graph?: Term): D;
+
+    /**
+     * Tests if the datasets a and b contain the same quads without doing a normalization step beforehand.
+     *
+     * That means Blank Node labels must also match. The comparison is done by testing `.size` of both dataset for
+     * equality and by looping over all quads of a and check if b contains it using the `.has` method. Returns `true` if
+     * both datasets are equal. Otherwise `false `is returned.
+     */
+    function equals(a: DatasetCore<BaseQuad>, b: DatasetCore<BaseQuad>): boolean;
+
+    /**
+     * Adds all quads from stream till the stream is finished.
+     *
+     * Errors emitted by the stream are forwarded as Promise rejects. Returns the given dataset.
+     */
+    function fromStream<D extends DatasetCore<BaseQuad> = DatasetCore>(dataset: D, stream: EventEmitter): Promise<D>;
+
+    /**
+     * Returns the canonical representation of the dataset as string.
+     */
+    function toCanonical(dataset: DatasetCore<BaseQuad>): string;
+
+    /**
+     * Creates a `Stream` which emits all quads of the given dataset. Returns the created stream.
+     */
+    function toStream<Q extends BaseQuad = Quad>(dataset: DatasetCore<Q>): Stream<Q>;
+
+}
+
+export = ext;

--- a/types/rdf-dataset-ext/rdf-dataset-ext-tests.ts
+++ b/types/rdf-dataset-ext/rdf-dataset-ext-tests.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { BaseQuad, DatasetCore, Quad, Stream, Term } from '../rdf-js';
+import { BaseQuad, DatasetCore, Quad, Stream, Term } from 'rdf-js';
 import grouped = require('rdf-dataset-ext');
 import addAll = require('rdf-dataset-ext/addAll');
 import deleteMatch = require('rdf-dataset-ext/deleteMatch');
@@ -18,9 +18,7 @@ const eventEmitter: EventEmitter = {} as any;
 // addAll
 
 const dataset1addAll1: DatasetCore = addAll(dataset1, iterable1);
-const dataset1addAll2: DatasetCore = addAll<Quad, DatasetCore<Quad>>(dataset1, iterable1);
-const dataset1addAll3: DatasetCore = grouped.addAll(dataset1, iterable1);
-const dataset1addAll4: DatasetCore = grouped.addAll<Quad, DatasetCore<Quad>>(dataset1, iterable1);
+const dataset1addAll2: DatasetCore = grouped.addAll(dataset1, iterable1);
 
 const dataset2addAll1: DatasetCore<BaseQuad> = addAll(dataset2, iterable2);
 const dataset2addAll2: DatasetCore<BaseQuad> = addAll<BaseQuad, DatasetCore<BaseQuad>>(dataset2, iterable2);
@@ -30,17 +28,15 @@ const dataset2addAll4: DatasetCore<BaseQuad> = grouped.addAll<BaseQuad, DatasetC
 // deleteMatch
 
 const dataset1deleteMatch1: DatasetCore = deleteMatch(dataset1);
-const dataset1deleteMatch2: DatasetCore = deleteMatch<DatasetCore<Quad>>(dataset1);
-const dataset1deleteMatch3: DatasetCore = deleteMatch(dataset1, term);
-const dataset1deleteMatch4: DatasetCore = deleteMatch(dataset1, term, term);
-const dataset1deleteMatch5: DatasetCore = deleteMatch(dataset1, term, term, term);
-const dataset1deleteMatch6: DatasetCore = deleteMatch(dataset1, term, term, term, term);
-const dataset1deleteMatch7: DatasetCore = grouped.deleteMatch(dataset1);
-const dataset1deleteMatch8: DatasetCore = grouped.deleteMatch<DatasetCore<Quad>>(dataset1);
-const dataset1deleteMatch9: DatasetCore = grouped.deleteMatch(dataset1, term);
-const dataset1deleteMatch10: DatasetCore = grouped.deleteMatch(dataset1, term, term);
-const dataset1deleteMatch11: DatasetCore = grouped.deleteMatch(dataset1, term, term, term);
-const dataset1deleteMatch12: DatasetCore = grouped.deleteMatch(dataset1, term, term, term, term);
+const dataset1deleteMatch2: DatasetCore = deleteMatch(dataset1, term);
+const dataset1deleteMatch3: DatasetCore = deleteMatch(dataset1, term, term);
+const dataset1deleteMatch4: DatasetCore = deleteMatch(dataset1, term, term, term);
+const dataset1deleteMatch5: DatasetCore = deleteMatch(dataset1, term, term, term, term);
+const dataset1deleteMatch6: DatasetCore = grouped.deleteMatch(dataset1);
+const dataset1deleteMatch7: DatasetCore = grouped.deleteMatch(dataset1, term);
+const dataset1deleteMatch8: DatasetCore = grouped.deleteMatch(dataset1, term, term);
+const dataset1deleteMatch9: DatasetCore = grouped.deleteMatch(dataset1, term, term, term);
+const dataset1deleteMatch10: DatasetCore = grouped.deleteMatch(dataset1, term, term, term, term);
 
 const dataset2deleteMatch1: DatasetCore<BaseQuad> = deleteMatch(dataset2);
 const dataset2deleteMatch2: DatasetCore<BaseQuad> = deleteMatch<DatasetCore<BaseQuad>>(dataset2);
@@ -67,11 +63,11 @@ const equals6: boolean = grouped.equals(dataset2, dataset1);
 // fromStream
 
 const fromStream1: Promise<DatasetCore> = fromStream(dataset1, eventEmitter);
-const fromStream2: Promise<DatasetCore> = fromStream<DatasetCore>(dataset1, eventEmitter);
-const fromStream3: Promise<DatasetCore<BaseQuad>> = fromStream(dataset2, eventEmitter);
+const fromStream2: Promise<DatasetCore<BaseQuad>> = fromStream(dataset2, eventEmitter);
+const fromStream3: Promise<DatasetCore<BaseQuad>> = fromStream<DatasetCore<BaseQuad>>(dataset2, eventEmitter);
 const fromStream4: Promise<DatasetCore> = grouped.fromStream(dataset1, eventEmitter);
-const fromStream5: Promise<DatasetCore> = grouped.fromStream<DatasetCore>(dataset1, eventEmitter);
-const fromStream6: Promise<DatasetCore<BaseQuad>> = grouped.fromStream(dataset2, eventEmitter);
+const fromStream5: Promise<DatasetCore<BaseQuad>> = grouped.fromStream(dataset2, eventEmitter);
+const fromStream6: Promise<DatasetCore<BaseQuad>> = grouped.fromStream<DatasetCore<BaseQuad>>(dataset2, eventEmitter);
 
 // toCanonical
 
@@ -83,8 +79,8 @@ const toCanonical4: string = grouped.toCanonical(dataset2);
 // toStream
 
 const toStream1: Stream = toStream(dataset1);
-const toStream2: Stream<Quad> = toStream<Quad>(dataset1);
-const toStream3: Stream<BaseQuad> = toStream(dataset2);
+const toStream2: Stream<BaseQuad> = toStream(dataset2);
+const toStream3: Stream<BaseQuad> = toStream<BaseQuad>(dataset2);
 const toStream4: Stream = grouped.toStream(dataset1);
-const toStream5: Stream<Quad> = grouped.toStream<Quad>(dataset1);
-const toStream6: Stream<BaseQuad> = grouped.toStream(dataset2);
+const toStream5: Stream<BaseQuad> = grouped.toStream(dataset2);
+const toStream6: Stream<BaseQuad> = grouped.toStream<BaseQuad>(dataset2);

--- a/types/rdf-dataset-ext/rdf-dataset-ext-tests.ts
+++ b/types/rdf-dataset-ext/rdf-dataset-ext-tests.ts
@@ -1,0 +1,90 @@
+import { EventEmitter } from 'events';
+import { BaseQuad, DatasetCore, Quad, Stream, Term } from '../rdf-js';
+import grouped = require('rdf-dataset-ext');
+import addAll = require('rdf-dataset-ext/addAll');
+import deleteMatch = require('rdf-dataset-ext/deleteMatch');
+import equals = require('rdf-dataset-ext/equals');
+import fromStream = require('rdf-dataset-ext/fromStream');
+import toCanonical = require('rdf-dataset-ext/toCanonical');
+import toStream = require('rdf-dataset-ext/toStream');
+
+const dataset1: DatasetCore = {} as any;
+const dataset2: DatasetCore<BaseQuad> = {} as any;
+const iterable1: Iterable<Quad> = [] as any;
+const iterable2: Iterable<BaseQuad> = [] as any;
+const term: Term = undefined as any;
+const eventEmitter: EventEmitter = {} as any;
+
+// addAll
+
+const dataset1addAll1: DatasetCore = addAll(dataset1, iterable1);
+const dataset1addAll2: DatasetCore = addAll<Quad, DatasetCore<Quad>>(dataset1, iterable1);
+const dataset1addAll3: DatasetCore = grouped.addAll(dataset1, iterable1);
+const dataset1addAll4: DatasetCore = grouped.addAll<Quad, DatasetCore<Quad>>(dataset1, iterable1);
+
+const dataset2addAll1: DatasetCore<BaseQuad> = addAll(dataset2, iterable2);
+const dataset2addAll2: DatasetCore<BaseQuad> = addAll<BaseQuad, DatasetCore<BaseQuad>>(dataset2, iterable2);
+const dataset2addAll3: DatasetCore<BaseQuad> = grouped.addAll(dataset2, iterable2);
+const dataset2addAll4: DatasetCore<BaseQuad> = grouped.addAll<BaseQuad, DatasetCore<BaseQuad>>(dataset2, iterable2);
+
+// deleteMatch
+
+const dataset1deleteMatch1: DatasetCore = deleteMatch(dataset1);
+const dataset1deleteMatch2: DatasetCore = deleteMatch<DatasetCore<Quad>>(dataset1);
+const dataset1deleteMatch3: DatasetCore = deleteMatch(dataset1, term);
+const dataset1deleteMatch4: DatasetCore = deleteMatch(dataset1, term, term);
+const dataset1deleteMatch5: DatasetCore = deleteMatch(dataset1, term, term, term);
+const dataset1deleteMatch6: DatasetCore = deleteMatch(dataset1, term, term, term, term);
+const dataset1deleteMatch7: DatasetCore = grouped.deleteMatch(dataset1);
+const dataset1deleteMatch8: DatasetCore = grouped.deleteMatch<DatasetCore<Quad>>(dataset1);
+const dataset1deleteMatch9: DatasetCore = grouped.deleteMatch(dataset1, term);
+const dataset1deleteMatch10: DatasetCore = grouped.deleteMatch(dataset1, term, term);
+const dataset1deleteMatch11: DatasetCore = grouped.deleteMatch(dataset1, term, term, term);
+const dataset1deleteMatch12: DatasetCore = grouped.deleteMatch(dataset1, term, term, term, term);
+
+const dataset2deleteMatch1: DatasetCore<BaseQuad> = deleteMatch(dataset2);
+const dataset2deleteMatch2: DatasetCore<BaseQuad> = deleteMatch<DatasetCore<BaseQuad>>(dataset2);
+const dataset2deleteMatch3: DatasetCore<BaseQuad> = deleteMatch(dataset2, term);
+const dataset2deleteMatch4: DatasetCore<BaseQuad> = deleteMatch(dataset2, term, term);
+const dataset2deleteMatch5: DatasetCore<BaseQuad> = deleteMatch(dataset2, term, term, term);
+const dataset2deleteMatch6: DatasetCore<BaseQuad> = deleteMatch(dataset2, term, term, term, term);
+const dataset2deleteMatch7: DatasetCore<BaseQuad> = grouped.deleteMatch(dataset2);
+const dataset2deleteMatch8: DatasetCore<BaseQuad> = grouped.deleteMatch<DatasetCore<BaseQuad>>(dataset2);
+const dataset2deleteMatch9: DatasetCore<BaseQuad> = grouped.deleteMatch(dataset2, term);
+const dataset2deleteMatch10: DatasetCore<BaseQuad> = grouped.deleteMatch(dataset2, term, term);
+const dataset2deleteMatch11: DatasetCore<BaseQuad> = grouped.deleteMatch(dataset2, term, term, term);
+const dataset2deleteMatch12: DatasetCore<BaseQuad> = grouped.deleteMatch(dataset2, term, term, term, term);
+
+// equals
+
+const equals1: boolean = equals(dataset1, dataset1);
+const equals2: boolean = equals(dataset1, dataset2);
+const equals3: boolean = equals(dataset2, dataset1);
+const equals4: boolean = grouped.equals(dataset1, dataset1);
+const equals5: boolean = grouped.equals(dataset1, dataset2);
+const equals6: boolean = grouped.equals(dataset2, dataset1);
+
+// fromStream
+
+const fromStream1: Promise<DatasetCore> = fromStream(dataset1, eventEmitter);
+const fromStream2: Promise<DatasetCore> = fromStream<DatasetCore>(dataset1, eventEmitter);
+const fromStream3: Promise<DatasetCore<BaseQuad>> = fromStream(dataset2, eventEmitter);
+const fromStream4: Promise<DatasetCore> = grouped.fromStream(dataset1, eventEmitter);
+const fromStream5: Promise<DatasetCore> = grouped.fromStream<DatasetCore>(dataset1, eventEmitter);
+const fromStream6: Promise<DatasetCore<BaseQuad>> = grouped.fromStream(dataset2, eventEmitter);
+
+// toCanonical
+
+const toCanonical1: string = toCanonical(dataset1);
+const toCanonical2: string = toCanonical(dataset2);
+const toCanonical3: string = grouped.toCanonical(dataset1);
+const toCanonical4: string = grouped.toCanonical(dataset2);
+
+// toStream
+
+const toStream1: Stream = toStream(dataset1);
+const toStream2: Stream<Quad> = toStream<Quad>(dataset1);
+const toStream3: Stream<BaseQuad> = toStream(dataset2);
+const toStream4: Stream = grouped.toStream(dataset1);
+const toStream5: Stream<Quad> = grouped.toStream<Quad>(dataset1);
+const toStream6: Stream<BaseQuad> = grouped.toStream(dataset2);

--- a/types/rdf-dataset-ext/toCanonical.d.ts
+++ b/types/rdf-dataset-ext/toCanonical.d.ts
@@ -1,0 +1,3 @@
+import { toCanonical } from '.';
+
+export = toCanonical;

--- a/types/rdf-dataset-ext/toStream.d.ts
+++ b/types/rdf-dataset-ext/toStream.d.ts
@@ -1,0 +1,3 @@
+import { toStream } from '.';
+
+export = toStream;

--- a/types/rdf-dataset-ext/tsconfig.json
+++ b/types/rdf-dataset-ext/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rdf-dataset-ext-tests.ts"
+    ]
+}

--- a/types/rdf-dataset-ext/tslint.json
+++ b/types/rdf-dataset-ext/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/rdf-dataset-ext/tslint.json
+++ b/types/rdf-dataset-ext/tslint.json
@@ -1,1 +1,1 @@
-{ "extends": "dtslint/dtslint.json" }
+{ "extends": "dtslint/dt.json" }

--- a/types/rdf-dataset-ext/tslint.json
+++ b/types/rdf-dataset-ext/tslint.json
@@ -1,1 +1,1 @@
-{ "extends": "dtslint/dt.json" }
+{ "extends": "dtslint/dtslint.json" }


### PR DESCRIPTION
Adds types for [`rdf-dataset-ext`](https://www.npmjs.com/package/rdf-dataset-ext).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.