### PR TITLE
Add esModule to the plugin options interface of mini-css-extract-plugin

### DIFF
--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -35,10 +35,10 @@ declare namespace MiniCssExtractPlugin {
          */
         ignoreOrder?: boolean;
         /**
-        * By default, mini-css-extract-plugin generates JS modules that use the CommonJS
-        * modules syntax. There are some cases in which using ES modules is beneficial,
-        * like in the case of module concatenation and tree shaking.
-        */
+         * By default, mini-css-extract-plugin generates JS modules that use the CommonJS
+         * modules syntax. There are some cases in which using ES modules is beneficial,
+         * like in the case of module concatenation and tree shaking.
+         */
         esModule?: boolean;
     }
 }

--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mini-css-extract-plugin 0.8
+// Type definitions for mini-css-extract-plugin 0.9
 // Project: https://github.com/webpack-contrib/mini-css-extract-plugin
 // Definitions by: JounQin <https://github.com/JounQin>
 //                 Katsuya Hino <https://github.com/dobogo>
@@ -34,6 +34,12 @@ declare namespace MiniCssExtractPlugin {
          * disabled by setting this flag to true for the plugin.
          */
         ignoreOrder?: boolean;
+        /**
+        * By default, mini-css-extract-plugin generates JS modules that use the CommonJS
+        * modules syntax. There are some cases in which using ES modules is beneficial,
+        * like in the case of module concatenation and tree shaking.
+        */
+        esModule?: boolean;
     }
 }
 


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack-contrib/mini-css-extract-plugin#esmodule
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.