### PR TITLE
[algoliasearch] Add ApiKey.indexes

### DIFF
--- a/types/algoliasearch/index.d.ts
+++ b/types/algoliasearch/index.d.ts
@@ -999,7 +999,7 @@ declare namespace algoliasearch {
   }
   /**
    * Describes the options used when generating new api keys
-   * 
+   *
    * @see https://www.algolia.com/doc/api-reference/api-methods/generate-secured-api-key/
    */
   interface SecuredApiOptions extends QueryParameters {
@@ -1318,7 +1318,7 @@ declare namespace algoliasearch {
     sortFacetValuesBy?: 'count' | 'alpha';
 
     ruleContexts?: string[];
-    
+
     /**
      * allow the usage of an AB-test. This parameter is only allowed for queries, not for settings.
      * default: true
@@ -1416,6 +1416,7 @@ declare namespace algoliasearch {
       | 'logs'
       | 'seeUnretrievableAttributes')[];
     validity: number;
+    indexes?: string[];
     description?: string;
   }
 


### PR DESCRIPTION
Algoliasearch: Added missing `indexes` field in the `ApiKey` definition.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.algolia.com/doc/api-reference/api-methods/get-api-key/?language=javascript#method-response-indexes