### PR TITLE
fix jsqubits complex type

### DIFF
--- a/types/jsqubits/index.d.ts
+++ b/types/jsqubits/index.d.ts
@@ -103,6 +103,8 @@ declare namespace jsqubits {
         }
 
         interface Complex {
+            real: number;
+            imaginary: number;
             add(other: number | Complex): Complex;
             multiply(other: number | Complex): Complex;
             conjugate(): Complex;
@@ -115,8 +117,6 @@ declare namespace jsqubits {
             subtract(other: number | Complex): Complex;
             eql(other: number | Complex): boolean;
             closeTo(other: Complex): number;
-            real(): number | Complex;
-            imaginary(): number | Complex;
         }
 
         interface Measurement {


### PR DESCRIPTION
This PR fix type mistake.

```
    this.real = real
    this.imaginary = imaginary
```
https://github.com/davidbkemp/jsqubits/blob/master/lib/Complex.js#L8
`Complex#real` and `Complex#imaginary` are properties as number type,  but current d.ts defined as methods.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see above
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. no, only d.ts update.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
