### PR TITLE
react-table: Fix type of useGetLatest

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -791,7 +791,7 @@ export function functionalUpdate<D extends object = {}>(
     old: Partial<TableState<D>>,
 ): Partial<TableState<D>>;
 
-export function useGetLatest(obj: any): any;
+export function useGetLatest<T>(obj: T): () => T;
 
 export function safeUseLayoutEffect(effect: EffectCallback, deps?: DependencyList): void;
 


### PR DESCRIPTION
Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [X ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tannerlinsley/react-table/blob/master/src/publicUtils.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
