### PR TITLE
[react-select] Add NonceProvider component

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -5,6 +5,7 @@
 //                 Nathan Bierema <https://github.com/Methuselah96>
 //                 Thomas Chia <https://github.com/thchia>
 //                 Daniel Del Core <https://github.com/danieldelcore>
+//                 Joonas Rouhiainen <https://github.com/rjoonas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -16,6 +17,7 @@ export * from './src/types';
 export { createFilter } from './src/filters';
 export { mergeStyles, Styles, StylesConfig } from './src/styles';
 
+export { NonceProvider } from './src/NonceProvider';
 export { Props, FormatOptionLabelMeta } from './src/Select';
 
 export { components, SelectComponentsConfig, IndicatorComponentType } from './src/components';

--- a/types/react-select/src/NonceProvider.d.ts
+++ b/types/react-select/src/NonceProvider.d.ts
@@ -1,0 +1,7 @@
+import { Component } from 'react';
+
+export interface NonceProviderProps {
+  nonce: string;
+}
+
+export class NonceProvider extends Component<NonceProviderProps> {}


### PR DESCRIPTION
react-select provides this simple wrapper for emotion's CacheProvider. See https://github.com/JedWatson/react-select/blob/e04ed3eab3246ef5552fcd2b9c266f6154446a4b/packages/react-select/src/NonceProvider.js

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

----

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/react-select/blob/e04ed3eab3246ef5552fcd2b9c266f6154446a4b/packages/react-select/src/NonceProvider.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
