### PR TITLE
d3-graphviz: fix graphviz() and selectWithoutDataPropagation()

### DIFF
--- a/types/d3-graphviz/d3-graphviz-tests.ts
+++ b/types/d3-graphviz/d3-graphviz-tests.ts
@@ -14,3 +14,6 @@ const options: d3Graphviz.GraphvizOptions = d3Graphviz.graphviz('').options();
 
 // Can set the options
 graphviz = graphviz.options(options);
+
+// Can use selectWithoutDataPropagation
+const selected = select('this').selectWithoutDataPropagation('that');

--- a/types/d3-graphviz/index.d.ts
+++ b/types/d3-graphviz/index.d.ts
@@ -19,13 +19,13 @@ declare module 'd3-selection' {
          * @param options either a GraphvizOptions object representing the options of the graphviz renderer or a boolean representing the
          *                  useWorker option.
          */
-        graphviz(options?: GraphvizOptions | boolean): Graphviz<GElement, Datum, BaseType, PDatum>;
+        graphviz(options?: GraphvizOptions | boolean): Graphviz<GElement, Datum, PElement, PDatum>;
 
         /**
          * For each selected element, selects the first descendant element that matches the specified selector string in the same ways as
          * d3-selection.select, but does not propagate any associated data from the current element to the corresponding selected element.
          */
-        selectWithoutDataPropagation(): Selection<GElement, Datum, PElement, PDatum>;
+        selectWithoutDataPropagation(name: string): Selection<BaseType, Datum, PElement, PDatum>;
     }
 }
 


### PR DESCRIPTION
The return type of graphviz() is more specific now.
Added the missing parameter for selectWithoutDataPropagation()
and fixed the return type.

-----------------------

CC @DomParfitt 

Calling graphviz() on a Selection doesn't change its template types.
selectWithoutDataPropagation()'s missing parameter was an error, it always had that parameter. The return type depends on what is actually selected, its first template parameter doesn't necessarily stays GElement, but will always extend from BaseType, so that one is used.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/magjac/d3-graphviz/blob/master/src/selection/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
