### PR TITLE
react-dom: When `act` is not async, don't return a Promise-like

### DIFF
--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -287,7 +287,7 @@ export function createRenderer(): ShallowRenderer;
  * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
  */
 // the "void | undefined" is here to forbid any sneaky "Promise" returns.
-export function act(callback: () => void | undefined): DebugPromiseLike;
+export function act(callback: () => void | undefined): void;
 // the "void | undefined" is here to forbid any sneaky return values
 // tslint:disable-next-line: void-return
 export function act(callback: () => Promise<void | undefined>): Promise<undefined>;

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -182,20 +182,33 @@ describe('React dom test utils', () => {
     });
 
     describe('act', () => {
-        it('accepts a sync callback that is void', () => {
-            ReactTestUtils.act(() => {});
+        describe('with sync callback', () => {
+            it('accepts a callback that is void', () => {
+                ReactTestUtils.act(() => {});
+            });
+            it('rejects a callback that returns null', () => {
+                // $ExpectError
+                ReactTestUtils.act(() => null);
+            });
+            it('returns a type that is not Promise-like', () => {
+                // tslint:disable-next-line no-void-expression
+                const result = ReactTestUtils.act(() => {});
+                // $ExpectError
+                result.then((x) => {});
+            });
         });
-        it('accepts an async callback that is void', async () => {
-            await ReactTestUtils.act(async () => {});
-        });
-        it('rejects a callback that returns null', () => {
-            // $ExpectError
-            ReactTestUtils.act(() => null);
-        });
-        it('returns a Promise-like that errors out on use', () => {
-            const result = ReactTestUtils.act(() => {});
-            // $ExpectError
-            Promise.resolve(result);
+        describe('with async callback', () => {
+            it('accepts a callback that is void', async () => {
+                await ReactTestUtils.act(async () => {});
+            });
+            it('rejects a callback that returns a value', async () => {
+                // $ExpectError
+                await ReactTestUtils.act(async () => null);
+            });
+            it('returns a Promise-like', () => {
+                const result = ReactTestUtils.act(async () => {});
+                result.then((x) => {});
+            });
         });
     });
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/blob/2e4948a34d4504eb852f7473d3c0315037f75d22/packages/react-dom/src/test-utils/ReactTestUtilsAct.js#L212-L216
  - The package spits out a warning at runtime, but this is TypeScript, so we can fix this problem at compile time instead
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

This fixes the return type of `ReactTestUtils.act`. The return value depends on whether its callback is **sync** or **async**. Presently, the return type for **async** is correct, but the return type for **sync** is incorrect—it returns a `Promise`-like, when it shouldn't. That causes downstream lint errors like this one:

```text
  57:5   error  Promises must be handled appropriately          @typescript-eslint/no-floating-promises
```

If you try to fix those errors, you instead get a runtime warning (from the source code linked above):

```text
  console.error ../../node_modules/react-dom/cjs/react-dom-test-utils.development.js:72
    Warning: Do not await the result of calling act(...) with sync logic, it is not a Promise.
```

This PR fixes all that, by making sure the non-Promise return value is not shaped like a Promise.