### PR TITLE
Add 'name' prop to gapi.client.drive.update

### DIFF
--- a/types/gapi.client.drive/index.d.ts
+++ b/types/gapi.client.drive/index.d.ts
@@ -1259,7 +1259,11 @@ declare namespace gapi.client {
                 keepRevisionForever?: boolean;
                 /** API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token. */
                 key?: string;
-                /** The name of the file. This is not necessarily unique within a folder. Note that for immutable items such as the top level folders of shared drives, My Drive root folder, and Application Data folder the name is constant. */
+                /**
+                 * The name of the file. This is not necessarily unique within a folder.
+                 * Note that for immutable items such as the top level folders of shared drives,
+                 * My Drive root folder, and Application Data folder the name is constant.
+                 */
                 name?: string;
                 /** OAuth 2.0 token for the current user. */
                 oauth_token?: string;

--- a/types/gapi.client.drive/index.d.ts
+++ b/types/gapi.client.drive/index.d.ts
@@ -1259,6 +1259,8 @@ declare namespace gapi.client {
                 keepRevisionForever?: boolean;
                 /** API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token. */
                 key?: string;
+                /** The name of the file. This is not necessarily unique within a folder. Note that for immutable items such as the top level folders of shared drives, My Drive root folder, and Application Data folder the name is constant. */
+                name?: string;
                 /** OAuth 2.0 token for the current user. */
                 oauth_token?: string;
                 /** A language hint for OCR processing during image import (ISO 639-1 code). */


### PR DESCRIPTION
Resolves issue #41212
Ref: https://developers.google.com/drive/api/v3/reference/files/update

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/drive/api/v3/reference/files/update
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

**Author notes**:
- Add or edit tests to reflect the change. (Run with npm test.): gapi.client.drive-tests.ts is generated via https://github.com/Bolisov/google-api-typings-generator - I've thus not edited it
- `npm run lint gapi.client.drive` exits with error:
```
13 verbose stack Error: definitely-typed@0.0.3 lint: `dtslint types "gapi.client.drive"`
13 verbose stack Exit status 1
13 verbose stack     at EventEmitter.<anonymous> (C:\Program Files\nodejs\node_modules\npm\node_modules\npm-lifecycle\index.js:332:16)
13 verbose stack     at EventEmitter.emit (events.js:210:5)
13 verbose stack     at ChildProcess.<anonymous> (C:\Program Files\nodejs\node_modules\npm\node_modules\npm-lifecycle\lib\spawn.js:55:14)
13 verbose stack     at ChildProcess.emit (events.js:210:5)
13 verbose stack     at maybeClose (internal/child_process.js:1021:16)
13 verbose stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)
14 verbose pkgid definitely-typed@0.0.3
15 verbose cwd C:\Users\g.furlan\Documents\GitHub\DefinitelyTyped
16 verbose Windows_NT 10.0.18362
17 verbose argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "run" "lint" "gapi.client.drive"
18 verbose node v12.11.1
19 verbose npm  v6.11.3
20 error code ELIFECYCLE
21 error errno 1
22 error definitely-typed@0.0.3 lint: `dtslint types "gapi.client.drive"`
22 error Exit status 1
23 error Failed at the definitely-typed@0.0.3 lint script.
23 error This is probably not a problem with npm. There is likely additional logging output above.
24 verbose exit [ 1, true ]
```

I'm obviously willing to help here if you explain me how to fix the issues :)