### PR TITLE
fix: rdf-ext factory does not accept base terms

### DIFF
--- a/types/rdf-ext/lib/DataFactory.d.ts
+++ b/types/rdf-ext/lib/DataFactory.d.ts
@@ -1,4 +1,4 @@
-import { DataFactory, Sink, NamedNode, BaseQuad, Quad, Stream } from 'rdf-js';
+import { DataFactory, Sink, NamedNode, BaseQuad, Quad, Stream, Quad_Subject, Quad_Predicate, Quad_Object, Quad_Graph } from 'rdf-js';
 import BlankNodeExt = require("./BlankNode");
 import LiteralExt = require("./Literal");
 import NamedNodeExt = require("./NamedNode");
@@ -29,8 +29,8 @@ declare class DataFactoryExt implements DataFactory {
   static literal(value: string, languageOrDatatype?: string | NamedNode): LiteralExt;
   static variable(value: string): VariableExt;
   static defaultGraph(): DefaultGraphExt;
-  static triple<Q extends BaseQuad = QuadExt>(subject: Q['subject'], predicate: Q['predicate'], object: Q['object']): Q;
-  static quad<Q extends BaseQuad = QuadExt>(subject: Q['subject'], predicate: Q['predicate'], object: Q['object'], graph?: Q['graph']): Q;
+  static triple(subject: Quad_Subject, predicate: Quad_Predicate, object: Quad_Object): QuadExt;
+  static quad(subject: Quad_Subject, predicate: Quad_Predicate, object: Quad_Object, graph?: Quad_Graph): QuadExt;
   static graph(quads?: any): Dataset;
   static prefixMap(prefixes: Prefixes): PrefixMap;
   static dataset(quads?: Quad[], graph?: PropType<QuadExt, 'graph'>): Dataset;
@@ -39,8 +39,10 @@ declare class DataFactoryExt implements DataFactory {
   defaultGraph(): DefaultGraphExt;
   literal(value: string, languageOrDatatype?: string | NamedNode): LiteralExt;
   namedNode(value: string): NamedNode;
-  quad<Q extends BaseQuad = QuadExt>(subject: Q['subject'], predicate: Q['predicate'], object: Q['object'], graph?: Q['graph']): Q;
-  triple<Q extends BaseQuad = QuadExt>(subject: Q['subject'], predicate: Q['predicate'], object: Q['object']): Q;
+  // tslint:disable:no-unnecessary-generics
+  quad<Q extends BaseQuad = QuadExt>(subject: Quad_Subject, predicate: Quad_Predicate, object: Quad_Object, graph?: Quad_Graph): Q;
+  triple<Q extends BaseQuad = QuadExt>(subject: Quad_Subject, predicate: Quad_Predicate, object: Quad_Object): Q;
+  // tslint:enable:no-unnecessary-generics
   variable(value: string): VariableExt;
 }
 

--- a/types/rdf-ext/rdf-ext-tests.ts
+++ b/types/rdf-ext/rdf-ext-tests.ts
@@ -1,5 +1,7 @@
 import rdf = require('rdf-ext');
-import { Literal, Quad, Dataset } from 'rdf-js';
+import { Literal, Quad, Dataset, NamedNode } from 'rdf-js';
+import QuadExt = require('rdf-ext/lib/Quad');
+import DataFactoryExt = require('rdf-ext/lib/DataFactory');
 
 function NamedNode_toCanonical(): string {
     const iri = 'http://example.org';
@@ -147,6 +149,44 @@ function Quad_withBlankSubject(): Quad {
         rdf.literal('object')
     );
 }
+
+function static_Quad_fromBaseTerms(): Quad {
+    const subject: NamedNode = <any> {};
+    const predicate: NamedNode = <any> {};
+    const object: NamedNode = <any> {};
+    const graph: NamedNode = <any> {};
+
+    return rdf.quad(subject, predicate, object, graph);
+}
+
+function static_Triple_fromBaseTerms(): Quad {
+    const subject: NamedNode = <any> {};
+    const predicate: NamedNode = <any> {};
+    const object: NamedNode = <any> {};
+
+    return rdf.triple(subject, predicate, object);
+}
+
+// tslint:disable:use-default-type-parameter
+function instance_Quad_fromBaseTerms(): Quad {
+    const factory: DataFactoryExt = <any> {};
+    const subject: NamedNode = <any> {};
+    const predicate: NamedNode = <any> {};
+    const object: NamedNode = <any> {};
+    const graph: NamedNode = <any> {};
+
+    return factory.quad<QuadExt>(subject, predicate, object, graph);
+}
+
+function instance_Triple_fromBaseTerms(): Quad {
+    const factory: DataFactoryExt = <any> {};
+    const subject: NamedNode = <any> {};
+    const predicate: NamedNode = <any> {};
+    const object: NamedNode = <any> {};
+
+    return factory.triple<QuadExt>(subject, predicate, object);
+}
+// tslint:enable:use-default-type-parameter
 
 function Quad_toJSON(): boolean {
     const quad = rdf.quad(


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.