### PR TITLE
types/react-stripe-elements: simplify StripeProps

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -12,7 +12,7 @@
 //                 Hiroshi Ioka <https://github.com/hirochachacha>
 //                 Austin Turner <https://github.com/paustint>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.5
 
 /// <reference types="stripe-v3" />
 import * as React from 'react';
@@ -43,10 +43,9 @@ export namespace ReactStripeElements {
         | { apiKey: string; stripe?: never } & StripeProviderOptions
         | { apiKey?: never; stripe: stripe.Stripe | null } & StripeProviderOptions;
 
-    interface StripeProps {
-        createSource(sourceData?: SourceOptions): Promise<SourceResponse>;
+    interface StripeOverrideProps {
         createToken(options?: TokenOptions): Promise<PatchedTokenResponse>;
-        paymentRequest: stripe.Stripe['paymentRequest'];
+        createSource(sourceData?: SourceOptions): Promise<SourceResponse>;
         createPaymentMethod(
             paymentMethodType: stripe.paymentMethod.paymentMethodType,
             data?: stripe.CreatePaymentMethodOptions,
@@ -57,12 +56,6 @@ export namespace ReactStripeElements {
             data?: stripe.CreatePaymentMethodOptions,
         ): Promise<stripe.PaymentMethodResponse>;
         createPaymentMethod(data: stripe.PaymentMethodData): Promise<stripe.PaymentMethodResponse>;
-        /**
-         * Use `stripe.handleCardAction` in the Payment Intents API manual confirmation flow
-         * to handle a PaymentIntent with the requires_action status.
-         * It will throw an error if the PaymentIntent has a different status.
-         */
-        handleCardAction(clientSecret: string): Promise<stripe.PaymentIntentResponse>;
         handleCardPayment(
             clientSecret: string,
             options?: stripe.HandleCardPaymentWithoutElementsOptions,
@@ -71,11 +64,9 @@ export namespace ReactStripeElements {
             clientSecret: string,
             data?: stripe.HandleCardSetupOptions,
         ): Promise<stripe.SetupIntentResponse>;
-        confirmCardPayment(
-            clientSecret: string,
-            data?: stripe.ConfirmCardPaymentData,
-        ): Promise<stripe.PaymentIntentResponse>;
-        confirmCardSetup(clientSecret: string, data?: stripe.ConfirmCardSetupData): Promise<stripe.SetupIntentResponse>;
+    }
+
+    interface StripeProps extends Omit<stripe.Stripe, keyof StripeOverrideProps>, StripeOverrideProps {
     }
 
     interface InjectOptions {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/stripe/react-stripe-elements/blob/66a2a25b80e0af31109a4fa018a407c7cec10e98/src/components/inject.js#L98-L108
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.