### PR TITLE
Sync frida-gum typings with Frida 12.8.3

### DIFF
--- a/types/frida-gum/frida-gum-tests.ts
+++ b/types/frida-gum/frida-gum-tests.ts
@@ -52,3 +52,11 @@ const obj = new ObjC.Object(ptr("0x42"));
 
 // $ExpectType Object
 obj;
+
+Java.enumerateClassLoadersSync()
+    .forEach(classLoader => {
+        // $ExpectType ClassFactory
+        const factory = Java.ClassFactory.get(classLoader);
+        // $ExpectType Wrapper
+        factory.use("java.lang.String");
+    });


### PR DESCRIPTION
Changelog at the end of:

        https://frida.re/news/2019/12/18/frida-12-8-released/

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://frida.re/news/2019/12/18/frida-12-8-released/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.