### PR TITLE
[@types/ts-nameof]: use any instead of void for function return type

### DIFF
--- a/types/ts-nameof/index.d.ts
+++ b/types/ts-nameof/index.d.ts
@@ -14,7 +14,7 @@
  * @param func An optional function for which the last identifier of the expression will be parsed.
  */
 // tslint:disable-next-line no-unnecessary-generics
-declare function nameof<T>(func?: (obj: T) => void): string;
+declare function nameof<T>(func?: (obj: T) => any): string;
 
 /**
  * Gets a string representation of the last identifier of the given expression.
@@ -56,7 +56,7 @@ declare namespace nameof {
      * A negative index can be used, indicating an offset from the end of the sequence.
      */
     // tslint:disable-next-line no-unnecessary-generics
-    function full<T>(func: (obj: T) => void, periodIndex?: number): string;
+    function full<T>(func: (obj: T) => any, periodIndex?: number): string;
 
     /**
      * Gets the string representation of the entire given expression.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`@typescript-eslint/no-misused-promises`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-misused-promises.md)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

-----

This changes the return type of function parameters from `void` to `any`, so that [`@typescript-eslint/no-misused-promises`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-misused-promises.md) is happy.

Otherwise, it'll error:

> 23:64  error  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises