### PR TITLE
added secondary_text_matched_substrings?:

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -749,6 +749,17 @@ const autocomplete = new google.maps.places.Autocomplete(document.createElement(
 const placeResult = autocomplete.getPlace();
 placeResult.name; // $ExpectType string
 
+/***** google.maps.places.AutocompleteService *****/
+new google.maps.places.AutocompleteService()
+    .getPlacePredictions(
+        {input: 'Kyiv, Ukr'},
+        (result) => {
+            result[0]
+                .structured_formatting
+                .secondary_text_matched_substrings // $ExpectType PredictionSubstring[] | undefined
+        }
+    );
+
 /***** google.maps.ImageMapType *****/
 const imageMapType = new google.maps.ImageMapType({
     alt: 'alt',

--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -756,7 +756,7 @@ new google.maps.places.AutocompleteService()
         (result) => {
             result[0]
                 .structured_formatting
-                .secondary_text_matched_substrings // $ExpectType PredictionSubstring[] | undefined
+                .secondary_text_matched_substrings; // $ExpectType PredictionSubstring[] | undefined
         }
     );
 

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -3548,6 +3548,7 @@ declare namespace google.maps {
             main_text: string;
             main_text_matched_substrings: PredictionSubstring[];
             secondary_text: string;
+            secondary_text_matched_substrings?: PredictionSubstring[];
         }
 
         interface OpeningHours {


### PR DESCRIPTION
added `secondary_text_matched_substrings?:` to the  `AutocompleteStructuredFormatting`, because if there is match, Google Maps API responses with this field. 
There is no such field in the [documentation](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#StructuredFormatting), so I also submitted feedback to add this field to the official docs.

<img width="757" alt="Screenshot 2020-01-08 at 16 33 48" src="https://user-images.githubusercontent.com/122360/71987258-8a694900-3236-11ea-8a7c-ef78baf37761.png">


Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

(current linting is broken, so I wasn't fixing it)
