### PR TITLE
[json-form-data] Update definitions to v1.7

### DIFF
--- a/types/json-form-data/index.d.ts
+++ b/types/json-form-data/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for json-form-data 1.5
+// Type definitions for json-form-data 1.7
 // Project: https://github.com/hyperatom/json-form-data
 // Definitions by: Aaron Ross <https://github.com/superhawk610>
+//                 Kamil Socha <https://github.com/ksocha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface ValidJSON {
@@ -9,12 +10,17 @@ interface ValidJSON {
 
 type ValidJSONValue = string | number | boolean | File | Blob | Date | null | undefined;
 
+interface InitialFormData {
+    append: FormData['append'];
+}
+
 /**
  * Formatting options for modifying the final generated FormData object.
  *
  * ## Defaults
  *
  *     const defaultOpts = {
+ *       initialFormData: new FormData(),
  *       showLeafArrayIndexes: true,
  *       includeNullValues: false,
  *       mapping: value => {
@@ -27,6 +33,11 @@ type ValidJSONValue = string | number | boolean | File | Blob | Date | null | un
  *     }
  */
 interface FormatOptions {
+    /**
+     * Existing form data which values will be appended to  (default: `new FormData()`).
+     * This can be used to support environments that do not have a global FormData object.
+     */
+    initialFormData?: InitialFormData;
     /**
      * Include index values in arrays (default: `true`).
      *

--- a/types/json-form-data/json-form-data-tests.ts
+++ b/types/json-form-data/json-form-data-tests.ts
@@ -14,7 +14,8 @@ const json = {
     prop5: true,
     prop6: false,
     prop7: new File(['file content'], 'my_file.txt'),
-    prop8: {
+    prop8: new Date('05 January 2020 16:52:00 GMT'),
+    prop9: {
         prop1: 'test',
         prop2: 2,
         prop3: null,
@@ -24,5 +25,14 @@ const json = {
         prop7: ['test', 2, null, undefined, true, false],
     },
 };
+
 // $ExpectType FormData
 asFormData(json);
+
+// $ExpectType FormData
+asFormData(json, {
+    includeNullValues: true,
+    initialFormData: new FormData(),
+    mapping: value => (Boolean(value) ? 'true' : 'false'),
+    showLeafArrayIndexes: false,
+});


### PR DESCRIPTION
Updating to v1.7. [https://github.com/hyperatom/json-form-data](https://github.com/hyperatom/json-form-data)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/hyperatom/json-form-data/commit/74dd06bda195667b5a0211f7f8ec7fe2bb30a5db](https://github.com/hyperatom/json-form-data/commit/74dd06bda195667b5a0211f7f8ec7fe2bb30a5db)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
