### PR TITLE
Bump @types/jest to 24.9

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 24.0
+// Type definitions for Jest 24.9
 // Project: https://jestjs.io/
 // Definitions by: Asana (https://asana.com)
 //                 Ivo Stratev <https://github.com/NoHomey>


### PR DESCRIPTION
The latest version of `jest` is `24.9.0` but `@types/jest` was still at `24.0.25`. 

[There are types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jest/index.d.ts#L240) for the `advanceTimersToNextTimer()` method that was added in jest `24.9.0` so I believe this could be bumped to `24.9`

Here's a link to the Jest 24.9 release: https://github.com/facebook/jest/blob/master/CHANGELOG.md#2490

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
