### PR TITLE
Adde animation prop types for react-native-star-rating

### DIFF
--- a/types/react-native-star-rating/index.d.ts
+++ b/types/react-native-star-rating/index.d.ts
@@ -31,6 +31,11 @@ export interface StarRatingProps {
     disabled?: boolean;
 
     /**
+     * Add an animation to the stars upon selection.
+     */
+    animation? : "bounce" | "flash" | "jello" | "pulse" | "rotate" | "rubberBand" | "shake" | "swing" | "tada" | "wobble";
+
+    /**
      * The name of the icon to represent an empty star.
      * Refer to react-native-vector-icons.
      * Also can be a image object, both {uri:xxx.xxx} and require('xx/xx/xx.xxx').

--- a/types/react-native-star-rating/index.d.ts
+++ b/types/react-native-star-rating/index.d.ts
@@ -33,7 +33,7 @@ export interface StarRatingProps {
     /**
      * Add an animation to the stars upon selection.
      */
-    animation? : "bounce" | "flash" | "jello" | "pulse" | "rotate" | "rubberBand" | "shake" | "swing" | "tada" | "wobble";
+    animation?: "bounce" | "flash" | "jello" | "pulse" | "rotate" | "rubberBand" | "shake" | "swing" | "tada" | "wobble";
 
     /**
      * The name of the icon to represent an empty star.

--- a/types/react-native-star-rating/react-native-star-rating-tests.tsx
+++ b/types/react-native-star-rating/react-native-star-rating-tests.tsx
@@ -21,6 +21,7 @@ class GeneralStarExample extends React.Component<{}, State> {
             <StarRating
                 disabled={false}
                 maxStars={5}
+                animation={'tada'}
                 rating={this.state.starCount}
                 selectedStar={this.onStarRatingPress}
             />


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/djchie/react-native-star-rating/blob/82ef914a906a57c68ff1fec9cc460bd5e09ce7c7/StarRating.js#L10
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

`npm run lint react-native-star-rating` throws this error and I couldn't find a solution:

```
> npm run lint react-native-star-rating

> definitely-typed@0.0.3 lint /Users/gezimhome/projects/temp/DefinitelyTyped
> dtslint types "react-native-star-rating"

Error: Errors in typescript@next for external dependencies:
../react/index.d.ts(33,22): error TS2307: Cannot find module 'csstype'.

    at /Users/gezimhome/projects/temp/DefinitelyTyped/node_modules/dtslint/bin/index.js:193:19
    at Generator.next (<anonymous>)
    at fulfilled (/Users/gezimhome/projects/temp/DefinitelyTyped/node_modules/dtslint/bin/index.js:6:58)
```