### PR TITLE
fix(RemoveToast): callback should be optional

### DIFF
--- a/types/react-toast-notifications/index.d.ts
+++ b/types/react-toast-notifications/index.d.ts
@@ -67,7 +67,7 @@ export interface Options {
 
 export type AddToast = (content: ReactNode, options?: Options, callback?: (id: string) => void) => void;
 
-export type RemoveToast = (id: string, callback: () => void) => void;
+export type RemoveToast = (id: string, callback?: () => void) => void;
 
 export const DefaultToastContainer: ComponentType<ToastContainerProps>;
 export const DefaultToast: ComponentType<ToastProps>;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [README](https://github.com/jossmac/react-toast-notifications)

Accordingly to docs in [README](https://github.com/jossmac/react-toast-notifications) the `removeToast` method's second argument is an optional callback.
