### PR TITLE
Add types for scss-parser

### DIFF
--- a/types/scss-parser/index.d.ts
+++ b/types/scss-parser/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for scss-parser 1.0
+// Project: https://github.com/salesforce-ux/scss-parser
+// Definitions by: Wessel van der Linden <https://github.com/wesselvanderlinden>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface InputStreamPosition {
+  cursor: number;
+  line: number;
+  column: number;
+}
+
+export interface Node {
+  type: string;
+  value: string | Node[];
+  start?: InputStreamPosition;
+  end?: InputStreamPosition;
+}
+
+export function parse(css: string): Node;
+
+export function stringify(node: Node): string;

--- a/types/scss-parser/scss-parser-tests.ts
+++ b/types/scss-parser/scss-parser-tests.ts
@@ -1,0 +1,6 @@
+import { Node, parse, stringify } from "scss-parser";
+
+declare const node: Node;
+
+parse(''); // $ExpectType Node
+stringify(node); // $ExpectType string

--- a/types/scss-parser/tsconfig.json
+++ b/types/scss-parser/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "files": [
+        "index.d.ts",
+        "scss-parser-tests.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/scss-parser/tslint.json
+++ b/types/scss-parser/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.