### PR TITLE
[node] Fix CommonJS import of 'module'

### DIFF
--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -16,4 +16,5 @@ declare module "module" {
 
         constructor(id: string, parent?: Module);
     }
+    export = Module;
 }

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -1,4 +1,4 @@
-import { Module } from 'module';
+import Module = require('module');
 import { URL } from 'url';
 require.extensions[".ts"] = () => "";
 
@@ -10,6 +10,7 @@ const m2: Module = new Module("moduleId");
 const b: string[] = Module.builtinModules;
 let paths: string[] = [];
 paths = m1.paths;
+m1 instanceof Module;
 
 Module.createRequireFromPath('./test')('test');
 


### PR DESCRIPTION
Fixes #41224

Verified empirically via the node 13 REPL:

```js
> typeof require('module');
'function'
```

so, it seems, the `module` module _must_ use a CommonJS export of the Module class. /cc @simonschick @Flarna for sanity check.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).