### PR TITLE
Add hast

### DIFF
--- a/types/hast/hast-tests.ts
+++ b/types/hast/hast-tests.ts
@@ -1,0 +1,34 @@
+import * as Hast from 'hast';
+
+const element: Hast.Element = {
+    type: 'element',
+    tagName: 'div',
+    children: [],
+};
+
+const doctype: Hast.Doctype = {
+    type: 'doctype',
+    name: 'html',
+};
+
+const comment: Hast.Comment = {
+    type: 'comment',
+    value: 'test',
+};
+
+const text: Hast.Text = {
+    type: 'text',
+    value: 'text',
+};
+
+const root: Hast.Root = {
+    type: 'root',
+    children: [element, doctype, comment, text],
+};
+
+const templateElement: Hast.Element = {
+    type: 'element',
+    tagName: 'template',
+    content: root,
+    children: [],
+};

--- a/types/hast/index.d.ts
+++ b/types/hast/index.d.ts
@@ -1,0 +1,102 @@
+// Type definitions for Hast 2.3
+// Project: https://github.com/syntax-tree/hast
+// Definitions by: Junyoung Choi <https://github.com/rokt33r>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import { Parent as UnistParent, Literal as UnistLiteral, Node } from 'unist';
+
+/**
+ * Parent (UnistParent) represents a node in hast containing other nodes (said to be children).
+ *
+ * Its content is limited to only other hast content.
+ */
+export interface Parent extends UnistParent {
+    children: Array<Element | Doctype | Comment | Text>;
+}
+
+/**
+ * Literal (UnistLiteral) represents a node in hast containing a value.
+ */
+export interface Literal extends UnistLiteral {
+    value: string;
+}
+
+/**
+ * Root (Parent) represents a document.
+ *
+ * Root can be used as the root of a tree, or as a value of the content field on a 'template' Element, never as a child.
+ */
+export interface Root extends Parent {
+    type: 'root';
+}
+
+/**
+ * Element (Parent) represents an Element ([DOM]).
+ *
+ * A tagName field must be present. It represents the element’s local name ([DOM]).
+ *
+ * The properties field represents information associated with the element. The value of the properties field implements the Properties interface.
+ *
+ * If the tagName field is 'template', a content field can be present. The value of the content field implements the Root interface.
+ *
+ * If the tagName field is 'template', the element must be a leaf.
+ *
+ * If the tagName field is 'noscript', its children should be represented as if scripting is disabled ([HTML]).
+ */
+export interface Element extends Parent {
+    type: 'element';
+    tagName: string;
+    properties?: Properties;
+    content?: Root;
+    children: Array<Element | Comment | Text>;
+}
+
+/**
+ * Properties represents information associated with an element.
+ *
+ * Every field must be a PropertyName and every value a PropertyValue.
+ */
+export interface Properties {
+    [key: string]: PropertyValue;
+}
+
+/**
+ * Property names are keys on Properties objects and reflect HTML, SVG, ARIA, XML, XMLNS, or XLink attribute names.
+ */
+export type PropertyName = string;
+
+/**
+ * Property values should reflect the data type determined by their property name.
+ */
+export type PropertyValue = any;
+
+/**
+ * Doctype (Node) represents a DocumentType ([DOM]).
+ *
+ * A name field must be present.
+ *
+ * A public field can be present. If present, it must be set to a string, and represents the document’s public identifier.
+ *
+ * A system field can be present. If system, it must be set to a string, and represents the document’s system identifier.
+ */
+export interface Doctype extends Node {
+    type: 'doctype';
+    name: string;
+    public?: string;
+    system?: string;
+}
+
+/**
+ * Comment (Literal) represents a Comment ([DOM]).
+ */
+export interface Comment extends Literal {
+    type: 'comment';
+}
+
+/**
+ * Text (Literal) represents a Text ([DOM]).
+ */
+export interface Text extends Literal {
+    type: 'text';
+}

--- a/types/hast/tsconfig.json
+++ b/types/hast/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "hast-tests.ts"]
+}

--- a/types/hast/tslint.json
+++ b/types/hast/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "dtslint/dt.json",
+  "rules": {
+    "npm-naming": false
+  }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

FYI, `npm-naming` rule is disabled because `hast` does not have actual npm package like `mdast` and `unist`

