### PR TITLE
feat(chart.js): allow to access charts instances container

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -300,6 +300,11 @@ const customTooltipsPieChart = new Chart(ctx, {
 // platform global values
 Chart.platform.disableCSSInjection = true;
 
+// Chart instances in the global namespace
+for (const id in Chart.instances) {
+    Chart.instances[id].resize();
+}
+
 // default global static values
 Chart.defaults.global.defaultFontColor = '#544615';
 Chart.defaults.global.defaultFontFamily = 'Arial';

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -77,6 +77,10 @@ declare class Chart {
 
     // Tooltip Static Options
     static Tooltip: Chart.ChartTooltipsStaticConfiguration;
+
+    static readonly instances: {
+        [key: string]: Chart;
+    };
 }
 declare class PluginServiceStatic {
     register(plugin: Chart.PluginServiceGlobalRegistration & Chart.PluginServiceRegistrationOptions): void;


### PR DESCRIPTION
This allows to access readonly container for charts from global
namespace required in some use-case scenarios.

```js
beforePrintHandler () {
    for (const id in Chart.instances) {
        Chart.instances[id].resize();
    }
}
```
https://www.chartjs.org/docs/latest/general/responsive.html#printing-resizeable-charts

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://www.chartjs.org/docs/latest/general/responsive.html#printing-resizeable-charts
https://github.com/chartjs/Chart.js/blob/9cb65d2c97136dab4e6ed8f44f3d3d5dd2cda88b/src/core/core.controller.js#L1030