### PR TITLE
[styled-components]: revert 'as' prop overload change for TS 3.7

### DIFF
--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -154,12 +154,17 @@ export interface StyledComponentBase<
     A extends keyof any = never
 > extends ForwardRefExoticBase<StyledComponentProps<C, T, O, A>> {
     // add our own fake call signature to implement the polymorphic 'as' prop
+    // TODO replace the following call signature with an actually polymorphic 'as' to make 'as' typesafe
     (
-        props: StyledComponentProps<C, T, O, A> & { as?: never }
-      ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
-    <AsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C>(
-      props: StyledComponentPropsWithAs<AsC, T, O, A>
-    ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A>>;
+        props: StyledComponentProps<C, T, O, A> & {
+            /**
+             * Typing Note: prefer using .withComponent for now as it is actually type-safe.
+             *
+             * String types need to be cast to themselves to become literal types (as={'a' as 'a'}).
+             */
+            as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+        }
+    ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
 
     withComponent<WithC extends AnyStyledComponent>(
         component: WithC


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

## Context
The overloads for the 'as' prop in styled-components was recently changed in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40209 which understood that
>This is potentially breaking for users that were using the as= property, but this is one of the "good breaks": the old as= behavior would use the wrong prop types.

However, the change has proven to be definitely breaking and more severe than assumed: users cannot use the 'as' prop at all because there are no types for it.
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/40358
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/40650

If this change only threw errors when 'as' causes the component to receive the wrong types due to component change then that would be understandable.

I do not have the typescript prowess to understand how close the below old code was to achieving truly polymorphic 'as' typings. If someone can make it possible then that would absolutely be the preferred resolution.
```
    // NOTE: TS <3.2 will refuse to infer the generic and this component becomes impossible to use in JSX
    // just the presence of the overload is enough to break JSX
    //
    // TODO (TypeScript 3.2): actually makes the 'as' prop polymorphic
    // (
    //     props: StyledComponentProps<C, T, O, A> & { as?: never }
    //   ): React.ReactElement<StyledComponentProps<C, T, O, A>>
    // <AsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C>(
    //   props: StyledComponentPropsWithAs<AsC, T, O, A>
    // ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A>>

    // TODO (TypeScript 3.2): delete this overload
    (
        props: StyledComponentProps<C, T, O, A> & {
            /**
             * Typing Note: prefer using .withComponent for now as it is actually type-safe.
             *
             * String types need to be cast to themselves to become literal types (as={'a' as 'a'}).
             */
            as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
        }
    ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
```

## Resolution
Therefore this PR simply re-instates the pre 3.7 overload for non-typesafe 'as'
