### PR TITLE
LokiJS DynamicView.branchResultset: parameter transform is optional

### DIFF
--- a/types/lokijs/index.d.ts
+++ b/types/lokijs/index.d.ts
@@ -1086,7 +1086,7 @@ declare class DynamicView<E extends object> extends LokiEventEmitter {
      * @param [parameters] - optional parameters (if optional transform requires them)
      * @returns A copy of the internal resultset for branched queries.
      */
-    public branchResultset(transform: string | string[] | Transform[], parameters?: object): Resultset<any>;
+    public branchResultset(transform?: string | string[] | Transform[], parameters?: object): Resultset<any>;
 
     /**
      * toJSON() - Override of toJSON to avoid circular references


### PR DESCRIPTION
In DefinitelyTyped, the parameter **transform** is (incorrectly) marked as required. I fixed this.

See also:
https://github.com/techfort/LokiJS/blob/v1.5.3/src/lokijs.js#L3971 (since npmjs.com states the current types are for LokiJS version 1.5.3, although this is correct for the latest version 1.5.8, too)
http://techfort.github.io/LokiJS/DynamicView.html (JSDoc)

