### PR TITLE
[sortablejs] adds some missing event properties

### DIFF
--- a/types/sortablejs/index.d.ts
+++ b/types/sortablejs/index.d.ts
@@ -139,6 +139,24 @@ declare namespace Sortable {
          * Pull mode if dragging into another sortable
          */
         pullMode: 'clone' | boolean | undefined;
+        /**
+         * When MultiDrag is used to sort, this holds a HTMLElement and oldIndex for each item selected.
+         *
+         * `oldIndicies[number]` is directly related to `newIndicies[number]`
+         *
+         * If MultiDrag is not used to sort, this array will be empty.
+         */
+        oldIndicies: { multiDragElement: HTMLElement; index: number }[];
+        /**
+         * When MultiDrag is used to sort, this holds a HTMLElement and newIndex for each item.
+         *
+         * `oldIndicies[number]` is directly related to `newIndicies[number]`
+         *
+         * If MultiDrag is not used to sort, this array will be empty.
+         */
+        newIndicies: { multiDragElement: HTMLElement; index: number }[];
+        /** When Swap is used to sort, this will contain the dragging item that was dropped on.*/
+        swapItem: HTMLElement | null;
     }
 
     export interface MoveEvent extends Event {

--- a/types/sortablejs/index.d.ts
+++ b/types/sortablejs/index.d.ts
@@ -96,7 +96,7 @@ declare namespace Sortable {
             SwapOptions {}
 
     /**
-     * A class that all plugins inherit from for the sake of types
+     * A class that all plugins inherit from for the sake of type inference.
      */
     export class Plugin extends SortablePlugin {}
     export class MultiDrag extends MultiDragPlugin {}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/SortableJS/Sortable/tree/master/plugins/MultiDrag#event-properties
  - https://github.com/SortableJS/Sortable/tree/master/plugins/Swap#event-properties