### PR TITLE
Adding TVEventHandler support to @types/react-native

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -163,7 +163,7 @@ interface EmitterSubscription extends EventSubscription {
 }
 
 interface DEPRECATED_RCTExport<T> {
-	getConstants(): Function;
+	getConstants?: () => {};
 }
 
 interface TurboModule extends DEPRECATED_RCTExport<void> {}

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -182,7 +182,7 @@ interface NativeTVNavigationEventEmitter {
 }
  
 declare class TVEventHandler {
-	new (): TVEventHandler;
+	constructor();
     enable(component: any, callback: Function): void;
     disable(): void;
 }

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -174,7 +174,7 @@ interface Spec extends TurboModule {
 }
 
 declare class TurboModuleRegistry {
-	get<TurboModule>(name: string): (legacyModule: any) => TurboModule
+	get<T extends TurboModule>(name: string): T | null | undefined
 }
 
 interface NativeTVNavigationEventEmitter {

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -23,8 +23,6 @@
 //                 Mike Martin <https://github.com/mcmar>
 //                 Theo Henry de Villeneuve <https://github.com/theohdv>
 //                 Eli White <https://github.com/TheSavior>
-
-
 //                 Romain Faust <https://github.com/romain-faust>
 //                 Be Birchall <https://github.com/bebebebebe>
 //                 Jesse Katsumata <https://github.com/Naturalclar>

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -23,6 +23,8 @@
 //                 Mike Martin <https://github.com/mcmar>
 //                 Theo Henry de Villeneuve <https://github.com/theohdv>
 //                 Eli White <https://github.com/TheSavior>
+
+
 //                 Romain Faust <https://github.com/romain-faust>
 //                 Be Birchall <https://github.com/bebebebebe>
 //                 Jesse Katsumata <https://github.com/Naturalclar>
@@ -160,6 +162,31 @@ interface EmitterSubscription extends EventSubscription {
      * for removing the subscription lies with the EventEmitter.
      */
     remove(): void;
+}
+
+interface DEPRECATED_RCTExport<T> {
+	getConstants(): Function;
+}
+
+interface TurboModule extends DEPRECATED_RCTExport<void> {}
+
+interface Spec extends TurboModule {
+    addListener(eventName: string): void;
+    removeListeners(count: number): void;
+}
+
+declare class TurboModuleRegistry {
+	get<TurboModule>(name: string): (legacyModule: any) => TurboModule
+}
+
+interface NativeTVNavigationEventEmitter {
+	addListener(eventName: string, callback: Function): NativeEventEmitter;
+}
+ 
+declare class TVEventHandler {
+	new (): TVEventHandler;
+    enable(component: any, callback: Function): void;
+    disable(): void;
 }
 
 interface EventEmitterListener {

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -183,7 +183,7 @@ interface NativeTVNavigationEventEmitter {
  
 declare class TVEventHandler {
 	constructor();
-    enable(component: any, callback: Function): void;
+    enable(component: any | null | undefined, callback: (component: any | null | undefined, data: unknown) => void): void;
     disable(): void;
 }
 


### PR DESCRIPTION
As TVEventHandler definition is not available in @types/react-native, unable to use typescript to build react-native TV apps since the metro-bundler is broken.
So, Changes are added to @types/react-native to make TVEventHandler support to develop react-native based TV apps

Thanks


