### PR TITLE
`history`: use interface for `LocationState` to allow augmentation

### DIFF
--- a/types/history/LocationUtils.d.ts
+++ b/types/history/LocationUtils.d.ts
@@ -1,12 +1,12 @@
 import { Path, LocationState, LocationKey, Location, LocationDescriptor } from './index';
 
-export function locationsAreEqual<S = LocationState>(
-  lv: LocationDescriptor<S>,
-  rv: LocationDescriptor<S>,
+export function locationsAreEqual(
+  lv: LocationDescriptor,
+  rv: LocationDescriptor,
 ): boolean;
-export function createLocation<S = LocationState>(
-  path: LocationDescriptor<S>,
-  state?: S,
+export function createLocation(
+  path: LocationDescriptor,
+  state?: LocationState,
   key?: LocationKey,
-  currentLocation?: Location<S>,
-): Location<S>;
+  currentLocation?: Location,
+): Location;

--- a/types/history/createMemoryHistory.d.ts
+++ b/types/history/createMemoryHistory.d.ts
@@ -8,12 +8,12 @@ export interface MemoryHistoryBuildOptions {
   keyLength?: number;
 }
 
-export interface MemoryHistory<HistoryLocationState = LocationState> extends History<HistoryLocationState> {
+export interface MemoryHistory extends History {
   index: number;
-  entries: Location<HistoryLocationState>[];
+  entries: Location[];
   canGo(n: number): boolean;
 }
 
-export default function createMemoryHistory<S = LocationState>(
+export default function createMemoryHistory(
   options?: MemoryHistoryBuildOptions,
-): MemoryHistory<S>;
+): MemoryHistory;

--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -125,3 +125,23 @@ let input = { value: "" };
     let supportsDOM = ExecutionEnvironment.canUseDOM;
     let isExtraneousPopstateEvent = DOMUtils.isExtraneousPopstateEvent;
 }
+
+//
+// Location state augmentation
+//
+
+declare module 'history' {
+    namespace History {
+        interface LocationState {
+            foo: string;
+        }
+    }
+}
+
+{
+    const anything: any = {};
+    const history: History = anything;
+    history.location.state; // $ExpectType LocationState
+    history.location.state.foo; // $ExpectType string
+    history.location.state.bar; // $ExpectError
+}

--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -133,7 +133,7 @@ let input = { value: "" };
 declare module 'history' {
     namespace History {
         interface LocationState {
-            foo: string;
+            foo?: string;
         }
     }
 }

--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -4,6 +4,29 @@ import * as PathUtils from 'history/PathUtils';
 import * as DOMUtils from 'history/DOMUtils';
 import * as ExecutionEnvironment from 'history/ExecutionEnvironment';
 
+//
+// Location state augmentation
+//
+
+declare module 'history' {
+    namespace History {
+        interface LocationState {
+            some?: string;
+            foo?: string;
+            value?: number;
+            the?: string;
+        }
+    }
+}
+
+{
+    const anything: any = {};
+    const history: History = anything;
+    history.location.state; // $ExpectType LocationState | undefined
+    history.location.state!.foo; // $ExpectType string | undefined
+    history.location.state!.bar; // $ExpectError
+}
+
 let input = { value: "" };
 
 {
@@ -43,7 +66,7 @@ let input = { value: "" };
 }
 
 {
-    let history: MemoryHistory<{the: 'state'}> = createMemoryHistory();
+    let history: MemoryHistory = createMemoryHistory();
 
     // Pushing a path string.
     history.push('/the/path');
@@ -65,7 +88,7 @@ let input = { value: "" };
     unblock();
 
     history.entries.forEach(function (location) {
-        let typedLocation: Location<{ the: 'state' }> = location;
+        let typedLocation: Location = location;
     });
 }
 
@@ -96,14 +119,14 @@ let input = { value: "" };
 }
 
 {
-    let location1 = LocationUtils.createLocation('path/1', 1);
-    let location2 = LocationUtils.createLocation({ pathname: 'pathname', state: 2 });
+    let location1 = LocationUtils.createLocation('path/1', { value: 1 });
+    let location2 = LocationUtils.createLocation({ pathname: 'pathname', state: { value: 2 } });
     LocationUtils.locationsAreEqual(location1, location2);
 }
 
 {
-    let location1 = LocationUtils.createLocation({ pathname: 'path/1' }, 1);
-    let location2 = LocationUtils.createLocation({ pathname: 'pathname', state: 2 });
+    let location1 = LocationUtils.createLocation({ pathname: 'path/1' }, { value: 1 });
+    let location2 = LocationUtils.createLocation({ pathname: 'pathname', state: { value: 2 } });
     LocationUtils.locationsAreEqual(location1, location2);
 }
 
@@ -125,24 +148,4 @@ let input = { value: "" };
 {
     let supportsDOM = ExecutionEnvironment.canUseDOM;
     let isExtraneousPopstateEvent = DOMUtils.isExtraneousPopstateEvent;
-}
-
-//
-// Location state augmentation
-//
-
-declare module 'history' {
-    namespace History {
-        interface LocationState {
-            foo?: string;
-        }
-    }
-}
-
-{
-    const anything: any = {};
-    const history: History = anything;
-    history.location.state; // $ExpectType LocationState | undefined
-    history.location.state!.foo; // $ExpectType string | undefined
-    history.location.state!.bar; // $ExpectError
 }

--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -142,7 +142,7 @@ declare module 'history' {
 {
     const anything: any = {};
     const history: History = anything;
-    history.location.state; // $ExpectType LocationState
-    history.location.state.foo; // $ExpectType string
-    history.location.state.bar; // $ExpectError
+    history.location.state; // $ExpectType LocationState | undefined
+    history.location.state!.foo; // $ExpectType string | undefined
+    history.location.state!.bar; // $ExpectError
 }

--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -114,7 +114,8 @@ let input = { value: "" };
 }
 
 {
-    let eventTarget: EventTarget;
+    const anything: any = {};
+    const eventTarget: EventTarget = anything;
     DOMUtils.addEventListener(eventTarget, 'onload', function (event) { event.preventDefault(); });
     DOMUtils.removeEventListener(eventTarget, 'onload', function (event) { event.preventDefault(); });
     DOMUtils.getConfirmation('confirm?', (result) => console.log(result));

--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -29,7 +29,7 @@ export interface History<HistoryLocationState = LocationState> {
 export interface Location<S = LocationState> {
     pathname: Pathname;
     search: Search;
-    state: S;
+    state: S | undefined;
     hash: Hash;
     key?: LocationKey;
 }

--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -11,71 +11,69 @@ export type UnregisterCallback = () => void;
 export interface History<HistoryLocationState = LocationState> {
   length: number;
   action: Action;
-  location: Location<HistoryLocationState>;
+  location: Location;
   push(path: Path, state?: HistoryLocationState): void;
-  push(location: LocationDescriptorObject<HistoryLocationState>): void;
+  push(location: LocationDescriptorObject): void;
   replace(path: Path, state?: HistoryLocationState): void;
-  replace(location: LocationDescriptorObject<HistoryLocationState>): void;
+  replace(location: LocationDescriptorObject): void;
   go(n: number): void;
   goBack(): void;
   goForward(): void;
   block(
-    prompt?: boolean | string | TransitionPromptHook<HistoryLocationState>,
+    prompt?: boolean | string | TransitionPromptHook,
   ): UnregisterCallback;
-  listen(listener: LocationListener<HistoryLocationState>): UnregisterCallback;
-  createHref(location: LocationDescriptorObject<HistoryLocationState>): Href;
+  listen(listener: LocationListener): UnregisterCallback;
+  createHref(location: LocationDescriptorObject): Href;
 }
 
-export interface Location<S = LocationState> {
+export interface Location {
     pathname: Pathname;
     search: Search;
-    state: S | undefined;
+    state: LocationState | undefined;
     hash: Hash;
     key?: LocationKey;
 }
 
-export interface LocationDescriptorObject<S = LocationState> {
+export interface LocationDescriptorObject {
     pathname?: Pathname;
     search?: Search;
-    state?: S;
+    state?: LocationState;
     hash?: Hash;
     key?: LocationKey;
 }
 
 export namespace History {
-    export type LocationDescriptor<S = LocationState> = Path | LocationDescriptorObject<S>;
+    export type LocationDescriptor = Path | LocationDescriptorObject;
     export type LocationKey = string;
-    export type LocationListener<S = LocationState> = (
-      location: Location<S>,
+    export type LocationListener = (
+      location: Location,
       action: Action,
     ) => void;
     export interface LocationState {}
     export type Path = string;
     export type Pathname = string;
     export type Search = string;
-    export type TransitionHook<S = LocationState> = (
-      location: Location<S>,
+    export type TransitionHook = (
+      location: Location,
       callback: (result: any) => void,
     ) => any;
-    export type TransitionPromptHook<S = LocationState> = (
-      location: Location<S>,
+    export type TransitionPromptHook = (
+      location: Location,
       action: Action,
     ) => string | false | void;
     export type Hash = string;
     export type Href = string;
 }
 
-export type LocationDescriptor<S = LocationState> = History.LocationDescriptor<S>;
+export type LocationDescriptor = History.LocationDescriptor;
 export type LocationKey = History.LocationKey;
-export type LocationListener<S = LocationState> = History.LocationListener<S>;
+export type LocationListener = History.LocationListener;
 export type LocationState = History.LocationState;
 export type Path = History.Path;
 export type Pathname = History.Pathname;
 export type Search = History.Search;
-export type TransitionHook<S = LocationState> = History.TransitionHook<S>;
-export type TransitionPromptHook<
-  S = LocationState
-> = History.TransitionPromptHook<S>;
+export type TransitionHook = History.TransitionHook;
+export type TransitionPromptHook = History.TransitionPromptHook;
 export type Hash = History.Hash;
 export type Href = History.Href;
 

--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -49,7 +49,7 @@ export namespace History {
       location: Location<S>,
       action: Action,
     ) => void;
-    export type LocationState = any;
+    export interface LocationState {}
     export type Path = string;
     export type Pathname = string;
     export type Search = string;

--- a/types/history/tsconfig.json
+++ b/types/history/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -54,27 +54,27 @@ export class HashRouter extends React.Component<HashRouterProps, any> {}
 
 export interface LinkProps<S = H.LocationState> extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
     component?: React.ComponentType<any>;
-    to: H.LocationDescriptor<S> | ((location: H.Location<S>) => H.LocationDescriptor<S>);
+    to: H.LocationDescriptor | ((location: H.Location) => H.LocationDescriptor);
     replace?: boolean;
     innerRef?: React.Ref<HTMLAnchorElement>;
 }
 export class Link<S = H.LocationState> extends React.Component<
-  LinkProps<S>,
+  LinkProps,
   any
 > {}
 
-export interface NavLinkProps<S = H.LocationState> extends LinkProps<S> {
+export interface NavLinkProps<S = H.LocationState> extends LinkProps {
   activeClassName?: string;
   activeStyle?: React.CSSProperties;
   exact?: boolean;
   strict?: boolean;
   isActive?<Params extends { [K in keyof Params]?: string }>(
     match: match<Params>,
-    location: H.Location<S>,
+    location: H.Location,
   ): boolean;
-  location?: H.Location<S>;
+  location?: H.Location;
 }
 export class NavLink<S = H.LocationState> extends React.Component<
-  NavLinkProps<S>,
+  NavLinkProps,
   any
 > {}

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -71,15 +71,15 @@ export interface RouteComponentProps<
     C extends StaticContext = StaticContext,
     S = H.LocationState
 > {
-    history: H.History<S>;
-    location: H.Location<S>;
+    history: H.History;
+    location: H.Location;
     match: match<Params>;
     staticContext?: C;
 }
 
 export interface RouteChildrenProps<Params extends { [K in keyof Params]?: string } = {}, S = H.LocationState> {
     history: H.History;
-    location: H.Location<S>;
+    location: H.Location;
     match: match<Params> | null;
 }
 
@@ -159,7 +159,7 @@ export const __RouterContext: React.Context<RouteComponentProps>;
 
 export function useHistory<HistoryLocationState = H.LocationState>(): H.History<HistoryLocationState>;
 
-export function useLocation<S = H.LocationState>(): H.Location<S>;
+export function useLocation<S = H.LocationState>(): H.Location;
 
 export function useParams<Params extends { [K in keyof Params]?: string } = {}>(): { [p in keyof Params]: string };
 

--- a/types/react-router/test/WithRouter.tsx
+++ b/types/react-router/test/WithRouter.tsx
@@ -64,8 +64,8 @@ declare module 'history' {
     type SomethingToRead = (Book | Magazine) & RouteComponentProps;
 
     const Readable: React.SFC<SomethingToRead> = props => {
-        props.location.state.foo; // $ExpectType number | undefined
-        props.history.location.state.foo; // $ExpectType number | undefined
+        props.location.state!.foo; // $ExpectType number | undefined
+        props.history.location.state!.foo; // $ExpectType number | undefined
 
         if (props.kind === 'magazine') {
             return <div>magazine #{props.issue}</div>;

--- a/types/react-router/test/WithRouter.tsx
+++ b/types/react-router/test/WithRouter.tsx
@@ -40,6 +40,15 @@ const WithRouterTestClass = () => <WithRouterComponentClass username="John" wrap
 const OnWrappedRef = React.createRef<ComponentClass>();
 const WithRouterTestClass2 = () => <WithRouterComponentClass username="John" wrappedComponentRef={OnWrappedRef} />;
 
+interface State { foo?: number; }
+
+declare module 'history' {
+    namespace History {
+        // tslint:disable-next-line: no-empty-interface
+        interface LocationState extends State {}
+    }
+}
+
 // union props
 {
     interface Book {
@@ -52,13 +61,11 @@ const WithRouterTestClass2 = () => <WithRouterComponentClass username="John" wra
         issue: number;
     }
 
-    interface State { foo: number; }
-
-    type SomethingToRead = (Book | Magazine) & RouteComponentProps<{}, StaticContext, State>;
+    type SomethingToRead = (Book | Magazine) & RouteComponentProps;
 
     const Readable: React.SFC<SomethingToRead> = props => {
-        props.location.state; // $ExpectType State
-        props.history.location.state; // $ExpectType State
+        props.location.state.foo; // $ExpectType number | undefined
+        props.history.location.state.foo; // $ExpectType number | undefined
 
         if (props.kind === 'magazine') {
             return <div>magazine #{props.issue}</div>;

--- a/types/react-router/test/examples-from-react-router-website/Auth.tsx
+++ b/types/react-router/test/examples-from-react-router-website/Auth.tsx
@@ -68,6 +68,14 @@ const PrivateRoute: React.SFC<RouteProps> = ({ component, ...rest }) => (
 const Public: React.SFC<RouteComponentProps> = () => <h3>Public</h3>;
 const Protected: React.SFC<RouteComponentProps> = () => <h3>Protected</h3>;
 
+declare module 'history' {
+    namespace History {
+        interface LocationState {
+            from: { pathname: string };
+        }
+    }
+}
+
 class Login extends React.Component<RouteComponentProps, {redirectToReferrer: boolean}> {
   state = {
     redirectToReferrer: false

--- a/types/react-router/test/examples-from-react-router-website/ModalGallery.tsx
+++ b/types/react-router/test/examples-from-react-router-website/ModalGallery.tsx
@@ -7,6 +7,14 @@ import {
   Link
 } from 'react-router-dom';
 
+declare module 'history' {
+    namespace History {
+        interface LocationState {
+            modal?: any;
+        }
+    }
+}
+
 // This example shows how to render two different screens
 // (or the same screen in a different context) at the same url,
 // depending on you got there.

--- a/types/react-router/test/hooks.tsx
+++ b/types/react-router/test/hooks.tsx
@@ -27,8 +27,8 @@ const HooksTest: React.FC = () => {
     // $ExpectType match<Params>
     const match4 = useRouteMatch<Params>();
 
-    history.location.state.s;
-    location.state.s;
+    history.location.state!.s;
+    location.state!.s;
     id && id.replace;
     params.id.replace;
     match1 && match1.params.id.replace;

--- a/types/react-router/test/hooks.tsx
+++ b/types/react-router/test/hooks.tsx
@@ -5,13 +5,17 @@ interface Params {
     id: string;
 }
 
-interface LocationState {
-    s: string;
+declare module 'history' {
+    namespace History {
+        interface LocationState {
+            s?: string;
+        }
+    }
 }
 
 const HooksTest: React.FC = () => {
-    const history = useHistory<LocationState>();
-    const location = useLocation<LocationState>();
+    const history = useHistory();
+    const location = useLocation();
     const { id } = useParams();
     const params = useParams<Params>();
     // $ExpectType match<Params> | null


### PR DESCRIPTION
Related:

- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23169
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/27699
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37718
- https://github.com/microsoft/TypeScript/issues/36178

Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/27012

Currently, `LocationState` defaults to any. A custom type can be provided via generics:

```ts
{
    const anything: any = {};
    const history: History<{ foo: string }> = anything;
    history.location.state; // $ExpectType { foo: string; }
    history.location.state.foo; // $ExpectType string
    history.location.state.bar; // $ExpectError
}
```

However, it is very easy to make the mistake of forgetting to provide the generic:

```ts
{
    const anything: any = {};
    const history: History = anything;
    history.location.state.bar; // $ExpectError, but got none, because `state` is `any`
}
```

Furthermore, this will not help when `history` or `location` are provided to you (meaning their types must be inferred):

```ts
withRouter(({ history, location }) => {
  history.location.state.bar; // $ExpectError, but got none, because `state` is `any`
  location.state.bar; // $ExpectError, but got none, because `state` is `any`
});
```

This PR proposes replacing `type LocationState = any` with `interface LocationState {}`. This means it will be an empty object by default, and custom properties can be added via module augmentation:

```ts
declare module 'history' {
    namespace History {
        interface LocationState {
            foo: string;
        }
    }
}

{
    const anything: any = {};
    const history: History = anything;
    history.location.state; // $ExpectType LocationState
    history.location.state.foo; // $ExpectType string
    history.location.state.bar; // $ExpectError
}
```

With this change, I don't see any reason to keep the `S` location state generic. If you're happy with these changes, I'll go ahead and remove that.

/cc @gwmccull

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.