### PR TITLE
feat: Add `tape‑promise`

### DIFF
--- a/types/tape-promise/index.d.ts
+++ b/types/tape-promise/index.d.ts
@@ -1,0 +1,81 @@
+// Type definitions for tape-promise 4.0
+// Project: https://github.com/jprichardson/tape-promise#readme
+// Definitions by: ExE Boss <https://github.com/ExE-Boss>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import tape = require('tape');
+import { TestOptions, StreamOptions } from 'tape';
+export { TestOptions, StreamOptions };
+
+export interface TestCase {
+	(test: Test): void | PromiseLike<void>;
+}
+
+// tslint:disable: ban-types
+export interface Test extends tape.Test {
+	test(name: string, cb: TestCase): void;
+	test(name: string, opts: TestOptions, cb: TestCase): void;
+
+	/**
+	 * Assert that the promise settles with a rejection result.
+	 *
+	 * @param expected if present, must be a RegExp or Function, which is used to test the exception object.
+	 */
+	rejects(promise: PromiseLike<any> | (() => PromiseLike<any>), msg?: string): Promise<void>;
+	rejects(
+		promise: PromiseLike<any> | (() => PromiseLike<any>),
+		expected?: RegExp | Function,
+		msg?: string,
+	): Promise<void>;
+
+	/**
+	 * Assert that the promise resolves successfully.
+	 */
+	doesNotReject(promise: PromiseLike<any> | (() => PromiseLike<any>), msg?: string): Promise<void>;
+	doesNotReject(
+		promise: PromiseLike<any> | (() => PromiseLike<any>),
+		expected?: RegExp | Function,
+		msg?: string,
+	): Promise<void>;
+}
+// tslint:enable: ban-types
+
+// tslint:disable: unified-signatures
+interface AsyncTapeFunction {
+	/**
+	 * Create a new test with an optional name string and optional opts object.
+	 * cb(t) fires with the new test object t once all preceding tests have finished.
+	 * Tests execute serially.
+	 */
+	(name: string, cb: TestCase): void;
+	(name: string, opts: TestOptions, cb: TestCase): void;
+	(cb: TestCase): void;
+	(opts: TestOptions, cb: TestCase): void;
+
+	/**
+	 * Generate a new test that will be skipped over.
+	 */
+	skip(name: string, cb: TestCase): void;
+	skip(name: string, opts: TestOptions, cb: TestCase): void;
+	skip(cb: TestCase): void;
+	skip(opts: TestOptions, cb: TestCase): void;
+
+	/**
+	 * Like test(name?, opts?, cb) except if you use .only this
+	 * is the only test case that will run for the entire process,
+	 * all other test cases using tape will be ignored.
+	 */
+	only(name: string, cb: TestCase): void;
+	only(name: string, opts: TestOptions, cb: TestCase): void;
+	only(cb: TestCase): void;
+	only(opts: TestOptions, cb: TestCase): void;
+
+	/**
+	 * Create a new test harness instance, which is a function like test(),
+	 * but with a new pending stack and test state.
+	 */
+	createHarness(): AsyncTapeFunction & typeof tape;
+}
+// tslint:enable: unified-signatures
+
+export default function tapePromiseFactory(tapeTest: any): AsyncTapeFunction & typeof tape;

--- a/types/tape-promise/tape.d.ts
+++ b/types/tape-promise/tape.d.ts
@@ -1,0 +1,19 @@
+import tapePromise = require('./index');
+
+declare const tape: ReturnType<typeof tapePromise.default>;
+declare namespace tape {
+	type Test = tapePromise.Test;
+	type TestCase = tapePromise.TestCase;
+
+	/**
+	 * Available opts options for the tape function.
+	 */
+	type TestOptions = tapePromise.TestOptions;
+
+	/**
+	 * Options for the createStream function.
+	 */
+	type StreamOptions = tapePromise.StreamOptions;
+}
+
+export = tape;

--- a/types/tape-promise/test/tape-promise.byot.ts
+++ b/types/tape-promise/test/tape-promise.byot.ts
@@ -1,0 +1,40 @@
+// tslint:disable: no-async-without-await
+import tapeSync = require('tape');
+import tapePromise = require('tape-promise');
+
+// Bring Your Own Tape:
+const tape = tapePromise.default(tapeSync);
+
+const name = String();
+const cb = async (test: tapePromise.Test) => {};
+const opts: tapePromise.TestOptions = {};
+let t: tapePromise.Test;
+
+tape(cb);
+tape(name, cb);
+tape(opts, cb);
+tape(name, opts, cb);
+
+tape(name, async (test: tapePromise.Test) => {
+	t = test;
+});
+
+tape.skip(cb);
+tape.skip(name, cb);
+tape.skip(opts, cb);
+tape.skip(name, opts, cb);
+
+tape.only(cb);
+tape.only(name, cb);
+tape.only(opts, cb);
+tape.only(name, opts, cb);
+
+tape(name, async (test: tapePromise.Test) => {
+	test.test(name, async st => {
+		t = st;
+	});
+
+	test.test(name, opts, async st => {
+		t = st;
+	});
+});

--- a/types/tape-promise/test/tape-promise.peer-dep.ts
+++ b/types/tape-promise/test/tape-promise.peer-dep.ts
@@ -1,0 +1,37 @@
+// tslint:disable: no-async-without-await
+// peerDependencies: { tape: '*' }
+import tape = require('tape-promise/tape');
+
+const name = String();
+const cb = async (test: tape.Test) => {};
+const opts: tape.TestOptions = {};
+let t: tape.Test;
+
+tape(cb);
+tape(name, cb);
+tape(opts, cb);
+tape(name, opts, cb);
+
+tape(name, async (test: tape.Test) => {
+	t = test;
+});
+
+tape.skip(cb);
+tape.skip(name, cb);
+tape.skip(opts, cb);
+tape.skip(name, opts, cb);
+
+tape.only(cb);
+tape.only(name, cb);
+tape.only(opts, cb);
+tape.only(name, opts, cb);
+
+tape(name, async (test: tape.Test) => {
+	test.test(name, async st => {
+		t = st;
+	});
+
+	test.test(name, opts, async st => {
+		t = st;
+	});
+});

--- a/types/tape-promise/tsconfig.json
+++ b/types/tape-promise/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": ["es6"],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": ["../"],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"test/tape-promise.byot.ts",
+		"test/tape-promise.peer-dep.ts",
+		"index.d.ts"
+	]
+}

--- a/types/tape-promise/tslint.json
+++ b/types/tape-promise/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

review?(@andrewbranch)