### PR TITLE
countries-and-timezones: add null return values

### DIFF
--- a/types/countries-and-timezones/countries-and-timezones-tests.ts
+++ b/types/countries-and-timezones/countries-and-timezones-tests.ts
@@ -4,5 +4,5 @@ const country = lib.getCountry('IT');
 const timezone = lib.getTimezone('Europe/Warsaw');
 const countries = lib.getAllCountries();
 const timezones = lib.getAllTimezones();
-lib.getCountryForTimezone(timezones[timezone.name].name);
-lib.getTimezonesForCountry(countries[country.id].id);
+timezone && lib.getCountryForTimezone(timezones[timezone.name].name);
+country && lib.getTimezonesForCountry(countries[country.id].id);

--- a/types/countries-and-timezones/index.d.ts
+++ b/types/countries-and-timezones/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: David Bird <https://github.com/zero51>
 //                 Piotr Okoński <https://github.com/pokonski>
 //                 Kanitkorn Sujautra <https://github.com/lukyth>
+//                 Erik Dalén <https://github.com/dalen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Country {
@@ -21,9 +22,9 @@ export interface Timezone {
 	country: string | null;
 }
 
-export function getCountry(id: string): Country;
-export function getTimezone(name: string): Timezone;
+export function getCountry(id: string): Country | null;
+export function getTimezone(name: string): Timezone | null;
 export function getAllCountries(): { [id: string]: Country };
 export function getAllTimezones(): { [name: string]: Timezone };
-export function getCountryForTimezone(name: string): Country;
+export function getCountryForTimezone(name: string): Country | null;
 export function getTimezonesForCountry(id: string): Timezone[];


### PR DESCRIPTION
Some functions can return null when there is no country of timezone corresponding to the input value.
This updates the types to reflect that.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/manuelmhtr/countries-and-timezones/blob/master/src/index.js#L23
