### PR TITLE
Break slack-winston dependency on winston

### DIFF
--- a/types/slack-winston/index.d.ts
+++ b/types/slack-winston/index.d.ts
@@ -4,9 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import Transport = require("winston-transport");
-
-export interface SlackTransportOptions extends Transport.TransportStreamOptions {
+export interface SlackTransportOptions {
   domain: string;
   token: string;
   webhook_url: string;
@@ -16,8 +14,39 @@ export interface SlackTransportOptions extends Transport.TransportStreamOptions 
   icon_emoji?: string;
   message?: string;
   queueDelay?: number;
+
+  // from winston-transport TransportStreamOptions
+  format?: Format;
+  level?: string;
+  silent?: boolean;
+  handleExceptions?: boolean;
+
+  log?(info: any, next: () => void): any;
+  logv?(info: any, next: () => void): any;
+  close?(): void;
 }
 
-export class Slack extends Transport {
+export class Slack {
   constructor(options?: SlackTransportOptions);
+  format?: Format;
+  level?: string;
+  silent?: boolean;
+  handleExceptions?: boolean;
+
+  log?(info: any, next: () => void): any;
+  logv?(info: any, next: () => void): any;
+  close?(): void;
+}
+
+export class Format {
+  constructor(opts?: object);
+
+  options?: object;
+  transform: (info: TransformableInfo, opts?: any) => TransformableInfo | boolean;
+}
+
+export interface TransformableInfo {
+  level: string;
+  message: string;
+  [key: string]: any;
 }

--- a/types/slack-winston/package.json
+++ b/types/slack-winston/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "@types/winston": "^2.3.9"
-    }
-}


### PR DESCRIPTION
slack-winston is nearly unused and seems abandoned, but has a dependency on the deprecated @types/winston. This is causing problems for DT automation, so I just inlined all the winston types that slack-winston uses. Since this package is unlikely to change, I don't think this is a problem.
