### PR TITLE
[bn.js] Fix module import without 'allowSyntheticDefaultImports'

### DIFF
--- a/types/bn.js/bn.js-tests.ts
+++ b/types/bn.js/bn.js-tests.ts
@@ -1,23 +1,33 @@
 // test that it works as a require
-import BN = require('bn.js');
+import BN_require = require('bn.js');
+// test that it works as module import
+import * as BN_esm from 'bn.js';
+import { Endianness, IPrimeName } from 'bn.js';
 
-let bn = new BN(42);
-bn = bn.add(bn);
-bn.isZero();
-bn.byteLength;
+function runTests(BN: typeof BN_esm) {
+    let bn = new BN(42);
+    bn = bn.add(bn);
+    bn.isZero();
+    bn.byteLength;
 
-bn.toArrayLike(Buffer, 'le', 2);
-const test = new BN(1, 'le');
+    const endian: Endianness = 'le';
+    bn.toArrayLike(Buffer, endian, 2);
+    const test = new BN(1, endian);
 
-const ctx = BN.red('p224');
-ctx.prime.name;
+    const primeName: IPrimeName = 'p224';
+    const ctx = BN.red(primeName);
+    ctx.prime.name;
 
-const red = bn.toRed(ctx);
-const newRed = red.redAdd(new BN(1));
-newRed.cmp(bn);
-newRed.fromRed();
+    const red = bn.toRed(ctx);
+    const newRed = red.redAdd(new BN(1).toRed(ctx));
+    newRed.cmp(bn);
+    newRed.fromRed();
 
-const expected = new BN(0x4020);
-const actualArray = new BN([0x40, 0x20]);
-const actualUint8Array =  new BN(new Uint8Array([0x40, 0x20]));
-const actualString = new BN('0x4020');
+    const expected = new BN(0x4020);
+    const actualArray = new BN([0x40, 0x20]);
+    const actualUint8Array =  new BN(new Uint8Array([0x40, 0x20]));
+    const actualString = new BN('0x4020');
+}
+
+runTests(BN_esm);
+runTests(BN_require);

--- a/types/bn.js/index.d.ts
+++ b/types/bn.js/index.d.ts
@@ -7,59 +7,59 @@
 
 /// <reference types="node"/>
 
-type Endianness = 'le' | 'be';
-type IPrimeName = 'k256' | 'p224' | 'p192' | 'p25519';
-
-interface MPrime {
-    name: string;
-    p: BN;
-    n: number;
-    k: BN;
-}
-
-interface ReductionContext {
-    m: number;
-    prime: MPrime;
-    [key: string]: any;
-}
-
 declare namespace BN {
-    /**
-     * @description  create a reduction context
-     */
-    function red(reductionContext: BN | IPrimeName): ReductionContext;
+    type Endianness = 'le' | 'be';
+    type IPrimeName = 'k256' | 'p224' | 'p192' | 'p25519';
 
-    /**
-     * @description  create a reduction context  with the Montgomery trick.
-     */
-    function mont(num: BN): ReductionContext;
+    interface MPrime {
+        name: string;
+        p: BN;
+        n: number;
+        k: BN;
+    }
 
-    /**
-     * @description returns true if the supplied object is a BN.js instance
-     */
-    function isBN(b: any): b is BN;
-
-    /**
-     * @description returns the maximum of 2 BN instances.
-     */
-    function max(left: BN, right: BN): BN;
-
-    /**
-     * @description returns the minimum of 2 BN instances.
-     */
-    function min(left: BN, right: BN): BN;
+    interface ReductionContext {
+        m: number;
+        prime: MPrime;
+        [key: string]: any;
+    }
 }
 
 declare class BN {
     constructor(
         number: number | string | number[] | Uint8Array | Buffer | BN,
         base?: number | 'hex',
-        endian?: Endianness
+        endian?: BN.Endianness
     );
     constructor(
         number: number | string | number[] | Uint8Array | Buffer | BN,
-        endian?: Endianness
+        endian?: BN.Endianness
     )
+
+    /**
+     * @description  create a reduction context
+     */
+    static red(reductionContext: BN | BN.IPrimeName): BN.ReductionContext;
+
+    /**
+     * @description  create a reduction context  with the Montgomery trick.
+     */
+    static mont(num: BN): BN.ReductionContext;
+
+    /**
+     * @description returns true if the supplied object is a BN.js instance
+     */
+    static isBN(b: any): b is BN;
+
+    /**
+     * @description returns the maximum of 2 BN instances.
+     */
+    static max(left: BN, right: BN): BN;
+
+    /**
+     * @description returns the minimum of 2 BN instances.
+     */
+    static min(left: BN, right: BN): BN;
 
     /**
      * @description  clone number
@@ -84,27 +84,27 @@ declare class BN {
     /**
      * @description  convert to byte Array, and optionally zero pad to length, throwing if already exceeding
      */
-    toArray(endian?: Endianness, length?: number): number[];
+    toArray(endian?: BN.Endianness, length?: number): number[];
 
     /**
      * @description convert to an instance of `type`, which must behave like an Array
      */
     toArrayLike(
         ArrayType: typeof Buffer,
-        endian?: Endianness,
+        endian?: BN.Endianness,
         length?: number
     ): Buffer;
 
     toArrayLike(
         ArrayType: any[],
-        endian?: Endianness,
+        endian?: BN.Endianness,
         length?: number
     ): any[];
 
     /**
      * @description  convert to Node.js Buffer (if available). For compatibility with browserify and similar tools, use this instead: a.toArrayLike(Buffer, endian, length)
      */
-    toBuffer(endian?: Endianness, length?: number): Buffer;
+    toBuffer(endian?: BN.Endianness, length?: number): Buffer;
 
     /**
      * @description get number of bits occupied
@@ -504,7 +504,7 @@ declare class BN {
     /**
      * @description Convert number to red
      */
-    toRed(reductionContext: ReductionContext): RedBN;
+    toRed(reductionContext: BN.ReductionContext): RedBN;
 }
 
 /**

--- a/types/bn.js/index.d.ts
+++ b/types/bn.js/index.d.ts
@@ -23,6 +23,33 @@ interface ReductionContext {
     [key: string]: any;
 }
 
+declare namespace BN {
+    /**
+     * @description  create a reduction context
+     */
+    function red(reductionContext: BN | IPrimeName): ReductionContext;
+
+    /**
+     * @description  create a reduction context  with the Montgomery trick.
+     */
+    function mont(num: BN): ReductionContext;
+
+    /**
+     * @description returns true if the supplied object is a BN.js instance
+     */
+    function isBN(b: any): b is BN;
+
+    /**
+     * @description returns the maximum of 2 BN instances.
+     */
+    function max(left: BN, right: BN): BN;
+
+    /**
+     * @description returns the minimum of 2 BN instances.
+     */
+    function min(left: BN, right: BN): BN;
+}
+
 declare class BN {
     constructor(
         number: number | string | number[] | Uint8Array | Buffer | BN,
@@ -33,31 +60,6 @@ declare class BN {
         number: number | string | number[] | Uint8Array | Buffer | BN,
         endian?: Endianness
     )
-
-    /**
-     * @description  create a reduction context
-     */
-    static red(reductionContext: BN | IPrimeName): ReductionContext;
-
-    /**
-     * @description  create a reduction context  with the Montgomery trick.
-     */
-    static mont(num: BN): ReductionContext;
-
-    /**
-     * @description returns true if the supplied object is a BN.js instance
-     */
-    static isBN(b: any): b is BN;
-
-    /**
-     * @description returns the maximum of 2 BN instances.
-     */
-    static max(left: BN, right: BN): BN;
-
-    /**
-     * @description returns the minimum of 2 BN instances.
-     */
-    static min(left: BN, right: BN): BN;
 
     /**
      * @description  clone number

--- a/types/bn.js/tslint.json
+++ b/types/bn.js/tslint.json
@@ -1,1 +1,11 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-duplicate-imports": {
+            "severity": "error",
+            "options": {
+                "allow-namespace-imports": true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Provide the ability to import this lib using `import * as bn from 'bn.js'` syntax, with default `tsconfig.json` settings. 

Previously, the bn.js lib could only be imported when using `allowSyntheticDefaultImports`, `require('bn.js')`, or ` // @ts-ignore \n import * as bn from 'bn.js'`. 

This causes problems for projects that wish to avoid the `esModuleInterop` flag:
* Projects that aim to have maximally readable js output, and js that closely mirrors the ts code -- therefore avoid the 10+ lines of helper code generated by esModuleInterop.
* Projects that aim to prevent the side-effects that this helper code generates -- when the flag is enabled, it begins to propagate throughout the codebase and used on module imports which do not actually need it. 
* Projects that wish to avoid causing issues with downstream dependencies, e.g.:
  * If the `// @ts-ignore` is used, it often requires downstreams dependencies to enable `skipLibCheck`.
  * If the `require('bn.js')` syntax is used, it often requires disabling their eslint/tslint rules for the line, and/or require downstream dependencies to do the same. 
* Many projects import and use `bn.js` package bare, without types in order to avoid these issues. 


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

