### PR TITLE
chore(bootstrap-datepicker): add missing types

### DIFF
--- a/types/bootstrap-datepicker/bootstrap-datepicker-tests.ts
+++ b/types/bootstrap-datepicker/bootstrap-datepicker-tests.ts
@@ -77,3 +77,28 @@ $(function () {
             $('#dp5').datepicker('hide');
         });
 });
+
+$("#dp6").datepicker({
+    startView: "days",
+    daysOfWeekDisabled: "12345"
+})
+$("#dp6").datepicker({
+    startView: "months",
+    daysOfWeekDisabled: [1, 2, 3, 4, 5]
+})
+$("#dp6").datepicker({
+    startView: "years",
+    daysOfWeekDisabled: "12345"
+})
+$("#dp6").datepicker({
+    startView: "decades",
+    daysOfWeekDisabled: "12345"
+})
+$("#dp6").datepicker({
+    startView: "centuries",
+    daysOfWeekDisabled: "12345"
+})
+$("#dp6").datepicker({
+    startView: "millenium",
+    daysOfWeekDisabled: "12345"
+})

--- a/types/bootstrap-datepicker/index.d.ts
+++ b/types/bootstrap-datepicker/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for bootstrap-datepicker
 // Project: https://github.com/eternicode/bootstrap-datepicker
 // Definitions by: Boris Yankov <https://github.com/borisyankov>
+//                 Jannik Keye <https://github.com/jannikkeye>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -35,43 +36,45 @@ type DatepickerOrientations =
  *  https://bootstrap-datepicker.readthedocs.io/en/latest/options.html
  */
 interface DatepickerOptions {
-    format?: string | DatepickerCustomFormatOptions;
-    weekStart?: number;
-    startDate?: Date|string;
-    endDate?: Date|string;
     autoclose?: boolean;
-    startView?: number;
-    todayBtn?: boolean|"linked";
-    todayHighlight?: boolean;
-    keyboardNavigation?: boolean;
-    language?: string;
-    beforeShowDay?: (date: Date) => undefined|string|boolean|DatepickerBeforeShowDayResponse;
-    beforeShowYear?: (date: Date) => undefined|string|boolean|DatepickerBeforeShowResponse;
-    beforeShowDecade?: (date: Date) => undefined|string|boolean|DatepickerBeforeShowResponse;
-    beforeShowCentury?: (date: Date) => undefined|string|boolean|DatepickerBeforeShowResponse;
+    assumeNearbyYear?: boolean | number;
+    beforeShowDay?: (date: Date) => undefined | string | boolean | DatepickerBeforeShowDayResponse;
+    beforeShowMonth?: (date: Date) => undefined | string | boolean | DatepickerBeforeShowResponse;
+    beforeShowYear?: (date: Date) => undefined | string | boolean | DatepickerBeforeShowResponse;
+    beforeShowDecade?: (date: Date) => undefined | string | boolean | DatepickerBeforeShowResponse;
+    beforeShowCentury?: (date: Date) => undefined | string | boolean | DatepickerBeforeShowResponse;
     calendarWeeks?: boolean;
     clearBtn?: boolean;
+    container?: string;
+    datesDisabled?: string | string[];
     daysOfWeekDisabled?: number[];
+    daysOfWeekHighlighted?: string | number[];
+    defaultViewDate?: Date | string | DatepickerViewDate;
+    enableOnReadonly?: boolean;
+    endDate?: Date | string;
     forceParse?: boolean;
+    format?: string | DatepickerCustomFormatOptions;
+    immediateUpdates?: boolean;
     inputs?: any[];
-    minViewMode?: DatepickerViewModes;
+    keepEmptyValues?: boolean;
+    keyboardNavigation?: boolean;
+    language?: string;
     maxViewMode?: DatepickerViewModes;
-    multidate?: boolean|number;
+    minViewMode?: DatepickerViewModes;
+    multidate?: boolean | number;
     multidateSeparator?: string;
     orientation?: DatepickerOrientations;
-    assumeNearbyYear?: boolean|number;
-    viewMode?: string;
-    templates?: any;
-    zIndexOffset?: number;
     showOnFocus?: boolean;
-    immediateUpdates?: boolean;
+    startDate?: Date | string;
+    startView?: number;
+    templates?: any;
+    showWeekDays?: boolean;
     title?: string;
-    container?: string;
-    datesDisabled?:string|string[];
-    daysOfWeekHighlighted?:string|number[];
-    defaultViewDate?:Date|string|DatepickerViewDate;
-    updateViewDate?:boolean;
-    enableOnReadonly?: boolean;
+    todayBtn?: boolean | "linked";
+    todayHighlight?: boolean;
+    updateViewDate?: boolean;
+    weekStart?: number;
+    zIndexOffset?: number;
 }
 
 interface DatepickerViewDate {

--- a/types/bootstrap-datepicker/index.d.ts
+++ b/types/bootstrap-datepicker/index.d.ts
@@ -47,7 +47,7 @@ interface DatepickerOptions {
     clearBtn?: boolean;
     container?: string;
     datesDisabled?: string | string[];
-    daysOfWeekDisabled?: number[];
+    daysOfWeekDisabled?: string | number[];
     daysOfWeekHighlighted?: string | number[];
     defaultViewDate?: Date | string | DatepickerViewDate;
     enableOnReadonly?: boolean;

--- a/types/bootstrap-datepicker/index.d.ts
+++ b/types/bootstrap-datepicker/index.d.ts
@@ -66,7 +66,7 @@ interface DatepickerOptions {
     orientation?: DatepickerOrientations;
     showOnFocus?: boolean;
     startDate?: Date | string;
-    startView?: number;
+    startView?: DatepickerViewModes;
     templates?: any;
     showWeekDays?: boolean;
     title?: string;


### PR DESCRIPTION
Added `beforeShowMonth` removed `viewMode` updated `startView` to options.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://bootstrap-datepicker.readthedocs.io/en/latest/options.html