### PR TITLE
Add types for bcp-47-match

### DIFF
--- a/types/bcp-47-match/bcp-47-match-tests.ts
+++ b/types/bcp-47-match/bcp-47-match-tests.ts
@@ -1,0 +1,17 @@
+import bcp47Match = require('bcp-47-match');
+
+const basic = bcp47Match.basicFilter;
+const extended = bcp47Match.extendedFilter;
+const lookup = bcp47Match.lookup;
+
+const tags = ['en', 'es'];
+const ranges = ['en-US', 'es-US'];
+
+const basicResult1: string[] = basic(tags, ranges);
+const basicResult2: string[] = basic(tags[0], ranges[0]);
+
+const extendedResult1: string[] = extended(tags, ranges);
+const extendedResult2: string[] = extended(tags[0], ranges[0]);
+
+const lookupResult1: string | undefined = lookup(tags, ranges);
+const lookupResult2: string | undefined = lookup(tags[0], ranges[0]);

--- a/types/bcp-47-match/index.d.ts
+++ b/types/bcp-47-match/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for bcp-47-match 1.0
+// Project: https://github.com/wooorm/bcp-47-match#readme
+// Definitions by: Chris Barth <https://github.com/cjbarth>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function basicFilter(tags: string | string[], ranges: string | string[]): string[];
+export function extendedFilter(tags: string | string[], ranges: string | string[]): string[];
+export function lookup(tags: string | string[], ranges: string | string[]): string | undefined;

--- a/types/bcp-47-match/tsconfig.json
+++ b/types/bcp-47-match/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "bcp-47-match-tests.ts"
+    ]
+}

--- a/types/bcp-47-match/tslint.json
+++ b/types/bcp-47-match/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
