### PR TITLE
[google__maps][@google/maps] Only allow calling `asPromise()` if client supports it

### DIFF
--- a/types/google__maps/google__maps-tests.ts
+++ b/types/google__maps/google__maps-tests.ts
@@ -1,28 +1,62 @@
 import { createClient } from '@google/maps';
 
+// Client without Promise support; the asPromise function is not available on requests
 const client = createClient({
+    key: 'my-google-maps-api-key',
+    language: 'ja',
+});
+
+// $ExpectError
+client.geocode({ address: 'Leaning Tower of Pisa' }).asPromise();
+client
+    .geocode({ address: 'Leaning Tower of Pisa' }, (response) => {
+        if (response === "timeout") {
+            return;
+        }
+        console.log(`Geocode Address Results: ${response.json.results.length} ${response.json.status}`);
+        response.json.results.forEach(result => {
+            // $ExpectType GeocodingResult
+            result;
+        });
+    });
+client
+    .geocode({ components: { postal_code: '94043' } }, (response) => {
+        if (response === 'timeout') {
+            return;
+        }
+        console.log(`Geocode Component Results: ${response.json.results.length} ${response.json.status}`);
+        response.json.results.forEach(result => {
+            // $ExpectType GeocodingResult
+            result;
+        });
+    });
+
+// Client with promise support will have access to the asPromise method
+const promisableClient = createClient({
     key: 'my-google-maps-api-key',
     language: 'ja',
     // tslint:disable-next-line
     Promise: Promise,
 });
 
-client
+promisableClient
     .geocode({ address: 'Leaning Tower of Pisa' })
     .asPromise()
     .then(response => {
         console.log(`Geocode Address Results: ${response.json.results.length} ${response.json.status}`);
         response.json.results.forEach(result => {
-            console.log(result.geometry.location);
+            // $ExpectType GeocodingResult
+            result;
         });
     });
 
-client
+promisableClient
     .geocode({ components: { postal_code: '94043' } })
     .asPromise()
     .then(response => {
         console.log(`Geocode Component Results: ${response.json.results.length} ${response.json.status}`);
         response.json.results.forEach(result => {
-            console.log(result.geometry.location);
+            // $ExpectType GeocodingResult
+            result;
         });
     });

--- a/types/google__maps/index.d.ts
+++ b/types/google__maps/index.d.ts
@@ -3,12 +3,12 @@
 // Definitions by: Indri Muska <https://github.com/indrimuska>
 //                 Paul Huynh <https://github.com/pheromonez>
 // Definitions: https://github.com/indrimuska/google-maps-api-typings
-// TypeScript Version: 2.8
+// TypeScript Version: 2.3
 
 /**
  * Creates a Google Maps client. The client object contains all the API methods.
  */
-export interface CreateClientOptionsBase {
+export interface CreateClientOptions {
     /** API key (required, unless clientID and clientSecret provided). */
     key: string;
     /** Maps API for Work client ID. */
@@ -27,14 +27,10 @@ export interface CreateClientOptionsBase {
     retryOptions?: RetryOptions;
 }
 /** Create a Google Maps client, with Promise support. */
-export interface CreateClientOptionsWithPromise extends CreateClientOptionsBase {
+export interface CreateClientOptionsWithPromise extends CreateClientOptions {
     /** Promise constructor */
     Promise: PromiseConstructor;
 }
-/**
- * Creates a Google Maps client. The client object contains all the API methods.
- */
-export type CreateClientOptions = CreateClientOptionsBase | CreateClientOptionsWithPromise;
 
 export interface RateOptions {
     /** Controls rate-limiting of requests. Maximum number of requests per period. (Default: 50). */
@@ -48,11 +44,8 @@ export interface RetryOptions {
     interval?: number;
 }
 
-export type CreateClientResult<O extends CreateClientOptions> =
-    O extends CreateClientOptionsWithPromise ? GoogleMapsClient :
-    O extends CreateClientOptionsBase ? GoogleMapsClient<"WITHOUT_PROMISE"> :
-    never;
-export function createClient<O extends CreateClientOptions>(options: O): CreateClientResult<O>;
+export function createClient(options: CreateClientOptionsWithPromise): GoogleMapsClientWithPromise;
+export function createClient(options: CreateClientOptions): GoogleMapsClient;
 
 /**
  * A callback function, which is called asynchronously when an API method completes.
@@ -80,7 +73,7 @@ export interface ClientResponse<T> {
 }
 
 /** A handle that allows cancelling a request. */
-export interface RequestHandleBase<T> {
+export interface RequestHandle<T> {
     /**
      * Cancels the request.
      * The ResponseCallback will not be invoked, and promises will not be settled.
@@ -92,11 +85,11 @@ export interface RequestHandleBase<T> {
      * or having been cancelled. Use this to clean up resources.
      * Returns this handle, for chaining.
      */
-    finally(callback: () => void): RequestHandleBase<T>;
+    finally(callback: () => void): RequestHandle<T>;
 }
 
 /** A handle that allows cancelling a request, or obtaining a Promise. */
-export interface RequestHandleWithPromise<T> extends RequestHandleBase<T> {
+export interface RequestHandleWithPromise<T> extends RequestHandle<T> {
     /**
      * Returns the response as a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
      * This method is only available if you supplied the `Promise` constructor to the `createClient()` method when you constructed
@@ -104,11 +97,6 @@ export interface RequestHandleWithPromise<T> extends RequestHandleBase<T> {
      */
     asPromise(): Promise<ClientResponse<T>>;
 }
-
-export type RequestHandle<T, P extends Promisable> =
-    P extends "WITH_PROMISE" ? RequestHandleWithPromise<T> :
-    P extends "WITHOUT_PROMISE" ? RequestHandleBase<T> :
-    never;
 
 export type LatLngArray = [number, number];
 
@@ -275,15 +263,14 @@ export type Language = (
     'zh-TW'
 );
 
-export type Promisable = 'WITH_PROMISE' | 'WITHOUT_PROMISE';
-
-export type GoogleMapsClientEndpoint<Request, Response, P extends Promisable = "WITH_PROMISE"> = (query: Request, callback?: ResponseCallback<Response>) => RequestHandle<Response, P>;
+export type GoogleMapsClientEndpoint<Request, Response> = (query: Request, callback?: ResponseCallback<Response>) => RequestHandle<Response>;
+export type GoogleMapsClientEndpointWithPromise<Request, Response> = (query: Request, callback?: ResponseCallback<Response>) => RequestHandleWithPromise<Response>;
 
 /**
  * Google Maps clieant that provides access to all the APIs.
  * @param Promisable Determine if `asPromise()` is available in request. Default is WITHOUT_PROMISE.
  */
-export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
+export interface GoogleMapsClient {
     /**
      * The Directions API is a service that calculates directions between locations using an HTTP request.
      *
@@ -308,7 +295,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/maps/documentation/directions/intro
      */
-    directions: GoogleMapsClientEndpoint<DirectionsRequest, DirectionsResponse, P>;
+    directions: GoogleMapsClientEndpoint<DirectionsRequest, DirectionsResponse>;
     /**
      * The Distance Matrix API is a service that provides travel distance and time for a matrix of origins and destinations.
      * The API returns information based on the recommended route between start and end points, as calculated by the Google Maps API,
@@ -316,7 +303,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/maps/documentation/distance-matrix/intro
      */
-    distanceMatrix: GoogleMapsClientEndpoint<DistanceMatrixRequest, DistanceMatrixResponse, P>;
+    distanceMatrix: GoogleMapsClientEndpoint<DistanceMatrixRequest, DistanceMatrixResponse>;
     /**
      * The Elevation API provides a simple interface to query locations on the earth for elevation data. With the Elevation API,
      * you can develop hiking and biking applications, positioning applications, or low resolution surveying applications.
@@ -332,7 +319,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/maps/documentation/elevation/intro
      */
-    elevation: GoogleMapsClientEndpoint<ElevationRequest, ElevationResponse, P>;
+    elevation: GoogleMapsClientEndpoint<ElevationRequest, ElevationResponse>;
     /**
      * You may request sampled elevation data along paths, allowing you to calculate elevation changes along routes.
      * With the Elevation API, you can develop hiking and biking applications, positioning applications,
@@ -340,7 +327,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/maps/documentation/elevation/intro
      */
-    elevationAlongPath: GoogleMapsClientEndpoint<ElevationAlongPathRequest, ElevationResponse, P>;
+    elevationAlongPath: GoogleMapsClientEndpoint<ElevationAlongPathRequest, ElevationResponse>;
     /**
      * The Places API allows you to query for place information on a variety of categories, such as: establishments,
      * prominent points of interest, geographic locations, and more. You can search for places either by proximity or a text string.
@@ -352,7 +339,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/places/web-service/search#FindPlaceRequests
      */
-    findPlace: GoogleMapsClientEndpoint<FindPlaceRequest, FindPlaceFromTextResponse, P>;
+    findPlace: GoogleMapsClientEndpoint<FindPlaceRequest, FindPlaceFromTextResponse>;
     /**
      * **Geocoding** is the process of converting addresses (like "1600 Amphitheatre Parkway, Mountain View, CA")
      * into geographic coordinates (like latitude 37.423021 and longitude -122.083739),
@@ -371,7 +358,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/maps/documentation/geocoding/intro#GeocodingRequests
      */
-    geocode: GoogleMapsClientEndpoint<GeocodingRequest, GeocodingResponse, P>;
+    geocode: GoogleMapsClientEndpoint<GeocodingRequest, GeocodingResponse>;
     /**
      * The Geolocation API returns a location and accuracy radius based on information about cell towers and WiFi nodes
      * that the mobile client can detect. This document describes the protocol used to send this data to the server and
@@ -379,7 +366,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/maps/documentation/geolocation/intro
      */
-    geolocate: GoogleMapsClientEndpoint<GeolocationRequest, GeolocationResponse, P>;
+    geolocate: GoogleMapsClientEndpoint<GeolocationRequest, GeolocationResponse>;
     /**
      * The Roads API takes up to 100 independent coordinates, and returns the closest road segment for each point.
      * The points passed do not need to be part of a continuous path.
@@ -388,7 +375,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/maps/documentation/roads/nearest
      */
-    nearestRoads: GoogleMapsClientEndpoint<NearestRoadsRequest, NearestRoadsResponse, P>;
+    nearestRoads: GoogleMapsClientEndpoint<NearestRoadsRequest, NearestRoadsResponse>;
     /**
      * Once you have a `place_id` from a Place Search, you can request more details about a particular establishment
      * or point of interest by initiating a Place Details request. A Place Details request returns more comprehensive
@@ -396,7 +383,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/places/web-service/details
      */
-    place: GoogleMapsClientEndpoint<PlaceDetailsRequest, PlaceDetailsResponse, P>;
+    place: GoogleMapsClientEndpoint<PlaceDetailsRequest, PlaceDetailsResponse>;
     /**
      * The Google Places API Text Search Service is a web service that returns information about a set of places
      * based on a string — for example "pizza in New York" or "shoe stores near Ottawa" or "123 Main Street".
@@ -413,7 +400,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/places/web-service/search#TextSearchRequests
      */
-    places: GoogleMapsClientEndpoint<PlacesRequest, PlaceSearchResponse, P>;
+    places: GoogleMapsClientEndpoint<PlacesRequest, PlaceSearchResponse>;
     /**
      * The Place Autocomplete service is a web service that returns place predictions in response to an HTTP request.
      * The request specifies a textual search string and optional geographic bounds.
@@ -422,14 +409,14 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/places/web-service/autocomplete
      */
-    placesAutoComplete: GoogleMapsClientEndpoint<PlaceAutocompleteRequest, PlaceAutocompleteResponse, P>;
+    placesAutoComplete: GoogleMapsClientEndpoint<PlaceAutocompleteRequest, PlaceAutocompleteResponse>;
     /**
      * A Nearby Search lets you search for places within a specified area.
      * You can refine your search request by supplying keywords or specifying the type of place you are searching for.
      *
      * @see https://developers.google.com/places/web-service/search#PlaceSearchRequests
      */
-    placesNearby: GoogleMapsClientEndpoint<PlacesNearbyRequest, PlaceSearchResponse, P>;
+    placesNearby: GoogleMapsClientEndpoint<PlacesNearbyRequest, PlaceSearchResponse>;
     /**
      * The Place Photo service, part of the Places API, is a read- only API that allows you to add high quality photographic content
      * to your application. The Place Photo service gives you access to the millions of photos stored in the Places database.
@@ -439,7 +426,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/places/web-service/photos
      */
-    placesPhoto: GoogleMapsClientEndpoint<PlacePhotoRequest, PlacePhotoResponse, P>;
+    placesPhoto: GoogleMapsClientEndpoint<PlacePhotoRequest, PlacePhotoResponse>;
     /**
      * The Query Autocomplete service can be used to provide a query prediction for text-based geographic searches,
      * by returning suggested queries as you type.
@@ -451,7 +438,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/places/web-service/query
      */
-    placesQueryAutoComplete: GoogleMapsClientEndpoint<QueryAutocompleteRequest, QueryAutocompleteResponse, P>;
+    placesQueryAutoComplete: GoogleMapsClientEndpoint<QueryAutocompleteRequest, QueryAutocompleteResponse>;
     /**
      * The Google Places API Radar Search Service allows you to search for up to 200 places at once,
      * but with less detail than is typically returned from a Text Search or Nearby Search request.
@@ -465,13 +452,13 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/places/web-service/search#RadarSearchRequests
      */
-    placesRadar: GoogleMapsClientEndpoint<PlaceRadarRequest, PlaceSearchResponse, P>;
+    placesRadar: GoogleMapsClientEndpoint<PlaceRadarRequest, PlaceSearchResponse>;
     /**
      * Reverse geocoding is the process of converting geographic coordinates into a human-readable address.
      *
      * @see https://developers.google.com/maps/documentation/geocoding/intro#ReverseGeocoding
      */
-    reverseGeocode: GoogleMapsClientEndpoint<ReverseGeocodingRequest, ReverseGeocodingResponse, P>;
+    reverseGeocode: GoogleMapsClientEndpoint<ReverseGeocodingRequest, ReverseGeocodingResponse>;
     /**
      * The Roads API returns the posted speed limit for a given road segment.
      * In the case of road segments with variable speed limits, the default speed limit for the segment is returned.
@@ -483,7 +470,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/maps/documentation/roads/speed-limits
      */
-    snappedSpeedLimits: GoogleMapsClientEndpoint<SnappedSpeedLimitsRequest, SpeedLimitsResponse, P>;
+    snappedSpeedLimits: GoogleMapsClientEndpoint<SnappedSpeedLimitsRequest, SpeedLimitsResponse>;
     /**
      * The Roads API takes up to 100 GPS points collected along a route, and returns a similar set of data,
      * with the points snapped to the most likely roads the vehicle was traveling along.
@@ -491,7 +478,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/maps/documentation/roads/snap
      */
-    snapToRoads: GoogleMapsClientEndpoint<SnapToRoadsRequest, SnapToRoadsResponse, P>;
+    snapToRoads: GoogleMapsClientEndpoint<SnapToRoadsRequest, SnapToRoadsResponse>;
     /**
      * The Roads API returns the posted speed limit for a given road segment.
      * In the case of road segments with variable speed limits, the default speed limit for the segment is returned.
@@ -503,7 +490,7 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/maps/documentation/roads/speed-limits
      */
-    speedLimits: GoogleMapsClientEndpoint<SpeedLimitsRequest, SpeedLimitsResponse, P>;
+    speedLimits: GoogleMapsClientEndpoint<SpeedLimitsRequest, SpeedLimitsResponse>;
     /**
      * The Time Zone API provides a simple interface to request the time zone for locations on the surface of the earth,
      * as well as the time offset from UTC for each of those locations. You request the time zone information for
@@ -512,7 +499,242 @@ export interface GoogleMapsClient<P extends Promisable = "WITH_PROMISE"> {
      *
      * @see https://developers.google.com/maps/documentation/timezone/intro
      */
-    timezone: GoogleMapsClientEndpoint<TimeZoneRequest, TimeZoneResponse, P>;
+    timezone: GoogleMapsClientEndpoint<TimeZoneRequest, TimeZoneResponse>;
+}
+
+/**
+ * Google Maps clieant that provides access to all the APIs. This supports the `asPromise()` function on API calls.
+ */
+export interface GoogleMapsClientWithPromise {
+    /**
+     * The Directions API is a service that calculates directions between locations using an HTTP request.
+     *
+     * With the Directions API, you can:
+     *  - Search for directions for several modes of transportation, including transit, driving, walking or cycling.
+     *  - Return multi-part directions using a series of waypoints.
+     *  - Specify origins, destinations, and waypoints as text strings
+     *    (e.g. "Chicago, IL" or "Darwin, NT, Australia"), or as latitude/longitude coordinates, or as place IDs.
+     *
+     * The API returns the most efficient routes when calculating directions. Travel time is the primary factor optimized,
+     * but the API may also take into account other factors such as distance, number of turns and many more when deciding
+     * which route is the most efficient.
+     *
+     * **Tip:** Calculating directions is a time and resource intensive task. Whenever possible, use the service to calculate
+     * known addresses ahead of time and store the results in a
+     * [**temporary cache**](https://developers.google.com/maps/documentation/directions/policies#pre-fetching-caching-or-storage-of-content)
+     * of your own design.
+     *
+     * **Note:** This service is not designed to respond in real time to user input. For dynamic directions calculations
+     * (for example, within a user interface element), consult the documentation for the
+     * [Maps JavaScript API Directions Service](https://developers.google.com/maps/documentation/javascript/directions)
+     *
+     * @see https://developers.google.com/maps/documentation/directions/intro
+     */
+    directions: GoogleMapsClientEndpointWithPromise<DirectionsRequest, DirectionsResponse>;
+    /**
+     * The Distance Matrix API is a service that provides travel distance and time for a matrix of origins and destinations.
+     * The API returns information based on the recommended route between start and end points, as calculated by the Google Maps API,
+     * and consists of rows containing duration and distance values for each pair.
+     *
+     * @see https://developers.google.com/maps/documentation/distance-matrix/intro
+     */
+    distanceMatrix: GoogleMapsClientEndpointWithPromise<DistanceMatrixRequest, DistanceMatrixResponse>;
+    /**
+     * The Elevation API provides a simple interface to query locations on the earth for elevation data. With the Elevation API,
+     * you can develop hiking and biking applications, positioning applications, or low resolution surveying applications.
+     *
+     * Elevation data is available for all locations on the surface of the earth, including depth locations on the ocean floor
+     * (which return negative values). In those cases where Google does not possess exact elevation measurements at the precise
+     * location you request, the service interpolates and returns an averaged value using the four nearest locations.
+     * Elevation values are expressed relative to local mean sea level (LMSL).
+     *
+     * You access the Elevation API through an HTTP interface. Users of the Maps JavaScript API may also access this API directly
+     * by using the `ElevationService()` object.
+     * (See [Elevation Service](https://developers.google.com/maps/documentation/javascript/elevation) for more information.)
+     *
+     * @see https://developers.google.com/maps/documentation/elevation/intro
+     */
+    elevation: GoogleMapsClientEndpointWithPromise<ElevationRequest, ElevationResponse>;
+    /**
+     * You may request sampled elevation data along paths, allowing you to calculate elevation changes along routes.
+     * With the Elevation API, you can develop hiking and biking applications, positioning applications,
+     * or low resolution surveying applications.
+     *
+     * @see https://developers.google.com/maps/documentation/elevation/intro
+     */
+    elevationAlongPath: GoogleMapsClientEndpointWithPromise<ElevationAlongPathRequest, ElevationResponse>;
+    /**
+     * The Places API allows you to query for place information on a variety of categories, such as: establishments,
+     * prominent points of interest, geographic locations, and more. You can search for places either by proximity or a text string.
+     * A Place Search returns a list of places along with summary information about each place; additional information is available
+     * via a [Place Details](https://developers.google.com/places/web-service/details) query.
+     *
+     * A Find Place request takes a text input, and returns a place.
+     * The text input can be any kind of Places data, for example, a name, address, or phone number.
+     *
+     * @see https://developers.google.com/places/web-service/search#FindPlaceRequests
+     */
+    findPlace: GoogleMapsClientEndpointWithPromise<FindPlaceRequest, FindPlaceFromTextResponse>;
+    /**
+     * **Geocoding** is the process of converting addresses (like "1600 Amphitheatre Parkway, Mountain View, CA")
+     * into geographic coordinates (like latitude 37.423021 and longitude -122.083739),
+     * which you can use to place markers on a map, or position the map.
+     *
+     * **Note:** This service is generally designed for geocoding static (known in advance) addresses for placement
+     * of application content on a map; this service is not designed to respond in real time to user input.
+     * For dynamic geocoding (for example, within a user interface element), consult the documentation for the
+     * [Maps JavaScript API client geocoder](https://developers.google.com/maps/documentation/javascript/geocoding) and/or the
+     * [Google Play services Location APIs](https://developer.android.com/google/play-services/location.html).
+     *
+     * **Tip:** Geocoding is a time and resource intensive task. Whenever possible, pre-geocode known addresses
+     * (using the Geocoding API described here or another geocoding service), and store your results in a
+     * [**temporary cache**](https://developers.google.com/maps/documentation/geocoding/policies#pre-fetching-caching-or-storage-of-content)
+     * of your own design.
+     *
+     * @see https://developers.google.com/maps/documentation/geocoding/intro#GeocodingRequests
+     */
+    geocode: GoogleMapsClientEndpointWithPromise<GeocodingRequest, GeocodingResponse>;
+    /**
+     * The Geolocation API returns a location and accuracy radius based on information about cell towers and WiFi nodes
+     * that the mobile client can detect. This document describes the protocol used to send this data to the server and
+     * to return a response to the client.
+     *
+     * @see https://developers.google.com/maps/documentation/geolocation/intro
+     */
+    geolocate: GoogleMapsClientEndpointWithPromise<GeolocationRequest, GeolocationResponse>;
+    /**
+     * The Roads API takes up to 100 independent coordinates, and returns the closest road segment for each point.
+     * The points passed do not need to be part of a continuous path.
+     *
+     * If you are working with sequential GPS points, use [Snap to Roads](https://developers.google.com/maps/documentation/roads/snap).
+     *
+     * @see https://developers.google.com/maps/documentation/roads/nearest
+     */
+    nearestRoads: GoogleMapsClientEndpointWithPromise<NearestRoadsRequest, NearestRoadsResponse>;
+    /**
+     * Once you have a `place_id` from a Place Search, you can request more details about a particular establishment
+     * or point of interest by initiating a Place Details request. A Place Details request returns more comprehensive
+     * information about the indicated place such as its complete address, phone number, user rating and reviews.
+     *
+     * @see https://developers.google.com/places/web-service/details
+     */
+    place: GoogleMapsClientEndpointWithPromise<PlaceDetailsRequest, PlaceDetailsResponse>;
+    /**
+     * The Google Places API Text Search Service is a web service that returns information about a set of places
+     * based on a string — for example "pizza in New York" or "shoe stores near Ottawa" or "123 Main Street".
+     * The service responds with a list of places matching the text string and any location bias that has been set.
+     *
+     * The service is especially useful for making
+     * [ambiguous address queries](https://developers.google.com/maps/documentation/geocoding/best-practices) in an automated system,
+     * and non-address components of the string may match businesses as well as addresses.
+     * Examples of ambiguous address queries are incomplete addresses, poorly formatted addresses,
+     * or a request that includes non-address components such as business names.
+     *
+     * The search response will include a list of places. You can send a Place Details request
+     * for more information about any of the places in the response.
+     *
+     * @see https://developers.google.com/places/web-service/search#TextSearchRequests
+     */
+    places: GoogleMapsClientEndpointWithPromise<PlacesRequest, PlaceSearchResponse>;
+    /**
+     * The Place Autocomplete service is a web service that returns place predictions in response to an HTTP request.
+     * The request specifies a textual search string and optional geographic bounds.
+     * The service can be used to provide autocomplete functionality for text-based geographic searches,
+     * by returning places such as businesses, addresses and points of interest as a user types.
+     *
+     * @see https://developers.google.com/places/web-service/autocomplete
+     */
+    placesAutoComplete: GoogleMapsClientEndpointWithPromise<PlaceAutocompleteRequest, PlaceAutocompleteResponse>;
+    /**
+     * A Nearby Search lets you search for places within a specified area.
+     * You can refine your search request by supplying keywords or specifying the type of place you are searching for.
+     *
+     * @see https://developers.google.com/places/web-service/search#PlaceSearchRequests
+     */
+    placesNearby: GoogleMapsClientEndpointWithPromise<PlacesNearbyRequest, PlaceSearchResponse>;
+    /**
+     * The Place Photo service, part of the Places API, is a read- only API that allows you to add high quality photographic content
+     * to your application. The Place Photo service gives you access to the millions of photos stored in the Places database.
+     * When you get place information using a Place Details request, photo references will be returned for relevant photographic content.
+     * The Nearby Search and Text Search requests also return a single photo reference per place, when relevant.
+     * Using the Photo service you can then access the referenced photos and resize the image to the optimal size for your application.
+     *
+     * @see https://developers.google.com/places/web-service/photos
+     */
+    placesPhoto: GoogleMapsClientEndpointWithPromise<PlacePhotoRequest, PlacePhotoResponse>;
+    /**
+     * The Query Autocomplete service can be used to provide a query prediction for text-based geographic searches,
+     * by returning suggested queries as you type.
+     *
+     * The Query Autocomplete service allows you to add on-the-fly geographic query predictions to your application.
+     * Instead of searching for a specific location, a user can type in a categorical search, such as "pizza near New York"
+     * and the service responds with a list of suggested queries matching the string. As the Query Autocomplete service can match
+     * on both full words and substrings, applications can send queries as the user types to provide on-the-fly predictions.
+     *
+     * @see https://developers.google.com/places/web-service/query
+     */
+    placesQueryAutoComplete: GoogleMapsClientEndpointWithPromise<QueryAutocompleteRequest, QueryAutocompleteResponse>;
+    /**
+     * The Google Places API Radar Search Service allows you to search for up to 200 places at once,
+     * but with less detail than is typically returned from a Text Search or Nearby Search request.
+     * With Radar Search, you can create applications that help users identify specific areas of interest within a geographic area.
+     *
+     * The search response will include up to 200 places, and will include only the following information about each place:
+     *  - The `geometry` field containing geographic coordinates.
+     *  - The `place_id`, which you can use in a Place Details request to get more information about the place.
+     *
+     * @deprecated Radar search is deprecated as of June 30, 2018. After that time, this feature will no longer be available.
+     *
+     * @see https://developers.google.com/places/web-service/search#RadarSearchRequests
+     */
+    placesRadar: GoogleMapsClientEndpointWithPromise<PlaceRadarRequest, PlaceSearchResponse>;
+    /**
+     * Reverse geocoding is the process of converting geographic coordinates into a human-readable address.
+     *
+     * @see https://developers.google.com/maps/documentation/geocoding/intro#ReverseGeocoding
+     */
+    reverseGeocode: GoogleMapsClientEndpointWithPromise<ReverseGeocodingRequest, ReverseGeocodingResponse>;
+    /**
+     * The Roads API returns the posted speed limit for a given road segment.
+     * In the case of road segments with variable speed limits, the default speed limit for the segment is returned.
+     *
+     * The accuracy of speed limit data returned by the Roads API cannot be guaranteed.
+     * The speed limit data provided is not real-time, and may be estimated, inaccurate, incomplete, and/or outdated.
+     * You may report inaccuracies in our speed limit data by filing a case in the
+     * [Google Cloud Support Portal](https://developers.google.com/maps/premium/support#support_portal).
+     *
+     * @see https://developers.google.com/maps/documentation/roads/speed-limits
+     */
+    snappedSpeedLimits: GoogleMapsClientEndpointWithPromise<SnappedSpeedLimitsRequest, SpeedLimitsResponse>;
+    /**
+     * The Roads API takes up to 100 GPS points collected along a route, and returns a similar set of data,
+     * with the points snapped to the most likely roads the vehicle was traveling along.
+     * Optionally, you can request that the points be interpolated, resulting in a path that smoothly follows the geometry of the road.
+     *
+     * @see https://developers.google.com/maps/documentation/roads/snap
+     */
+    snapToRoads: GoogleMapsClientEndpointWithPromise<SnapToRoadsRequest, SnapToRoadsResponse>;
+    /**
+     * The Roads API returns the posted speed limit for a given road segment.
+     * In the case of road segments with variable speed limits, the default speed limit for the segment is returned.
+     *
+     * The accuracy of speed limit data returned by the Roads API cannot be guaranteed.
+     * The speed limit data provided is not real-time, and may be estimated, inaccurate, incomplete, and/or outdated.
+     * You may report inaccuracies in our speed limit data by filing a case in the
+     * [Google Cloud Support Portal](https://developers.google.com/maps/premium/support#support_portal).
+     *
+     * @see https://developers.google.com/maps/documentation/roads/speed-limits
+     */
+    speedLimits: GoogleMapsClientEndpointWithPromise<SpeedLimitsRequest, SpeedLimitsResponse>;
+    /**
+     * The Time Zone API provides a simple interface to request the time zone for locations on the surface of the earth,
+     * as well as the time offset from UTC for each of those locations. You request the time zone information for
+     * a specific latitude/longitude pair and date. The API returns the name of that time zone, the time offset from UTC,
+     * and the daylight savings offset.
+     *
+     * @see https://developers.google.com/maps/documentation/timezone/intro
+     */
+    timezone: GoogleMapsClientEndpointWithPromise<TimeZoneRequest, TimeZoneResponse>;
 }
 
 export interface DirectionsRequest {

--- a/types/google__maps/index.d.ts
+++ b/types/google__maps/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for @google/maps 0.5
 // Project: https://github.com/googlemaps/google-maps-services-js
 // Definitions by: Indri Muska <https://github.com/indrimuska>
-//                 Paul Huynh <https://github.com/pheromonez>
 // Definitions: https://github.com/indrimuska/google-maps-api-typings
 // TypeScript Version: 2.3
 
@@ -268,7 +267,6 @@ export type GoogleMapsClientEndpointWithPromise<Request, Response> = (query: Req
 
 /**
  * Google Maps clieant that provides access to all the APIs.
- * @param Promisable Determine if `asPromise()` is available in request. Default is WITHOUT_PROMISE.
  */
 export interface GoogleMapsClient {
     /**


### PR DESCRIPTION
All requests created with the `GoogleMapsClient` currently allow calling `asPromise()` even if the client was not created with the `Promise` option set.
This change will only add the `asRequest()` function to requests if they are made using a client that was created with `Promise` specified.

This makes use of a TypeScript 2.8 feature, [Conditional Types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#conditional-types), which will break compatibility with projects using older Typescript versions.

I've made the assumption that most people will be using Promises, so the behaviour of `GoogleMapsClient` will support `asPromise` by default. If anyone is using the `GoogleMapsClient` directly in their code then the type definitions will assume that promises are supported.
``` typescript
func doSomething (client: GoogleMapsClient) {
  // Promise supported by default
  client.geocode({...}).asPromise()...
}
```

On the other hand, if the user is not supporting promises then there will be a little more work, unfortunately.
``` typescript
func doSomething (client: GoogleMapsClient<"WITHOUT_PROMISE">) {
  // Promise not supported; will indicate that `asPromise` is not defined on type
  client.geocode({...}).asPromise()...
}
```

It _might_ be worth introducing a type alias for `GoogleMapsClient<"WITHOUT_PROMISE">` called `PromiselessGoogleMapsClient` or something, but ideally people wouldn't need to be using these types in their own code, and they would just be using the client in the way shown in the tests.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Source code](https://github.com/googlemaps/google-maps-services-js/blob/1e20ccc7264e8858723dcf4971d9ad10dc9e5ff2/lib/internal/make-api-call.js#L149); `asPromise` only added if `options.Promise` is defined