### PR TITLE
@hapi/joi: fixed invalid typed method 'append'

### DIFF
--- a/types/hapi__joi/index.d.ts
+++ b/types/hapi__joi/index.d.ts
@@ -1512,7 +1512,7 @@ declare namespace Joi {
         /**
          * Appends the allowed object keys. If schema is null, undefined, or {}, no changes will be applied.
          */
-        append(schema?: SchemaMap<TSchema>): this;
+        append<TAddSchema>(schema?: SchemaMap<TAddSchema>): ObjectSchema<TSchema & TAddSchema>;
 
         /**
          * Verifies an assertion where.


### PR DESCRIPTION
Fixed `ObjectSchems`'s method `append` to reflect [the spec](https://hapi.dev/family/joi/?v=16.1.8#objectappendschema).