### PR TITLE
Make ExpectError locations same for TS 3.8

### DIFF
--- a/types/amap-js-api-map-type/amap-js-api-map-type-tests.ts
+++ b/types/amap-js-api-map-type/amap-js-api-map-type-tests.ts
@@ -12,9 +12,7 @@ const mapType = new AMap.MapType({
 });
 
 // $ExpectError
-new AMap.MapType({
-    defaultType: 2
-});
+new AMap.MapType({ defaultType: 2 });
 
 // $ExpectType void
 mapType.show();

--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -320,37 +320,19 @@ statement = {
 };
 
 // $ExpectError
-statement = {
-    Effect: str,
-    Action: str,
-    Principal: 123,
-};
+statement = { Effect: str, Action: str, Principal: 123, };
 
 // Bad Resource
 // $ExpectError
-statement = {
-    Effect: str,
-    Action: str,
-    Resource: 123,
-};
+statement = { Effect: str, Action: str, Resource: 123, };
 
 // Bad Resource with valid Principal
 // $ExpectError
-statement = {
-    Effect: str,
-    Action: str,
-    Principal: { Service: str },
-    Resource: 123,
-};
+statement = { Effect: str, Action: str, Principal: { Service: str }, Resource: 123, };
 
 // Bad principal with valid Resource
 // $ExpectError
-statement = {
-    Effect: str,
-    Action: str,
-    Principal: 123,
-    Resource: str,
-};
+statement = { Effect: str, Action: str, Principal: 123, Resource: str, };
 
 // No Effect
 // $ExpectError

--- a/types/compression-webpack-plugin/compression-webpack-plugin-tests.ts
+++ b/types/compression-webpack-plugin/compression-webpack-plugin-tests.ts
@@ -46,10 +46,7 @@ const zlib: Configuration = {
 const badZlib: Configuration = {
     plugins: [
         // $ExpectError
-        new CompressionPlugin({
-            algorithm: "deflate",
-            compressionOptions: 5
-        })
+        new CompressionPlugin({ algorithm: "deflate", compressionOptions: 5 })
     ]
 };
 
@@ -68,9 +65,6 @@ const custom: Configuration = {
 const badCustom: Configuration = {
     plugins: [
         // $ExpectError
-        new CompressionPlugin({
-            algorithm: customAlgorithm,
-            compressionOptions: { flush: 5 }
-        })
+        new CompressionPlugin({ algorithm: customAlgorithm, compressionOptions: { flush: 5 } })
     ]
 };

--- a/types/ember__application/test/application-instance.ts
+++ b/types/ember__application/test/application-instance.ts
@@ -24,10 +24,7 @@ appInstance.register('templates:foo/bar', hbs`<h1>Hello World</h1>`, {
     instantiate: true
 });
 // $ExpectError
-appInstance.register('templates:foo/bar', hbs`<h1>Hello World</h1>`, {
-    singleton: 'true',
-    instantiate: true
-});
+appInstance.register('templates:foo/bar', hbs`<h1>Hello World</h1>`, { singleton: 'true', instantiate: true });
 
 appInstance.register('some:injection', class Foo {}, {
     singleton: false,

--- a/types/okta__okta-vue/okta__okta-vue-tests.ts
+++ b/types/okta__okta-vue/okta__okta-vue-tests.ts
@@ -17,20 +17,11 @@ authOpts.tokenManager = null; // $ExpectError
 
 // Must use valid tokenManager options
 // $ExpectError
-authOpts.tokenManager = {
-    storage: 'bad-option'
-};
+authOpts.tokenManager = { storage: 'bad-option' };
 // $ExpectError
-authOpts.tokenManager = {
-    storage: 'cookie',
-    secure: 'string'
-};
+authOpts.tokenManager = { storage: 'cookie', secure: 'string' };
 // $ExpectError
-authOpts.tokenManager = {
-    storage: 'cookie',
-    secure: true,
-    autoRenew: 'string'
-};
+authOpts.tokenManager = { storage: 'cookie', secure: true, autoRenew: 'string' };
 // Valid token manager options
 authOpts.tokenManager = {
     storage: 'cookie',

--- a/types/rmfr/rmfr-tests.ts
+++ b/types/rmfr/rmfr-tests.ts
@@ -29,11 +29,7 @@ import rmfr = require("rmfr");
     // $ExpectError
     await rmfr("foo", { chmod: new Set(["a"]) });
     // $ExpectError
-    await rmfr("foo", {
-        maxBusyTries: "foo",
-        emfileWait: "bar",
-        glob: "baz"
-    });
+    await rmfr("foo", { maxBusyTries: "foo", emfileWait: "bar", glob: "baz" });
     // $ExpectError
     await rmfr("foo", { disableGlob: true });
 })();

--- a/types/theme-ui/theme-ui-tests.tsx
+++ b/types/theme-ui/theme-ui-tests.tsx
@@ -73,16 +73,10 @@ const workingThemeColorModes: Theme = {
     },
 };
 
-const incompleteThemeColorModes: Theme = {
-    initialColorMode: 'light',
-    // $ExpectError
-    colors: {
-        text: '#000',
-        background: '#fff',
-        primary: '#07c',
-        secondary: '#05a',
-        muted: '#f6f6f6f',
-        modes: {
+// $ExpectError
+const incompleteThemeColorModes: Theme = { colors: { modes: { papaya: {
+                text: '#433',
+            },
             dark: {
                 text: '#fff',
                 background: '#000',
@@ -90,11 +84,14 @@ const incompleteThemeColorModes: Theme = {
                 secondary: '#09c',
                 muted: '#111',
             },
-            papaya: {
-                text: '#433',
-            },
         },
+        text: '#000',
+        background: '#fff',
+        primary: '#07c',
+        secondary: '#05a',
+        muted: '#f6f6f6f',
     },
+    initialColorMode: 'light',
 };
 
 const themeWithStyles: Theme = {

--- a/types/yargs-parser/v11/yargs-parser-tests.ts
+++ b/types/yargs-parser/v11/yargs-parser-tests.ts
@@ -10,9 +10,7 @@ parse(['--foo', '-bar'], {
 
 // prettier-ignore
 // $ExpectError
-parse(['--foo', '-bar'], {
-    string: 123,
-});
+parse(['--foo', '-bar'], { string: 123, });
 
 parse(['--foo', '-bar'], {
     // $ExpectError

--- a/types/yargs-parser/yargs-parser-tests.ts
+++ b/types/yargs-parser/yargs-parser-tests.ts
@@ -6,9 +6,7 @@ parse(['--foo', '-bar']);
 
 // prettier-ignore
 // $ExpectError
-parse(['--foo', '-bar'], {
-    string: 123,
-});
+parse(['--foo', '-bar'], { string: 123, });
 
 parse(['--foo', '-bar'], {
     // $ExpectError

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -655,7 +655,7 @@ yup.object<MyInterface>({ stringField: yup.number().required(),
             testField: yup.string().required(),
         })
         .required(),
-    arrayField: yup.array(yup.string()).required(), // + 1
+    arrayField: yup.array(yup.string()).required(),
 });
 
 // $ExpectError

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -648,15 +648,14 @@ yup.object<MyInterface>({
 });
 
 // $ExpectError
-yup.object<MyInterface>({
-    stringField: yup.number().required(),
+yup.object<MyInterface>({ stringField: yup.number().required(),
     numberField: yup.number().required(),
     subFields: yup
         .object({
             testField: yup.string().required(),
         })
         .required(),
-    arrayField: yup.array(yup.string()).required(),
+    arrayField: yup.array(yup.string()).required(), // + 1
 });
 
 // $ExpectError
@@ -667,14 +666,13 @@ yup.object<MyInterface>({
 });
 
 // $ExpectError
-yup.object<MyInterface>({
-    stringField: yup.string().required(),
-    numberField: yup.number().required(),
-    subFields: yup
+yup.object<MyInterface>({ subFields: yup
         .object({
             testField: yup.number().required(),
         })
         .required(),
+    stringField: yup.string().required(),
+    numberField: yup.number().required(),
     arrayField: yup.array(yup.string()).required(),
 });
 


### PR DESCRIPTION
Error locations changed for some object literals in TS 3.8. This breaks
tests that use ExpectError since the ExpectError needs to be closer to
the actual error.

To fix this, I merged a lot of multi-line object literals into one-line
literals.
