### PR TITLE
@types/through: Add missing queue method to through.ThroughStream

### DIFF
--- a/types/through/index.d.ts
+++ b/types/through/index.d.ts
@@ -17,7 +17,7 @@ declare function through(write?: (data: any) => void,
 declare namespace through {
     export interface ThroughStream extends stream.Transform {
         autoDestroy: boolean;
-        queue: (chunk: any, encoding?: string | undefined) => any;
+        queue: (chunk: any) => any;
     }
 }
 

--- a/types/through/index.d.ts
+++ b/types/through/index.d.ts
@@ -17,6 +17,7 @@ declare function through(write?: (data: any) => void,
 declare namespace through {
     export interface ThroughStream extends stream.Transform {
         autoDestroy: boolean;
+        queue: (chunk: any, encoding?: string | undefined) => any;
     }
 }
 

--- a/types/through/index.d.ts
+++ b/types/through/index.d.ts
@@ -5,14 +5,15 @@
 
 /// <reference types="node" />
 
+import stream = require('stream');
 
-import stream = require("stream");
-
-declare function through(write?: (data: any) => void,
+declare function through(
+    write?: (data: any) => void,
     end?: () => void,
     opts?: {
         autoDestroy: boolean;
-    }): through.ThroughStream;
+    },
+): through.ThroughStream;
 
 declare namespace through {
     export interface ThroughStream extends stream.Transform {

--- a/types/through/through-tests.ts
+++ b/types/through/through-tests.ts
@@ -1,10 +1,12 @@
-
 import through = require('through');
 
 var i = 0;
 through(
-	function () {
-		this.queue((i++).toString());
-	}, function () {
-		this.queue(null);
-	}, { autoDestroy: true }).pipe(process.stdout);
+    function(this: through.ThroughStream) {
+        this.queue((i++).toString());
+    },
+    function(this: through.ThroughStream) {
+        this.queue(null);
+    },
+    { autoDestroy: true },
+).pipe(process.stdout);

--- a/types/through/tsconfig.json
+++ b/types/through/tsconfig.json
@@ -5,8 +5,8 @@
             "es6"
         ],
         "noImplicitAny": true,
-        "noImplicitThis": false,
-        "strictNullChecks": false,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
  (kind of- updating the tsconfig makes the tests catch the issue that I'm fixing)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/dominictarr/through/blob/master/index.js#L40>

The `ThroughStream` object uses `queue` as an alias for `push`; both do the same thing (see link to source code above). While the `push` property is inherited from `stream.Transform`, `queue` is not.

Looking at the source code, I also notice that `stream.Transform.push` is a function that takes a `chunk` and an optional `encoding` argument, while `through.ThroughStream.(push | queue)` takes only the chunk. I wonder if the definition for `push` should be overridden to omit that argument?

As per https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#some-packages-have-no-tslintjson-and-some-tsconfigjson-are-missing-noimplicitany-true-noimplicitthis-true-or-strictnullchecks-true, I updated the tsconfig (this update actually makes the test fail to compile without my change).