### PR TITLE
feat(stripe-v3): Update methods options. Closes #41144

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -55,6 +55,11 @@ declare namespace stripe {
             clientSecret: string,
             options?: HandleCardPaymentWithoutElementsOptions,
         ): Promise<PaymentIntentResponse>;
+        /**
+         * Use stripe.confirmCardPayment when the customer submits your payment form.
+         * When called, it will confirm the PaymentIntent with data you provide and
+         * carry out 3DS or other next actions if they are required.
+         */
         confirmCardPayment(
             clientSecret: string,
             data?: ConfirmCardPaymentData,
@@ -87,6 +92,7 @@ declare namespace stripe {
             clientSecret: string,
             data?: ConfirmSepaDebitSetupData,
         ): Promise<SetupIntentResponse>;
+        /** @deprecated */
         confirmPaymentIntent(
             clientSecret: string,
             element: elements.Element,
@@ -427,11 +433,19 @@ declare namespace stripe {
     }
 
     interface ShippingDetails {
+        /** Shipping address. */
         address: ShippingDetailsAddress;
-        name: string | null;
-        carrier: string | null;
-        phone: string | null;
-        tracking_number: string | null;
+        /** Recipient name. */
+        name: string;
+        /** The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc. */
+        carrier?: string;
+        /** Recipient phone (including extension). */
+        phone?: string;
+        /**
+         * The tracking number for a physical product, obtained from the delivery service.
+         * If multiple tracking numbers were generated for this purchase, please separate them with commas.
+         */
+        tracking_number?: string;
     }
 
     interface CreatePaymentMethodOptions {
@@ -502,12 +516,16 @@ declare namespace stripe {
        source?: string;
     }
 
+    /**
+     * Data to be sent with the request.
+     * Refer to the Payment Intents API for a full list of parameters.
+     */
     interface ConfirmCardPaymentData {
         /*
-         * Pass an object to confirm using data collected by a card or
-         * cardNumber Element or an with an existing token and to supply
-         * additional data relevant to the PaymentMethod, such as billing
-         * details:
+         * Either the id of an existing PaymentMethod,
+         * or an object containing data to create a PaymentMethod with.
+         * See the use case sections below for details.
+         * Recomended
          */
         payment_method?: string | {
             /*
@@ -526,6 +544,30 @@ declare namespace stripe {
              */
             billing_details?: BillingDetails,
         };
+        /**
+         * The shipping details for the payment, if collected.
+         * Recomended
+         */
+        shipping?: ShippingDetails;
+        /**
+         * If you are handling next actions yourself,
+         * pass in a return_url. If the subsequent action is redirect_to_url,
+         * this URL will be used on the return path for the redirect.
+         */
+        return_url?: string;
+        /**
+         * Email address that the receipt for the resulting payment will be sent to.
+         */
+        receipt_email?: string;
+        /**
+         * If the PaymentIntent is associated with a customer and this parameter is set to true,
+         * the provided payment method will be attached to the customer. Default is false.
+         */
+        save_payment_method?: boolean;
+        /**
+         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+         */
+        setup_future_usage?: boolean;
     }
     interface ConfirmCardPaymentOptions {
         /*
@@ -585,10 +627,8 @@ declare namespace stripe {
 
     interface ConfirmPaymentIntentOptions {
         /**
-         * A return_url may be supplied if you are not planning to use
-         * stripe.handleCardPayment to complete the payment. If you are
-         * handling next actions yourself, pass in a return_url. If the
-         * subsequent action is redirect_to_url, this URL will be used
+         * If you are handling next actions yourself, pass in a return_url.
+         * If the subsequent action is redirect_to_url, this URL will be used
          * on the return path for the redirect.
          */
         return_url?: string;
@@ -616,6 +656,10 @@ declare namespace stripe {
          * customer. Default is false.
          */
         save_payment_method?: boolean;
+        /**
+         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+         */
+        setup_future_usage?: string;
     }
 
     interface ConfirmPaymentIntentWithoutElementsOptions extends ConfirmPaymentIntentOptions {

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -278,23 +278,97 @@ describe("Stripe elements", () => {
             }
           });
 
-        stripe.confirmCardPayment(
-            'pi_18eYalAHEMiOZZp1l9ZTjSU0_secret_NibvRz4PMmJqjfb0sqmT7aq2',
-            {
-                payment_method: {
-                    card,
+        // confirmCardPayment
+
+        // stripe.confirmCardPayment(clientSecret)
+        stripe
+            .confirmCardPayment(
+                'pi_18eYalAHEMiOZZp1l9ZTjSU0_secret_NibvRz4PMmJqjfb0sqmT7aq2'
+            )
+            .then(_result => {
+                // Handle result.error or result.paymentIntent
+            });
+        // stripe.confirmCardPayment(clientSecret,data?)
+        stripe
+            .confirmCardPayment(
+                'pi_18eYalAHEMiOZZp1l9ZTjSU0_secret_NibvRz4PMmJqjfb0sqmT7aq2',
+                {
+                    payment_method: {
+                        card,
+                        billing_details: {
+                            name: 'Jenny Rosen',
+                        },
+                    },
+                    shipping: {
+                        address: {
+                            line1: 'Line 1',
+                        },
+                        name: 'Recipient name',
+                    },
+                }
+            )
+            .then(_result => {
+                // Handle result.error or result.paymentIntent
+            });
+        // stripe.confirmCardPayment(clientSecret,data?,options?)
+        stripe
+            .confirmCardPayment(
+                'pi_18eYalAHEMiOZZp1l9ZTjSU0_secret_NibvRz4PMmJqjfb0sqmT7aq2',
+                {
+                    payment_method: {
+                        card,
+                        billing_details: {
+                            name: 'Jenny Rosen',
+                        },
+                    },
+                },
+                {
+                    handleActions: false,
+                }
+            )
+            .then(_result => {
+                // Handle result.error or result.paymentIntent
+            });
+
+        // confirmPaymentIntent
+
+        // stripe.confirmPaymentIntent(clientSecret)
+        stripe
+            .confirmPaymentIntent('{PAYMENT_INTENT_CLIENT_SECRET}')
+            .then(_result => {
+                // Handle result.error or result.paymentIntent
+            });
+
+        // stripe.confirmPaymentIntent(clientSecret,element)
+        stripe
+            .confirmPaymentIntent('{PAYMENT_INTENT_CLIENT_SECRET}', card)
+            .then(_result => {
+                // Handle result.error or result.paymentIntent
+            });
+
+        // stripe.confirmPaymentIntent(clientSecret,element,data?)
+        stripe
+            .confirmPaymentIntent('{PAYMENT_INTENT_CLIENT_SECRET}', card, {
+                payment_method_data: {
                     billing_details: {
                         name: 'Jenny Rosen',
                     },
-                }
-            }
-        ).then(result => {
-            if (result.error) {
-                console.error(result.error.message);
-            } else if (result.paymentIntent) {
-              console.log(result.paymentIntent.source);
-            }
-        });
+                },
+                return_url: 'https://example.com/return_url',
+            })
+            .then(_result => {
+                // Handle result.error or result.paymentIntent
+            });
+
+        // stripe.confirmPaymentIntent(clientSecret,data?)
+        stripe
+            .confirmPaymentIntent('{PAYMENT_INTENT_CLIENT_SECRET}', {
+                payment_method: '{PAYMENT_METHOD_ID}',
+                return_url: 'https://example.com/return_url',
+            })
+            .then(_result => {
+                // Handle result.error or result.paymentIntent
+            });
 
         const ibanElement = elements.create('iban');
         stripe.confirmSepaDebitPayment(


### PR DESCRIPTION
- new and missing documentation for `ShippingDetails`,
`CreatePaymentMethodOptions`, `ConfirmPaymentIntentOptions`
- @deprecated tag for `confirmPaymentIntent`
- tests update

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/js/payment_intents/confirm_card_payment
https://stripe.com/docs/js/deprecated/confirm_payment_intent
https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-shipping