### PR TITLE
[codemirror] EditorConfiguration.scrollbarStyle

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -941,7 +941,7 @@ declare namespace CodeMirror {
          * Chooses a scrollbar implementation. The default is "native", showing native scrollbars. The core library also
          * provides the "null" style, which completely hides the scrollbars. Addons can implement additional scrollbar models.
          */
-        scrollbarStyle?: string;
+        scrollbarStyle: string | null;
 
         /**
          * When fixedGutter is on, and there is a horizontal scrollbar, by default the gutter will be visible to the left of this scrollbar.


### PR DESCRIPTION
`EditorConfiguration.scrollbarStyle` must not be set to `undefined` (CodeMirror would fail to set up because of [how initScrollbars() works](https://github.com/codemirror/CodeMirror/blob/ed8dfeb5e2ed25b5dd1f1eccc7b757ca6dbd118d/src/display/scrollbars.js#L180), expecting a [valid key for scrollbarModel](https://github.com/codemirror/CodeMirror/blob/ed8dfeb5e2ed25b5dd1f1eccc7b757ca6dbd118d/src/display/scrollbars.js#L171)). Scrollbars should be disabled with `null`.