### PR TITLE
react-query: Update refetch return type to promise

### DIFF
--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -52,7 +52,7 @@ export interface QueryResult<TResult, TVariables> {
     isFetching: boolean;
     isCached: boolean;
     failureCount: number;
-    refetch: (arg?: {variables?: TVariables, merge?: (...args: any[]) => any, disableThrow?: boolean}) => void;
+    refetch: (arg?: {variables?: TVariables, merge?: (...args: any[]) => any, disableThrow?: boolean}) => Promise<void>;
 }
 
 export interface QueryResultPaginated<TResult, TVariables> extends QueryResult<TResult[], TVariables> {

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -8,7 +8,7 @@ const querySimple = useQuery('todos',
 querySimple.data; // $ExpectType string | null
 querySimple.error; // $ExpectType Error | null
 querySimple.isLoading; // $ExpectType boolean
-querySimple.refetch(); // $ExpectType void
+querySimple.refetch(); // $ExpectType Promise<void>
 queryPaginated.fetchMore; // $ExpectError
 queryPaginated.canFetchMore; // $ExpectError
 queryPaginated.isFetchingMore; // $ExpectError

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -19,7 +19,7 @@ const queryVariables = useQuery(['todos', {param}],
     (variables) => Promise.resolve(variables.param === 'test'));
 
 queryVariables.data; // $ExpectType boolean | null
-queryVariables.refetch({variables: {param: 'foo'}}); // $ExpectType void
+queryVariables.refetch({variables: {param: 'foo'}}); // $ExpectType Promise<void>
 queryVariables.refetch({variables: {other: 'foo'}}); // $ExpectError
 
 // Query with falsey query key


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/owinter86/react-query/blob/master/src/index.js#L438>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
