### PR TITLE
Add types for tz-lookup

### DIFF
--- a/types/tz-lookup/index.d.ts
+++ b/types/tz-lookup/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for tz-lookup 6.1
+// Project: https://github.com/darkskyapp/tz-lookup#readme
+// Definitions by: Ulf Winkelvos <https://github.com/uwinkelvos>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function tz_lookup(lat: number, long: number): string;
+export = tz_lookup;

--- a/types/tz-lookup/tsconfig.json
+++ b/types/tz-lookup/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "tz-lookup-tests.ts"
+    ]
+}

--- a/types/tz-lookup/tslint.json
+++ b/types/tz-lookup/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/tz-lookup/tz-lookup-tests.ts
+++ b/types/tz-lookup/tz-lookup-tests.ts
@@ -1,0 +1,3 @@
+import tzLookup = require('tz-lookup');
+
+const tz: string = tzLookup(0.0, 0.0);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration` (see: https://github.com/darkskyapp/tz-lookup/pull/58)
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
