### PR TITLE
[react-modal] Use correct type for style objects 

### DIFF
--- a/types/react-modal/index.d.ts
+++ b/types/react-modal/index.d.ts
@@ -7,6 +7,7 @@
 //                 Uwe Wiemer <https://github.com/hallowatcher>,
 //                 Peter Blazejewicz <https://github.com/peterblazejewicz>,
 //                 Justin Powell <https://github.com/jpowell>
+//                 Juwan Wheatley <https://github.com/fiberjw>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -17,12 +18,8 @@ export as namespace ReactModal;
 
 declare namespace ReactModal {
     interface Styles {
-        content?: {
-            [key: string]: any;
-        };
-        overlay?: {
-            [key: string]: any;
-        };
+        content?: React.CSSProperties;
+        overlay?: React.CSSProperties;
     }
 
     interface Classes {
@@ -72,7 +69,7 @@ declare namespace ReactModal {
         onAfterClose?(): void;
 
         /* Function that will be run when the modal is requested to be closed, prior to actually closing. */
-        onRequestClose?(event: (React.MouseEvent | React.KeyboardEvent)): void;
+        onRequestClose?(event: React.MouseEvent | React.KeyboardEvent): void;
 
         /* Number indicating the milliseconds to wait before closing the modal. Defaults to zero (no timeout). */
         closeTimeoutMS?: number;

--- a/types/react-modal/react-modal-tests.tsx
+++ b/types/react-modal/react-modal-tests.tsx
@@ -1,86 +1,86 @@
-import * as React from 'react';
+import * as React from "react";
 import ReactModal = require('react-modal');
 
 // tests for static method
 // string
-ReactModal.setAppElement('#main');
+ReactModal.setAppElement("#main");
 // HTMLElement
-ReactModal.setAppElement(document.getElementById('#main'));
+ReactModal.setAppElement(document.getElementById("#main"));
 
 class ExampleOfUsingReactModal extends React.Component {
-    contentRef: HTMLDivElement;
-    overlayRef: HTMLDivElement;
-    render() {
-        const onAfterOpenFn = () => {};
-        const onAfterCloseFn = () => {};
-        const onRequestCloseFn = (event: React.MouseEvent | React.KeyboardEvent) => {};
-        const customStyle: { overlay: React.CSSProperties; content: React.CSSProperties } = {
-            overlay: {
-                position: 'fixed',
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: 0,
-                backgroundColor: 'rgba(255, 255, 255, 0.75)',
-            },
-            content: {
-                position: 'absolute',
-                top: '40px',
-                left: '40px',
-                right: '40px',
-                bottom: '40px',
-                border: '1px solid #ccc',
-                background: '#fff',
-                overflow: 'auto',
-                WebkitOverflowScrolling: 'touch',
-                borderRadius: '4px',
-                outline: 'none',
-                padding: '20px',
-            },
-        };
-        const customClasses = {
-            afterOpen: 'afterOpen',
-            base: 'base',
-            beforeClose: 'beforeClose',
-        };
-        const customOverlayClasses = {
-            afterOpen: 'afterOpen',
-            base: 'base',
-            beforeClose: 'beforeClose',
-        };
-        const customAriaVariables = {
-            labelledby: 'labelledby',
-            describedby: 'describedby',
-            modal: true,
-        };
-        const customDataVariables = {
-            dataOne: 'one',
-            dataTwo: 'two',
-        };
-        return (
-            <ReactModal
-                isOpen={true}
-                onAfterOpen={onAfterOpenFn}
-                onAfterClose={onAfterCloseFn}
-                onRequestClose={onRequestCloseFn}
-                contentLabel="demo label"
-                closeTimeoutMS={1000}
-                style={customStyle}
-                className={customClasses}
-                overlayClassName={customOverlayClasses}
-                bodyOpenClassName={'bodyOpenClassName'}
-                htmlOpenClassName={'htmlOpenClassName'}
-                aria={customAriaVariables}
-                data={customDataVariables}
-                contentRef={instance => (this.contentRef = instance)}
-                overlayRef={instance => (this.overlayRef = instance)}
-                testId="modal-content"
-            >
-                <h1>Modal Content</h1>
-                <p>Etc.</p>
-            </ReactModal>
-        );
-    }
+  contentRef: HTMLDivElement;
+  overlayRef: HTMLDivElement;
+  render() {
+    const onAfterOpenFn = () => { };
+    const onAfterCloseFn = () => { };
+    const onRequestCloseFn = (event: React.MouseEvent | React.KeyboardEvent) => { };
+    const customStyle: { overlay: React.CSSProperties, content: React.CSSProperties } = {
+      overlay: {
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(255, 255, 255, 0.75)'
+      },
+      content: {
+        position: 'absolute',
+        top: '40px',
+        left: '40px',
+        right: '40px',
+        bottom: '40px',
+        border: '1px solid #ccc',
+        background: '#fff',
+        overflow: 'auto',
+        WebkitOverflowScrolling: 'touch',
+        borderRadius: '4px',
+        outline: 'none',
+        padding: '20px'
+      }
+    };
+    const customClasses = {
+      afterOpen: 'afterOpen',
+      base: 'base',
+      beforeClose: 'beforeClose'
+    };
+    const customOverlayClasses = {
+      afterOpen: 'afterOpen',
+      base: 'base',
+      beforeClose: 'beforeClose'
+    };
+    const customAriaVariables = {
+      labelledby: 'labelledby',
+      describedby: 'describedby',
+      modal: true,
+    };
+    const customDataVariables = {
+      dataOne: 'one',
+      dataTwo: 'two'
+    };
+    return (
+      <ReactModal
+        isOpen={true}
+        onAfterOpen={onAfterOpenFn}
+        onAfterClose={onAfterCloseFn}
+        onRequestClose={onRequestCloseFn}
+        contentLabel="demo label"
+        closeTimeoutMS={1000}
+        style={customStyle}
+        className={customClasses}
+        overlayClassName={customOverlayClasses}
+        bodyOpenClassName={'bodyOpenClassName'}
+        htmlOpenClassName={'htmlOpenClassName'}
+        aria={customAriaVariables}
+        data={customDataVariables}
+        contentRef={instance => this.contentRef = instance}
+        overlayRef={instance => this.overlayRef = instance}
+        testId="modal-content"
+        >
+        <h1>Modal Content</h1>
+        <p>Etc.</p>
+      </ReactModal>
+    );
+  }
 }
 
 const MyWrapperComponent: React.FC = () => {
@@ -90,9 +90,5 @@ const MyWrapperComponent: React.FC = () => {
         reactModaRef.current.portal.content.focus();
     });
 
-    return (
-        <ReactModal isOpen ref={reactModaRef}>
-            Hello, World!
-        </ReactModal>
-    );
+    return <ReactModal isOpen ref={reactModaRef}>Hello, World!</ReactModal>;
 };

--- a/types/react-modal/react-modal-tests.tsx
+++ b/types/react-modal/react-modal-tests.tsx
@@ -14,7 +14,7 @@ class ExampleOfUsingReactModal extends React.Component {
     const onAfterOpenFn = () => { };
     const onAfterCloseFn = () => { };
     const onRequestCloseFn = (event: React.MouseEvent | React.KeyboardEvent) => { };
-    const customStyle: { overlay: React.CSSProperties, content: React.CSSProperties } = {
+    const customStyle: ReactModal.Styles = {
       overlay: {
         position: 'fixed',
         top: 0,

--- a/types/react-modal/react-modal-tests.tsx
+++ b/types/react-modal/react-modal-tests.tsx
@@ -1,86 +1,86 @@
-import * as React from "react";
+import * as React from 'react';
 import ReactModal = require('react-modal');
 
 // tests for static method
 // string
-ReactModal.setAppElement("#main");
+ReactModal.setAppElement('#main');
 // HTMLElement
-ReactModal.setAppElement(document.getElementById("#main"));
+ReactModal.setAppElement(document.getElementById('#main'));
 
 class ExampleOfUsingReactModal extends React.Component {
-  contentRef: HTMLDivElement;
-  overlayRef: HTMLDivElement;
-  render() {
-    const onAfterOpenFn = () => { };
-    const onAfterCloseFn = () => { };
-    const onRequestCloseFn = (event: React.MouseEvent | React.KeyboardEvent) => { };
-    const customStyle = {
-      overlay: {
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(255, 255, 255, 0.75)'
-      },
-      content: {
-        position: 'absolute',
-        top: '40px',
-        left: '40px',
-        right: '40px',
-        bottom: '40px',
-        border: '1px solid #ccc',
-        background: '#fff',
-        overflow: 'auto',
-        WebkitOverflowScrolling: 'touch',
-        borderRadius: '4px',
-        outline: 'none',
-        padding: '20px'
-      }
-    };
-    const customClasses = {
-      afterOpen: 'afterOpen',
-      base: 'base',
-      beforeClose: 'beforeClose'
-    };
-    const customOverlayClasses = {
-      afterOpen: 'afterOpen',
-      base: 'base',
-      beforeClose: 'beforeClose'
-    };
-    const customAriaVariables = {
-      labelledby: 'labelledby',
-      describedby: 'describedby',
-      modal: true,
-    };
-    const customDataVariables = {
-      dataOne: 'one',
-      dataTwo: 'two'
-    };
-    return (
-      <ReactModal
-        isOpen={true}
-        onAfterOpen={onAfterOpenFn}
-        onAfterClose={onAfterCloseFn}
-        onRequestClose={onRequestCloseFn}
-        contentLabel="demo label"
-        closeTimeoutMS={1000}
-        style={customStyle}
-        className={customClasses}
-        overlayClassName={customOverlayClasses}
-        bodyOpenClassName={'bodyOpenClassName'}
-        htmlOpenClassName={'htmlOpenClassName'}
-        aria={customAriaVariables}
-        data={customDataVariables}
-        contentRef={instance => this.contentRef = instance}
-        overlayRef={instance => this.overlayRef = instance}
-        testId="modal-content"
-        >
-        <h1>Modal Content</h1>
-        <p>Etc.</p>
-      </ReactModal>
-    );
-  }
+    contentRef: HTMLDivElement;
+    overlayRef: HTMLDivElement;
+    render() {
+        const onAfterOpenFn = () => {};
+        const onAfterCloseFn = () => {};
+        const onRequestCloseFn = (event: React.MouseEvent | React.KeyboardEvent) => {};
+        const customStyle: { overlay: React.CSSProperties; content: React.CSSProperties } = {
+            overlay: {
+                position: 'fixed',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                backgroundColor: 'rgba(255, 255, 255, 0.75)',
+            },
+            content: {
+                position: 'absolute',
+                top: '40px',
+                left: '40px',
+                right: '40px',
+                bottom: '40px',
+                border: '1px solid #ccc',
+                background: '#fff',
+                overflow: 'auto',
+                WebkitOverflowScrolling: 'touch',
+                borderRadius: '4px',
+                outline: 'none',
+                padding: '20px',
+            },
+        };
+        const customClasses = {
+            afterOpen: 'afterOpen',
+            base: 'base',
+            beforeClose: 'beforeClose',
+        };
+        const customOverlayClasses = {
+            afterOpen: 'afterOpen',
+            base: 'base',
+            beforeClose: 'beforeClose',
+        };
+        const customAriaVariables = {
+            labelledby: 'labelledby',
+            describedby: 'describedby',
+            modal: true,
+        };
+        const customDataVariables = {
+            dataOne: 'one',
+            dataTwo: 'two',
+        };
+        return (
+            <ReactModal
+                isOpen={true}
+                onAfterOpen={onAfterOpenFn}
+                onAfterClose={onAfterCloseFn}
+                onRequestClose={onRequestCloseFn}
+                contentLabel="demo label"
+                closeTimeoutMS={1000}
+                style={customStyle}
+                className={customClasses}
+                overlayClassName={customOverlayClasses}
+                bodyOpenClassName={'bodyOpenClassName'}
+                htmlOpenClassName={'htmlOpenClassName'}
+                aria={customAriaVariables}
+                data={customDataVariables}
+                contentRef={instance => (this.contentRef = instance)}
+                overlayRef={instance => (this.overlayRef = instance)}
+                testId="modal-content"
+            >
+                <h1>Modal Content</h1>
+                <p>Etc.</p>
+            </ReactModal>
+        );
+    }
 }
 
 const MyWrapperComponent: React.FC = () => {
@@ -90,5 +90,9 @@ const MyWrapperComponent: React.FC = () => {
         reactModaRef.current.portal.content.focus();
     });
 
-    return <ReactModal isOpen ref={reactModaRef}>Hello, World!</ReactModal>;
+    return (
+        <ReactModal isOpen ref={reactModaRef}>
+            Hello, World!
+        </ReactModal>
+    );
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/react-modal/blob/master/src/components/ModalPortal.js#L351

The type for React `style` props should be `React.CSSProperties`, but this library is written in JS which can't express that, so the existing typings for this library mimic this behavior. This PR fixes that and simultaneously improves the DX for people using these typings by providing better autocomplete and checks to make writing incorrect style properties harder.

Thanks for taking the time to check this out!

<p align="center">
<img alt=":)" src="https://user-images.githubusercontent.com/12488826/71935101-d777ed00-315a-11ea-93fc-2182de3d977f.gif" />
</p>