### PR TITLE
[react-native] Improve undefined type checking of Platform.select

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5569,7 +5569,8 @@ interface PlatformStatic {
     /**
      * @see https://facebook.github.io/react-native/docs/platform-specific-code.html#content
      */
-    select<T>(specifics: { [platform in PlatformOSType | 'default']?: T }): T;
+    select<T>(specifics: ({ [platform in PlatformOSType]?: T } & { default: T }) | ({ [platform in PlatformOSType]: T })): T;
+    select<T>(specifics: { [platform in PlatformOSType]?: T }): T | undefined;
 }
 
 interface PlatformIOSStatic extends PlatformStatic {

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -21,6 +21,7 @@ import {
     CheckBox,
     ColorPropType,
     DataSourceAssetCallback,
+    DeviceEventEmitter,
     DeviceEventEmitterStatic,
     Dimensions,
     Image,
@@ -242,7 +243,7 @@ const combinedStyle5: StyleProp<TextStyle> = StyleSheet.compose(
     Math.random() < 0.5 ? composeTextStyle : null,
 );
 
-const combinedStyle6: StyleProp<TextStyle> = StyleSheet.compose(
+const combinedStyle6: StyleProp<TextStyle | null> = StyleSheet.compose(
     null,
     null,
 );
@@ -438,7 +439,7 @@ export class SectionListTest extends React.Component<SectionListProps<string>, {
     }
 
     scrollMe = () => {
-        this.myList.current.scrollToLocation({ itemIndex: 0, sectionIndex: 1 });
+        this.myList.current && this.myList.current.scrollToLocation({ itemIndex: 0, sectionIndex: 1 });
     };
 
     render() {
@@ -661,7 +662,7 @@ const dataSourceAssetCallback1: DataSourceAssetCallback = {
 const dataSourceAssetCallback2: DataSourceAssetCallback = {};
 
 // DeviceEventEmitterStatic
-const deviceEventEmitterStatic: DeviceEventEmitterStatic = null;
+const deviceEventEmitterStatic: DeviceEventEmitterStatic = DeviceEventEmitter;
 deviceEventEmitterStatic.addListener("keyboardWillShow", data => true);
 deviceEventEmitterStatic.addListener("keyboardWillShow", data => true, {});
 
@@ -726,7 +727,7 @@ class TextInputTest extends React.Component<{}, { username: string }> {
     render() {
         return (
             <View>
-                <Text onPress={() => this.username.focus()}>Username</Text>
+                <Text onPress={() => this.username && this.username.focus()}>Username</Text>
 
                 <TextInput
                     ref={input => (this.username = input)}
@@ -776,7 +777,7 @@ export class ImageTest extends React.Component {
         const image: ImageResolvedAssetSource = Image.resolveAssetSource({ uri });
         console.log(image.width, image.height, image.scale, image.uri);
 
-        Image.queryCache([uri]).then(({ [uri]: status }) => {
+        Image.queryCache && Image.queryCache([uri]).then(({ [uri]: status }) => {
             if (status === undefined) {
                 console.log("Image is not in cache");
             } else {
@@ -984,6 +985,11 @@ const PlatformTest = () => {
             return Platform.isTV ? 40 : 44;
     }
 };
+
+Platform.select({ android: 1 }); // $ExpectType number | undefined
+Platform.select({ android: 1, ios: 2, default: 0 }); // $ExpectType number
+Platform.select({ android: 1, ios: 2, macos: 3, web: 4, windows: 5 }); // $ExpectType number
+Platform.select({ android: 1, ios: 2, macos: 3, web: 4, windows: 5, default: 0 }); // $ExpectType number
 
 // ProgressBarAndroid
 const ProgressBarAndroidTest = () => {

--- a/types/react-native/tsconfig.json
+++ b/types/react-native/tsconfig.json
@@ -4,7 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "jsx": "react",


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/master/Libraries/Utilities/Platform.ios.js#L64

If you run this code on ios, you will get: `Uncaught TypeError: create is not a function`
```ts
useEffect(Platform.select({
  web: () => {},
  android: () => {},
}), []);
```

I created an overload to correctly handle this case. It's a breaking change, but it can avoid a lot of runtime errors when supporting a new platform.
I needed to enable strictNullChecks to test this behaviour in test. I quickly fixed the existing null check issues.

Tell me what you think