### PR TITLE
[office-js, office-js-preview] Removing prompt verbage from selection binding options

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -1331,7 +1331,7 @@ declare namespace Office {
         asyncContext?: any
     }
     /**
-     * Provides options for configuring the prompt and identifying the binding that is created.
+     * Provides options for identifying the binding that is created.
      */
     interface AddBindingFromSelectionOptions {
         /**
@@ -2599,7 +2599,7 @@ declare namespace Office {
          *
          * @param bindingType Specifies the type of the binding object to create. Required. 
          *                    Returns null if the selected object cannot be coerced into the specified type.
-         * @param options Provides options for configuring the prompt and identifying the binding that is created.
+         * @param options Provides options for identifying the binding that is created.
          * @param callback Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}.
          *                  The `value` property of the result is the Binding object that represents the selection specified by the user.
          */

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -1246,7 +1246,7 @@ declare namespace Office {
         asyncContext?: any
     }
     /**
-     * Provides options for configuring the prompt and identifying the binding that is created.
+     * Provides options for identifying the binding that is created.
      */
     interface AddBindingFromSelectionOptions {
         /**
@@ -2505,7 +2505,7 @@ declare namespace Office {
          *
          * @param bindingType Specifies the type of the binding object to create. Required. 
          *                    Returns null if the selected object cannot be coerced into the specified type.
-         * @param options Provides options for configuring the prompt and identifying the binding that is created.
+         * @param options Provides options for identifying the binding that is created.
          * @param callback Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}.
          *                  The `value` property of the result is the Binding object that represents the selection specified by the user.
          */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.microsoft.com/en-us/javascript/api/office/office.addbindingfromselectionoptions?view=excel-js-preview
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.