### PR TITLE
value validators accept number or date

### DIFF
--- a/types/vuelidate/lib/validators.d.ts
+++ b/types/vuelidate/lib/validators.d.ts
@@ -37,9 +37,9 @@ export function requiredIf(field: string | ((vm: any, parentVm?: Vue) => any)): 
 export function requiredUnless(field: string | ((vm: any, parentVm?: Vue) => any)): ValidationRule
 export function minLength(length: number): ValidationRule
 export function maxLength(length: number): ValidationRule
-export function minValue(min: number): ValidationRule
-export function maxValue(max: number): ValidationRule
-export function between(min: number, max: number): ValidationRule
+export function minValue(min: number | Date): ValidationRule
+export function maxValue(max: number | Date): ValidationRule
+export function between(min: number | Date, max: number | Date): ValidationRule
 export function alpha(): ValidationRule
 export function alphaNum(): ValidationRule
 export function numeric(): ValidationRule

--- a/types/vuelidate/package.json
+++ b/types/vuelidate/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "vue": "^2.5.16"
+        "vue": "^2.6.11"
     }
 }


### PR DESCRIPTION
As can be seen  in the current vuelidate project source files, the validators handle dates as well as numbers (to be precise they handle strings which can be converted to numbers as well, but I haven't addressed this use case):

https://github.com/vuelidate/vuelidate/blob/master/src/validators/minValue.js
https://github.com/vuelidate/vuelidate/blob/master/src/validators/between.js

