### PR TITLE
keygrip: Use ReadonlyArray for keys

### DIFF
--- a/types/keygrip/index.d.ts
+++ b/types/keygrip/index.d.ts
@@ -10,8 +10,8 @@ interface Keygrip {
 }
 
 interface KeygripFunction {
-    new (keys: string[], algorithm?: string, encoding?: string): Keygrip;
-    (keys: string[], algorithm?: string, encoding?: string): Keygrip;
+    new (keys: ReadonlyArray<string>, algorithm?: string, encoding?: string): Keygrip;
+    (keys: ReadonlyArray<string>, algorithm?: string, encoding?: string): Keygrip;
 }
 
 declare const Keygrip: KeygripFunction;

--- a/types/keygrip/keygrip-tests.ts
+++ b/types/keygrip/keygrip-tests.ts
@@ -1,4 +1,12 @@
 import * as Keygrip from 'keygrip';
 
 const keys = Keygrip(['123']);
+
+new Keygrip(['456']);
+
+const readonlyArray: ReadonlyArray<string> = ['789'];
+Keygrip(readonlyArray);
+
 const hash = keys.sign('abc');
+const index = keys.index('def', 'ghi');
+const verify = keys.verify('jkl', 'mno');


### PR DESCRIPTION
`keygrip` doesn't modify the `keys` argument, so I marked it as `ReadonlyArray`.

I also improved the tests.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/crypto-utils/keygrip/blob/master/index.js>