### PR TITLE
`history`: switch default `LocationState` generic from `any` to `unknown`

### DIFF
--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -9,6 +9,8 @@ let input = { value: "" };
 {
     let history = createBrowserHistory<{ some: 'state' }>();
 
+    history.location.state; // $ExpectType { some: "state"; }
+
     // Listen for changes to the current location. The
     // listener is called once immediately.
     let unlisten = history.listen(function (location) {

--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -128,3 +128,9 @@ let input = { value: "" };
     let supportsDOM = ExecutionEnvironment.canUseDOM;
     let isExtraneousPopstateEvent = DOMUtils.isExtraneousPopstateEvent;
 }
+
+{
+    const anything: any = {};
+    const history: History = anything;
+    history.location.state; // $ExpectType PoorMansUnknown
+}

--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -114,7 +114,8 @@ let input = { value: "" };
 }
 
 {
-    let eventTarget: EventTarget;
+    const anything: any = {};
+    const eventTarget: EventTarget = anything;
     DOMUtils.addEventListener(eventTarget, 'onload', function (event) { event.preventDefault(); });
     DOMUtils.removeEventListener(eventTarget, 'onload', function (event) { event.preventDefault(); });
     DOMUtils.getConfirmation('confirm?', (result) => console.log(result));

--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -49,7 +49,10 @@ export namespace History {
       location: Location<S>,
       action: Action,
     ) => void;
-    export type LocationState = any;
+    // The value type here is a "poor man's `unknown`". When these types support TypeScript
+    // 3.0+, we can replace this with `unknown`.
+    type PoorMansUnknown = {} | null | undefined;
+    export type LocationState = PoorMansUnknown;
     export type Path = string;
     export type Pathname = string;
     export type Search = string;

--- a/types/history/tsconfig.json
+++ b/types/history/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/react-router/test/examples-from-react-router-website/Auth.tsx
+++ b/types/react-router/test/examples-from-react-router-website/Auth.tsx
@@ -8,6 +8,7 @@ import {
   Redirect,
   withRouter
 } from 'react-router-dom';
+import { StaticContext } from 'react-router';
 
 ////////////////////////////////////////////////////////////
 // 1. Click the public page
@@ -68,7 +69,9 @@ const PrivateRoute: React.SFC<RouteProps> = ({ component, ...rest }) => (
 const Public: React.SFC<RouteComponentProps> = () => <h3>Public</h3>;
 const Protected: React.SFC<RouteComponentProps> = () => <h3>Protected</h3>;
 
-class Login extends React.Component<RouteComponentProps, {redirectToReferrer: boolean}> {
+type Props = RouteComponentProps<{}, StaticContext, { from: { pathname: string; }; }>;
+
+class Login extends React.Component<Props, {redirectToReferrer: boolean}> {
   state = {
     redirectToReferrer: false
   };

--- a/types/react-router/test/examples-from-react-router-website/ModalGallery.tsx
+++ b/types/react-router/test/examples-from-react-router-website/ModalGallery.tsx
@@ -6,6 +6,7 @@ import {
   Route,
   Link
 } from 'react-router-dom';
+import { StaticContext } from 'react-router';
 
 // This example shows how to render two different screens
 // (or the same screen in a different context) at the same url,
@@ -16,7 +17,9 @@ import {
 // are the same as before but now we see them inside a modal
 // on top of the old screen.
 
-class ModalSwitch extends React.Component<RouteComponentProps> {
+type Props = RouteComponentProps<{}, StaticContext, { modal: boolean }>;
+
+class ModalSwitch extends React.Component<Props> {
   // We can pass a location to <Switch/> that will tell it to
   // ignore the router's current location and use the location
   // prop instead.
@@ -31,7 +34,7 @@ class ModalSwitch extends React.Component<RouteComponentProps> {
   // is still `/` even though its `/images/2`.
   previousLocation = this.props.location;
 
-  componentWillUpdate(nextProps: RouteComponentProps) {
+  componentWillUpdate(nextProps: Props) {
     const { location } = this.props;
     // set previousLocation if props.location is not modal
     if (


### PR DESCRIPTION
`any` disables type checking, so it should be avoided:

```ts
declare const any: any;
any.foo.bar; // no compile error, but runtime exception!
```

Related:

- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41568
- https://github.com/microsoft/TypeScript/issues/36178
- https://github.com/DefinitelyTyped/DefinitelyTyped/issues/27012

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.