### PR TITLE
Fix aws-param-store path parameter type 

### DIFF
--- a/types/aws-param-store/aws-param-store-tests.ts
+++ b/types/aws-param-store/aws-param-store-tests.ts
@@ -12,7 +12,6 @@ import {
 
 declare let bool: boolean;
 declare let query: ParameterQuery;
-declare let path: string;
 declare let psName: SSM.Types.PSParameterName;
 declare let psNames: SSM.Types.ParameterNameList;
 declare let options: SSM.Types.ClientConfiguration;
@@ -27,7 +26,7 @@ declare let promiseAllParamResults: Promise<typeof allParamResults>;
 
 query = parameterQuery();
 
-query.path(path);
+query.path(psName);
 query.named(psName);
 query.named(psNames);
 query.decryption(bool);
@@ -66,8 +65,8 @@ promiseParamResult = getParameter(psName, options);
 promiseParamsResult = getParameters(psNames);
 promiseParamsResult = getParameters(psNames, options);
 
-promiseParamsByPathResult = getParametersByPath(path);
-promiseParamsByPathResult = getParametersByPath(path, options);
+promiseParamsByPathResult = getParametersByPath(psName);
+promiseParamsByPathResult = getParametersByPath(psName, options);
 
 paramResult = getParameterSync(psName);
 paramResult = getParameterSync(psName, options);
@@ -75,5 +74,5 @@ paramResult = getParameterSync(psName, options);
 paramsResult = getParametersSync(psNames);
 paramsResult = getParametersSync(psNames, options);
 
-paramsByPathResult = getParametersByPathSync(path);
-paramsByPathResult = getParametersByPathSync(path, options);
+paramsByPathResult = getParametersByPathSync(psName);
+paramsByPathResult = getParametersByPathSync(psName, options);

--- a/types/aws-param-store/aws-param-store-tests.ts
+++ b/types/aws-param-store/aws-param-store-tests.ts
@@ -12,6 +12,7 @@ import {
 
 declare let bool: boolean;
 declare let query: ParameterQuery;
+declare let path: string;
 declare let psName: SSM.Types.PSParameterName;
 declare let psNames: SSM.Types.ParameterNameList;
 declare let options: SSM.Types.ClientConfiguration;
@@ -26,7 +27,7 @@ declare let promiseAllParamResults: Promise<typeof allParamResults>;
 
 query = parameterQuery();
 
-query.path(psName);
+query.path(path);
 query.named(psName);
 query.named(psNames);
 query.decryption(bool);
@@ -65,8 +66,8 @@ promiseParamResult = getParameter(psName, options);
 promiseParamsResult = getParameters(psNames);
 promiseParamsResult = getParameters(psNames, options);
 
-promiseParamsByPathResult = getParametersByPath(psNames);
-promiseParamsByPathResult = getParametersByPath(psNames, options);
+promiseParamsByPathResult = getParametersByPath(path);
+promiseParamsByPathResult = getParametersByPath(path, options);
 
 paramResult = getParameterSync(psName);
 paramResult = getParameterSync(psName, options);
@@ -74,5 +75,5 @@ paramResult = getParameterSync(psName, options);
 paramsResult = getParametersSync(psNames);
 paramsResult = getParametersSync(psNames, options);
 
-paramsByPathResult = getParametersByPathSync(psNames);
-paramsByPathResult = getParametersByPathSync(psNames, options);
+paramsByPathResult = getParametersByPathSync(path);
+paramsByPathResult = getParametersByPathSync(path, options);

--- a/types/aws-param-store/index.d.ts
+++ b/types/aws-param-store/index.d.ts
@@ -27,17 +27,17 @@ export function getParametersSync(
 ): SSM.Types.GetParametersResult;
 
 export function getParametersByPath(
-    path: string,
+    path: SSM.Types.PSParameterName,
     options?: SSM.Types.ClientConfiguration
 ): Promise<SSM.Types.ParameterList>;
 
 export function getParametersByPathSync(
-    path: string,
+    path: SSM.Types.PSParameterName,
     options?: SSM.Types.ClientConfiguration
 ): SSM.Types.ParameterList;
 
 export interface ParameterQuery {
-    path(path: string): ParameterQuery;
+    path(path: SSM.Types.PSParameterName): ParameterQuery;
     named(nameOrNames: SSM.Types.PSParameterName | SSM.Types.ParameterNameList): ParameterQuery;
     decryption(enabled: boolean): ParameterQuery;
     recursive(enabled: boolean): ParameterQuery;

--- a/types/aws-param-store/index.d.ts
+++ b/types/aws-param-store/index.d.ts
@@ -27,17 +27,17 @@ export function getParametersSync(
 ): SSM.Types.GetParametersResult;
 
 export function getParametersByPath(
-    path: SSM.Types.ParameterNameList,
+    path: string,
     options?: SSM.Types.ClientConfiguration
 ): Promise<SSM.Types.ParameterList>;
 
 export function getParametersByPathSync(
-    path: SSM.Types.ParameterNameList,
+    path: string,
     options?: SSM.Types.ClientConfiguration
 ): SSM.Types.ParameterList;
 
 export interface ParameterQuery {
-    path(path: SSM.Types.PSParameterName): ParameterQuery;
+    path(path: string): ParameterQuery;
     named(nameOrNames: SSM.Types.PSParameterName | SSM.Types.ParameterNameList): ParameterQuery;
     decryption(enabled: boolean): ParameterQuery;
     recursive(enabled: boolean): ParameterQuery;

--- a/types/aws-param-store/index.d.ts
+++ b/types/aws-param-store/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for aws-param-store 2.1
 // Project: https://github.com/vandium-io/aws-param-store#readme
-// Definitions by: Jason Gray <https://github.com/jasonthomasgray>
+// Definitions by: Jason Gray <https://github.com/jasonthomasgray>, Nathan Oertel <https://github.com/nathanoertel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />


### PR DESCRIPTION
According to the [documentation](https://docs.aws.amazon.com/cli/latest/reference/ssm/get-parameters-by-path.html#options) the --path parameter is a string not a parameter name array.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/cli/latest/reference/ssm/get-parameters-by-path.html#options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.