### PR TITLE
Add types for leaflet.browser.print

### DIFF
--- a/types/leaflet.browser.print/index.d.ts
+++ b/types/leaflet.browser.print/index.d.ts
@@ -1,0 +1,95 @@
+// Type definitions for leaflet.browser.print 1.0
+// Project: https://github.com/Igor-Vladyka/leaflet.browser.print
+// Definitions by: Benjamin Ihrig <https://github.com/ihrigb>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.6
+
+import * as leaflet from 'leaflet';
+
+declare module 'leaflet' {
+    namespace control {
+        interface BrowserPrintControlOptions extends ControlOptions {
+            title?: string;
+            documentTitle?: string;
+            printLayer?: L.TileLayer;
+            printModes?: Control.BrowserPrint.Mode[];
+            closePopupsOnPrint?: boolean;
+            contentSelector?: string;
+            pageSelector?: string;
+            manualMode?: boolean;
+            customPrintStyle?: L.PolylineOptions;
+        }
+
+        function browserPrint(options?: BrowserPrintControlOptions): Control.BrowserPrint;
+
+        type LandscapeModeType = 'Landscape';
+        type PortraitModeType = 'Portrait';
+        type AutoModeType = 'Auto';
+        type CustomModeType = 'Custom';
+
+        type ModeType = LandscapeModeType | PortraitModeType | AutoModeType | CustomModeType;
+
+        namespace browserPrint {
+            function mode(mode: ModeType, title?: string, pageSize?: string): Control.BrowserPrint.Mode;
+
+            namespace mode {
+                function portrait(title?: string, pageSize?: string, action?: any): Control.BrowserPrint.Mode;
+                function landscape(title?: string, pageSize?: string, action?: any): Control.BrowserPrint.Mode;
+                function auto(title?: string, pageSize?: string, action?: any): Control.BrowserPrint.Mode;
+                function custom(title?: string, pageSize?: string, action?: any): Control.BrowserPrint.Mode;
+            }
+        }
+    }
+
+    namespace Control {
+        interface BrowserPrint {
+            addTo(map: L.Map): HTMLDivElement;
+        }
+
+        namespace BrowserPrint {
+            class Mode { }
+
+            type LandscapeModeType = 'Landscape';
+            type PortraitModeType = 'Portrait';
+            type AutoModeType = 'Auto';
+            type CustomModeType = 'Custom';
+
+            type ModeType = LandscapeModeType | PortraitModeType | AutoModeType | CustomModeType;
+
+            namespace Mode {
+                type Landscape = LandscapeModeType;
+                type Portrait = PortraitModeType;
+                type Auto = AutoModeType;
+                type Custom = CustomModeType;
+            }
+
+            function Mode(mode: ModeType, title?: string, pageSize?: string): any;
+
+            namespace Size {
+                interface SizeDefinition {
+                    Width: number;
+                    Height: number;
+                }
+
+                const A: SizeDefinition;
+                const B: SizeDefinition;
+                const C: SizeDefinition;
+                const D: SizeDefinition;
+                const LETTER: SizeDefinition;
+                const HALFLETTER: SizeDefinition;
+                const LEGAL: SizeDefinition;
+                const JUNIORLEGAL: SizeDefinition;
+                const TABLOID: SizeDefinition;
+                const LEDGER: SizeDefinition;
+            }
+
+            namespace Event {
+                const PrintInit: 'browser-print-init';
+                const PrePrint: 'browser-pre-print';
+                const PrintStart: 'browser-print-start';
+                const Print: 'browser-print';
+                const PrintEnd: 'browser-print-end';
+            }
+        }
+    }
+}

--- a/types/leaflet.browser.print/leaflet.browser.print-tests.ts
+++ b/types/leaflet.browser.print/leaflet.browser.print-tests.ts
@@ -1,0 +1,16 @@
+import * as L from 'leaflet';
+import 'leaflet.browser.print';
+
+const osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+const osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
+const map = L.map('map', {layers: [osm], center: L.latLng(-37.7772, 175.2756), zoom: 15 });
+
+L.control.browserPrint({
+    title: 'Print',
+    documentTitle: 'DocumentTitle',
+    position: 'topleft',
+    printModes: [
+        L.control.browserPrint.mode.portrait('Landscape', 'A4')
+    ]
+}).addTo(map);

--- a/types/leaflet.browser.print/tsconfig.json
+++ b/types/leaflet.browser.print/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "leaflet.browser.print-tests.ts"
+    ]
+}

--- a/types/leaflet.browser.print/tslint.json
+++ b/types/leaflet.browser.print/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.