### PR TITLE
Fix redux-form selectors types so that generics can be passed into getFormValues and other selectors

### DIFF
--- a/types/redux-form/lib/selectors.d.ts
+++ b/types/redux-form/lib/selectors.d.ts
@@ -1,10 +1,10 @@
 import { FormErrors, GetFormState } from "../index";
 
-export type DataSelector<FormData = {}, State = {}> = (formName: string, getFormState?: GetFormState) => (state: State) => FormData;
-export type ErrorSelector<FormData = {}, State = {}, ErrorType = string> = (formName: string, getFormState?: GetFormState) => (state: State) => FormErrors<FormData, ErrorType>;
-export type BooleanSelector<State = {}> = (formName: string, getFormState?: GetFormState) => (state: State) => boolean;
-export type NamesSelector<State = {}> = (getFormState?: GetFormState) => (state: State) => string[];
-export type FormOrFieldsBooleanSelector<State = {}> = (formName: string, getFormState?: GetFormState) => (state: State, ...fields: string[]) => boolean;
+export type DataSelector = <FormData = {}, State = {}>(formName: string, getFormState?: GetFormState) => (state: State) => FormData;
+export type ErrorSelector = <FormData = {}, State = {}, ErrorType = string>(formName: string, getFormState?: GetFormState) => (state: State) => FormErrors<FormData, ErrorType>;
+export type BooleanSelector = <State = {}>(formName: string, getFormState?: GetFormState) => (state: State) => boolean;
+export type NamesSelector = <State = {}>(getFormState?: GetFormState) => (state: State) => string[];
+export type FormOrFieldsBooleanSelector = <State = {}>(formName: string, getFormState?: GetFormState) => (state: State, ...fields: string[]) => boolean;
 
 export const getFormValues: DataSelector;
 export const getFormInitialValues: DataSelector;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [x] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [x] Delete the package's directory.
- [x] Add it to `notNeededPackages.json`.
