### PR TITLE
Remove references to obsolete DOM interfaces

### DIFF
--- a/types/offscreencanvas/index.d.ts
+++ b/types/offscreencanvas/index.d.ts
@@ -72,8 +72,8 @@ interface MessagePort extends EventTarget {
     postMessage(message: any, transfer?: Array<Transferable | OffscreenCanvas>): void;
 }
 
-interface Window extends EventTarget, WindowTimers, WindowSessionStorage, WindowLocalStorage, WindowConsole,
-    GlobalEventHandlers, IDBEnvironment, WindowBase64, WindowOrWorkerGlobalScope, WindowEventHandlers {
+interface Window extends EventTarget, WindowSessionStorage, WindowLocalStorage, WindowConsole,
+    GlobalEventHandlers, WindowOrWorkerGlobalScope, WindowEventHandlers {
     postMessage(message: any, targetOrigin: string, transfer?: Array<Transferable | OffscreenCanvas>): void;
 }
 


### PR DESCRIPTION
1. WindowTimers
2. IDBEnvironment
3. WindowBase64

They are removed in Typescript 3.8.