### PR TITLE
fix: node.equals should allow null and undefined

### DIFF
--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -40,7 +40,7 @@ export interface NamedNode {
      * @param other The term to compare with.
      * @return True if and only if other has termType "NamedNode" and the same `value`.
      */
-    equals(other: Term): boolean;
+    equals(other: Term | null | undefined): boolean;
 }
 
 /**
@@ -63,7 +63,7 @@ export interface BlankNode {
      * @param other The term to compare with.
      * @return True if and only if other has termType "BlankNode" and the same `value`.
      */
-    equals(other: Term): boolean;
+    equals(other: Term | null | undefined): boolean;
 }
 
 /**
@@ -94,7 +94,7 @@ export interface Literal {
      * @return True if and only if other has termType "Literal"
      *                   and the same `value`, `language`, and `datatype`.
      */
-    equals(other: Term): boolean;
+    equals(other: Term | null | undefined): boolean;
 }
 
 /**
@@ -114,7 +114,7 @@ export interface Variable {
      * @param other The term to compare with.
      * @return True if and only if other has termType "Variable" and the same `value`.
      */
-    equals(other: Term): boolean;
+    equals(other: Term | null | undefined): boolean;
 }
 
 /**
@@ -135,7 +135,7 @@ export interface DefaultGraph {
      * @param other The term to compare with.
      * @return True if and only if other has termType "DefaultGraph".
      */
-    equals(other: Term): boolean;
+    equals(other: Term | null | undefined): boolean;
 }
 
 /**

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -14,29 +14,39 @@ function test_terms() {
     const namedNode: NamedNode = <any> {};
     const termType1: string = namedNode.termType;
     const value1: string = namedNode.value;
-    namedNode.equals(someTerm);
+    let namedNodeEqual: boolean = namedNode.equals(someTerm);
+    namedNodeEqual = namedNode.equals(null);
+    namedNodeEqual = namedNode.equals(undefined);
 
     const blankNode: BlankNode = <any> {};
     const termType2: string = blankNode.termType;
     const value2: string = blankNode.value;
-    blankNode.equals(someTerm);
+    let blankNodeEqual: boolean = blankNode.equals(someTerm);
+    blankNodeEqual = blankNode.equals(null);
+    blankNodeEqual = blankNode.equals(undefined);
 
     const literal: Literal = <any> {};
     const termType3: string = literal.termType;
     const value3: string = literal.value;
     const language3: string = literal.language;
     const datatype3: NamedNode = literal.datatype;
-    literal.equals(someTerm);
+    let literalEqual: boolean = literal.equals(someTerm);
+    literalEqual = literal.equals(null);
+    literalEqual = literal.equals(undefined);
 
     const variable: Variable = <any> {};
     const termType4: string = variable.termType;
     const value4: string = variable.value;
-    variable.equals(someTerm);
+    let variableEqual = variable.equals(someTerm);
+    variableEqual = variable.equals(null);
+    variableEqual = variable.equals(undefined);
 
     const defaultGraph: DefaultGraph = <any> {};
     const termType5: string = defaultGraph.termType;
     const value5: string = defaultGraph.value;
-    defaultGraph.equals(someTerm);
+    let defaultGraphEqual: boolean = defaultGraph.equals(someTerm);
+    defaultGraphEqual = defaultGraph.equals(null);
+    defaultGraphEqual = defaultGraph.equals(undefined);
 }
 
 function test_quads() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://rdf.js.org/data-model-spec/#dom-term-equals
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.