### PR TITLE
fix: jsqubits type bug

### DIFF
--- a/types/jsqubits/index.d.ts
+++ b/types/jsqubits/index.d.ts
@@ -12,7 +12,7 @@ declare namespace jsqubits {
     namespace jsqubits {
         interface QState {
             numBits(): number;
-            amplitude(basisState: string | QState): Complex;
+            amplitude(basisState: string | number): Complex;
             each: (callBack: (stateWithAmplitude: StateWithAmplitude) => false | void) => void;
 
             multiply(amount: number | Complex): QState;


### PR DESCRIPTION
This PR fix type mistake.

```
    this.amplitude = (basisState) => {
      const numericIndex = typecheck.isString(basisState)
        ? parseBitString(basisState).value
        : basisState;
      return amplitudes[numericIndex] || Complex.ZERO;
    };
```
https://github.com/davidbkemp/jsqubits/blob/master/lib/QState.js#L158
This function `QState#amplitude()` require `string or number` , but current d.ts defined `string or QState` .

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see above
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. no, only d.ts update.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
