### PR TITLE
Swap Element with HTMLElement for TS type validation with Mapbox types.

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -361,7 +361,7 @@ declare namespace mapboxgl {
         crossSourceCollisions?: boolean;
 
         /** ID of the container element */
-        container: string | Element;
+        container: string | HTMLElement;
 
         /** String or strings to show in an AttributionControl.
          * Only applicable if options.attributionControl is `true`. */


### PR DESCRIPTION
I believe this `container` `Element` should actually be an `HTMLElement`, as I'm getting a type validation error when trying to pass a valid version if the `MapboxOptions` interface to a `new mapboxgl.Map()` constructor. In the `mapbox-gl` [source](https://github.com/mapbox/mapbox-gl-js/blob/master/src/ui/map.js#L70-L104) for those options they have it typed as an `HTMLElement | string`, so I think this should be good.

![image](https://user-images.githubusercontent.com/25542515/71955689-fdcb7600-31b6-11ea-81c0-0b197ba9f25e.png)
