### PR TITLE
react-table: fixes to the react-table v7 rc.15 definitions

### DIFF
--- a/types/react-table/Readme.md
+++ b/types/react-table/Readme.md
@@ -58,6 +58,7 @@ import {
   UseFiltersState,
   UseGlobalFiltersInstanceProps,
   UseGlobalFiltersOptions,
+  UseGlobalFiltersState,
   UseGroupByCellProps,
   UseGroupByColumnOptions,
   UseGroupByColumnProps,
@@ -131,6 +132,7 @@ declare module 'react-table' {
     extends UseColumnOrderState<D>,
       UseExpandedState<D>,
       UseFiltersState<D>,
+      UseGlobalFiltersState<D>,
       UseGroupByState<D>,
       UsePaginationState<D>,
       UseResizeColumnsState<D>,
@@ -150,8 +152,8 @@ declare module 'react-table' {
       UseResizeColumnsColumnProps<D>,
       UseSortByColumnProps<D> {}
 
-  export interface Cell<D extends object = {}> 
-    extends UseGroupByCellProps<D>, 
+  export interface Cell<D extends object = {}>
+    extends UseGroupByCellProps<D>,
       UseRowStateCellProps<D> {}
 
   export interface Row<D extends object = {}>

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -148,16 +148,16 @@ export interface UseTableHooks<D extends object> extends Record<string, any> {
             instance?: TableInstance<D>,
         ) => ReducerTableState<D> | undefined
     >;
-    columns: Array<(columns: Array<Column<D>>, instance: TableInstance<D>) => Array<Column<D>>>;
-    columnsDeps: Array<(deps: any[], instance: TableInstance<D>) => any[]>;
-    flatColumns: Array<(flatColumns: Array<Column<D>>, instance: TableInstance<D>) => Array<Column<D>>>;
-    flatColumnsDeps: Array<(deps: any[], instance: TableInstance<D>) => any[]>;
-    headerGroups: Array<(flatColumns: Array<HeaderGroup<D>>, instance: TableInstance<D>) => Array<HeaderGroup<D>>>;
-    headerGroupDeps: Array<(deps: any[], instance: TableInstance<D>) => any[]>;
+    columns: Array<(columns: Array<Column<D>>, meta: Meta<D>) => Array<Column<D>>>;
+    columnsDeps: Array<(deps: any[], meta: Meta<D>) => any[]>;
+    flatColumns: Array<(flatColumns: Array<Column<D>>, meta: Meta<D>) => Array<Column<D>>>;
+    flatColumnsDeps: Array<(deps: any[], meta: Meta<D>) => any[]>;
+    headerGroups: Array<(flatColumns: Array<HeaderGroup<D>>, meta: Meta<D>) => Array<HeaderGroup<D>>>;
+    headerGroupDeps: Array<(deps: any[], meta: Meta<D>) => any[]>;
     useInstanceBeforeDimensions: Array<(instance: TableInstance<D>) => void>;
     useInstance: Array<(instance: TableInstance<D>) => void>;
-    useRows: Array<(rows: Array<Row<D>>, instance: TableInstance<D>) => Array<Row<D>>>;
-    prepareRow: Array<(row: Row<D>, instance: TableInstance<D>) => void>;
+    useRows: Array<(rows: Array<Row<D>>, meta: Meta<D>) => Array<Row<D>>>;
+    prepareRow: Array<(row: Row<D>, meta: Meta<D>) => void>;
     useControlledState: Array<(state: TableState<D>, meta: Meta<D>) => TableState<D>>;
 
     getTableProps: Array<TablePropGetter<D>>;
@@ -411,7 +411,7 @@ export type DefaultFilterTypes =
     | 'between';
 
 export interface FilterType<D extends object> {
-    (rows: Array<Row<D>>, columnId: Array<IdType<D>>, filterValue: FilterValue): Array<Row<D>>;
+    (rows: Array<Row<D>>, columnIds: Array<IdType<D>>, filterValue: FilterValue): Array<Row<D>>;
 
     autoRemove?: (filterValue: FilterValue) => boolean;
 }
@@ -434,11 +434,15 @@ export namespace useGlobalFilter {
 }
 
 export type UseGlobalFiltersOptions<D extends object> = Partial<{
-    globalFilter: ((filterValue: FilterValue) => void) | string;
+    globalFilter: ((rows: Array<Row<D>>, columnIds: Array<IdType<D>>, filterValue: any) => Array<Row<D>>) | string;
     manualGlobalFilter: boolean;
     filterTypes: FilterTypes<D>;
     autoResetGlobalFilter?: boolean;
 }>;
+
+export interface UseGlobalFiltersState<D extends object> {
+    globalFilter: any;
+}
 
 export interface UseGlobalFiltersInstanceProps<D extends object> {
     rows: Array<Row<D>>;


### PR DESCRIPTION
This PR applies a few fixes to the rc.15 pf react-table, recently merged from the DefinitelyTyped#40816:

- Added a `UseGlobalFiltersState` interface. Source: https://github.com/tannerlinsley/react-table/blob/master/docs/api/useGlobalFilter.md#table-options, at `initialState.globalFilter`.
- Proper type for the `globalFilter` in the `UseGlobalFiltersOptions`. Source: same URL, at `globalFilter: String | Function`.
- Applied the `Meta` interface for a bunch of hooks that use it. Source commit with this change: https://github.com/tannerlinsley/react-table/commit/30a40aa0a2be51a9b48ff5f57f758206f6d597c8#diff-58070e993396b86d9cd977598221d49e

<!-- -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
