### PR TITLE
Add types for bmp-js

### DIFF
--- a/types/bmp-js/bmp-js-tests.ts
+++ b/types/bmp-js/bmp-js-tests.ts
@@ -1,0 +1,8 @@
+import { decode, encode } from "bmp-js";
+import { readFileSync, writeFileSync } from "fs";
+
+const bmpBuffer = readFileSync('grayscale.bmp');
+const decoded = decode(bmpBuffer);
+const { width, height, data } = decoded;
+console.log("got bmp with %s x %s (%s bytes)", width, height, data.byteLength);
+writeFileSync("testoutput.bmp", encode(decoded).data);

--- a/types/bmp-js/index.d.ts
+++ b/types/bmp-js/index.d.ts
@@ -1,0 +1,76 @@
+// Type definitions for bmp-js 0.1
+// Project: https://github.com/shaozilee/bmp-js
+// Definitions by: Robert Krahn <https://github.com/rksm>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+export interface ImageData {
+    readonly data: Buffer;
+    readonly height: number;
+    readonly width: number;
+}
+
+export type Encode = (imgData: ImageData, quality?: number) => ImageData;
+
+/**
+ * Bmp format decoder, support 1bit 4bit 8bit 24bit bmp
+ */
+export class BmpDecoder implements ImageData {
+    private pos: number;
+    data: Buffer;
+    fileSize: number;
+    reserved: number;
+    offset: number;
+    headerSize: number;
+    width: number;
+    height: number;
+    planes: number;
+    bitPP: number;
+    compress: number;
+    rawSize: number;
+    hr: number;
+    vr: number;
+    colors: number;
+    importantColors: number;
+    bottom_up: boolean;
+
+    palette: Array<{
+        red: number;
+        green: number;
+        blue: number;
+        quad: number;
+    }>;
+
+    constructor(buffer: Buffer, is_with_alpha?: boolean);
+
+    /**
+     * Returns the data buffer - byte array order by ABGR ABGR ABGR,4 bytes per pixel
+     */
+    getData(): Buffer;
+
+    private parseHeader(): void;
+    private parseRGBA(): void;
+    private bit1(): void;
+    private bit4(): void;
+    private bit8(): void;
+    private bit15(): void;
+    private bit16(): void;
+    private bit24(): void;
+    private bit32(): void;
+}
+
+export type Decode = (bmpData: Buffer) => BmpDecoder;
+
+/**
+ * var bmp = require("bmp-js");
+ * var bmpBuffer = fs.readFileSync('bit24.bmp');
+ * var bmpData = bmp.decode(bmpBuffer);
+ */
+export const decode: Decode;
+
+/**
+ * var bmp = require("bmp-js");
+ * var rawData = bmp.encode(bmpData); //default no compression,write rawData to .bmp file
+ */
+export const encode: Encode;

--- a/types/bmp-js/tsconfig.json
+++ b/types/bmp-js/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "bmp-js-tests.ts"
+  ]
+}

--- a/types/bmp-js/tslint.json
+++ b/types/bmp-js/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
