### PR TITLE
webpack: Add few missing type definitions on compilation.MainTemplate

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1073,9 +1073,13 @@ declare namespace webpack {
           hooks: {
             jsonpScript?: SyncWaterfallHook<string, Chunk, string>;
             requireExtensions: SyncWaterfallHook<string, Chunk, string>;
+            requireEnsure: SyncWaterfallHook<string, Chunk, string>;
+            localVars: SyncWaterfallHook<string, Chunk, string>;
           };
           outputOptions: Output;
           requireFn: string;
+          renderRequireFunctionForModule(hash: string, chunk: Chunk, varModuleId?: number | string): string;
+          renderAddModule(hash: string, chunk: Chunk, varModuleId: number | string | undefined, varModule: string): string;
         }
         class ChunkTemplate extends Tapable {}
         class HotUpdateChunkTemplate extends Tapable {}

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -307,6 +307,14 @@ configuration = {
         mainTemplate.hooks.requireExtensions.tap('SomePlugin', resource => {
           return resource.trimLeft();
         });
+        mainTemplate.hooks.requireEnsure.tap('SomePlugin', (resource, chunk, hash, chunkIdExpression: string) => {
+          mainTemplate.renderRequireFunctionForModule(hash, chunk, 'moduleId');
+          mainTemplate.renderAddModule(hash, chunk, 'moduleId', JSON.stringify({ ok: true }));
+          return `${resource};/* additional requests for ${chunkIdExpression} */`;
+        });
+        mainTemplate.hooks.localVars.tap('SomePlugin', resource => {
+          return resource.trimLeft();
+        });
         if (mainTemplate.hooks.jsonpScript == null) {
           return;
         }


### PR DESCRIPTION
- adds mainTemplate.hooks.requireEnsure hook
- adds mainTemplate.hooks.localVars hook
- adds mainTemplate.renderRequireFunctionForModule method
- adds mainTemplate.renderAddModule method

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * [requireEnsure hook](https://github.com/webpack/webpack/blob/v4.41.5/lib/MainTemplate.js#L81-L86)
  * [localVars hook](https://github.com/webpack/webpack/blob/v4.41.5/lib/MainTemplate.js#L94)
  * [renderRequireFunctionForModule method](https://github.com/webpack/webpack/blob/v4.41.5/lib/MainTemplate.js#L467)
  * [renderAddModule method](https://github.com/webpack/webpack/blob/v4.41.5/lib/MainTemplate.js#L484) 
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

