### PR TITLE
add missing field "env" in WorkerOptions in worker_threads

### DIFF
--- a/types/node/v12/worker_threads.d.ts
+++ b/types/node/v12/worker_threads.d.ts
@@ -60,6 +60,7 @@ declare module "worker_threads" {
         stdout?: boolean;
         stderr?: boolean;
         execArgv?: string[];
+        env?: symbol;
     }
 
     class Worker extends EventEmitter {


### PR DESCRIPTION
Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [X ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://nodejs.org/docs/latest-v12.x/api/worker_threads.html#worker_threads_worker_share_env
https://nodejs.org/docs/latest-v12.x/api/worker_threads.html#worker_threads_new_worker_filename_options
