### PR TITLE
[styled-components] Allow props from initial component when using as

### DIFF
--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -158,8 +158,8 @@ export interface StyledComponentBase<
         props: StyledComponentProps<C, T, O, A> & { as?: never }
       ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
     <AsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C>(
-      props: StyledComponentPropsWithAs<AsC, T, O, A>
-    ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A>>;
+      props: Partial<StyledComponentProps<C, T, O, A>> & StyledComponentPropsWithAs<AsC, T, O, A>
+    ): React.ReactElement<Partial<StyledComponentProps<C, T, O, A>> & StyledComponentPropsWithAs<AsC, T, O, A>>;
 
     withComponent<WithC extends AnyStyledComponent>(
         component: WithC

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -610,9 +610,10 @@ class Test2Container extends React.Component<Test2ContainerProps> {
     }
 }
 
-const containerTest = (
-    <StyledTestContainer as={Test2Container} type='foo' />
-);
+<StyledTestContainer as={Test2Container} type="foo" />;
+<StyledTestContainer as={Test2Container} size="small" type="foo" />;
+<StyledTestContainer as={Test2Container} size="small" type="foo" foo="bar" />; // $ExpectError
+
 
 // 4.0 refs
 


### PR DESCRIPTION
When using the `as` prop, the props from the original component are skipped. 

```ts
type Props = {
  foo: string;
};

const StyledDiv = styled.div<Props>``;

<StyledDiv foo="bar" />;
<StyledDiv as="span" foo="bar" />; // This is supposed to be valid but reports an error
```

This PR makes initial component props allowed when using the `as` prop.

--- 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
