### PR TITLE
Add @rdfjs/serializer-jsonld-ext

### DIFF
--- a/types/rdfjs__serializer-jsonld-ext/index.d.ts
+++ b/types/rdfjs__serializer-jsonld-ext/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for @rdfjs/serializer-jsonld-ext 2.0
+// Project: https://github.com/rdfjs-base/serializer-jsonld-ext
+// Definitions by: Chris Wilkinson <https://github.com/thewilkybarkid>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { EventEmitter } from 'events';
+import { Context } from 'jsonld/jsonld-spec';
+import { Sink, Stream } from 'rdf-js';
+
+declare namespace Serializer {
+    interface SerializerOptions {
+        context?: Context;
+        compact?: boolean;
+        encoding?: 'string' | 'object';
+        flatten?: boolean;
+        frame?: boolean;
+        skipContext?: boolean;
+        skipGraphProperty?: boolean;
+    }
+}
+
+declare class Serializer implements Sink {
+    constructor(options?: Serializer.SerializerOptions);
+
+    import(stream: Stream, options?: Serializer.SerializerOptions): EventEmitter;
+}
+
+export = Serializer;

--- a/types/rdfjs__serializer-jsonld-ext/rdfjs__serializer-jsonld-ext-tests.ts
+++ b/types/rdfjs__serializer-jsonld-ext/rdfjs__serializer-jsonld-ext-tests.ts
@@ -1,0 +1,35 @@
+import Serializer = require('@rdfjs/serializer-jsonld-ext');
+import { EventEmitter } from 'events';
+import { Context } from 'jsonld/jsonld-spec';
+import { Sink, Stream } from 'rdf-js';
+
+const context: Context = {} as any;
+const stream: Stream = {} as any;
+
+const serializer1 = new Serializer();
+const serializer2 = new Serializer({});
+const serializer3 = new Serializer({
+    context,
+    compact: true,
+    encoding: 'string',
+    flatten: true,
+    frame: true,
+    skipContext: true,
+    skipGraphProperty: true
+});
+const serializer4 = new Serializer({ encoding: 'object' });
+
+const sink: Sink = serializer1;
+
+const eventEmitter1: EventEmitter = serializer1.import(stream);
+const eventEmitter2: EventEmitter = serializer1.import(stream, {});
+const eventEmitter3: EventEmitter = serializer1.import(stream, {
+    context,
+    compact: true,
+    encoding: 'string',
+    flatten: true,
+    frame: true,
+    skipContext: true,
+    skipGraphProperty: true
+});
+const eventEmitter4: EventEmitter = serializer1.import(stream, { encoding: 'object' });

--- a/types/rdfjs__serializer-jsonld-ext/tsconfig.json
+++ b/types/rdfjs__serializer-jsonld-ext/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@rdfjs/serializer-jsonld-ext": [
+                "rdfjs__serializer-jsonld-ext"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "rdfjs__serializer-jsonld-ext-tests.ts"
+    ]
+}

--- a/types/rdfjs__serializer-jsonld-ext/tslint.json
+++ b/types/rdfjs__serializer-jsonld-ext/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Moved from https://github.com/rdfjs-base/serializer-jsonld-ext/pull/2.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.