### PR TITLE
blueimp-load-image: Add Event to LoadImageCallback argument

### DIFF
--- a/types/blueimp-load-image/blueimp-load-image-tests.ts
+++ b/types/blueimp-load-image/blueimp-load-image-tests.ts
@@ -22,7 +22,7 @@ const b64DataJPEG =
   '2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwDAQACEQMRAD8A/v4ooooA/9k=';
 const imageUrlJPEG = 'data:image/jpeg;base64,' + b64DataJPEG;
 
-loadImage(imageUrlJPEG, (image: HTMLCanvasElement | HTMLImageElement, data?: MetaData): void => {
+loadImage(imageUrlJPEG, (image: Event | HTMLCanvasElement | HTMLImageElement, data?: MetaData): void => {
   const canvas = image as HTMLCanvasElement;
   console.log(data);
   canvas.toBlob((blob: Blob | null): void => {

--- a/types/blueimp-load-image/index.d.ts
+++ b/types/blueimp-load-image/index.d.ts
@@ -8,7 +8,7 @@
 
 /// <reference types="node" />
 
-export type LoadImageCallback = (image: HTMLCanvasElement | HTMLImageElement, data?: MetaData) => void;
+export type LoadImageCallback = (eventOrImage: Event | HTMLCanvasElement | HTMLImageElement, data?: MetaData) => void;
 
 export type ParseMetaDataCallback = (data: ImageHead) => void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    
    https://github.com/blueimp/JavaScript-Load-Image#api
    
    Specifically the section that says:
    > The callback function is passed two arguments.
    > The first is either an HTML img element, a canvas element, or an Event object of type error.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

----

I'm not sure how I should bump the version number for this. It will introduce type errors because consumers won't be handling the `Event` type — that feels like a breaking change. On the other hand it looks like the version number of this package tries to mirror that of blueimp-load-image — that will be lost if the major version number increases.

Let me know what you'd like me to do.