### PR TITLE
[meteor] Make check an assertion function

### DIFF
--- a/types/angular-meteor/index.d.ts
+++ b/types/angular-meteor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Urigo/angular-meteor
 // Definitions by: Peter Grman <https://github.com/pgrm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// Minimum TypeScript Version: 3.7
 
 /// <reference types="meteor" />
 

--- a/types/meteor-astronomy/index.d.ts
+++ b/types/meteor-astronomy/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jagi/meteor-astronomy/
 // Definitions by: Igor Golovin <https://github.com/Deadly0>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// Minimum TypeScript Version: 3.7
 
 /// <reference types="meteor" />
 

--- a/types/meteor-jboulhous-dev/index.d.ts
+++ b/types/meteor-jboulhous-dev/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jboulhous/dev
 // Definitions by: Robbie Van Gorkom <https://github.com/vangorra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// Minimum TypeScript Version: 3.7
 
 /// <reference types="meteor" />
 

--- a/types/meteor-persistent-session/index.d.ts
+++ b/types/meteor-persistent-session/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/okgrow/meteor-persistent-session
 // Definitions by: Robbie Van Gorkom <https://github.com/vangorra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// Minimum TypeScript Version: 3.7
 
 /// <reference types="meteor" />
 

--- a/types/meteor-prime8consulting-oauth2/index.d.ts
+++ b/types/meteor-prime8consulting-oauth2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/prime-8-consulting/meteor-oauth2/
 // Definitions by: Robbie Van Gorkom <https://github.com/vangorra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// Minimum TypeScript Version: 3.7
 
 /// <reference types="meteor" />
 

--- a/types/meteor-publish-composite/index.d.ts
+++ b/types/meteor-publish-composite/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Robert Van Gorkom <https://github.com/vangorra>
 //                 Matthew Zartman <https://github.com/mrz5018>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// Minimum TypeScript Version: 3.7
 
 /// <reference types="meteor" />
 

--- a/types/meteor-roles/index.d.ts
+++ b/types/meteor-roles/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Robbie Van Gorkom <https://github.com/vangorra>
 //                 Matthew Zartman <https://github.com/mattmm3d>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// Minimum TypeScript Version: 3.7
 
 /// <reference types="meteor" />
 

--- a/types/meteor-universe-i18n/index.d.ts
+++ b/types/meteor-universe-i18n/index.d.ts
@@ -2,7 +2,7 @@
 // Project: meteor-universe-i18n
 // Definitions by: Mathias Scherer <https://github.com/mathewmeconry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// Minimum TypeScript Version: 3.7
 
 /// <reference types="react" />
 /// <reference types="node" />

--- a/types/meteor/check.d.ts
+++ b/types/meteor/check.d.ts
@@ -1,24 +1,45 @@
 declare module "meteor/check" {
     module Match {
-        var Any: any;
-        var String: any;
-        var Integer: any;
-        var Boolean: any;
-        var undefined: any;
-        var Object: any;
+        interface Matcher<T> { _meteorCheckMatcherBrand: void }
+        export type Pattern =
+            typeof String |
+            typeof Number |
+            typeof Boolean |
+            typeof Object |
+            typeof Function |
+            (new (...args: any[]) => any) |
+            undefined | null | string | number | boolean |
+            [Pattern] |
+            {[key: string]: Pattern} |
+            Matcher<any>;
+        export type PatternMatch<T extends Pattern> =
+            T extends Matcher<infer U> ? U :
+            T extends typeof String ? string :
+            T extends typeof Number ? number :
+            T extends typeof Boolean ? boolean :
+            T extends typeof Object ? object :
+            T extends typeof Function ? Function :
+            T extends undefined | null | string | number | boolean ? T :
+            T extends new (...args: any[]) => infer U ? U :
+            T extends [Pattern] ? PatternMatch<T[0]>[] :
+            T extends {[key: string]: Pattern} ? {[K in keyof T]: PatternMatch<T[K]>} :
+            unknown;
 
-        function Maybe(pattern: any): boolean;
+        var Any: Matcher<any>;
+        var Integer: Matcher<number>;
 
-        function Optional(pattern: any): boolean;
+        function Maybe<T extends Pattern>(pattern: T): Matcher<PatternMatch<T> | undefined | null>;
 
-        function ObjectIncluding(dico: any): boolean;
+        function Optional<T extends Pattern>(pattern: T): Matcher<PatternMatch<T> | undefined>;
 
-        function OneOf(...patterns: any[]): any;
+        function ObjectIncluding<T extends {[key: string]: Pattern}>(dico: T): Matcher<PatternMatch<T>>;
 
-        function Where(condition: any): any;
+        function OneOf<T extends Pattern>(...patterns: T[]): Matcher<PatternMatch<T>>;
 
-        function test(value: any, pattern: any): boolean;
+        function Where(condition: (val: any) => boolean): Matcher<any>;
+
+        function test<T extends Pattern>(value: any, pattern: T): value is PatternMatch<T>;
     }
 
-    function check(value: any, pattern: any): void;
+    function check<T extends Match.Pattern>(value: any, pattern: T): asserts value is Match.PatternMatch<T>;
 }

--- a/types/meteor/globals/check.d.ts
+++ b/types/meteor/globals/check.d.ts
@@ -1,22 +1,43 @@
 declare module Match {
-    var Any: any;
-    var String: any;
-    var Integer: any;
-    var Boolean: any;
-    var undefined: any;
-    var Object: any;
+    interface Matcher<T> { _meteorCheckMatcherBrand: void }
+    export type Pattern =
+        typeof String |
+        typeof Number |
+        typeof Boolean |
+        typeof Object |
+        typeof Function |
+        (new (...args: any[]) => any) |
+        undefined | null | string | number | boolean |
+        [Pattern] |
+        {[key: string]: Pattern} |
+        Matcher<any>;
+    export type PatternMatch<T extends Pattern> =
+        T extends Matcher<infer U> ? U :
+        T extends typeof String ? string :
+        T extends typeof Number ? number :
+        T extends typeof Boolean ? boolean :
+        T extends typeof Object ? object :
+        T extends typeof Function ? Function :
+        T extends undefined | null | string | number | boolean ? T :
+        T extends new (...args: any) => infer U ? U :
+        T extends [Pattern] ? PatternMatch<T[0]>[] :
+        T extends {[key: string]: Pattern} ? {[K in keyof T]: PatternMatch<T[K]>} :
+        unknown;
 
-    function Maybe(pattern: any): boolean;
+    var Any: Matcher<any>;
+    var Integer: Matcher<number>;
 
-    function Optional(pattern: any): boolean;
+    function Maybe<T extends Pattern>(pattern: T): Matcher<PatternMatch<T> | undefined | null>;
 
-    function ObjectIncluding(dico: any): boolean;
+    function Optional<T extends Pattern>(pattern: T): Matcher<PatternMatch<T> | undefined>;
 
-    function OneOf(...patterns: any[]): any;
+    function ObjectIncluding<T extends {[key: string]: Pattern}>(dico: T): Matcher<PatternMatch<T>>;
 
-    function Where(condition: any): any;
+    function OneOf<T extends Pattern>(...patterns: T[]): Matcher<PatternMatch<T>>;
 
-    function test(value: any, pattern: any): boolean;
+    function Where(condition: (val: any) => boolean): Matcher<any>;
+
+    function test<T extends Pattern>(value: any, pattern: T): value is PatternMatch<T>;
 }
 
-declare function check(value: any, pattern: any): void;
+declare function check<T extends Match.Pattern>(value: any, pattern: T): asserts value is Match.PatternMatch<T>;

--- a/types/meteor/index.d.ts
+++ b/types/meteor/index.d.ts
@@ -13,8 +13,9 @@
 //                 alesn <https://github.com/alesn>
 //                 Per Bergland <https://github.com/perbergland>
 //                 Nicusor Chiciuc <https://github.com/nicu-chiciuc>
+//                 Evan Broder <https://github.com/ebroder>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// Minimum TypeScript Version: 3.7
 
 /// <reference path="./accounts-base.d.ts" />
 /// <reference path="./globals/accounts-base.d.ts" />

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -66,8 +66,10 @@ Meteor.publish("adminSecretInfo", function () {
     return Rooms.find({ admin: this.userId }, { fields: { secretInfo: 1 } });
 });
 
-Meteor.publish("roomAndMessages", function (roomId: string) {
+Meteor.publish("roomAndMessages", function (roomId: unknown) {
     check(roomId, String);
+    // $ExpectType string
+    roomId;
     return [
         Rooms.find({ _id: roomId }, { fields: { secretInfo: 0 } }),
         Messages.find({ roomId: roomId })
@@ -77,9 +79,11 @@ Meteor.publish("roomAndMessages", function (roomId: string) {
 /**
  * Also from Publish and Subscribe, Meteor.publish section
  */
-Meteor.publish("counts-by-room", function (roomId: string) {
+Meteor.publish("counts-by-room", function (roomId: unknown) {
     var self = this;
     check(roomId, String);
+    // $ExpectType string
+    roomId;
     var count = 0;
     var initializing = true;
     var handle = Messages.find({ roomId: roomId }).observeChanges({
@@ -136,9 +140,14 @@ Tracker.autorun(function () {
  * From Methods, Meteor.methods section
  */
 Meteor.methods({
-    foo: function (arg1: string, arg2: number[]) {
+    foo: function (arg1: unknown, arg2: unknown) {
         check(arg1, String);
         check(arg2, [Number]);
+
+        // $ExpectType string
+        arg1;
+        // $ExpectType number[]
+        arg2;
 
         var you_want_to_throw_an_error = true;
         if (you_want_to_throw_an_error)
@@ -595,14 +604,16 @@ var body = Template.body;
  */
 var Chats = new Mongo.Collection('chats');
 
-Meteor.publish("chats-in-room", function (roomId: string) {
+Meteor.publish("chats-in-room", function (roomId: unknown) {
     // Make sure roomId is a string, not an arbitrary mongo selector object.
     check(roomId, String);
+    // $ExpectType string
+    roomId;
     return Chats.find({ room: roomId });
 });
 
 Meteor.methods({
-    addChat: function (roomId: string, message: { text: string, timestamp: Date, tags: string }) {
+    addChat: function (roomId: unknown, message: unknown) {
         check(roomId, String);
         check(message, {
             text: String,
@@ -611,7 +622,14 @@ Meteor.methods({
             tags: Match.Optional('Test String')
         });
 
-        // ... do something with the message ...
+        // $ExpectType string
+        roomId;
+        // $ExpectType string
+        message.text;
+        // $ExpectType Date
+        message.timestamp;
+        // $ExpectType "Test String"
+        message.tags;
     }
 });
 

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -80,8 +80,10 @@ Meteor.publish("adminSecretInfo", function () {
     return Rooms.find({ admin: this.userId }, { fields: { secretInfo: 1 } });
 });
 
-Meteor.publish("roomAndMessages", function (roomId: string) {
+Meteor.publish("roomAndMessages", function (roomId: unknown) {
     check(roomId, String);
+    // $ExpectType string
+    roomId;
     return [
         Rooms.find({ _id: roomId }, { fields: { secretInfo: 0 } }),
         Messages.find({ roomId: roomId })
@@ -91,9 +93,11 @@ Meteor.publish("roomAndMessages", function (roomId: string) {
 /**
  * Also from Publish and Subscribe, Meteor.publish section
  */
-Meteor.publish("counts-by-room", function (roomId: string) {
+Meteor.publish("counts-by-room", function (roomId: unknown) {
     var self = this;
     check(roomId, String);
+    // $ExpectType string
+    roomId;
     var count = 0;
     var initializing = true;
     var handle = Messages.find({ roomId: roomId }).observeChanges({
@@ -150,9 +154,14 @@ Tracker.autorun(function () {
  * From Methods, Meteor.methods section
  */
 Meteor.methods({
-    foo: function (arg1: string, arg2: number[]) {
+    foo: function (arg1: unknown, arg2: unknown) {
         check(arg1, String);
         check(arg2, [Number]);
+
+        // $ExpectType string
+        arg1;
+        // $ExpectType number[]
+        arg2;
 
         var you_want_to_throw_an_error = true;
         if (you_want_to_throw_an_error)
@@ -609,14 +618,16 @@ var body = Template.body;
  */
 var Chats = new Mongo.Collection('chats');
 
-Meteor.publish("chats-in-room", function (roomId: string) {
+Meteor.publish("chats-in-room", function (roomId: unknown) {
     // Make sure roomId is a string, not an arbitrary mongo selector object.
     check(roomId, String);
+    // $ExpectType string
+    roomId;
     return Chats.find({ room: roomId });
 });
 
 Meteor.methods({
-    addChat: function (roomId: string, message: { text: string, timestamp: Date, tags: string }) {
+    addChat: function (roomId: unknown, message: unknown) {
         check(roomId, String);
         check(message, {
             text: String,
@@ -625,7 +636,14 @@ Meteor.methods({
             tags: Match.Optional('Test String')
         });
 
-        // ... do something with the message ...
+        // $ExpectType string
+        roomId;
+        // $ExpectType string
+        message.text;
+        // $ExpectType Date
+        message.timestamp;
+        // $ExpectType "Test String"
+        message.tags;
     }
 });
 
@@ -633,8 +651,9 @@ Meteor.methods({
  * From Match patterns section
  */
 var pat = { name: Match.Optional('test') };
-check({ name: "something" }, pat) // OK
+check({ name: "test" }, pat) // OK
 check({}, pat) // OK
+check({ name: "something" }, pat) // Throws an exception
 check({ name: undefined }, pat) // Throws an exception
 
 // Outside an object


### PR DESCRIPTION
Meteor's check is an assertion function, and Match.test returns a type predicate. TypeScript 3.7 is expressive enough to capture this. This lets us reduce duplication in Meteor code (e.g. needing to keep function parameter types and check calls in sync with each other).

Is this a good idea? I think so - I'd find it useful in my code. Is it worth constraining to the newest version of TypeScript? I'm less sure. My project is already on 3.7 so it's not a big deal to me.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [:heavy_check_mark:] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [:heavy_check_mark:] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: check API is documented [here](https://docs.meteor.com/api/check.html)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.