### PR TITLE
Add pica library type definition files

### DIFF
--- a/types/pica/index.d.ts
+++ b/types/pica/index.d.ts
@@ -70,7 +70,7 @@ interface PicaResizeOptions {
 
 interface PicaResizeBufferOptions {
     // Uint8Array with source data.
-    src?: number[];
+    src: number[];
     // src image width.
     width: number;
     // src image height.

--- a/types/pica/index.d.ts
+++ b/types/pica/index.d.ts
@@ -1,0 +1,85 @@
+// Type definitions for pica 5.1
+// Project: https://github.com/nodeca/pica
+// Definitions by: Hamit YILMAZ <https://github.com/hmtylmz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare class Pica {
+    constructor(config?: PicaOptions);
+    /**
+     * Resize image from one canvas (or image) to another. Sizes are taken from source and destination objects.
+     * Result is Promise, resolved with to on success.
+     * (!) If you need to process multiple images, do it sequentially to optimize CPU & memory use. Pica already knows how to use multiple cores (if browser allows).
+     */
+    resize(
+        from: HTMLCanvasElement | HTMLImageElement | File | Blob,
+        to: HTMLCanvasElement,
+        options?: PicaResizeOptions
+    ): Promise<HTMLCanvasElement>;
+
+    /**
+     * Convenience method, similar to canvas.toBlob(), but with promise interface & polyfill for old browsers.
+     */
+    toBlob(
+        canvas: HTMLCanvasElement,
+        mimeType: string,
+        quality?: number
+    ): Promise<Blob>;
+
+    /**
+     * Supplementary method, not recommended for direct use. Resize Uint8Array with raw RGBA bitmap (don't confuse with jpeg / png / ... binaries). It does not use tiles & webworkers. Left for special cases when you really need to process raw binary data (for example, if you decode jpeg files "manually").
+     */
+    resizeBuffer(
+        options: PicaResizeBufferOptions
+    ): Promise<Array<number>>;
+}
+
+interface PicaOptions {
+    // tile width/height. Images are processed by regions, to restrict peak memory use. Default 1024.
+    tile?: number;
+    // list of features to use. Default is [ 'js', 'wasm', 'ww' ]. Can be [ 'js', 'wasm', 'cib', 'ww' ] or [ 'all' ]. Note, resize via createImageBitmap() ('cib') disabled by default due problems with quality.
+    features?: Array<string>;
+    // cache timeout, ms. Webworkers create is not fast. This option allow reuse webworkers effectively. Default 2000.
+    idle?: number;
+    // max webworkers pool size. Default is autodetected CPU count, but not more than 4.
+    concurrency?: number;
+}
+
+interface PicaResizeOptions {
+    // 0..3. Default = 3 (lanczos, win=3).
+    quality?: number;
+    // use alpha channel. Default = false.
+    alpha?: boolean;
+    // >=0, in percents. Default = 0 (off). Usually between 50 to 100 is good.
+    unsharpAmount?: number;
+    //  0.5..2.0. By default it's not set. Radius of Gaussian blur. If it is less than 0.5, Unsharp Mask is off. Big values are clamped to 2.0.
+    unsharpRadius?: number;
+    // 0..255. Default = 0. Threshold for applying unsharp mask.
+    unsharpThreshold?: number;
+    // Promise instance. If defined, current operation will be terminated on rejection.
+    cancelToken?: string;
+}
+
+interface PicaResizeBufferOptions {
+    // Uint8Array with source data.
+    src?: Array<number>;
+    // src image width.
+    width: number;
+    // src image height.
+    height: number;
+    // output width, >=0, in pixels.
+    toWidth: number;
+    // output height, >=0, in pixels.
+    toHeigh: number;
+    // 0..3. Default = 3 (lanczos, win=3).
+    quality?: number;
+    // use alpha channel. Default = false.
+    alpha?: boolean;
+    // >=0, in percents. Default = 0 (off). Usually between 50 to 100 is good.
+    unsharpAmount?: number;
+    // 0.5..2.0. Radius of Gaussian blur. If it is less than 0.5, Unsharp Mask is off. Big values are clamped to 2.0.
+    unsharpRadius?: number;
+    // 0..255. Default = 0. Threshold for applying unsharp mask.
+    unsharpThreshold?: number;
+    // Optional. Output buffer to write data, if you don't wish pica to create new one.
+    dest?: string;
+}

--- a/types/pica/index.d.ts
+++ b/types/pica/index.d.ts
@@ -6,9 +6,11 @@
 declare class Pica {
     constructor(config?: PicaOptions);
     /**
-     * Resize image from one canvas (or image) to another. Sizes are taken from source and destination objects.
+     * Resize image from one canvas (or image) to another.
+     * Sizes are taken from source and destination objects.
      * Result is Promise, resolved with to on success.
-     * (!) If you need to process multiple images, do it sequentially to optimize CPU & memory use. Pica already knows how to use multiple cores (if browser allows).
+     * (!) If you need to process multiple images, do it sequentially to optimize CPU & memory use.
+     * Pica already knows how to use multiple cores (if browser allows).
      */
     resize(
         from: HTMLCanvasElement | HTMLImageElement | File | Blob,
@@ -26,19 +28,25 @@ declare class Pica {
     ): Promise<Blob>;
 
     /**
-     * Supplementary method, not recommended for direct use. Resize Uint8Array with raw RGBA bitmap (don't confuse with jpeg / png / ... binaries). It does not use tiles & webworkers. Left for special cases when you really need to process raw binary data (for example, if you decode jpeg files "manually").
+     * Supplementary method, not recommended for direct use.
+     * Resize Uint8Array with raw RGBA bitmap (don't confuse with jpeg / png / ... binaries).
+     * It does not use tiles & webworkers. Left for special cases when you really need to process raw binary data (for example, if you decode jpeg files "manually").
      */
     resizeBuffer(
         options: PicaResizeBufferOptions
-    ): Promise<Array<number>>;
+    ): Promise<number[]>;
 }
 
 interface PicaOptions {
-    // tile width/height. Images are processed by regions, to restrict peak memory use. Default 1024.
+    // tile width/height.
+    // Images are processed by regions, to restrict peak memory use. Default 1024.
     tile?: number;
-    // list of features to use. Default is [ 'js', 'wasm', 'ww' ]. Can be [ 'js', 'wasm', 'cib', 'ww' ] or [ 'all' ]. Note, resize via createImageBitmap() ('cib') disabled by default due problems with quality.
-    features?: Array<string>;
-    // cache timeout, ms. Webworkers create is not fast. This option allow reuse webworkers effectively. Default 2000.
+    // list of features to use.
+    // Default is [ 'js', 'wasm', 'ww' ]. Can be [ 'js', 'wasm', 'cib', 'ww' ] or [ 'all' ].
+    // Note, resize via createImageBitmap() ('cib') disabled by default due problems with quality.
+    features?: string[];
+    // cache timeout, ms. Webworkers create is not fast.
+    // This option allow reuse webworkers effectively. Default 2000.
     idle?: number;
     // max webworkers pool size. Default is autodetected CPU count, but not more than 4.
     concurrency?: number;
@@ -51,7 +59,8 @@ interface PicaResizeOptions {
     alpha?: boolean;
     // >=0, in percents. Default = 0 (off). Usually between 50 to 100 is good.
     unsharpAmount?: number;
-    //  0.5..2.0. By default it's not set. Radius of Gaussian blur. If it is less than 0.5, Unsharp Mask is off. Big values are clamped to 2.0.
+    //  0.5..2.0. By default it's not set. Radius of Gaussian blur.
+    // If it is less than 0.5, Unsharp Mask is off. Big values are clamped to 2.0.
     unsharpRadius?: number;
     // 0..255. Default = 0. Threshold for applying unsharp mask.
     unsharpThreshold?: number;
@@ -61,7 +70,7 @@ interface PicaResizeOptions {
 
 interface PicaResizeBufferOptions {
     // Uint8Array with source data.
-    src?: Array<number>;
+    src?: number[];
     // src image width.
     width: number;
     // src image height.
@@ -76,7 +85,8 @@ interface PicaResizeBufferOptions {
     alpha?: boolean;
     // >=0, in percents. Default = 0 (off). Usually between 50 to 100 is good.
     unsharpAmount?: number;
-    // 0.5..2.0. Radius of Gaussian blur. If it is less than 0.5, Unsharp Mask is off. Big values are clamped to 2.0.
+    // 0.5..2.0. Radius of Gaussian blur.
+    // If it is less than 0.5, Unsharp Mask is off. Big values are clamped to 2.0.
     unsharpRadius?: number;
     // 0..255. Default = 0. Threshold for applying unsharp mask.
     unsharpThreshold?: number;

--- a/types/pica/pica-tests.ts
+++ b/types/pica/pica-tests.ts
@@ -31,7 +31,9 @@ resizer.toBlob(canvas, 'image/png', 9);
 resizerWithOptions.toBlob(canvas, 'image/png', 9);
 
 // Resize buffer
+let resizeBufferSrc: number[] = [21, 31];
 let resizeBufferOptions: PicaResizeBufferOptions = {
+    src: resizeBufferSrc,
     width: 100,
     height: 100,
     toWidth: 50,

--- a/types/pica/pica-tests.ts
+++ b/types/pica/pica-tests.ts
@@ -1,0 +1,34 @@
+let picaOptions: PicaOptions = { features: ['js', 'wasm', 'ww', 'cib'] };
+let resizer: Pica = new Pica(picaOptions);
+
+let image: HTMLImageElement = document.createElement('img');
+image.width = 100;
+image.height = 100;
+
+let canvas: HTMLCanvasElement = document.createElement('canvas');
+canvas.width = 100;
+canvas.height = 100;
+
+// Resize image
+resizer.resize(image, canvas);
+
+// Resize image with options
+let resizeOptions: PicaResizeOptions = {
+    quality: 9
+};
+resizer.resize(image, canvas, resizeOptions);
+
+// Blob canvas
+resizer.toBlob(canvas, 'image/png');
+
+// Blob canvas with quality
+resizer.toBlob(canvas, 'image/png', 9);
+
+// Resize buffer
+let resizeBufferOptions: PicaResizeBufferOptions = {
+    width: 100,
+    height: 100,
+    toWidth: 50,
+    toHeigh: 50,
+};
+resizer.resizeBuffer(resizeBufferOptions);

--- a/types/pica/pica-tests.ts
+++ b/types/pica/pica-tests.ts
@@ -1,5 +1,7 @@
+let resizer: Pica = new Pica();
+
 let picaOptions: PicaOptions = { features: ['js', 'wasm', 'ww', 'cib'] };
-let resizer: Pica = new Pica(picaOptions);
+let resizerWithOptions: Pica = new Pica(picaOptions);
 
 let image: HTMLImageElement = document.createElement('img');
 image.width = 100;
@@ -11,18 +13,22 @@ canvas.height = 100;
 
 // Resize image
 resizer.resize(image, canvas);
+resizerWithOptions.resize(image, canvas);
 
 // Resize image with options
 let resizeOptions: PicaResizeOptions = {
     quality: 9
 };
 resizer.resize(image, canvas, resizeOptions);
+resizerWithOptions.resize(image, canvas, resizeOptions);
 
 // Blob canvas
 resizer.toBlob(canvas, 'image/png');
+resizerWithOptions.toBlob(canvas, 'image/png');
 
 // Blob canvas with quality
 resizer.toBlob(canvas, 'image/png', 9);
+resizerWithOptions.toBlob(canvas, 'image/png', 9);
 
 // Resize buffer
 let resizeBufferOptions: PicaResizeBufferOptions = {
@@ -32,3 +38,4 @@ let resizeBufferOptions: PicaResizeBufferOptions = {
     toHeigh: 50,
 };
 resizer.resizeBuffer(resizeBufferOptions);
+resizerWithOptions.resizeBuffer(resizeBufferOptions);

--- a/types/pica/tsconfig.json
+++ b/types/pica/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "pica-tests.ts"
+    ]
+}

--- a/types/pica/tslint.json
+++ b/types/pica/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

I write a type definition file and add pull request library itself. But author said:
https://github.com/nodeca/pica/pull/171