### PR TITLE
dygraphs: add missing getRowForX() definition

### DIFF
--- a/types/dygraphs/index.d.ts
+++ b/types/dygraphs/index.d.ts
@@ -1285,6 +1285,16 @@ declare class Dygraph {
     indexFromSetName(name: string): number;
 
     /**
+     * Find the row number corresponding to the given x-value.
+     * Returns null if there is no such x-value in the data.
+     * If there are multiple rows with the same x-value, this will return the
+     * first one.
+     * @param {number} xVal The x-value to look for (e.g. millis since epoch).
+     * @return {?number} The row number, which you can pass to getValue(), or null.
+     */
+    getRowForX(xVal: number): number | null;
+
+    /**
      * Trigger a callback when the dygraph has drawn itself and is ready to be
      * manipulated. This is primarily useful when dygraphs has to do an XHR for the
      * data (i.e. a URL is passed as the data source) and the chart is drawn

--- a/types/dygraphs/index.d.ts
+++ b/types/dygraphs/index.d.ts
@@ -1289,8 +1289,8 @@ declare class Dygraph {
      * Returns null if there is no such x-value in the data.
      * If there are multiple rows with the same x-value, this will return the
      * first one.
-     * @param {number} xVal The x-value to look for (e.g. millis since epoch).
-     * @return {?number} The row number, which you can pass to getValue(), or null.
+     * @param xVal The x-value to look for (e.g. millis since epoch).
+     * @return The row number, which you can pass to getValue(), or null.
      */
     getRowForX(xVal: number): number | null;
 


### PR DESCRIPTION
Documentation: http://dygraphs.com/jsdoc/symbols/Dygraph.html#getRowForX
Source code: https://github.com/danvk/dygraphs/blob/27cee3f7233fbbbeed31f0cf03ea81bf92555b18/src/dygraph.js#L3345-L3372

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
