### PR TITLE
Node: `querystring`: allow nullish values in input type

### DIFF
--- a/types/node/querystring.d.ts
+++ b/types/node/querystring.d.ts
@@ -11,7 +11,7 @@ declare module "querystring" {
     interface ParsedUrlQuery { [key: string]: string | string[]; }
 
     interface ParsedUrlQueryInput {
-        [key: string]: string | number | boolean | string[] | number[] | boolean[];
+        [key: string]: string | number | boolean | string[] | number[] | boolean[] | undefined | null;
     }
 
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;

--- a/types/node/test/querystring.ts
+++ b/types/node/test/querystring.ts
@@ -26,7 +26,9 @@ interface SampleObject { [key: string]: string; }
         baz: true,
         foo2: ['a', 'b'],
         bar2: [1, 2],
-        baz2: [true, false]
+        baz2: [true, false],
+        a: undefined,
+        b: null
     });
 }
 


### PR DESCRIPTION
Forgot to include these in #41014 