### PR TITLE
[testing-library__dom] Fix async bound queries

### DIFF
--- a/types/testing-library__dom/get-queries-for-element.d.ts
+++ b/types/testing-library__dom/get-queries-for-element.d.ts
@@ -8,6 +8,8 @@ export type BoundFunction<T> = T extends (
     options: infer Q,
 ) => infer R
     ? (text: P, options?: Q) => R
+    : T extends (a1: any, text: infer P, options: infer Q, waitForElementOptions: infer W) => infer R
+    ? (text: P, options?: Q, waitForElementOptions?: W) => R
     : T extends (a1: any, text: infer P, options: infer Q) => infer R
     ? (text: P, options?: Q) => R
     : never;

--- a/types/testing-library__dom/index.d.ts
+++ b/types/testing-library__dom/index.d.ts
@@ -6,6 +6,7 @@
 //                 Weyert de Boer <https://github.com/weyert>
 //                 Ronald Rey <https://github.com/reyronald>
 //                 Justin Hall <https://github.com/wKovacs64>
+//                 Wesley Tsai <https://github.com/wezleytsai>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/testing-library__dom/testing-library__dom-tests.ts
+++ b/types/testing-library__dom/testing-library__dom-tests.ts
@@ -1,6 +1,6 @@
 import { queries, screen, isInaccessible } from '@testing-library/dom';
 
-const { getByText, queryByText, findByText, getAllByText, queryAllByText, findAllByText, queryByRole } = queries;
+const { getByText, queryByText, findByText, getAllByText, queryAllByText, findAllByText, queryByRole, findByRole } = queries;
 
 async function testQueries() {
     // element queries
@@ -8,20 +8,24 @@ async function testQueries() {
     getByText(element, 'foo');
     queryByText(element, 'foo');
     await findByText(element, 'foo');
+    await findByText(element, 'foo', undefined, { timeout: 10 });
     getAllByText(element, 'bar');
     queryAllByText(element, 'bar');
     await findAllByText(element, 'bar');
+    await findAllByText(element, 'bar', undefined, { timeout: 10 });
 
     // screen queries
     screen.getByText('foo');
     screen.queryByText('foo');
     await screen.findByText('foo');
+    await screen.findByText('foo', undefined, { timeout: 10 });
     screen.getAllByText('bar');
     screen.queryAllByText('bar');
     await screen.findAllByText('bar');
+    await screen.findAllByText('bar', undefined, { timeout: 10 });
 }
 
-function testByRole() {
+async function testByRole() {
     const element = document.createElement('button');
     element.setAttribute('aria-hidden', 'true');
 
@@ -30,6 +34,9 @@ function testByRole() {
 
     console.assert(screen.queryByRole('button') === null);
     console.assert(screen.queryByRole('button', { hidden: true }) !== null);
+
+    console.assert(await findByRole(element, 'button', undefined, { timeout: 10 }) === null);
+    console.assert(await findByRole(element, 'button', { hidden: true }, { timeout: 10 }) !== null);
 }
 
 function testA11yHelper() {


### PR DESCRIPTION
Fixes https://github.com/testing-library/react-testing-library/issues/366

Many queries accept arguments of type `container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: WaitForElementOptions`. The existing `BoundFunction` definition does not take this into account and matches these to `T extends (a1: any, text: infer P, options: infer Q) => infer R`, resulting in the bound query to be of type `(text: P, options?: Q) => R`, which makes it impossible to supply the `waitForElementOptions` argument in a type-safe manner. This fixes `BoundFunction` to account for the async function signature so that the bound query will have type `(text: P, options?: Q, waitForElementOptions?: W) => R`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
