### PR TITLE
[@types/hapi__hapi] Supporting v17's Hapi.server new syntax

### DIFF
--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -3968,7 +3968,7 @@ export class Server {
 /**
  * Supporting v17 introduced new syntax
  */
-export function server(opts?: ServerOptions): Server
+export function server(opts?: ServerOptions): Server;
 
 /* + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +
  +                                                                           +

--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -3965,6 +3965,11 @@ export class Server {
     table(host?: string): RequestRoute[];
 }
 
+/**
+ * Supporting v17 introduced new syntax
+ */
+export function server(opts?: ServerOptions): Server
+
 /* + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +
  +                                                                           +
  +                                                                           +


### PR DESCRIPTION
Following up #32994's proposed fix by @SimonSchick [here](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/32994#issuecomment-462877289), I've tried this fix and it worked. 

Applying it to the actual file.