### PR TITLE
feat(semver): migrate to v7. Fixes #41326

### DIFF
--- a/types/semver/classes/comparator.d.ts
+++ b/types/semver/classes/comparator.d.ts
@@ -1,0 +1,17 @@
+import sermver = require('../');
+import SemVer = require('./semver');
+
+declare class Comparator {
+    constructor(comp: string | Comparator, optionsOrLoose?: boolean | sermver.Options);
+
+    semver: SemVer;
+    operator: '' | '=' | '<' | '>' | '<=' | '>=';
+    value: string;
+    loose: boolean;
+    options: sermver.Options;
+    parse(comp: string): void;
+    test(version: string | SemVer): boolean;
+    intersects(comp: Comparator, optionsOrLoose?: boolean | sermver.Options): boolean;
+}
+
+export = Comparator;

--- a/types/semver/classes/range.d.ts
+++ b/types/semver/classes/range.d.ts
@@ -1,0 +1,21 @@
+import semver = require('../');
+import Comparator = require('./comparator');
+import SemVer = require('./semver');
+
+declare class Range {
+    constructor(range: string | Range, optionsOrLoose?: boolean | semver.Options);
+
+    range: string;
+    raw: string;
+    loose: boolean;
+    options: semver.Options;
+    includePrerelease: boolean;
+    format(): string;
+    inspect(): string;
+
+    set: ReadonlyArray<ReadonlyArray<Comparator>>;
+    parseRange(range: string): ReadonlyArray<Comparator>;
+    test(version: string | SemVer): boolean;
+    intersects(range: Range, optionsOrLoose?: boolean | semver.Options): boolean;
+}
+export = Range;

--- a/types/semver/classes/semver.d.ts
+++ b/types/semver/classes/semver.d.ts
@@ -1,0 +1,62 @@
+import semver = require('../');
+
+declare class SemVer {
+    constructor(version: string | SemVer, optionsOrLoose?: boolean | semver.Options);
+
+    raw: string;
+    loose: boolean;
+    options: semver.Options;
+    format(): string;
+    inspect(): string;
+
+    major: number;
+    minor: number;
+    patch: number;
+    version: string;
+    build: ReadonlyArray<string>;
+    prerelease: ReadonlyArray<string | number>;
+
+    /**
+     * Compares two versions excluding build identifiers (the bit after `+` in the semantic version string).
+     *
+     * @return
+     * - `0` if `this` == `other`
+     * - `1` if `this` is greater
+     * - `-1` if `other` is greater.
+     */
+    compare(other: string | SemVer): 1 | 0 | -1;
+
+    /**
+     * Compares the release portion of two versions.
+     *
+     * @return
+     * - `0` if `this` == `other`
+     * - `1` if `this` is greater
+     * - `-1` if `other` is greater.
+     */
+    compareMain(other: string | SemVer): 1 | 0 | -1;
+
+    /**
+     * Compares the prerelease portion of two versions.
+     *
+     * @return
+     * - `0` if `this` == `other`
+     * - `1` if `this` is greater
+     * - `-1` if `other` is greater.
+     */
+    comparePre(other: string | SemVer): 1 | 0 | -1;
+
+    /**
+     * Compares the build identifier of two versions.
+     *
+     * @return
+     * - `0` if `this` == `other`
+     * - `1` if `this` is greater
+     * - `-1` if `other` is greater.
+     */
+    compareBuild(other: string | SemVer): 1 | 0 | -1;
+
+    inc(release: semver.ReleaseType, identifier?: string): SemVer;
+}
+
+export = SemVer;

--- a/types/semver/functions/clean.d.ts
+++ b/types/semver/functions/clean.d.ts
@@ -1,0 +1,8 @@
+import semver = require('../');
+
+/**
+ * Returns cleaned (removed leading/trailing whitespace, remove '=v' prefix) and parsed version, or null if version is invalid.
+ */
+declare function clean(version: string, optionsOrLoose?: boolean | semver.Options): string | null;
+
+export = clean;

--- a/types/semver/functions/cmp.d.ts
+++ b/types/semver/functions/cmp.d.ts
@@ -1,0 +1,16 @@
+import semver = require('../');
+import SemVer = require('../classes/semver');
+
+/**
+ * Pass in a comparison string, and it'll call the corresponding semver comparison function.
+ * "===" and "!==" do simple string comparison, but are included for completeness.
+ * Throws if an invalid comparison string is provided.
+ */
+declare function cmp(
+    v1: string | SemVer,
+    operator: semver.Operator,
+    v2: string | SemVer,
+    optionsOrLoose?: boolean | semver.Options,
+): boolean;
+
+export = cmp;

--- a/types/semver/functions/coerce.d.ts
+++ b/types/semver/functions/coerce.d.ts
@@ -1,0 +1,12 @@
+import semver = require('../');
+import SemVer = require('../classes/semver');
+
+/**
+ * Coerces a string to SemVer if possible
+ */
+declare function coerce(
+    version: string | number | SemVer | null | undefined,
+    options?: semver.CoerceOptions,
+): SemVer | null;
+
+export = coerce;

--- a/types/semver/functions/compare-build.d.ts
+++ b/types/semver/functions/compare-build.d.ts
@@ -1,0 +1,16 @@
+import SemVer = require('../classes/semver');
+
+/**
+ * Compares two versions including build identifiers (the bit after `+` in the semantic version string).
+ *
+ * Sorts in ascending order when passed to `Array.sort()`.
+ *
+ * @return
+ * - `0` if `v1` == `v2`
+ * - `1` if `v1` is greater
+ * - `-1` if `v2` is greater.
+ *
+ * @since 6.1.0
+ */
+declare function compareBuild(a: string | SemVer, b: string | SemVer): 1 | 0 | -1;
+export = compareBuild;

--- a/types/semver/functions/compare-loose.d.ts
+++ b/types/semver/functions/compare-loose.d.ts
@@ -1,0 +1,5 @@
+import SemVer = require('../classes/semver');
+
+declare function compareLoose(v1: string | SemVer, v2: string | SemVer): 1 | 0 | -1;
+
+export = compareLoose;

--- a/types/semver/functions/compare.d.ts
+++ b/types/semver/functions/compare.d.ts
@@ -1,0 +1,20 @@
+import semver = require('../');
+import SemVer = require('../classes/semver');
+
+/**
+ * Compares two versions excluding build identifiers (the bit after `+` in the semantic version string).
+ *
+ * Sorts in ascending order when passed to `Array.sort()`.
+ *
+ * @return
+ * - `0` if `v1` == `v2`
+ * - `1` if `v1` is greater
+ * - `-1` if `v2` is greater.
+ */
+declare function compare(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    optionsOrLoose?: boolean | semver.Options,
+): 1 | 0 | -1;
+
+export = compare;

--- a/types/semver/functions/diff.d.ts
+++ b/types/semver/functions/diff.d.ts
@@ -1,0 +1,13 @@
+import semver = require('../');
+import SemVer = require('../classes/semver');
+
+/**
+ * Returns difference between two versions by the release type (major, premajor, minor, preminor, patch, prepatch, or prerelease), or null if the versions are the same.
+ */
+declare function diff(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    optionsOrLoose?: boolean | semver.Options,
+): semver.ReleaseType | null;
+
+export = diff;

--- a/types/semver/functions/eq.d.ts
+++ b/types/semver/functions/eq.d.ts
@@ -1,0 +1,9 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * v1 == v2 This is true if they're logically equivalent, even if they're not the exact same string. You already know how to compare strings.
+ */
+declare function eq(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | semver.Options): boolean;
+
+export = eq;

--- a/types/semver/functions/gt.d.ts
+++ b/types/semver/functions/gt.d.ts
@@ -1,0 +1,9 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * v1 > v2
+ */
+declare function gt(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | semver.Options): boolean;
+
+export = gt;

--- a/types/semver/functions/gte.d.ts
+++ b/types/semver/functions/gte.d.ts
@@ -1,0 +1,9 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * v1 >= v2
+ */
+declare function gte(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | semver.Options): boolean;
+
+export = gte;

--- a/types/semver/functions/inc.d.ts
+++ b/types/semver/functions/inc.d.ts
@@ -1,0 +1,15 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Return the version incremented by the release type (major, minor, patch, or prerelease), or null if it's not valid.
+ */
+declare function inc(
+    version: string | SemVer,
+    release: semver.ReleaseType,
+    optionsOrLoose?: boolean | semver.Options,
+    identifier?: string,
+): string | null;
+declare function inc(version: string | SemVer, release: semver.ReleaseType, identifier?: string): string | null;
+
+export = inc;

--- a/types/semver/functions/lt.d.ts
+++ b/types/semver/functions/lt.d.ts
@@ -1,0 +1,9 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * v1 < v2
+ */
+declare function lt(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | semver.Options): boolean;
+
+export = lt;

--- a/types/semver/functions/lte.d.ts
+++ b/types/semver/functions/lte.d.ts
@@ -1,0 +1,8 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * v1 <= v2
+ */
+declare function lte(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | semver.Options): boolean;
+export = lte;

--- a/types/semver/functions/major.d.ts
+++ b/types/semver/functions/major.d.ts
@@ -1,0 +1,9 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Return the major version number.
+ */
+declare function major(version: string | SemVer, optionsOrLoose?: boolean | semver.Options): number;
+
+export = major;

--- a/types/semver/functions/minor.d.ts
+++ b/types/semver/functions/minor.d.ts
@@ -1,0 +1,9 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Return the minor version number.
+ */
+declare function minor(version: string | SemVer, optionsOrLoose?: boolean | semver.Options): number;
+
+export = minor;

--- a/types/semver/functions/neq.d.ts
+++ b/types/semver/functions/neq.d.ts
@@ -1,0 +1,9 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * v1 != v2 The opposite of eq.
+ */
+declare function neq(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | semver.Options): boolean;
+
+export = neq;

--- a/types/semver/functions/parse.d.ts
+++ b/types/semver/functions/parse.d.ts
@@ -1,0 +1,12 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Return the parsed version as a SemVer object, or null if it's not valid.
+ */
+declare function parse(
+    version: string | SemVer | null | undefined,
+    optionsOrLoose?: boolean | semver.Options,
+): SemVer | null;
+
+export = parse;

--- a/types/semver/functions/patch.d.ts
+++ b/types/semver/functions/patch.d.ts
@@ -1,0 +1,9 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Return the patch version number.
+ */
+declare function patch(version: string | SemVer, optionsOrLoose?: boolean | semver.Options): number;
+
+export = patch;

--- a/types/semver/functions/prerelease.d.ts
+++ b/types/semver/functions/prerelease.d.ts
@@ -1,0 +1,12 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Returns an array of prerelease components, or null if none exist.
+ */
+declare function prerelease(
+    version: string | SemVer,
+    optionsOrLoose?: boolean | semver.Options,
+): ReadonlyArray<string> | null;
+
+export = prerelease;

--- a/types/semver/functions/rcompare.d.ts
+++ b/types/semver/functions/rcompare.d.ts
@@ -1,0 +1,15 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * The reverse of compare.
+ *
+ * Sorts in descending order when passed to `Array.sort()`.
+ */
+declare function rcompare(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    optionsOrLoose?: boolean | semver.Options,
+): 1 | 0 | -1;
+
+export = rcompare;

--- a/types/semver/functions/rsort.d.ts
+++ b/types/semver/functions/rsort.d.ts
@@ -1,0 +1,9 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Sorts an array of semver entries in descending order using `compareBuild()`.
+ */
+declare function rsort<T extends string | SemVer>(list: T[], optionsOrLoose?: boolean | semver.Options): T[];
+
+export = rsort;

--- a/types/semver/functions/satisfies.d.ts
+++ b/types/semver/functions/satisfies.d.ts
@@ -1,0 +1,14 @@
+import Range = require('../classes/range');
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Return true if the version satisfies the range.
+ */
+declare function satisfies(
+    version: string | SemVer,
+    range: string | Range,
+    optionsOrLoose?: boolean | semver.Options,
+): boolean;
+
+export = satisfies;

--- a/types/semver/functions/sort.d.ts
+++ b/types/semver/functions/sort.d.ts
@@ -1,0 +1,9 @@
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Sorts an array of semver entries in ascending order using `compareBuild()`.
+ */
+declare function sort<T extends string | SemVer>(list: T[], optionsOrLoose?: boolean | semver.Options): T[];
+
+export = sort;

--- a/types/semver/functions/valid.d.ts
+++ b/types/semver/functions/valid.d.ts
@@ -1,0 +1,11 @@
+import semver = require('../');
+import SemVer = require('../classes/semver');
+/**
+ * Return the parsed version as a string, or null if it's not valid.
+ */
+declare function valid(
+    version: string | SemVer | null | undefined,
+    optionsOrLoose?: boolean | semver.Options,
+): string | null;
+
+export = valid;

--- a/types/semver/index.d.ts
+++ b/types/semver/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for semver 6.2
+// Type definitions for semver 7.1
 // Project: https://github.com/npm/node-semver
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 //                 BendingBender <https://github.com/BendingBender>
@@ -7,15 +7,111 @@
 //                 ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/semver
 
-export const SEMVER_SPEC_VERSION: "2.0.0";
+/// <reference types="node" />
 
-export type ReleaseType = "major" | "premajor" | "minor" | "preminor" | "patch" | "prepatch" | "prerelease";
+// re-exports for index file
+
+// functions for working with versions
+import semverParse = require('./functions/parse');
+import semverValid = require('./functions/valid');
+import semverClean = require('./functions/clean');
+import semverInc = require('./functions/inc');
+import semverDiff = require('./functions/diff');
+import semverMajor = require('./functions/major');
+import semverMinor = require('./functions/minor');
+import semverPatch = require('./functions/patch');
+import semverPrerelease = require('./functions/prerelease');
+import semverCompare = require('./functions/compare');
+import semverRcompare = require('./functions/rcompare');
+import semverCompareLoose = require('./functions/compare-loose');
+import semverCompareBuild = require('./functions/compare-build');
+import semverSort = require('./functions/sort');
+import semverRsort = require('./functions/rsort');
+
+export {
+    semverParse as parse,
+    semverValid as valid,
+    semverClean as clean,
+    semverInc as inc,
+    semverDiff as diff,
+    semverMajor as major,
+    semverMinor as minor,
+    semverPatch as patch,
+    semverPrerelease as prerelease,
+    semverCompare as compare,
+    semverRcompare as rcompare,
+    semverCompareLoose as compareLoose,
+    semverCompareBuild as compareBuild,
+    semverSort as sort,
+    semverRsort as rsort,
+};
+
+// low-level comparators between versions
+import semverGt = require('./functions/gt');
+import semverLt = require('./functions/lt');
+import semverEq = require('./functions/eq');
+import semverNeq = require('./functions/neq');
+import semverGte = require('./functions/gte');
+import semverLte = require('./functions/lte');
+import semverCmp = require('./functions/cmp');
+import semverCoerce = require('./functions/coerce');
+
+export {
+    semverGt as gt,
+    semverLt as lt,
+    semverEq as eq,
+    semverNeq as neq,
+    semverGte as gte,
+    semverLte as lte,
+    semverCmp as cmp,
+    semverCoerce as coerce,
+};
+
+// working with ranges
+import semverSatisfies = require('./functions/satisfies');
+import semverMaxSatisfying = require('./ranges/max-satisfying');
+import semverMinSatisfying = require('./ranges/min-satisfying');
+import semverToComparators = require('./ranges/to-comparators');
+import semverMinVersion = require('./ranges/min-version');
+import semverValidRange = require('./ranges/valid');
+import semverOutside = require('./ranges/outside');
+import semverGtr = require('./ranges/gtr');
+import semverLtr = require('./ranges/ltr');
+import semverIntersects = require('./ranges/intersects');
+
+export {
+    semverSatisfies as satisfies,
+    semverMaxSatisfying as maxSatisfying,
+    semverMinSatisfying as minSatisfying,
+    semverToComparators as toComparators,
+    semverMinVersion as minVersion,
+    semverValidRange as validRange,
+    semverOutside as outside,
+    semverGtr as gtr,
+    semverLtr as ltr,
+    semverIntersects as intersects,
+};
+
+// classes
+import SemVer = require('./classes/semver');
+import Range = require('./classes/range');
+import Comparator = require('./classes/comparator');
+
+export { SemVer, Range, Comparator };
+
+// internals
+import identifiers = require('./internals/identifiers');
+export import compareIdentifiers = identifiers.compareIdentifiers;
+export import rcompareIdentifiers = identifiers.rcompareIdentifiers;
+
+export const SEMVER_SPEC_VERSION: '2.0.0';
+
+export type ReleaseType = 'major' | 'premajor' | 'minor' | 'preminor' | 'patch' | 'prepatch' | 'prerelease';
 
 export interface Options {
     loose?: boolean;
     includePrerelease?: boolean;
 }
-
 export interface CoerceOptions extends Options {
     /**
      * Used by `coerce()` to coerce from right to left.
@@ -31,269 +127,4 @@ export interface CoerceOptions extends Options {
     rtl?: boolean;
 }
 
-/**
- * Return the parsed version as a SemVer object, or null if it's not valid.
- */
-export function parse(version: string | SemVer | null | undefined, optionsOrLoose?: boolean | Options): SemVer | null;
-
-/**
- * Return the parsed version as a string, or null if it's not valid.
- */
-export function valid(version: string | SemVer | null | undefined, optionsOrLoose?: boolean | Options): string | null;
-
-/**
- * Coerces a string to SemVer if possible
- */
-export function coerce(version: string | number | SemVer | null | undefined, options?: CoerceOptions): SemVer | null;
-
-/**
- * Returns cleaned (removed leading/trailing whitespace, remove '=v' prefix) and parsed version, or null if version is invalid.
- */
-export function clean(version: string, optionsOrLoose?: boolean | Options): string | null;
-
-/**
- * Return the version incremented by the release type (major, minor, patch, or prerelease), or null if it's not valid.
- */
-export function inc(version: string | SemVer, release: ReleaseType, optionsOrLoose?: boolean | Options, identifier?: string): string | null;
-export function inc(version: string | SemVer, release: ReleaseType, identifier?: string): string | null;
-
-/**
- * Return the major version number.
- */
-export function major(version: string | SemVer, optionsOrLoose?: boolean | Options): number;
-
-/**
- * Return the minor version number.
- */
-export function minor(version: string | SemVer, optionsOrLoose?: boolean | Options): number;
-
-/**
- * Return the patch version number.
- */
-export function patch(version: string | SemVer, optionsOrLoose?: boolean | Options): number;
-
-/**
- * Returns an array of prerelease components, or null if none exist.
- */
-export function prerelease(version: string | SemVer, optionsOrLoose?: boolean | Options): ReadonlyArray<string> | null;
-
-// Comparison
-/**
- * v1 > v2
- */
-export function gt(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
-/**
- * v1 >= v2
- */
-export function gte(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
-/**
- * v1 < v2
- */
-export function lt(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
-/**
- * v1 <= v2
- */
-export function lte(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
-/**
- * v1 == v2 This is true if they're logically equivalent, even if they're not the exact same string. You already know how to compare strings.
- */
-export function eq(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
-/**
- * v1 != v2 The opposite of eq.
- */
-export function neq(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
-
-/**
- * Pass in a comparison string, and it'll call the corresponding semver comparison function.
- * "===" and "!==" do simple string comparison, but are included for completeness.
- * Throws if an invalid comparison string is provided.
- */
-export function cmp(v1: string | SemVer, operator: Operator, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
 export type Operator = '===' | '!==' | '' | '=' | '==' | '!=' | '>' | '>=' | '<' | '<=';
-
-/**
- * Compares two versions excluding build identifiers (the bit after `+` in the semantic version string).
- *
- * Sorts in ascending order when passed to `Array.sort()`.
- *
- * @return
- * - `0` if `v1` == `v2`
- * - `1` if `v1` is greater
- * - `-1` if `v2` is greater.
- */
-export function compare(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): 1 | 0 | -1;
-/**
- * The reverse of compare.
- *
- * Sorts in descending order when passed to `Array.sort()`.
- */
-export function rcompare(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): 1 | 0 | -1;
-
-/**
- * Compares two identifiers, must be numeric strings or truthy/falsy values.
- *
- * Sorts in ascending order when passed to `Array.sort()`.
- */
-export function compareIdentifiers(a: string | null | undefined, b: string | null | undefined): 1 | 0 | -1;
-/**
- * The reverse of compareIdentifiers.
- *
- * Sorts in descending order when passed to `Array.sort()`.
- */
-export function rcompareIdentifiers(a: string | null | undefined, b: string | null | undefined): 1 | 0 | -1;
-
-/**
- * Compares two versions including build identifiers (the bit after `+` in the semantic version string).
- *
- * Sorts in ascending order when passed to `Array.sort()`.
- *
- * @return
- * - `0` if `v1` == `v2`
- * - `1` if `v1` is greater
- * - `-1` if `v2` is greater.
- *
- * @since 6.1.0
- */
-export function compareBuild(a: string | SemVer, b: string | SemVer): 1 | 0 | -1;
-
-/**
- * Sorts an array of semver entries in ascending order using `compareBuild()`.
- */
-export function sort<T extends string | SemVer>(list: T[], optionsOrLoose?: boolean | Options): T[];
-/**
- * Sorts an array of semver entries in descending order using `compareBuild()`.
- */
-export function rsort<T extends string | SemVer>(list: T[], optionsOrLoose?: boolean | Options): T[];
-
-/**
- * Returns difference between two versions by the release type (major, premajor, minor, preminor, patch, prepatch, or prerelease), or null if the versions are the same.
- */
-export function diff(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): ReleaseType | null;
-
-// Ranges
-/**
- * Return the valid range or null if it's not valid
- */
-export function validRange(range: string | Range | null | undefined, optionsOrLoose?: boolean | Options): string;
-/**
- * Return true if the version satisfies the range.
- */
-export function satisfies(version: string | SemVer, range: string | Range, optionsOrLoose?: boolean | Options): boolean;
-/**
- * Return the highest version in the list that satisfies the range, or null if none of them do.
- */
-export function maxSatisfying<T extends string | SemVer>(versions: ReadonlyArray<T>, range: string | Range, optionsOrLoose?: boolean | Options): T | null;
-/**
- * Return the lowest version in the list that satisfies the range, or null if none of them do.
- */
-export function minSatisfying<T extends string | SemVer>(versions: ReadonlyArray<T>, range: string | Range, optionsOrLoose?: boolean | Options): T | null;
-/**
- * Return the lowest version that can possibly match the given range.
- */
-export function minVersion(range: string | Range, optionsOrLoose?: boolean | Options): SemVer | null;
-/**
- * Return true if version is greater than all the versions possible in the range.
- */
-export function gtr(version: string | SemVer, range: string | Range, optionsOrLoose?: boolean | Options): boolean;
-/**
- * Return true if version is less than all the versions possible in the range.
- */
-export function ltr(version: string | SemVer, range: string | Range, optionsOrLoose?: boolean | Options): boolean;
-/**
- * Return true if the version is outside the bounds of the range in either the high or low direction.
- * The hilo argument must be either the string '>' or '<'. (This is the function called by gtr and ltr.)
- */
-export function outside(version: string | SemVer, range: string | Range, hilo: '>' | '<', optionsOrLoose?: boolean | Options): boolean;
-/**
- * Return true if any of the ranges comparators intersect
- */
-export function intersects(range1: string | Range, range2: string | Range, optionsOrLoose?: boolean | Options): boolean;
-
-export class SemVer {
-    constructor(version: string | SemVer, optionsOrLoose?: boolean | Options);
-
-    raw: string;
-    loose: boolean;
-    options: Options;
-    format(): string;
-    inspect(): string;
-
-    major: number;
-    minor: number;
-    patch: number;
-    version: string;
-    build: ReadonlyArray<string>;
-    prerelease: ReadonlyArray<string | number>;
-
-    /**
-     * Compares two versions excluding build identifiers (the bit after `+` in the semantic version string).
-     *
-     * @return
-     * - `0` if `this` == `other`
-     * - `1` if `this` is greater
-     * - `-1` if `other` is greater.
-     */
-    compare(other: string | SemVer): 1 | 0 | -1;
-
-    /**
-     * Compares the release portion of two versions.
-     *
-     * @return
-     * - `0` if `this` == `other`
-     * - `1` if `this` is greater
-     * - `-1` if `other` is greater.
-     */
-    compareMain(other: string | SemVer): 1 | 0 | -1;
-
-    /**
-     * Compares the prerelease portion of two versions.
-     *
-     * @return
-     * - `0` if `this` == `other`
-     * - `1` if `this` is greater
-     * - `-1` if `other` is greater.
-     */
-    comparePre(other: string | SemVer): 1 | 0 | -1;
-
-    /**
-     * Compares the build identifier of two versions.
-     *
-     * @return
-     * - `0` if `this` == `other`
-     * - `1` if `this` is greater
-     * - `-1` if `other` is greater.
-     */
-    compareBuild(other: string | SemVer): 1 | 0 | -1;
-
-    inc(release: ReleaseType, identifier?: string): SemVer;
-}
-
-export class Comparator {
-    constructor(comp: string | Comparator, optionsOrLoose?: boolean | Options);
-
-    semver: SemVer;
-    operator: '' | '=' | '<' | '>' | '<=' | '>=';
-    value: string;
-    loose: boolean;
-    options: Options;
-    parse(comp: string): void;
-    test(version: string | SemVer): boolean;
-    intersects(comp: Comparator, optionsOrLoose?: boolean | Options): boolean;
-}
-
-export class Range {
-    constructor(range: string | Range, optionsOrLoose?: boolean | Options);
-
-    range: string;
-    raw: string;
-    loose: boolean;
-    options: Options;
-    includePrerelease: boolean;
-    format(): string;
-    inspect(): string;
-
-    set: ReadonlyArray<ReadonlyArray<Comparator>>;
-    parseRange(range: string): ReadonlyArray<Comparator>;
-    test(version: string | SemVer): boolean;
-    intersects(range: Range, optionsOrLoose?: boolean | Options): boolean;
-}

--- a/types/semver/internals/identifiers.d.ts
+++ b/types/semver/internals/identifiers.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Compares two identifiers, must be numeric strings or truthy/falsy values.
+ *
+ * Sorts in ascending order when passed to `Array.sort()`.
+ */
+export function compareIdentifiers(a: string | null | undefined, b: string | null | undefined): 1 | 0 | -1;
+
+/**
+ * The reverse of compareIdentifiers.
+ *
+ * Sorts in descending order when passed to `Array.sort()`.
+ */
+export function rcompareIdentifiers(a: string | null | undefined, b: string | null | undefined): 1 | 0 | -1;

--- a/types/semver/preload.d.ts
+++ b/types/semver/preload.d.ts
@@ -1,0 +1,2 @@
+import semver = require('.');
+export = semver;

--- a/types/semver/ranges/gtr.d.ts
+++ b/types/semver/ranges/gtr.d.ts
@@ -1,0 +1,14 @@
+import Range = require('../classes/range');
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Return true if version is greater than all the versions possible in the range.
+ */
+declare function gtr(
+    version: string | SemVer,
+    range: string | Range,
+    optionsOrLoose?: boolean | semver.Options,
+): boolean;
+
+export = gtr;

--- a/types/semver/ranges/intersects.d.ts
+++ b/types/semver/ranges/intersects.d.ts
@@ -1,0 +1,13 @@
+import Range = require('../classes/range');
+import semver = require('../');
+
+/**
+ * Return true if any of the ranges comparators intersect
+ */
+declare function intersects(
+    range1: string | Range,
+    range2: string | Range,
+    optionsOrLoose?: boolean | semver.Options,
+): boolean;
+
+export = intersects;

--- a/types/semver/ranges/ltr.d.ts
+++ b/types/semver/ranges/ltr.d.ts
@@ -1,0 +1,14 @@
+import Range = require('../classes/range');
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Return true if version is less than all the versions possible in the range.
+ */
+declare function ltr(
+    version: string | SemVer,
+    range: string | Range,
+    optionsOrLoose?: boolean | semver.Options,
+): boolean;
+
+export = ltr;

--- a/types/semver/ranges/max-satisfying.d.ts
+++ b/types/semver/ranges/max-satisfying.d.ts
@@ -1,0 +1,14 @@
+import Range = require('../classes/range');
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Return the highest version in the list that satisfies the range, or null if none of them do.
+ */
+declare function maxSatisfying<T extends string | SemVer>(
+    versions: ReadonlyArray<T>,
+    range: string | Range,
+    optionsOrLoose?: boolean | semver.Options,
+): T | null;
+
+export = maxSatisfying;

--- a/types/semver/ranges/min-satisfying.d.ts
+++ b/types/semver/ranges/min-satisfying.d.ts
@@ -1,0 +1,14 @@
+import Range = require('../classes/range');
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Return the lowest version in the list that satisfies the range, or null if none of them do.
+ */
+declare function minSatisfying<T extends string | SemVer>(
+    versions: ReadonlyArray<T>,
+    range: string | Range,
+    optionsOrLoose?: boolean | semver.Options,
+): T | null;
+
+export = minSatisfying;

--- a/types/semver/ranges/min-version.d.ts
+++ b/types/semver/ranges/min-version.d.ts
@@ -1,0 +1,10 @@
+import Range = require('../classes/range');
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Return the lowest version that can possibly match the given range.
+ */
+declare function minVersion(range: string | Range, optionsOrLoose?: boolean | semver.Options): SemVer | null;
+
+export = minVersion;

--- a/types/semver/ranges/outside.d.ts
+++ b/types/semver/ranges/outside.d.ts
@@ -1,0 +1,15 @@
+import Range = require('../classes/range');
+import SemVer = require('../classes/semver');
+import semver = require('../');
+
+/**
+ * Return true if the version is outside the bounds of the range in either the high or low direction.
+ * The hilo argument must be either the string '>' or '<'. (This is the function called by gtr and ltr.)
+ */
+declare function outside(
+    version: string | SemVer,
+    range: string | Range,
+    hilo: '>' | '<',
+    optionsOrLoose?: boolean | semver.Options,
+): boolean;
+export = outside;

--- a/types/semver/ranges/to-comparators.d.ts
+++ b/types/semver/ranges/to-comparators.d.ts
@@ -1,0 +1,9 @@
+import Range = require('../classes/range');
+import semver = require('../');
+
+/**
+ * Mostly just for testing and legacy API reasons
+ */
+declare function toComparators(range: string | Range, optionsOrLoose?: boolean | semver.Options): string;
+
+export = toComparators;

--- a/types/semver/ranges/valid.d.ts
+++ b/types/semver/ranges/valid.d.ts
@@ -1,0 +1,12 @@
+import Range = require('../classes/range');
+import semver = require('../');
+
+/**
+ * Return the valid range or null if it's not valid
+ */
+declare function validRange(
+    range: string | Range | null | undefined,
+    optionsOrLoose?: boolean | semver.Options,
+): string;
+
+export = validRange;

--- a/types/semver/semver-tests.ts
+++ b/types/semver/semver-tests.ts
@@ -1,4 +1,90 @@
-import * as semver from "semver";
+// As a node module:
+import * as semver from 'semver';
+
+semver.valid('1.2.3'); // $ExpectType string | null
+semver.valid('a.b.c'); // $ExpectType string | null
+semver.clean('  =v1.2.3   '); // $ExpectType string | null
+semver.satisfies('1.2.3', '1.x || >=2.5.0 || 5.0.0 - 7.2.3'); // $ExpectType boolean
+semver.gt('1.2.3', '9.8.7'); // $ExpectType boolean
+semver.lt('1.2.3', '9.8.7'); // $ExpectType boolean
+semver.minVersion('>=1.0.0'); // $ExpectType SemVer | null
+semver.valid(semver.coerce('v2')); // $ExpectType string | null
+semver.valid(semver.coerce('42.6.7.9.3-alpha')); // $ExpectType string | null
+
+// This module uses getters to lazily load only the parts of the package that are used.
+// To use it with Webpack and other projects that need string literals as the argument to require(),
+// load it this way:
+
+// load the whole API at once in a single object
+import semverPreload = require('semver/preload');
+semverPreload.valid('1.2.3'); // $ExpectType string | null
+semverPreload.valid('a.b.c'); // $ExpectType string | null
+semverPreload.clean('  =v1.2.3   '); // $ExpectType string | null
+semverPreload.satisfies('1.2.3', '1.x || >=2.5.0 || 5.0.0 - 7.2.3'); // $ExpectType boolean
+semverPreload.gt('1.2.3', '9.8.7'); // $ExpectType boolean
+semverPreload.lt('1.2.3', '9.8.7'); // $ExpectType boolean
+semverPreload.minVersion('>=1.0.0'); // $ExpectType SemVer | null
+semverPreload.valid(semverPreload.coerce('v2')); // $ExpectType string | null
+semverPreload.valid(semverPreload.coerce('42.6.7.9.3-alpha')); // $ExpectType string | null
+
+// or just load the bits you need
+// all of them listed here, just pick and choose what you want
+
+// classes
+import SemVer = require('semver/classes/semver');
+import Comparator = require('semver/classes/comparator');
+import Range = require('semver/classes/range');
+
+// functions for working with versions
+import semverParse = require('semver/functions/parse');
+import semverValid = require('semver/functions/valid');
+import semverClean = require('semver/functions/clean');
+import semverInc = require('semver/functions/inc');
+import semverDiff = require('semver/functions/diff');
+import semverMajor = require('semver/functions/major');
+import semverMinor = require('semver/functions/minor');
+import semverPatch = require('semver/functions/patch');
+import semverPrerelease = require('semver/functions/prerelease');
+import semverCompare = require('semver/functions/compare');
+import semverRcompare = require('semver/functions/rcompare');
+import semverCompareLoose = require('semver/functions/compare-loose');
+import semverCompareBuild = require('semver/functions/compare-build');
+import semverSort = require('semver/functions/sort');
+import semverRsort = require('semver/functions/rsort');
+
+// low-level comparators between versions
+import semverGt = require('semver/functions/gt');
+import semverLt = require('semver/functions/lt');
+import semverEq = require('semver/functions/eq');
+import semverNeq = require('semver/functions/neq');
+import semverGte = require('semver/functions/gte');
+import semverLte = require('semver/functions/lte');
+import semverCmp = require('semver/functions/cmp');
+import semverCoerce = require('semver/functions/coerce');
+
+// working with ranges
+import semverSatisfies = require('semver/functions/satisfies');
+import semverMaxSatisfying = require('semver/ranges/max-satisfying');
+import semverMinSatisfying = require('semver/ranges/min-satisfying');
+import semverToComparators = require('semver/ranges/to-comparators');
+import semverMinVersion = require('semver/ranges/min-version');
+import semverValidRange = require('semver/ranges/valid');
+import semverOutside = require('semver/ranges/outside');
+import semverGtr = require('semver/ranges/gtr');
+import semverLtr = require('semver/ranges/ltr');
+import semverIntersects = require('semver/ranges/intersects');
+
+semverValid('1.2.3'); // $ExpectType string | null
+semverValid('a.b.c'); // $ExpectType string | null
+semverClean('  =v1.2.3   '); // $ExpectType string | null
+semverSatisfies('1.2.3', '1.x || >=2.5.0 || 5.0.0 - 7.2.3'); // $ExpectType boolean
+semverGt('1.2.3', '9.8.7'); // $ExpectType boolean
+semverLt('1.2.3', '9.8.7'); // $ExpectType boolean
+semverMinVersion('>=1.0.0'); // $ExpectType SemVer | null
+semverValid(semverCoerce('v2')); // $ExpectType string | null
+semverValid(semverCoerce('42.6.7.9.3-alpha')); // $ExpectType string | null
+
+// v6 tests
 
 let bool: boolean;
 let num: number;
@@ -8,8 +94,8 @@ let str = String(Math.random());
 let strn: string | null = Math.random() < 0.5 ? null : str;
 let diff: semver.ReleaseType | null;
 const op: semver.Operator = '';
-declare const arr: any[];
-declare const exp: RegExp;
+// declare const arr: any[];
+// declare const exp: RegExp;
 let strArr: ReadonlyArray<string> | null;
 let strNumArr: ReadonlyArray<string | number>;
 declare const numArr: string[];
@@ -36,14 +122,14 @@ strn = semver.clean(str);
 
 strn = semver.valid(str, loose);
 strn = semver.clean(str, loose);
-strn = semver.inc(str, "major", loose);
-strn = semver.inc(str, "premajor", loose);
-strn = semver.inc(str, "minor", loose);
-strn = semver.inc(str, "preminor", loose);
-strn = semver.inc(str, "patch", loose);
-strn = semver.inc(str, "prepatch", loose);
-strn = semver.inc(str, "prerelease", loose);
-strn = semver.inc(str, "prerelease", loose, "alpha");
+strn = semver.inc(str, 'major', loose);
+strn = semver.inc(str, 'premajor', loose);
+strn = semver.inc(str, 'minor', loose);
+strn = semver.inc(str, 'preminor', loose);
+strn = semver.inc(str, 'patch', loose);
+strn = semver.inc(str, 'prepatch', loose);
+strn = semver.inc(str, 'prerelease', loose);
+strn = semver.inc(str, 'prerelease', loose, 'alpha');
 strn = semver.inc(str, 'prerelease', 'beta');
 num = semver.major(str, loose);
 num = semver.minor(str, loose);
@@ -114,14 +200,14 @@ ver.prerelease = strNumArr;
 comparatorResult = ver.compare(ver);
 comparatorResult = ver.compareMain(ver);
 comparatorResult = ver.comparePre(ver);
-ver = ver.inc("major");
-ver = ver.inc("premajor");
-ver = ver.inc("minor");
-ver = ver.inc("preminor");
-ver = ver.inc("patch");
-ver = ver.inc("prepatch");
-ver = ver.inc("prerelease");
-ver = ver.inc("prerelease", "alpha");
+ver = ver.inc('major');
+ver = ver.inc('premajor');
+ver = ver.inc('minor');
+ver = ver.inc('preminor');
+ver = ver.inc('patch');
+ver = ver.inc('prepatch');
+ver = ver.inc('prerelease');
+ver = ver.inc('prerelease', 'alpha');
 
 const comp = new semver.Comparator(str, bool);
 str = comp.toString();
@@ -144,8 +230,6 @@ bool = range.test(ver);
 bool = range.intersects(new semver.Range(''));
 bool = range.intersects(new semver.Range(''), bool);
 
-let sets: ReadonlyArray<ReadonlyArray<semver.Comparator>>;
-sets = range.set;
+const sets: ReadonlyArray<ReadonlyArray<semver.Comparator>> = range.set;
 
-let lims: ReadonlyArray<semver.Comparator>;
-lims = range.parseRange(str);
+const lims: ReadonlyArray<semver.Comparator> = range.parseRange(str);

--- a/types/semver/v6/index.d.ts
+++ b/types/semver/v6/index.d.ts
@@ -1,0 +1,299 @@
+// Type definitions for semver 6.2
+// Project: https://github.com/npm/node-semver
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
+//                 BendingBender <https://github.com/BendingBender>
+//                 Lucian Buzzo <https://github.com/LucianBuzzo>
+//                 Klaus Meinhardt <https://github.com/ajafff>
+//                 ExE Boss <https://github.com/ExE-Boss>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/semver
+
+export const SEMVER_SPEC_VERSION: "2.0.0";
+
+export type ReleaseType = "major" | "premajor" | "minor" | "preminor" | "patch" | "prepatch" | "prerelease";
+
+export interface Options {
+    loose?: boolean;
+    includePrerelease?: boolean;
+}
+
+export interface CoerceOptions extends Options {
+    /**
+     * Used by `coerce()` to coerce from right to left.
+     *
+     * @default false
+     *
+     * @example
+     * coerce('1.2.3.4', { rtl: true });
+     * // => SemVer { version: '2.3.4', ... }
+     *
+     * @since 6.2.0
+     */
+    rtl?: boolean;
+}
+
+/**
+ * Return the parsed version as a SemVer object, or null if it's not valid.
+ */
+export function parse(version: string | SemVer | null | undefined, optionsOrLoose?: boolean | Options): SemVer | null;
+
+/**
+ * Return the parsed version as a string, or null if it's not valid.
+ */
+export function valid(version: string | SemVer | null | undefined, optionsOrLoose?: boolean | Options): string | null;
+
+/**
+ * Coerces a string to SemVer if possible
+ */
+export function coerce(version: string | number | SemVer | null | undefined, options?: CoerceOptions): SemVer | null;
+
+/**
+ * Returns cleaned (removed leading/trailing whitespace, remove '=v' prefix) and parsed version, or null if version is invalid.
+ */
+export function clean(version: string, optionsOrLoose?: boolean | Options): string | null;
+
+/**
+ * Return the version incremented by the release type (major, minor, patch, or prerelease), or null if it's not valid.
+ */
+export function inc(version: string | SemVer, release: ReleaseType, optionsOrLoose?: boolean | Options, identifier?: string): string | null;
+export function inc(version: string | SemVer, release: ReleaseType, identifier?: string): string | null;
+
+/**
+ * Return the major version number.
+ */
+export function major(version: string | SemVer, optionsOrLoose?: boolean | Options): number;
+
+/**
+ * Return the minor version number.
+ */
+export function minor(version: string | SemVer, optionsOrLoose?: boolean | Options): number;
+
+/**
+ * Return the patch version number.
+ */
+export function patch(version: string | SemVer, optionsOrLoose?: boolean | Options): number;
+
+/**
+ * Returns an array of prerelease components, or null if none exist.
+ */
+export function prerelease(version: string | SemVer, optionsOrLoose?: boolean | Options): ReadonlyArray<string> | null;
+
+// Comparison
+/**
+ * v1 > v2
+ */
+export function gt(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
+/**
+ * v1 >= v2
+ */
+export function gte(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
+/**
+ * v1 < v2
+ */
+export function lt(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
+/**
+ * v1 <= v2
+ */
+export function lte(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
+/**
+ * v1 == v2 This is true if they're logically equivalent, even if they're not the exact same string. You already know how to compare strings.
+ */
+export function eq(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
+/**
+ * v1 != v2 The opposite of eq.
+ */
+export function neq(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
+
+/**
+ * Pass in a comparison string, and it'll call the corresponding semver comparison function.
+ * "===" and "!==" do simple string comparison, but are included for completeness.
+ * Throws if an invalid comparison string is provided.
+ */
+export function cmp(v1: string | SemVer, operator: Operator, v2: string | SemVer, optionsOrLoose?: boolean | Options): boolean;
+export type Operator = '===' | '!==' | '' | '=' | '==' | '!=' | '>' | '>=' | '<' | '<=';
+
+/**
+ * Compares two versions excluding build identifiers (the bit after `+` in the semantic version string).
+ *
+ * Sorts in ascending order when passed to `Array.sort()`.
+ *
+ * @return
+ * - `0` if `v1` == `v2`
+ * - `1` if `v1` is greater
+ * - `-1` if `v2` is greater.
+ */
+export function compare(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): 1 | 0 | -1;
+/**
+ * The reverse of compare.
+ *
+ * Sorts in descending order when passed to `Array.sort()`.
+ */
+export function rcompare(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): 1 | 0 | -1;
+
+/**
+ * Compares two identifiers, must be numeric strings or truthy/falsy values.
+ *
+ * Sorts in ascending order when passed to `Array.sort()`.
+ */
+export function compareIdentifiers(a: string | null | undefined, b: string | null | undefined): 1 | 0 | -1;
+/**
+ * The reverse of compareIdentifiers.
+ *
+ * Sorts in descending order when passed to `Array.sort()`.
+ */
+export function rcompareIdentifiers(a: string | null | undefined, b: string | null | undefined): 1 | 0 | -1;
+
+/**
+ * Compares two versions including build identifiers (the bit after `+` in the semantic version string).
+ *
+ * Sorts in ascending order when passed to `Array.sort()`.
+ *
+ * @return
+ * - `0` if `v1` == `v2`
+ * - `1` if `v1` is greater
+ * - `-1` if `v2` is greater.
+ *
+ * @since 6.1.0
+ */
+export function compareBuild(a: string | SemVer, b: string | SemVer): 1 | 0 | -1;
+
+/**
+ * Sorts an array of semver entries in ascending order using `compareBuild()`.
+ */
+export function sort<T extends string | SemVer>(list: T[], optionsOrLoose?: boolean | Options): T[];
+/**
+ * Sorts an array of semver entries in descending order using `compareBuild()`.
+ */
+export function rsort<T extends string | SemVer>(list: T[], optionsOrLoose?: boolean | Options): T[];
+
+/**
+ * Returns difference between two versions by the release type (major, premajor, minor, preminor, patch, prepatch, or prerelease), or null if the versions are the same.
+ */
+export function diff(v1: string | SemVer, v2: string | SemVer, optionsOrLoose?: boolean | Options): ReleaseType | null;
+
+// Ranges
+/**
+ * Return the valid range or null if it's not valid
+ */
+export function validRange(range: string | Range | null | undefined, optionsOrLoose?: boolean | Options): string;
+/**
+ * Return true if the version satisfies the range.
+ */
+export function satisfies(version: string | SemVer, range: string | Range, optionsOrLoose?: boolean | Options): boolean;
+/**
+ * Return the highest version in the list that satisfies the range, or null if none of them do.
+ */
+export function maxSatisfying<T extends string | SemVer>(versions: ReadonlyArray<T>, range: string | Range, optionsOrLoose?: boolean | Options): T | null;
+/**
+ * Return the lowest version in the list that satisfies the range, or null if none of them do.
+ */
+export function minSatisfying<T extends string | SemVer>(versions: ReadonlyArray<T>, range: string | Range, optionsOrLoose?: boolean | Options): T | null;
+/**
+ * Return the lowest version that can possibly match the given range.
+ */
+export function minVersion(range: string | Range, optionsOrLoose?: boolean | Options): SemVer | null;
+/**
+ * Return true if version is greater than all the versions possible in the range.
+ */
+export function gtr(version: string | SemVer, range: string | Range, optionsOrLoose?: boolean | Options): boolean;
+/**
+ * Return true if version is less than all the versions possible in the range.
+ */
+export function ltr(version: string | SemVer, range: string | Range, optionsOrLoose?: boolean | Options): boolean;
+/**
+ * Return true if the version is outside the bounds of the range in either the high or low direction.
+ * The hilo argument must be either the string '>' or '<'. (This is the function called by gtr and ltr.)
+ */
+export function outside(version: string | SemVer, range: string | Range, hilo: '>' | '<', optionsOrLoose?: boolean | Options): boolean;
+/**
+ * Return true if any of the ranges comparators intersect
+ */
+export function intersects(range1: string | Range, range2: string | Range, optionsOrLoose?: boolean | Options): boolean;
+
+export class SemVer {
+    constructor(version: string | SemVer, optionsOrLoose?: boolean | Options);
+
+    raw: string;
+    loose: boolean;
+    options: Options;
+    format(): string;
+    inspect(): string;
+
+    major: number;
+    minor: number;
+    patch: number;
+    version: string;
+    build: ReadonlyArray<string>;
+    prerelease: ReadonlyArray<string | number>;
+
+    /**
+     * Compares two versions excluding build identifiers (the bit after `+` in the semantic version string).
+     *
+     * @return
+     * - `0` if `this` == `other`
+     * - `1` if `this` is greater
+     * - `-1` if `other` is greater.
+     */
+    compare(other: string | SemVer): 1 | 0 | -1;
+
+    /**
+     * Compares the release portion of two versions.
+     *
+     * @return
+     * - `0` if `this` == `other`
+     * - `1` if `this` is greater
+     * - `-1` if `other` is greater.
+     */
+    compareMain(other: string | SemVer): 1 | 0 | -1;
+
+    /**
+     * Compares the prerelease portion of two versions.
+     *
+     * @return
+     * - `0` if `this` == `other`
+     * - `1` if `this` is greater
+     * - `-1` if `other` is greater.
+     */
+    comparePre(other: string | SemVer): 1 | 0 | -1;
+
+    /**
+     * Compares the build identifier of two versions.
+     *
+     * @return
+     * - `0` if `this` == `other`
+     * - `1` if `this` is greater
+     * - `-1` if `other` is greater.
+     */
+    compareBuild(other: string | SemVer): 1 | 0 | -1;
+
+    inc(release: ReleaseType, identifier?: string): SemVer;
+}
+
+export class Comparator {
+    constructor(comp: string | Comparator, optionsOrLoose?: boolean | Options);
+
+    semver: SemVer;
+    operator: '' | '=' | '<' | '>' | '<=' | '>=';
+    value: string;
+    loose: boolean;
+    options: Options;
+    parse(comp: string): void;
+    test(version: string | SemVer): boolean;
+    intersects(comp: Comparator, optionsOrLoose?: boolean | Options): boolean;
+}
+
+export class Range {
+    constructor(range: string | Range, optionsOrLoose?: boolean | Options);
+
+    range: string;
+    raw: string;
+    loose: boolean;
+    options: Options;
+    includePrerelease: boolean;
+    format(): string;
+    inspect(): string;
+
+    set: ReadonlyArray<ReadonlyArray<Comparator>>;
+    parseRange(range: string): ReadonlyArray<Comparator>;
+    test(version: string | SemVer): boolean;
+    intersects(range: Range, optionsOrLoose?: boolean | Options): boolean;
+}

--- a/types/semver/v6/semver-tests.ts
+++ b/types/semver/v6/semver-tests.ts
@@ -1,0 +1,151 @@
+import * as semver from "semver";
+
+let bool: boolean;
+let num: number;
+// $ExpectType string
+let str = String(Math.random());
+// $ExpectType string | null
+let strn: string | null = Math.random() < 0.5 ? null : str;
+let diff: semver.ReleaseType | null;
+const op: semver.Operator = '';
+declare const arr: any[];
+declare const exp: RegExp;
+let strArr: ReadonlyArray<string> | null;
+let strNumArr: ReadonlyArray<string | number>;
+declare const numArr: string[];
+let comparatorResult: -1 | 0 | 1;
+let versionsArr: Array<string | semver.SemVer>;
+
+const v1 = '';
+const v2 = '';
+const version = '';
+const versions: string[] = [];
+const loose = true;
+// $ExpectType SemVer | null
+let sem: semver.SemVer | null = Math.random() < 0.5 ? new semver.SemVer(str, {}) : null;
+
+// $ExpectType string | SemVer | null | undefined
+const anyVersion = Math.random() < 0.5 ? undefined : Math.random() < 0.5 ? strn : sem;
+
+sem = new semver.SemVer(str, { includePrerelease: false });
+sem = new semver.SemVer(str, { loose: true });
+
+sem = semver.parse(str);
+strn = semver.valid(str);
+strn = semver.clean(str);
+
+strn = semver.valid(str, loose);
+strn = semver.clean(str, loose);
+strn = semver.inc(str, "major", loose);
+strn = semver.inc(str, "premajor", loose);
+strn = semver.inc(str, "minor", loose);
+strn = semver.inc(str, "preminor", loose);
+strn = semver.inc(str, "patch", loose);
+strn = semver.inc(str, "prepatch", loose);
+strn = semver.inc(str, "prerelease", loose);
+strn = semver.inc(str, "prerelease", loose, "alpha");
+strn = semver.inc(str, 'prerelease', 'beta');
+num = semver.major(str, loose);
+num = semver.minor(str, loose);
+num = semver.patch(str, loose);
+strArr = semver.prerelease(str, loose);
+
+// Comparison
+bool = semver.gt(v1, v2, loose);
+bool = semver.gte(v1, v2, loose);
+bool = semver.lt(v1, v2, loose);
+bool = semver.lte(v1, v2, loose);
+bool = semver.eq(v1, v2, loose);
+bool = semver.neq(v1, v2, loose);
+bool = semver.cmp(v1, op, v2, loose);
+comparatorResult = semver.compare(v1, v2, loose);
+comparatorResult = semver.rcompare(v1, v2, loose);
+comparatorResult = semver.compareIdentifiers(str, str);
+comparatorResult = semver.rcompareIdentifiers(str, str);
+versionsArr = semver.sort(['', new semver.SemVer('')]);
+versionsArr = semver.rsort(['', new semver.SemVer('')]);
+diff = semver.diff(v1, v2, loose);
+
+// Ranges
+str = semver.validRange(str, loose);
+bool = semver.satisfies(version, str, loose);
+strn = semver.maxSatisfying(versions, str, loose);
+strn = semver.minSatisfying(versions, str, loose);
+bool = semver.gtr(version, str, loose);
+bool = semver.ltr(version, str, loose);
+bool = semver.outside(version, str, '<', loose);
+bool = semver.intersects(str, str, loose);
+sem = semver.minVersion(str, loose);
+
+// Coercion
+sem = semver.coerce(str);
+
+sem = semver.coerce(strn);
+sem = semver.coerce(strn, { rtl: false });
+sem = semver.coerce(strn, { rtl: true });
+
+sem = semver.coerce(sem);
+sem = semver.coerce(sem, { rtl: false });
+sem = semver.coerce(sem, { rtl: true });
+
+sem = semver.coerce(1);
+sem = semver.coerce(2, { rtl: false });
+sem = semver.coerce(3, { rtl: true });
+
+sem = semver.coerce(anyVersion);
+sem = semver.coerce(anyVersion, { rtl: false });
+sem = semver.coerce(anyVersion, { rtl: true });
+
+let ver = new semver.SemVer(str, bool);
+str = ver.raw;
+bool = ver.loose;
+str = ver.format();
+str = ver.inspect();
+str = ver.toString();
+
+num = ver.major;
+num = ver.minor;
+num = ver.patch;
+str = ver.version;
+strArr = ver.build;
+strNumArr = ver.prerelease;
+ver.prerelease = strNumArr;
+
+comparatorResult = ver.compare(ver);
+comparatorResult = ver.compareMain(ver);
+comparatorResult = ver.comparePre(ver);
+ver = ver.inc("major");
+ver = ver.inc("premajor");
+ver = ver.inc("minor");
+ver = ver.inc("preminor");
+ver = ver.inc("patch");
+ver = ver.inc("prepatch");
+ver = ver.inc("prerelease");
+ver = ver.inc("prerelease", "alpha");
+
+const comp = new semver.Comparator(str, bool);
+str = comp.toString();
+
+ver = comp.semver;
+str = comp.operator;
+str = comp.value;
+comp.parse(str);
+bool = comp.test(ver);
+bool = comp.intersects(new semver.Comparator(str));
+bool = comp.intersects(new semver.Comparator(str), bool);
+
+const range = new semver.Range(str, bool);
+str = range.raw;
+bool = range.loose;
+str = range.format();
+str = range.inspect();
+str = range.toString();
+bool = range.test(ver);
+bool = range.intersects(new semver.Range(''));
+bool = range.intersects(new semver.Range(''), bool);
+
+let sets: ReadonlyArray<ReadonlyArray<semver.Comparator>>;
+sets = range.set;
+
+let lims: ReadonlyArray<semver.Comparator>;
+lims = range.parseRange(str);

--- a/types/semver/v6/tsconfig.json
+++ b/types/semver/v6/tsconfig.json
@@ -1,14 +1,22 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es5", "es6"],
+        "lib": ["es5"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
-        "baseUrl": "../",
-        "typeRoots": ["../"],
+        "baseUrl": "../../",
+        "typeRoots": ["../../"],
         "types": [],
+        "paths": {
+            "semver": [
+                "semver/v6"
+            ],
+            "semver/*": [
+                "semver/v6/*"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/semver/v6/tslint.json
+++ b/types/semver/v6/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- migrate modules to support new v7 usage
- create v6 folder to support older version
- update v7 tests with usage samples from readme while preserving
v6 tests

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/node-semver#usage
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.