### PR TITLE
Add types for knuth-shuffle

### DIFF
--- a/types/knuth-shuffle/index.d.ts
+++ b/types/knuth-shuffle/index.d.ts
@@ -1,0 +1,6 @@
+// Type definitions for knuth-shuffle 1.0
+// Project: https://git.coolaj86.com/coolaj86/knuth-shuffle.js
+// Definitions by: Chris Atkin <https://github.com/atkinchris>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function knuthShuffle(array: any[]): void;

--- a/types/knuth-shuffle/index.d.ts
+++ b/types/knuth-shuffle/index.d.ts
@@ -3,4 +3,4 @@
 // Definitions by: Chris Atkin <https://github.com/atkinchris>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function knuthShuffle(array: any[]): void;
+export function knuthShuffle<T>(array: T[]): T[];

--- a/types/knuth-shuffle/knuth-shuffle-tests.ts
+++ b/types/knuth-shuffle/knuth-shuffle-tests.ts
@@ -1,0 +1,3 @@
+import { knuthShuffle } from "knuth-shuffle";
+
+knuthShuffle([4, 8, 15, 16, 23, 42]); // $ExpectType void

--- a/types/knuth-shuffle/knuth-shuffle-tests.ts
+++ b/types/knuth-shuffle/knuth-shuffle-tests.ts
@@ -1,3 +1,4 @@
 import { knuthShuffle } from "knuth-shuffle";
 
-knuthShuffle([4, 8, 15, 16, 23, 42]); // $ExpectType void
+knuthShuffle([4, 8, 15, 16, 23, 42]); // $ExpectType number[]
+knuthShuffle(['a', 'b', 'c', 'd']); // $ExpectType string[]

--- a/types/knuth-shuffle/tsconfig.json
+++ b/types/knuth-shuffle/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "knuth-shuffle-tests.ts"
+    ]
+}

--- a/types/knuth-shuffle/tslint.json
+++ b/types/knuth-shuffle/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This adds types for the [`knuth-shuffle`](https://www.npmjs.com/package/knuth-shuffle)  package.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.