### PR TITLE
[react-document-title] Switch to = export

### DIFF
--- a/types/react-document-title/index.d.ts
+++ b/types/react-document-title/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-document-title 2.0
 // Project: https://github.com/gaearon/react-document-title
 // Definitions by: Cleve Littlefield <https://github.com/cleverguy25>
+//                 Evan Broder <https://github.com/ebroder>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -13,4 +14,4 @@ interface DocumentTitleProps {
 declare class DocumentTitle extends React.Component<DocumentTitleProps, any> {
 }
 
-export default DocumentTitle;
+export = DocumentTitle;

--- a/types/react-document-title/react-document-title-tests.tsx
+++ b/types/react-document-title/react-document-title-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import DocumentTitle from 'react-document-title';
+import * as DocumentTitle from 'react-document-title';
 
 class TitleTest extends React.Component<any, any> {
 	render() {


### PR DESCRIPTION
react-document-title exports the DocumentType React component directly to module.exports, meaning that a default export doesn't work. I'm still not 100% sure that I understand default exports vs. = exports, but I'm pretty sure that this matches the behavior of the upstream library.

- [:heavy_check_mark:] Use a meaningful title for the pull request. Include the name of the package modified.
- [:heavy_check_mark:] Test the change in your own code. (Compile and run.)
- [:heavy_check_mark:] Add or edit tests to reflect the change. (Run with `npm test`.)
- [:heavy_check_mark:] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [:heavy_check_mark:] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [:x:] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

(I wasn't able to get lint to run because of an error with react depending on csstype, but that seems unrelated to my change)

If changing an existing definition:
- [:heavy_check_mark:] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gaearon/react-document-title/blob/56c71c934ad78aeed759b1972e6d332724176783/index.js#L37-L40
- [:x:] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [:x:] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
