### PR TITLE
types for downscale - uses esmoduleinterop for export default

### DIFF
--- a/types/downscale/downscale-tests.ts
+++ b/types/downscale/downscale-tests.ts
@@ -1,0 +1,19 @@
+import downscale from 'downscale';
+
+const image = new HTMLImageElement();
+const video = new HTMLVideoElement();
+const file = new File([], 'abc');
+const string = '';
+
+downscale(image, 0, 0);
+downscale(video, 0, 0);
+downscale(file, 0, 0);
+downscale(string, 0, 0);
+
+async function doTheTests() {
+    const string_returned: string = await downscale(image, 0, 0);
+
+    const canvas_returned: HTMLCanvasElement = await downscale(image, 0, 0, { returnCanvas: true });
+
+    const blob_returned: Blob = await downscale(image, 0, 0, { returnBlob: true });
+}

--- a/types/downscale/index.d.ts
+++ b/types/downscale/index.d.ts
@@ -22,3 +22,5 @@ declare function downscale(source: ImageSource, width: number, height: number, o
 declare function downscale(source: ImageSource, width: number, height: number, options?: DownscaleOptions & { returnCanvas: true; }): Promise<HTMLCanvasElement>;
 
 export = downscale;
+
+export as namespace downscale;

--- a/types/downscale/index.d.ts
+++ b/types/downscale/index.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for downscale 1.0
+// Project: https://github.com/ytiurin/downscale
+// Definitions by: Gabriel Soicher <https://github.com/Lunrtick>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type ImageSource = File | HTMLImageElement | HTMLVideoElement | string;
+
+interface DownscaleOptions {
+    imageType?: string;
+    quality?: number;
+    returnBlob?: boolean;
+    returnCanvas?: boolean;
+    sourceX?: number;
+    sourceY?: number;
+}
+
+/**
+ * Overloads that automatically type the return value based on the selected options
+ */
+declare function downscale(source: ImageSource, width: number, height: number, options?: DownscaleOptions & { returnBlob?: false; returnCanvas?: false; }): Promise<string>;
+declare function downscale(source: ImageSource, width: number, height: number, options?: DownscaleOptions & { returnBlob: true; }): Promise<Blob>;
+declare function downscale(source: ImageSource, width: number, height: number, options?: DownscaleOptions & { returnCanvas: true; }): Promise<HTMLCanvasElement>;
+
+export = downscale;

--- a/types/downscale/tsconfig.json
+++ b/types/downscale/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "esModuleInterop": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "downscale-tests.ts"
+    ]
+}

--- a/types/downscale/tslint.json
+++ b/types/downscale/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.