### PR TITLE
@Types/Chance CharacterOptions.symbols is wrong type

### DIFF
--- a/types/chance/chance-tests.ts
+++ b/types/chance/chance-tests.ts
@@ -1,4 +1,5 @@
 import { Chance } from 'chance';
+
 // Instantiation
 const chance = new Chance();
 const createYourOwn = new Chance(Math.random);
@@ -19,6 +20,11 @@ const strArr2: string[] = chance.n((a) => a.value, 42, { value: 'test' });
 
 const uniqInts: number[] = chance.unique(chance.integer, 99);
 const uniqInts2: number[] = chance.unique(a => chance.integer({ min: 0, max: 999 }) + a.value, 99, { value: 1000 });
+
+interface currencyType { name: string; code: string; }
+
+const currencyComparator = (arr: currencyType[], value: currencyType): boolean => arr.findIndex(x => x.code === value.code && x.name === value.name) > -1;
+const uniqCurrencies: currencyType[] = chance.unique(chance.currency, 2, { comparator: currencyComparator });
 
 const currencyPair = chance.currency_pair();
 const firstCurrency = currencyPair[0];

--- a/types/chance/chance-tests.ts
+++ b/types/chance/chance-tests.ts
@@ -18,7 +18,7 @@ const strArr: string[] = chance.n(chance.string, 42);
 const strArr2: string[] = chance.n((a) => a.value, 42, { value: 'test' });
 
 const uniqInts: number[] = chance.unique(chance.integer, 99);
-const uniqInts2: number[] = chance.unique((a) => { return chance.integer(0, 999) + a.value }, 99, { value: 1000 });
+const uniqInts2: number[] = chance.unique(a => chance.integer({ min: 0, max: 999 }) + a.value, 99, { value: 1000 });
 
 const currencyPair = chance.currency_pair();
 const firstCurrency = currencyPair[0];

--- a/types/chance/chance-tests.ts
+++ b/types/chance/chance-tests.ts
@@ -112,14 +112,14 @@ randomString = chance.string({ length: 10 });
 randomString = chance.string({ casing: 'upper' });
 randomString = chance.string({ alpha: true });
 randomString = chance.string({ numeric: true });
-randomString = chance.string({ symbols: '!@#$' });
+randomString = chance.string({ symbols: true });
 randomString = chance.string({
     pool: 'abcdef',
     length: 10,
     casing: 'lower',
     alpha: true,
     numeric: true,
-    symbols: ')(*&',
+    symbols: true,
 });
 
 let char: string = chance.character();
@@ -127,8 +127,8 @@ char = chance.character({ pool: 'abcdef' });
 char = chance.character({ casing: 'upper' });
 char = chance.character({ alpha: true });
 char = chance.character({ numeric: true });
-char = chance.character({ symbols: '!@#$' });
-char = chance.character({ pool: 'abcdef', casing: 'lower', alpha: true, numeric: true, symbols: ')(*&' });
+char = chance.character({ symbols: true });
+char = chance.character({ pool: 'abcdef', casing: 'lower', alpha: true, numeric: true, symbols: true });
 
 let url: string = chance.url();
 url = chance.url({protocol: 'http'});

--- a/types/chance/chance-tests.ts
+++ b/types/chance/chance-tests.ts
@@ -18,7 +18,7 @@ const strArr: string[] = chance.n(chance.string, 42);
 const strArr2: string[] = chance.n((a) => a.value, 42, { value: 'test' });
 
 const uniqInts: number[] = chance.unique(chance.integer, 99);
-const uniqInts2: number[] = chance.unique(a => a.value, 99, { value: 1 });
+const uniqInts2: number[] = chance.unique((a) => { return chance.integer(0, 999) + a.value }, 99, { value: 1000 });
 
 const currencyPair = chance.currency_pair();
 const firstCurrency = currencyPair[0];
@@ -101,7 +101,8 @@ const languages: string[] = chance.locales();
 const regions: string[] = chance.locales({region: true});
 
 let word: string = chance.word();
-word = chance.word({syllables: 10, length: 10, capitalize: true});
+word = chance.word({syllables: 10, capitalize: true});
+word = chance.word({length: 10, capitalize: true});
 word = chance.word({syllables: 10});
 word = chance.word({length: 10});
 word = chance.word({capitalize: true});

--- a/types/chance/index.d.ts
+++ b/types/chance/index.d.ts
@@ -174,7 +174,7 @@ declare namespace Chance {
         rpg(dice: string, opts?: Options): number[] | number;
         tv(opts?: Options): string;
         unique<T>(generator: () => T, count: number): T[];
-        unique<T, O extends Options>(generator: (options: O) => T, count: number, options: O): T[];
+        unique<T, O extends UniqueOptions<T>>(generator: (options: O) => T, count: number, options: O): T[];
         weighted<T>(values: T[], weights: number[]): T;
 
         // "Hidden"
@@ -268,6 +268,10 @@ declare namespace Chance {
         day?: number;
         min?: Date;
         max?: Date;
+    }
+
+    interface UniqueOptions<T> implements Options {
+        comparator?: (array: Array<T>, value: T) => boolean;
     }
 
     interface Month {

--- a/types/chance/index.d.ts
+++ b/types/chance/index.d.ts
@@ -4,6 +4,7 @@
 //                 Brice BERNARD <https://github.com/brikou>
 //                 Carlos Sanchez <https://github.com/cafesanu>
 //                 Colby M. White <https://github.com/colbywhite>
+//                 Zachary Dow <https://github.com/NewDark90>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -270,9 +271,7 @@ declare namespace Chance {
         max?: Date;
     }
 
-    interface UniqueOptions<T> implements Options {
-        comparator?: (array: Array<T>, value: T) => boolean;
-    }
+    type UniqueOptions<T> = { comparator?: (array: T[], value: T) => boolean } & Options;
 
     interface Month {
         name: string;

--- a/types/chance/index.d.ts
+++ b/types/chance/index.d.ts
@@ -205,7 +205,7 @@ declare namespace Chance {
         pool: string;
         alpha: boolean;
         numeric: boolean;
-        symbols: string;
+        symbols: boolean;
     }
 
     type StringOptions = CharacterOptions & { length: number } ;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://chancejs.com/basics/character.html
https://chancejs.com/miscellaneous/unique.html
https://github.com/chancejs/chancejs/blob/master/chance.js

Symbols is a boolean. Fixed some tests to match. Also fixed some other broken tests.