### PR TITLE
fix: rdf-js sink must accept other stream types

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -151,7 +151,7 @@ export interface StreamParserConstructor {
 }
 export const StreamParser: StreamParserConstructor;
 
-export interface N3StreamParser<Q extends BaseQuad = Quad> extends RDF.Stream<Q>, NodeJS.WritableStream, RDF.Sink<Q> {
+export interface N3StreamParser<Q extends BaseQuad = Quad> extends RDF.Stream<Q>, NodeJS.WritableStream, RDF.Sink<EventEmitter, RDF.Stream<Q>> {
     // Below are the NodeJS.ReadableStream methods,
     // we can not extend the interface directly,
     // as `read` clashes with RDF.Sink.
@@ -199,7 +199,7 @@ export interface StreamWriterConstructor {
 }
 export const StreamWriter: StreamWriterConstructor;
 
-export interface N3StreamWriter<Q extends RDF.BaseQuad = Quad> extends NodeJS.ReadWriteStream, RDF.Sink<Q> {}
+export interface N3StreamWriter<Q extends RDF.BaseQuad = Quad> extends NodeJS.ReadWriteStream, RDF.Sink<RDF.Stream<Q>, EventEmitter> {}
 
 export interface N3Store<Q_RDF extends RDF.BaseQuad = RDF.Quad, Q_N3 extends BaseQuad = Quad> extends RDF.Store<Q_RDF> {
     readonly size: number;

--- a/types/rdf-ext/index.d.ts
+++ b/types/rdf-ext/index.d.ts
@@ -7,20 +7,21 @@
 import { Sink } from 'rdf-js';
 import DataFactory = require('./lib/DataFactory');
 import EventEmitter = require('events');
+import { Stream } from 'stream';
 
-type SinkMap = {
-  find(mediaType: string): Sink;
+type SinkMap<InputStream extends EventEmitter, OutputStream extends EventEmitter> = {
+  find(mediaType: string): Sink<InputStream, OutputStream>;
   import(mediaType: string, input: any, options: any): any;
   list(): string[];
 } & {
-  [mediaType: string]: Sink;
+  [mediaType: string]: Sink<InputStream, OutputStream>;
 };
 
 declare class DataFactoryExt extends DataFactory {
   static asEvent: (p: any) => EventEmitter;
   static waitFor: (event: any) => Promise<any>;
-  static Parsers: SinkMap;
-  static Serializers: SinkMap;
+  static Parsers: SinkMap<EventEmitter, Stream>;
+  static Serializers: SinkMap<Stream, EventEmitter>;
 }
 
 export = DataFactoryExt;

--- a/types/rdf-ext/rdf-ext-tests.ts
+++ b/types/rdf-ext/rdf-ext-tests.ts
@@ -1,7 +1,10 @@
 import rdf = require('rdf-ext');
-import { Literal, Quad, Dataset, NamedNode } from 'rdf-js';
+import { Literal, Quad, Dataset, NamedNode, Stream, Sink } from 'rdf-js';
 import QuadExt = require('rdf-ext/lib/Quad');
 import DataFactoryExt = require('rdf-ext/lib/DataFactory');
+import DatasetExt = require('rdf-ext/lib/Dataset');
+import { EventEmitter } from 'events';
+import { Readable } from 'stream';
 
 function NamedNode_toCanonical(): string {
     const iri = 'http://example.org';
@@ -278,4 +281,12 @@ function Dataset_toJSON() {
         && quad.object.termType === 'Literal'
         && quad.graph !== null;
     });
+}
+
+async function dataset_parserImport() {
+    const dataset: DatasetExt = <any> {};
+    const parserSink: Sink<EventEmitter, Stream> = <any> {};
+    const stream: Readable = <any> {};
+
+    const promise: DatasetExt = await dataset.import(parserSink.import(stream));
 }

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -365,7 +365,7 @@ export interface Source<Q extends BaseQuad = Quad> {
  *
  * For example parsers, serializers, transformations and stores can implement the Sink interface.
  */
-export interface Sink<Q extends BaseQuad = Quad> {
+export interface Sink<InputStream extends EventEmitter, OutputStream extends EventEmitter> {
     /**
      * Consumes the given stream.
      *
@@ -376,7 +376,7 @@ export interface Sink<Q extends BaseQuad = Quad> {
      * @param stream The stream that will be consumed.
      * @return The resulting event emitter.
      */
-    import(stream: Stream<Q>): EventEmitter;
+    import(stream: InputStream): OutputStream;
 }
 
 /**
@@ -387,7 +387,7 @@ export interface Sink<Q extends BaseQuad = Quad> {
  *
  * Access to stores LDP or SPARQL endpoints can be implemented with a Store inteface.
  */
-export interface Store<Q extends BaseQuad = Quad> extends Source<Q>, Sink<Q> {
+export interface Store<Q extends BaseQuad = Quad> extends Source<Q>, Sink<Stream<Q>, EventEmitter> {
     /**
      * Removes all streamed quads.
      *

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -109,13 +109,13 @@ function test_stream() {
     const matchStream8: Stream = source.match(term, term, term, term);
     const matchStream9: Stream = source.match(term, term, term, /.*/);
 
-    const sink: Sink = <any> {};
+    const sink: Sink<Stream, EventEmitter> = <any> {};
     const graph: Quad_Graph = <any> {};
     const eventEmitter1: EventEmitter = sink.import(stream);
 
     const store: Store = <any> {};
     const storeSource: Source = store;
-    const storeSink: Sink = store;
+    const storeSink: Sink<Stream, EventEmitter> = store;
     const eventEmitter2: EventEmitter = store.remove(stream);
     const eventEmitter3: EventEmitter = store.removeMatches();
     const eventEmitter4: EventEmitter = store.removeMatches(term);

--- a/types/rdfjs__parser-jsonld/index.d.ts
+++ b/types/rdfjs__parser-jsonld/index.d.ts
@@ -5,6 +5,7 @@
 
 import { Context } from 'jsonld/jsonld-spec';
 import { DataFactory, Sink, Stream, BaseQuad, Quad } from 'rdf-js';
+import { EventEmitter } from 'events';
 
 declare namespace Parser {
     interface ParserOptions {
@@ -14,10 +15,10 @@ declare namespace Parser {
     }
 }
 
-declare class Parser<Q extends BaseQuad = Quad> implements Sink<Q> {
+declare class Parser<Q extends BaseQuad = Quad> implements Sink<EventEmitter, Stream<Q>> {
     constructor(options?: Parser.ParserOptions);
 
-    import(stream: Stream<Q>, options?: Parser.ParserOptions): Stream<Q>;
+    import(stream: EventEmitter, options?: Parser.ParserOptions): Stream<Q>;
 }
 
 export = Parser;

--- a/types/rdfjs__parser-jsonld/rdfjs__parser-jsonld-tests.ts
+++ b/types/rdfjs__parser-jsonld/rdfjs__parser-jsonld-tests.ts
@@ -1,6 +1,7 @@
 import Parser = require('@rdfjs/parser-jsonld');
 import { Context } from 'jsonld/jsonld-spec';
 import { DataFactory, Sink, Stream, BaseQuad } from 'rdf-js';
+import { EventEmitter } from 'events';
 
 const baseIRI = '';
 const context: Context = {} as any;
@@ -11,7 +12,7 @@ const parser1 = new Parser();
 const parser2 = new Parser({});
 const parser3 = new Parser({ baseIRI, context, factory });
 
-const sink: Sink = parser1;
+const sink: Sink<EventEmitter, Stream> = parser1;
 
 const eventEmitter1: Stream = parser1.import(stream);
 const eventEmitter2: Stream = parser1.import(stream, {});

--- a/types/rdfjs__parser-n3/index.d.ts
+++ b/types/rdfjs__parser-n3/index.d.ts
@@ -4,16 +4,17 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Sink, Stream, DataFactory, BaseQuad, Quad } from 'rdf-js';
+import { EventEmitter } from 'events';
 
 interface ParserOptions {
     baseIRI?: string;
     factory?: DataFactory;
 }
 
-declare class Parser<Q extends BaseQuad = Quad> implements Sink<Q> {
+declare class Parser<Q extends BaseQuad = Quad> implements Sink<EventEmitter, Stream<Q>> {
     constructor(options?: ParserOptions);
 
-    import(stream: Stream<Q>, options?: ParserOptions): Stream<Q>;
+    import(stream: EventEmitter, options?: ParserOptions): Stream<Q>;
 }
 
 export = Parser;

--- a/types/rdfjs__parser-n3/rdfjs__parser-n3-tests.ts
+++ b/types/rdfjs__parser-n3/rdfjs__parser-n3-tests.ts
@@ -1,5 +1,6 @@
 import ParserN3 = require('@rdfjs/parser-n3');
 import { Stream, DataFactory, Sink, BaseQuad } from 'rdf-js';
+import { EventEmitter } from 'events';
 
 const factory: DataFactory = <any> {};
 const baseIRI = '';
@@ -9,7 +10,7 @@ const parser1 = new ParserN3({});
 const parser2 = new ParserN3({ factory });
 const parser3 = new ParserN3({ baseIRI });
 
-const sink: Sink = parser;
+const sink: Sink<EventEmitter, Stream> = parser;
 
 const input: Stream = <any> {};
 const output: Stream = parser.import(input);

--- a/types/rdfjs__serializer-jsonld-ext/index.d.ts
+++ b/types/rdfjs__serializer-jsonld-ext/index.d.ts
@@ -19,7 +19,7 @@ declare namespace Serializer {
     }
 }
 
-declare class Serializer<Q extends BaseQuad = Quad> implements Sink<Q> {
+declare class Serializer<Q extends BaseQuad = Quad> implements Sink<Stream<Q>, EventEmitter> {
     constructor(options?: Serializer.SerializerOptions);
 
     import(stream: Stream<Q>, options?: Serializer.SerializerOptions): EventEmitter;

--- a/types/rdfjs__serializer-jsonld-ext/rdfjs__serializer-jsonld-ext-tests.ts
+++ b/types/rdfjs__serializer-jsonld-ext/rdfjs__serializer-jsonld-ext-tests.ts
@@ -17,9 +17,9 @@ const serializer3 = new Serializer({
     skipContext: true,
     skipGraphProperty: true
 });
-const serializer4 = new Serializer({ encoding: 'object' });
+const serializer4: Serializer = new Serializer({ encoding: 'object' });
 
-const sink: Sink = serializer1;
+const sink: Sink<Stream, EventEmitter> = serializer1;
 
 const eventEmitter1: EventEmitter = serializer1.import(stream);
 const eventEmitter2: EventEmitter = serializer1.import(stream, {});

--- a/types/rdfjs__serializer-jsonld/index.d.ts
+++ b/types/rdfjs__serializer-jsonld/index.d.ts
@@ -12,7 +12,7 @@ declare namespace Serializer {
     }
 }
 
-declare class Serializer<Q extends BaseQuad = Quad> implements Sink<Q> {
+declare class Serializer<Q extends BaseQuad = Quad> implements Sink<Stream<Q>, EventEmitter> {
     constructor(options?: Serializer.SerializerOptions);
 
     import(stream: Stream<Q>, options?: Serializer.SerializerOptions): EventEmitter;

--- a/types/rdfjs__serializer-jsonld/rdfjs__serializer-jsonld-tests.ts
+++ b/types/rdfjs__serializer-jsonld/rdfjs__serializer-jsonld-tests.ts
@@ -9,7 +9,7 @@ const serializer2 = new Serializer({});
 const serializer3 = new Serializer({ encoding: 'string' });
 const serializer4 = new Serializer({ encoding: 'object' });
 
-const sink: Sink = serializer1;
+const sink: Sink<Stream, EventEmitter> = serializer1;
 
 const eventEmitter1: EventEmitter = serializer1.import(stream);
 const eventEmitter2: EventEmitter = serializer1.import(stream, {});


### PR DESCRIPTION
This PR refactors the `Sink` interface so that different kinds of streams can be represented. Here's example code which it fixes:

```ts
import stringToStream from 'string-to-stream'
import rdf from 'rdf-ext'
import Parser from '@rdfjs/parser-n3'

const parser = new Parser()

function parse (triples: string) {
  const dataset = rdf.dataset()
  const stream = stringToStream(triples)

  return dataset.import(parser.import(stream))
}
```

The above code works, but will fail typescript compilation unless it's changed:

```diff
-  return dataset.import(await parser.import(stream))
+  return dataset.import(await parser.import(stream as any))
```

By redefining the sink and parsers/serializers it will work without `any`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://rdf.js.org/stream-spec/#sink-interface>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.