### PR TITLE
[jszip] add string output type

### DIFF
--- a/types/jszip/index.d.ts
+++ b/types/jszip/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for JSZip 3.1
 // Project: http://stuk.github.com/jszip/, https://github.com/stuk/jszip
-// Definitions by: mzeiher <https://github.com/mzeiher>, forabi <https://github.com/forabi>
+// Definitions by: mzeiher <https://github.com/mzeiher>
+//                 forabi <https://github.com/forabi>
+//                 Florian Keller <https://github.com/ffflorian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -15,7 +17,7 @@ interface JSZipSupport {
 
 type Compression = 'STORE' | 'DEFLATE';
 
-interface Metadata  {
+interface Metadata {
     percent: number;
     currentFile: string;
 }
@@ -37,6 +39,7 @@ interface InputByType {
 interface OutputByType {
     base64: string;
     text: string;
+    string: string;
     binarystring: string;
     array: number[];
     uint8array: Uint8Array;

--- a/types/jszip/jszip-tests.ts
+++ b/types/jszip/jszip-tests.ts
@@ -69,6 +69,10 @@ function testJSZip() {
 		}).catch((e: any) => log(SEVERITY.ERROR, e));
 
 	const folder = newJszip.folder("test");
+
+		folder.file("test.txt").async('string'); // $ExpectType Promise<string>
+		folder.file("test.txt").async('text'); // $ExpectType Promise<string>
+
 		folder.file("test.txt").async('text').then((text: string) => {
 			if (text === "test string") {
 		log(SEVERITY.INFO, "all ok");


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stuk.github.io/jszip/documentation/api_zipobject/async.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
