### PR TITLE
[swagger-ui-express] Add explorer to opts

### DIFF
--- a/types/swagger-ui-express/index.d.ts
+++ b/types/swagger-ui-express/index.d.ts
@@ -22,6 +22,7 @@ export interface SwaggerUiOptions {
     customfavIcon?: string;
     customJs?: string;
     customSiteTitle?: string;
+    explorer?: boolean;
     isExplorer?: boolean;
     options?: SwaggerOptions;
     swaggerUrl?: string;


### PR DESCRIPTION
Template below, this adds `explorer` to the `SwaggerUiOptions` because currently if you try to use this option with swagger-ui-express typescript will throw an error incorrectly. 

You can see that [on this line](https://github.com/scottie1984/swagger-ui-express/blob/master/index.js#L148) it's using the `explorer` property from the options object, and is recommend in the [readme](https://github.com/scottie1984/swagger-ui-express/blob/master/README.md) as well, so this is the correct syntax.

`isExplorer = opts.explorer`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/scottie1984/swagger-ui-express/blob/master/index.js#L148
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
