### PR TITLE
[conventional-changelog] Added type definitions

### DIFF
--- a/types/conventional-changelog-core/conventional-changelog-core-tests.ts
+++ b/types/conventional-changelog-core/conventional-changelog-core-tests.ts
@@ -1,0 +1,19 @@
+/* tslint:disable:no-mergeable-namespace no-namespace */
+"use strict";
+
+import conventionalChangelogCore from "conventional-changelog-core";
+
+namespace Test {
+    declare const context: conventionalChangelogCore.Context;
+    declare const gitRawCommitsOpts: conventionalChangelogCore.GitRawCommitsOptions;
+    declare const options: conventionalChangelogCore.Options;
+    declare const parserOpts: conventionalChangelogCore.ParserOptions;
+    declare const writerOpts: conventionalChangelogCore.WriterOptions;
+
+    conventionalChangelogCore(); // $ExpectType Readable
+    conventionalChangelogCore(options); // $ExpectType Readable
+    conventionalChangelogCore(options, context); // $ExpectType Readable
+    conventionalChangelogCore(options, context, gitRawCommitsOpts); // $ExpectType Readable
+    conventionalChangelogCore(options, context, gitRawCommitsOpts, parserOpts); // $ExpectType Readable
+    conventionalChangelogCore(options, context, gitRawCommitsOpts, parserOpts, writerOpts); // $ExpectType Readable
+}

--- a/types/conventional-changelog-core/conventional-changelog-core-tests.ts
+++ b/types/conventional-changelog-core/conventional-changelog-core-tests.ts
@@ -3,17 +3,24 @@
 
 import conventionalChangelogCore from "conventional-changelog-core";
 
-namespace Test {
+namespace Module {
     declare const context: conventionalChangelogCore.Context;
     declare const gitRawCommitsOpts: conventionalChangelogCore.GitRawCommitsOptions;
     declare const options: conventionalChangelogCore.Options;
     declare const parserOpts: conventionalChangelogCore.ParserOptions;
     declare const writerOpts: conventionalChangelogCore.WriterOptions;
 
-    conventionalChangelogCore(); // $ExpectType Readable
-    conventionalChangelogCore(options); // $ExpectType Readable
-    conventionalChangelogCore(options, context); // $ExpectType Readable
-    conventionalChangelogCore(options, context, gitRawCommitsOpts); // $ExpectType Readable
-    conventionalChangelogCore(options, context, gitRawCommitsOpts, parserOpts); // $ExpectType Readable
-    conventionalChangelogCore(options, context, gitRawCommitsOpts, parserOpts, writerOpts); // $ExpectType Readable
+    // $ExpectType Readable
+    conventionalChangelogCore();
+    // $ExpectType Readable
+    conventionalChangelogCore(options);
+    // $ExpectType Readable
+    conventionalChangelogCore(options, context);
+    // $ExpectType Readable
+    conventionalChangelogCore(options, context, gitRawCommitsOpts);
+    // $ExpectType Readable
+    conventionalChangelogCore(options, context, gitRawCommitsOpts, parserOpts);
+    // $ExpectType Readable
+    conventionalChangelogCore(options, context, gitRawCommitsOpts, parserOpts, writerOpts);
+    // $ExpectType Readable
 }

--- a/types/conventional-changelog-core/conventional-changelog-core-tests.ts
+++ b/types/conventional-changelog-core/conventional-changelog-core-tests.ts
@@ -22,5 +22,4 @@ namespace Module {
     conventionalChangelogCore(options, context, gitRawCommitsOpts, parserOpts);
     // $ExpectType Readable
     conventionalChangelogCore(options, context, gitRawCommitsOpts, parserOpts, writerOpts);
-    // $ExpectType Readable
 }

--- a/types/conventional-changelog-core/index.d.ts
+++ b/types/conventional-changelog-core/index.d.ts
@@ -1,0 +1,367 @@
+// Type definitions for conventional-changelog-core 4.1
+// Project: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-core#readme
+// Definitions by: Jason Kwok <https://github.com/JasonHK>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
+
+/// <reference types="node" />
+
+import * as Stream from "stream";
+
+import { Commit, Options as BaseParserOptions } from "conventional-commits-parser";
+import { Context as BaseContext, Options as BaseWriterOptions } from "conventional-changelog-writer";
+import { GitOptions as BaseGitRawCommitsOptions } from "git-raw-commits";
+import { Package } from "normalize-package-data";
+
+/**
+ * Returns a readable stream.
+ *
+ * @param options
+ * @param context
+ * @param gitRawCommitsOpts
+ * @param parserOpts
+ * @param writerOpts
+ */
+// tslint:disable-next-line max-line-length
+declare function conventionalChangelogCore<TCommit extends Commit = Commit, TContext extends BaseContext = Context>(options?: Options<TCommit, TContext>, context?: Partial<TContext>, gitRawCommitsOpts?: GitRawCommitsOptions, parserOpts?: ParserOptions, writerOpts?: WriterOptions<TCommit, TContext>): Stream.Readable;
+
+declare namespace conventionalChangelogCore {
+    interface Context extends BaseContext {
+        /**
+         * The hosting website. Eg: `'https://github.com'` or `'https://bitbucket.org'`.
+         *
+         * @defaults
+         * Normalized host found in `package.json`.
+         */
+        host?: BaseContext["host"];
+
+        /**
+         * Version number of the up-coming release. If `version` is found in the last
+         * commit before generating logs, it will be overwritten.
+         *
+         * @defaults
+         * Version found in `package.json`.
+         */
+        version?: BaseContext["version"];
+
+        /**
+         * The owner of the repository. Eg: `'stevemao'`.
+         *
+         * @defaults
+         * Extracted from normalized `package.json` `repository.url` field.
+         */
+        owner?: BaseContext["owner"];
+
+        /**
+         * The repository name on `host`. Eg: `'conventional-changelog-writer'`.
+         *
+         * @defaults
+         * Extracted from normalized `package.json` `repository.url` field.
+         */
+        repository?: BaseContext["repository"];
+
+        /**
+         * The whole repository url. Eg: `'https://github.com/conventional-changelog/conventional-changelog-writer'`.
+         * The should be used as a fallback when `context.repository` doesn't exist.
+         *
+         * @defaults
+         * The whole normalized repository url in `package.json`.
+         */
+        repoUrl?: BaseContext["repoUrl"];
+
+        /**
+         * @defaults
+         * Previous semver tag or the first commit hash if no previous tag.
+         */
+        previousTag?: string;
+
+        /**
+         * @defaults
+         * Current semver tag or `'v'` + version if no current tag.
+         */
+        currentTag?: string;
+
+        /**
+         * Should link to the page that compares current tag with previous tag?
+         *
+         * @defaults
+         * `true` if `previousTag` and `currentTag` are truthy.
+         */
+        linkCompare?: boolean;
+    }
+
+    /**
+     * Please check the available options at http://git-scm.com/docs/git-log.
+     *
+     * There are some defaults:
+     *
+     * @remarks
+     * Single dash arguments are not supported because of https://github.com/sindresorhus/dargs/blob/master/index.js#L5.
+     *
+     * @remarks
+     * For `<revision range>` we can also use `<from>..<to>` pattern, and this
+     * module has the following extra options for shortcut of this pattern:
+     *
+     * * `from`
+     * * `to`
+     *
+     * This module also have the following additions:
+     *
+     * * `format`
+     * * `debug`
+     * * `path`
+     */
+    interface GitRawCommitsOptions extends BaseGitRawCommitsOptions {
+        /**
+         * @default
+         * '%B%n-hash-%n%H%n-gitTags-%n%d%n-committerDate-%n%ci'
+         */
+        format?: BaseGitRawCommitsOptions["format"];
+
+        /**
+         * @defaults
+         * Based on `options.releaseCount`.
+         */
+        from?: BaseGitRawCommitsOptions["from"];
+
+        /**
+         * @defaults
+         * `true` if `options.append` is truthy.
+         */
+        reverse?: boolean;
+
+        /**
+         * A function to get debug information.
+         *
+         * @default
+         * options.debug
+         */
+        debug?: BaseGitRawCommitsOptions["debug"];
+    }
+
+    type MergedContext<T extends BaseContext> = T & MergedContext.ExtraContext;
+
+    namespace MergedContext {
+        interface ExtraContext {
+            /**
+             * All git semver tags found in the repository. You can't overwrite this value.
+             */
+            readonly gitSemverTags?: ReadonlyArray<string>;
+
+            /**
+             * Your `package.json` data. You can't overwrite this value.
+             */
+            readonly packageData?: Readonly<Partial<Package>>;
+        }
+    }
+
+    interface Options<TCommit extends Commit = Commit, TContext extends BaseContext = Context> {
+        /**
+         * This should serve as default values for other arguments of
+         * `conventionalChangelogCore` so you don't need to rewrite the same or similar
+         * config across your projects. Any value in this could be overwritten. If this
+         * is a promise (recommended if async), it should resolve with the config. If
+         * this is a function, it expects a node style callback with the config object.
+         * If this is an object, it is the config object. The config object should
+         * include `context`, `gitRawCommitsOpts`, `parserOpts` and `writerOpts`.
+         */
+        config?: Options.Config<TCommit, TContext>;
+
+        pkg?: Options.Pkg;
+
+        /**
+         * Should the log be appended to existing data.
+         *
+         * @default
+         * false
+         */
+        append?: boolean;
+
+        /**
+         * How many releases of changelog you want to generate. It counts from the
+         * upcoming release. Useful when you forgot to generate any previous changelog.
+         * Set to `0` to regenerate all.
+         *
+         * @default
+         * 1
+         */
+        releaseCount?: number;
+
+        /**
+         * A debug function. EG: `console.debug.bind(console)`.
+         *
+         * @default
+         * function () {}
+         */
+        debug?: Options.Logger;
+
+        /**
+         * A warn function. EG: `grunt.verbose.writeln`.
+         *
+         * @default
+         * options.debug
+         */
+        warn?: Options.Logger;
+
+        /**
+         * A transform function that applies after the parser and before the writer.
+         *
+         * This is the place to modify the parsed commits.
+         */
+        transform?: Options.Transform<TCommit>;
+
+        /**
+         * If this value is `true` and `context.version` equals last release then
+         * `context.version` will be changed to `'Unreleased'`.
+         *
+         * @remarks
+         * You may want to combine this option with `releaseCount` set to `0` to always
+         * overwrite the whole CHANGELOG. `conventional-changelog` only outputs a
+         * CHANGELOG but doesn't read any existing one.
+         *
+         * @defaults
+         * `true` if a different version than last release is given. Otherwise `false`.
+         */
+        outputUnreleased?: boolean;
+
+        /**
+         * Specify a package in lerna-style monorepo that the CHANGELOG should be
+         * generated for.
+         *
+         * Lerna tags releases in the format `foo-package@1.0.0` and assumes that
+         * packages are stored in the directory structure `./packages/foo-package`.
+         *
+         * @default
+         * null
+         */
+        lernaPackage?: string | null;
+
+        /**
+         * Specify a prefix for the git tag that will be taken into account during the
+         * comparison. For instance if your version tag is prefixed by `version/`
+         * instead of `v` you would specify `--tagPrefix=version/`.
+         */
+        tagPrefix?: string;
+    }
+
+    namespace Options {
+        type Config<TCommit extends Commit, TContext extends BaseContext> = Promise<Config.Object<TCommit, TContext>> | Config.Function<TCommit, TContext> | Config.Object<TCommit, TContext>;
+
+        namespace Config {
+            type FunctionType<TCommit extends Commit, TContext extends BaseContext> = (callback: FunctionType.Callback<TCommit, TContext>) => void;
+
+            namespace FunctionType {
+                type Callback<TCommit extends Commit, TContext extends BaseContext> = (error: any, config: ObjectType<TCommit, TContext>) => void;
+            }
+
+            interface ObjectType<TCommit extends Commit, TContext extends BaseContext> {
+                context?: Partial<TContext>;
+                gitRawCommitsOpts?: GitRawCommitsOptions;
+                parserOpts?: ParserOptions;
+                writerOpts?: WriterOptions<TCommit, TContext>;
+            }
+
+            export {
+                FunctionType as Function,
+                ObjectType as Object,
+            };
+        }
+
+        type Logger = (message?: any) => void;
+
+        interface Pkg {
+            /**
+             * The location of your "package.json".
+             */
+            path?: string;
+
+            /**
+             * A function that takes `package.json` data as the argument and returns the
+             * modified data. Note this is performed before normalizing package.json data.
+             * Useful when you need to add a leading 'v' to your version or modify your
+             * repository url, etc.
+             *
+             * @defaults
+             * Pass through.
+             */
+            transform?: (pkg: Record<string, any>) => Record<string, any>;
+        }
+
+        interface Transform<T extends Commit = Commit> {
+            /**
+             * A transform function that applies after the parser and before the writer.
+             *
+             * This is the place to modify the parsed commits.
+             *
+             * @param commit The commit from conventional-commits-parser.
+             * @param cb     Callback when you are done.
+             */
+            (this: Stream.Transform, commit: Commit, cb: Transform.Callback<T>): void;
+        }
+
+        namespace Transform {
+            type Callback<T extends Commit = Commit> = (error: any, commit: T) => void;
+        }
+    }
+
+    interface ParserOptions extends BaseParserOptions {
+        /**
+         * What warn function to use. For example, `console.warn.bind(console)` or
+         * `grunt.log.writeln`. By default, it's a noop. If it is `true`, it will error
+         * if commit cannot be parsed (strict).
+         *
+         * @default
+         * options.warn
+         */
+        warn?: BaseParserOptions["warn"];
+    }
+
+    interface WriterOptions<TCommit extends Commit = Commit, TContext extends BaseContext = Context> extends BaseWriterOptions<TCommit, MergedContext<TContext>> {
+        /**
+         * Last chance to modify your context before generating a changelog.
+         *
+         * Finalize context is used for generating above context.
+         *
+         * @remarks
+         * If you overwrite this value the above context defaults will be gone.
+         */
+        finalizeContext?: BaseWriterOptions<TCommit, MergedContext<TContext>>["finalizeContext"];
+
+        /**
+         * A function to get debug information.
+         *
+         * @default
+         * options.debug
+         */
+        debug?: BaseWriterOptions["debug"];
+
+        /**
+         * The normal order means reverse chronological order. `reverse` order means
+         * chronological order. Are the commits from upstream in the reverse order? You
+         * should only worry about this when generating more than one blocks of logs
+         * based on `generateOn`. If you find the last commit is in the wrong block
+         * inverse this value.
+         *
+         * @default
+         * options.append
+         */
+        reverse?: BaseWriterOptions["reverse"];
+
+        /**
+         * If `true`, the stream will flush out the last bit of commits (could be empty)
+         * to changelog.
+         *
+         * @default
+         * options.outputUnreleased
+         */
+        doFlush?: BaseWriterOptions["doFlush"];
+    }
+}
+
+type Context = conventionalChangelogCore.Context;
+type GitRawCommitsOptions = conventionalChangelogCore.GitRawCommitsOptions;
+type Options<TCommit extends Commit, TContext extends BaseContext> = conventionalChangelogCore.Options<TCommit, TContext>;
+type ParserOptions = conventionalChangelogCore.ParserOptions;
+type WriterOptions<TCommit extends Commit = Commit, TContext extends BaseContext = Context> = conventionalChangelogCore.WriterOptions<TCommit, TContext>;
+
+export = conventionalChangelogCore;

--- a/types/conventional-changelog-core/tsconfig.json
+++ b/types/conventional-changelog-core/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "conventional-changelog-core-tests.ts"
+    ]
+}

--- a/types/conventional-changelog-core/tslint.json
+++ b/types/conventional-changelog-core/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/conventional-changelog-preset-loader/conventional-changelog-preset-loader-tests.ts
+++ b/types/conventional-changelog-preset-loader/conventional-changelog-preset-loader-tests.ts
@@ -1,0 +1,35 @@
+/* tslint:disable:no-mergeable-namespace no-namespace */
+"use strict";
+
+import conventionalChangelogPresetLoader from "conventional-changelog-preset-loader";
+
+namespace Test {
+    declare const path: string;
+    declare const config: conventionalChangelogPresetLoader.Config;
+
+    // $ExpectType Config<Commit<string | number | symbol>, Context>
+    conventionalChangelogPresetLoader(path);
+    // $ExpectType Config<Commit<string | number | symbol>, Context>
+    conventionalChangelogPresetLoader(config);
+
+    // $ExpectError
+    conventionalChangelogPresetLoader();
+}
+
+namespace Test.presetLoader {
+    declare const require: conventionalChangelogPresetLoader.presetLoader.RequireMethod;
+
+    // $ExpectType typeof conventionalChangelogPresetLoader
+    conventionalChangelogPresetLoader.presetLoader(require);
+
+    // $ExpectError
+    conventionalChangelogPresetLoader.presetLoader();
+}
+
+namespace Test.Config {
+    declare const config: conventionalChangelogPresetLoader.Config;
+
+    // $ExpectType Config
+    config;
+    config.name; // $ExpectType string
+}

--- a/types/conventional-changelog-preset-loader/conventional-changelog-preset-loader-tests.ts
+++ b/types/conventional-changelog-preset-loader/conventional-changelog-preset-loader-tests.ts
@@ -3,7 +3,7 @@
 
 import conventionalChangelogPresetLoader from "conventional-changelog-preset-loader";
 
-namespace Test {
+namespace Module {
     declare const path: string;
     declare const config: conventionalChangelogPresetLoader.Config;
 
@@ -16,7 +16,7 @@ namespace Test {
     conventionalChangelogPresetLoader();
 }
 
-namespace Test.presetLoader {
+namespace Module.presetLoader {
     declare const require: conventionalChangelogPresetLoader.presetLoader.RequireMethod;
 
     // $ExpectType typeof conventionalChangelogPresetLoader
@@ -26,7 +26,7 @@ namespace Test.presetLoader {
     conventionalChangelogPresetLoader.presetLoader();
 }
 
-namespace Test.Config {
+namespace Module.Config {
     declare const config: conventionalChangelogPresetLoader.Config;
 
     // $ExpectType Config

--- a/types/conventional-changelog-preset-loader/index.d.ts
+++ b/types/conventional-changelog-preset-loader/index.d.ts
@@ -1,0 +1,54 @@
+// Type definitions for conventional-changelog-preset-loader 2.3
+// Project: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-preset-loader#readme
+// Definitions by: Jason Kwok <https://github.com/JasonHK>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
+
+import { Options as CoreOptions } from "conventional-changelog-core";
+import { Commit } from "conventional-commits-parser";
+import { Context as WriterContext } from "conventional-changelog-writer";
+
+/**
+ * The string that is passed to the preset loader is manipulated by prepending
+ * `conventional-changelog` to the name.
+ *
+ * For example:
+ *
+ * * `angular` => `conventional-changelog-angular`
+ * * `angular/preset/path` => `conventional-changelog-angular/preset/path`
+ * * `@scope/angular` => `@scope/conventional-changelog-angular`
+ * * `@scope/angular/preset/path` => `@scope/conventional-changelog-angular/preset/path`
+ *
+ * Will return whatever is exported by the preset package. That may be a
+ * configuration object, a function, or a promise.
+ *
+ * @param path
+ */
+declare function conventionalChangelogPresetLoader(path: string | Config): CoreOptions.Config<Commit, WriterContext>;
+
+declare namespace conventionalChangelogPresetLoader {
+    function presetLoader(requireMethod: presetLoader.RequireMethod): typeof conventionalChangelogPresetLoader;
+
+    namespace presetLoader {
+        type RequireMethod = (id: string) => any;
+    }
+
+    interface Config {
+        /**
+         * The string that is passed to the preset loader is manipulated by prepending
+         * `conventional-changelog` to the name.
+         *
+         * For example:
+         *
+         * * `angular` => `conventional-changelog-angular`
+         * * `angular/preset/path` => `conventional-changelog-angular/preset/path`
+         * * `@scope/angular` => `@scope/conventional-changelog-angular`
+         * * `@scope/angular/preset/path` => `@scope/conventional-changelog-angular/preset/path`
+         */
+        name: string;
+    }
+}
+
+type Config = conventionalChangelogPresetLoader.Config;
+
+export = conventionalChangelogPresetLoader;

--- a/types/conventional-changelog-preset-loader/tsconfig.json
+++ b/types/conventional-changelog-preset-loader/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "conventional-changelog-preset-loader-tests.ts"
+    ]
+}

--- a/types/conventional-changelog-preset-loader/tslint.json
+++ b/types/conventional-changelog-preset-loader/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/conventional-changelog-writer/conventional-changelog-writer-tests.ts
+++ b/types/conventional-changelog-writer/conventional-changelog-writer-tests.ts
@@ -1,0 +1,21 @@
+"use strict";
+
+import conventionalChangelogWriter from "conventional-changelog-writer";
+
+declare const context: conventionalChangelogWriter.Context;
+declare const options: conventionalChangelogWriter.Options;
+
+// $ExpectType Transform
+conventionalChangelogWriter();
+
+// $ExpectType Transform
+conventionalChangelogWriter(context);
+
+// $ExpectType Transform
+conventionalChangelogWriter(context, options);
+
+// $ExpectError
+conventionalChangelogWriter(options);
+
+// $ExpectError
+conventionalChangelogWriter(options, context);

--- a/types/conventional-changelog-writer/index.d.ts
+++ b/types/conventional-changelog-writer/index.d.ts
@@ -1,0 +1,363 @@
+// Type definitions for conventional-changelog-writer 4.0
+// Project: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-writer#readme
+// Definitions by: Jason Kwok <https://github.com/JasonHK>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
+
+/// <reference types="node" />
+
+import * as Stream from "stream";
+
+import { Commit } from "conventional-commits-parser";
+
+/**
+ * Returns a transform stream.
+ *
+ * @param context Variables that will be interpolated to the template. This
+ *                object contains, but not limits to the following fields.
+ * @param options
+ */
+// tslint:disable-next-line no-unnecessary-generics
+declare function conventionalChangelogWriter<C extends Commit = Commit>(context?: conventionalChangelogWriter.Context, options?: conventionalChangelogWriter.Options<C>): Stream.Transform;
+
+declare namespace conventionalChangelogWriter {
+    interface CommitGroup<C extends Commit = Commit> {
+        title: string | false;
+        commits: Array<TransformedCommit<C>>;
+    }
+
+    interface Context {
+        /**
+         * Version number of the up-coming release. If `version` is found in the last
+         * commit before generating logs, it will be overwritten.
+         */
+        version?: string;
+
+        title?: string;
+
+        /**
+         * By default, this value is true if `version`'s patch is `0`.
+         *
+         * @default
+         * semver.patch(context.version) !== 0
+         */
+        isPatch?: boolean;
+
+        /**
+         * The hosting website. Eg: `'https://github.com'` or `'https://bitbucket.org'`.
+         */
+        host?: string;
+
+        /**
+         * The owner of the repository. Eg: `'stevemao'`.
+         */
+        owner?: string;
+
+        /**
+         * The repository name on `host`. Eg: `'conventional-changelog-writer'`.
+         */
+        repository?: string;
+
+        /**
+         * The whole repository url. Eg: `'https://github.com/conventional-changelog/conventional-changelog-writer'`.
+         * The should be used as a fallback when `context.repository` doesn't exist.
+         */
+        repoUrl?: string;
+
+        /**
+         * Should all references be linked?
+         *
+         * @default
+         * (context.repository || context.repoUrl) && context.commit && context.issue
+         */
+        linkReferences?: boolean;
+
+        /**
+         * Commit keyword in the url if `context.linkReferences === true`.
+         *
+         * @default
+         * 'commits'
+         */
+        commit?: string;
+
+        /**
+         * Issue or pull request keyword in the url if `context.linkReferences === true`.
+         *
+         * @default
+         * 'issues'
+         */
+        issue?: string;
+
+        /**
+         * Default to formatted (`'yyyy-mm-dd'`) today's date. [dateformat](https://github.com/felixge/node-dateformat)
+         * is used for formatting the date. If `version` is found in the last commit,
+         * `committerDate` will overwrite this.
+         *
+         * @default
+         * dateFormat(new Date(), 'yyyy-mm-dd', true)
+         */
+        date?: string;
+    }
+
+    interface NoteGroup {
+        title: string | false;
+        commits: Commit.Note[];
+    }
+
+    interface Options<C extends Commit = Commit> {
+        /**
+         * Replace with new values in each commit.
+         *
+         * If this is an object, the keys are paths to a nested object property. the
+         * values can be a string (static) and a function (dynamic) with the old value
+         * and path passed as arguments. This value is merged with your own transform
+         * object.
+         *
+         * If this is a function, the commit chunk will be passed as the argument and
+         * the returned value would be the new commit object. This is a handy function
+         * if you can't provide a transform stream as an upstream of this one. If
+         * returns a falsy value this commit is ignored.
+         *
+         * A `raw` object that is originally poured form upstream is attached to `commit`.
+         */
+        transform?: Options.Transform;
+
+        /**
+         * How to group the commits. EG: based on the same type. If this value is falsy,
+         * commits are not grouped.
+         *
+         * @default
+         * 'type'
+         */
+        groupBy?: string | false;
+
+        /**
+         * A compare function used to sort commit groups. If it's a string or array, it
+         * sorts on the property(ies) by `localeCompare`. Will not sort if this is a
+         * falsy value.
+         *
+         * The string can be a dot path to a nested object property.
+         */
+        commitGroupsSort?: Options.Sort<CommitGroup<C>> | false;
+
+        /**
+         * A compare function used to sort commits. If it's a string or array, it sorts
+         * on the property(ies) by `localeCompare`. Will not sort if this is a falsy
+         * value.
+         *
+         * The string can be a dot path to a nested object property.
+         *
+         * @default
+         * 'header'
+         */
+        commitsSort?: Options.Sort<TransformedCommit<C>> | false;
+
+        /**
+         * A compare function used to sort note groups. If it's a string or array, it
+         * sorts on the property(ies) by `localeCompare`. Will not sort if this is a
+         * falsy value.
+         *
+         * The string can be a dot path to a nested object property.
+         *
+         * @default
+         * 'title'
+         */
+        noteGroupsSort?: Options.Sort<NoteGroup> | false;
+
+        /**
+         * A compare function used to sort note groups. If it's a string or array, it
+         * sorts on the property(ies) by `localeCompare`. Will not sort if this is a
+         * falsy value.
+         *
+         * The string can be a dot path to a nested object property.
+         *
+         * @default
+         * 'text'
+         */
+        notesSort?: Options.Sort<Commit.Note> | false;
+
+        /**
+         * When the upstream finishes pouring the commits it will generate a block of
+         * logs if `doFlush` is `true`. However, you can generate more than one block
+         * based on this criteria (usually a version) even if there are still commits
+         * from the upstream.
+         *
+         * @remarks
+         * It checks on the transformed commit chunk instead of the original one (you
+         * can check on the original by access the `raw` object on the `commit`).
+         * However, if the transformed commit is ignored it falls back to the original
+         * commit.
+         *
+         * @remarks
+         * If this value is a `string`, it checks the existence of the field. Set to
+         * other type to disable it.
+         *
+         * @default
+         * function (commit) {
+         *   return semverValid(commit.version)
+         * }
+         */
+        generateOn?: Options.GenerateOn | object;
+
+        /**
+         * Last chance to modify your context before generating a changelog.
+         *
+         * @default
+         * function (context) {
+         *   return context
+         * }
+         */
+        finalizeContext?: Options.FinalizeContext;
+
+        /**
+         * A function to get debug information.
+         *
+         * @default
+         * function () {}
+         */
+        debug?: (message?: any) => void;
+
+        /**
+         * The normal order means reverse chronological order. `reverse` order means
+         * chronological order. Are the commits from upstream in the reverse order? You
+         * should only worry about this when generating more than one blocks of logs
+         * based on `generateOn`. If you find the last commit is in the wrong block
+         * inverse this value.
+         *
+         * @default
+         * false
+         */
+        reverse?: boolean;
+
+        /**
+         * If this value is `true`, instead of emitting strings of changelog, it emits
+         * objects containing the details the block.
+         *
+         * @remarks
+         * The downstream must be in object mode if this is `true`.
+         *
+         * @default
+         * false
+         */
+        includeDetails?: boolean;
+
+        /**
+         * If `true`, reverted commits will be ignored.
+         *
+         * @default
+         * true
+         */
+        ignoreReverted?: boolean;
+
+        /**
+         * If `true`, the stream will flush out the last bit of commits (could be empty)
+         * to changelog.
+         *
+         * @default
+         * true
+         */
+        doFlush?: boolean;
+
+        /**
+         * The main handlebars template.
+         *
+         * @remarks
+         * Default template: [template.hbs](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-writer/templates/template.hbs)
+         */
+        mainTemplate?: string;
+
+        /**
+         * @remarks
+         * Default template: [header.hbs](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-writer/templates/header.hbs)
+         */
+        headerPartial?: string;
+
+        /**
+         * @remarks
+         * Default template: [commit.hbs](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-writer/templates/commit.hbs)
+         */
+        commitPartial?: string;
+
+        /**
+         * @remarks
+         * Default template: [footer.hbs](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-writer/templates/footer.hbs)
+         */
+        footerPartial?: string;
+
+        /**
+         * Partials that used in the main template, if any. The key should be the
+         * partial name and the value should be handlebars template strings. If you are
+         * using handlebars template files, read files by yourself.
+         */
+        partials?: Record<string, string>;
+    }
+
+    namespace Options {
+        interface FinalizeContext<C extends Commit = Commit> {
+            /**
+             * @param context   The generated context based on original input `context` and
+             *                  `options`.
+             * @param options   Normalized options.
+             * @param commits   Filtered commits from your git metadata.
+             * @param keyCommit The commit that triggers to generate the log.
+             */
+            (context: Context, options: Options, commits: Array<TransformedCommit<C>>, keyCommit: TransformedCommit<C>): Context;
+        }
+
+        type GenerateOn<C extends Commit = Commit> = GenerateOn.Function<C> | string;
+
+        namespace GenerateOn {
+            interface GenerateOnFunction<C extends Commit = Commit> {
+                /**
+                 * @param commit  Current commit.
+                 * @param commits Current collected commits.
+                 * @param context The generated context based on original input `context` and
+                 *                `options`.
+                 * @param options Normalized options.
+                 */
+                (commit: TransformedCommit<C>, commits: Array<TransformedCommit<C>>, context: Context, options: Options): boolean;
+            }
+
+            export {
+                GenerateOnFunction as Function,
+            };
+        }
+
+        type Sort<T = any> = Sort.Function | string | ReadonlyArray<string>;
+
+        namespace Sort {
+            type SortFunction<T = any> = (a: T, b: T) => number;
+
+            export {
+                SortFunction as Function,
+            };
+        }
+
+        type Transform<C extends Commit = Commit> = Transform.Object | Transform.Function<C>;
+
+        namespace Transform {
+            type TransformFunction<C extends Commit = Commit> = (commit: C, context: Context) => C | false;
+
+            type TransformObject = Record<string, object | TransformObject.Function>;
+
+            namespace TransformObject {
+                type TransformObjectFunction<T = any> = (value: T, path: string) => T;
+
+                export {
+                    TransformObjectFunction as Function,
+                };
+            }
+
+            export {
+                TransformFunction as Function,
+                TransformObject as Object,
+            };
+        }
+    }
+
+    type TransformedCommit<C extends Commit = Commit> = Omit<C, "raw"> & { raw: C; };
+}
+
+type Omit<T, K extends string | number | symbol> = { [P in Exclude<keyof T, K>]: T[P]; };
+
+export = conventionalChangelogWriter;

--- a/types/conventional-changelog-writer/index.d.ts
+++ b/types/conventional-changelog-writer/index.d.ts
@@ -323,7 +323,7 @@ declare namespace conventionalChangelogWriter {
         type GenerateOn<TContext extends Context = Context, TCommit extends Commit = Commit> = GenerateOn.Function<TContext, TCommit> | string | object;
 
         namespace GenerateOn {
-            interface IFunction<TContext extends Context = Context, TCommit extends Commit = Commit> {
+            interface FunctionType<TContext extends Context = Context, TCommit extends Commit = Commit> {
                 /**
                  * @param commit  Current commit.
                  * @param commits Current collected commits.
@@ -335,40 +335,40 @@ declare namespace conventionalChangelogWriter {
             }
 
             export {
-                IFunction as Function,
+                FunctionType as Function,
             };
         }
 
         type Sort<T = any> = Sort.Function<T> | string | ReadonlyArray<string> | false;
 
         namespace Sort {
-            type SortFunction<T = any> = (a: T, b: T) => number;
+            type FunctionType<T = any> = (a: T, b: T) => number;
 
             export {
-                SortFunction as Function,
+                FunctionType as Function,
             };
         }
 
         type Transform<TCommit extends Commit = Commit, TContext extends Context = Context> = Transform.Object | Transform.Function<TCommit, TContext>;
 
         namespace Transform {
-            interface TransformFunction<TCommit extends Commit = Commit, TContext extends Context = Context> {
+            interface FunctionType<TCommit extends Commit = Commit, TContext extends Context = Context> {
                 (commit: Commit, context: TContext): TCommit | false;
             }
 
-            type TransformObject = Record<string, object | TransformObject.Function>;
+            type ObjectType = Record<string, object | ObjectType.Function>;
 
-            namespace TransformObject {
-                type TransformObjectFunction<T = any> = (value: T, path: string) => T;
+            namespace ObjectType {
+                type FunctionType<T = any> = (value: T, path: string) => T;
 
                 export {
-                    TransformObjectFunction as Function,
+                    FunctionType as Function,
                 };
             }
 
             export {
-                TransformFunction as Function,
-                TransformObject as Object,
+                FunctionType as Function,
+                ObjectType as Object,
             };
         }
     }

--- a/types/conventional-changelog-writer/index.d.ts
+++ b/types/conventional-changelog-writer/index.d.ts
@@ -138,7 +138,7 @@ declare namespace conventionalChangelogWriter {
          *
          * The string can be a dot path to a nested object property.
          */
-        commitGroupsSort?: Options.Sort<CommitGroup<C>> | false;
+        commitGroupsSort?: Options.Sort<CommitGroup<C>>;
 
         /**
          * A compare function used to sort commits. If it's a string or array, it sorts
@@ -150,7 +150,7 @@ declare namespace conventionalChangelogWriter {
          * @default
          * 'header'
          */
-        commitsSort?: Options.Sort<TransformedCommit<C>> | false;
+        commitsSort?: Options.Sort<TransformedCommit<C>>;
 
         /**
          * A compare function used to sort note groups. If it's a string or array, it
@@ -162,7 +162,7 @@ declare namespace conventionalChangelogWriter {
          * @default
          * 'title'
          */
-        noteGroupsSort?: Options.Sort<NoteGroup> | false;
+        noteGroupsSort?: Options.Sort<NoteGroup>;
 
         /**
          * A compare function used to sort note groups. If it's a string or array, it
@@ -174,7 +174,7 @@ declare namespace conventionalChangelogWriter {
          * @default
          * 'text'
          */
-        notesSort?: Options.Sort<Commit.Note> | false;
+        notesSort?: Options.Sort<Commit.Note>;
 
         /**
          * When the upstream finishes pouring the commits it will generate a block of
@@ -197,7 +197,7 @@ declare namespace conventionalChangelogWriter {
          *   return semverValid(commit.version)
          * }
          */
-        generateOn?: Options.GenerateOn | object;
+        generateOn?: Options.GenerateOn;
 
         /**
          * Last chance to modify your context before generating a changelog.
@@ -304,7 +304,7 @@ declare namespace conventionalChangelogWriter {
             (context: Context, options: Options, commits: Array<TransformedCommit<C>>, keyCommit: TransformedCommit<C>): Context;
         }
 
-        type GenerateOn<C extends Commit = Commit> = GenerateOn.Function<C> | string;
+        type GenerateOn<C extends Commit = Commit> = GenerateOn.Function<C> | string | object;
 
         namespace GenerateOn {
             interface GenerateOnFunction<C extends Commit = Commit> {
@@ -323,7 +323,7 @@ declare namespace conventionalChangelogWriter {
             };
         }
 
-        type Sort<T = any> = Sort.Function | string | ReadonlyArray<string>;
+        type Sort<T = any> = Sort.Function | string | ReadonlyArray<string> | false;
 
         namespace Sort {
             type SortFunction<T = any> = (a: T, b: T) => number;

--- a/types/conventional-changelog-writer/tsconfig.json
+++ b/types/conventional-changelog-writer/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "conventional-changelog-writer-tests.ts"
+    ]
+}

--- a/types/conventional-changelog-writer/tslint.json
+++ b/types/conventional-changelog-writer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/conventional-commits-parser/conventional-commits-parser-tests.ts
+++ b/types/conventional-commits-parser/conventional-commits-parser-tests.ts
@@ -11,10 +11,10 @@ conventionalCommitsParser();
 // $ExpectType Transform
 conventionalCommitsParser(options);
 
-// $ExpectType Commit
+// $ExpectType Commit<string | number | symbol>
 conventionalCommitsParser.sync(commit);
 
-// $ExpectType Commit
+// $ExpectType Commit<string | number | symbol>
 conventionalCommitsParser.sync(commit, options);
 
 // $ExpectError

--- a/types/conventional-commits-parser/conventional-commits-parser-tests.ts
+++ b/types/conventional-commits-parser/conventional-commits-parser-tests.ts
@@ -1,24 +1,70 @@
+/* tslint:disable:no-mergeable-namespace no-namespace */
 "use strict";
 
 import conventionalCommitsParser from "conventional-commits-parser";
 
-declare const commit: string;
-declare const options: conventionalCommitsParser.Options;
+namespace Test {
+    declare const options: conventionalCommitsParser.Options;
 
-// $ExpectType Transform
-conventionalCommitsParser();
+    conventionalCommitsParser(); // $ExpectType Transform
+    conventionalCommitsParser(options); // $ExpectType Transform
+}
 
-// $ExpectType Transform
-conventionalCommitsParser(options);
+namespace Test.sync {
+    declare const commit: string;
+    declare const options: conventionalCommitsParser.Options;
 
-// $ExpectType Commit<string | number | symbol>
-conventionalCommitsParser.sync(commit);
+    conventionalCommitsParser.sync(commit); // $ExpectType Commit<string | number | symbol>
+    conventionalCommitsParser.sync(commit, options); // $ExpectType Commit<string | number | symbol>
+}
 
-// $ExpectType Commit<string | number | symbol>
-conventionalCommitsParser.sync(commit, options);
+namespace Test.Commit {
+    namespace Case01 {
+        declare const commit: conventionalCommitsParser.Commit;
 
-// $ExpectError
-conventionalCommitsParser.sync(options);
+        // $ExpectType Commit<string | number | symbol>
+        commit;
+        commit.body; // $ExpectType Field
+        commit.footer; // $ExpectType Field
+        commit.header; // $ExpectType Field
+        commit.mentions; // $ExpectType string[]
+        commit.merge; // $ExpectType Field
+        commit.notes; // $ExpectType Note[]
+        commit.references; // $ExpectType Reference[]
+        commit.revert; // $ExpectType Revert | null
+        commit.scope; // $ExpectType string | null | undefined
+        commit.subject; // $ExpectType string | null | undefined
+        commit.type; // $ExpectType string | null | undefined
+    }
+}
 
-// $ExpectError
-conventionalCommitsParser.sync(options, commit);
+namespace Test.Commit.Note {
+    declare const note: conventionalCommitsParser.Commit.Note;
+
+    // $ExpectType Note
+    note;
+    note.text; // $ExpectType string
+    note.title; // $ExpectType string
+}
+
+namespace Test.Commit.Reference {
+    declare const reference: conventionalCommitsParser.Commit.Reference;
+
+    // $ExpectType Reference
+    reference;
+    reference.action; // $ExpectType Field
+    reference.issue; // $ExpectType string
+    reference.owner; // $ExpectType Field
+    reference.prefix; // $ExpectType string
+    reference.raw; // $ExpectType string
+    reference.repository; // $ExpectType Field
+}
+
+namespace Test.Commit.Revert {
+    declare const revert: conventionalCommitsParser.Commit.Revert;
+
+    // $ExpectType Revert
+    revert;
+    revert.hash; // $ExpectType string | null | undefined
+    revert.header; // $ExpectType string | null | undefined
+}

--- a/types/conventional-commits-parser/conventional-commits-parser-tests.ts
+++ b/types/conventional-commits-parser/conventional-commits-parser-tests.ts
@@ -1,0 +1,24 @@
+"use strict";
+
+import conventionalCommitsParser from "conventional-commits-parser";
+
+declare const commit: string;
+declare const options: conventionalCommitsParser.Options;
+
+// $ExpectType Transform
+conventionalCommitsParser();
+
+// $ExpectType Transform
+conventionalCommitsParser(options);
+
+// $ExpectType Commit
+conventionalCommitsParser.sync(commit);
+
+// $ExpectType Commit
+conventionalCommitsParser.sync(commit, options);
+
+// $ExpectError
+conventionalCommitsParser.sync(options);
+
+// $ExpectError
+conventionalCommitsParser.sync(options, commit);

--- a/types/conventional-commits-parser/conventional-commits-parser-tests.ts
+++ b/types/conventional-commits-parser/conventional-commits-parser-tests.ts
@@ -3,14 +3,14 @@
 
 import conventionalCommitsParser from "conventional-commits-parser";
 
-namespace Test {
+namespace Module {
     declare const options: conventionalCommitsParser.Options;
 
     conventionalCommitsParser(); // $ExpectType Transform
     conventionalCommitsParser(options); // $ExpectType Transform
 }
 
-namespace Test.sync {
+namespace Module.sync {
     declare const commit: string;
     declare const options: conventionalCommitsParser.Options;
 
@@ -18,7 +18,7 @@ namespace Test.sync {
     conventionalCommitsParser.sync(commit, options); // $ExpectType Commit<string | number | symbol>
 }
 
-namespace Test.Commit {
+namespace Module.Commit {
     namespace Case01 {
         declare const commit: conventionalCommitsParser.Commit;
 
@@ -38,7 +38,7 @@ namespace Test.Commit {
     }
 }
 
-namespace Test.Commit.Note {
+namespace Module.Commit.Note {
     declare const note: conventionalCommitsParser.Commit.Note;
 
     // $ExpectType Note
@@ -47,7 +47,7 @@ namespace Test.Commit.Note {
     note.title; // $ExpectType string
 }
 
-namespace Test.Commit.Reference {
+namespace Module.Commit.Reference {
     declare const reference: conventionalCommitsParser.Commit.Reference;
 
     // $ExpectType Reference
@@ -60,7 +60,7 @@ namespace Test.Commit.Reference {
     reference.repository; // $ExpectType Field
 }
 
-namespace Test.Commit.Revert {
+namespace Module.Commit.Revert {
     declare const revert: conventionalCommitsParser.Commit.Revert;
 
     // $ExpectType Revert

--- a/types/conventional-commits-parser/index.d.ts
+++ b/types/conventional-commits-parser/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#readme
 // Definitions by: Jason Kwok <https://github.com/JasonHK>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.7
+// TypeScript Version: 2.9
 
 /// <reference types="node" />
 
@@ -25,7 +25,47 @@ declare namespace conventionalCommitsParser {
      */
     function sync(commit: string, options?: Options): Commit;
 
-    interface Commit {
+    type Commit<Fields extends string | number | symbol = string | number | symbol> = CommitBase & { [Field in Exclude<Fields, keyof CommitBase>]?: Commit.Field };
+
+    namespace Commit {
+        type Field = string | null;
+
+        interface Note {
+            title: string;
+            text: string;
+        }
+
+        interface Reference {
+            issue: string;
+
+            /**
+             * @default
+             * null
+             */
+            action: Field;
+
+            /**
+             * @default
+             * null
+             */
+            owner: Field;
+
+            /**
+             * @default
+             * null
+             */
+            repository: Field;
+
+            prefix: string;
+            raw: string;
+        }
+
+        interface Revert {
+            [field: string]: Field;
+        }
+    }
+
+    interface CommitBase {
         /**
          * @default
          * null
@@ -77,44 +117,6 @@ declare namespace conventionalCommitsParser {
         type?: Commit.Field;
         scope?: Commit.Field;
         subject?: Commit.Field;
-    }
-
-    namespace Commit {
-        type Field = string | null;
-
-        interface Note {
-            title: string;
-            text: string;
-        }
-
-        interface Reference {
-            issue: string;
-
-            /**
-             * @default
-             * null
-             */
-            action: Field;
-
-            /**
-             * @default
-             * null
-             */
-            owner: Field;
-
-            /**
-             * @default
-             * null
-             */
-            repository: Field;
-
-            prefix: string;
-            raw: string;
-        }
-
-        interface Revert {
-            [field: string]: Field;
-        }
     }
 
     interface Options {
@@ -294,6 +296,12 @@ declare namespace conventionalCommitsParser {
 
         type Prefixes = string[] | string | null;
     }
+
+    export {
+        Commit,
+        Options,
+        sync,
+    };
 }
 
 export = conventionalCommitsParser;

--- a/types/conventional-commits-parser/index.d.ts
+++ b/types/conventional-commits-parser/index.d.ts
@@ -1,0 +1,299 @@
+// Type definitions for conventional-commits-parser 3.0
+// Project: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#readme
+// Definitions by: Jason Kwok <https://github.com/JasonHK>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+/// <reference types="node" />
+
+import * as Stream from "stream";
+
+/**
+ * Returns an transform stream. If there is any malformed commits it will be
+ * gracefully ignored (an empty data will be emitted so down stream can notice).
+ *
+ * @param options
+ */
+declare function conventionalCommitsParser(options?: conventionalCommitsParser.Options): Stream.Transform;
+
+declare namespace conventionalCommitsParser {
+    /**
+     * The sync version. Useful when parsing a single commit. Returns the result.
+     *
+     * @param commit  A single commit to be parsed.
+     * @param options Same as the `options` of `conventionalCommitsParser`.
+     */
+    function sync(commit: string, options?: Options): Commit;
+
+    interface Commit {
+        /**
+         * @default
+         * null
+         */
+        merge: Commit.Field;
+
+        /**
+         * @default
+         * null
+         */
+        header: Commit.Field;
+
+        /**
+         * @default
+         * null
+         */
+        body: Commit.Field;
+
+        /**
+         * @default
+         * null
+         */
+        footer: Commit.Field;
+
+        /**
+         * @default
+         * []
+         */
+        notes: Commit.Note[];
+
+        /**
+         * @default
+         * []
+         */
+        references: Commit.Reference[];
+
+        /**
+         * @default
+         * []
+         */
+        mentions: string[];
+
+        /**
+         * @default
+         * null
+         */
+        revert: Commit.Revert | null;
+
+        type?: Commit.Field;
+        scope?: Commit.Field;
+        subject?: Commit.Field;
+    }
+
+    namespace Commit {
+        type Field = string | null;
+
+        interface Note {
+            title: string;
+            text: string;
+        }
+
+        interface Reference {
+            issue: string;
+
+            /**
+             * @default
+             * null
+             */
+            action: Field;
+
+            /**
+             * @default
+             * null
+             */
+            owner: Field;
+
+            /**
+             * @default
+             * null
+             */
+            repository: Field;
+
+            prefix: string;
+            raw: string;
+        }
+
+        interface Revert {
+            [field: string]: Field;
+        }
+    }
+
+    interface Options {
+        /**
+         * Pattern to match merge headers. EG: branch merge, GitHub or GitLab like pull
+         * requests headers. When a merge header is parsed, the next line is used for
+         * conventional header parsing.
+         *
+         * For example, if we have a commit
+         *
+         * ```text
+         * Merge pull request #1 from user/feature/feature-name
+         *
+         * feat(scope): broadcast $destroy event on scope destruction
+         * ```
+         *
+         * We can parse it with these options and the default headerPattern:
+         *
+         * ```javascript
+         * {
+         *  mergePattern: /^Merge pull request #(\d+) from (.*)$/,
+         *  mergeCorrespondence: ['id', 'source']
+         * }
+         * ```
+         *
+         * @default
+         * null
+         */
+        mergePattern?: Options.Pattern;
+
+        /**
+         * Used to define what capturing group of `mergePattern`.
+         *
+         * If it's a `string` it will be converted to an `array` separated by a comma.
+         *
+         * @default
+         * null
+         */
+        mergeCorrespondence?: Options.Correspondence;
+
+        /**
+         * Used to match header pattern.
+         *
+         * @default
+         * /^(\w*)(?:\(([\w\$\.\-\* ]*)\))?\: (.*)$/
+         */
+        headerPattern?: Options.Pattern;
+
+        /**
+         * Used to define what capturing group of `headerPattern` captures what header
+         * part. The order of the array should correspond to the order of
+         * `headerPattern`'s capturing group. If the part is not captured it is `null`.
+         * If it's a `string` it will be converted to an `array` separated by a comma.
+         *
+         * @default
+         * ['type', 'scope', 'subject']
+         */
+        headerCorrespondence?: Options.Correspondence;
+
+        /**
+         * Keywords to reference an issue. This value is case __insensitive__. If it's a
+         * `string` it will be converted to an `array` separated by a comma.
+         *
+         * Set it to `null` to reference an issue without any action.
+         *
+         * @default
+         * ['close', 'closes', 'closed', 'fix', 'fixes', 'fixed', 'resolve', 'resolves', 'resolved']
+         */
+        referenceActions?: Options.Actions;
+
+        /**
+         * The prefixes of an issue. EG: In `gh-123` `gh-` is the prefix.
+         *
+         * @default
+         * ['#']
+         */
+        issuePrefixes?: Options.Prefixes;
+
+        /**
+         * Used to define if `issuePrefixes` should be considered case sensitive.
+         *
+         * @default
+         * false
+         */
+        issuePrefixesCaseSensitive?: boolean;
+
+        /**
+         * Keywords for important notes. This value is case __insensitive__. If it's a
+         * `string` it will be converted to an `array` separated by a comma.
+         *
+         * @default
+         * ['BREAKING CHANGE']
+         */
+        noteKeywords?: Options.Keywords;
+
+        /**
+         * Pattern to match other fields.
+         *
+         * @default
+         * /^-(.*?)-$/
+         */
+        fieldPattern?: Options.Pattern;
+
+        /**
+         * Pattern to match what this commit reverts.
+         *
+         * @default
+         * /^Revert\s"([\s\S]*)"\s*This reverts commit (\w*)\./
+         */
+        revertPattern?: Options.Pattern;
+
+        /**
+         * Used to define what capturing group of `revertPattern` captures what reverted
+         * commit fields. The order of the array should correspond to the order of
+         * `revertPattern`'s capturing group.
+         *
+         * For example, if we had commit
+         *
+         * ```
+         * Revert "throw an error if a callback is passed"
+         *
+         * This reverts commit 9bb4d6c.
+         * ```
+         *
+         * If configured correctly, the parsed result would be
+         *
+         * ```
+         * {
+         *  revert: {
+         *    header: 'throw an error if a callback is passed',
+         *    hash: '9bb4d6c'
+         *  }
+         * }
+         * ```
+         *
+         * It implies that this commit reverts a commit with header `'throw an error if
+         * a callback is passed'` and hash `'9bb4d6c'`.
+         *
+         * If it's a `string` it will be converted to an `array` separated by a comma.
+         *
+         * @default
+         * ['header', 'hash']
+         */
+        revertCorrespondence?: Options.Correspondence;
+
+        /**
+         * What commentChar to use. By default it is `null`, so no comments are stripped.
+         * Set to `#` if you pass the contents of `.git/COMMIT_EDITMSG` directly.
+         *
+         * If you have configured the git commentchar via git config `core.commentchar`
+         * you'll want to pass what you have set there.
+         *
+         * @default
+         * null
+         */
+        commentChar?: string | null;
+
+        /**
+         * What warn function to use. For example, `console.warn.bind(console)` or
+         * `grunt.log.writeln`. By default, it's a noop. If it is `true`, it will error
+         * if commit cannot be parsed (strict).
+         *
+         * @default
+         * function () {}
+         */
+        warn?: (message?: any) => void | boolean;
+    }
+
+    namespace Options {
+        type Actions = string[] | string | null;
+
+        type Correspondence = string[] | string | null;
+
+        type Keywords = string[] | string | null;
+
+        type Pattern = RegExp | string | null;
+
+        type Prefixes = string[] | string | null;
+    }
+}
+
+export = conventionalCommitsParser;

--- a/types/conventional-commits-parser/index.d.ts
+++ b/types/conventional-commits-parser/index.d.ts
@@ -287,13 +287,9 @@ declare namespace conventionalCommitsParser {
 
     namespace Options {
         type Actions = string[] | string | null;
-
         type Correspondence = string[] | string | null;
-
         type Keywords = string[] | string | null;
-
         type Pattern = RegExp | string | null;
-
         type Prefixes = string[] | string | null;
     }
 

--- a/types/conventional-commits-parser/index.d.ts
+++ b/types/conventional-commits-parser/index.d.ts
@@ -61,7 +61,9 @@ declare namespace conventionalCommitsParser {
         }
 
         interface Revert {
-            [field: string]: Field;
+            hash?: Field;
+            header?: Field;
+            [field: string]: Field | undefined;
         }
     }
 

--- a/types/conventional-commits-parser/tsconfig.json
+++ b/types/conventional-commits-parser/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "conventional-commits-parser-tests.ts"
+    ]
+}

--- a/types/conventional-commits-parser/tslint.json
+++ b/types/conventional-commits-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/conventional-recommended-bump/conventional-recommended-bump-tests.ts
+++ b/types/conventional-recommended-bump/conventional-recommended-bump-tests.ts
@@ -1,0 +1,65 @@
+/* tslint:disable:no-mergeable-namespace no-namespace */
+"use strict";
+
+import conventionalCommitsParser from "conventional-commits-parser";
+import conventionalRecommendedBump from "conventional-recommended-bump";
+
+namespace Test {
+    declare const callback: conventionalRecommendedBump.Callback;
+    declare const options: conventionalRecommendedBump.Options;
+    declare const parserOpts: conventionalCommitsParser.Options;
+
+    // $ExpectType void
+    conventionalRecommendedBump(options, callback);
+    // $ExpectType void
+    conventionalRecommendedBump(options, parserOpts, callback);
+
+    // $ExpectError
+    conventionalRecommendedBump();
+}
+
+namespace Test.Callback {
+    const callback: conventionalRecommendedBump.Callback = (error, recommendation) => {
+        // $ExpectType any
+        error;
+
+        // $ExpectType Recommendation
+        recommendation;
+        recommendation.level; // $ExpectType number | undefined
+        recommendation.reason; // $ExpectType string | undefined
+        recommendation.releaseType; // $ExpectType "major" | "minor" | "patch" | undefined
+    };
+}
+
+namespace Test.Options {
+    declare const options: conventionalRecommendedBump.Options;
+
+    // $ExpectType Options
+    options;
+    // tslint:disable-next-line max-line-length
+    options.ignoreReverted; // $ExpectType boolean | undefined
+    options.lernaPackage; // $ExpectType string | undefined
+    options.preset; // $ExpectType string | undefined
+    options.tagPrefix; // $ExpectType string | undefined
+    options.whatBump; // $ExpectType WhatBump | undefined
+}
+
+namespace Test.Options.WhatBump {
+    declare const commits: conventionalCommitsParser.Commit[];
+    declare const whatBump: conventionalRecommendedBump.Options.WhatBump;
+
+    // $ExpectType Result
+    whatBump(commits);
+
+    // $ExpectError
+    whatBump();
+}
+
+namespace Test.Options.WhatBump.Result {
+    declare const result: conventionalRecommendedBump.Options.WhatBump.Result;
+
+    // $ExpectType Result
+    result;
+    result.level; // $ExpectType number | undefined
+    result.reason; // $ExpectType string | undefined
+}

--- a/types/conventional-recommended-bump/conventional-recommended-bump-tests.ts
+++ b/types/conventional-recommended-bump/conventional-recommended-bump-tests.ts
@@ -4,7 +4,7 @@
 import conventionalCommitsParser from "conventional-commits-parser";
 import conventionalRecommendedBump from "conventional-recommended-bump";
 
-namespace Test {
+namespace Module {
     declare const callback: conventionalRecommendedBump.Callback;
     declare const options: conventionalRecommendedBump.Options;
     declare const parserOpts: conventionalCommitsParser.Options;
@@ -18,7 +18,7 @@ namespace Test {
     conventionalRecommendedBump();
 }
 
-namespace Test.Callback {
+namespace Module.Callback {
     const callback: conventionalRecommendedBump.Callback = (error, recommendation) => {
         // $ExpectType any
         error;
@@ -31,7 +31,7 @@ namespace Test.Callback {
     };
 }
 
-namespace Test.Options {
+namespace Module.Options {
     declare const options: conventionalRecommendedBump.Options;
 
     // $ExpectType Options
@@ -44,7 +44,7 @@ namespace Test.Options {
     options.whatBump; // $ExpectType WhatBump | undefined
 }
 
-namespace Test.Options.WhatBump {
+namespace Module.Options.WhatBump {
     declare const commits: conventionalCommitsParser.Commit[];
     declare const whatBump: conventionalRecommendedBump.Options.WhatBump;
 
@@ -55,7 +55,7 @@ namespace Test.Options.WhatBump {
     whatBump();
 }
 
-namespace Test.Options.WhatBump.Result {
+namespace Module.Options.WhatBump.Result {
     declare const result: conventionalRecommendedBump.Options.WhatBump.Result;
 
     // $ExpectType Result

--- a/types/conventional-recommended-bump/index.d.ts
+++ b/types/conventional-recommended-bump/index.d.ts
@@ -1,0 +1,165 @@
+// Type definitions for conventional-recommended-bump 6.0
+// Project: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-recommended-bump#readme
+// Definitions by: Jason Kwok <https://github.com/JasonHK>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
+
+import { Options as CoreOptions } from "conventional-changelog-core";
+import { Commit, Options as ParserOptions } from "conventional-commits-parser";
+import { Context as WriterContext } from "conventional-changelog-writer";
+
+/**
+ * @param options  `options` is an object with the following properties:
+ *
+ *                 * `ignoreReverted`
+ *                 * `preset`
+ *                 * `config`
+ *                 * `whatBump`
+ * @param callback
+ */
+declare function conventionalRecommendedBump(options: Options, callback: Callback): void;
+
+/**
+ *
+ * @param options    `options` is an object with the following properties:
+ *
+ *                   * `ignoreReverted`
+ *                   * `preset`
+ *                   * `config`
+ *                   * `whatBump`
+ * @param parserOpts See the [conventional-commits-parser](https://github.com/conventional-changelog/conventional-commits-parser)
+ *                   documentation for available options.
+ * @param callback
+ */
+declare function conventionalRecommendedBump(options: Options, parserOpts: ParserOptions, callback: Callback): void;
+
+declare namespace conventionalRecommendedBump {
+    /**
+     * `recommendation` is an `object` with a single property, `releaseType`.
+     *
+     * `releaseType` is a `string`: Possible values: `major`, `minor` and `patch`,
+     * or `undefined` if `whatBump` does not return a valid `level` property, or
+     * the `level` property is not set by `whatBump`.
+     */
+    interface Callback {
+        /**
+         * @param error
+         * @param recommendation `recommendation` is an `object` with a single property,
+         *                       `releaseType`.
+         */
+        (error: any, recommendation: Callback.Recommendation): void;
+    }
+
+    namespace Callback {
+        /**
+         * `recommendation` is an `object` with a single property, `releaseType`.
+         *
+         * `releaseType` is a `string`: Possible values: `major`, `minor` and `patch`,
+         * or `undefined` if `whatBump` does not return a valid `level` property, or
+         * the `level` property is not set by `whatBump`.
+         */
+        interface Recommendation extends Options.WhatBump.Result {
+            /**
+             * `releaseType` is a `string`: Possible values: `major`, `minor` and `patch`,
+             * or `undefined` if `whatBump` does not return a valid `level` property, or
+             * the `level` property is not set by `whatBump`.
+             */
+            releaseType?: Recommendation.ReleaseType;
+        }
+
+        namespace Recommendation {
+            type ReleaseType = "major" | "minor" | "patch";
+        }
+    }
+
+    /**
+     * `options` is an object with the following properties:
+     * * `ignoreReverted`
+     * * `preset`
+     * * `config`
+     * * `whatBump`
+     */
+    interface Options {
+        /**
+         * If `true`, reverted commits will be ignored.
+         *
+         * @default
+         * true
+         */
+        ignoreReverted?: boolean;
+
+        /**
+         * It's recommended to use a preset so you don't have to define everything
+         * yourself.
+         *
+         * The value is passed to [`conventional-changelog-preset-loader`](https://www.npmjs.com/package/conventional-changelog-preset-loader).
+         */
+        preset?: string;
+
+        /**
+         * This should serve as default values for other arguments of
+         * `conventional-recommended-bump` so you don't need to rewrite the same or
+         * similar config across your projects.
+         *
+         * @remarks
+         * `config` option will be overwritten by the value loaded by
+         * `conventional-changelog-preset-loader` if the `preset` options is set.
+         */
+        config?: CoreOptions.Config<Commit, WriterContext>;
+
+        /**
+         * A function that takes parsed commits as an argument.
+         *
+         * ```
+         * whatBump(commits) {};
+         * ```
+         *
+         * `commits` is an array of all commits from last semver tag to `HEAD` as parsed
+         * by `conventional-commits-parser`.
+         *
+         * This should return an object including but not limited to `level` and `reason`.
+         * `level` is a `number` indicating what bump it should be and `reason` is the
+         * reason of such release.
+         */
+        whatBump?: Options.WhatBump;
+
+        /**
+         * Specify a prefix for the git tag that will be taken into account during the
+         * comparison.
+         *
+         * For instance if your version tag is prefixed by `version/` instead of `v` you
+         * would specifying `--tagPrefix=version/` using the CLI, or `version/` as the
+         * value of the `tagPrefix` option.
+         */
+        tagPrefix?: string;
+
+        /**
+         * Specify the name of a package in a [Lerna](https://lernajs.io/)-managed
+         * repository. The package name will be used when fetching all changes to a
+         * package since the last time that package was released.
+         *
+         * For instance if your project contained a package named
+         * `conventional-changelog`, you could have only commits that have happened
+         * since the last release of `conventional-changelog` was tagged by
+         * specifying `--lernaPackage=conventional-changelog` using the CLI, or
+         * `conventional-changelog` as the value of the `lernaPackage` option.
+         */
+        lernaPackage?: string;
+    }
+
+    namespace Options {
+        type WhatBump = (commits: Commit[]) => WhatBump.Result;
+
+        namespace WhatBump {
+            interface Result {
+                level?: number;
+                reason?: string;
+            }
+        }
+    }
+}
+
+type Callback = conventionalRecommendedBump.Callback;
+type Options = conventionalRecommendedBump.Options;
+
+export = conventionalRecommendedBump;

--- a/types/conventional-recommended-bump/tsconfig.json
+++ b/types/conventional-recommended-bump/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "conventional-recommended-bump-tests.ts"
+    ]
+}

--- a/types/conventional-recommended-bump/tslint.json
+++ b/types/conventional-recommended-bump/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/git-raw-commits/git-raw-commits-tests.ts
+++ b/types/git-raw-commits/git-raw-commits-tests.ts
@@ -1,0 +1,18 @@
+"use strict";
+
+import gitRawCommits from "git-raw-commits";
+
+declare const execOptions: gitRawCommits.ExecOptions;
+declare const gitOptions: gitRawCommits.GitOptions;
+
+// $ExpectType Readable
+gitRawCommits(gitOptions);
+
+// $ExpectType Readable
+gitRawCommits(gitOptions, execOptions);
+
+// $ExpectError
+gitRawCommits();
+
+// $ExpectError
+gitRawCommits(execOptions, gitOptions);

--- a/types/git-raw-commits/index.d.ts
+++ b/types/git-raw-commits/index.d.ts
@@ -1,0 +1,84 @@
+// Type definitions for git-raw-commits 2.0
+// Project: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/git-raw-commits#readme
+// Definitions by: Jason Kwok <https://github.com/JasonHK>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+/// <reference types="node" />
+
+import * as Stream from "stream";
+
+/**
+ * Returns a readable stream. Stream is split to break on each commit.
+ *
+ * @param gitOpts
+ * @param execOpts Options to pass to `git` `childProcess`.
+ */
+declare function gitRawCommits(gitOptions: gitRawCommits.GitOptions, execOptions?: gitRawCommits.ExecOptions): Stream.Readable;
+
+declare namespace gitRawCommits {
+    /**
+     * Options to pass to `git` `childProcess`.
+     */
+    interface ExecOptions {
+        /**
+         * Current working directory to execute git in.
+         */
+        cwd?: string;
+    }
+
+    /**
+     * Please check the available options at http://git-scm.com/docs/git-log.
+     *
+     * @remarks
+     * Single dash arguments are not supported because of https://github.com/sindresorhus/dargs/blob/master/index.js#L5.
+     *
+     * @remarks
+     * For `<revision range>` we can also use `<from>..<to>` pattern, and this
+     * module has the following extra options for shortcut of this pattern:
+     *
+     * * `from`
+     * * `to`
+     *
+     * This module also have the following additions:
+     *
+     * * `format`
+     * * `debug`
+     * * `path`
+     */
+    interface GitOptions {
+        /**
+         * @default
+         * ''
+         */
+        from?: string;
+
+        /**
+         * @default
+         * 'HEAD'
+         */
+        to?: string;
+
+        /**
+         * Please check http://git-scm.com/docs/git-log for format options.
+         *
+         * @default
+         * '%B'
+         */
+        format?: string;
+
+        /**
+         * A function to get debug information.
+         */
+        debug?: (message: any) => void;
+
+        /**
+         * Filter commits to the path provided.
+         */
+        path?: string;
+
+        [options: string]: any;
+    }
+}
+
+export = gitRawCommits;

--- a/types/git-raw-commits/tsconfig.json
+++ b/types/git-raw-commits/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "git-raw-commits-tests.ts"
+    ]
+}

--- a/types/git-raw-commits/tslint.json
+++ b/types/git-raw-commits/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
