### PR TITLE
Fix Lazy.js flatten method return type to properly handle shallow parameter on type level

### DIFF
--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -225,3 +225,8 @@ stringSeq = stringSeq.substring(num);
 stringSeq = stringSeq.substring(num, num);
 stringSeq = stringSeq.toLowerCase();
 stringSeq = stringSeq.toUpperCase();
+
+// flatten
+var fooSeqSeqSequence: LazyJS.Sequence<LazyJS.Sequence<LazyJS.Sequence<Foo>>>;
+fooSequence = fooSeqSeqSequence.flatten();
+fooSequence = fooSeqSeqSequence.flatten(true).flatten(true);


### PR DESCRIPTION
`Sequence<T>.flatten()` returns `Sequence<T>` again, that is wrong in case `T` is `Sequence<U>`. After this PR is merged, `flatten(shallow: boolean)` will return type that takes shallow parameter into account and return either `Sequence<U>` if `shallow=true` and `Sequence<V>` otherwise, where `V` is the type of element that produces the deepest `Sequence` in combinator chain.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
