### PR TITLE
More highland fixes

### DIFF
--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -412,11 +412,17 @@ barStream = fooStream.through(readwritable);
 // $ExpectError
 fooStream.through((x: Highland.Stream<Bar>) => bar);
 
-fooStream = fooStream.zip(fooStream);
-fooStream = fooStream.zip([foo, foo]);
+// $ExpectType Stream<[Foo, Foo]>
+fooStream.zip(fooStream);
+
+// $ExpectType Stream<[Foo, Bar]>
+fooStream.zip(barStream);
 
 fooArrStream = fooStream.zipAll([[foo, foo], [foo, foo]]);
 fooArrStream = fooStream.zipAll(_([[foo, foo], [foo, foo]]));
+
+// $ExpectType Stream<(Foo | Bar)[]>
+fooStream.zipAll(barStreamStream);
 
 // $ExpectType Stream<Foo[]>
 fooStreamStream.zipAll0();

--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -169,6 +169,9 @@ fooArrStream = _(fooArrThen);
 fooStream = _(fooIterable);
 fooStream = _(fooIterator);
 
+// $ExpectType Stream<Stream<Foo>>
+_([fooStream]);
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // STREAM OBJECTS
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -1380,8 +1380,8 @@ declare namespace Highland {
 		 * @param {Array | Stream} ys - the other stream to combine values with
 		 * @api public
 		 */
-		zip(ys: R[]): Stream<R>;
-		zip(ys: Stream<R>): Stream<R>;
+		zip<U>(ys: U[]): Stream<[R, U]>;
+		zip<U>(ys: Stream<U>): Stream<[R, U]>;
 
 		/**
 		 * Takes a stream and a *finite* stream of `N` streams
@@ -1396,8 +1396,9 @@ declare namespace Highland {
 		 * @param {Array | Stream} ys - the array of streams to combine values with
 		 * @api public
 		 */
-		zipAll(ys: R[][]): Stream<R[]>;
-		zipAll(ys: Stream<R[]>): Stream<R[]>;
+		zipAll<U>(ys: U[][]): Stream<Array<R | U>>;
+		zipAll<U>(ys: Stream<U[]>): Stream<Array<R | U>>;
+		zipAll<U>(ys: Stream<Stream<U>>): Stream<Array<R | U>>;
 
 		/**
 		 * Takes a *finite* stream of streams and returns a stream where the first

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -127,7 +127,6 @@ interface HighlandStatic {
 	 * @api public
 	 */
 	<R>(): Highland.Stream<R>;
-	<R>(source: Highland.Stream<R>[]): Highland.Stream<R>;
 	<R>(source: R[]): Highland.Stream<R>;
 	<R>(source: (push: (err: Error | null, x?: R | Highland.Nil) => void, next: () => void) => void): Highland.Stream<R>;
 


### PR DESCRIPTION
Fixes the types of `zip` and `zipAll`, and removes (what looks like) an incorrect constructor overload

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://highlandjs.org/#zip
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
