### PR TITLE
kurento-client package definition file

### DIFF
--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -7,15 +7,15 @@
 type Callback<T> = (error: Error, result: T) => void;
 
 interface Options {
-    failAfter: number;
-    enableTransactions: boolean;
-    useImplicitTransactions: boolean;
-    strict: boolean;
-    request_timeout: number;
-    response_timeout: number;
-    duplicates_timeout: number;
-    access_token: string;
-    socket: any;
+    failAfter?: number;
+    enableTransactions?: boolean;
+    useImplicitTransactions?: boolean;
+    strict?: boolean;
+    request_timeout?: number;
+    response_timeout?: number;
+    duplicates_timeout?: number;
+    access_token?: string;
+    socket?: any;
 }
 
 interface Error {

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -4,36 +4,37 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-interface IOptions {
-    failAfter: number;
-    enableTransactions: boolean;
-    useImplicitTransactions: boolean;
-    strict: boolean;
-    request_timeout: number;
-    response_timeout: number;
-    duplicates_timeout: number;
-    access_token: string;
-    socket: any;
-}
-
-type CreateTypes = 'MediaPipeline' | 'WebRtcEndpoint';
-type EventTypes = 'OnIceCandidate';
-type ComplexTypes = 'IceCandidate'
-
-export declare class KurentoClient {
-    create: (type: CreateTypes) => KurentoClient;
+interface KurentoClient {
+    id: string;
+    create: (type: 'MediaPipeline' | 'WebRtcEndpoint') => Promise<KurentoClient>;
+    connect: (client: KurentoClient, callback: (error: Error) => void) => void;
+    release: () => void;
     addIceCandidate: (candidate: RTCIceCandidate) => KurentoClient;
     processOffer: (sdpOffer: string) => Promise<string>;
     gatherCandidates: (callback: (error: Error) => void) => void;
     getMediaobjectById: (objectId: string) => Promise<KurentoClient>
-    on: (event: EventTypes, callback: (data: any) => void) => void;
+    on: (event: 'OnIceCandidate', callback: (data: any) => void) => void;
 }
 
-declare const client: (ws_uri: string, options: IOptions) => Promise<KurentoClient>;
-declare const getComplexType: (complex: ComplexTypes) => (value: any) => any;
+declare module 'kurento-client' {
+    interface Options {
+        failAfter: number;
+        enableTransactions: boolean;
+        useImplicitTransactions: boolean;
+        strict: boolean;
+        request_timeout: number;
+        response_timeout: number;
+        duplicates_timeout: number;
+        access_token: string;
+        socket: any;
+    }
 
-export default client;
+    interface Kurento {
+        (ws_uri: string, options?: Options): Promise<KurentoClient>;
+        getComplexType: (complex: 'IceCandidate') => (value: any) => any;
+    }
 
-export {
-    getComplexType
+    const kurento: Kurento;
+
+    export = kurento;
 }

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -117,6 +117,7 @@ declare class KurentoClient {
     on(event: 'Error', callback: (error: Error) => void): void;
     on(event: 'Recording' | 'Paused' | 'Stopped', callback: () => void): void;
     getMediaobjectById(objectId: string): Promise<any>;
+    close(): void;
 }
 
 interface Kurento {

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -91,14 +91,12 @@ interface WebRtcEndpoint extends KurentoClient, MediaObject {
 }
 
 declare class KurentoClient {
-    public create(type: 'MediaPipeline'): Promise<MediaPipeline>;
-    public create(type: 'WebRtcEndpoint'): Promise<WebRtcEndpoint>;
-    public on(event: 'OnIceCandidate', callback: (event: IceCandidate) => void): void;
-    public on(event: 'Error', callback: (error: Error) => void): void;
-    public on(event: 'Recording', callback: () => void): void;
-    public on(event: 'Paused', callback: () => void): void;
-    public on(event: 'Stopped', callback: () => void): void;
-    public getMediaobjectById(objectId: string): Promise<any>;
+    create(type: 'MediaPipeline'): Promise<MediaPipeline>;
+    create(type: 'WebRtcEndpoint'): Promise<WebRtcEndpoint>;
+    on(event: 'OnIceCandidate', callback: (event: IceCandidate) => void): void;
+    on(event: 'Error', callback: (error: Error) => void): void;
+    on(event: 'Recording' | 'Paused' | 'Stopped', callback: () => void): void;
+    getMediaobjectById(objectId: string): Promise<any>;
 }
 
 interface Kurento {
@@ -109,4 +107,4 @@ interface Kurento {
 declare const kurento: Kurento;
 
 export default kurento;
-export { KurentoClient, MediaPipeline, WebRtcEndpoint }
+export { KurentoClient, MediaPipeline, WebRtcEndpoint };

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -4,129 +4,129 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-type Callback<T> = (error: Error, result: T) => void;
+declare namespace KurentoClient {
+    interface Constructor {
+        (ws_uri: string, options?: Options): Promise<ClientInstance>;
+        getComplexType: (complex: 'IceCandidate') => (value: any) => any;
+    }
 
-interface Options {
-    failAfter?: number;
-    enableTransactions?: boolean;
-    useImplicitTransactions?: boolean;
-    strict?: boolean;
-    request_timeout?: number;
-    response_timeout?: number;
-    duplicates_timeout?: number;
-    access_token?: string;
-    socket?: any;
+    class ClientInstance {
+        create(type: 'MediaPipeline'): Promise<MediaPipeline>;
+        create(type: 'WebRtcEndpoint'): Promise<WebRtcEndpoint>;
+        on(event: 'OnIceCandidate', callback: (event: IceCandidate) => void): void;
+        on(event: 'Error', callback: (error: Error) => void): void;
+        on(event: 'Recording' | 'Paused' | 'Stopped', callback: () => void): void;
+        getMediaobjectById(objectId: string): Promise<any>;
+        close(): void;
+    }
+
+    interface MediaObject {
+        id: string;
+        name: string;
+        tags: object;
+        addTag: (key: string, value: string, callback?: Callback<void>) => Promise<void>;
+        getTag: (key: string, callback?: Callback<string>) => Promise<string>;
+        getTags: (callback?: Callback<Tag[]>) => Promise<Tag[]>;
+        removeTag: (key: string, callback?: Callback<void>) => Promise<void>;
+        getChildren: (callback?: Callback<MediaObject[]>) => Promise<MediaObject[]>;
+        getCreationTime: (callback?: Callback<number>) => Promise<number>;
+        getMediaPipeline: (callback?: Callback<MediaPipeline>) => Promise<MediaPipeline>;
+        getParent: (callback?: Callback<MediaObject>) => Promise<MediaObject>;
+        getName: (callback?: Callback<string>) => Promise<string>;
+        setName: (name: string, callback?: Callback<void>) => Promise<void>;
+    }
+
+    interface MediaElement {
+        connect: (sink: MediaElement, callback?: Callback<void>) => Promise<void>;
+        disconnect: (sink: MediaElement, callback?: Callback<void>) => Promise<void>;
+        getSinkConnections: (callback?: Callback<ElementConnectionData[]>) => Promise<ElementConnectionData[]>;
+        getSourceConnections: (callback?: Callback<ElementConnectionData[]>) => Promise<ElementConnectionData[]>;
+    }
+
+    interface MediaPipeline extends ClientInstance, MediaObject {
+        getGstreamerDot: (callback?: Callback<string>) => Promise<string>;
+        getLatencyStats: (callback?: Callback<boolean>) => Promise<boolean>;
+        setLatencyStats: (callback?: Callback<string>) => Promise<string>;
+    }
+
+    interface WebRtcEndpoint extends ClientInstance, MediaObject, MediaElement {
+        addIceCandidate: (candidate: RTCIceCandidate, callback?: Callback<void>) => Promise<void>;
+        closeDataChannel: (channelId: number, callback?: Callback<void>) => Promise<void>;
+        createDataChannel: (label?: string, ordered?: boolean, maxPacketLifeTime?: number, maxRetransmits?: number, protocol?: string, callback?: Callback<void>) => Promise<void>;
+        gatherCandidates: (callback?: Callback<void>) => Promise<void>;
+        getConnectionState: (callback?: Callback<any>) => Promise<any>;
+        getICECandidatePairs: (callback?: Callback<any>) => Promise<any>;
+        getIceConnectionState: (callback?: Callback<IceConnection>) => Promise<IceConnection>;
+        setMaxAudioRecvBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
+        getMaxAudioRecvBandwidth: (callback?: Callback<number>) => Promise<number>;
+        setMinVideoRecvBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
+        getMinVideoRecvBandwidth: (callback?: Callback<number>) => Promise<number>;
+        setMaxVideoRecvBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
+        getMaxVideoRecvBandwidth: (callback?: Callback<number>) => Promise<number>;
+        setMinVideoSendBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
+        getMinVideoSendBandwidth: (callback?: Callback<number>) => Promise<number>;
+        setMaxVideoSendBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
+        getMaxVideoSendBandwidth: (callback?: Callback<number>) => Promise<number>;
+        setMinOutputBitrate: (value: number, callback?: Callback<void>) => Promise<void>;
+        getMinOutputBitrate: (callback?: Callback<number>) => Promise<number>;
+        setMaxOutputBitrate: (value: number, callback?: Callback<void>) => Promise<void>;
+        getMaxOutputBitrate: (callback?: Callback<number>) => Promise<number>;
+        getMediaState: (callback?: Callback<number>) => Promise<any>;
+        setStunServerAddress: (server: string, callback?: Callback<void>) => Promise<void>;
+        getStunServerAddress: (callback?: Callback<string>) => Promise<string>;
+        setStunServerPort: (port: number, callback?: Callback<void>) => Promise<void>;
+        getStunServerPort: (callback?: Callback<number>) => Promise<number>;
+        setTurnUrl: (url: string, callback?: Callback<void>) => Promise<void>;
+        getTurnUrl: (callback?: Callback<string>) => Promise<string>;
+        processOffer: (offer: string, callback?: Callback<string>) => Promise<string>;
+    }
+
+    interface ElementConnectionData {
+        source: WebRtcEndpoint;
+        sink: WebRtcEndpoint;
+        type: any;
+        sourceDescription: string;
+        sinkDescription: string;
+    }
+
+    interface Error {
+        description: string;
+        errorCode: number;
+        type: string;
+    }
+
+    interface Tag {
+        key: string;
+        value: string;
+    }
+
+    interface IceConnection {
+        streamId: string;
+        componentId: number;
+        state: any;
+    }
+
+    interface IceCandidate {
+        candidate: string;
+        sdpMid: string;
+        sdpMLineIndex: number;
+    }
+
+    type Callback<T> = (error: Error, result: T) => void;
+
+    interface Options {
+        failAfter?: number;
+        enableTransactions?: boolean;
+        useImplicitTransactions?: boolean;
+        strict?: boolean;
+        request_timeout?: number;
+        response_timeout?: number;
+        duplicates_timeout?: number;
+        access_token?: string;
+        socket?: any;
+    }
 }
 
-interface Error {
-    description: string;
-    errorCode: number;
-    type: string;
-}
+declare const kurento: KurentoClient.Constructor;
 
-interface Tag {
-    key: string;
-    value: string;
-}
-
-interface IceConnection {
-    streamId: string;
-    componentId: number;
-    state: any;
-}
-
-interface IceCandidate {
-    candidate: string;
-    sdpMid: string;
-    sdpMLineIndex: number;
-}
-
-interface ElementConnectionData {
-    source: WebRtcEndpoint;
-    sink: WebRtcEndpoint;
-    type: any;
-    sourceDescription: string;
-    sinkDescription: string;
-}
-
-interface MediaObject {
-    id: string;
-    name: string;
-    tags: object;
-    addTag: (key: string, value: string, callback?: Callback<void>) => Promise<void>;
-    getTag: (key: string, callback?: Callback<string>) => Promise<string>;
-    getTags: (callback?: Callback<Tag[]>) => Promise<Tag[]>;
-    removeTag: (key: string, callback?: Callback<void>) => Promise<void>;
-    getChildren: (callback?: Callback<MediaObject[]>) => Promise<MediaObject[]>;
-    getCreationTime: (callback?: Callback<number>) => Promise<number>;
-    getMediaPipeline: (callback?: Callback<MediaPipeline>) => Promise<MediaPipeline>;
-    getParent: (callback?: Callback<MediaObject>) => Promise<MediaObject>;
-    getName: (callback?: Callback<string>) => Promise<string>;
-    setName: (name: string, callback?: Callback<void>) => Promise<void>;
-}
-
-interface MediaElement {
-    connect: (sink: MediaElement, callback?: Callback<void>) => Promise<void>;
-    disconnect: (sink: MediaElement, callback?: Callback<void>) => Promise<void>;
-    getSinkConnections: (callback?: Callback<ElementConnectionData[]>) => Promise<ElementConnectionData[]>;
-    getSourceConnections: (callback?: Callback<ElementConnectionData[]>) => Promise<ElementConnectionData[]>;
-}
-
-interface MediaPipeline extends KurentoClient, MediaObject {
-    getGstreamerDot: (callback?: Callback<string>) => Promise<string>;
-    getLatencyStats: (callback?: Callback<boolean>) => Promise<boolean>;
-    setLatencyStats: (callback?: Callback<string>) => Promise<string>;
-}
-
-interface WebRtcEndpoint extends KurentoClient, MediaObject, MediaElement {
-    addIceCandidate: (candidate: RTCIceCandidate, callback?: Callback<void>) => Promise<void>;
-    closeDataChannel: (channelId: number, callback?: Callback<void>) => Promise<void>;
-    createDataChannel: (label?: string, ordered?: boolean, maxPacketLifeTime?: number, maxRetransmits?: number, protocol?: string, callback?: Callback<void>) => Promise<void>;
-    gatherCandidates: (callback?: Callback<void>) => Promise<void>;
-    getConnectionState: (callback?: Callback<any>) => Promise<any>;
-    getICECandidatePairs: (callback?: Callback<any>) => Promise<any>;
-    getIceConnectionState: (callback?: Callback<IceConnection>) => Promise<IceConnection>;
-    setMaxAudioRecvBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
-    getMaxAudioRecvBandwidth: (callback?: Callback<number>) => Promise<number>;
-    setMinVideoRecvBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
-    getMinVideoRecvBandwidth: (callback?: Callback<number>) => Promise<number>;
-    setMaxVideoRecvBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
-    getMaxVideoRecvBandwidth: (callback?: Callback<number>) => Promise<number>;
-    setMinVideoSendBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
-    getMinVideoSendBandwidth: (callback?: Callback<number>) => Promise<number>;
-    setMaxVideoSendBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
-    getMaxVideoSendBandwidth: (callback?: Callback<number>) => Promise<number>;
-    setMinOutputBitrate: (value: number, callback?: Callback<void>) => Promise<void>;
-    getMinOutputBitrate: (callback?: Callback<number>) => Promise<number>;
-    setMaxOutputBitrate: (value: number, callback?: Callback<void>) => Promise<void>;
-    getMaxOutputBitrate: (callback?: Callback<number>) => Promise<number>;
-    getMediaState: (callback?: Callback<number>) => Promise<any>;
-    setStunServerAddress: (server: string, callback?: Callback<void>) => Promise<void>;
-    getStunServerAddress: (callback?: Callback<string>) => Promise<string>;
-    setStunServerPort: (port: number, callback?: Callback<void>) => Promise<void>;
-    getStunServerPort: (callback?: Callback<number>) => Promise<number>;
-    setTurnUrl: (url: string, callback?: Callback<void>) => Promise<void>;
-    getTurnUrl: (callback?: Callback<string>) => Promise<string>;
-    processOffer: (offer: string, callback?: Callback<string>) => Promise<string>;
-}
-
-declare class KurentoClient {
-    create(type: 'MediaPipeline'): Promise<MediaPipeline>;
-    create(type: 'WebRtcEndpoint'): Promise<WebRtcEndpoint>;
-    on(event: 'OnIceCandidate', callback: (event: IceCandidate) => void): void;
-    on(event: 'Error', callback: (error: Error) => void): void;
-    on(event: 'Recording' | 'Paused' | 'Stopped', callback: () => void): void;
-    getMediaobjectById(objectId: string): Promise<any>;
-    close(): void;
-}
-
-interface Kurento {
-    (ws_uri: string, options?: Options): Promise<KurentoClient>;
-    getComplexType: (complex: 'IceCandidate') => (value: any) => any;
-}
-
-declare const kurento: Kurento;
-
-// tslint:disable-next-line npm-naming
-export default kurento;
-export { KurentoClient, MediaPipeline, WebRtcEndpoint };
+export = kurento;

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -18,6 +18,7 @@ interface IOptions {
 
 type CreateTypes = 'MediaPipeline' | 'WebRtcEndpoint';
 type EventTypes = 'OnIceCandidate';
+type ComplexTypes = 'IceCandidate'
 
 export declare class KurentoClient {
     create: (type: CreateTypes) => KurentoClient;
@@ -29,7 +30,7 @@ export declare class KurentoClient {
 }
 
 declare const client: (ws_uri: string, options: IOptions) => Promise<KurentoClient>;
-declare const getComplexType: (complex: ComplexTypes) => any;
+declare const getComplexType: (complex: ComplexTypes) => (value: any) => any;
 
 export default client;
 

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -106,5 +106,6 @@ interface Kurento {
 
 declare const kurento: Kurento;
 
+// tslint:disable-next-line npm-naming
 export default kurento;
 export { KurentoClient, MediaPipeline, WebRtcEndpoint };

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -66,8 +66,8 @@ interface MediaObject {
 }
 
 interface MediaElement {
-    connect: (sink: WebRtcEndpoint, callback?: Callback<void>) => Promise<void>;
-    disconnect: (sink: WebRtcEndpoint, callback?: Callback<void>) => Promise<void>;
+    connect: (sink: MediaElement, callback?: Callback<void>) => Promise<void>;
+    disconnect: (sink: MediaElement, callback?: Callback<void>) => Promise<void>;
     getSinkConnections: (callback?: Callback<ElementConnectionData[]>) => Promise<ElementConnectionData[]>;
     getSourceConnections: (callback?: Callback<ElementConnectionData[]>) => Promise<ElementConnectionData[]>;
 }

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for kurento-client 6.12
+// Project: https://github.com/Kurento/kurento-client-js, https://www.kurento.org
+// Definitions by: James Hill <https://github.com/jhdevuk>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+interface IOptions {
+    failAfter: number;
+    enableTransactions: boolean;
+    useImplicitTransactions: boolean;
+    strict: boolean;
+    request_timeout: number;
+    response_timeout: number;
+    duplicates_timeout: number;
+    access_token: string;
+    socket: any;
+}
+
+type CreateTypes = 'MediaPipeline' | 'WebRtcEndpoint';
+type EventTypes = 'OnIceCandidate';
+
+export declare class KurentoClient {
+    create: (type: CreateTypes) => KurentoClient;
+    addIceCandidate: (candidate: RTCIceCandidate) => KurentoClient;
+    processOffer: (sdpOffer: string) => Promise<string>;
+    gatherCandidates: (callback: (error: Error) => void) => void;
+    getMediaobjectById: (objectId: string) => Promise<KurentoClient>
+    on: (event: EventTypes, callback: (data: any) => void) => void;
+}
+
+declare const client: (ws_uri: string, options: IOptions) => Promise<KurentoClient>;
+declare const getComplexType: (complex: ComplexTypes) => any;
+
+export default client;
+
+export {
+    getComplexType
+}

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -65,13 +65,20 @@ interface MediaObject {
     setName: (name: string, callback?: Callback<void>) => Promise<void>;
 }
 
+interface MediaElement {
+    connect: (sink: WebRtcEndpoint, callback?: Callback<void>) => Promise<void>;
+    disconnect: (sink: WebRtcEndpoint, callback?: Callback<void>) => Promise<void>;
+    getSinkConnections: (callback?: Callback<ElementConnectionData[]>) => Promise<ElementConnectionData[]>;
+    getSourceConnections: (callback?: Callback<ElementConnectionData[]>) => Promise<ElementConnectionData[]>;
+}
+
 interface MediaPipeline extends KurentoClient, MediaObject {
     getGstreamerDot: (callback?: Callback<string>) => Promise<string>;
     getLatencyStats: (callback?: Callback<boolean>) => Promise<boolean>;
     setLatencyStats: (callback?: Callback<string>) => Promise<string>;
 }
 
-interface WebRtcEndpoint extends KurentoClient, MediaObject {
+interface WebRtcEndpoint extends KurentoClient, MediaObject, MediaElement {
     addIceCandidate: (candidate: RTCIceCandidate, callback?: Callback<void>) => Promise<void>;
     closeDataChannel: (channelId: number, callback?: Callback<void>) => Promise<void>;
     createDataChannel: (label?: string, ordered?: boolean, maxPacketLifeTime?: number, maxRetransmits?: number, protocol?: string, callback?: Callback<void>) => Promise<void>;
@@ -79,6 +86,7 @@ interface WebRtcEndpoint extends KurentoClient, MediaObject {
     getConnectionState: (callback?: Callback<any>) => Promise<any>;
     getICECandidatePairs: (callback?: Callback<any>) => Promise<any>;
     getIceConnectionState: (callback?: Callback<IceConnection>) => Promise<IceConnection>;
+    setMaxAudioRecvBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
     getMaxAudioRecvBandwidth: (callback?: Callback<number>) => Promise<number>;
     setMinVideoRecvBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
     getMinVideoRecvBandwidth: (callback?: Callback<number>) => Promise<number>;
@@ -88,11 +96,10 @@ interface WebRtcEndpoint extends KurentoClient, MediaObject {
     getMinVideoSendBandwidth: (callback?: Callback<number>) => Promise<number>;
     setMaxVideoSendBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
     getMaxVideoSendBandwidth: (callback?: Callback<number>) => Promise<number>;
-    setMaxAudioRecvBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
-    getMinOutputBitrate: (callback?: Callback<number>) => Promise<number>;
-    getMaxOutputBitrate: (callback?: Callback<number>) => Promise<number>;
-    setMaxOutputBitrate: (value: number, callback?: Callback<void>) => Promise<void>;
     setMinOutputBitrate: (value: number, callback?: Callback<void>) => Promise<void>;
+    getMinOutputBitrate: (callback?: Callback<number>) => Promise<number>;
+    setMaxOutputBitrate: (value: number, callback?: Callback<void>) => Promise<void>;
+    getMaxOutputBitrate: (callback?: Callback<number>) => Promise<number>;
     getMediaState: (callback?: Callback<number>) => Promise<any>;
     setStunServerAddress: (server: string, callback?: Callback<void>) => Promise<void>;
     getStunServerAddress: (callback?: Callback<string>) => Promise<string>;
@@ -101,9 +108,6 @@ interface WebRtcEndpoint extends KurentoClient, MediaObject {
     setTurnUrl: (url: string, callback?: Callback<void>) => Promise<void>;
     getTurnUrl: (callback?: Callback<string>) => Promise<string>;
     processOffer: (offer: string, callback?: Callback<string>) => Promise<string>;
-    connect: (sink: WebRtcEndpoint, callback?: Callback<void>) => Promise<void>;
-    disconnect: (sink: WebRtcEndpoint, callback?: Callback<void>) => Promise<void>;
-    getSinkConnections: (callback?: Callback<ElementConnectionData[]>) => Promise<ElementConnectionData[]>;
 }
 
 declare class KurentoClient {

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -4,37 +4,109 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-interface KurentoClient {
+type Callback<T> = (error: Error, result: T) => void;
+
+interface Options {
+    failAfter: number;
+    enableTransactions: boolean;
+    useImplicitTransactions: boolean;
+    strict: boolean;
+    request_timeout: number;
+    response_timeout: number;
+    duplicates_timeout: number;
+    access_token: string;
+    socket: any;
+}
+
+interface Error {
+    description: string;
+    errorCode: number;
+    type: string;
+}
+
+interface IceConnection {
+    streamId: string;
+    componentId: number;
+    state: any;
+}
+
+interface IceCandidate {
+    candidate: string;
+    sdpMid: string;
+    sdpMLineIndex: number;
+}
+
+interface MediaObject {
     id: string;
-    create: (type: 'MediaPipeline' | 'WebRtcEndpoint') => Promise<KurentoClient>;
-    connect: (client: KurentoClient, callback: (error: Error) => void) => void;
-    release: () => void;
-    addIceCandidate: (candidate: RTCIceCandidate) => KurentoClient;
-    processOffer: (sdpOffer: string) => Promise<string>;
-    gatherCandidates: (callback: (error: Error) => void) => void;
-    getMediaobjectById: (objectId: string) => Promise<KurentoClient>
-    on: (event: 'OnIceCandidate', callback: (data: any) => void) => void;
+    name: string;
+    tags: object;
+    addTag: (key: string, value: string) => Promise<any>;
+    getTag: (key: string) => Promise<string>;
+    getTags: (callback?: Callback<any>) => Promise<any[]>;
+    removeTag: (key: string) => Promise<any>;
+    getChildren: (callback?: Callback<MediaObject[]>) => Promise<MediaObject[]>;
+    getCreationTime: () => Promise<number>;
+    getMediaPipeline: (callback?: Callback<MediaPipeline>) => Promise<MediaPipeline>;
+    getParent: (callback?: Callback<MediaObject>) => Promise<MediaObject>;
+    getName: () => Promise<string>;
+    setName: (name: string) => Promise<void>;
 }
 
-declare module 'kurento-client' {
-    interface Options {
-        failAfter: number;
-        enableTransactions: boolean;
-        useImplicitTransactions: boolean;
-        strict: boolean;
-        request_timeout: number;
-        response_timeout: number;
-        duplicates_timeout: number;
-        access_token: string;
-        socket: any;
-    }
-
-    interface Kurento {
-        (ws_uri: string, options?: Options): Promise<KurentoClient>;
-        getComplexType: (complex: 'IceCandidate') => (value: any) => any;
-    }
-
-    const kurento: Kurento;
-
-    export = kurento;
+interface MediaPipeline extends KurentoClient, MediaObject {
+    getGstreamerDot: (callback?: Callback<string>) => Promise<string>;
+    getLatencyStats: (callback?: Callback<boolean>) => Promise<boolean>;
+    setLatencyStats: (callback?: Callback<string>) => Promise<string>;
 }
+
+interface WebRtcEndpoint extends KurentoClient, MediaObject {
+    addIceCandidate: (candidate: RTCIceCandidate) => Promise<void>;
+    closeDataChannel: (channelId: number) => Promise<void>;
+    createDataChannel: (label?: string, ordered?: boolean, maxPacketLifeTime?: number, maxRetransmits?: number, protocol?: string) => Promise<void>;
+    gatherCandidates: (callback?: Callback<void>) => Promise<void>;
+    getConnectionState: (callback?: Callback<any>) => Promise<any>;
+    getICECandidatePairs: (callback?: Callback<any>) => Promise<any>;
+    getIceConnectionState: (callback?: Callback<IceConnection>) => Promise<IceConnection>;
+    getMaxAudioRecvBandwidth: (callback?: Callback<number>) => Promise<number>;
+    setMinVideoRecvBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
+    getMinVideoRecvBandwidth: (callback?: Callback<number>) => Promise<number>;
+    setMaxVideoRecvBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
+    getMaxVideoRecvBandwidth: (callback?: Callback<number>) => Promise<number>;
+    setMinVideoSendBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
+    getMinVideoSendBandwidth: (callback?: Callback<number>) => Promise<number>;
+    setMaxVideoSendBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
+    getMaxVideoSendBandwidth: (callback?: Callback<number>) => Promise<number>;
+    setMaxAudioRecvBandwidth: (value: number, callback?: Callback<void>) => Promise<void>;
+    getMinOutputBitrate: (callback?: Callback<number>) => Promise<number>;
+    getMaxOutputBitrate: (callback?: Callback<number>) => Promise<number>;
+    setMaxOutputBitrate: (value: number, callback?: Callback<void>) => Promise<void>;
+    setMinOutputBitrate: (value: number, callback?: Callback<void>) => Promise<void>;
+    getMediaState: (callback?: Callback<number>) => Promise<any>;
+    setStunServerAddress: (server: string, callback?: Callback<void>) => Promise<void>;
+    getStunServerAddress: (callback?: Callback<string>) => Promise<string>;
+    setStunServerPort: (port: number, callback?: Callback<void>) => Promise<void>;
+    getStunServerPort: (callback?: Callback<number>) => Promise<number>;
+    setTurnUrl: (url: string, callback?: Callback<void>) => Promise<void>;
+    getTurnUrl: (callback?: Callback<string>) => Promise<string>;
+    processOffer: (offer: string, callback?: Callback<string>) => Promise<string>;
+}
+
+declare class KurentoClient {
+    public create(type: 'MediaPipeline'): Promise<MediaPipeline>;
+    public create(type: 'WebRtcEndpoint'): Promise<WebRtcEndpoint>;
+    public on(event: 'OnIceCandidate', callback: (event: IceCandidate) => void): void;
+    public on(event: 'Error', callback: (error: Error) => void): void;
+    public on(event: 'Recording', callback: () => void): void;
+    public on(event: 'Paused', callback: () => void): void;
+    public on(event: 'Stopped', callback: () => void): void;
+    public getMediaobjectById(objectId: string): Promise<any>;
+}
+
+interface Kurento {
+    (ws_uri: string, options?: Options): Promise<KurentoClient>;
+    getComplexType: (complex: 'IceCandidate') => (value: any) => any;
+}
+
+declare const kurento: Kurento;
+
+export default kurento;
+export { KurentoClient, MediaPipeline, WebRtcEndpoint }

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -24,6 +24,11 @@ interface Error {
     type: string;
 }
 
+interface Tag {
+    key: string;
+    value: string;
+}
+
 interface IceConnection {
     streamId: string;
     componentId: number;
@@ -36,20 +41,28 @@ interface IceCandidate {
     sdpMLineIndex: number;
 }
 
+interface ElementConnectionData {
+    source: WebRtcEndpoint;
+    sink: WebRtcEndpoint;
+    type: any;
+    sourceDescription: string;
+    sinkDescription: string;
+}
+
 interface MediaObject {
     id: string;
     name: string;
     tags: object;
-    addTag: (key: string, value: string) => Promise<any>;
-    getTag: (key: string) => Promise<string>;
-    getTags: (callback?: Callback<any>) => Promise<any[]>;
-    removeTag: (key: string) => Promise<any>;
+    addTag: (key: string, value: string, callback?: Callback<void>) => Promise<void>;
+    getTag: (key: string, callback?: Callback<string>) => Promise<string>;
+    getTags: (callback?: Callback<Tag[]>) => Promise<Tag[]>;
+    removeTag: (key: string, callback?: Callback<void>) => Promise<void>;
     getChildren: (callback?: Callback<MediaObject[]>) => Promise<MediaObject[]>;
-    getCreationTime: () => Promise<number>;
+    getCreationTime: (callback?: Callback<number>) => Promise<number>;
     getMediaPipeline: (callback?: Callback<MediaPipeline>) => Promise<MediaPipeline>;
     getParent: (callback?: Callback<MediaObject>) => Promise<MediaObject>;
-    getName: () => Promise<string>;
-    setName: (name: string) => Promise<void>;
+    getName: (callback?: Callback<string>) => Promise<string>;
+    setName: (name: string, callback?: Callback<void>) => Promise<void>;
 }
 
 interface MediaPipeline extends KurentoClient, MediaObject {
@@ -59,9 +72,9 @@ interface MediaPipeline extends KurentoClient, MediaObject {
 }
 
 interface WebRtcEndpoint extends KurentoClient, MediaObject {
-    addIceCandidate: (candidate: RTCIceCandidate) => Promise<void>;
-    closeDataChannel: (channelId: number) => Promise<void>;
-    createDataChannel: (label?: string, ordered?: boolean, maxPacketLifeTime?: number, maxRetransmits?: number, protocol?: string) => Promise<void>;
+    addIceCandidate: (candidate: RTCIceCandidate, callback?: Callback<void>) => Promise<void>;
+    closeDataChannel: (channelId: number, callback?: Callback<void>) => Promise<void>;
+    createDataChannel: (label?: string, ordered?: boolean, maxPacketLifeTime?: number, maxRetransmits?: number, protocol?: string, callback?: Callback<void>) => Promise<void>;
     gatherCandidates: (callback?: Callback<void>) => Promise<void>;
     getConnectionState: (callback?: Callback<any>) => Promise<any>;
     getICECandidatePairs: (callback?: Callback<any>) => Promise<any>;
@@ -88,6 +101,9 @@ interface WebRtcEndpoint extends KurentoClient, MediaObject {
     setTurnUrl: (url: string, callback?: Callback<void>) => Promise<void>;
     getTurnUrl: (callback?: Callback<string>) => Promise<string>;
     processOffer: (offer: string, callback?: Callback<string>) => Promise<string>;
+    connect: (endpoint: WebRtcEndpoint, callback?: Callback<void>) => Promise<void>;
+    disconnect: (endpoint: WebRtcEndpoint, callback?: Callback<void>) => Promise<void>;
+    getSinkConnections: (callback?: Callback<ElementConnectionData[]>) => Promise<ElementConnectionData[]>;
 }
 
 declare class KurentoClient {

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -101,8 +101,8 @@ interface WebRtcEndpoint extends KurentoClient, MediaObject {
     setTurnUrl: (url: string, callback?: Callback<void>) => Promise<void>;
     getTurnUrl: (callback?: Callback<string>) => Promise<string>;
     processOffer: (offer: string, callback?: Callback<string>) => Promise<string>;
-    connect: (endpoint: WebRtcEndpoint, callback?: Callback<void>) => Promise<void>;
-    disconnect: (endpoint: WebRtcEndpoint, callback?: Callback<void>) => Promise<void>;
+    connect: (sink: WebRtcEndpoint, callback?: Callback<void>) => Promise<void>;
+    disconnect: (sink: WebRtcEndpoint, callback?: Callback<void>) => Promise<void>;
     getSinkConnections: (callback?: Callback<ElementConnectionData[]>) => Promise<ElementConnectionData[]>;
 }
 

--- a/types/kurento-client/kurento-client-tests.ts
+++ b/types/kurento-client/kurento-client-tests.ts
@@ -4,7 +4,7 @@ async () => {
     const sdpOffer = 'offer';
     const candidate = new RTCIceCandidate();
 
-    const client = await kurento('//server');
+    const client = await kurento('//server', { failAfter: 500, useImplicitTransactions: true });
     const pipeline = await client.create('MediaPipeline');
     const endpoint = await pipeline.create('WebRtcEndpoint');
 

--- a/types/kurento-client/kurento-client-tests.ts
+++ b/types/kurento-client/kurento-client-tests.ts
@@ -1,0 +1,5 @@
+import kurento from 'kurento-client';
+
+async () => {
+    const client = await kurento('//server');
+};

--- a/types/kurento-client/kurento-client-tests.ts
+++ b/types/kurento-client/kurento-client-tests.ts
@@ -1,5 +1,28 @@
 import kurento from 'kurento-client';
 
 async () => {
+    const sdpOffer = 'offer';
+    const candidate = new RTCIceCandidate();
+
     const client = await kurento('//server');
+    const pipeline = await client.create('MediaPipeline');
+    const endpoint = await pipeline.create('WebRtcEndpoint');
+
+    endpoint.addIceCandidate(candidate);
+
+    endpoint.on('OnIceCandidate', ({ candidate }) => {
+        const value = kurento.getComplexType('IceCandidate')(
+            candidate
+        );
+
+        endpoint.addIceCandidate(value);
+    });
+
+    const sdpAnswer = await endpoint.processOffer(sdpOffer);
+
+    endpoint.gatherCandidates(error => {
+        // ok
+    });
+
+    return { sdpAnswer };
 };

--- a/types/kurento-client/tsconfig.json
+++ b/types/kurento-client/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+    ]
+}

--- a/types/kurento-client/tsconfig.json
+++ b/types/kurento-client/tsconfig.json
@@ -9,6 +9,7 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
+        "esModuleInterop": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"
@@ -19,5 +20,6 @@
     },
     "files": [
         "index.d.ts",
+        "kurento-client-tests.ts"
     ]
 }

--- a/types/kurento-client/tslint.json
+++ b/types/kurento-client/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/kurento-client/tslint.json
+++ b/types/kurento-client/tslint.json
@@ -1,6 +1,1 @@
-{ 
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "npm-naming": false
-    }
-}
+{ "extends": "dtslint/dt.json" }

--- a/types/kurento-client/tslint.json
+++ b/types/kurento-client/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{ 
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}


### PR DESCRIPTION
Created typescript definitions for the `kurento-client` package as they are currently without.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.