### PR TITLE
[git-semver-tags] Added type definitions for git-semver-tags

### DIFF
--- a/types/git-semver-tags/git-semver-tags-tests.ts
+++ b/types/git-semver-tags/git-semver-tags-tests.ts
@@ -1,0 +1,21 @@
+"use strict";
+
+import gitSemverTags from "git-semver-tags";
+
+declare const callback: gitSemverTags.Callback;
+declare const options: gitSemverTags.Options;
+
+// $ExpectType void
+gitSemverTags(callback);
+
+// $ExpectType void
+gitSemverTags(options, callback);
+
+// $ExpectError
+gitSemverTags();
+
+// $ExpectError
+gitSemverTags(options);
+
+// $ExpectError
+gitSemverTags(callback, options);

--- a/types/git-semver-tags/index.d.ts
+++ b/types/git-semver-tags/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for git-semver-tags 3.0
+// Project: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/git-semver-tags#readme
+// Definitions by: Jason Kwok <https://github.com/JasonHK>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+declare function gitSemverTags(callback: gitSemverTags.Callback): void;
+declare function gitSemverTags(options: gitSemverTags.Options, callback: gitSemverTags.Callback): void;
+
+declare namespace gitSemverTags {
+    type Callback = (error: any, tags: string[]) => void;
+
+    interface Options {
+        /**
+         * Extract lerna style tags (`foo-package@2.0.0`) from the git history, rather
+         * than `v1.0.0` format.
+         */
+        lernaTags?: boolean;
+
+        /**
+         * What package should lerna style tags be listed for, e.g., `foo-package`.
+         */
+        package?: string;
+
+        /**
+         * Specify a prefix for the git tag to be ignored from the semver checks.
+         */
+        tagPrefix?: string;
+    }
+}
+
+export = gitSemverTags;

--- a/types/git-semver-tags/tsconfig.json
+++ b/types/git-semver-tags/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "git-semver-tags-tests.ts"
+    ]
+}

--- a/types/git-semver-tags/tslint.json
+++ b/types/git-semver-tags/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
