### PR TITLE
[react-breadcrumbs] fix: add missing 'separator' property to Breadcrumbs

### DIFF
--- a/types/react-breadcrumbs/index.d.ts
+++ b/types/react-breadcrumbs/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-breadcrumbs 2.1
 // Project: https://github.com/svenanders/react-breadcrumbs
 // Definitions by: Guo Yunhe <https://github.com/guoyunhe>
+//                 Kohei Matsubara <https://github.com/matsuby>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -13,6 +14,7 @@ declare module "react-breadcrumbs" {
     interface BreadcrumbsProps {
         className?: string;
         hidden?: boolean;
+        separator?: React.ReactNode;
         setCrumbs?: (crumbs: Crumbs) => React.ReactNode;
         wrapper?: React.StatelessComponent | React.ComponentClass;
     }

--- a/types/react-breadcrumbs/react-breadcrumbs-tests.tsx
+++ b/types/react-breadcrumbs/react-breadcrumbs-tests.tsx
@@ -18,6 +18,7 @@ class MyComponent extends React.Component {
                 <Breadcrumbs
                     className="demo__crumbs"
                     hidden
+                    separator="|"
                     setCrumbs={crumbs => null}
                     wrapper={Wrapper}
                 />


### PR DESCRIPTION
ref: https://github.com/svenanders/react-breadcrumbs/blob/v2.1.6/src/breadcrumbs.jsx#L16-L33

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29535/files>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.