### PR TITLE
Fix $ExpectType in new esm package

### DIFF
--- a/types/esm/esm-tests.ts
+++ b/types/esm/esm-tests.ts
@@ -1,3 +1,3 @@
 import esm = require("esm");
 
-esm(exports); // $ExpectType Require
+esm(exports); // $ExpectType NodeRequire


### PR DESCRIPTION
I think that CI ran on the previous PR before `@types/node` upgraded to 13.