### PR TITLE
Add types for remove-files-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,9 @@
             "_comment": "This will remove husky from when we started migrating to use prettier",
             "pre-commit": "npm uninstall husky"
         }
+    },
+    "dependencies": {
+        "@types/source-map": "^0.5.7",
+        "@types/webpack": "^4.41.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -31,9 +31,5 @@
             "_comment": "This will remove husky from when we started migrating to use prettier",
             "pre-commit": "npm uninstall husky"
         }
-    },
-    "dependencies": {
-        "@types/source-map": "^0.5.7",
-        "@types/webpack": "^4.41.0"
     }
 }

--- a/types/remove-files-webpack-plugin/index.d.ts
+++ b/types/remove-files-webpack-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for remove-files-webpack-plugin 1.2.0
+// Type definitions for remove-files-webpack-plugin 1.2
 // Project: https://github.com/Amaimersion/remove-files-webpack-plugin/blob/master/README.md
 // Definitions by: Sergey Kuznetsov <https://github.com/Amaimersion>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/remove-files-webpack-plugin/index.d.ts
+++ b/types/remove-files-webpack-plugin/index.d.ts
@@ -2,11 +2,9 @@
 // Project: https://github.com/Amaimersion/remove-files-webpack-plugin/blob/master/README.md
 // Definitions by: Sergey Kuznetsov <https://github.com/Amaimersion>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.7.3
+// TypeScript Version: 3.7
 
-
-import {Plugin, compilation, Compiler} from "webpack";
-
+import { Plugin, compilation, Compiler } from "webpack";
 
 /**
  * A plugin for webpack that removes files and
@@ -16,7 +14,6 @@ declare class RemovePlugin extends Plugin {
     constructor(parameters: PluginParameters);
     apply(compiler: Compiler): void;
 }
-
 
 /**
  * A parameters of plugin.
@@ -32,7 +29,6 @@ interface PluginParameters {
      */
     after?: RemoveParameters;
 }
-
 
 /**
  * A parameters of removing.
@@ -128,7 +124,6 @@ interface RemoveParameters {
     allowRootAndOutside?: boolean;
 }
 
-
 /**
  * A folder for testing of files that should be removed.
  */
@@ -153,6 +148,5 @@ interface TestObject {
      */
     recursive?: boolean;
 }
-
 
 export = RemovePlugin;

--- a/types/remove-files-webpack-plugin/index.d.ts
+++ b/types/remove-files-webpack-plugin/index.d.ts
@@ -1,0 +1,158 @@
+// Type definitions for remove-files-webpack-plugin 1.2.0
+// Project: https://github.com/Amaimersion/remove-files-webpack-plugin/blob/master/README.md
+// Definitions by: Sergey Kuznetsov <https://github.com/Amaimersion>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.7.3
+
+
+import {Plugin, compilation, Compiler} from "webpack";
+
+
+/**
+ * A plugin for webpack that removes files and
+ * folders before and after compilation.
+ */
+declare class RemovePlugin extends Plugin {
+    constructor(parameters: PluginParameters);
+    apply(compiler: Compiler): void;
+}
+
+
+/**
+ * A parameters of plugin.
+ */
+interface PluginParameters {
+    /**
+     * Executes before compilation.
+     */
+    before?: RemoveParameters;
+
+    /**
+     * Executes after compilation.
+     */
+    after?: RemoveParameters;
+}
+
+
+/**
+ * A parameters of removing.
+ */
+interface RemoveParameters {
+    /**
+     * A root directory.
+     * Not absolute paths will be appended to this.
+     *
+     * Defaults to `.` (where package.json and
+     * node_modules are located).
+     */
+    root?: string;
+
+    /**
+     * A folders or files for removing.
+     *
+     * Defaults to `[]`.
+     */
+    include?: ReadonlyArray<string>;
+
+    /**
+     * A files for excluding.
+     *
+     * Defaults to `[]`.
+     */
+    exclude?: ReadonlyArray<string>;
+
+    /**
+     * A folders for testing.
+     *
+     * Defaults to `[]`.
+     */
+    test?: ReadonlyArray<TestObject>;
+
+    /**
+     * Move folders or files to trash (recycle bin)
+     * instead of permanent removing.
+     *
+     * Defaults to `true`.
+     */
+    trash?: boolean;
+
+    /**
+     * Print messages of "info" level
+     * (example: "Which folders or files have been removed").
+     *
+     * Defaults to `true`.
+     */
+    log?: boolean;
+
+    /**
+     * Print messages of "warning" level
+     * (example: "An items for removing not found").
+     *
+     * Defaults to `true`.
+     */
+    logWarning?: boolean;
+
+    /**
+     * Print messages of "error" level
+     * (example: "No such file or directory").
+     *
+     * Defaults to `false`.
+     */
+    logError?: boolean;
+
+    /**
+     * Print messages of "debug" level
+     * (used for developers of the plugin).
+     *
+     * Defaults to `false`.
+     */
+    logDebug?: boolean;
+
+    /**
+     * Emulate remove process.
+     * Print which folders or files will be removed
+     * without actually removing them.
+     * Ignores `log` value.
+     *
+     * Defaults to `false`.
+     */
+    emulate?: boolean;
+
+    /**
+     * Allow removing of `root` directory or outside `root` directory.
+     * It is kind of safe mode.
+     * **Don't turn it on if you don't know what you actually do!**
+     *
+     * Defaults to `false`.
+     */
+    allowRootAndOutside?: boolean;
+}
+
+
+/**
+ * A folder for testing of files that should be removed.
+ */
+interface TestObject {
+    /**
+     * A path to the folder.
+     */
+    folder: string;
+
+    /**
+     * A method that accepts file path
+     * (root + directoryPath + fileName) and
+     * returns value that indicates should be
+     * this file be removed or not.
+     */
+    method: (filePath: string) => boolean;
+
+    /**
+     * Test in all subfolders, not just in `folder`.
+     *
+     * Defaults to `false`.
+     */
+    recursive?: boolean;
+}
+
+
+export = RemovePlugin;

--- a/types/remove-files-webpack-plugin/remove-files-webpack-plugin-tests.ts
+++ b/types/remove-files-webpack-plugin/remove-files-webpack-plugin-tests.ts
@@ -1,6 +1,5 @@
 import RemovePlugin = require("remove-files-webpack-plugin");
 
-
 new RemovePlugin({
     before: {
         root: ".",

--- a/types/remove-files-webpack-plugin/remove-files-webpack-plugin-tests.ts
+++ b/types/remove-files-webpack-plugin/remove-files-webpack-plugin-tests.ts
@@ -1,0 +1,38 @@
+import RemovePlugin = require("remove-files-webpack-plugin");
+
+
+new RemovePlugin({
+    before: {
+        root: ".",
+        include: [
+            "./test"
+        ],
+        exclude: [
+            "./test/test.txt"
+        ],
+        trash: false,
+        log: false,
+        emulate: true,
+        allowRootAndOutside: true
+    },
+    after: {
+        test: [
+            {
+                folder: "./",
+                method: (filePath) => {
+                    return filePath.includes('.map');
+                }
+            },
+            {
+                folder: "./test",
+                method: (filePath) => {
+                    return filePath.includes('.map');
+                },
+                recursive: true
+            }
+        ],
+        logWarning: true,
+        logError: true,
+        logDebug: true
+    }
+});

--- a/types/remove-files-webpack-plugin/tsconfig.json
+++ b/types/remove-files-webpack-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "remove-files-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/remove-files-webpack-plugin/tslint.json
+++ b/types/remove-files-webpack-plugin/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Hello.

Here is a types for remove-files-webpack-plugin.
GitHub – https://github.com/Amaimersion/remove-files-webpack-plugin
NPM – https://www.npmjs.com/package/remove-files-webpack-plugin

# Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
  - **Note**: current JSDoc types in the plugin file cannot be treated as a providing of it's own types. I created it only for local usage and not all editors or IDE's can treat this as a truly type.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
