### PR TITLE
[parse] Make Parse.Cloud.run and Parse.Cloud.define generic

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -1011,10 +1011,14 @@ namespace Parse {
             message: (response: any) => void;
         }
 
-        interface FunctionRequest {
+        interface Params {
+            [key: string]: any;
+        }
+
+        interface FunctionRequest<T extends Params = Params> {
             installationId?: string;
             master?: boolean;
-            params?: any;
+            params: T;
             user?: User;
         }
 
@@ -1075,7 +1079,13 @@ namespace Parse {
         ): void;
         function afterFind(arg1: any, func?: (request: AfterFindRequest) => any): void;
         function beforeLogin(func?: (request: TriggerRequest) => any): void;
-        function define(name: string, func?: (request: FunctionRequest) => any): void;
+        function define(name: string, func: (request: FunctionRequest) => any): void;
+        function define<T extends (
+            param: { [P in keyof Parameters<T>[0]]: Parameters<T>[0][P] }
+        ) => any>(
+            name: string,
+            func: (request: FunctionRequest<Parameters<T>[0]>) => ReturnType<T>
+        ): void;
         /**
          * Gets data for the current set of cloud jobs.
          * @returns A promise that will be resolved with the result of the function.
@@ -1089,7 +1099,19 @@ namespace Parse {
         function getJobStatus(jobStatusId: string): Promise<Object>;
         function httpRequest(options: HTTPOptions): Promise<HttpResponse>;
         function job(name: string, func?: (request: JobRequest) => Promise<void> | void): HttpResponse;
-        function run(name: string, data?: any, options?: RunOptions): Promise<any>;
+        function run(name: string, data?: Params, options?: RunOptions): Promise<any>;
+        function run<T extends () => any>(
+            name: string,
+            data?: null,
+            options?: RunOptions
+        ): Promise<ReturnType<T>>;
+        function run<T extends (
+            param: { [P in keyof Parameters<T>[0]]: Parameters<T>[0][P] }
+        ) => any>(
+            name: string,
+            data: Parameters<T>[0],
+            options?: RunOptions
+        ): Promise<ReturnType<T>>;
         /**
          * Starts a given cloud job, which will process asynchronously.
          * @param jobName The function name.

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -430,7 +430,7 @@ function test_facebook_util() {
     });
 }
 
-function test_cloud_functions() {
+async function test_cloud_functions() {
     Parse.Cloud.run(
         'hello',
         {},
@@ -441,6 +441,39 @@ function test_cloud_functions() {
             error: (error: any) => {},
         },
     );
+
+    // $ExpectType any
+    await Parse.Cloud.run('SomeFunction');
+
+    // $ExpectType any
+    await Parse.Cloud.run('SomeFunction', { something: 'whatever' });
+
+    // $ExpectType any
+    await Parse.Cloud.run('SomeFunction', null, { useMasterKey: true });
+
+    // ExpectType boolean
+    await Parse.Cloud.run<() => boolean>('SomeFunction');
+
+    // $ExpectType boolean
+    await Parse.Cloud.run<() => boolean>('SomeFunction', null);
+
+    // $ExpectType boolean
+    await Parse.Cloud.run<() => boolean>('SomeFunction', null, { useMasterKey: true });
+
+    // $ExpectType number
+    await Parse.Cloud.run<(params: { paramA: string }) => number>('SomeFunction', { paramA: 'hello' });
+
+    // $ExpectError
+    await Parse.Cloud.run<(params: { paramA: string }) => number>('SomeFunction');
+
+    // $ExpectError
+    await Parse.Cloud.run<(params: { paramA: string }) => number>('SomeFunction', { paramZ: 'hello' });
+
+    // $ExpectError
+    await Parse.Cloud.run<(params: { paramA: string}) => number>('SomeFunction', null, { useMasterKey: true });
+
+    // $ExpectError
+    await Parse.Cloud.run<(params: string) => any>('SomeFunction', 'hello');
 
     Parse.Cloud.afterDelete('MyCustomClass', (request: Parse.Cloud.AfterDeleteRequest) => {
         // result
@@ -528,6 +561,33 @@ function test_cloud_functions() {
     Parse.Cloud.define('AFunc', (request: Parse.Cloud.FunctionRequest) => {
         return 'Some result';
     });
+
+    Parse.Cloud.define('AFunc', (request) => {
+        // $ExpectType Params
+        request.params;
+
+        // $ExpectType any
+        request.params.anything;
+    });
+
+    Parse.Cloud.define<(params: { something: string }) => number>('AFunc', (request) => {
+        // $ExpectType { something: string; }
+        request.params;
+
+        // $ExpectError
+        request.params.somethingElse;
+
+        return 123;
+    });
+
+    // $ExpectError
+    Parse.Cloud.define('AFunc');
+
+    // $ExpectError
+    Parse.Cloud.define<() => string>('AFunc', () => 123);
+
+    // $ExpectError
+    Parse.Cloud.define<(params: string) => number>('AFunc', () => 123);
 
     Parse.Cloud.job('AJob', (request: Parse.Cloud.JobRequest) => {
         request.message('Message to associate with this job run');


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <http://parseplatform.org/Parse-SDK-JS/api/2.10.0/>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

-----

This PR allows `Parse.Cloud.define` and `Parse.Cloud.run` to be generic methods. This will allow the same function type in the form of `(params: SomeInterface) => SomeReturnType` to be passed to each method, creating a "contract" between server and client.

Server:
```ts
import { SomeFunctionType } from 'my-types';

Parse.Cloud.define<SomeFunctionType>('SomeFunction', (request) => {
    // implementation - request.params will be Parameters<SomeFunctionType>[0]
    // and the expected return type will be ReturnType<SomeFunctionType>
});
```

Client:
```ts
import { SomeFunctionType } from 'my-types';
Parse.Cloud.run<SomeFunctionType>('SomeFunction', {
    // params required by SomeFunctionType
})  // return type will be Promise<ReturnType<SomeFunctionType>>
```

