### PR TITLE
WIP: Improve assert for TypeScript 3.7+

### DIFF
--- a/types/node/package.json
+++ b/types/node/package.json
@@ -2,6 +2,11 @@
     "private": true,
     "types": "index",
     "typesVersions": {
+        ">=3.7.0-0": {
+            "*": [
+                "ts3.7/*"
+            ]
+        },
         ">=3.2.0-0": {
             "*": [
                 "ts3.2/*"

--- a/types/node/ts3.7/assert.d.ts
+++ b/types/node/ts3.7/assert.d.ts
@@ -1,0 +1,57 @@
+// tslint:disable-next-line:no-bad-reference
+/// <reference path="../assert.d.ts" />
+
+declare module "assert" {
+    function internal(value: any, message?: string | Error): asserts value;
+    namespace internal {
+        class AssertionError implements Error {
+            name: string;
+            message: string;
+            actual: any;
+            expected: any;
+            operator: string;
+            generatedMessage: boolean;
+            code: 'ERR_ASSERTION';
+
+            constructor(options?: {
+                message?: string; actual?: any; expected?: any;
+                operator?: string; stackStartFn?: Function
+            });
+        }
+
+        type AssertPredicate = RegExp | (new() => object) | ((thrown: any) => boolean) | object | Error;
+
+        function fail(message?: string | Error): never;
+        /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
+        function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
+        function ok(value: any, message?: string | Error): void;
+        function equal<A, B extends A>(actual: A, expected: B, message?: string | Error): asserts actual is B;
+        function equal(actual: any, expected: any, message?: string | Error): void;
+        function notEqual(actual: any, expected: any, message?: string | Error): void;
+        function deepEqual<A, B extends A>(actual: A, expected: B, message?: string | Error): asserts actual is B;
+        function deepEqual(actual: any, expected: any, message?: string | Error): void;
+        function notDeepEqual(actual: any, expected: any, message?: string | Error): void;
+        function strictEqual<A, B extends A>(actual: A, expected: B, message?: string | Error): asserts actual is B;
+        function strictEqual(actual: any, expected: any, message?: string | Error): void;
+        function notStrictEqual(actual: any, expected: any, message?: string | Error): void;
+        function deepStrictEqual<A, B extends A>(actual: A, expected: B, message?: string | Error): asserts actual is B;
+        function deepStrictEqual(actual: any, expected: any, message?: string | Error): void;
+        function notDeepStrictEqual(actual: any, expected: any, message?: string | Error): void;
+
+        function throws(block: () => any, message?: string | Error): void;
+        function throws(block: () => any, error: AssertPredicate, message?: string | Error): void;
+        function doesNotThrow(block: () => any, message?: string | Error): void;
+        function doesNotThrow(block: () => any, error: RegExp | Function, message?: string | Error): void;
+
+        function ifError(value: any): void;
+
+        function rejects(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
+        function rejects(block: (() => Promise<any>) | Promise<any>, error: AssertPredicate, message?: string | Error): Promise<void>;
+        function doesNotReject(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
+        function doesNotReject(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
+
+        const strict: typeof internal;
+    }
+
+    export = internal;
+}

--- a/types/node/ts3.7/index.d.ts
+++ b/types/node/ts3.7/index.d.ts
@@ -1,0 +1,17 @@
+// NOTE: These definitions support NodeJS and TypeScript 3.7.
+
+// Reference required types from the default lib:
+/// <reference lib="es2018" />
+/// <reference lib="esnext.asynciterable" />
+/// <reference lib="esnext.intl" />
+/// <reference lib="esnext.bigint" />
+
+// Base definitions for all NodeJS modules that are not specific to any version of TypeScript:
+// tslint:disable-next-line:no-bad-reference
+/// <reference path="../base.d.ts" />
+
+// TypeScript 3.7-specific augmentations:
+/// <reference path="assert.d.ts" />
+
+// TypeScript 3.2-specific augmentations:
+/// <reference path="../ts3.2/index.d.ts"/>

--- a/types/node/ts3.7/node-tests.ts
+++ b/types/node/ts3.7/node-tests.ts
@@ -1,0 +1,33 @@
+// tslint:disable-next-line:no-bad-reference
+import '../node-tests';
+import '../assert';
+import '../buffer';
+import '../child_process';
+import '../cluster';
+import '../crypto';
+import '../dgram';
+import '../global';
+import '../http';
+import '../http2';
+import '../net';
+import '../os';
+import '../path';
+import '../perf_hooks';
+import '../process';
+import '../querystring';
+import '../readline';
+import '../repl';
+import '../stream';
+import '../tls';
+import '../tty';
+import '../util';
+import '../worker_threads';
+import '../zlib';
+
+import assert from 'assert';
+
+{
+    const a: 0 | 1 | 2 | true | false | "" | "foo" | undefined | null = null;
+    assert(a);
+    const b: 1 | 2 | true | "foo" = a;
+}


### PR DESCRIPTION
* Changed `assert(value: any): void` to `assert(value: any): asserts value`
* Made similar changes to `assert.equal` and family

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
