### PR TITLE
cursor of `scan` can be a string

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -12,6 +12,7 @@
 //                 Ting-Wai To <https://github.com/tingwai-to>
 //                 Alex Petty <https://github.com/pettyalex>
 //                 Simon Schick <https://github.com/SimonSchick>
+//                 Tianlin <https://github.com/tianlinle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -502,13 +503,13 @@ declare namespace IORedis {
         quit(callback: (err: Error, res: string) => void): void;
         quit(): Promise<string>;
 
-        scan(cursor: number): Promise<[string, string[]]>;
+        scan(cursor: number | string): Promise<[string, string[]]>;
 
-        scan(cursor: number, matchOption: 'match' | 'MATCH', pattern: string): Promise<[string, string[]]>;
-        scan(cursor: number, countOption: 'count' | 'COUNT', count: number): Promise<[string, string[]]>;
+        scan(cursor: number | string, matchOption: 'match' | 'MATCH', pattern: string): Promise<[string, string[]]>;
+        scan(cursor: number | string, countOption: 'count' | 'COUNT', count: number): Promise<[string, string[]]>;
 
-        scan(cursor: number, matchOption: 'match' | 'MATCH', pattern: string, countOption: 'count' | 'COUNT', count: number): Promise<[string, string[]]>;
-        scan(cursor: number, countOption: 'count' | 'COUNT', count: number, matchOption: 'match' | 'MATCH', pattern: string): Promise<[string, string[]]>;
+        scan(cursor: number | string, matchOption: 'match' | 'MATCH', pattern: string, countOption: 'count' | 'COUNT', count: number): Promise<[string, string[]]>;
+        scan(cursor: number | string, countOption: 'count' | 'COUNT', count: number, matchOption: 'match' | 'MATCH', pattern: string): Promise<[string, string[]]>;
 
         sscan(key: KeyType, cursor: number, ...args: ValueType[]): Promise<[string, string[]]>;
 
@@ -551,7 +552,7 @@ declare namespace IORedis {
 
         xread(...args: ValueType[]): Array<[string, string[]]>;
 
-        xreadgroup(groupOption: 'GROUP' | 'group', group: string, consumer: string,  ...args: ValueType[]): any;
+        xreadgroup(groupOption: 'GROUP' | 'group', group: string, consumer: string, ...args: ValueType[]): any;
 
         xrevrange(key: KeyType, end: string, start: string, ...args: ValueType[]): Promise<Array<[string, string[]]>>;
 
@@ -865,13 +866,13 @@ declare namespace IORedis {
 
         quit(callback?: (err: Error, res: string) => void): Pipeline;
 
-        scan(cursor: number): Pipeline;
+        scan(cursor: number | string): Pipeline;
 
-        scan(cursor: number, matchOption: 'match' | 'MATCH', pattern: string): Pipeline;
-        scan(cursor: number, countOption: 'count' | 'COUNT', count: number): Pipeline;
+        scan(cursor: number | string, matchOption: 'match' | 'MATCH', pattern: string): Pipeline;
+        scan(cursor: number | string, countOption: 'count' | 'COUNT', count: number): Pipeline;
 
-        scan(cursor: number, matchOption: 'match' | 'MATCH', pattern: string, countOption: 'count' | 'COUNT', count: number): Pipeline;
-        scan(cursor: number, countOption: 'count' | 'COUNT', count: number, matchOption: 'match' | 'MATCH', pattern: string): Pipeline;
+        scan(cursor: number | string, matchOption: 'match' | 'MATCH', pattern: string, countOption: 'count' | 'COUNT', count: number): Pipeline;
+        scan(cursor: number | string, countOption: 'count' | 'COUNT', count: number, matchOption: 'match' | 'MATCH', pattern: string): Pipeline;
         sscan(key: KeyType, cursor: number, ...args: ValueType[]): Pipeline;
 
         hscan(key: KeyType, cursor: number, ...args: ValueType[]): Pipeline;
@@ -904,7 +905,7 @@ declare namespace IORedis {
 
         xread(...args: ValueType[]): Pipeline;
 
-        xreadgroup(command: 'GROUP' | 'group', group: string, consumer: string,  ...args: ValueType[]): Pipeline;
+        xreadgroup(command: 'GROUP' | 'group', group: string, consumer: string, ...args: ValueType[]): Pipeline;
 
         xrevrange(key: KeyType, end: string, start: string, ...args: ValueType[]): Pipeline;
 
@@ -993,7 +994,7 @@ declare namespace IORedis {
     }
 
     interface ClusterStatic extends EventEmitter, Commander {
-        new (nodes: ClusterNode[], options?: ClusterOptions): Cluster;
+        new(nodes: ClusterNode[], options?: ClusterOptions): Cluster;
     }
 
     interface RedisOptions {
@@ -1182,7 +1183,7 @@ declare namespace IORedis {
 
     type DNSLookupFunction = (hostname: string, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void) => void;
     interface NatMap {
-        [key: string]: {host: string, port: number};
+        [key: string]: { host: string, port: number };
     }
 
     interface ClusterOptions {


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
