### PR TITLE
[iobroker] add getObjectList[Async] to the adapter interface

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -332,7 +332,7 @@ declare global {
         /** Parameters for @link{Objects.getObjectList} */
         interface GetObjectListParams extends GetObjectViewParams {
             /** Whether docs should be included in the return list */ // TODO: What are docs?
-            include_docs: boolean;
+            include_docs?: boolean;
         }
 
         type LogLevel = 'silly' | 'debug' | 'info' | 'warn' | 'error';
@@ -838,6 +838,30 @@ declare global {
                 params: GetObjectViewParams | null | undefined,
                 options?: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<GetObjectViewCallback>>;
+
+            /**
+             * Returns a list of objects with id between params.startkey and params.endkey
+             * @param params Parameters determining the objects included in the return list. Null to include all objects
+             * @param options If the returned list should be sorted. And some internal options.
+             * @param callback Is called when the operation has finished (successfully or not)
+             */
+            // TODO: options should be optional: https://github.com/ioBroker/ioBroker.js-controller/issues/574
+            // getObjectList(params: GetObjectListParams | null, callback: GetObjectListCallback): void;
+            getObjectList(
+                params: GetObjectListParams | null,
+                options: { sorted?: boolean } | Record<string, any>,
+                callback: GetObjectListCallback,
+            ): void;
+            /**
+             * Returns a list of objects with id between params.startkey and params.endkey
+             * @param params Parameters determining the objects included in the return list. Null to include all objects
+             * @param options If the returned list should be sorted. And some internal options.
+             * @param callback Is called when the operation has finished (successfully or not)
+             */
+            getObjectListAsync(
+                params: GetObjectListParams | null,
+                options: { sorted?: boolean } | Record<string, any>,
+            ): Promise<NonNullCallbackReturnTypeOf<GetObjectListCallback>>;
 
             // ==============================
             // states

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -198,6 +198,15 @@ adapter.getObjectViewAsync("system", "admin", {startkey: "foo", endkey: "bar"}).
     docs && docs.rows[0] && docs.rows[0].id.toLowerCase();
 });
 
+// TODO: https://github.com/ioBroker/ioBroker.js-controller/issues/574
+// {} should be left out or undefined
+adapter.getObjectList({startkey: "foo", endkey: "bar"}, {}, (err, result) => {
+    result && result.rows[0] && result.rows[0].id.toLowerCase();
+});
+adapter.getObjectListAsync({startkey: "foo", endkey: "bar"}, {}).then(result => {
+    result && result.rows[0] && result.rows[0].id.toLowerCase();
+});
+
 adapter.subscribeObjects("*");
 adapter.subscribeStates("*");
 adapter.subscribeForeignObjects("*");


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41161 removed the method from the Objects interface but failed to add it to the Adapter interface
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.