### PR TITLE
[react-aria-menubutton] Remove the nonexistent `isOpen` prop

### DIFF
--- a/types/react-aria-menubutton/index.d.ts
+++ b/types/react-aria-menubutton/index.d.ts
@@ -41,8 +41,6 @@ export interface WrapperProps<T extends HTMLElement>
 	 */
 	closeOnBlur?: boolean;
 
-	isOpen?: boolean;
-
 	tag?: T["tagName"];
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source code](https://github.com/davidtheclark/react-aria-menubutton/blob/5b88ff9459b8c1f6543186ae2c98a8dca7a30868/src/Wrapper.js)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (It's already the right version — this prop just shouldn't be there)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This prop is [never recognized nor used by the component](https://github.com/davidtheclark/react-aria-menubutton/blob/5b88ff9459b8c1f6543186ae2c98a8dca7a30868/src/Wrapper.js). It [might have been there for a short time 5 years ago](https://github.com/davidtheclark/react-aria-menubutton/issues/16), but is not since then. When provided, it's passed down to the underlying DOM element, which causes React to display a warning in development mode.

```
Warning: React does not recognize the `isOpen` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `isopen` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

