### PR TITLE
fix(hls-parser): Updates Playlist constructor parameters

### DIFF
--- a/types/hls-parser/hls-parser-tests.ts
+++ b/types/hls-parser/hls-parser-tests.ts
@@ -8,7 +8,7 @@ if (playlist.isMasterPlaylist) {
     // Media playlist
 }
 
-const { MediaPlaylist, Segment } = HLS.types;
+const { MediaPlaylist, MasterPlaylist, Segment } = HLS.types;
 
 new MediaPlaylist({
     targetDuration: 9,
@@ -21,4 +21,9 @@ new MediaPlaylist({
             discontinuitySequence: 0,
         }),
     ],
+});
+
+new MasterPlaylist({
+    version: 3,
+    variants: [],
 });

--- a/types/hls-parser/index.d.ts
+++ b/types/hls-parser/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for hls-parser 0.5
 // Project: https://github.com/kuu/hls-parser#readme
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
+//                 Christopher Manouvrier <https://github.com/cmanou>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.4
 
@@ -20,6 +21,14 @@ export class Data {
 }
 
 export namespace types {
+    interface BasePlaylistConstructorProperties {
+        uri?: string;
+        version?: number;
+        independentSegments?: boolean;
+        start?: { offset: number; precise: boolean };
+        source?: string;
+    }
+
     class Playlist extends Data {
         isMasterPlaylist: boolean;
 
@@ -33,14 +42,7 @@ export namespace types {
 
         source?: string;
 
-        constructor(properties: {
-            isMasterPlaylist: boolean;
-            uri?: string;
-            version?: number;
-            independentSegments: boolean;
-            start?: { offset: number; precise: boolean };
-            source?: string;
-        });
+        constructor(properties: BasePlaylistConstructorProperties & { isMasterPlaylist: boolean });
     }
 
     class MasterPlaylist extends Playlist {
@@ -52,13 +54,15 @@ export namespace types {
 
         sessionKeyList: readonly Key[];
 
-        constructor(properties: {
-            variants?: readonly Variant[];
-            currentVariant?: number;
-            sessionDataList?: readonly SessionData[];
-            sessionKeyList?: readonly Key[];
-            source?: string;
-        });
+        constructor(
+            properties: BasePlaylistConstructorProperties & {
+                variants?: readonly Variant[];
+                currentVariant?: number;
+                sessionDataList?: readonly SessionData[];
+                sessionKeyList?: readonly Key[];
+                source?: string;
+            },
+        );
     }
 
     class MediaPlaylist extends Playlist {
@@ -76,16 +80,18 @@ export namespace types {
 
         segments: readonly Segment[];
 
-        constructor(properties: {
-            targetDuration: number;
-            mediaSequenceBase?: number;
-            discontinuitySequenceBase?: number;
-            endlist?: boolean;
-            playlistType?: 'EVENT' | 'VOD';
-            isIFrame?: boolean;
-            segments?: readonly Segment[];
-            source?: string;
-        });
+        constructor(
+            properties: BasePlaylistConstructorProperties & {
+                targetDuration: number;
+                mediaSequenceBase?: number;
+                discontinuitySequenceBase?: number;
+                endlist?: boolean;
+                playlistType?: 'EVENT' | 'VOD';
+                isIFrame?: boolean;
+                segments?: readonly Segment[];
+                source?: string;
+            },
+        );
     }
 
     class Variant {


### PR DESCRIPTION
Fixes
 - Updates `independentSegments` to be optional in `Playlist` constructor since the library has a default
- Updates both `MasterPlaylist` and `MediaPlaylist` constructors to allow the base playlist properties excluding `isMasterPlaylist`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/kuu/hls-parser/blob/172871428798abf1a9ea2387428fd37d62d6cbbb/types.js#L171
  - https://github.com/kuu/hls-parser/blob/172871428798abf1a9ea2387428fd37d62d6cbbb/types.js#L189
  - https://github.com/kuu/hls-parser/blob/172871428798abf1a9ea2387428fd37d62d6cbbb/types.js#L206