### PR TITLE
[web-bluetooth] Added missing BluetoothDevice event

### DIFF
--- a/types/web-bluetooth/index.d.ts
+++ b/types/web-bluetooth/index.d.ts
@@ -1,7 +1,8 @@
 // Type definitions for Web Bluetooth
 // Project: https://webbluetoothcg.github.io/web-bluetooth/
 // Definitions by: Uri Shaked <https://github.com/urish>
-// 								 Xavier Lozinguez <http://github.com/xlozinguez>
+//					Xavier Lozinguez <http://github.com/xlozinguez>
+//					Rob Moran <https://github.com/thegecko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 type BluetoothServiceUUID = number | string;
@@ -83,7 +84,7 @@ interface BluetoothRemoteGATTService extends EventTarget, CharacteristicEventHan
 	addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 }
 
-interface BluetoothRemoteGATTServer extends EventTarget {
+interface BluetoothRemoteGATTServer {
 	readonly device: BluetoothDevice;
 	readonly connected: boolean;
 	connect(): Promise<BluetoothRemoteGATTServer>;
@@ -93,6 +94,7 @@ interface BluetoothRemoteGATTServer extends EventTarget {
 }
 
 interface BluetoothDeviceEventHandlers {
+	onadvertisementreceived: (this: this, ev: Event) => any;
 	ongattserverdisconnected: (this: this, ev: Event) => any;
 }
 


### PR DESCRIPTION
Added missing `onadvertisementreceived` event and stopped `BluetoothRemoteGATTServer` from extending `EventTarget`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

- Missing `onadvertisementreceived` event is outlined in the [bluetoothdeviceeventhandlers here](https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdeviceeventhandlers)
- `BluetoothRemoteGATTServer` has no events as [seen here](https://webbluetoothcg.github.io/web-bluetooth/#bluetoothremotegattserver)

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
