### PR TITLE
[esquery] use discriminated union for Selector

### DIFF
--- a/types/esquery/esquery-tests.ts
+++ b/types/esquery/esquery-tests.ts
@@ -10,7 +10,7 @@ function f (n) {
 
 const s = 'FunctionDeclaration !VariableDeclaration > VariableDeclarator[init.value > 3]';
 
-// $ExpectType Selector | undefined
+// $ExpectType Selector
 const selector = esquery.parse(s);
 
 // $ExpectType Node[]
@@ -22,16 +22,27 @@ esquery(AST, s);
 // $ExpectError
 esquery.parse(3);
 
-if (selector) {
-    // $ExpectType Node[]
-    esquery.match(AST, selector);
+// $ExpectType Node[]
+esquery.match(AST, selector);
 
-    // $ExpectError
-    esquery.match(AST, 'VariableDeclarator');
+// $ExpectError
+esquery.match(AST, 'VariableDeclarator');
 
-    // $ExpectType boolean
-    esquery.matches(nodes[0], selector, esquery(AST, 'FunctionDeclaration'));
-}
+// $ExpectType boolean
+esquery.matches(nodes[0], selector, esquery(AST, 'FunctionDeclaration'));
 
 // $ExpectError
 esquery.match(3, selector);
+
+switch (selector.type) {
+    case 'adjacent':
+        // $ExpectType SubjectSelector
+        selector.left;
+        // $ExpectType SubjectSelector
+        selector.right;
+        break;
+
+    case 'attribute':
+        // $ExpectType string
+        selector.name;
+}

--- a/types/esquery/index.d.ts
+++ b/types/esquery/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for esquery 1.0
 // Project: https://github.com/jrfeenst/esquery
 // Definitions by: cherryblossom000 <https://github.com/cherryblossom000>
+//                 Brad Zacher <https://github.com/bradzacher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Node } from 'estree';
@@ -9,35 +10,12 @@ export as namespace esquery;
 
 export = query;
 
-interface Atom { type: string; }
-
-interface Literal extends Atom {
-    type: 'literal';
-    value: string | number;
-}
-interface StringLiteral extends Literal { value: string; }
-interface NumericLiteral extends Literal { value: number; }
-interface RegExpSelector extends Atom {
-    type: 'regexp';
-    value: RegExp;
-}
-
-interface Nth extends query.Selector { index: NumericLiteral; }
-interface BinarySelector extends query.Selector {
-    type: 'child' | 'sibling' | 'adjacent' | 'descendant';
-    left: query.Selector;
-    right: query.Selector;
-}
-interface MultiSelector extends query.Selector {
-    selectors: query.Selector[];
-}
-
 /** Query the code AST using the selector string. */
 declare function query(ast: Node, selector: string): Node[];
 
 declare namespace query {
     /** Parse a selector and return its AST. */
-    function parse(selector: string): Selector | undefined;
+    function parse(selector: string): Selector;
     /** From a JS AST and a selector AST, collect all JS AST nodes that match the selector. */
     function match(ast: Node, selector: Selector): Node[];
     /** Given a `node` and its ancestors, determine if `node` is matched by `selector`. */
@@ -45,8 +23,86 @@ declare namespace query {
     /** Query the code AST using the selector string. */
     function query(ast: Node, selector: string): Node[];
 
-    interface Selector extends Atom { subject?: boolean; }
+    //
+    // Unions
+    //
+    type Selector =  Field
+        | Type
+        | Sequence
+        | Identifier
+        | Wildcard
+        | Attribute
+        | NthChild
+        | NthLastChild
+        | Descendant
+        | Child
+        | Sibling
+        | Adjacent
+        | Negation
+        | Matches
+        | Has
+        | Class;
+    type MultiSelector = Sequence
+        | Negation
+        | Matches
+        | Has;
+    type BinarySelector = Descendant
+        | Child
+        | Sibling
+        | Adjacent;
+    type NthSelector = NthChild
+        | NthLastChild;
+    type SubjectSelector = NthSelector
+        | BinarySelector
+        | MultiSelector
+        | Identifier
+        | Wildcard
+        | Attribute;
+    type Literal = StringLiteral
+        | NumericLiteral;
 
+    //
+    // Base Atoms
+    //
+    interface Atom {
+        type: string;
+    }
+    interface SubjectSelectorAtom extends Atom {
+        subject?: boolean;
+    }
+    interface NthSelectorAtom extends SubjectSelectorAtom {
+        index: NumericLiteral;
+    }
+    interface BinarySelectorAtom extends SubjectSelectorAtom {
+        type: 'child' | 'sibling' | 'adjacent' | 'descendant';
+        left: SubjectSelector;
+        right: SubjectSelector;
+    }
+    interface MultiSelectorAtom extends SubjectSelectorAtom {
+        selectors: SubjectSelector[];
+    }
+    interface LiteralAtom extends Atom {
+        type: 'literal';
+        value: string | number;
+    }
+
+    //
+    // Literals
+    //
+    interface StringLiteral extends LiteralAtom {
+        value: string;
+    }
+    interface NumericLiteral extends LiteralAtom {
+        value: number;
+    }
+    interface RegExpLiteral extends Atom {
+        type: 'regexp';
+        value: RegExp;
+    }
+
+    //
+    // Atoms
+    //
     interface Field extends Atom {
         type: 'field';
         name: string;
@@ -55,30 +111,50 @@ declare namespace query {
         type: 'type';
         value: string;
     }
-    interface Sequence extends MultiSelector { type: 'compound'; }
-    interface Identifier extends Selector {
+    interface Sequence extends MultiSelectorAtom {
+        type: 'compound';
+    }
+    interface Identifier extends SubjectSelectorAtom {
         type: 'identifier';
         value: string;
     }
-    interface Wildcard extends Selector {
+    interface Wildcard extends SubjectSelectorAtom {
         type: 'wildcard';
         value: '*';
     }
-    interface Attribute extends Selector {
+    interface Attribute extends SubjectSelectorAtom {
         type: 'attribute';
         name: string;
         operator?: '=' | '!=' | '>' | '<' | '>=' | '<=';
-        value?: Literal | RegExpSelector | Type;
+        value?: Literal | RegExpLiteral | Type;
     }
-    interface NthChild extends Nth { type: 'nth-child'; }
-    interface NthLastChild extends Nth { type: 'nth-last-child'; }
-    interface Descendant extends BinarySelector { type: 'descendant'; }
-    interface Child extends BinarySelector { type: 'child'; }
-    interface Sibling extends BinarySelector { type: 'sibling'; }
-    interface Adjacent extends BinarySelector { type: 'adjacent'; }
-    interface Negation extends MultiSelector { type: 'not'; }
-    interface Matches extends MultiSelector { type: 'matches'; }
-    interface Has extends MultiSelector { type: 'has'; }
+    interface NthChild extends NthSelectorAtom {
+        type: 'nth-child';
+    }
+    interface NthLastChild extends NthSelectorAtom {
+        type: 'nth-last-child';
+    }
+    interface Descendant extends BinarySelectorAtom {
+        type: 'descendant';
+    }
+    interface Child extends BinarySelectorAtom {
+        type: 'child';
+    }
+    interface Sibling extends BinarySelectorAtom {
+        type: 'sibling';
+    }
+    interface Adjacent extends BinarySelectorAtom {
+        type: 'adjacent';
+    }
+    interface Negation extends MultiSelectorAtom {
+        type: 'not';
+    }
+    interface Matches extends MultiSelectorAtom {
+        type: 'matches';
+    }
+    interface Has extends MultiSelectorAtom {
+        type: 'has';
+    }
     interface Class extends Atom {
         type: 'class';
         name: 'declaration' | 'expression' | 'function' | 'pattern' | 'statement';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~ N/A
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~ N/A
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~ N/A

---

The initial types returned the "super type" `Selector` interface. This makes it really hard to use the types, because you have to do manual assertion casts after checking the `type` prop:
```ts
const selector = esquery.parse(selectorString);
switch (selector.type) {
    case 'adjacent':
        // $ExpectError
        selector.left;

        const adjacentSelector = selector as esquery.Adjacent;
        // $ExpectType SubjectSelector
        selector.left;
        break;

    case 'attribute':
        // $ExpectError
        selector.name;

        const attributeSelector = selector as esquery.Attribute;
        // $ExpectType string
        selector.name;
}
```

This PR just introduces a discriminated union on top of the existing types, so that this now "just works":
```ts
const selector = esquery.parse(selectorString);
switch (selector.type) {
    case 'adjacent':
        // $ExpectType SubjectSelector
        selector.left;
        // $ExpectType SubjectSelector
        selector.right;
        break;

    case 'attribute':
        // $ExpectType string
        selector.name;
}
```

Also, upon inspecting the source code, it looks like `esquery.parse` can never return `undefined`, it only returns a valid selector, or it throws.