### PR TITLE
[N3] Type constructors properly as they require the new keyword

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -129,7 +129,6 @@ export interface BlankTriple<Q extends RDF.BaseQuad = RDF.Quad> {
 
 export interface ParserConstructor {
     new<Q extends BaseQuad = Quad> (options?: ParserOptions): N3Parser<Q>;
-    <Q extends BaseQuad = Quad>(options?: ParserOptions): N3Parser<Q>;
 }
 export const Parser: ParserConstructor;
 
@@ -149,7 +148,6 @@ export interface N3Parser<Q extends BaseQuad = Quad> {
 
 export interface StreamParserConstructor {
   new<Q extends BaseQuad = Quad> (options?: ParserOptions): N3StreamParser<Q>;
-  <Q extends BaseQuad = Quad>(options?: ParserOptions): N3StreamParser<Q>;
 }
 export const StreamParser: StreamParserConstructor;
 
@@ -178,8 +176,6 @@ export interface WriterOptions {
 export interface WriterConstructor {
     new<Q extends RDF.BaseQuad = RDF.Quad> (options?: WriterOptions): N3Writer<Q>;
     new<Q extends RDF.BaseQuad = RDF.Quad> (fd: any, options?: WriterOptions): N3Writer<Q>;
-    <Q extends RDF.BaseQuad = RDF.Quad>(options?: WriterOptions): N3Writer<Q>;
-    <Q extends RDF.BaseQuad = RDF.Quad>(fd: any, options?: WriterOptions): N3Writer<Q>;
 }
 export const Writer: WriterConstructor;
 
@@ -200,8 +196,6 @@ export interface N3Writer<Q extends RDF.BaseQuad = RDF.Quad> {
 export interface StreamWriterConstructor {
   new<Q extends RDF.BaseQuad = RDF.Quad> (options?: WriterOptions): N3StreamWriter<Q>;
   new<Q extends RDF.BaseQuad = RDF.Quad> (fd: any, options?: WriterOptions): N3StreamWriter<Q>;
-  <Q extends RDF.BaseQuad = RDF.Quad>(options?: WriterOptions): N3StreamWriter<Q>;
-  <Q extends RDF.BaseQuad = RDF.Quad>(fd: any, options?: WriterOptions): N3StreamWriter<Q>;
 }
 export const StreamWriter: StreamWriterConstructor;
 
@@ -232,7 +226,6 @@ export interface N3Store<Q_RDF extends RDF.BaseQuad = RDF.Quad, Q_N3 extends Bas
 }
 export interface StoreConstructor {
   new<Q_RDF extends RDF.BaseQuad = RDF.Quad, Q_N3 extends BaseQuad = Quad> (triples?: Q_RDF[], options?: StoreOptions): N3Store<Q_RDF, Q_N3>;
-  <Q_RDF extends RDF.BaseQuad = RDF.Quad, Q_N3 extends BaseQuad = Quad>(triples?: Q_RDF[], options?: StoreOptions): N3Store<Q_RDF, Q_N3>;
 }
 export const Store: StoreConstructor;
 

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -71,9 +71,9 @@ function test_doc_rdf_to_triples_2() {
     const parser2: N3.N3Parser = new N3.Parser({ format: 'application/trig' });
     // Notation3 (N3) is supported only through the format argument:
 
-    const parser3: N3.N3Parser = N3.Parser({ format: 'N3' });
-    const parser4: N3.N3Parser = N3.Parser({ format: 'Notation3' });
-    const parser5: N3.N3Parser = N3.Parser({ format: 'text/n3' });
+    const parser3: N3.N3Parser = new N3.Parser({ format: 'N3' });
+    const parser4: N3.N3Parser = new N3.Parser({ format: 'Notation3' });
+    const parser5: N3.N3Parser = new N3.Parser({ format: 'text/n3' });
 }
 
 function test_doc_rdf_sync_to_triples_1() {
@@ -95,7 +95,7 @@ function test_doc_rdf_stream_to_triples_1() {
     const parser: N3.N3Parser<QuadBnode> = new N3.Parser<QuadBnode>({factory: N3.DataFactory});
     parser.parse('abc', console.log);
 
-    const streamParser: N3.N3StreamParser = N3.StreamParser();
+    const streamParser: N3.N3StreamParser = new N3.StreamParser();
     const quad: RDF.Quad = streamParser.read();
     const rdfStream = fs.createReadStream('cartoons.ttl');
     const pipedStreamParser: N3.N3StreamParser = rdfStream.pipe(streamParser);
@@ -124,8 +124,8 @@ function test_doc_from_triples_to_string() {
     ));
     writer.end((error, result: string) => { console.log(result); });
 
-    const writer1: N3.N3Writer = N3.Writer({ format: 'N-Triples' });
-    const writer2: N3.N3Writer = N3.Writer({ format: 'application/trig' });
+    const writer1: N3.N3Writer = new N3.Writer({ format: 'N-Triples' });
+    const writer2: N3.N3Writer = new N3.Writer({ format: 'application/trig' });
 }
 
 function test_doc_from_triples_to_rdf_stream() {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rdfjs/N3.js/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Constructors such as the N3 parser and writer all require proper instantiation via the `new` keyword. Not doing so would throw the error `TypeError: Class constructor <x> cannot be invoked without 'new'`.
In this PR, typescript would indicate an error as well when `new` is omitted
