### PR TITLE
Add types for bcp-47

### DIFF
--- a/types/bcp-47/bcp-47-tests.ts
+++ b/types/bcp-47/bcp-47-tests.ts
@@ -1,0 +1,21 @@
+import bcp47 = require('bcp-47');
+
+const bcpParse = bcp47.parse;
+const bcpStringify = bcp47.stringify;
+
+const result: bcp47.Schema = bcpParse('en-US');
+
+const locale: string = bcpStringify(result);
+
+const schema: bcp47.Schema = {
+    language: 'en',
+    region: 'US'
+};
+
+bcpStringify(schema);
+
+const parseOptions: bcp47.ParseOptions = {
+    warning: (message: string, code: number, offset: number) => {},
+};
+
+bcpParse('en-US', parseOptions);

--- a/types/bcp-47/index.d.ts
+++ b/types/bcp-47/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for bcp-47 1.0
+// Project: https://github.com/wooorm/bcp-47#readme
+// Definitions by: Chris Barth <https://github.com/cjbarth>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function parse(tag: string, options?: ParseOptions): Schema;
+export function stringify(schema: Schema): string;
+
+export interface ParseOptions {
+    warning?: (errorMessage: string, errorCode: ErrorCodes, offset: number) => void;
+    forgiving?: boolean;
+    normalize?: boolean;
+}
+
+export interface Schema {
+    language?: string;
+    extendedLanguageSubtags?: string[];
+    script?: string;
+    region?: string;
+    variants?: string[];
+    extensions?: LocaleExtension[];
+    privateuse?: string[];
+    regular?: string;
+    irregular?: string;
+}
+
+export interface LocaleExtension {
+    singleton: string;
+    extensions: string[];
+}
+
+export enum ErrorCodes {
+    errVariantTooLong = 1,
+    errExtensionTooLong = 2,
+    errTooManySubtags = 3,
+    errEmptyExtension = 4,
+    errPrivateUseTooLong = 5,
+    errExtraContent = 6,
+}

--- a/types/bcp-47/tsconfig.json
+++ b/types/bcp-47/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "bcp-47-tests.ts"
+    ]
+}

--- a/types/bcp-47/tslint.json
+++ b/types/bcp-47/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
