### PR TITLE
fix(redux-actions): map object incompatibility with handleActions

### DIFF
--- a/types/redux-actions/index.d.ts
+++ b/types/redux-actions/index.d.ts
@@ -6,6 +6,7 @@
 //                 Alexey Pelykh <https://github.com/alexey-pelykh>
 //                 Thiago de Andrade <https://github.com/7hi4g0>
 //                 Ziyu <https://github.com/oddui>
+//                 Andrei Todorut<https://github.com//candreitodorut>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -180,6 +181,24 @@ export function handleActions<State, Payload>(
 
 export function handleActions<State, Payload, Meta>(
     reducerMap: ReducerMapMeta<State, Payload, Meta>,
+    initialState: State,
+    options?: Options
+): ReduxCompatibleReducerMeta<State, Payload, Meta>;
+
+export function handleActions<StateAndPayload>(
+    reducerMap: Map<string | ActionFunctions<StateAndPayload> | CombinedActionType, Reducer<StateAndPayload, StateAndPayload>>,
+    initialState: StateAndPayload,
+    options?: Options
+): ReduxCompatibleReducer<StateAndPayload, StateAndPayload>;
+
+export function handleActions<State, Payload>(
+    reducerMap: Map<string | ActionFunctions<Payload> | CombinedActionType, Reducer<State, Payload>>,
+    initialState: State,
+    options?: Options
+): ReduxCompatibleReducer<State, Payload>;
+
+export function handleActions<State, Payload, Meta>(
+    reducerMap: Map<string | ActionWithMetaFunctions<Payload, Meta> | CombinedActionType, ReducerMeta<State, Payload, Meta>>,
     initialState: State,
     options?: Options
 ): ReduxCompatibleReducerMeta<State, Payload, Meta>;


### PR DESCRIPTION
The Map object doesn't work properly with `handleActions` method. The first parameter of handleActions method shows me the following error: 
```
Argument of type 'Map<ActionFunction1<ActionDto[], Action<ActionDto[]>>, (state: TActionState, action: Action<ActionDto[]>) => TActionState>' is not assignable to parameter of type 'ReducerMap<TActionState, ActionDto[]>
```
I did further investigations about that in the current `d.ts` files related to `redux-actions` package and I found that the `ReducerMap` works well with literal objects.
```javascript
const actionsMap = {
    [EActionEntityActions.ACTIONS_FETCHED]: (state: TActionState, action: Action<ActionDto[]>) => ({...state, ...action.payload}),
}
```
but with Map doesn't work:
```javascript 
const actionsMap = new Map([
    [
        storeActions,
        (state: TActionState, action: Action<ActionDto[]>) => {
            // console.log(state, action, 'in reducer');
            return state;
        }
    ]
]);

// without the overloading for Map object, the issue is triggered on the actionsMap parameter.
export const actionReducer = handleActions<TActionState, ActionDto[]>(actionsMap, initialState)
```
Just to mention that the documentation specifies that `handleActions` works with `Map` object.
https://redux-actions.js.org/api/handleaction

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: ( I added the code above )