### PR TITLE
Types + tests for existing npm module multibase

### DIFF
--- a/types/multibase/index.d.ts
+++ b/types/multibase/index.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for multibase 0.6
+// Project: https://github.com/multiformats/js-multibase#readme
+// Definitions by: Carson Farmer <https://github.com/carsonfarmer>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node" />
+
+declare namespace Multibase {
+    /**
+     * Encode data with the specified base and add the multibase prefix.
+     *
+     * @param nameOrCode The multibase name or code number.
+     * @param buf The data to be encoded.
+     */
+    function encode(nameOrCode: string | number, buf: Buffer): Buffer;
+
+    /**
+     * Takes a buffer or string encoded with multibase header, decodes it and
+     * returns the decoded buffer
+     *
+     * @param bufOrString The data to be decoded.
+     *
+     */
+    function decode(bufOrString: Buffer | string): Buffer;
+
+    /**
+     * Is the given data multibase encoded?
+     *
+     * @param bufOrString The data to be checked.
+     */
+    function isEncoded(bufOrString: Buffer | string): string | false;
+
+    /**
+     * A frozen Array of supported base encoding names.
+     */
+    const names: ReadonlyArray<string>;
+    /**
+     * A frozen Array of supported base encoding codes.
+     */
+    const codes: ReadonlyArray<string | number>;
+}
+
+/**
+ * Create a new buffer with the multibase varint+code.
+ *
+ * @param nameOrCode The multibase name or code number.
+ * @param buf The data to be prefixed with multibase.
+ */
+declare function Multibase(nameOrCode: string | number, buf: Buffer): Buffer;
+
+export = Multibase;

--- a/types/multibase/index.d.ts
+++ b/types/multibase/index.d.ts
@@ -4,14 +4,32 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 
-declare namespace Multibase {
+declare namespace multibase {
+    type name =
+        | 'base1'
+        | 'base2'
+        | 'base8'
+        | 'base10'
+        | 'base16'
+        | 'base32'
+        | 'base32pad'
+        | 'base32hex'
+        | 'base32hexpad'
+        | 'base32z'
+        | 'base58flickr'
+        | 'base58btc'
+        | 'base64'
+        | 'base64pad'
+        | 'base64url'
+        | 'base64urlpad';
+    type code = '1' | '0' | '7' | '9' | 'f' | 'b' | 'c' | 'v' | 't' | 'h' | 'Z' | 'z' | 'm' | 'M' | 'u' | 'U';
     /**
      * Encode data with the specified base and add the multibase prefix.
      *
      * @param nameOrCode The multibase name or code number.
      * @param buf The data to be encoded.
      */
-    function encode(nameOrCode: string | number, buf: Buffer): Buffer;
+    function encode(nameOrCode: name | code, buf: Buffer): Buffer;
 
     /**
      * Takes a buffer or string encoded with multibase header, decodes it and
@@ -27,16 +45,16 @@ declare namespace Multibase {
      *
      * @param bufOrString The data to be checked.
      */
-    function isEncoded(bufOrString: Buffer | string): string | false;
+    function isEncoded(bufOrString: Buffer | string): name | false;
 
     /**
      * A frozen Array of supported base encoding names.
      */
-    const names: ReadonlyArray<string>;
+    const names: ReadonlyArray<name>;
     /**
      * A frozen Array of supported base encoding codes.
      */
-    const codes: ReadonlyArray<string | number>;
+    const codes: ReadonlyArray<code>;
 }
 
 /**
@@ -45,6 +63,6 @@ declare namespace Multibase {
  * @param nameOrCode The multibase name or code number.
  * @param buf The data to be prefixed with multibase.
  */
-declare function Multibase(nameOrCode: string | number, buf: Buffer): Buffer;
+declare function multibase(nameOrCode: multibase.name | multibase.code, buf: Buffer): Buffer;
 
-export = Multibase;
+export = multibase;

--- a/types/multibase/multibase-tests.ts
+++ b/types/multibase/multibase-tests.ts
@@ -1,0 +1,23 @@
+import multibase from 'multibase';
+
+const buf = Buffer.from('÷ïÿ🥰÷ïÿ😎🥶🤯'); // base64
+const bufOut = 'mw7fDr8O/8J+lsMO3w6/Dv/CfmI7wn6W28J+krw';
+const str = 'foobar';
+const strOut = 'mZm9vYmFy';
+
+// $ExpectType string | false
+const name = multibase.isEncoded(bufOut);
+multibase.isEncoded(buf);
+
+const multibasedBuf = multibase.encode(name || 'm', buf);
+console.log(multibasedBuf.toString() === bufOut); // true
+multibase.encode('base64', Buffer.from(str));
+
+// $ExpectType Buffer
+multibase.decode(strOut);
+multibase.decode(buf); // Error but right type
+
+console.log(multibase.codes);
+
+// $ExpectType ReadonlyArray<string>
+multibase.names;

--- a/types/multibase/multibase-tests.ts
+++ b/types/multibase/multibase-tests.ts
@@ -5,7 +5,6 @@ const bufOut = 'mw7fDr8O/8J+lsMO3w6/Dv/CfmI7wn6W28J+krw';
 const str = 'foobar';
 const strOut = 'mZm9vYmFy';
 
-// $ExpectType string | false
 const name = multibase.isEncoded(bufOut);
 multibase.isEncoded(buf);
 
@@ -17,7 +16,5 @@ multibase.encode('base64', Buffer.from(str));
 multibase.decode(strOut);
 multibase.decode(buf); // Error but right type
 
-console.log(multibase.codes);
-
-// $ExpectType ReadonlyArray<string>
-multibase.names;
+console.log(multibase.codes[0] !== 'm');
+console.log(multibase.names[0] === 'base1');

--- a/types/multibase/tsconfig.json
+++ b/types/multibase/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "multibase-tests.ts"
+    ]
+}

--- a/types/multibase/tslint.json
+++ b/types/multibase/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.