### PR TITLE
Add types for dom-parser

### DIFF
--- a/types/dom-parser/dom-parser-tests.ts
+++ b/types/dom-parser/dom-parser-tests.ts
@@ -1,0 +1,29 @@
+import DomParser = require('dom-parser');
+
+const parser = new DomParser();
+
+const exampleHtml =
+    '<html><body><div id="one" class="myclass"></div><div id="two" class="myclass"></div></body></html>';
+
+const dom = parser.parseFromString(exampleHtml); // $ExpectType Dom
+
+const element = dom.getElementById('one'); // $ExpectType Node | null
+dom.getElementsByClassName('myclass'); // $ExpectType Node[] | null
+dom.getElementsByTagName('div'); // $ExpectType Node[] | null
+dom.getElementsByName('somenonexistentname'); // $ExpectType Node[] | null
+dom.getElementsByAttribute('nonexistentattr'); // $ExpectType Node[] | null
+
+if (element) {
+    element.getAttribute('madeupattr'); // $ExpectType string | null
+
+    element.nodeType; // $ExpectType NodeType
+    element.nodeName; // $ExpectType string
+    element.childNodes; // $ExpectType Node[]
+    element.firstChild; // $ExpectType Node | null
+    element.lastChild; // $ExpectType Node | null
+    element.parentNode; // $ExpectType Node | null
+    element.attributes; // $ExpectType string[]
+    element.innerHTML; // $ExpectType string
+    element.outerHTML; // $ExpectType string
+    element.textContent; // $ExpectType string
+}

--- a/types/dom-parser/index.d.ts
+++ b/types/dom-parser/index.d.ts
@@ -1,0 +1,55 @@
+// Type definitions for dom-parser 0.1
+// Project: https://github.com/ershov-konst/dom-parser#readme
+// Definitions by: Guy Bidkar <https://github.com/gbidkar>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare class DomParser {
+    constructor();
+
+    parseFromString(html: string): DomParser.Dom;
+}
+
+declare namespace DomParser {
+    interface Dom extends DOMSearchable {
+        getElementsByClassName(className: string): Node[] | null;
+        getElementsByTagName(tagName: string): Node[] | null;
+        getElementsByName(name: string): Node[] | null;
+        getElementById(id: string): Node | null;
+
+        getElementsByAttribute(attribute: string): Node[] | null;
+    }
+
+    interface Node extends DOMSearchable {
+        nodeType: NodeType;
+        nodeName: string;
+        childNodes: Node[];
+        firstChild: Node | null;
+        lastChild: Node | null;
+        parentNode: Node | null;
+        attributes: string[];
+        innerHTML: string;
+        outerHTML: string;
+        textContent: string;
+
+        getElementsByClassName(className: string): Node[] | null;
+        getElementsByTagName(tagName: string): Node[] | null;
+        getElementsByName(name: string): Node[] | null;
+        getElementById(id: string): Node | null;
+
+        getAttribute(name: string): string | null;
+    }
+
+    interface DOMSearchable {
+        getElementsByClassName(className: string): Node[] | null;
+        getElementsByTagName(tagName: string): Node[] | null;
+        getElementsByName(name: string): Node[] | null;
+        getElementById(id: string): Node | null;
+    }
+
+    enum NodeType {
+        ELEMENT_NODE = 1,
+        TEXT_NODE = 3
+    }
+}
+
+export = DomParser;

--- a/types/dom-parser/tsconfig.json
+++ b/types/dom-parser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "dom-parser-tests.ts"
+    ]
+}

--- a/types/dom-parser/tslint.json
+++ b/types/dom-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Add types to [dom-parser](https://www.npmjs.com/package/dom-parser)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding new declarations
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
