### PR TITLE
[bent] Add types for overriding headers in request call

### DIFF
--- a/types/bent/index.d.ts
+++ b/types/bent/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for bent 7.0
 // Project: https://github.com/mikeal/bent#readme
-// Definitions by: Ovyerus <https://github.com/me>
+// Definitions by: Ovyerus <https://github.com/Ovyerus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 

--- a/types/bent/index.d.ts
+++ b/types/bent/index.d.ts
@@ -11,7 +11,9 @@ import { PassThrough, Stream } from 'stream';
 type HttpMethod = 'GET' | 'POST' | 'DELETE' | 'PUT' | 'PATCH' | 'HEAD' | 'OPTIONS' | 'CONNECT' | 'TRACE';
 type StatusCode = number;
 type BaseUrl = string;
-interface Headers { [key: string]: any; }
+interface Headers {
+    [key: string]: any;
+}
 
 // Type first
 declare function bent(type: 'string', ...args: bent.Options[]): bent.RequestFunction<string>;
@@ -20,7 +22,11 @@ declare function bent(type: 'json', ...args: bent.Options[]): bent.RequestFuncti
 
 // Method or url first
 declare function bent(baseUrl: string, type: 'string', ...args: bent.Options[]): bent.RequestFunction<string>;
-declare function bent(baseUrl: string, type: 'buffer', ...args: bent.Options[]): bent.RequestFunction<Buffer | ArrayBuffer>;
+declare function bent(
+    baseUrl: string,
+    type: 'buffer',
+    ...args: bent.Options[]
+): bent.RequestFunction<Buffer | ArrayBuffer>;
 declare function bent(baseUrl: string, type: 'json', ...args: bent.Options[]): bent.RequestFunction<bent.Json>;
 declare function bent(baseUrl: string, ...args: bent.Options[]): bent.RequestFunction<bent.ValidResponse>;
 
@@ -33,18 +39,18 @@ declare function bent(...args: bent.Options[]): bent.RequestFunction<bent.ValidR
 // declare function bent(...args: (bent.Options | 'json')[]): bent.RequestFunction<Json>;
 
 declare namespace bent {
-    type RequestFunction<T extends ValidResponse> = (url: string, body?: RequestBody) => Promise<T>;
+    type RequestFunction<T extends ValidResponse> = (url: string, body?: RequestBody, headers?: Headers) => Promise<T>;
     type Options = HttpMethod | StatusCode | Headers | BaseUrl;
     type RequestBody = string | Stream | Buffer | ArrayBuffer | Json;
     type NodeResponse = PassThrough & {
         statusCode: number;
         statusMessage: string;
-        headers: Headers
+        headers: Headers;
     };
-    type FetchResponse = Response & {statusCode: number};
+    type FetchResponse = Response & { statusCode: number };
     type BentResponse = NodeResponse | FetchResponse;
 
-    type Json = { [key: string]: any; [key: number]: any; } | any[];
+    type Json = { [key: string]: any; [key: number]: any } | any[];
     type ValidResponse = BentResponse | string | Buffer | ArrayBuffer | Json;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mikeal/bent#async-requesturl-bodynull-headers
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (can't because the author put it under a patch version lol)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
