### PR TITLE
add: type definition for react-native-check-box

### DIFF
--- a/types/react-native-check-box/index.d.ts
+++ b/types/react-native-check-box/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for react-native-check-box 2.1
+// Project: https://github.com/crazycodeboy/react-native-check-box#readme
+// Definitions by: Rodolphe Lemasquerier <https://github.com/rlemasquerier>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'react';
+import { StyleProp, TextStyle, ViewStyle } from 'react-native';
+
+export interface CheckBoxProps {
+    style?: StyleProp<ViewStyle>;
+    leftText?: string;
+    leftTextStyle?: StyleProp<TextStyle>;
+    leftTextView?: React.ReactNode;
+    rightText?: string;
+    rightTextStyle?: StyleProp<TextStyle>;
+    rightTextView?: React.ReactNode;
+    checkedImage?: React.ReactElement;
+    uncheckedImage?: React.ReactElement;
+    isChecked: boolean;
+    onClick: () => void;
+    disabled?: boolean;
+    checkBoxColor?: string;
+    checkedCheckBoxColor?: string;
+    uncheckedCheckBoxColor?: string;
+}
+
+declare class CheckBox extends React.Component<CheckBoxProps> {}
+
+export default CheckBox;

--- a/types/react-native-check-box/react-native-check-box-tests.tsx
+++ b/types/react-native-check-box/react-native-check-box-tests.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import CheckBox from 'react-native-check-box';
+import { View, Image } from 'react-native';
+
+export default class MyCheckBox extends React.Component {
+    render() {
+        return (
+            <CheckBox
+                style={{ margin: 20 }}
+                onClick={() => {
+                    console.log('clicked');
+                }}
+                checkBoxColor={'#000'}
+                isChecked={true}
+                leftTextStyle={{ color: 'red', fontSize: 10 }}
+                leftText={'Check me!'}
+                checkedImage={<Image source={{ uri: 'path/to/image.webp' }} />}
+                rightTextView={<View />}
+            />
+        );
+    }
+}

--- a/types/react-native-check-box/tsconfig.json
+++ b/types/react-native-check-box/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "lib": ["es6", "es2017"],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": ["../"],
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true,
+      "jsx": "react-native"
+  },
+  "files": ["index.d.ts", "react-native-check-box-tests.tsx"]
+}

--- a/types/react-native-check-box/tslint.json
+++ b/types/react-native-check-box/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
