### PR TITLE
Adding support for viz.js

### DIFF
--- a/types/viz.js/common.d.ts
+++ b/types/viz.js/common.d.ts
@@ -1,0 +1,23 @@
+interface Options {
+  format?: string;
+  engine?: string;
+  files?: string[];
+  images?: string[];
+  yInvert?: boolean;
+}
+
+/**
+ * This interface defines the shape of an object that is held by the caller.
+ * This `Module` was created by emscripten, and is therefore largely arcane.
+ * This currently just lists a subset of what is defined in `Module`.
+ */
+interface Module {
+  run(): void;
+}
+
+type renderFunction = (instance: Module, src: string, options: Options) => string;
+
+declare class Viz {
+  constructor(arg: { Module: Module; render: renderFunction });
+  renderString(src: string, options?: Options): Promise<string>;
+}

--- a/types/viz.js/common.d.ts
+++ b/types/viz.js/common.d.ts
@@ -15,9 +15,9 @@ interface Module {
   run(): void;
 }
 
-type renderFunction = (instance: Module, src: string, options: Options) => string;
+type RenderFunction = (instance: Module, src: string, options: Options) => string;
 
 declare class Viz {
-  constructor(arg: { Module: Module; render: renderFunction });
+  constructor(arg: { Module: Module; render: RenderFunction });
   renderString(src: string, options?: Options): Promise<string>;
 }

--- a/types/viz.js/full.render.js.d.ts
+++ b/types/viz.js/full.render.js.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="common.d.ts" />
+export const Module: Module;
+export function render(instance: Module, src: string, options: Options): string;

--- a/types/viz.js/index.d.ts
+++ b/types/viz.js/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for viz.js 2.1
+// Project: https://github.com/mdaines/viz.js
+// Definitions by: McKay Salisbury <https://github.com/mckaysalisbury>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="common.d.ts" />
+export = Viz;

--- a/types/viz.js/tsconfig.json
+++ b/types/viz.js/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "viz.js-tests.ts"
+    ]
+}

--- a/types/viz.js/tslint.json
+++ b/types/viz.js/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/viz.js/viz.js-tests.ts
+++ b/types/viz.js/viz.js-tests.ts
@@ -1,0 +1,28 @@
+import Viz = require('viz.js');
+import { Module, render } from 'viz.js/full.render.js';
+
+// Correct usage
+const viz = new Viz({ Module, render });
+let promise: Promise<string>;
+promise = viz.renderString("graph a { b }", { format: "svg" });
+promise = viz.renderString("digraph a { b }");
+
+// This won't necessarily work, but shouldn't violate typing rules
+new Viz({Module, render: (instance: Module, src: string, options: Options) => "string"});
+new Viz({Module, render: (instance: Module, src: string, options: {format?: string}) => "string"});
+new Viz({Module, render: (instance: Module, src: string, options: {format?: string, garbage?: number}) => "string"});
+viz.renderString("string", {files: []});
+viz.renderString("string", {images: ["totally a file"]});
+viz.renderString("string", {format: "svg", engine: "fdp", files: ["test"], images: ["totally an image"], yInvert: false});
+
+// Incorrect
+new Viz({Module: 1, render}); // $ExpectError
+new Viz({Module: {}, render}); // $ExpectError
+new Viz({Module, render: (instance: Module, src: string, options: Options) => 1}); // $ExpectError
+new Viz({Module, render: (instance: string, src: string, options: Options) => "hello"}); // $ExpectError
+new Viz({Module, render: (instance: Module, src: number, options: Options) => "string"}); // $ExpectError
+new Viz({Module, render: (instance: Module, src: string, options: {format: string}) => "string"}); // $ExpectError
+viz.renderString(1, {}); // $ExpectError
+viz.renderString("string", { a: 1 }); // $ExpectError
+viz.renderString("string", { yInvert: "true" }); // $ExpectError
+viz.renderString("string", { engine: 1}); // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [☑️] Use a meaningful title for the pull request. Include the name of the package modified.
- [✔️] Test the change in your own code. (Compile and run.)
- [✅] Add or edit tests to reflect the change. (Run with `npm test`.)
- [✓] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [☑] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✔] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [✅] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [✓] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [☑️] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [Accurate, but not complete (see comment in `common.d.ts`)] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [✔️] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [✅] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
