### PR TITLE
feat(mui-datatables): refine `onDownload` callback: Fixes #40838

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -204,12 +204,17 @@ export interface MUIDataTableOptions {
     onChangeRowsPerPage?: (numberOfRows: number) => void;
     onColumnSortChange?: (changedColumn: string, direction: string) => void;
     onColumnViewChange?: (changedColumn: string, action: string) => void;
+    /**
+     * A callback function that triggers when the user downloads the CSV file.
+     * In the callback, you can control what is written to the CSV file.
+     * Return false to cancel download of file.
+     */
     onDownload?: (
         buildHead: (columns: any) => string,
         buildBody: (data: any) => string,
         columns: any,
-        data: any
-    ) => string;
+        data: any,
+    ) => string | boolean;
     onFilterChange?: (changedColumn: string, filterList: any[], type: FilterType | 'chip' | 'reset') => void;
     onFilterDialogOpen?: () => void;
     onFilterDialogClose?: () => void;

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -5,6 +5,7 @@ interface Props extends MUIDataTableOptions {
     data: any;
     title: string;
     textLabels?: MUIDataTableTextLabels;
+    options?: MUIDataTableOptions;
 }
 
 const MuiCustomTable: React.FC<Props> = (props) => {
@@ -120,4 +121,16 @@ const TableFruits = [
     { id: 5, name: "Orange", amount: 9 },
 ];
 
-<MuiCustomTable title="Awesome Table" data={TableFruits} />;
+const options: MUIDataTableOptions = {
+    filter: true,
+    filterType: 'dropdown',
+    responsive: 'scrollMaxHeight',
+    onDownload: (buildHead, buildBody, columns, data) => {
+        if (data) {
+            return buildHead(columns) + buildBody(data);
+        }
+        return false;
+    },
+};
+
+<MuiCustomTable title="Awesome Table" data={TableFruits} options={options} />;


### PR DESCRIPTION
- refine return type definition
- update documentation
- add test coverage

Thanks!

Please fill in this template.

/cc @dandrews 
This was partially refined as part of: #40839, whilte still requiring boolean return type as per implementation, e.g.:
https://github.com/gregnb/mui-datatables/blob/6d448052ae2cd73819efcd76ab67b9c9e407429d/examples/csv-export/index.js#L82-L88

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gregnb/mui-datatables/blob/e63291c93102dd1f61efc66e18ad794846d5f7c4/README.md#options