### PR TITLE
Add type definitions for blake2

### DIFF
--- a/types/blake2/blake2-tests.ts
+++ b/types/blake2/blake2-tests.ts
@@ -1,0 +1,11 @@
+import { createHash, createKeyedHash, Hash, KeyedHash } from 'blake2';
+
+const fakeKey = Buffer.alloc(0);
+const keyedHash: KeyedHash = createKeyedHash('blake2b', fakeKey);
+
+keyedHash.update(Buffer.alloc(0)).digest();
+
+const regularHash: Hash = createHash('blake2s', { digestLength: 256 });
+const regularHashViaCtor: Hash = new Hash('blake2bp');
+
+const copy: Hash = regularHash.copy();

--- a/types/blake2/index.d.ts
+++ b/types/blake2/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for blake2 4.0
+// Project: https://github.com/vrza/node-blake2
+// Definitions by: Antoine Beauvais-Lacasse <https://github.com/beaulac>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+import { Transform, TransformOptions } from 'stream';
+import { HexBase64Latin1Encoding } from 'crypto';
+
+export interface Blake2Options extends TransformOptions {
+    digestLength: number;
+}
+
+export type Blake2Algorithm = 'blake2b' | 'blake2bp' | 'blake2s' | 'blake2sp' | 'bypass';
+
+export class Hash extends Transform {
+    constructor(algorithm: Blake2Algorithm, options?: Blake2Options);
+
+    update(buf: Buffer): this;
+
+    digest(encoding: HexBase64Latin1Encoding): string;
+    digest(): Buffer;
+
+    copy(): this;
+}
+
+export function createHash(algorithm: Blake2Algorithm, options?: Blake2Options): Hash;
+
+export class KeyedHash extends Transform {
+    constructor(algorithm: Blake2Algorithm, key: Buffer, options?: Blake2Options);
+
+    update(buf: Buffer): this;
+
+    digest(encoding: HexBase64Latin1Encoding): string;
+    digest(): Buffer;
+
+    copy(): this;
+}
+
+export function createKeyedHash(algorithm: Blake2Algorithm, key: Buffer, options?: Blake2Options): KeyedHash;

--- a/types/blake2/tsconfig.json
+++ b/types/blake2/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "blake2-tests.ts"
+    ]
+}

--- a/types/blake2/tslint.json
+++ b/types/blake2/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adds (new) type definitions for [blake2](https://www.npmjs.com/package/blake2)


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

New type definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
