### PR TITLE
[google__maps] Fix DistanceMatrixResponse interface

### DIFF
--- a/types/google__maps/index.d.ts
+++ b/types/google__maps/index.d.ts
@@ -1358,7 +1358,7 @@ export interface DistanceMatrixResponse {
      * contains an array of addresses as returned by the API from your original request.
      * These are formatted by the geocoder and localized according to the language parameter passed with the request.
      */
-    origin_addresses: string;
+    origin_addresses: string[];
     /**
      * contains an array of addresses as returned by the API from your original request.
      * As with origin_addresses, these are localized if appropriate.


### PR DESCRIPTION
[As documented by the Google Maps Platform Distance Matrix, `origin_addresses` should be an array of addresses](https://developers.google.com/maps/documentation/distance-matrix/intro#DirectionsResponseElements).

Per the documentation,
>origin_addresses contains an array of addresses as returned by the API from your original request. These are formatted by the geocoder and localized according to the language parameter passed with the request.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developers.google.com/maps/documentation/distance-matrix/intro#DirectionsResponseElements>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

