### PR TITLE
fix: preserve term generic type when constructing from another graph

### DIFF
--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -1,8 +1,9 @@
-import { Term, NamedNode, Dataset, Literal } from 'rdf-js';
+import { Term, NamedNode, Dataset, Literal, DatasetCore, BlankNode } from 'rdf-js';
 import Clownface = require('clownface/lib/Clownface');
 import clownface = require('clownface');
 
 const node: NamedNode = <any> {};
+const blankNode: BlankNode = <any> {};
 const predicate: NamedNode = <any> {};
 const literal: Literal = <any> {};
 let term: Term = <any> {};
@@ -13,8 +14,8 @@ const graph: NamedNode = <any> {};
 
 let cf = new Clownface({ dataset });
 cf = new Clownface({ dataset, graph });
-cf = new Clownface({ dataset, term });
-cf = new Clownface({ dataset, term: [term, term] });
+const typedByTerm: Clownface<DatasetCore, NamedNode> = new Clownface({ dataset, term: node });
+const typedByTerms: Clownface<DatasetCore, NamedNode | BlankNode> = new Clownface({ dataset, term: [node, blankNode] });
 cf = new Clownface({ dataset, value: 'foo' });
 cf = new Clownface({ dataset, value: ['foo', 'bar'] });
 cf = new Clownface({ dataset, term: [term, term], value: ['foo', 'bar'] });
@@ -50,10 +51,10 @@ cf = cf.addOut(predicate, child => {
 cf = cf.addOut(cf.node(predicate), cf.node(node));
 
 // .blankNode
-let blankNode: Clownface;
-blankNode = cf.blankNode();
-blankNode = cf.blankNode('label');
-blankNode = cf.blankNode([ 'b1', 'b2' ]);
+let blankContext: Clownface;
+blankContext = cf.blankNode();
+blankContext = cf.blankNode('label');
+blankContext = cf.blankNode([ 'b1', 'b2' ]);
 
 // .deleteIn
 cf = cf.deleteIn();
@@ -73,6 +74,25 @@ cf = clownface({ dataset });
 cf = clownface({ dataset, term });
 cf = clownface({ dataset, graph });
 cf = clownface({ dataset, value: 'foo' });
+
+const termContext: Clownface = clownface({
+    dataset,
+    term
+});
+
+const namedContext: Clownface<DatasetCore, NamedNode> = clownface({
+    dataset,
+    term: node,
+});
+
+const maybeNamed: BlankNode | NamedNode = <any> {};
+const altContext: Clownface<DatasetCore, BlankNode | NamedNode> = clownface({
+    dataset,
+    term: maybeNamed,
+});
+
+const literalContext: clownface.SingleContextClownface<Dataset, Literal> = <any> {};
+const deriveContextFromOtherGraph: Clownface<Dataset, Literal>  = clownface(literalContext);
 
 // .filter
 cf = cf.filter(() => true);

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -29,8 +29,8 @@ declare namespace clownface {
         value: string | string[];
     }
 
-    interface WithTerm {
-        term: Term | Term[];
+    interface WithTerm<T extends Term = Term> {
+        term: T | T[];
     }
 
     interface Clownface<D extends DatasetCore = DatasetCore, T extends Term = Term> {
@@ -87,7 +87,11 @@ declare namespace clownface {
     }
 }
 
-declare function clownface<D extends DatasetCore>(options: clownface.ClownfaceInit<D> & clownface.WithTerm | clownface.ClownfaceInit<D> & clownface.WithValue): clownface.SafeClownface<D>;
-declare function clownface<D extends DatasetCore>(options: clownface.ClownfaceInit<D>): clownface.Clownface<D>;
+type ClownfaceInitWithNode<D extends DatasetCore, T extends Term> =
+    clownface.ClownfaceInit<D> & clownface.WithTerm<T> |
+    clownface.ClownfaceInit<D> & clownface.WithValue;
+
+declare function clownface<D extends DatasetCore, T extends Term = Term>(options: ClownfaceInitWithNode<D, T>): clownface.SafeClownface<D, T>;
+declare function clownface<D extends DatasetCore, T extends Term = Term>(options: clownface.ClownfaceInit<D, T>): clownface.Clownface<D, T>;
 
 export = clownface;

--- a/types/clownface/lib/Clownface.d.ts
+++ b/types/clownface/lib/Clownface.d.ts
@@ -1,55 +1,55 @@
-    import { BlankNode, DatasetCore, Literal, NamedNode, Quad_Graph, Term } from 'rdf-js';
-    import {
-        Clownface as ClownfaceContract,
-        ClownfaceInit,
-        AddCallback,
-        NodeOptions,
-        SafeClownface,
-        SingleOrArray,
-        SingleOrArrayOfTerms,
-        SingleOrArrayOfTermsOrLiterals,
-        WithValue,
-        WithTerm
-    } from '..';
+import { BlankNode, DatasetCore, Literal, NamedNode, Quad_Graph, Term } from 'rdf-js';
+import {
+    Clownface as ClownfaceContract,
+    ClownfaceInit,
+    AddCallback,
+    NodeOptions,
+    SafeClownface,
+    SingleOrArray,
+    SingleOrArrayOfTerms,
+    SingleOrArrayOfTermsOrLiterals,
+    WithValue,
+    WithTerm
+} from '..';
 
-    declare class Clownface<D extends DatasetCore = DatasetCore, T extends Term = Term> implements ClownfaceContract<D, T> {
-        constructor(options: ClownfaceInit & Partial<WithTerm<T>> & Partial<WithValue>);
-        readonly term: T | undefined;
-        readonly terms: T[];
-        readonly value: string | undefined;
-        readonly values: string[];
-        readonly dataset: D;
-        readonly datasets: D[];
-        readonly _context: any;
-        list(): Iterator<Term>;
-        toArray(): Array<Clownface<D, T>>;
-        filter(cb: (quad: Clownface<D, T>) => boolean): Clownface<D, T>;
-        forEach(cb: (quad: Clownface<D, T>) => void): void;
-        map<X>(cb: (quad: Clownface<D, T>, index: number) => X): X[];
+declare class Clownface<D extends DatasetCore = DatasetCore, T extends Term = Term> implements ClownfaceContract<D, T> {
+    constructor(options: ClownfaceInit & Partial<WithTerm<T>> & Partial<WithValue>);
+    readonly term: T | undefined;
+    readonly terms: T[];
+    readonly value: string | undefined;
+    readonly values: string[];
+    readonly dataset: D;
+    readonly datasets: D[];
+    readonly _context: any;
+    list(): Iterator<Term>;
+    toArray(): Array<Clownface<D, T>>;
+    filter(cb: (quad: Clownface<D, T>) => boolean): Clownface<D, T>;
+    forEach(cb: (quad: Clownface<D, T>) => void): void;
+    map<X>(cb: (quad: Clownface<D, T>, index: number) => X): X[];
 
-        // tslint:disable:no-unnecessary-generics
-        node<X extends Term = Term>(values: SingleOrArray<boolean | string | number | Term | null>, options?: NodeOptions): SafeClownface<D, X>;
-        blankNode(values?: SingleOrArray<string>): SafeClownface<D, BlankNode>;
-        literal(values: SingleOrArray<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): SafeClownface<D, Literal>;
-        namedNode(values: SingleOrArray<string | NamedNode>): SafeClownface<D, NamedNode>;
+    // tslint:disable:no-unnecessary-generics
+    node<X extends Term = Term>(values: SingleOrArray<boolean | string | number | Term | null>, options?: NodeOptions): SafeClownface<D, X>;
+    blankNode(values?: SingleOrArray<string>): SafeClownface<D, BlankNode>;
+    literal(values: SingleOrArray<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): SafeClownface<D, Literal>;
+    namedNode(values: SingleOrArray<string | NamedNode>): SafeClownface<D, NamedNode>;
 
-        in<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
-        out<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
+    in<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
+    out<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
 
-        has<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTermsOrLiterals): SafeClownface<D, X>;
+    has<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTermsOrLiterals): SafeClownface<D, X>;
 
-        addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
-        addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
+    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
+    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
 
-        addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
-        addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
+    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
+    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
 
-        addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTerms, callback?: AddCallback<D, X>): SafeClownface<D, X>;
+    addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTerms, callback?: AddCallback<D, X>): SafeClownface<D, X>;
 
-        deleteIn<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-        deleteOut<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-        deleteList<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
-        // tslint:enable:no-unnecessary-generics
-    }
+    deleteIn<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
+    deleteOut<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
+    deleteList<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
+    // tslint:enable:no-unnecessary-generics
+}
 
-    export = Clownface;
+export = Clownface;

--- a/types/clownface/lib/Clownface.d.ts
+++ b/types/clownface/lib/Clownface.d.ts
@@ -1,55 +1,55 @@
-import { BlankNode, DatasetCore, Literal, NamedNode, Quad_Graph, Term } from 'rdf-js';
-import {
-    Clownface as ClownfaceContract,
-    ClownfaceInit,
-    AddCallback,
-    NodeOptions,
-    SafeClownface,
-    SingleOrArray,
-    SingleOrArrayOfTerms,
-    SingleOrArrayOfTermsOrLiterals,
-    WithValue,
-    WithTerm
-} from '..';
+    import { BlankNode, DatasetCore, Literal, NamedNode, Quad_Graph, Term } from 'rdf-js';
+    import {
+        Clownface as ClownfaceContract,
+        ClownfaceInit,
+        AddCallback,
+        NodeOptions,
+        SafeClownface,
+        SingleOrArray,
+        SingleOrArrayOfTerms,
+        SingleOrArrayOfTermsOrLiterals,
+        WithValue,
+        WithTerm
+    } from '..';
 
-declare class Clownface<D extends DatasetCore = DatasetCore, T extends Term = Term> implements ClownfaceContract<D, T> {
-    constructor(options: ClownfaceInit & Partial<WithTerm> & Partial<WithValue>);
-    readonly term: T | undefined;
-    readonly terms: T[];
-    readonly value: string | undefined;
-    readonly values: string[];
-    readonly dataset: D;
-    readonly datasets: D[];
-    readonly _context: any;
-    list(): Iterator<Term>;
-    toArray(): Array<Clownface<D, T>>;
-    filter(cb: (quad: Clownface<D, T>) => boolean): Clownface<D, T>;
-    forEach(cb: (quad: Clownface<D, T>) => void): void;
-    map<X>(cb: (quad: Clownface<D, T>, index: number) => X): X[];
+    declare class Clownface<D extends DatasetCore = DatasetCore, T extends Term = Term> implements ClownfaceContract<D, T> {
+        constructor(options: ClownfaceInit & Partial<WithTerm<T>> & Partial<WithValue>);
+        readonly term: T | undefined;
+        readonly terms: T[];
+        readonly value: string | undefined;
+        readonly values: string[];
+        readonly dataset: D;
+        readonly datasets: D[];
+        readonly _context: any;
+        list(): Iterator<Term>;
+        toArray(): Array<Clownface<D, T>>;
+        filter(cb: (quad: Clownface<D, T>) => boolean): Clownface<D, T>;
+        forEach(cb: (quad: Clownface<D, T>) => void): void;
+        map<X>(cb: (quad: Clownface<D, T>, index: number) => X): X[];
 
-    // tslint:disable:no-unnecessary-generics
-    node<X extends Term = Term>(values: SingleOrArray<boolean | string | number | Term | null>, options?: NodeOptions): SafeClownface<D, X>;
-    blankNode(values?: SingleOrArray<string>): SafeClownface<D, BlankNode>;
-    literal(values: SingleOrArray<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): SafeClownface<D, Literal>;
-    namedNode(values: SingleOrArray<string | NamedNode>): SafeClownface<D, NamedNode>;
+        // tslint:disable:no-unnecessary-generics
+        node<X extends Term = Term>(values: SingleOrArray<boolean | string | number | Term | null>, options?: NodeOptions): SafeClownface<D, X>;
+        blankNode(values?: SingleOrArray<string>): SafeClownface<D, BlankNode>;
+        literal(values: SingleOrArray<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): SafeClownface<D, Literal>;
+        namedNode(values: SingleOrArray<string | NamedNode>): SafeClownface<D, NamedNode>;
 
-    in<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
-    out<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
+        in<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
+        out<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
 
-    has<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTermsOrLiterals): SafeClownface<D, X>;
+        has<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTermsOrLiterals): SafeClownface<D, X>;
 
-    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
-    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
+        addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
+        addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
 
-    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
-    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
+        addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
+        addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
 
-    addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTerms, callback?: AddCallback<D, X>): SafeClownface<D, X>;
+        addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTerms, callback?: AddCallback<D, X>): SafeClownface<D, X>;
 
-    deleteIn<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-    deleteOut<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-    deleteList<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
-    // tslint:enable:no-unnecessary-generics
-}
+        deleteIn<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
+        deleteOut<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
+        deleteList<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
+        // tslint:enable:no-unnecessary-generics
+    }
 
-export = Clownface;
+    export = Clownface;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
