### PR TITLE
[w3c-web-usb] Complete strongly-typed EventTarget functions

### DIFF
--- a/types/w3c-web-usb/index.d.ts
+++ b/types/w3c-web-usb/index.d.ts
@@ -108,12 +108,14 @@ declare class USBIsochronousOutTransferResult {
 }
 
 declare class USB extends EventTarget {
-    onconnect(): (this: this, ev: Event) => any;
-    ondisconnect(): (this: this, ev: Event) => any;
+    onconnect: ((this: this, ev: USBConnectionEvent) => any) | null;
+    ondisconnect: ((this: this, ev: USBConnectionEvent) => any) | null;
     getDevices(): Promise<USBDevice[]>;
     requestDevice(options?: USBDeviceRequestOptions): Promise<USBDevice>;
     addEventListener(type: "connect" | "disconnect", listener: (this: this, ev: USBConnectionEvent) => any, useCapture?: boolean): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(type: "connect" | "disconnect", callback: (this: this, ev: USBConnectionEvent) => any, useCapture?: boolean): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean): void;
 }
 
 declare class USBDevice {


### PR DESCRIPTION
Updated the `onconnect` and `ondisconnect` syntax and completed the strongly-typed events with `removeEventListener`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: `onconnect` and `ondisconnect` events updated to follow [common dom pattern](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L5903)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
