### PR TITLE
feat(react-toast-notification): align with version 2.4.0

### DIFF
--- a/types/react-toast-notifications/index.d.ts
+++ b/types/react-toast-notifications/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-toast-notifications 2.0
+// Type definitions for react-toast-notifications 2.4
 // Project: https://github.com/jossmac/react-toast-notifications
 // Definitions by: Spencer Elliott <https://github.com/elliottsj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -62,13 +62,19 @@ export interface Options {
     appearance: AppearanceTypes;
     autoDismiss?: boolean;
     onDismiss?: (id: string) => void;
-    pauseOnHover?: boolean;
+}
+
+export interface UpdateOptions extends Options {
+    content?: string;
 }
 
 export type AddToast = (content: ReactNode, options?: Options, callback?: (id: string) => void) => void;
 
-export type RemoveToast = (id: string, callback: () => void) => void;
+export type RemoveToast = (id: string, callback?: () => void) => void;
 
+export type RemoveAllToasts = () => void;
+
+export type UpdateToast = (id: string, options?: Options, callback?: (id: string) => void) => void;
 export const DefaultToastContainer: ComponentType<ToastContainerProps>;
 export const DefaultToast: ComponentType<ToastProps>;
 export const ToastConsumer: ComponentType<ToastConsumerProps>;
@@ -77,9 +83,11 @@ export function withToastManager(...args: any[]): any;
 export function useToasts(): {
     addToast: AddToast;
     removeToast: RemoveToast;
+    removeAllToasts: RemoveAllToasts;
     toastStack: Array<{
         content: ReactNode;
         id: string;
         appearance: AppearanceTypes;
     }>;
+    updateToast: UpdateToast;
 };

--- a/types/react-toast-notifications/react-toast-notifications-tests.tsx
+++ b/types/react-toast-notifications/react-toast-notifications-tests.tsx
@@ -7,29 +7,125 @@ const CustomToast: React.FC<ToastProps> = ({ children, ...props }) => (
     </DefaultToast>
 );
 
+// ToastProvider Props
+
 const MyApp: React.FC = () => (
-    <ToastProvider>
-        <Main1 />
-        <Main2 />
+    <ToastProvider
+        autoDismiss
+        autoDismissTimeout={6000}
+        components={{ Toast: CustomToast }}
+        placement="bottom-center"
+        transitionDuration={2000}
+    >
+        <ToastConsumerTest />
+        <AddToast />
+        <RemoveAllToasts />
+        <RemoveAllToasts />
+        <ToastStack />
+        <UpdateToast />
     </ToastProvider>
 );
 
-const Main1: React.FC = () => (
+// ToastConsumer
+
+const ToastConsumerTest: React.FC = () => (
     <ToastConsumer>
         {context => (
             <div>
-                <button onClick={() => context.add('Toast')}>Add</button>
+                <button
+                    onClick={() =>
+                        context.add(
+                            'Toast',
+                            {
+                                appearance: 'info',
+                            },
+                            () => {},
+                        )
+                    }
+                >
+                    Add Toast
+                </button>
             </div>
         )}
     </ToastConsumer>
 );
 
-const Main2: React.FC = () => {
-    const { addToast, removeToast, toastStack } = useToasts();
+// Hooks
+
+const AddToast: React.FC = () => {
+    const { addToast } = useToasts();
 
     return (
         <div>
-            <button onClick={() => addToast('Toast')}>Add</button>
+            <button
+                onClick={() =>
+                    addToast(
+                        'Toast',
+                        {
+                            appearance: 'error',
+                            autoDismiss: true,
+                        },
+                        () => {},
+                    )
+                }
+            >
+                Add Toast
+            </button>
+        </div>
+    );
+};
+
+const RemoveAllToasts: React.FC = () => {
+    const { removeAllToasts } = useToasts();
+
+    return (
+        <div>
+            <button onClick={removeAllToasts}>Remove All Toasts</button>
+        </div>
+    );
+};
+
+const RemoveToast: React.FC = () => {
+    const { removeToast } = useToasts();
+
+    return (
+        <div>
+            <button onClick={() => removeToast('to-be-removed', () => {})}>Remove Toast</button>
+        </div>
+    );
+};
+
+const ToastStack: React.FC = () => {
+    const { removeAllToasts, toastStack } = useToasts();
+
+    const onSubmit = () => {
+        if (toastStack.length > 0) {
+            removeAllToasts();
+        }
+    };
+
+    return <form onSubmit={onSubmit}>Save Form</form>;
+};
+
+const UpdateToast: React.FC = () => {
+    const { updateToast } = useToasts();
+
+    return (
+        <div>
+            <button
+                onClick={() =>
+                    updateToast(
+                        'to-be-updated',
+                        {
+                            appearance: 'error',
+                            autoDismiss: true,
+                        },
+                        () => {},
+                    )
+                }
+            >
+                Update Toast
+            </button>
         </div>
     );
 };


### PR DESCRIPTION
- remove `pauseOnHover` property
- add `removeAllToasts` and `updateToast` hooks
- mark `callback` option optional in `removeToast` hook
- extends options with `UpdateOptions` variant to provide optional
content property
- rewrite tests to cover all hooks and provider properties

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jossmac/react-toast-notifications/commit/30aeb369c28a8d35435e4a7a3dcf743cd34fd069
https://github.com/jossmac/react-toast-notifications#toastprovider-props
https://github.com/jossmac/react-toast-notifications#toast-props
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.