### PR TITLE
[Jest] .toBe uses Object.is, not ===

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -757,7 +757,7 @@ declare namespace jest {
          */
         nthReturnedWith<E = any>(n: number, value: E): R;
         /**
-         * Checks that a value is what you expect. It uses `===` to check strict equality.
+         * Checks that a value is what you expect. It uses `Object.is` to check strict equality.
          * Don't use `toBe` with floating-point numbers.
          *
          * Optionally, you can provide a type for the expected value via a generic.


### PR DESCRIPTION
[Jest] .toBe uses Object.is, not ===

The current description for `.toBe` is not entirely accurate and [can cause confusion](https://stackoverflow.com/q/59343675). See [Jest docs](https://jestjs.io/docs/en/expect#tobevalue).

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

---

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://jestjs.io/docs/en/expect#tobevalue