### PR TITLE
Add type base for redux-enhancer-react-native-appstate

### DIFF
--- a/types/redux-enhancer-react-native-appstate/index.d.ts
+++ b/types/redux-enhancer-react-native-appstate/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for color 3.0
+// Project: https://github.com/bamlab/redux-enhancer-react-native-appstate
+// Definitions by: Thibault Maekelbergh <https://github.com/thibmaek>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.7
+
+import { createStore as createStoreFn, Store } from 'redux';
+
+export type FOREGROUND = 'APP_STATE.FOREGROUND';
+export type BACKGROUND = 'APP_STATE.BACKGROUND';
+export type INACTIVE = 'APP_STATE.INACTIVE';
+
+type StateListener = () => (createStore: typeof createStoreFn) => (...args: any[]) => Store;
+
+declare const StateListener: StateListener;
+
+export = StateListener;

--- a/types/redux-enhancer-react-native-appstate/index.d.ts
+++ b/types/redux-enhancer-react-native-appstate/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for color 3.0
+// Type definitions for redux-enhancer-react-native-appstate 0.3
 // Project: https://github.com/bamlab/redux-enhancer-react-native-appstate
 // Definitions by: Thibault Maekelbergh <https://github.com/thibmaek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -12,6 +12,4 @@ export type INACTIVE = 'APP_STATE.INACTIVE';
 
 type StateListener = () => (createStore: typeof createStoreFn) => (...args: any[]) => Store;
 
-declare const StateListener: StateListener;
-
-export = StateListener;
+export declare const StateListener: StateListener;

--- a/types/redux-enhancer-react-native-appstate/package.json
+++ b/types/redux-enhancer-react-native-appstate/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "redux": "^4.6.0"
+  }
+}

--- a/types/redux-enhancer-react-native-appstate/package.json
+++ b/types/redux-enhancer-react-native-appstate/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "redux": "^4.6.0"
+    "redux": "^4.0.5"
   }
 }

--- a/types/redux-enhancer-react-native-appstate/redux-enhancer-react-native-appstate-tests.ts
+++ b/types/redux-enhancer-react-native-appstate/redux-enhancer-react-native-appstate-tests.ts
@@ -1,0 +1,5 @@
+import { FOREGROUND, BACKGROUND, INACTIVE } from 'redux-enhancer-react-native-appstate';
+
+const foreground: FOREGROUND = 'APP_STATE.FOREGROUND';
+const background: BACKGROUND = 'APP_STATE.BACKGROUND';
+const inactive: INACTIVE = 'APP_STATE.INACTIVE';

--- a/types/redux-enhancer-react-native-appstate/tsconfig.json
+++ b/types/redux-enhancer-react-native-appstate/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+          "es6"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": [
+          "../"
+      ],
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+      "index.d.ts",
+      "redux-enhancer-react-native-appstate-tests.ts"
+  ]
+}

--- a/types/redux-enhancer-react-native-appstate/tslint.json
+++ b/types/redux-enhancer-react-native-appstate/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
