### PR TITLE
[amqp-connection-manager] Loosen publish and sendToQueue signatures.

### DIFF
--- a/types/amqp-connection-manager/amqp-connection-manager-tests.ts
+++ b/types/amqp-connection-manager/amqp-connection-manager-tests.ts
@@ -24,6 +24,9 @@ channelWrapper.sendToQueue("foo", Buffer.from("bar"))
         // nothing
     });
 
+// Test that plain objects are implicitly serialized.
+channelWrapper.sendToQueue("foo", {a: 'bar'}).catch(_ => {});
+
 // Checking connection options
 amqpConMgr.connect(["foo", "bar"], {
     findServers(callback) {

--- a/types/amqp-connection-manager/index.d.ts
+++ b/types/amqp-connection-manager/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for amqp-connection-manager 2.0
 // Project: https://github.com/benbria/node-amqp-connection-manager
 // Definitions by: rogierschouten <https://github.com/rogierschouten>
+//                 tstelzer <https://github.com/tstelzer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 
@@ -158,7 +159,7 @@ export interface ChannelWrapper extends EventEmitter {
 	 * @param options
 	 * @param callback
 	 */
-    publish(exchange: string, routingKey: string, content: Buffer, options?: Options.Publish, callback?: (err: any, ok: Replies.Empty) => void): Promise<void>;
+    publish(exchange: string, routingKey: string, content: Buffer | object, options?: Options.Publish, callback?: (err: any, ok: Replies.Empty) => void): Promise<void>;
 
 	/**
 	 * @see amqplib
@@ -167,7 +168,7 @@ export interface ChannelWrapper extends EventEmitter {
 	 * @param options
 	 * @param callback
 	 */
-    sendToQueue(queue: string, content: Buffer, options?: Options.Publish, callback?: (err: any, ok: Replies.Empty) => void): Promise<void>;
+    sendToQueue(queue: string, content: Buffer | object, options?: Options.Publish, callback?: (err: any, ok: Replies.Empty) => void): Promise<void>;
 
 	/**
 	 * @see amqplib


### PR DESCRIPTION
As per the
[documentation](https://github.com/benbria/node-amqp-connection-manager#amqpconnectionmanagercreatechanneloptions), the
`content` field in `publish` and `sendToQueue` can be a plain object, when `createChannel`s `json` option is set.

This commit extends the `content` parameter of those two functions. The change should be backwards compatible, as we're
loosening requirements.

Fixes #37295

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
