### PR TITLE
Add isDirectory to resolve options

### DIFF
--- a/types/resolve/index.d.ts
+++ b/types/resolve/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for resolve
+// Type definitions for resolve 1.14.1
 // Project: https://github.com/substack/node-resolve
 // Definitions by: Mario Nebl <https://github.com/marionebl>
 //                 Klaus Meinhardt <https://github.com/ajafff>

--- a/types/resolve/index.d.ts
+++ b/types/resolve/index.d.ts
@@ -21,12 +21,12 @@ interface PackageMeta {
 type resolveCallback = (err: Error | null, resolved?: string, pkg?: PackageMeta) => void;
 
 /**
- * Callback invoked when checking if a file exists
+ * Callback invoked when checking if a file or directory exists
  *
  * @param error
- * @param isFile If the given file exists
+ * @param exists If the given file or directory exists
  */
-type isFileCallback = (err: Error | null, isFile?: boolean) => void;
+type existsCallback = (err: Error | null, isFile?: boolean) => void;
 
 /**
  * Callback invoked when reading a file
@@ -96,7 +96,9 @@ declare namespace resolve {
     /** how to read files asynchronously (defaults to fs.readFile) */
     readFile?: (file: string, cb: readFileCallback) => void;
     /** function to asynchronously test whether a file exists */
-    isFile?: (file: string, cb: isFileCallback) => void;
+    isFile?: (file: string, cb: existsCallback) => void;
+    /** function to asynchronously test whether a directory exists */
+    isDirectory?: (directory: string, cb: existsCallback) => boolean;
   }
 
   export interface SyncOpts extends Opts {
@@ -104,6 +106,8 @@ declare namespace resolve {
     readFileSync?: (file: string, charset: string) => string | Buffer;
     /** function to synchronously test whether a file exists */
     isFile?: (file: string) => boolean;
+    /** function to synchronously test whether a directory exists */
+    isDirectory?: (directory: string) => boolean;
   }
 
   export var sync: typeof resolveSync;

--- a/types/resolve/index.d.ts
+++ b/types/resolve/index.d.ts
@@ -98,7 +98,7 @@ declare namespace resolve {
     /** function to asynchronously test whether a file exists */
     isFile?: (file: string, cb: existsCallback) => void;
     /** function to asynchronously test whether a directory exists */
-    isDirectory?: (directory: string, cb: existsCallback) => boolean;
+    isDirectory?: (directory: string, cb: existsCallback) => void;
   }
 
   export interface SyncOpts extends Opts {

--- a/types/resolve/resolve-tests.ts
+++ b/types/resolve/resolve-tests.ts
@@ -2,107 +2,111 @@ import * as fs from 'fs';
 import resolve = require('resolve');
 
 function test_basic_async() {
-  resolve('typescript', function(error, resolved, pkg) {
-    if (error) {
-      console.error(error.message);
-      return;
-    }
-    console.log(resolved);
-    console.log(pkg.version);
-  });
+    resolve('typescript', function(error, resolved, pkg) {
+        if (error) {
+            console.error(error.message);
+            return;
+        }
+        console.log(resolved);
+        console.log(pkg.version);
+    });
 }
 
 function test_basic_sync() {
-  var resolved = resolve.sync('typescript');
-  console.log(resolved);
+    var resolved = resolve.sync('typescript');
+    console.log(resolved);
 }
 
 function test_options_async() {
-  resolve('typescript', {
-    basedir: process.cwd(),
-    package: {},
-    extensions: ['.js'],
-    packageFilter: function(pkg, pkgfile) {
-      return pkg;
-    },
-    pathFilter: function(pkg, path, relativePath) {
-      return path
-    },
-    paths: [process.cwd()],
-    moduleDirectory: 'node_modules',
-    readFile: fs.readFile,
-    isDirectory: function(directory, cb) {
-      fs.stat(directory, function(error, stat) {
-        if (error && error.code === 'ENOENT') {
-          return cb(null, false);
-        } else if (error) {
-          return cb(error);
-        } else {
-          return cb(null, stat.isDirectory());
-        }
-      });
-    },
-    isFile: function(file, cb) {
-      fs.stat(file, function(error, stat) {
-        if (error && error.code === 'ENOENT') {
-          return cb(null, false);
-        } else if (error) {
-          return cb(error);
-        } else {
-          return cb(null, stat.isFile());
-        }
-      });
-    },
-    preserveSymlinks: false,
-  }, function(error, resolved, pkg) {
-    if (error) {
-      console.error(error.message);
-      return;
-    }
-    console.log(resolved);
-    console.log(pkg.version);
-  });
+    resolve(
+        'typescript',
+        {
+            basedir: process.cwd(),
+            package: {},
+            extensions: ['.js'],
+            packageFilter: function(pkg, pkgfile) {
+                return pkg;
+            },
+            pathFilter: function(pkg, path, relativePath) {
+                return path;
+            },
+            paths: [process.cwd()],
+            moduleDirectory: 'node_modules',
+            readFile: fs.readFile,
+            isDirectory: function(directory, cb) {
+                fs.stat(directory, function(error, stat) {
+                    if (error && error.code === 'ENOENT') {
+                        return cb(null, false);
+                    } else if (error) {
+                        return cb(error);
+                    } else {
+                        return cb(null, stat.isDirectory());
+                    }
+                });
+            },
+            isFile: function(file, cb) {
+                fs.stat(file, function(error, stat) {
+                    if (error && error.code === 'ENOENT') {
+                        return cb(null, false);
+                    } else if (error) {
+                        return cb(error);
+                    } else {
+                        return cb(null, stat.isFile());
+                    }
+                });
+            },
+            preserveSymlinks: false,
+        },
+        function(error, resolved, pkg) {
+            if (error) {
+                console.error(error.message);
+                return;
+            }
+            console.log(resolved);
+            console.log(pkg.version);
+        },
+    );
 }
 
 function test_options_sync() {
-  var resolved = resolve.sync('typescript', {
-    basedir: process.cwd(),
-    package: {},
-    extensions: ['.js'],
-    packageFilter: function(pkg, pkgfile) {
-      return pkg;
-    },
-    pathFilter: function(pkg, path, relativePath) {
-      return path
-    },
-    paths: [process.cwd()],
-    moduleDirectory: 'node_modules',
-    readFileSync: fs.readFileSync,
-    isDirectory: function(directory) {
-      try {
-        return fs.statSync(directory).isDirectory();
-      } catch (error) {
-        return false;
-      }
-    },
-    isFile: function(file) {
-      try {
-        return fs.statSync(file).isFile();
-      } catch (error) {
-        return false;
-      }
-    },
-    preserveSymlinks: true,
-  });
-  console.log(resolved);
-  resolved = resolve.sync('typescript', {
-      readFileSync(file, charset) {
-          return fs.readFileSync(file, charset);
-      }
-  });
+    var resolved = resolve.sync('typescript', {
+        basedir: process.cwd(),
+        package: {},
+        extensions: ['.js'],
+        packageFilter: function(pkg, pkgfile) {
+            return pkg;
+        },
+        pathFilter: function(pkg, path, relativePath) {
+            return path;
+        },
+        paths: [process.cwd()],
+        moduleDirectory: 'node_modules',
+        readFileSync: fs.readFileSync,
+        isDirectory: function(directory) {
+            try {
+                return fs.statSync(directory).isDirectory();
+            } catch (error) {
+                return false;
+            }
+        },
+        isFile: function(file) {
+            try {
+                return fs.statSync(file).isFile();
+            } catch (error) {
+                return false;
+            }
+        },
+        preserveSymlinks: true,
+    });
+    console.log(resolved);
+    resolved = resolve.sync('typescript', {
+        readFileSync(file, charset) {
+            return fs.readFileSync(file, charset);
+        },
+    });
 }
 
 function test_is_core() {
-  var fsIsCore = resolve.isCore('fs');
-  var typescriptIsCore = resolve.isCore('typescript');
+    var fsIsCore = resolve.isCore('fs');
+    var typescriptIsCore = resolve.isCore('typescript');
 }

--- a/types/resolve/resolve-tests.ts
+++ b/types/resolve/resolve-tests.ts
@@ -31,6 +31,17 @@ function test_options_async() {
     paths: [process.cwd()],
     moduleDirectory: 'node_modules',
     readFile: fs.readFile,
+    isDirectory: function(directory, cb) {
+      fs.stat(directory, function(error, stat) {
+        if (error && error.code === 'ENOENT') {
+          return cb(null, false);
+        } else if (error) {
+          return cb(error);
+        } else {
+          return cb(null, stat.isDirectory());
+        }
+      });
+    },
     isFile: function(file, cb) {
       fs.stat(file, function(error, stat) {
         if (error && error.code === 'ENOENT') {
@@ -67,6 +78,13 @@ function test_options_sync() {
     paths: [process.cwd()],
     moduleDirectory: 'node_modules',
     readFileSync: fs.readFileSync,
+    isDirectory: function(directory) {
+      try {
+        return fs.statSync(directory).isDirectory();
+      } catch (error) {
+        return false;
+      }
+    },
     isFile: function(file) {
       try {
         return fs.statSync(file).isFile();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  https://github.com/browserify/resolve#resolveid-opts-cb 
  https://github.com/browserify/resolve#resolvesyncid-opts
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
