### PR TITLE
Add types for `hh-mm-ss` module

### DIFF
--- a/types/hh-mm-ss/hh-mm-ss-tests.ts
+++ b/types/hh-mm-ss/hh-mm-ss-tests.ts
@@ -1,0 +1,13 @@
+import { fromMs, fromS, toMs, toS } from 'hh-mm-ss';
+
+const ms = fromMs(60000);
+const msWithFormat = fromMs(60000, 'mm:ss');
+
+const s = fromS(3000);
+const sWithFormat = fromS(3000, 'hh:mm:ss');
+
+const ms2 = toMs('12:23:34');
+const msWithFormat2 = toMs('12:23:34', 'mm:ss');
+
+const s2 = toS('12:23:34');
+const sWithFormat2 = toS('12:23:34', 'mm:ss');

--- a/types/hh-mm-ss/index.d.ts
+++ b/types/hh-mm-ss/index.d.ts
@@ -1,0 +1,42 @@
+// Type definitions for hh-mm-ss 1.2
+// Project: https://github.com/Goldob/hh-mm-ss#readme
+// Definitions by: Thomas Cazade <https://github.com/TotomInc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Convert given `hh:mm:ss` formatted string to miliseconds
+ *
+ * @param time String representation
+ * @param format Default input format. If present, it will be used to resolve
+ *  ambiguities during interpretation. If not specified, `mm:ss` is implied.
+ *  [See section below for supported format list](https://github.com/Goldob/hh-mm-ss#supported-time-formats)
+ */
+export function toMs(time: string, format?: string): string;
+
+/**
+ * Convert given `hh:mm:ss` formatted string to seconds
+ *
+ * @param time String representation
+ * @param format Default input format. If present, it will be used to resolve
+ *  amiguities during interpretation. If not specified, `mm:ss` is implied.
+ *  [See section below for supported format list](https://github.com/Goldob/hh-mm-ss#supported-time-formats)
+ */
+export function toS(time: string, format?: string): string;
+
+/**
+ * Generate formatted string from time in miliseconds
+ *
+ * @param ms Time in miliseconds
+ * @param format Default output format. If not specified, `mm:ss` is implied.
+ *  [See section below for supported format list](https://github.com/Goldob/hh-mm-ss#supported-time-formats)
+ */
+export function fromMs(ms: number, format?: string): string;
+
+/**
+ * Generate formatted string from time in seconds
+ *
+ * @param s Time in seconds
+ * @param format Default output format. If not specified, `mm:ss` is implied.
+ *  [See section below for supported format list](https://github.com/Goldob/hh-mm-ss#supported-time-formats)
+ */
+export function fromS(s: number, format?: string): string;

--- a/types/hh-mm-ss/tsconfig.json
+++ b/types/hh-mm-ss/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "hh-mm-ss-tests.ts"
+    ]
+}

--- a/types/hh-mm-ss/tslint.json
+++ b/types/hh-mm-ss/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.