### PR TITLE
Use types from tar-stream as return types of tar-fs

### DIFF
--- a/types/tar-fs/index.d.ts
+++ b/types/tar-fs/index.d.ts
@@ -9,11 +9,10 @@
 /// <reference types="node" />
 
 import fs = require('fs');
-import stream = require('stream');
+import tarStream = require('tar-stream');
 
-// Replace these return values with the value of tar-stream when it becomes available
-export function pack(cwd: string, opts?: PackOptions): stream.Readable;
-export function extract(cwd: string, opts?: ExtractOptions): stream.Writable;
+export function pack(cwd: string, opts?: PackOptions): tarStream.Pack;
+export function extract(cwd: string, opts?: ExtractOptions): tarStream.Extract;
 
 export interface Options {
     ignore?: (name: string) => boolean;

--- a/types/tar-fs/index.d.ts
+++ b/types/tar-fs/index.d.ts
@@ -14,6 +14,9 @@ import tarStream = require('tar-stream');
 export function pack(cwd: string, opts?: PackOptions): tarStream.Pack;
 export function extract(cwd: string, opts?: ExtractOptions): tarStream.Extract;
 
+export type Pack = tarStream.Pack;
+export type Extract = tarStream.Extract;
+
 export interface Options {
     ignore?: (name: string) => boolean;
     filter?: (name: string) => boolean;

--- a/types/tar-fs/tar-fs-tests.ts
+++ b/types/tar-fs/tar-fs-tests.ts
@@ -1,7 +1,6 @@
 import tar = require("tar-fs");
 import fs = require("fs");
 import path = require("path");
-import stream = require("stream");
 
 /*
  * Default test
@@ -96,3 +95,9 @@ tar.pack('./my-directory', {
 	strict: false,
 	dereference: true,
 });
+
+/*
+ * Return type of tar-stream
+ */
+tar.pack('./my-directory').entry({ name: 'generated-file.txt' }, '1234');
+tar.pack('./my-directory').finalize();


### PR DESCRIPTION
This PR addresses the comment found in the typings for `tar-fs` to use the types from `tar-stream` as the return types of `pack()` and `extract()`. By doing exactly that, we now properly represent the return type of the two mentioned functions as being a union of a readable/writeable stream and other defined methods of the return value.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/mafintosh/tar-fs/blob/master/index.js#L328
  - https://github.com/mafintosh/tar-fs/blob/master/index.js#L157

~- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
~- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
