### PR TITLE
fix(matter-js): collision filter parameter should have been optional

### DIFF
--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -3096,9 +3096,9 @@ declare namespace Matter {
     }
 
     export interface ICollisionFilter {
-        category: number;
-        mask: number;
-        group: number;
+        category?: number;
+        mask?: number;
+        group?: number;
     }
 
     export interface IMousePoint {

--- a/types/matter-js/matter-js-tests.ts
+++ b/types/matter-js/matter-js-tests.ts
@@ -46,6 +46,17 @@ Body.setCentre(circle1, Matter.Vector.create(10, 10), true);
 World.addBody(engine.world, box1);
 World.add(engine.world, [box2, circle1]);
 
+// Body - collision filter
+var box3 = Bodies.rectangle(400,200,80,80, {
+	collisionFilter: {
+		category: 1 // Allows only one option to be defined
+	}
+});
+
+var box4 = Bodies.rectangle(400,200,80,80, {
+	collisionFilter: {} // Or none
+});
+
 
 //Composites
 var stack = Composites.stack(0, 100, 5, 1, 20, 0, function(x:number, y:number, column:number, row:number) {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: ([code](https://brm.io/matter-js/docs/classes/Body.html#property_collisionFilter.category))

As per the [documentation](https://brm.io/matter-js/docs/classes/Body.html#property_collisionFilter.category) and the [demo code](https://github.com/liabru/matter-js/blob/master/examples/collisionFiltering.js#L87), the `collisionFilter` option is not all required. It has their own default values, therefore, in my opinion it should have been optional. Let me know if this was a mistake. Thank you.