### PR TITLE
[color-hash] Add definitions

### DIFF
--- a/types/color-hash/color-hash-tests.ts
+++ b/types/color-hash/color-hash-tests.ts
@@ -1,0 +1,31 @@
+import * as ColorHash from 'color-hash';
+
+const colorHash = new ColorHash();
+
+const result1: [number, number, number] = colorHash.hsl('Hello World');
+const result2: [number, number, number] = colorHash.rgb('Hello World');
+const result3: string = colorHash.hex('Hello World');
+
+// Custom Hash
+const customHash = (str: string) => 5;
+
+new ColorHash({ hash: customHash });
+
+// Custom Hue
+new ColorHash({ hue: 90 });
+new ColorHash({ hue: { min: 90, max: 270 } });
+new ColorHash({
+    hue: [
+        { min: 30, max: 90 },
+        { min: 180, max: 210 },
+        { min: 270, max: 285 },
+    ],
+});
+
+// Custom Lightness
+new ColorHash({ lightness: 0.5 });
+new ColorHash({ lightness: [0.35, 0.5, 0.65] });
+
+// Custom Saturation
+new ColorHash({ saturation: 0.5 });
+new ColorHash({ saturation: [0.35, 0.5, 0.65] });

--- a/types/color-hash/color-hash-tests.ts
+++ b/types/color-hash/color-hash-tests.ts
@@ -1,4 +1,4 @@
-import * as ColorHash from 'color-hash';
+import ColorHash = require('color-hash');
 
 const colorHash = new ColorHash();
 

--- a/types/color-hash/index.d.ts
+++ b/types/color-hash/index.d.ts
@@ -1,0 +1,58 @@
+// Type definitions for color-hash 1.0
+// Project: https://github.com/zenozeng/color-hash
+// Definitions by: Johannes Hoppe <https://github.com/JohannesHoppe>
+//                 Kamil Socha <https://github.com/ksocha>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type ColorValueArray = [number, number, number];
+
+interface HueObject {
+    min: number;
+    max: number;
+}
+
+type Hue = number | HueObject | ReadonlyArray<HueObject>;
+type Lightness = number | ColorValueArray;
+type Saturation = number | ColorValueArray;
+
+type HashFunction = (input: string) => number;
+
+interface ColorHashOptions {
+    lightness?: Lightness;
+    saturation?: Saturation;
+    hue?: Hue;
+    hash?: HashFunction;
+}
+
+declare class ColorHash {
+    constructor(options?: ColorHashOptions);
+
+    /**
+     * Returns the hash in [h, s, l].
+     * Note that H ∈ [0, 360); S ∈ [0, 1]; L ∈ [0, 1];
+     *
+     * @param input string to hash
+     * @returns [h, s, l]
+     */
+    hsl(input: string): ColorValueArray;
+
+    /**
+     * Returns the hash in [r, g, b].
+     * Note that R, G, B ∈ [0, 255]
+     *
+     * @param input string to hash
+     * @returns [r, g, b]
+     */
+    rgb(input: string): ColorValueArray;
+
+    /**
+     * Returns the hash in hex.
+     *
+     * @param input string to hash
+     * @returns hex with #
+     */
+    hex(input: string): string;
+}
+
+declare namespace ColorHash {}
+export = ColorHash;

--- a/types/color-hash/index.d.ts
+++ b/types/color-hash/index.d.ts
@@ -54,5 +54,5 @@ declare class ColorHash {
     hex(input: string): string;
 }
 
-declare namespace ColorHash {}
+export as namespace ColorHash;
 export = ColorHash;

--- a/types/color-hash/tsconfig.json
+++ b/types/color-hash/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "color-hash-tests.ts"
+    ]
+}

--- a/types/color-hash/tslint.json
+++ b/types/color-hash/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Definitions for [color-hash](https://github.com/zenozeng/color-hash)
I've used [this](https://github.com/zenozeng/color-hash/issues/24) issue as a starting point.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.