### PR TITLE
types/aws-serverless-express: extend http.IncomingMessage

### DIFF
--- a/types/aws-serverless-express/aws-serverless-express-tests.ts
+++ b/types/aws-serverless-express/aws-serverless-express-tests.ts
@@ -2,14 +2,7 @@ import * as awsServerlessExpress from 'aws-serverless-express';
 import express = require('express');
 import { eventContext } from 'aws-serverless-express/middleware';
 
-const app = express();
-app.use(eventContext());
-
-const server = awsServerlessExpress.createServer(app, () => {}, []);
-
-const mockEvent = {
-    key: 'value'
-};
+declare let mockEvent: AWSLambda.APIGatewayEvent;
 
 const mockContext = {
     callbackWaitsForEmptyEventLoop: true,
@@ -25,6 +18,17 @@ const mockContext = {
     fail: (error: any) => false,
     succeed: (message: string) => false
 };
+
+const app = express();
+app.use(eventContext());
+app.get('/', (req, res) => {
+  if (req.apiGateway) {
+    req.apiGateway.event;
+    req.apiGateway.context;
+  }
+});
+
+const server = awsServerlessExpress.createServer(app, () => {}, []);
 
 awsServerlessExpress.proxy(server, mockEvent, mockContext);
 awsServerlessExpress.proxy(server, mockEvent, mockContext, 'CALLBACK', () => {});

--- a/types/aws-serverless-express/index.d.ts
+++ b/types/aws-serverless-express/index.d.ts
@@ -5,7 +5,7 @@
 //                 Matthias Meyer <https://github.com/mattmeye>
 //                 Alberto Vasquez <https://github.com/albertovasquez>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.5
 
 /// <reference types="node"/>
 import * as http from 'http';
@@ -29,20 +29,20 @@ export function createServer(
 
 export function proxy(
     server: http.Server,
-    event: any,
+    event: lambda.APIGatewayProxyEvent,
     context: lambda.Context,
 ): http.Server;
 
 export function proxy(
     server: http.Server,
-    event: any,
+    event: lambda.APIGatewayProxyEvent,
     context: lambda.Context,
     resolutionMode: 'CONTEXT_SUCCEED' | 'PROMISE',
 ): ProxyResult;
 
 export function proxy(
     server: http.Server,
-    event: any,
+    event: lambda.APIGatewayProxyEvent,
     context: lambda.Context,
     resolutionMode: 'CALLBACK',
     callback?: (error: any, response: Response) => void

--- a/types/aws-serverless-express/middleware.d.ts
+++ b/types/aws-serverless-express/middleware.d.ts
@@ -1,4 +1,18 @@
+import { IncomingMessage } from 'http';
+import { APIGatewayProxyEvent, Context } from 'aws-lambda';
 import { RequestHandler } from 'express';
+
+type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T];  // tslint:disable-line:ban-types
+type NonFunctionProperties<T> = Pick<T, NonFunctionPropertyNames<T>>;
+
+declare module 'http' {
+  interface IncomingMessage {
+    apiGateway?: {
+      event: Omit<APIGatewayProxyEvent, 'body'>;
+      context: NonFunctionProperties<Context>;
+    };
+  }
+}
 
 export interface Options {
     reqPropKey?: string;
@@ -6,3 +20,5 @@ export interface Options {
 }
 
 export function eventContext(options?: Options): RequestHandler;
+
+export {};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  * https://github.com/awslabs/aws-serverless-express/blob/ecdafec8f05eecc97791930b26d93e63a84e6188/src/index.js#L50-L54
  * https://github.com/awslabs/aws-serverless-express/blob/ecdafec8f05eecc97791930b26d93e63a84e6188/src/middleware.js#L1-L23
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.