### PR TITLE
jest: Infer arg passed to `test.each` as array of tuples

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -25,6 +25,7 @@
 //                 Mario Beltrán Alarcón <https://github.com/Belco90>
 //                 Tony Hallett <https://github.com/tonyhallett>
 //                 Jason Yu <https://github.com/ycmjason>
+//                 Devansh Jethmalani <https://github.com/devanshj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -327,7 +328,7 @@ declare namespace jest {
 
     interface Each {
         // Exclusively arrays.
-        <T extends any[]>(cases: ReadonlyArray<T>): (name: string, fn: (...args: T) => any, timeout?: number) => void;
+        <T extends any[] | [any]>(cases: ReadonlyArray<T>): (name: string, fn: (...args: T) => any, timeout?: number) => void;
         <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (name: string, fn: (...args: ExtractEachCallbackArgs<T>) => any, timeout?: number) => void;
         // Not arrays.
         <T>(cases: ReadonlyArray<T>): (name: string, fn: (...args: T[]) => any, timeout?: number) => void;

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1537,6 +1537,14 @@ test.each`
     5000
 );
 
+test.each([
+    [1, "1"],
+    [2, "2"]
+])("", (a, b) => {
+    a; // $ExpectType number
+    b; // $ExpectType string
+});
+
 test.only.each([[1, 1, 2], [1, 2, 3], [2, 1, 3]])('.add(%i, %i)', (a, b, expected) => {
     expect(a + b).toBe(expected);
 });


### PR DESCRIPTION
Currently:
```typescript
test.each([
    [1, "1"],
    [2, "2"]
])("", (a, b) => {
	/*
	the inference of arg passed to each is (number | string)[][]
	instead of [number, string][]
	*/
    a; // number | string
    b; // number | string
	/*
	not cool as you can't write `a.toString()` and 
	we know `a` will be of type number
	*/
});
```

After PR is merged:
```typescript
test.each([
    [1, "1"],
    [2, "2"]
])("", (a, b) => {
    a; // number
    b; // string
});
```

How does it work? Uses a little trick (not original ofc):
```typescript
const arrayInference = <T extends any[]>(x: T) => x;
const tupleInference = <T extends any[] | [any]>(x: T) => x;

let foo = arrayInference([1, "1"]) // foo is (number | string)[]
let bar = tupleInference([1, "1"]) // bar is [number, string]
```
[Playground](https://www.typescriptlang.org/play/?ssl=1&ssc=1&pln=5&pc=55#code/MYewdgzgLgBAhgJwXAngSTAMwKYO2YbGAXhgB4AVGbADynwBMJ4wUBtAXQD4AKGgLhgUAlCS4waAbgBQoSLCgBXAA4AbbBhx4CRUpWp1GzOK04wAPjDYmU3PoJFiJM6etiYQIEvCSpNufEIeNgBGABoYACIQyI5RAHp4mA8vAEtmHjBFAFsAI1wLGGgEVLAAc2FOV2xYXMRvJTUNLACdYPComLiYRJg6hBh0qyy83Aji0rKOIA)

Since `describe.each`, `test.each`, `test.only.each`, etc use the same interface it's applicable to all.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jestjs.io/docs/en/api#testeachtablename-fn-timeout (applies to all kinds of `foo.bar.each`)
- [x] (not applicable) If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] (not applicable) If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.