### PR TITLE
Update jest-axe tests for new axe-core version

### DIFF
--- a/types/jest-axe/jest-axe-tests.ts
+++ b/types/jest-axe/jest-axe-tests.ts
@@ -10,6 +10,7 @@ const newJestWithOptions: JestAxe = configureAxe({
     rules: {},
     runOnly: {
         type: 'rules',
+        values: [],
     },
     selectors: false,
 });


### PR DESCRIPTION
I just fixed the type error; the actual value, `[]` is not valid at runtime because it is supposed to contain a list of rules. But the jest-axe test doesn't have any rules either. So the test is already invalid at runtime.
