### PR TITLE
fix(@rdfjs/namespace): builder can be called without params

### DIFF
--- a/types/rdfjs__namespace/index.d.ts
+++ b/types/rdfjs__namespace/index.d.ts
@@ -9,7 +9,7 @@ declare function namespace(baseIRI: string, options?: namespace.BuilderOptions):
 
 declare namespace namespace {
     interface NamespaceBuilder {
-        (property: TemplateStringsArray | string): NamedNode;
+        (property?: TemplateStringsArray | string): NamedNode;
 
         readonly [property: string]: NamedNode;
     }

--- a/types/rdfjs__namespace/rdfjs__namespace-tests.ts
+++ b/types/rdfjs__namespace/rdfjs__namespace-tests.ts
@@ -14,3 +14,4 @@ const node3: NamedNode = builder1('Thing');
 const node4: NamedNode = builder1('url');
 const node5: NamedNode = builder1`'Thing'`;
 const node6: NamedNode = builder1`url`;
+const node7: NamedNode = builder1();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/rdfjs-base/namespace/blob/master/index.js#L9>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.