### PR TITLE
Unsplash-JS: end of the partial update to version 6.0 by removing deprecated API

### DIFF
--- a/types/unsplash-js/index.d.ts
+++ b/types/unsplash-js/index.d.ts
@@ -6,7 +6,6 @@
 
 export default class Unsplash {
     auth: UnsplashApi.Auth;
-    categories: UnsplashApi.Categories;
     collections: UnsplashApi.Collections;
     currentUser: UnsplashApi.CurrentUser;
     users: UnsplashApi.Users;
@@ -18,10 +17,11 @@ export default class Unsplash {
         apiUrl?: string;
         apiVersion?: string;
         accessKey: string;
-        secret: string;
+        secret?: string;
         callbackUrl?: string;
         bearerToken?: string;
         headers?: { [key: string]: string };
+        timeout?: number;
     });
 
     request(requestOptions: {
@@ -38,136 +38,59 @@ export function toJson(response: any): any;
 
 export namespace UnsplashApi {
     interface Photo {
-        listPhotos(
-            page?: number,
-            perPage?: number,
-            orderBy?: string
-        ): Promise<Response>;
+        listPhotos(page?: number, perPage?: number, orderBy?: string): Promise<Response>;
 
-        listCuratedPhotos(
-            page?: number,
-            perPage?: number,
-            orderBy?: string
-        ): Promise<Response>;
-
-        searchPhotos(
-            query: string,
-            categories: ReadonlyArray<string>,
-            page: number,
-            perPage: number
-        ): Promise<Response>;
-
-        getPhoto(
-            id: string,
-            width?: number,
-            height?: number,
-            rectangle?: ReadonlyArray<number>
-        ): Promise<Response>;
+        getPhoto(id: string): Promise<Response>;
 
         getPhotoStats(id: string): Promise<Response>;
 
         getRandomPhoto(options: {
-            width?: number;
-            height?: number;
             query?: string;
             username?: string;
             featured?: boolean;
+            orientation?: string;
             collections?: ReadonlyArray<string>;
             count?: number;
         }): Promise<Response>;
-
-        uploadPhoto(photo: object): void;
 
         likePhoto(id: string): Promise<Response>;
 
         unlikePhoto(id: string): Promise<Response>;
 
-        downloadPhoto(photo: {
-            links: { download_location: string };
-        }): Promise<Response>;
+        downloadPhoto(photo: { links: { download_location: string } }): Promise<Response>;
     }
 
     interface Collections {
-        listCollections(
-            page?: number,
-            perPage?: number,
-            orderBy?: string
-        ): Promise<Response>;
-
-        listCuratedCollections(
-            page?: number,
-            perPage?: number
-        ): Promise<Response>;
-
-        listFeaturedCollections(
-            page?: number,
-            perPage?: number
-        ): Promise<Response>;
+        listCollections(page?: number, perPage?: number, orderBy?: string): Promise<Response>;
 
         getCollection(id: number): Promise<Response>;
 
-        getCollectionPhotos(
-            id: number,
-            page?: number,
-            perPage?: number,
-            orderBy?: string
-        ): Promise<Response>;
+        getCollectionPhotos(id: number, page?: number, perPage?: number, orderBy?: string): Promise<Response>;
 
-        getCuratedCollectionPhotos(
-            id: number,
-            page?: number,
-            perPage?: number,
-            orderBy?: string
-        ): Promise<Response>;
+        createCollection(title: string, description?: string, isPrivate?: boolean): Promise<Response>;
 
-        createCollection(
-            title: string,
-            description?: string,
-            private?: boolean
-        ): Promise<Response>;
-
-        updateCollection(
-            id: number,
-            title?: string,
-            description?: string,
-            private?: boolean
-        ): Promise<Response>;
+        updateCollection(id: number, title?: string, description?: string, isPrivate?: boolean): Promise<Response>;
 
         deleteCollection(id: number): Promise<Response>;
 
-        addPhotoToCollection(
-            collectionId: number,
-            photoId: string
-        ): Promise<Response>;
+        addPhotoToCollection(collectionId: number, photoId: string): Promise<Response>;
 
-        removePhotoFromCollection(
-            collectionId: number,
-            photoId: string
-        ): Promise<Response>;
+        removePhotoFromCollection(collectionId: number, photoId: string): Promise<Response>;
 
         listRelatedCollections(collectionId: number): Promise<Response>;
     }
 
     interface Search {
-        all(keyword: string, page: number, per_page: number): Promise<Response>;
-
         photos(
             keyword: string,
             page?: number,
-            per_page?: number
+            perPage?: number,
+            filters?: { orientation?: string; collections?: ReadonlyArray<string> },
         ): Promise<Response>;
 
-        users(
-            keyword: string,
-            page?: number,
-            per_page?: number
-        ): Promise<Response>;
+        users(keyword: string, page?: number, perPage?: number): Promise<Response>;
 
-        collections(
-            keyword: string,
-            page?: number,
-            per_page?: number
-        ): Promise<Response>;
+        collections(keyword: string, page?: number, perPage?: number): Promise<Response>;
     }
 
     interface Stats {
@@ -192,45 +115,13 @@ export namespace UnsplashApi {
     interface Users {
         profile(username: string): Promise<Response>;
 
-        statistics(
-            username: string,
-            resolution?: string,
-            quantity?: number
-        ): Promise<Response>;
+        photos(username: string, page?: number, perPage?: number, orderBy?: string, stats?: boolean): Promise<Response>;
 
-        photos(
-            username: string,
-            page?: number,
-            perPage?: number,
-            orderBy?: string,
-            stats?: boolean
-        ): Promise<Response>;
+        likes(username: string, page?: number, perPage?: number, orderBy?: string): Promise<Response>;
 
-        likes(
-            username: string,
-            page?: number,
-            perPage?: number,
-            orderBy?: string
-        ): Promise<Response>;
+        collections(username: string, page?: number, perPage?: number, orderBy?: string): Promise<Response>;
 
-        collections(
-            username: string,
-            page?: number,
-            perPage?: number,
-            orderBy?: string
-        ): Promise<Response>;
-    }
-
-    interface Categories {
-        listCategories(): Promise<Response>;
-
-        category(id: any): Promise<Response>;
-
-        categoryPhotos(
-            id: any,
-            page?: number,
-            perPage?: number
-        ): Promise<Response>;
+        statistics(username: string, resolution?: string, quantity?: number): Promise<Response>;
     }
 
     interface Auth {

--- a/types/unsplash-js/unsplash-js-tests.ts
+++ b/types/unsplash-js/unsplash-js-tests.ts
@@ -1,20 +1,20 @@
-import Unsplash, { toJson } from "unsplash-js";
+import Unsplash, { toJson } from 'unsplash-js';
 
 const unsplash = new Unsplash({
-    accessKey: "{APP_ACCESS_KEY}",
-    secret: "{APP_SECRET}"
+    accessKey: '{APP_ACCESS_KEY}',
+    secret: '{APP_SECRET}',
 });
 
 const authenticationUrl = unsplash.auth.getAuthenticationUrl([
-    "public",
-    "read_user",
-    "write_user",
-    "read_photos",
-    "write_photos"
+    'public',
+    'read_user',
+    'write_user',
+    'read_photos',
+    'write_photos',
 ]);
 
 unsplash.auth
-    .userAuthentication("{OAUTH_CODE}")
+    .userAuthentication('{OAUTH_CODE}')
     .then(toJson)
     .then(json => {
         unsplash.auth.setBearerToken(json.access_token);
@@ -23,78 +23,67 @@ unsplash.auth
 unsplash.currentUser.profile();
 
 unsplash.currentUser.updateProfile({
-    username: "drizzy",
-    firstName: "Aubrey",
-    lastName: "Graham",
-    email: "drizzy@octobersveryown.com",
-    url: "http://octobersveryown.com",
-    location: "Toronto, Ontario, Canada",
-    bio: "Views from the 6",
-    instagramUsername: "champagnepapi"
+    username: 'drizzy',
+    firstName: 'Aubrey',
+    lastName: 'Graham',
+    email: 'drizzy@octobersveryown.com',
+    url: 'http://octobersveryown.com',
+    location: 'Toronto, Ontario, Canada',
+    bio: 'Views from the 6',
+    instagramUsername: 'champagnepapi',
 });
 
-unsplash.users.profile("naoufal");
+unsplash.users.profile('naoufal');
 
-unsplash.users.statistics("naoufal", "days", 30);
+unsplash.users.statistics('naoufal', 'days', 30);
 
-unsplash.users.photos("naoufal", 1, 10, "popular", false);
+unsplash.users.photos('naoufal', 1, 10, 'popular', false);
 
-unsplash.users.likes("naoufal", 2, 15, "popular");
+unsplash.users.likes('naoufal', 2, 15, 'popular');
 
-unsplash.users.collections("naoufal", 2, 15, "updated");
+unsplash.users.collections('naoufal', 2, 15, 'updated');
 
-unsplash.photos.listPhotos(2, 15, "latest");
+unsplash.photos.listPhotos(2, 15, 'latest');
 
-unsplash.photos.getPhoto("mtNweauBsMQ", 1920, 1080, [0, 0, 1920, 1080]);
+unsplash.photos.getPhoto('mtNweauBsMQ');
 
-unsplash.photos.getPhotoStats("mtNweauBsMQ");
+unsplash.photos.getPhotoStats('mtNweauBsMQ');
 
-unsplash.photos.getRandomPhoto({ username: "naoufal" });
+unsplash.photos.getRandomPhoto({ username: 'naoufal' });
 
-unsplash.photos.likePhoto("mtNweauBsMQ");
+unsplash.photos.likePhoto('mtNweauBsMQ');
 
-unsplash.photos.unlikePhoto("mtNweauBsMQ");
+unsplash.photos.unlikePhoto('mtNweauBsMQ');
 
 unsplash.photos
-    .getPhoto("mtNweauBsMQ")
+    .getPhoto('mtNweauBsMQ')
     .then(toJson)
     .then(json => {
         unsplash.photos.downloadPhoto(json);
     });
 
-unsplash.collections.listCollections(1, 10, "popular");
-
-unsplash.collections.listFeaturedCollections(1, 10);
+unsplash.collections.listCollections(1, 10, 'popular');
 
 unsplash.collections.getCollection(123456);
 
-unsplash.collections.getCollectionPhotos(123456, 1, 10, "popular");
+unsplash.collections.getCollectionPhotos(123456, 1, 10, 'popular');
 
-unsplash.collections.createCollection(
-    "Birds",
-    "Wild birds from 'round the world",
-    true
-);
+unsplash.collections.createCollection('Birds', "Wild birds from 'round the world", true);
 
-unsplash.collections.updateCollection(
-    12345,
-    "Wild Birds",
-    "Wild birds from around the world",
-    false
-);
+unsplash.collections.updateCollection(12345, 'Wild Birds', 'Wild birds from around the world', false);
 
 unsplash.collections.deleteCollection(42);
 
-unsplash.collections.addPhotoToCollection(88, "abc1234");
+unsplash.collections.addPhotoToCollection(88, 'abc1234');
 
-unsplash.collections.removePhotoFromCollection(88, "abc1234");
+unsplash.collections.removePhotoFromCollection(88, 'abc1234');
 
 unsplash.collections.listRelatedCollections(88);
 
-unsplash.search.photos("dogs", 1);
+unsplash.search.photos('dogs', 1);
 
-unsplash.search.users("steve", 1);
+unsplash.search.users('steve', 1);
 
-unsplash.search.collections("dogs", 1);
+unsplash.search.collections('dogs', 1);
 
 unsplash.stats.total();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [[6.0] Remove deprecated methods, endpoints, & parameters](https://github.com/unsplash/unsplash-js/commit/0cd532d50487062bdb3479903fba766fb70d6ae2)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
