### PR TITLE
[gm]: Make modulate 2nd and 3rd param optional

### DIFF
--- a/types/gm/index.d.ts
+++ b/types/gm/index.d.ts
@@ -182,7 +182,7 @@ declare namespace m {
         median(radius?: number): State;
         minify(factor: number): State;
         mode(mode: OperationMode | string): State;
-        modulate(b: number, s: number, h: number): State;
+        modulate(b: number, s?: number, h?: number): State;
         monitor(): State;
         monochrome(): State;
         montage(otherImg: string): State;


### PR DESCRIPTION
According to the documentation the second and third option of .modulate() are optional:
http://aheckmann.github.io/gm/docs.html#modulate

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://aheckmann.github.io/gm/docs.html#modulate
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.