### PR TITLE
feat: add types for @mdx-js/react

### DIFF
--- a/types/mdx-js__react/index.d.ts
+++ b/types/mdx-js__react/index.d.ts
@@ -1,0 +1,154 @@
+// Type definitions for @mdx-js/react 1.5
+// Project: https://mdxjs.com
+// Definitions by: Ifiok Jr. <https://github.com/ifiokjr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import { Component, ComponentType, ReactNode, StyleHTMLAttributes, FC } from 'react';
+
+interface MDXProviderComponents {
+    /**
+     * The wrapper component can be used to set the layout for the MDX document.
+     * It’s often used to set container width, borders, background colors, etc.
+     * However, it’s also unique because it has access to the children passed to
+     * it.
+     *
+     * This means that you can do powerful things with the MDX document
+     * elements.
+     */
+    wrapper?: ComponentType<any>;
+    /**
+     * Paragraph
+     */
+    p?: ComponentType<any>;
+    /**
+     * Heading 1	#
+     */
+    h1?: ComponentType<any>;
+    /**
+     * Heading 2	##
+     */
+    h2?: ComponentType<any>;
+    /**
+     * Heading 3	###
+     */
+    h3?: ComponentType<any>;
+    /**
+     * Heading 4	####
+     */
+    h4?: ComponentType<any>;
+    /**
+     * Heading 5	#####
+     */
+    h5?: ComponentType<any>;
+    /**
+     * Heading 6	######
+     */
+    h6?: ComponentType<any>;
+    /**
+     * Thematic break	***
+     */
+    thematicBreak?: ComponentType<any>;
+    /**
+     * Blockquote	>
+     */
+    blockquote?: ComponentType<any>;
+    /**
+     * List	-
+     */
+    ul?: ComponentType<any>;
+    /**
+     * Ordered list	1.
+     */
+    ol?: ComponentType<any>;
+    /**
+     * List item
+     */
+    li?: ComponentType<any>;
+    /**
+     * Table
+     */
+    table?: ComponentType<any>;
+    /**
+     * Table row
+     */
+    tr?: ComponentType<any>;
+    /**
+     * Table Cell
+     */
+    th?: ComponentType<any>;
+    td?: ComponentType<any>;
+    /**
+     * Pre
+     */
+    pre?: ComponentType<any>;
+    /**
+     * Code	`\code```
+     */
+    code?: ComponentType<any>;
+    /**
+     * Emphasis	_emphasis_
+     */
+    em?: ComponentType<any>;
+    /**
+     * Strong	**strong**
+     */
+    strong?: ComponentType<any>;
+    /**
+     * Delete	~~strikethrough~~
+     */
+    delete?: ComponentType<any>;
+    /**
+     * InlineCode	`inlineCode`
+     */
+    inlineCode?: ComponentType<any>;
+    /**
+     * Break	---
+     */
+    hr?: ComponentType<any>;
+    /**
+     * Link	<https://mdxjs.com> or [MDX](https://mdxjs.com)
+     */
+    a?: ComponentType<any>;
+    /**
+     * Image	![alt](https://mdx-logo.now.sh)
+     */
+    img?: ComponentType<any>;
+
+    /**
+     * Any other components we wish to define
+     */
+    [key: string]: ReactNode;
+}
+
+type MDXProviderComponentsProp = MDXProviderComponents | ((components: MDXProviderComponents) => MDXProviderComponents);
+
+interface MDXProviderProps {
+    children: React.ReactNode;
+    components: MDXProviderComponentsProp;
+}
+
+declare const MDXProvider: FC<MDXProviderProps>;
+
+declare function useMDXComponents(components?: MDXProviderComponentsProp): MDXProviderComponents;
+
+interface InjectedMDXProviderProps {
+    components: MDXProviderComponents;
+}
+
+// Taken from https://github.com/sindresorhus/type-fest/blob/794de74c6e0d1650fe07b91d22d970b68c1d3e37/source/except.d.ts#L1-L22
+type Except<ObjectType, KeysType extends keyof ObjectType> = Pick<ObjectType, Exclude<keyof ObjectType, KeysType>>;
+
+declare function withMDXComponents<GProps extends InjectedMDXProviderProps>(
+    Component: ComponentType<GProps>,
+): FC<Except<GProps, keyof InjectedMDXProviderProps>>;
+
+export {
+    withMDXComponents,
+    useMDXComponents,
+    MDXProvider,
+    MDXProviderProps,
+    InjectedMDXProviderProps,
+    MDXProviderComponentsProp,
+    MDXProviderComponents,
+};

--- a/types/mdx-js__react/mdx-js__react-tests.tsx
+++ b/types/mdx-js__react/mdx-js__react-tests.tsx
@@ -1,0 +1,35 @@
+import { FC } from 'react';
+import { MDXProvider, useMDXComponents, withMDXComponents, InjectedMDXProviderProps } from '@mdx-js/react';
+import { renderToString } from 'react-dom/server';
+
+const H1: FC = props => <h1 style={{ color: 'tomato' }} {...props} />;
+
+renderToString(
+    <MDXProvider components={{ h1: H1 }}>
+        <div />
+    </MDXProvider>,
+);
+
+renderToString(
+    <MDXProvider components={c => ({ ...c, h1: H1 })}>
+        <div />
+    </MDXProvider>,
+);
+
+const Hooked: FC = () => {
+    const components = useMDXComponents();
+    return null;
+};
+
+const HookedFN: FC = () => {
+    const components = useMDXComponents(c => ({ ...c, h1: H1 }));
+    return null;
+};
+
+const HOC: FC<InjectedMDXProviderProps & { t: string }> = props => {
+    return null;
+};
+
+const InjectedHOC = withMDXComponents(HOC);
+
+renderToString(<InjectedHOC t="" />);

--- a/types/mdx-js__react/tsconfig.json
+++ b/types/mdx-js__react/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+        "jsx": "preserve",
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "paths": {
+            "@mdx-js/react": ["mdx-js__react"]
+        },
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mdx-js__react-tests.tsx"
+    ]
+}

--- a/types/mdx-js__react/tslint.json
+++ b/types/mdx-js__react/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
