### PR TITLE
feat: Add `w3c‑xmlserializer`

### DIFF
--- a/types/w3c-xmlserializer/index.d.ts
+++ b/types/w3c-xmlserializer/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for w3c-xmlserializer 2.0
+// Project: https://github.com/jsdom/w3c-xmlserializer#readme
+// Definitions by: ExE Boss <https://github.com/ExE-Boss>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace serialize {
+	interface Options {
+		/**
+		 * Whether the serialization algorithm will throw an `Error`
+		 * when the `Node` can't be serialized to well-formed XML.
+		 *
+		 * @default false
+		 */
+		requireWellFormed?: boolean;
+	}
+}
+
+declare function serialize(root: Node, options?: serialize.Options): string;
+export = serialize;

--- a/types/w3c-xmlserializer/tsconfig.json
+++ b/types/w3c-xmlserializer/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": ["es5", "dom"],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": ["../"],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"w3c-xmlserializer-tests.ts",
+		"index.d.ts"
+	]
+}

--- a/types/w3c-xmlserializer/tslint.json
+++ b/types/w3c-xmlserializer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/w3c-xmlserializer/w3c-xmlserializer-tests.ts
+++ b/types/w3c-xmlserializer/w3c-xmlserializer-tests.ts
@@ -1,0 +1,9 @@
+import serialize = require('w3c-xmlserializer');
+
+serialize(document); // $ExpectType string
+serialize(document.documentElement); // $ExpectType string
+serialize(window); // $ExpectError
+
+serialize(document, { requireWellFormed: true }); // $ExpectType string
+serialize(document.documentElement, { requireWellFormed: true }); // $ExpectType string
+serialize(window, { requireWellFormed: true }); // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

review?(@pmdartus, @RyanCavanaugh, @TimothyGu)