### PR TITLE
[pg-pool] Made all args in connect callback optional

### DIFF
--- a/types/pg-pool/index.d.ts
+++ b/types/pg-pool/index.d.ts
@@ -12,7 +12,7 @@ declare class Pool<T extends pg.Client> extends pg.Pool {
     constructor(config?: Pool.Config<T>, client?: Pool.ClientLikeCtr<T>);
 
     connect(): Promise<T & pg.PoolClient>;
-    connect(callback: (err: Error, client: T & pg.PoolClient, done: (release?: any) => void) => void): void;
+    connect(callback: (err?: Error, client?: T & pg.PoolClient, done?: (release?: any) => void) => void): void;
 
     on(event: 'error', listener: (err: Error, client: T & pg.PoolClient) => void): this;
     on(event: 'connect' | 'acquire' | 'remove', listener: (client: T & pg.PoolClient) => void): this;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/blob/master/packages/pg-pool/index.js#L145
https://github.com/brianc/node-postgres/blob/master/packages/pg-pool/test/connection-timeout.js#L70
https://github.com/brianc/node-postgres/blob/master/packages/pg-pool/test/connection-timeout.js#L74

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

