### PR TITLE
parse: Improve typing of GeoPoint constructor

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -292,7 +292,8 @@ namespace Parse {
         latitude: number;
         longitude: number;
 
-        constructor(arg1?: number[] | { latitude: number, longitude: number } | number, arg2?: number);
+        constructor(latitude: number, longitude: number);
+        constructor(coords?: { latitude: number, longitude: number } | [number, number]);
 
         current(options?: SuccessFailureOptions): GeoPoint;
         radiansTo(point: GeoPoint): number;

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -546,6 +546,10 @@ function test_geo_points() {
     let point = new Parse.GeoPoint();
     // $ExpectError
     point = new Parse.GeoPoint('40.0');
+    // $ExpectError
+    point = new Parse.GeoPoint(40.0);
+    // $ExpectError
+    point = new Parse.GeoPoint([40.0, -30.0, 20.0]);
     point = new Parse.GeoPoint([40.0, -30.0]);
     point = new Parse.GeoPoint(40.0, -30.0);
     point = new Parse.GeoPoint({ latitude: 40.0, longitude: -30.0 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [n/a] Test the change in your own code. (Compile and run.) (I'm not using this currently 😅)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [n/a] Provide a URL to documentation or source code which provides context for the suggested changes (not changing external api)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

-----

This change tightens up the checking for the GeoPoint constructor a bit. Specifically, it disallows initialising with only one argument if that argument is a number (as that would be incomplete `new GeoPoint(30.0)`), and disallows giving to many values if providing an array (e.g. `new GeoPoint([1, 2, 3])`)

This has the nice side effect of showing which parameter is `latitude` and which is `longitude` when providing two `number` arguments, as these are now named appropriately instead of `arg1` and `arg2` ✨ 