### PR TITLE
[react-helmet]: fix types of htmlAttributes and bodyAttributes values

### DIFF
--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -12,13 +12,13 @@
 
 import * as React from 'react';
 
-type HtmlProps = JSX.IntrinsicElements['html'] & {
-    [key: string]: string;
-};
+interface OtherElementAttributes {
+    [key: string]: string | number | boolean | null | undefined;
+}
 
-type BodyProps = JSX.IntrinsicElements['body'] & {
-    [key: string]: string;
-};
+type HtmlProps = JSX.IntrinsicElements['html'] & OtherElementAttributes;
+
+type BodyProps = JSX.IntrinsicElements['body'] & OtherElementAttributes;
 
 type LinkProps = JSX.IntrinsicElements['link'];
 

--- a/types/react-helmet/react-helmet-tests.tsx
+++ b/types/react-helmet/react-helmet-tests.tsx
@@ -108,6 +108,27 @@ function HTML() {
     <html lang="en" />
 </HelmetDefaultExport>;
 
+// undefined value
+<Helmet htmlAttributes={{ id: undefined }} />;
+<Helmet bodyAttributes={{ id: undefined }} />;
+
+// boolean value
+<Helmet htmlAttributes={{ draggable: false }} />;
+<Helmet bodyAttributes={{ draggable: false }} />;
+
+// number value
+<Helmet htmlAttributes={{ tabIndex: -1 }} />;
+<Helmet bodyAttributes={{ tabIndex: -1 }} />;
+
+// arbitrary data- attribute
+<Helmet htmlAttributes={{ 'data-foo': 'bar' }} />;
+<Helmet bodyAttributes={{ 'data-foo': 'bar' }} />;
+
+// $ExpectError
+<Helmet htmlAttributes={{ hidden: 42 }} />;
+// $ExpectError
+<Helmet bodyAttributes={{ hidden: 42 }} />;
+
 // $ExpectError
 <Helmet link={[ invalidProp: 'foo' ]} />;
 // $ExpectError


### PR DESCRIPTION
I tried to add a test for the scenario this PR intends to fix (an undefined prop value) like @fluidsonic reported, but for some reason it passes even without this PR (when it fails type checking in an actual app). Maybe someone else knows how to test it properly or why this doesn't work?

```ts
const PropWithUndefinedValue: React.FC<{ lang?: string; }> = ({ lang }) => {
    return (
        // $ExpectError
        <Helmet htmlAttributes={{ lang }} />
    )
}
```

Regardless, this change does appear to resolve the issue in real apps.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39983#issuecomment-570185165
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
