### PR TITLE
Added Plotly.js LayoutAxis property

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -372,7 +372,7 @@ export interface LayoutAxis extends Axis {
 	position: number;
 	rangeslider: Partial<RangeSlider>;
 	rangeselector: Partial<RangeSelector>;
-	automargin: boolean;
+    automargin: boolean;
     autotick: boolean;
 }
 

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -373,6 +373,7 @@ export interface LayoutAxis extends Axis {
 	rangeslider: Partial<RangeSlider>;
 	rangeselector: Partial<RangeSelector>;
 	automargin: boolean;
+    autotick: boolean;
 }
 
 export interface SceneAxis extends Axis {

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -372,8 +372,8 @@ export interface LayoutAxis extends Axis {
 	position: number;
 	rangeslider: Partial<RangeSlider>;
 	rangeselector: Partial<RangeSelector>;
-    automargin: boolean;
-    autotick: boolean;
+	automargin: boolean;
+	autotick: boolean;
 }
 
 export interface SceneAxis extends Axis {


### PR DESCRIPTION
Added `autotick` property for `LayoutAxis`.

The existing definition lacks `autotick: boolean` as per the example defined in the [Plotly.js documentation](https://plot.ly/javascript/axes/)