### PR TITLE
babel-plugin-macros: Export all types and fix References type

### DIFF
--- a/types/babel-plugin-macros/babel-plugin-macros-tests.ts
+++ b/types/babel-plugin-macros/babel-plugin-macros-tests.ts
@@ -1,8 +1,8 @@
-import { createMacro, MacroError } from 'babel-plugin-macros';
+import { createMacro, MacroError, References, Options, MacroParams, MacroHandler } from 'babel-plugin-macros';
 
 const macro = createMacro(
     ({ references, state, babel }) => {
-        references.forEach(() => {});
+        Object.keys(references).forEach(() => {});
         references.default.forEach(() => {});
         state.abc = 123;
         babel.parse("console.log('Hello world!')");

--- a/types/babel-plugin-macros/index.d.ts
+++ b/types/babel-plugin-macros/index.d.ts
@@ -1,23 +1,26 @@
 // Type definitions for babel-plugin-macros 2.6
 // Project: https://github.com/kentcdodds/babel-plugin-macros
 // Definitions by: Billy Kwok <https://github.com/billykwok>
+//                 Jake Runzer <https://github.com/coffee-cup>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 import * as Babel from '@babel/core';
 
-type References = Babel.NodePath[];
+export interface References {
+    [key: string]: Babel.NodePath[];
+}
 
-interface Options {
+export interface Options {
     configName?: string;
 }
 
-interface MacroParams {
-    references: { default: References } & References;
+export interface MacroParams {
+    references: { default: Babel.NodePath[] } & References;
     state: any;
     babel: typeof Babel;
 }
 
-type MacroHandler = (params: MacroParams) => void;
+export type MacroHandler = (params: MacroParams) => void;
 
 declare function babel_plugin_macros(
     babel: typeof Babel,

--- a/types/babel-plugin-macros/index.d.ts
+++ b/types/babel-plugin-macros/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Billy Kwok <https://github.com/billykwok>
 //                 Jake Runzer <https://github.com/coffee-cup>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.7
+// TypeScript Version: 2.9
 import * as Babel from '@babel/core';
 
 export interface References {

--- a/types/babel-plugin-macros/index.d.ts
+++ b/types/babel-plugin-macros/index.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for babel-plugin-macros 2.6
+// Type definitions for babel-plugin-macros 2.8
 // Project: https://github.com/kentcdodds/babel-plugin-macros
 // Definitions by: Billy Kwok <https://github.com/billykwok>
 //                 Jake Runzer <https://github.com/coffee-cup>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// TypeScript Version: 3.7
 import * as Babel from '@babel/core';
 
 export interface References {

--- a/types/babel-plugin-macros/index.d.ts
+++ b/types/babel-plugin-macros/index.d.ts
@@ -22,18 +22,6 @@ export interface MacroParams {
 
 export type MacroHandler = (params: MacroParams) => void;
 
-declare function babel_plugin_macros(
-    babel: typeof Babel,
-    ref: {
-        require: (path: string) => any;
-        resolvePath: (src: string, baseDir: string) => any;
-    },
-): Babel.PluginObj;
+export class MacroError extends Error {}
 
-declare namespace babel_plugin_macros {
-    class MacroError extends Error {}
-
-    function createMacro(handler: MacroHandler, options?: Options): any;
-}
-
-export = babel_plugin_macros;
+export function createMacro(handler: MacroHandler, options?: Options): any;


### PR DESCRIPTION
This PR does 2 things

- Export all types
- Fix `references` type. Previously it was an object of `Babel.NodePath`. However, [the docs](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/author.md#references) say it is an object.

I've been unable to lint these packages locally because of the following error

![image](https://user-images.githubusercontent.com/3044853/71816893-f94e7280-307b-11ea-9559-215261179d3c.png)

Any advice on how to fix it is appreciated.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/author.md#references
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
