### PR TITLE
argparse: ArgumentOptions.metavar can be an array

### DIFF
--- a/types/argparse/index.d.ts
+++ b/types/argparse/index.d.ts
@@ -109,7 +109,7 @@ export interface ArgumentOptions {
     choices?: string | string[];
     required?: boolean;
     help?: string;
-    metavar?: string;
+    metavar?: string | string[];
 }
 
 export namespace Const {


### PR DESCRIPTION
This is essential for useful docs for nargs >= 2.

https://docs.python.org/dev/library/argparse.html#metavar says this
about metavar and nargs:

Different values of nargs may cause the metavar to be used multiple
times. Providing a tuple to metavar specifies a different display for
each of the arguments.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.python.org/dev/library/argparse.html#metavar
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
