### PR TITLE
[parse] Parse.Object.toJSON and some generic static methods

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -460,7 +460,7 @@ namespace Parse {
         pinAll(objects: Object[]): Promise<void>;
         pinAllWithName(name: string, objects: Object[]): Promise<void>;
         registerSubclass<T extends Object>(className: string, clazz: new (options?: any) => T): void;
-        saveAll<T extends Object>(list: T[], options?: Object.SaveAllOptions): Promise<T[]>;
+        saveAll<T extends readonly Object[]>(list: T, options?: Object.SaveAllOptions): Promise<T>;
         unPinAll(objects: Object[]): Promise<void>;
         unPinAllObjects(): Promise<void>;
         unPinAllObjectsWithName(name: string): Promise<void>;

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -21,7 +21,7 @@
 //                  Linus Unnebäck <https://github.com/LinusU>
 //                  Patrick O'Sullivan <https://github.com/REPTILEHAUS>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.7
 
 /// <reference types="node" />
 /// <reference path="node.d.ts" />
@@ -181,6 +181,12 @@ namespace Parse {
         createdAt: Date;
         objectId: string;
         updatedAt: Date;
+    }
+
+    interface JSONBaseAttributes {
+        createdAt: string;
+        objectId: string;
+        updatedAt: string;
     }
 
     /**
@@ -360,13 +366,13 @@ namespace Parse {
         attributes: T;
         className: string;
 
-        add<K extends Extract<keyof T, string>>(
+        add<K extends { [K in keyof T]: T[K] extends any[] ? K : never }[keyof T]>(
             attr: K,
-            item: ((x: any[]) => void) extends ((x: T[K]) => void) ? T[K][number] : never
+            item: T[K][number]
         ): this | false;
-        addAll<K extends Extract<keyof T, string>>(
+        addAll<K extends { [K in keyof T]: T[K] extends any[] ? K : never }[keyof T]>(
             attr: K,
-            items: ((x: any[]) => void) extends ((x: T[K]) => void) ? T[K] : never
+            items: T[K]
         ): this | false;
         addAllUnique: this['addAll'];
         addUnique: this['add'];
@@ -427,7 +433,7 @@ namespace Parse {
             options?: Object.SetOptions
         ): this | false;
         setACL(acl: ACL, options?: SuccessFailureOptions): this | false;
-        toJSON(): any;
+        toJSON(): Object.ToJSON<T> & JSONBaseAttributes;
         toPointer(): Pointer;
         unPin(): Promise<void>;
         unPinWithName(name: string): Promise<void>;
@@ -487,6 +493,27 @@ namespace Parse {
         interface SetOptions extends ErrorOption, SilentOption {
             promise?: any;
         }
+
+        // From https://github.com/parse-community/Parse-SDK-JS/blob/master/src/encode.js
+        type Encode<T> = (
+            T extends Object
+                ? ReturnType<T['toJSON']> | Pointer
+                : T extends (ACL | GeoPoint | Polygon | Relation | File)
+                    ? ReturnType<T['toJSON']>
+                    : T extends Date
+                        ? { __type: 'Date'; iso: string; }
+                        : T extends RegExp
+                            ? string
+                            : T extends Array<infer R>
+                                ? Array<Encode<R>>
+                                : T extends object
+                                    ? ToJSON<T>
+                                    : T
+        );
+
+        type ToJSON<T> = {
+            [K in keyof T]: Encode<T[K]>
+        };
     }
 
     class Polygon {
@@ -766,7 +793,7 @@ namespace Parse {
      */
     interface Role<T extends Attributes = Attributes> extends Object<T> {
         getRoles(): Relation<Role, Role>;
-        getUsers(): Relation<Role, User>;
+        getUsers<U extends User>(): Relation<Role, U>;
         getName(): string;
         setName(name: string, options?: SuccessFailureOptions): any;
     }
@@ -828,15 +855,15 @@ namespace Parse {
         new(attributes?: Attributes): User;
 
         allowCustomUserClass(isAllowed: boolean): void;
-        become(sessionToken: string, options?: UseMasterKeyOption): Promise<User>;
-        current<T extends Attributes>(): User<T> | undefined;
-        currentAsync(): Promise<User | null>;
-        signUp(username: string, password: string, attrs: any, options?: SignUpOptions): Promise<User>;
-        logIn(username: string, password: string, options?: FullOptions): Promise<User>;
-        logOut(): Promise<User>;
-        requestPasswordReset(email: string, options?: SuccessFailureOptions): Promise<User>;
+        become<T extends User>(sessionToken: string, options?: UseMasterKeyOption): Promise<T>;
+        current<T extends User>(): T | undefined;
+        currentAsync<T extends User>(): Promise<T | null>;
+        signUp<T extends User>(username: string, password: string, attrs: any, options?: SignUpOptions): Promise<T>;
+        logIn<T extends User>(username: string, password: string, options?: FullOptions): Promise<T>;
+        logOut<T extends User>(): Promise<T>;
+        requestPasswordReset<T extends User>(email: string, options?: SuccessFailureOptions): Promise<T>;
         extend(protoProps?: any, classProps?: any): any;
-        hydrate(userJSON: any): Promise<User>;
+        hydrate<T extends User>(userJSON: any): Promise<T>;
         enableUnsafeCurrentUser(): void;
     }
     const User: UserConstructor;

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -614,7 +614,7 @@ function test_geo_points() {
     point = new Parse.GeoPoint(40.0, -30.0);
     point = new Parse.GeoPoint({ latitude: 40.0, longitude: -30.0 });
 
-    const userObject = Parse.User.current<{ location: Parse.GeoPoint }>()!;
+    const userObject = Parse.User.current<Parse.User<{ location: Parse.GeoPoint }>>()!;
 
     // User's location
     const userGeoPoint = userObject.get('location');
@@ -1145,12 +1145,77 @@ function testObject() {
         objTyped.set('other', 100);
     }
 
-    function testToJSON(objUntyped: Parse.Object, objTyped: Parse.Object<{ example: string }>) {
-        // $ExpectType any
-        objUntyped.toJSON();
+    interface AttributesAllTypes {
+        someString: string;
+        someNumber: number;
+        someBoolean: boolean;
+        someDate: Date;
+        someJSONObject: AttributesAllTypes;
+        someJSONArray: AttributesAllTypes[];
+        someRegExp: RegExp;
+        someUndefined: undefined;
+        someNull: null;
+        someParseObjectUntyped: Parse.Object;
+        someParseObjectTyped: Parse.Object<AttributesAllTypes>;
+        someParseACL: Parse.ACL;
+        someParseGeoPoint: Parse.GeoPoint;
+        someParsePolygon: Parse.Polygon;
+        someParseRelation: Parse.Relation;
+        someParseFile: Parse.File;
+    }
 
+    function testToJSON(objUntyped: Parse.Object, objTyped: Parse.Object<AttributesAllTypes>) {
+        // $ExpectType ToJSON<Attributes> & JSONBaseAttributes
+        const JSONUntyped = objUntyped.toJSON();
+        // $ExpectType string
+        JSONUntyped.objectId;
+        // $ExpectType string
+        JSONUntyped.createdAt;
+        // $ExpectType string
+        JSONUntyped.updatedAt;
         // $ExpectType any
-        objTyped.toJSON();
+        JSONUntyped.anything;
+
+        // $ExpectType ToJSON<AttributesAllTypes> & JSONBaseAttributes
+        const JSONTyped = objTyped.toJSON();
+        // $ExpectType string
+        JSONTyped.objectId;
+        // $ExpectType string
+        JSONTyped.createdAt;
+        // $ExpectType string
+        JSONTyped.updatedAt;
+        // $ExpectType string
+        JSONTyped.someString;
+        // $ExpectType number
+        JSONTyped.someNumber;
+        // $ExpectType boolean
+        JSONTyped.someBoolean;
+        // $ExpectType { __type: "Date"; iso: string; }
+        JSONTyped.someDate;
+        // $ExpectType ToJSON<AttributesAllTypes>
+        JSONTyped.someJSONObject;
+        // $ExpectType ToJSON<AttributesAllTypes>[]
+        JSONTyped.someJSONArray;
+        // $ExpectType string
+        JSONTyped.someRegExp;
+        // $ExpectType undefined
+        JSONTyped.someUndefined;
+        // $ExpectType null
+        JSONTyped.someNull;
+        // $ExpectType Pointer | (ToJSON<Attributes> & JSONBaseAttributes)
+        JSONTyped.someParseObjectUntyped;
+        // $ExpectType Pointer | (ToJSON<AttributesAllTypes> & JSONBaseAttributes)
+        JSONTyped.someParseObjectTyped;
+        // $ExpectType any
+        JSONTyped.someParseACL;
+        // $ExpectType any
+        JSONTyped.someParseGeoPoint;
+        // $ExpectType any
+        JSONTyped.someParsePolygon;
+        // $ExpectType any
+        JSONTyped.someParseRelation;
+        // $ExpectType { __type: string; name: string; url: string; }
+        JSONTyped.someParseFile;
     }
 
     function testUnset(objUntyped: Parse.Object, objTyped: Parse.Object<{ example: string }>) {

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -823,6 +823,22 @@ function testObject() {
         new Parse.Object<{ example: boolean }>('TestObject', { example: 'hello' });
     }
 
+    function testStaticMethods() {
+        async function testSaveAll(objUntyped: Parse.Object, objTyped: Parse.Object<{ example: string }>) {
+            // $ExpectType Object<Attributes>[]
+            await Parse.Object.saveAll([ objUntyped ]);
+
+            // $ExpectType Object<{ example: string; }>[]
+            await Parse.Object.saveAll([ objTyped ]);
+
+            // $ExpectType [Object<Attributes>, Object<{ example: string; }>]
+            await Parse.Object.saveAll<[ typeof objUntyped, typeof objTyped ]>([ objUntyped, objTyped ]);
+
+            // $ExpectError
+            await Parse.Object.saveAll([ 123 ]);
+        }
+    }
+
     function testAttributes(objUntyped: Parse.Object, objTyped: Parse.Object<{ example: string }>) {
         // $ExpectType any
         objUntyped.attributes.whatever;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <http://parseplatform.org/Parse-SDK-JS/api/2.10.0/>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

-----

Up until now, `Parse.Object.toJSON` has been typed as `any`, which ultimately defeats the purpose of having a typed Parse Object at all. This PR types the return of `toJSON` in accordance with the Parse library's [ParseObject.toJSON](https://github.com/parse-community/Parse-SDK-JS/blob/master/src/ParseObject.js#L436) logic. The `ToJSON` type uses another new `Encode` type to map types in accordance with the library's [encode function](https://github.com/parse-community/Parse-SDK-JS/blob/master/src/encode.js#L22). 

In order for the type to reflect the recursive behavior of `encode` itself, this did require bumping the TS version to 3.7 - but we had already been bumped up to 3.5, so this isn't as large of a jump as we made a few weeks ago from 2.x to 3.x.

Additionally, some methods needed to be made generic in order to have better control over their return type.

