### PR TITLE
feat(react-modal): optional parametrized `onAfterOpen`

### DIFF
--- a/types/react-modal/index.d.ts
+++ b/types/react-modal/index.d.ts
@@ -40,6 +40,19 @@ declare namespace ReactModal {
         modal?: boolean | 'false' | 'true';
     }
 
+    /** Describes overlay and content element references passed to onAfterOpen function */
+    interface OnAfterOpenCallbackOptions {
+        /** overlay element reference */
+        overlayEl: Element;
+        /** content element reference */
+        contentEl: HTMLDivElement;
+    }
+
+    /** Describes unction that will be run after the modal has opened */
+    interface OnAfterOpenCallback {
+        (obj?: OnAfterOpenCallbackOptions): void;
+    }
+
     interface Props {
         /* Boolean describing if the modal should be shown or not. Defaults to false. */
         isOpen: boolean;
@@ -66,7 +79,7 @@ declare namespace ReactModal {
         appElement?: HTMLElement | {};
 
         /* Function that will be run after the modal has opened. */
-        onAfterOpen?(): void;
+        onAfterOpen?: OnAfterOpenCallback;
 
         /* Function that will be run after the modal has closed. */
         onAfterClose?(): void;

--- a/types/react-modal/react-modal-tests.tsx
+++ b/types/react-modal/react-modal-tests.tsx
@@ -11,7 +11,12 @@ class ExampleOfUsingReactModal extends React.Component {
   contentRef: HTMLDivElement;
   overlayRef: HTMLDivElement;
   render() {
-    const onAfterOpenFn = () => { };
+    const reactModalRef = React.useRef<ReactModal>();
+    // typed params of `OnAfterOpen` callback
+    const onAfterOpenFn: ReactModal.OnAfterOpenCallback = ({ contentEl, overlayEl }) => {
+        console.assert(contentEl === reactModalRef.current.portal.content);
+        console.assert(overlayEl === reactModalRef.current.portal.overlay);
+    };
     const onAfterCloseFn = () => { };
     const onRequestCloseFn = (event: React.MouseEvent | React.KeyboardEvent) => { };
     const customStyle = {
@@ -85,10 +90,18 @@ class ExampleOfUsingReactModal extends React.Component {
 
 const MyWrapperComponent: React.FC = () => {
     const reactModaRef = React.useRef<ReactModal>();
+    // typed params of `OnAfterOpen` are optional for backward compatible types
+    const onAfterOpenOptionalObjFn = () => {};
 
     React.useLayoutEffect(() => {
         reactModaRef.current.portal.content.focus();
     });
 
-    return <ReactModal isOpen ref={reactModaRef}>Hello, World!</ReactModal>;
+    return (
+        <ReactModal isOpen
+            onAfterOpen={onAfterOpenOptionalObjFn}
+            ref={reactModaRef}>
+            Hello, World!
+        </ReactModal>
+    );
 };


### PR DESCRIPTION
This aligns definition of the `onAfterOpen` callback function with
changes introduced here:
reactjs/react-modal#741
that is optionally typed object containing references to the overlay and
content elements.

This change proposes change that is backward compatible with existing code (no change required after update for the `onAfterOpen` existing implementations in usage)

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/react-modal/pull/741