### PR TITLE
[mustache] More correct definitions and reduce the amount of `any`

### DIFF
--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -1,6 +1,8 @@
-// Type definitions for Mustache 0.8.4
+// Type definitions for Mustache 3.2.1
 // Project: https://github.com/janl/mustache.js
-// Definitions by: Mark Ashley Bell <https://github.com/markashleybell>, Manuel Thalmann <https://github.com/manuth>
+// Definitions by: Mark Ashley Bell <https://github.com/markashleybell>,
+//                 Manuel Thalmann <https://github.com/manuth>,
+//                 Phillip Johnsen <https://github.com/phillipj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**
@@ -10,22 +12,27 @@ interface MustacheStatic {
     /**
      * The name of the module.
      */
-    name: string;
+    readonly name: string;
 
     /**
      * The version of the module.
      */
-    version: string;
+    readonly version: string;
 
     /**
-     * The opening and closing tags to parse.
+     * The default opening and closing tags used while parsing the templates.
+     *
+     * Different default tags can be overridden by setting this field. They will have effect on all subsequent
+     * calls to `.render()` or `.parse()`, unless custom tags are given as arguments to those functions.
+     *
+     * Default value is `[ "{{", "}}" ]`.
      */
-    tags: string[];
+    tags: OpeningAndClosingTags;
 
     /**
      * A simple string scanner that is used by the template parser to find tokens in template strings.
      */
-    Scanner: typeof MustacheScanner
+    Scanner: typeof MustacheScanner;
 
     /**
      * Represents a rendering context by wrapping a view object and maintaining a reference to the parent context.
@@ -63,7 +70,7 @@ interface MustacheStatic {
      * @param tags
      * The tags to use.
      */
-    parse(template: string, tags?: string[]): any;
+    parse(template: string, tags?: OpeningAndClosingTags): any;
 
     /**
      * Renders the `template` with the given `view` and `partials` using the default writer.
@@ -84,7 +91,7 @@ interface MustacheStatic {
      * @param tags
      * The tags to use.
      */
-    render(template: string, view: any | MustacheContext, partials?: any, tags?: string[]): string;
+    render(template: string, view: any | MustacheContext, partials?: PartialsOrLookupFn, tags?: OpeningAndClosingTags): string;
 
     /**
      * Renders the `template` with the given `view` and `partials` using the default writer.
@@ -102,7 +109,8 @@ interface MustacheStatic {
      *
      * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
      */
-    to_html(template: string, view: any | MustacheContext, partials?: any, send?: any): any;
+    to_html(template: string, view: any | MustacheContext, partials?: PartialsOrLookupFn): string;
+    to_html(template: string, view: any | MustacheContext, partials?: PartialsOrLookupFn, send?: (result: string) => void): void;
 }
 
 /**
@@ -151,17 +159,12 @@ declare class MustacheScanner {
  */
 declare class MustacheContext {
     view: any;
-    parentContext: MustacheContext;
+    parentContext: MustacheContext | undefined;
 
     /**
-     * Initializes a new instance of the `MustacheContenxt` class.
+     * Initializes a new instance of the `MustacheContext` class.
      */
-    constructor(view: any, parentContext: MustacheContext);
-
-    /**
-     * Initializes a new instance of the `MustacheContenxt` class.
-     */
-    constructor(view: any);
+    constructor(view: any, parentContext?: MustacheContext);
 
     /**
      * Creates a new context using the given view with this context as the parent.
@@ -205,7 +208,7 @@ declare class MustacheWriter {
      * @param tags
      * The tags to use.
      */
-    parse(template: string, tags?: string[]): any;
+    parse(template: string, tags?: OpeningAndClosingTags): any;
 
     /**
      * High-level method that is used to render the given `template` with the given `view`.
@@ -226,7 +229,7 @@ declare class MustacheWriter {
      * @param tags
      * The tags to use.
      */
-    render(template: string, view: any | MustacheContext, partials: any, tags?: string[]): string;
+    render(template: string, view: any | MustacheContext, partials?: PartialsOrLookupFn, tags?: OpeningAndClosingTags): string;
 
     /**
      * Low-level method that renders the given array of `tokens` using the given `context` and `partials`.
@@ -245,8 +248,23 @@ declare class MustacheWriter {
      *
      * If the template doesn't use higher-order sections, this argument may be omitted.
      */
-    renderTokens(tokens: string[], context: MustacheContext, partials: any, originalTemplate: any): string;
+    renderTokens(tokens: string[], context: MustacheContext, partials?: PartialsOrLookupFn, originalTemplate?: string): string;
 }
+
+/**
+ * An array of two strings, representing the opening and closing tags respectively, to be used in the templates being rendered.
+ */
+type OpeningAndClosingTags = [string, string];
+
+/**
+ * Whenever partials are provided, it can either be an object that contains the names and templates of partials that are used in tempaltes
+ *
+ * -- or --
+ *
+ * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
+ */
+type PartialsOrLookupFn = Record<string, string> | PartialLookupFn
+type PartialLookupFn = (partialName: string) => string | undefined
 
 /**
  * Provides the functionality to render templates with `{{mustaches}}`.

--- a/types/mustache/mustache-tests.ts
+++ b/types/mustache/mustache-tests.ts
@@ -31,3 +31,6 @@ var html4 = Mustache.render(template4, view4);
 var view5 = { title: "Joe", calc: function () { return 2 + 4; } };
 var template5 = "[[title]] spends [[calc]]";
 var output5 = Mustache.render(template5, view5, {}, ["[[", "]]"]);
+
+Mustache.render("{{>text}}", {}, {"text":"from partial"});
+Mustache.render("{{>text}}", {}, (partialName) => partialName === "text" ? "from partial" : undefined);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [janl/mustache.js/mustache.mjs](https://github.com/janl/mustache.js/blob/master/mustache.mjs)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

<hr>

As a maintainer of mustache.js, I noticed the were was quite a lot of `any`s in the current definitions and other tweaks that makes these definitions more correct in general:

- More strict definition of tags, going from an array of string to an array of only two string items
- Make `Mustache.version | .name` fields `readonly`
- Partials from `any` to `Record<string, string>` or a lookup function
- `originalTemplate` from `any` to `string`