### PR TITLE
Add types for sax-stream

### DIFF
--- a/types/sax-stream/index.d.ts
+++ b/types/sax-stream/index.d.ts
@@ -1,0 +1,54 @@
+// Type definitions for sax-stream 1.3
+// Project: https://github.com/melitele/sax-stream
+// Definitions by: Michael de Wit <https://github.com/mjwwit>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import stream = require("stream");
+
+declare namespace saxStream {
+    interface Options {
+        /**
+         * Name of the tag to select objects from XML file, an Array of tag names can be used -
+         * when multiple tags are specified stream pushes `{ tag, record }` tuples.
+         */
+        tag: string | ReadonlyArray<string>;
+        /**
+         * Size of internal transform stream buffer - defaults to 350 objects.
+         */
+        highWaterMark?: number;
+        /**
+         * Default to false, if true makes sax parser to accept valid XML only.
+         */
+        strict?: boolean;
+        /**
+         * Whether or not to trim text and comment nodes.
+         */
+        trim?: boolean;
+        /**
+         * If true, then turn any whitespace into a single space.
+         */
+        normalize?: boolean;
+        /**
+         * If true, then lowercase tag names and attribute names in loose mode, rather than uppercasing them.
+         */
+        lowercase?: boolean;
+        /**
+         * If true, then namespaces are supported.
+         */
+        xmlns?: boolean;
+        /**
+         * If false, then don't track line/col/position.
+         */
+        trackPosition?: boolean;
+        /**
+         * If true, only parse predefined XML entities (&amp;, &apos;, &gt;, &lt;, and &quot;).
+         */
+        strictEntities?: boolean;
+    }
+}
+
+declare function saxStream(options: saxStream.Options): stream.Transform;
+
+export = saxStream;

--- a/types/sax-stream/sax-stream-tests.ts
+++ b/types/sax-stream/sax-stream-tests.ts
@@ -1,0 +1,23 @@
+import saxStream = require('sax-stream');
+
+// $ExpectType Transform
+saxStream({ tag: '' });
+
+// $ExpectType Transform
+saxStream({
+    tag: '',
+    highWaterMark: 1,
+    strict: true,
+    trim: true,
+    normalize: true,
+    lowercase: true,
+    xmlns: true,
+    trackPosition: true,
+    strictEntities: true
+});
+
+// $ExpectError
+saxStream({});
+
+// $ExpectError
+saxStream();

--- a/types/sax-stream/tsconfig.json
+++ b/types/sax-stream/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "sax-stream-tests.ts"
+    ]
+}

--- a/types/sax-stream/tslint.json
+++ b/types/sax-stream/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.