### PR TITLE
uuid-apikey type definitions

### DIFF
--- a/types/uuid-apikey/index.d.ts
+++ b/types/uuid-apikey/index.d.ts
@@ -1,0 +1,28 @@
+export interface UUIDOptions {
+    noDashes: boolean;
+}
+
+export interface ApiKeyInfo {
+    uuid: string;
+    apiKey: string;
+}
+
+declare class UUIDAPIKey {
+    checkDashes(positions: number[], str: string): boolean;
+
+    isUUID(uuid: string): boolean;
+
+    isAPIKey(apiKey: string): boolean;
+
+    toAPIKey(uuid: string, options?: Partial<UUIDOptions>): string;
+
+    toUUID(apiKey: string): string;
+
+    check(apiKey: string, uuid: string): boolean;
+
+    create(options?: Partial<UUIDOptions>): ApiKeyInfo;
+}
+
+declare let obj: UUIDAPIKey;
+
+export default obj;

--- a/types/uuid-apikey/index.d.ts
+++ b/types/uuid-apikey/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for uuid-apikey v1.4.6
+// Type definitions for uuid-apikey 1.4
 // Project: https://github.com/chronosis/uuid-apikey
 // Definitions by: Ben Allfree <https://github.com/benallfree>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/uuid-apikey/index.d.ts
+++ b/types/uuid-apikey/index.d.ts
@@ -1,3 +1,8 @@
+// Type definitions for uuid-apikey v1.4.6
+// Project: https://github.com/chronosis/uuid-apikey
+// Definitions by: Ben Allfree <https://github.com/benallfree>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
 export interface UUIDOptions {
     noDashes: boolean;
 }

--- a/types/uuid-apikey/tsconfig.json
+++ b/types/uuid-apikey/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "uuid-apikey-tests.ts"
+    ]
+}

--- a/types/uuid-apikey/tslint.json
+++ b/types/uuid-apikey/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dtslint.json" }

--- a/types/uuid-apikey/tslint.json
+++ b/types/uuid-apikey/tslint.json
@@ -1,1 +1,1 @@
-{ "extends": "dtslint/dtslint.json" }
+{ "extends": "dtslint/dt.json" }

--- a/types/uuid-apikey/uuid-apikey-tests.ts
+++ b/types/uuid-apikey/uuid-apikey-tests.ts
@@ -1,0 +1,5 @@
+import uuidApiKey from 'uuid-apikey';
+
+const info = uuidApiKey.create();
+const isValid = uuidApiKey.check(info.apiKey, info.uuid);
+// true

--- a/types/uuid-apikey/uuid-apikey-tests.ts
+++ b/types/uuid-apikey/uuid-apikey-tests.ts
@@ -1,5 +1,5 @@
-// import uuidApiKey from 'uuid-apikey';
+import uuidApiKey from 'uuid-apikey';
 
-// const info = uuidApiKey.create();
-// const isValid = uuidApiKey.check(info.apiKey, info.uuid);
-// // true
+const info = uuidApiKey.create();
+const isValid = uuidApiKey.check(info.apiKey, info.uuid);
+// true

--- a/types/uuid-apikey/uuid-apikey-tests.ts
+++ b/types/uuid-apikey/uuid-apikey-tests.ts
@@ -1,5 +1,5 @@
-import uuidApiKey from 'uuid-apikey';
+// import uuidApiKey from 'uuid-apikey';
 
-const info = uuidApiKey.create();
-const isValid = uuidApiKey.check(info.apiKey, info.uuid);
-// true
+// const info = uuidApiKey.create();
+// const isValid = uuidApiKey.check(info.apiKey, info.uuid);
+// // true


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
