### PR TITLE
Add rdf-dataset-indexed

### DIFF
--- a/types/rdf-dataset-indexed/index.d.ts
+++ b/types/rdf-dataset-indexed/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for rdf-dataset-indexed 0.4
+// Project: https://github.com/rdf-ext/rdf-dataset-indexed
+// Definitions by: Chris Wilkinson <https://github.com/thewilkybarkid>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { BaseQuad, DataFactory, DatasetCore, Quad } from 'rdf-js';
+
+declare function datasetFactory<Q extends BaseQuad = Quad>(quads?: Q[], dataFactory?: DataFactory): DatasetCore<Q>;
+
+export = datasetFactory;

--- a/types/rdf-dataset-indexed/rdf-dataset-indexed-tests.ts
+++ b/types/rdf-dataset-indexed/rdf-dataset-indexed-tests.ts
@@ -1,0 +1,12 @@
+import datasetFactory = require('rdf-dataset-indexed');
+import { BaseQuad, DataFactory, DatasetCore, Quad } from 'rdf-js';
+
+const dataFactory: DataFactory = {} as any;
+const quads1: Quad[] = [] as any;
+const quads2: BaseQuad[] = [] as any;
+
+const test1: DatasetCore = datasetFactory();
+const test2: DatasetCore = datasetFactory(quads1);
+const test3: DatasetCore = datasetFactory(quads1, dataFactory);
+const test4: DatasetCore<BaseQuad> = datasetFactory(quads2);
+const test5: DatasetCore<BaseQuad> = datasetFactory<BaseQuad>(quads2);

--- a/types/rdf-dataset-indexed/tsconfig.json
+++ b/types/rdf-dataset-indexed/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rdf-dataset-indexed-tests.ts"
+    ]
+}

--- a/types/rdf-dataset-indexed/tslint.json
+++ b/types/rdf-dataset-indexed/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Moved from https://github.com/rdf-ext/rdf-dataset-indexed/pull/5.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.