### PR TITLE
Improve type definitions for sizeof

### DIFF
--- a/types/sizeof/index.d.ts
+++ b/types/sizeof/index.d.ts
@@ -3,5 +3,6 @@
 // Definitions by: Daniel Perez Alvarez <https://github.com/unindented>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function sizeof(object: object, pretty?: boolean): number | string;
+export function sizeof(object: any, pretty?: false): number;
+export function sizeof(object: any, pretty: true): string;
 export function format(bytes: number): string;

--- a/types/sizeof/sizeof-tests.ts
+++ b/types/sizeof/sizeof-tests.ts
@@ -8,6 +8,7 @@ const anyObject = {
   },
 };
 
-console.log(sizeof(anyObject)); // 50
+console.log(sizeof(anyObject) + 0); // 50
+console.log(sizeof(anyObject, false) + 0); // 50
 console.log(sizeof(anyObject, true)); // 50B
 console.log(format(50)); // 50B


### PR DESCRIPTION
Rather than always return `number | string`, we can type things more precisely based on the presence of the second argument of `sizeof`.

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lyroyce/sizeof/blob/e5974ba031dd076c3393c01bbb86785209e3f24e/lib/sizeof.js#L25
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
