### PR TITLE
wordpress__components: Fix Card types

### DIFF
--- a/types/wordpress__components/card/body/index.d.ts
+++ b/types/wordpress__components/card/body/index.d.ts
@@ -1,4 +1,3 @@
-import { ComponentProps, ComponentType, ElementType } from '@wordpress/element';
 import Card from '..';
 
 declare namespace CardBody {

--- a/types/wordpress__components/card/body/index.d.ts
+++ b/types/wordpress__components/card/body/index.d.ts
@@ -1,5 +1,5 @@
+import { ComponentProps, ComponentType, ElementType } from '@wordpress/element';
 import Card from '..';
-import { StyledComponent } from '@emotion/styled';
 
 declare namespace CardFooter {
     interface Props {
@@ -14,9 +14,14 @@ declare namespace CardFooter {
         isShady?: boolean;
 
         size?: Card.CardSize;
+
+        /**
+         * Render as a different element type
+         */
+        as?: ElementType;
     }
 }
 
-declare const CardFooter: StyledComponent<JSX.IntrinsicElements['div'], CardFooter.Props, {}>;
+declare const CardFooter: ComponentType<CardFooter.Props>;
 
 export default CardFooter;

--- a/types/wordpress__components/card/body/index.d.ts
+++ b/types/wordpress__components/card/body/index.d.ts
@@ -1,8 +1,8 @@
 import { ComponentProps, ComponentType, ElementType } from '@wordpress/element';
 import Card from '..';
 
-declare namespace CardFooter {
-    interface Props {
+declare namespace CardBody {
+    type Props<T extends keyof JSX.IntrinsicElements> = {
         /**
          * `className` of the container.
          */
@@ -18,10 +18,11 @@ declare namespace CardFooter {
         /**
          * Render as a different element type
          */
-        as?: ElementType;
-    }
+        as?: T;
+    } & JSX.IntrinsicElements[T];
 }
 
-declare const CardFooter: ComponentType<CardFooter.Props>;
+// tslint:disable-next-line no-unnecessary-generics
+declare function CardBody<T extends keyof JSX.IntrinsicElements = 'div'>(props: CardBody.Props<T>): JSX.Element;
 
-export default CardFooter;
+export default CardBody;

--- a/types/wordpress__components/card/divider/index.d.ts
+++ b/types/wordpress__components/card/divider/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentProps } from '@wordpress/element';
+import { ComponentProps, ComponentType, ElementType } from '@wordpress/element';
 import { HorizontalRule } from '../../primitives';
 import { StyledComponent } from '@emotion/styled';
 
@@ -10,6 +10,11 @@ declare namespace CardDivider {
         className?: string;
 
         children?: never;
+
+        /**
+         * Render as a different element type
+         */
+        as?: ElementType;
     }
 }
 

--- a/types/wordpress__components/card/divider/index.d.ts
+++ b/types/wordpress__components/card/divider/index.d.ts
@@ -17,9 +17,10 @@ declare namespace CardDivider {
     } & JSX.IntrinsicElements[T];
 }
 
-// tslint:disable-next-line no-unnecessary-generics
+// tslint:disable:no-unnecessary-generics
 declare function CardDivider<T extends keyof JSX.IntrinsicElements = typeof HorizontalRule>(
     props: CardDivider.Props<T>,
 ): JSX.Element;
+// tslint:enable:no-unnecessary-generics
 
 export default CardDivider;

--- a/types/wordpress__components/card/divider/index.d.ts
+++ b/types/wordpress__components/card/divider/index.d.ts
@@ -1,4 +1,3 @@
-import { ComponentProps, ComponentType, ElementType } from '@wordpress/element';
 import { HorizontalRule } from '../../primitives';
 
 declare namespace CardDivider {

--- a/types/wordpress__components/card/divider/index.d.ts
+++ b/types/wordpress__components/card/divider/index.d.ts
@@ -1,9 +1,8 @@
 import { ComponentProps, ComponentType, ElementType } from '@wordpress/element';
 import { HorizontalRule } from '../../primitives';
-import { StyledComponent } from '@emotion/styled';
 
 declare namespace CardDivider {
-    interface Props {
+    type Props<T extends keyof JSX.IntrinsicElements> = {
         /**
          * `className` of the container.
          */
@@ -14,10 +13,13 @@ declare namespace CardDivider {
         /**
          * Render as a different element type
          */
-        as?: ElementType;
-    }
+        as?: T;
+    } & JSX.IntrinsicElements[T];
 }
 
-declare const CardDivider: StyledComponent<ComponentProps<typeof HorizontalRule>, CardDivider.Props, {}>;
+// tslint:disable-next-line no-unnecessary-generics
+declare function CardDivider<T extends keyof JSX.IntrinsicElements = typeof HorizontalRule>(
+    props: CardDivider.Props<T>,
+): JSX.Element;
 
 export default CardDivider;

--- a/types/wordpress__components/card/footer/index.d.ts
+++ b/types/wordpress__components/card/footer/index.d.ts
@@ -2,7 +2,7 @@ import { ComponentType, ElementType } from '@wordpress/element';
 import Card from '..';
 
 declare namespace CardFooter {
-    interface Props {
+    type Props<T extends keyof JSX.IntrinsicElements> = {
         /**
          * `className` of the container.
          */
@@ -23,10 +23,11 @@ declare namespace CardFooter {
         /**
          * Render as a different element type
          */
-        as?: ElementType;
-    }
+        as?: T;
+    } & JSX.IntrinsicElements[T];
 }
 
-declare const CardFooter: ComponentType<CardFooter.Props>;
+// tslint:disable-next-line no-unnecessary-generics
+declare function CardFooter<T extends keyof JSX.IntrinsicElements = 'div'>(props: CardFooter.Props<T>): JSX.Element;
 
 export default CardFooter;

--- a/types/wordpress__components/card/footer/index.d.ts
+++ b/types/wordpress__components/card/footer/index.d.ts
@@ -1,4 +1,3 @@
-import { ComponentType, ElementType } from '@wordpress/element';
 import Card from '..';
 
 declare namespace CardFooter {

--- a/types/wordpress__components/card/footer/index.d.ts
+++ b/types/wordpress__components/card/footer/index.d.ts
@@ -1,5 +1,5 @@
+import { ComponentType, ElementType } from '@wordpress/element';
 import Card from '..';
-import { StyledComponent } from '@emotion/styled';
 
 declare namespace CardFooter {
     interface Props {
@@ -19,9 +19,14 @@ declare namespace CardFooter {
         isShady?: boolean;
 
         size?: Card.CardSize;
+
+        /**
+         * Render as a different element type
+         */
+        as?: ElementType;
     }
 }
 
-declare const CardFooter: StyledComponent<JSX.IntrinsicElements['div'], CardFooter.Props, {}>;
+declare const CardFooter: ComponentType<CardFooter.Props>;
 
 export default CardFooter;

--- a/types/wordpress__components/card/header/index.d.ts
+++ b/types/wordpress__components/card/header/index.d.ts
@@ -1,5 +1,5 @@
+import { ComponentType, ElementType } from '@wordpress/element';
 import Card from '..';
-import { StyledComponent } from '@emotion/styled';
 
 declare namespace CardHeader {
     interface Props {
@@ -19,9 +19,14 @@ declare namespace CardHeader {
         isShady?: boolean;
 
         size?: Card.CardSize;
+
+        /**
+         * Render as a different element type
+         */
+        as?: ElementType;
     }
 }
 
-declare const CardHeader: StyledComponent<JSX.IntrinsicElements['div'], CardHeader.Props, {}>;
+declare const CardHeader: ComponentType<CardHeader.Props>;
 
 export default CardHeader;

--- a/types/wordpress__components/card/header/index.d.ts
+++ b/types/wordpress__components/card/header/index.d.ts
@@ -2,7 +2,7 @@ import { ComponentType, ElementType } from '@wordpress/element';
 import Card from '..';
 
 declare namespace CardHeader {
-    interface Props {
+    type Props<T extends keyof JSX.IntrinsicElements> = {
         /**
          * `className` of the container.
          */
@@ -23,10 +23,11 @@ declare namespace CardHeader {
         /**
          * Render as a different element type
          */
-        as?: ElementType;
-    }
+        as?: T;
+    } & JSX.IntrinsicElements[T];
 }
 
-declare const CardHeader: ComponentType<CardHeader.Props>;
+// tslint:disable-next-line no-unnecessary-generics
+declare function CardHeader<T extends keyof JSX.IntrinsicElements = 'div'>(props: CardHeader.Props<T>): JSX.Element;
 
 export default CardHeader;

--- a/types/wordpress__components/card/header/index.d.ts
+++ b/types/wordpress__components/card/header/index.d.ts
@@ -1,4 +1,3 @@
-import { ComponentType, ElementType } from '@wordpress/element';
 import Card from '..';
 
 declare namespace CardHeader {

--- a/types/wordpress__components/card/index.d.ts
+++ b/types/wordpress__components/card/index.d.ts
@@ -1,8 +1,12 @@
-import { ComponentType, ElementType } from '@wordpress/element';
+import { ComponentType, HTMLProps, ElementType } from '@wordpress/element';
+
+type Assign<T, U> = {
+    [P in keyof (T & U)]: P extends keyof T ? T[P] : P extends keyof U ? U[P] : never;
+};
 
 declare namespace Card {
     type CardSize = 'large' | 'medium' | 'small' | 'extraSmall';
-    interface Props {
+    interface BaseProps {
         /**
          * `className` of the container.
          */
@@ -24,14 +28,10 @@ declare namespace Card {
          * @defaultValue "medium"
          */
         size?: CardSize;
-
-        /**
-         * Render as a different element type
-         */
-        as?: ElementType;
     }
+    interface DivProps extends Assign<BaseProps, HTMLProps<HTMLDivElement>> {}
 }
 
-declare const Card: ComponentType<Card.Props>;
+declare const Card: ComponentType<Card.DivProps>;
 
 export default Card;

--- a/types/wordpress__components/card/index.d.ts
+++ b/types/wordpress__components/card/index.d.ts
@@ -32,6 +32,7 @@ declare namespace Card {
     } & JSX.IntrinsicElements[T];
 }
 
+// tslint:disable-next-line no-unnecessary-generics
 declare function Card<T extends keyof JSX.IntrinsicElements = 'div'>(props: Card.Props<T>): JSX.Element;
 
 export default Card;

--- a/types/wordpress__components/card/index.d.ts
+++ b/types/wordpress__components/card/index.d.ts
@@ -1,4 +1,4 @@
-import { StyledComponent } from '@emotion/styled';
+import { ComponentType, ElementType } from '@wordpress/element';
 
 declare namespace Card {
     type CardSize = 'large' | 'medium' | 'small' | 'extraSmall';
@@ -24,9 +24,14 @@ declare namespace Card {
          * @defaultValue "medium"
          */
         size?: CardSize;
+
+        /**
+         * Render as a different element type
+         */
+        as?: ElementType;
     }
 }
 
-declare const Card: StyledComponent<JSX.IntrinsicElements['div'], Card.Props, {}>;
+declare const Card: ComponentType<Card.Props>;
 
 export default Card;

--- a/types/wordpress__components/card/index.d.ts
+++ b/types/wordpress__components/card/index.d.ts
@@ -1,5 +1,3 @@
-import { ComponentType, HTMLProps } from '@wordpress/element';
-
 declare namespace Card {
     type CardSize = 'large' | 'medium' | 'small' | 'extraSmall';
     type Props<T extends keyof JSX.IntrinsicElements> = {

--- a/types/wordpress__components/card/index.d.ts
+++ b/types/wordpress__components/card/index.d.ts
@@ -1,12 +1,8 @@
-import { ComponentType, HTMLProps, ElementType } from '@wordpress/element';
-
-type Assign<T, U> = {
-    [P in keyof (T & U)]: P extends keyof T ? T[P] : P extends keyof U ? U[P] : never;
-};
+import { ComponentType, HTMLProps } from '@wordpress/element';
 
 declare namespace Card {
     type CardSize = 'large' | 'medium' | 'small' | 'extraSmall';
-    interface BaseProps {
+    type Props<T extends keyof JSX.IntrinsicElements> = {
         /**
          * `className` of the container.
          */
@@ -29,11 +25,13 @@ declare namespace Card {
          */
         size?: CardSize;
 
-        as?: ElementType;
-    }
-    interface DivProps extends Assign<BaseProps, HTMLProps<HTMLDivElement>> {}
+        /**
+         * Render as a different element type
+         */
+        as?: T;
+    } & JSX.IntrinsicElements[T];
 }
 
-declare const Card: ComponentType<Card.DivProps>;
+declare function Card<T extends keyof JSX.IntrinsicElements = 'div'>(props: Card.Props<T>): JSX.Element;
 
 export default Card;

--- a/types/wordpress__components/card/index.d.ts
+++ b/types/wordpress__components/card/index.d.ts
@@ -28,6 +28,8 @@ declare namespace Card {
          * @defaultValue "medium"
          */
         size?: CardSize;
+
+        as?: ElementType;
     }
     interface DivProps extends Assign<BaseProps, HTMLProps<HTMLDivElement>> {}
 }

--- a/types/wordpress__components/card/media/index.d.ts
+++ b/types/wordpress__components/card/media/index.d.ts
@@ -1,5 +1,3 @@
-import { ComponentType, ElementType } from '@wordpress/element';
-
 declare namespace CardMedia {
     type Props<T extends keyof JSX.IntrinsicElements> = {
         /**

--- a/types/wordpress__components/card/media/index.d.ts
+++ b/types/wordpress__components/card/media/index.d.ts
@@ -1,7 +1,7 @@
 import { ComponentType, ElementType } from '@wordpress/element';
 
 declare namespace CardMedia {
-    interface Props {
+    type Props<T extends keyof JSX.IntrinsicElements> = {
         /**
          * `className` of the container.
          */
@@ -10,10 +10,11 @@ declare namespace CardMedia {
         /**
          * Render as a different element type
          */
-        as?: ElementType;
-    }
+        as?: T;
+    } & JSX.IntrinsicElements[T];
 }
 
-declare const CardMedia: ComponentType<CardMedia.Props>;
+// tslint:disable-next-line no-unnecessary-generics
+declare function CardMedia<T extends keyof JSX.IntrinsicElements = 'div'>(props: CardMedia.Props<T>): JSX.Element;
 
 export default CardMedia;

--- a/types/wordpress__components/card/media/index.d.ts
+++ b/types/wordpress__components/card/media/index.d.ts
@@ -1,4 +1,4 @@
-import { StyledComponent } from '@emotion/styled';
+import { ComponentType, ElementType } from '@wordpress/element';
 
 declare namespace CardMedia {
     interface Props {
@@ -6,9 +6,14 @@ declare namespace CardMedia {
          * `className` of the container.
          */
         className?: string;
+
+        /**
+         * Render as a different element type
+         */
+        as?: ElementType;
     }
 }
 
-declare const CardMedia: StyledComponent<JSX.IntrinsicElements['div'], CardMedia.Props, {}>;
+declare const CardMedia: ComponentType<CardMedia.Props>;
 
 export default CardMedia;

--- a/types/wordpress__components/package.json
+++ b/types/wordpress__components/package.json
@@ -1,7 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@emotion/styled": "^10.0.0",
         "re-resizable": "^4.7.1"
     }
 }

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -98,8 +98,13 @@ interface MyCompleteOption {
 
 // These components can be rendered as other components:
 <C.Card as={C.HorizontalRule} />;
-// `as="button"` renders a `button`, autoFocus is allowed
-<C.Card as="button" onClick={(e: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {}} />;
+// Card renders a `div` by default:
+<C.Card onClick={(e: ReactMouseEvent<HTMLDivElement, MouseEvent>) => {}} />;
+// `div` doesn't support autoFocus:
+// $ExpectError
+<C.Card autoFocus onClick={(e: ReactMouseEvent<HTMLDivElement, MouseEvent>) => {}} />;
+// With `as="button"`, a `button` element is rendered and `button` props are accepted:
+<C.Card as="button" autoFocus onClick={(e: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {}} />;
 
 <C.CardBody isShady size="extraSmall">
     Hello world!

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -1,5 +1,5 @@
 import * as C from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { Component, MouseEvent as ReactMouseEvent } from '@wordpress/element';
 
 //
 // primitives
@@ -94,14 +94,18 @@ interface MyCompleteOption {
 <C.Card isElevated isBorderless className="card" size="large">
     I'm a card with props!
 </C.Card>;
+<C.Card onClick={(e: ReactMouseEvent<HTMLDivElement, MouseEvent>) => {}} />;
 
 // Card is <div /> by default, autoFocus prop is not allowed
 // $ExpectError
 <C.Card autoFocus>`div` can't have autoFocus :(</C.Card>;
 
-// `withComponent` renders a `button`
-const ButtonCard = C.Card.withComponent('button');
-<ButtonCard autoFocus>`button` _can_ have autoFocus :D</ButtonCard>;
+// These components can be rendered as other components:
+<C.Card as={C.HorizontalRule} />;
+// `as="button"` renders a `button`, autoFocus is allowed
+<C.Card as="button" autoFocus>
+    `button` _can_ have autoFocus :D
+</C.Card>;
 
 <C.CardBody isShady size="extraSmall">
     Hello world!

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -96,16 +96,10 @@ interface MyCompleteOption {
 </C.Card>;
 <C.Card onClick={(e: ReactMouseEvent<HTMLDivElement, MouseEvent>) => {}} />;
 
-// Card is <div /> by default, autoFocus prop is not allowed
-// $ExpectError
-<C.Card autoFocus>`div` can't have autoFocus :(</C.Card>;
-
 // These components can be rendered as other components:
 <C.Card as={C.HorizontalRule} />;
 // `as="button"` renders a `button`, autoFocus is allowed
-<C.Card as="button" autoFocus>
-    `button` _can_ have autoFocus :D
-</C.Card>;
+<C.Card as="button" onClick={(e: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {}} />;
 
 <C.CardBody isShady size="extraSmall">
     Hello world!

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -102,7 +102,7 @@ interface MyCompleteOption {
 <C.Card onClick={(e: ReactMouseEvent<HTMLDivElement, MouseEvent>) => {}} />;
 // `div` doesn't support autoFocus:
 // $ExpectError
-<C.Card autoFocus onClick={(e: ReactMouseEvent<HTMLDivElement, MouseEvent>) => {}} />;
+<C.Card autoFocus />;
 // With `as="button"`, a `button` element is rendered and `button` props are accepted:
 <C.Card as="button" autoFocus onClick={(e: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {}} />;
 


### PR DESCRIPTION
Card does not expose underlying emotion `withComponent` customization, but allows `as` for customization.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.