### PR TITLE
fix: rdf-js parsers actually return a quad stream

### DIFF
--- a/types/rdfjs__parser-jsonld/index.d.ts
+++ b/types/rdfjs__parser-jsonld/index.d.ts
@@ -3,9 +3,8 @@
 // Definitions by: Chris Wilkinson <https://github.com/thewilkybarkid>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { EventEmitter } from 'events';
 import { Context } from 'jsonld/jsonld-spec';
-import { DataFactory, Sink, Stream } from 'rdf-js';
+import { DataFactory, Sink, Stream, BaseQuad, Quad } from 'rdf-js';
 
 declare namespace Parser {
     interface ParserOptions {
@@ -15,10 +14,10 @@ declare namespace Parser {
     }
 }
 
-declare class Parser implements Sink {
+declare class Parser<Q extends BaseQuad = Quad> implements Sink<Q> {
     constructor(options?: Parser.ParserOptions);
 
-    import(stream: Stream, options?: Parser.ParserOptions): EventEmitter;
+    import(stream: Stream<Q>, options?: Parser.ParserOptions): Stream<Q>;
 }
 
 export = Parser;

--- a/types/rdfjs__parser-jsonld/rdfjs__parser-jsonld-tests.ts
+++ b/types/rdfjs__parser-jsonld/rdfjs__parser-jsonld-tests.ts
@@ -1,6 +1,6 @@
 import Parser = require('@rdfjs/parser-jsonld');
 import { Context } from 'jsonld/jsonld-spec';
-import { DataFactory, Sink, Stream } from 'rdf-js';
+import { DataFactory, Sink, Stream, BaseQuad } from 'rdf-js';
 
 const baseIRI = '';
 const context: Context = {} as any;
@@ -16,3 +16,12 @@ const sink: Sink = parser1;
 const eventEmitter1: Stream = parser1.import(stream);
 const eventEmitter2: Stream = parser1.import(stream, {});
 const eventEmitter3: Stream = parser1.import(stream, { baseIRI, context, factory });
+
+interface SpecializedQuad extends BaseQuad {
+    foo: string;
+}
+const typedStream: Stream<SpecializedQuad> = <any> {};
+const typedParser: Parser<SpecializedQuad> = <any> {};
+const typedImported: Stream<SpecializedQuad> = typedParser.import(typedStream);
+const typedImported1: Stream<SpecializedQuad> = typedParser.import(typedStream, {});
+const typedImported2: Stream<SpecializedQuad> = typedParser.import(typedStream, { baseIRI, context, factory });

--- a/types/rdfjs__parser-jsonld/rdfjs__parser-jsonld-tests.ts
+++ b/types/rdfjs__parser-jsonld/rdfjs__parser-jsonld-tests.ts
@@ -1,5 +1,4 @@
 import Parser = require('@rdfjs/parser-jsonld');
-import { EventEmitter } from 'events';
 import { Context } from 'jsonld/jsonld-spec';
 import { DataFactory, Sink, Stream } from 'rdf-js';
 
@@ -14,6 +13,6 @@ const parser3 = new Parser({ baseIRI, context, factory });
 
 const sink: Sink = parser1;
 
-const eventEmitter1: EventEmitter = parser1.import(stream);
-const eventEmitter2: EventEmitter = parser1.import(stream, {});
-const eventEmitter3: EventEmitter = parser1.import(stream, { baseIRI, context, factory });
+const eventEmitter1: Stream = parser1.import(stream);
+const eventEmitter2: Stream = parser1.import(stream, {});
+const eventEmitter3: Stream = parser1.import(stream, { baseIRI, context, factory });

--- a/types/rdfjs__parser-n3/index.d.ts
+++ b/types/rdfjs__parser-n3/index.d.ts
@@ -3,18 +3,17 @@
 // Definitions by: tpluscode <https://github.com/tpluscode>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { EventEmitter } from 'events';
-import { Sink, Stream, DataFactory } from 'rdf-js';
+import { Sink, Stream, DataFactory, BaseQuad, Quad } from 'rdf-js';
 
 interface ParserOptions {
     baseIRI?: string;
     factory?: DataFactory;
 }
 
-declare class Parser implements Sink {
+declare class Parser<Q extends BaseQuad = Quad> implements Sink<Q> {
     constructor(options?: ParserOptions);
 
-    import(stream: Stream, options?: ParserOptions): EventEmitter;
+    import(stream: Stream<Q>, options?: ParserOptions): Stream<Q>;
 }
 
 export = Parser;

--- a/types/rdfjs__parser-n3/rdfjs__parser-n3-tests.ts
+++ b/types/rdfjs__parser-n3/rdfjs__parser-n3-tests.ts
@@ -1,6 +1,5 @@
 import ParserN3 = require('@rdfjs/parser-n3');
 import { Stream, DataFactory, Sink } from 'rdf-js';
-import { EventEmitter } from 'events';
 
 const factory: DataFactory = <any> {};
 const baseIRI = '';
@@ -13,7 +12,7 @@ const parser3 = new ParserN3({ baseIRI });
 const sink: Sink = parser;
 
 const input: Stream = <any> {};
-const output: EventEmitter = parser.import(input);
-const output1: EventEmitter = parser.import(input, {});
-const output2: EventEmitter = parser.import(input, { factory });
-const output3: EventEmitter = parser.import(input, { baseIRI });
+const output: Stream = parser.import(input);
+const output1: Stream = parser.import(input, {});
+const output2: Stream = parser.import(input, { factory });
+const output3: Stream = parser.import(input, { baseIRI });

--- a/types/rdfjs__parser-n3/rdfjs__parser-n3-tests.ts
+++ b/types/rdfjs__parser-n3/rdfjs__parser-n3-tests.ts
@@ -1,5 +1,5 @@
 import ParserN3 = require('@rdfjs/parser-n3');
-import { Stream, DataFactory, Sink } from 'rdf-js';
+import { Stream, DataFactory, Sink, BaseQuad } from 'rdf-js';
 
 const factory: DataFactory = <any> {};
 const baseIRI = '';
@@ -16,3 +16,12 @@ const output: Stream = parser.import(input);
 const output1: Stream = parser.import(input, {});
 const output2: Stream = parser.import(input, { factory });
 const output3: Stream = parser.import(input, { baseIRI });
+
+interface SpecializedQuad extends BaseQuad {
+    foo: string;
+}
+const typedStream: Stream<SpecializedQuad> = <any> {};
+const typedParser: ParserN3<SpecializedQuad> = <any> {};
+const typedImported: Stream<SpecializedQuad> = typedParser.import(typedStream);
+const typedImported1: Stream<SpecializedQuad> = typedParser.import(typedStream, {});
+const typedImported2: Stream<SpecializedQuad> = typedParser.import(typedStream, { baseIRI, factory });

--- a/types/rdfjs__serializer-jsonld-ext/index.d.ts
+++ b/types/rdfjs__serializer-jsonld-ext/index.d.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from 'events';
 import { Context } from 'jsonld/jsonld-spec';
-import { Sink, Stream } from 'rdf-js';
+import { Sink, Stream, BaseQuad, Quad } from 'rdf-js';
 
 declare namespace Serializer {
     interface SerializerOptions {
@@ -19,10 +19,10 @@ declare namespace Serializer {
     }
 }
 
-declare class Serializer implements Sink {
+declare class Serializer<Q extends BaseQuad = Quad> implements Sink<Q> {
     constructor(options?: Serializer.SerializerOptions);
 
-    import(stream: Stream, options?: Serializer.SerializerOptions): EventEmitter;
+    import(stream: Stream<Q>, options?: Serializer.SerializerOptions): EventEmitter;
 }
 
 export = Serializer;

--- a/types/rdfjs__serializer-jsonld/index.d.ts
+++ b/types/rdfjs__serializer-jsonld/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { EventEmitter } from 'events';
-import { Sink, Stream } from 'rdf-js';
+import { Sink, Stream, BaseQuad, Quad } from 'rdf-js';
 
 declare namespace Serializer {
     interface SerializerOptions {
@@ -12,10 +12,10 @@ declare namespace Serializer {
     }
 }
 
-declare class Serializer implements Sink {
+declare class Serializer<Q extends BaseQuad = Quad> implements Sink<Q> {
     constructor(options?: Serializer.SerializerOptions);
 
-    import(stream: Stream, options?: Serializer.SerializerOptions): EventEmitter;
+    import(stream: Stream<Q>, options?: Serializer.SerializerOptions): EventEmitter;
 }
 
 export = Serializer;


### PR DESCRIPTION
The base `EventEmitter` is not enough to write the code below:

```typescript
import stringToStream from 'string-to-stream'
import rdf from 'rdf-ext'
import { Dataset } from 'rdf-js'

export function parse(quads: string): Promise<Dataset> {
  const stream = stringToStream(quads) as any

  return rdf.dataset().import(parser.import(stream))
}
```

This code works fine and for typings to be correct the `parser.stream()` should return a stream

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: _see above_
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

