### PR TITLE
[office-js, office-js-preview] Allowing 1.10 to work without CommentRichContent

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -36767,13 +36767,24 @@ declare namespace Excel {
          *
          * Creates a new comment with the given content on the given cell. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
          *
-         * [Api set: ExcelApi 1.10]
+         * [Api set: ExcelApiOnline 1.1]
          *
          * @param cellAddress The cell to which the comment is added. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
-         * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions. [Api set: ExcelApi 1.10 for string, ExcelApiOnline 1.1 for CommentRichContent object]
-         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. [Api set: ExcelApi 1.10 for Enum ContentType.Plain, ExcelApiOnline 1.1 for Enum ContentType.Mention]
+         * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions.
+         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. 
          */
         add(cellAddress: Range | string, content: CommentRichContent | string, contentType?: Excel.ContentType): Excel.Comment;
+        /**
+         *
+         * Creates a new comment with the given content on the given cell. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
+         *
+         * [Api set: ExcelApiOnline 1.1]
+         *
+         * @param cellAddress The cell to which the comment is added. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
+         * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions.
+         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. 
+         */
+        add(cellAddress: Range | string, content: CommentRichContent | string, contentType?: "Plain" | "Mention"): Excel.Comment;
         /**
          *
          * Creates a new comment with the given content on the given cell. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
@@ -36781,10 +36792,9 @@ declare namespace Excel {
          * [Api set: ExcelApi 1.10]
          *
          * @param cellAddress The cell to which the comment is added. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
-         * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions. [Api set: ExcelApi 1.10 for string, ExcelApiOnline 1.1 for CommentRichContent object]
-         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. [Api set: ExcelApi 1.10 for Enum ContentType.Plain, ExcelApiOnline 1.1 for Enum ContentType.Mention]
+         * @param content The comment's content, as a string representing plain text.
          */
-        add(cellAddress: Range | string, content: CommentRichContent | string, contentType?: "Plain" | "Mention"): Excel.Comment;
+        add(cellAddress: Range | string, content: string): Excel.Comment;
         /**
          *
          * Gets the number of comments in the collection.
@@ -37004,22 +37014,31 @@ declare namespace Excel {
          *
          * Creates a comment reply for comment.
          *
-         * [Api set: ExcelApi 1.10]
+         * [Api set: ExcelApiOnline 1.1]
          *
-         * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions). [Api set: ExcelApi 1.10 for string, ExcelApiOnline 1.1 for CommentRichContent object]
-         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. [Api set: ExcelApi 1.10 for Enum ContentType.Plain, ExcelApiOnline 1.1 for Enum ContentType.Mention]
+         * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions). 
+         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`.
          */
         add(content: CommentRichContent | string, contentType?: Excel.ContentType): Excel.CommentReply;
         /**
          *
          * Creates a comment reply for comment.
          *
-         * [Api set: ExcelApi 1.10]
+         * [Api set: ExcelApiOnline 1.1]
          *
-         * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions). [Api set: ExcelApi 1.10 for string, ExcelApiOnline 1.1 for CommentRichContent object]
-         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. [Api set: ExcelApi 1.10 for Enum ContentType.Plain, ExcelApiOnline 1.1 for Enum ContentType.Mention]
+         * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions).
+         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. 
          */
         add(content: CommentRichContent | string, contentType?: "Plain" | "Mention"): Excel.CommentReply;
+        /**
+         *
+         * Creates a comment reply for comment.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param content The comment's plain text content.
+         */
+        add(content: string): Excel.CommentReply;
         /**
          *
          * Gets the number of comment replies in the collection.

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -1331,7 +1331,7 @@ declare namespace Office {
         asyncContext?: any
     }
     /**
-     * Provides options for configuring the prompt and identifying the binding that is created.
+     * Provides options for identifying the binding that is created.
      */
     interface AddBindingFromSelectionOptions {
         /**
@@ -2599,7 +2599,7 @@ declare namespace Office {
          *
          * @param bindingType Specifies the type of the binding object to create. Required. 
          *                    Returns null if the selected object cannot be coerced into the specified type.
-         * @param options Provides options for configuring the prompt and identifying the binding that is created.
+         * @param options Provides options for identifying the binding that is created.
          * @param callback Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}.
          *                  The `value` property of the result is the Binding object that represents the selection specified by the user.
          */

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -1331,7 +1331,7 @@ declare namespace Office {
         asyncContext?: any
     }
     /**
-     * Provides options for identifying the binding that is created.
+     * Provides options for configuring the prompt and identifying the binding that is created.
      */
     interface AddBindingFromSelectionOptions {
         /**
@@ -2599,7 +2599,7 @@ declare namespace Office {
          *
          * @param bindingType Specifies the type of the binding object to create. Required. 
          *                    Returns null if the selected object cannot be coerced into the specified type.
-         * @param options Provides options for identifying the binding that is created.
+         * @param options Provides options for configuring the prompt and identifying the binding that is created.
          * @param callback Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}.
          *                  The `value` property of the result is the Binding object that represents the selection specified by the user.
          */

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -1246,7 +1246,7 @@ declare namespace Office {
         asyncContext?: any
     }
     /**
-     * Provides options for identifying the binding that is created.
+     * Provides options for configuring the prompt and identifying the binding that is created.
      */
     interface AddBindingFromSelectionOptions {
         /**
@@ -2505,7 +2505,7 @@ declare namespace Office {
          *
          * @param bindingType Specifies the type of the binding object to create. Required. 
          *                    Returns null if the selected object cannot be coerced into the specified type.
-         * @param options Provides options for identifying the binding that is created.
+         * @param options Provides options for configuring the prompt and identifying the binding that is created.
          * @param callback Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}.
          *                  The `value` property of the result is the Binding object that represents the selection specified by the user.
          */

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -1246,7 +1246,7 @@ declare namespace Office {
         asyncContext?: any
     }
     /**
-     * Provides options for configuring the prompt and identifying the binding that is created.
+     * Provides options for identifying the binding that is created.
      */
     interface AddBindingFromSelectionOptions {
         /**
@@ -2505,7 +2505,7 @@ declare namespace Office {
          *
          * @param bindingType Specifies the type of the binding object to create. Required. 
          *                    Returns null if the selected object cannot be coerced into the specified type.
-         * @param options Provides options for configuring the prompt and identifying the binding that is created.
+         * @param options Provides options for identifying the binding that is created.
          * @param callback Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}.
          *                  The `value` property of the result is the Binding object that represents the selection specified by the user.
          */

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -35658,7 +35658,7 @@ declare namespace Excel {
          *
          * Creates a new comment with the given content on the given cell. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
          *
-         * [Api set: ExcelApi 1.10]
+         * [Api set: ExcelApiOnline 1.1]
          *
          * @param cellAddress The cell to which the comment is added. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
          * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions. [Api set: ExcelApi 1.10 for string, ExcelApiOnline 1.1 for CommentRichContent object]
@@ -35669,13 +35669,23 @@ declare namespace Excel {
          *
          * Creates a new comment with the given content on the given cell. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
          *
-         * [Api set: ExcelApi 1.10]
+         * [Api set: ExcelApiOnline 1.1]
          *
          * @param cellAddress The cell to which the comment is added. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
          * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions. [Api set: ExcelApi 1.10 for string, ExcelApiOnline 1.1 for CommentRichContent object]
          * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. [Api set: ExcelApi 1.10 for Enum ContentType.Plain, ExcelApiOnline 1.1 for Enum ContentType.Mention]
          */
         add(cellAddress: Range | string, content: CommentRichContent | string, contentType?: "Plain" | "Mention"): Excel.Comment;
+        /**
+         *
+         * Creates a new comment with the given content on the given cell. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param cellAddress The cell to which the comment is added. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
+         * @param content The comment's content, as a string representing plain text.
+         */
+        add(cellAddress: Range | string, content: string): Excel.Comment;
         /**
          *
          * Gets the number of comments in the collection.
@@ -35887,7 +35897,7 @@ declare namespace Excel {
          *
          * Creates a comment reply for comment.
          *
-         * [Api set: ExcelApi 1.10]
+         * [Api set: ExcelApiOnline 1.1]
          *
          * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions). [Api set: ExcelApi 1.10 for string, ExcelApiOnline 1.1 for CommentRichContent object]
          * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. [Api set: ExcelApi 1.10 for Enum ContentType.Plain, ExcelApiOnline 1.1 for Enum ContentType.Mention]
@@ -35897,12 +35907,30 @@ declare namespace Excel {
          *
          * Creates a comment reply for comment.
          *
-         * [Api set: ExcelApi 1.10]
+         * [Api set: ExcelApiOnline 1.1]
          *
          * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions). [Api set: ExcelApi 1.10 for string, ExcelApiOnline 1.1 for CommentRichContent object]
          * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. [Api set: ExcelApi 1.10 for Enum ContentType.Plain, ExcelApiOnline 1.1 for Enum ContentType.Mention]
          */
         add(content: CommentRichContent | string, contentType?: "Plain" | "Mention"): Excel.CommentReply;
+        /**
+         *
+         * Creates a comment reply for comment.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param content The comment's plain text content.
+         */
+        add(content: string): Excel.CommentReply;
+        /**
+         *
+         * Creates a comment reply for comment.
+         *
+         * [Api set: ExcelApi 1.10]
+         *
+         * @param content The comment's plain text content.
+         */
+        add(content: string): Excel.CommentReply;
         /**
          *
          * Gets the number of comment replies in the collection.

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -35661,8 +35661,8 @@ declare namespace Excel {
          * [Api set: ExcelApiOnline 1.1]
          *
          * @param cellAddress The cell to which the comment is added. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
-         * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions. [Api set: ExcelApi 1.10 for string, ExcelApiOnline 1.1 for CommentRichContent object]
-         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. [Api set: ExcelApi 1.10 for Enum ContentType.Plain, ExcelApiOnline 1.1 for Enum ContentType.Mention]
+         * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions.
+         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`.
          */
         add(cellAddress: Range | string, content: CommentRichContent | string, contentType?: Excel.ContentType): Excel.Comment;
         /**
@@ -35672,8 +35672,8 @@ declare namespace Excel {
          * [Api set: ExcelApiOnline 1.1]
          *
          * @param cellAddress The cell to which the comment is added. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
-         * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions. [Api set: ExcelApi 1.10 for string, ExcelApiOnline 1.1 for CommentRichContent object]
-         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. [Api set: ExcelApi 1.10 for Enum ContentType.Plain, ExcelApiOnline 1.1 for Enum ContentType.Mention]
+         * @param content The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions.
+         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`.
          */
         add(cellAddress: Range | string, content: CommentRichContent | string, contentType?: "Plain" | "Mention"): Excel.Comment;
         /**
@@ -35899,8 +35899,8 @@ declare namespace Excel {
          *
          * [Api set: ExcelApiOnline 1.1]
          *
-         * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions). [Api set: ExcelApi 1.10 for string, ExcelApiOnline 1.1 for CommentRichContent object]
-         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. [Api set: ExcelApi 1.10 for Enum ContentType.Plain, ExcelApiOnline 1.1 for Enum ContentType.Mention]
+         * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions).
+         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`.
          */
         add(content: CommentRichContent | string, contentType?: Excel.ContentType): Excel.CommentReply;
         /**
@@ -35909,19 +35909,10 @@ declare namespace Excel {
          *
          * [Api set: ExcelApiOnline 1.1]
          *
-         * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions). [Api set: ExcelApi 1.10 for string, ExcelApiOnline 1.1 for CommentRichContent object]
-         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. [Api set: ExcelApi 1.10 for Enum ContentType.Plain, ExcelApiOnline 1.1 for Enum ContentType.Mention]
+         * @param content The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions).
+         * @param contentType Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`.
          */
         add(content: CommentRichContent | string, contentType?: "Plain" | "Mention"): Excel.CommentReply;
-        /**
-         *
-         * Creates a comment reply for comment.
-         *
-         * [Api set: ExcelApi 1.10]
-         *
-         * @param content The comment's plain text content.
-         */
-        add(content: string): Excel.CommentReply;
         /**
          *
          * Creates a comment reply for comment.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://review.docs.microsoft.com/en-us/javascript/api/excel/excel.comment?view=excel-js-preview&branch=AlexJ-CommentUpdate

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
