### PR TITLE
Remove direct dependency to `@types\node`

### DIFF
--- a/types/object-hash/index.d.ts
+++ b/types/object-hash/index.d.ts
@@ -3,9 +3,10 @@
 // Definitions by: Michael Zabka <https://github.com/misak113>, Artur Diniz <https://github.com/artdiniz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="node" />
-
-import stream = require("stream");
+interface IStream {
+    update?(chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
+    write?(chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
+}
 
 import HashStatic = ObjectHash.HashStatic;
 export = HashStatic;
@@ -33,8 +34,8 @@ declare namespace ObjectHash {
 		keys(object: any): string;
 		MD5(object: any): string;
 		keysMD5(object: any): string;
-		writeToStream(value: any, stream: stream.PassThrough): void;
-		writeToStream(value: any, options: IOptions, stream: stream.PassThrough): void;
+		writeToStream(value: any, stream: IStream): void;
+		writeToStream(value: any, options: IOptions, stream: IStream): void;
 	}
 
 	export var HashStatic: Hash;

--- a/types/object-hash/object-hash-tests.ts
+++ b/types/object-hash/object-hash-tests.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import hash = require('object-hash');
 import stream = require('stream')
 


### PR DESCRIPTION
in favour of simple interface. Since `object-hash` library can be used both in NodeJS and in a browser, loading Node type definitions together with DOM definitions causes problems.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **there has been no changes in the library and no breaking changes in the type definitions, this only removes dependency to node type definitions.**
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header: **there has been no changes in the library and no breaking changes in the type definitions, this only removes dependency to node type definitions.**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. **changes are non-braking and minimal**
