### PR TITLE
[@types/stripe] Fix IPaymentIntentListOptions

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -7593,7 +7593,7 @@ declare namespace Stripe {
             /**
              * Only return PaymentIntents for the customer specified by this customer ID.
              */
-            customer?: string
+            customer?: string;
         }
     }
 

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -35,6 +35,7 @@
 //                 Aseel Al Dallal <https://github.com/Aseelaldallal>
 //                 Collin Pham <https://github.com/collin-pham>
 //                 Timon van Spronsen <https://github.com/TimonVS>
+//                 Sean Chen <https://github.com/kamiyo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -7590,14 +7591,9 @@ declare namespace Stripe {
 
         interface IPaymentIntentListOptions extends IListOptionsCreated {
             /**
-             * Filter links by their expiration status. By default, all links are returned.
+             * Only return PaymentIntents for the customer specified by this customer ID.
              */
-            expired?: boolean;
-
-            /**
-             * Only return links for the given file.
-             */
-            file?: boolean;
+            customer?: string
         }
     }
 

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -2091,6 +2091,7 @@ stripe.paymentIntents.create(
         amount: 2000,
         currency: 'eur',
         payment_method_types: ['card', 'ideal', 'sepa_debit'],
+        customer: 'cus_5rfJKDJkuxzh5Q',
     },
     (err, intent) => {},
 );
@@ -2100,6 +2101,7 @@ stripe.paymentIntents
         amount: 2000,
         currency: 'eur',
         payment_method_types: ['card', 'ideal', 'sepa_debit'],
+        customer: 'cus_5rfJKDJkuxzh5Q',
     })
     .then(intent => {});
 
@@ -2107,8 +2109,8 @@ stripe.paymentIntents.list({}, (err, intent) => {});
 stripe.paymentIntents.list({}).then(intent => {});
 stripe.paymentIntents.list((err, intent) => {});
 stripe.paymentIntents.list().then(intent => {});
-stripe.paymentIntents.list({ expired: true }, (err, intent) => {});
-stripe.paymentIntents.list({ expired: true }).then(intent => {});
+stripe.paymentIntents.list({ customer: 'cus_5rfJKDJkuxzh5Q' }, (err, intent) => {});
+stripe.paymentIntents.list({ customer: 'cus_5rfJKDJkuxzh5Q' }).then(intent => {});
 
 stripe.paymentIntents.update(
     'pi_Aabcxyz01aDfoo',


### PR DESCRIPTION
IPaymentIntentListOptions had incorrect fields (seemed like it was copied from IFileLinkListOptions).
Fixed it to contain only customer as an optional string (in addition to the extended interfaces), per [Stripe API](https://stripe.com/docs/api/payment_intents/list).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Stripe API](https://stripe.com/docs/api/payment_intents/list)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
