### PR TITLE
[N3] Use correct typings for prefix utility function

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -18,7 +18,7 @@ export interface Prefixes<I = RDF.NamedNode> {
 }
 
 export type Term = NamedNode | BlankNode | Literal | Variable | DefaultGraph;
-export type PrefixedToIri = (suffix: string) => RDF.NamedNode;
+export type PrefixedToIri = (suffix: string) => NamedNode;
 
 export class NamedNode implements RDF.NamedNode {
     readonly termType: "NamedNode";

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -239,4 +239,5 @@ function test_doc_utility() {
     const prefixes: N3.Prefixes = { rdfs: N3.DataFactory.namedNode('http://www.w3.org/2000/01/rdf-schema#') };
     const namedNode1: RDF.NamedNode = N3Util.prefix('http://www.w3.org/2000/01/rdf-schema#')('label');
     const namedNode2: RDF.NamedNode = N3Util.prefixes(prefixes)('rdfs')('label');
+    const namedNode3: N3.NamedNode = N3Util.prefixes(prefixes)('rdfs')('label');
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rdfjs/N3.js/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The N3 prefix utility returns an N3 NamedNode. We're incorrectly typing it as an rdfjs NamedNode
