### PR TITLE
react-shadow-dom-retarget-events: update tests

### DIFF
--- a/types/react-shadow-dom-retarget-events/react-shadow-dom-retarget-events-tests.tsx
+++ b/types/react-shadow-dom-retarget-events/react-shadow-dom-retarget-events-tests.tsx
@@ -19,4 +19,4 @@ class MyCustomElement extends HTMLElement {
     }
 }
 
-customElements.define(name, MyCustomElement);
+customElements.define(name, () => new MyCustomElement());


### PR DESCRIPTION
Typescript 3.8 has a stricter type for customElements.define, so I updated the tests to match the type.