### PR TITLE
fix(parse/query): missing base attributes in doesNotMatchKeyInQuery()

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -598,7 +598,7 @@ namespace Parse {
         count(options?: Query.CountOptions): Promise<number>;
         descending<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K | K[]): this;
         doesNotExist<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K): this;
-        doesNotMatchKeyInQuery<U extends Object, K extends keyof T['attributes'], X extends Extract<keyof U['attributes'], string>>(key: K, queryKey: X, query: Query<U>): this;
+        doesNotMatchKeyInQuery<U extends Object, K extends (keyof T['attributes'] | keyof BaseAttributes), X extends Extract<keyof U['attributes'], string>>(key: K, queryKey: X, query: Query<U>): this;
         doesNotMatchQuery<U extends Object, K extends keyof T['attributes']>(key: K, query: Query<U>): this;
         distinct<K extends keyof T['attributes'], V = T['attributes'][K]>(key: K): Promise<V>;
         each(callback: Function, options?: Query.EachOptions): Promise<void>;

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -598,7 +598,9 @@ namespace Parse {
         count(options?: Query.CountOptions): Promise<number>;
         descending<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K | K[]): this;
         doesNotExist<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K): this;
-        doesNotMatchKeyInQuery<U extends Object, K extends (keyof T['attributes'] | keyof BaseAttributes), X extends Extract<keyof U['attributes'], string>>(key: K, queryKey: X, query: Query<U>): this;
+        doesNotMatchKeyInQuery<U extends Object,
+            K extends (keyof T['attributes'] | keyof BaseAttributes),
+            X extends Extract<keyof U['attributes'], string>>(key: K, queryKey: X, query: Query<U>): this;
         doesNotMatchQuery<U extends Object, K extends keyof T['attributes']>(key: K, query: Query<U>): this;
         distinct<K extends keyof T['attributes'], V = T['attributes'][K]>(key: K): Promise<V>;
         each(callback: Function, options?: Query.EachOptions): Promise<void>;

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1147,7 +1147,7 @@ function testQuery() {
     }
 
     async function testQueryMethodTypes() {
-        class AnotherSubclass extends Parse.Object<{x: number}> { }
+        class AnotherSubclass extends Parse.Object<{x: any}> { }
         class MySubClass extends Parse.Object<{attribute1: string, attribute2: number, attribute3: AnotherSubclass}> { }
         const query = new Parse.Query(MySubClass);
 

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1147,7 +1147,7 @@ function testQuery() {
     }
 
     async function testQueryMethodTypes() {
-        class AnotherSubclass extends Parse.Object<{x: any}> { }
+        class AnotherSubclass extends Parse.Object<{x: number}> { }
         class MySubClass extends Parse.Object<{attribute1: string, attribute2: number, attribute3: AnotherSubclass}> { }
         const query = new Parse.Query(MySubClass);
 
@@ -1219,6 +1219,10 @@ function testQuery() {
         query.doesNotMatchKeyInQuery('unexistenProp', 'x', new Parse.Query(AnotherSubclass));
         // $ExpectError
         query.doesNotMatchKeyInQuery('attribute1', 'unknownKey', new Parse.Query(AnotherSubclass));
+        // $ExpectType Query<MySubClass>
+        query.doesNotMatchKeyInQuery('objectId', 'x', new Parse.Query(AnotherSubclass));
+        // $ExpectType Query<MySubClass>
+        query.doesNotMatchKeyInQuery('updatedAt', 'x', new Parse.Query(AnotherSubclass));
 
         // $ExpectType Query<MySubClass>
         query.doesNotMatchQuery('attribute1', new Parse.Query('Example'));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://parseplatform.org/Parse-SDK-JS/api/2.11.0/Parse.Query.html#doesNotMatchKeyInQuery
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
