### PR TITLE
dropzone: Add options to dropzone instances, add type for options, add type for options.headers

### DIFF
--- a/types/dropzone/dropzone-tests.ts
+++ b/types/dropzone/dropzone-tests.ts
@@ -174,6 +174,10 @@ dropzoneWithOptionsVariations = new Dropzone('.test', {
 const dropzone = new Dropzone('.test');
 
 dropzone.options.clickable = true;
+if (!dropzone.options.headers) {
+	dropzone.options.headers = {};
+}
+dropzone.options.headers.test = 'test';
 dropzone.enable();
 dropzone.disable();
 

--- a/types/dropzone/dropzone-tests.ts
+++ b/types/dropzone/dropzone-tests.ts
@@ -6,6 +6,7 @@ const dropzoneRenameFunction = (name: string): string => {
 
 Dropzone.createElement('<div id="divTest"></div>');
 Dropzone.isBrowserSupported();
+Dropzone.options['divTest'] = { clickable: true };
 console.log(Dropzone.instances.length);
 
 const dropzoneWithOptions = new Dropzone('.test', {
@@ -172,6 +173,7 @@ dropzoneWithOptionsVariations = new Dropzone('.test', {
 
 const dropzone = new Dropzone('.test');
 
+dropzone.options.clickable = true;
 dropzone.enable();
 dropzone.disable();
 

--- a/types/dropzone/dropzone-tests.ts
+++ b/types/dropzone/dropzone-tests.ts
@@ -7,6 +7,7 @@ const dropzoneRenameFunction = (name: string): string => {
 Dropzone.createElement('<div id="divTest"></div>');
 Dropzone.isBrowserSupported();
 Dropzone.options['divTest'] = { clickable: true };
+Dropzone.options['noDiscover'] = false;
 console.log(Dropzone.instances.length);
 
 const dropzoneWithOptions = new Dropzone('.test', {

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -154,7 +154,7 @@ declare class Dropzone {
     constructor(container: string | HTMLElement, options?: Dropzone.DropzoneOptions);
 
     static autoDiscover: boolean;
-    static options: any;
+    static options: { [key: string]: Dropzone.DropzoneOptions };
     static confirm: (question: string, accepted: () => void, rejected?: () => void) => void;
     static createElement(string: string): HTMLElement;
     static isBrowserSupported(): boolean;
@@ -171,6 +171,7 @@ declare class Dropzone {
 
     files: Dropzone.DropzoneFile[];
     defaultOptions: Dropzone.DropzoneOptions;
+    options: Dropzone.DropzoneOptions;
 
     enable(): void;
 

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -71,7 +71,7 @@ declare namespace Dropzone {
         filesizeBase?: number;
         maxFiles?: number;
         params?: {};
-        headers?: {};
+        headers?: { [key: string]: string };
         clickable?: boolean | string | HTMLElement | (string | HTMLElement)[];
         ignoreHiddenFiles?: boolean;
         acceptedFiles?: string;

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -154,7 +154,7 @@ declare class Dropzone {
     constructor(container: string | HTMLElement, options?: Dropzone.DropzoneOptions);
 
     static autoDiscover: boolean;
-    static options: { [key: string]: Dropzone.DropzoneOptions };
+    static options: { [key: string]: Dropzone.DropzoneOptions | false };
     static confirm: (question: string, accepted: () => void, rejected?: () => void) => void;
     static createElement(string: string): HTMLElement;
     static isBrowserSupported(): boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

1. Headers are given to XMLHttpRequest.setRequestHeader which accepts strings (https://gitlab.com/meno/dropzone/blob/master/src/dropzone.js#L2026)
2. Dropzone.options is a map from HTMLElement id (string) to DropzoneOptions (https://gitlab.com/meno/dropzone/blob/master/src/dropzone.js#L2304)
3. Options exists as an instance property and is the only way to change options of an existing instance (https://gitlab.com/meno/dropzone/blob/master/src/dropzone.js#L959) 
