### PR TITLE
Fix socketio-wildcard for @types/node@13

### DIFF
--- a/types/socketio-wildcard/index.d.ts
+++ b/types/socketio-wildcard/index.d.ts
@@ -6,10 +6,10 @@
 /// <reference types="socket.io-client" />
 import SocketIO = require("socket.io");
 
-import EventEmitter = NodeJS.EventEmitter;
+import Events = require("events");
 import Socket = SocketIO.Socket;
 import ClientSocket = SocketIOClient.Socket;
 
 export = sioWildcard;
 
-declare function sioWildcard(emitterCtor?: { prototype: typeof EventEmitter.prototype }): (socket: Socket | ClientSocket, next?: (err?: any) => void) => void;
+declare function sioWildcard(emitterCtor?: { prototype: typeof Events.prototype }): (socket: Socket | ClientSocket, next?: (err?: any) => void) => void;


### PR DESCRIPTION
EventEmitter is just an interface now, so we have to use the class provided by `require("events")` instead.