### PR TITLE
Add support for forwardedAs to styled-components

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -89,7 +89,7 @@ type StyledComponentPropsWithAs<
     T extends object,
     O extends object,
     A extends keyof any
-> = StyledComponentProps<C, T, O, A> & { as?: C };
+> = StyledComponentProps<C, T, O, A> & { as?: C, forwardedAs?: C };
 
 export type FalseyValue = undefined | null | false;
 export type Interpolation<P> =
@@ -190,6 +190,7 @@ export interface StyledComponentBase<
              * String types need to be cast to themselves to become literal types (as={'a' as 'a'}).
              */
             as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+            forwardedAs?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
         }
     ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
 

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -587,8 +587,6 @@ const asTest = (
     <>
         <WithComponentH1 as="h2" />
         <WithComponentH1 as={WithComponentH2} />
-        <WithComponentH1 as="a" href="" />
-        <WithComponentH1 as="div" href="" /> // $ExpectError
     </>
 );
 
@@ -598,8 +596,6 @@ const forwardedAsTest = (
     <>
         <ForwardedAsComponent forwardedAs="h2" />
         <ForwardedAsComponent forwardedAs={WithComponentH2} />
-        <ForwardedAsComponent forwardedAs="a" href="" />
-        <ForwardedAsComponent forwardedAs="div" href="" /> // $ExpectError
     </>
 );
 

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -587,6 +587,8 @@ const asTest = (
     <>
         <WithComponentH1 as="h2" />
         <WithComponentH1 as={WithComponentH2} />
+        <WithComponentH1 as="a" href="" />
+        <WithComponentH1 as="div" href="" /> // $ExpectError
     </>
 );
 
@@ -596,6 +598,8 @@ const forwardedAsTest = (
     <>
         <ForwardedAsComponent forwardedAs="h2" />
         <ForwardedAsComponent forwardedAs={WithComponentH2} />
+        <ForwardedAsComponent forwardedAs="a" href="" />
+        <ForwardedAsComponent forwardedAs="div" href="" /> // $ExpectError
     </>
 );
 

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -590,6 +590,15 @@ const asTest = (
     </>
 );
 
+const ForwardedAsNestedComponent = styled.div``;
+const ForwardedAsComponent = styled(ForwardedAsNestedComponent)``;
+const forwardedAsTest = (
+    <>
+        <ForwardedAsComponent forwardedAs="h2" />
+        <ForwardedAsComponent forwardedAs={WithComponentH2} />
+    </>
+);
+
 interface TestContainerProps {
     size: "big" | "small";
     test?: boolean;

--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -75,7 +75,7 @@ type StyledComponentPropsWithAs<
     T extends object,
     O extends object,
     A extends keyof any
-> = StyledComponentProps<C, T, O, A> & { as?: C };
+> = StyledComponentProps<C, T, O, A> & { as?: C, forwardedAs?: C };
 
 export type FalseyValue = undefined | null | false;
 export type Interpolation<P> =
@@ -155,7 +155,7 @@ export interface StyledComponentBase<
 > extends ForwardRefExoticBase<StyledComponentProps<C, T, O, A>> {
     // add our own fake call signature to implement the polymorphic 'as' prop
     (
-        props: StyledComponentProps<C, T, O, A> & { as?: never }
+        props: StyledComponentProps<C, T, O, A> & { as?: never, forwardedAs?: never }
       ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
     <AsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C>(
       props: StyledComponentPropsWithAs<AsC, T, O, A>

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -586,6 +586,8 @@ const asTest = (
     <>
         <WithComponentH1 as="h2" />
         <WithComponentH1 as={WithComponentH2} />
+        <WithComponentH1 as="a" href="" />
+        <WithComponentH1 as="div" href="" /> // $ExpectError
     </>
 );
 
@@ -595,6 +597,8 @@ const forwardedAsTest = (
     <>
         <ForwardedAsComponent forwardedAs="h2" />
         <ForwardedAsComponent forwardedAs={WithComponentH2} />
+        <ForwardedAsComponent forwardedAs="a" href="" />
+        <ForwardedAsComponent forwardedAs="div" href="" /> // $ExpectError
     </>
 );
 

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -586,8 +586,6 @@ const asTest = (
     <>
         <WithComponentH1 as="h2" />
         <WithComponentH1 as={WithComponentH2} />
-        <WithComponentH1 as="a" href="" />
-        <WithComponentH1 as="div" href="" /> // $ExpectError
     </>
 );
 
@@ -597,8 +595,6 @@ const forwardedAsTest = (
     <>
         <ForwardedAsComponent forwardedAs="h2" />
         <ForwardedAsComponent forwardedAs={WithComponentH2} />
-        <ForwardedAsComponent forwardedAs="a" href="" />
-        <ForwardedAsComponent forwardedAs="div" href="" /> // $ExpectError
     </>
 );
 

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -589,6 +589,15 @@ const asTest = (
     </>
 );
 
+const ForwardedAsNestedComponent = styled.div``;
+const ForwardedAsComponent = styled(ForwardedAsNestedComponent)``;
+const forwardedAsTest = (
+    <>
+        <ForwardedAsComponent forwardedAs="h2" />
+        <ForwardedAsComponent forwardedAs={WithComponentH2} />
+    </>
+);
+
 interface TestContainerProps {
     size: "big" | "small";
     test?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.styled-components.com/docs/api#forwardedas-prop
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

This change adds support for the [`forwardedAs`](https://www.styled-components.com/docs/api#forwardedas-prop) prop. It amounts to duplicating all instances of `as?` and renaming them to `forwardedAs` — if there's anything more to do here, I'd appreciate pointing me in the right direction.

Unfortunately, linter and tests fail even on master for me, so I wasn't able to make sure that the new addition passes them, but I think that it should. After having linked the modified repo to my own project, it worked fine.