### PR TITLE
Use union types instead of overloads

### DIFF
--- a/types/scrollreveal/index.d.ts
+++ b/types/scrollreveal/index.d.ts
@@ -39,34 +39,20 @@ declare namespace scrollReveal {
         useDelay ? : string;
         viewFactor ? : number;
         viewOffset ? : ScrollRevealPositionObject;
-        beforeReveal ? (domEl: HTMLElement): void;
-        afterReveal ? (domEl: HTMLElement): void;
-        beforeReset ? (domEl: HTMLElement): void;
-        afterReset ? (domEl: HTMLElement): void;
-        beforeReveal ? (domEl: NodeListOf<Element>): void;
-        afterReveal ? (domEl: NodeListOf<Element>): void;
-        beforeReset ? (domEl: NodeListOf<Element>): void;
-        afterReset ? (domEl: NodeListOf<Element>): void;
+        beforeReveal ? (domEl: HTMLElement | NodeListOf<Element>): void;
+        afterReveal ? (domEl: HTMLElement | NodeListOf<Element>): void;
+        beforeReset ? (domEl: HTMLElement | NodeListOf<Element>): void;
+        afterReset ? (domEl: HTMLElement | NodeListOf<Element>): void;
     }
 
 
     interface ScrollRevealObject {
         (): ScrollRevealObject;
         (options: ScrollRevealObjectOptions): ScrollRevealObject;
-        reveal(selector: string): ScrollRevealObject;
-        reveal(selector: string, interval: number): ScrollRevealObject;
-        reveal(selector: string, options: ScrollRevealObjectOptions): ScrollRevealObject;
-        reveal(selector: string, options: ScrollRevealObjectOptions, interval: number): ScrollRevealObject;
-        
-        reveal(selector: HTMLElement): ScrollRevealObject;
-        reveal(selector: HTMLElement, interval: number): ScrollRevealObject;
-        reveal(selector: HTMLElement, options: ScrollRevealObjectOptions): ScrollRevealObject;
-        reveal(selector: HTMLElement, options: ScrollRevealObjectOptions, interval: number): ScrollRevealObject;
-
-        reveal(selector: NodeListOf<Element>): ScrollRevealObject;
-        reveal(selector: NodeListOf<Element>, interval: number): ScrollRevealObject;
-        reveal(selector: NodeListOf<Element>, options: ScrollRevealObjectOptions): ScrollRevealObject;
-        reveal(selector: NodeListOf<Element>, options: ScrollRevealObjectOptions, interval: number): ScrollRevealObject;
+        reveal(selector: string | HTMLElement | NodeListOf<Element>): ScrollRevealObject;
+        reveal(selector: string | HTMLElement | NodeListOf<Element>, interval: number): ScrollRevealObject;
+        reveal(selector: string | HTMLElement | NodeListOf<Element>, options: ScrollRevealObjectOptions): ScrollRevealObject;
+        reveal(selector: string | HTMLElement | NodeListOf<Element>, options: ScrollRevealObjectOptions, interval: number): ScrollRevealObject;
 
         sync(): void;
     }

--- a/types/scrollreveal/index.d.ts
+++ b/types/scrollreveal/index.d.ts
@@ -24,35 +24,41 @@ declare namespace scrollReveal {
     }
 
     interface ScrollRevealObjectOptions {
-        origin ? : string;
-        distance ? : string;
-        duration ? : number;
-        delay ? : number;
-        interval ? : number;
-        rotate ? : ScrollRevealRotateObject;
-        opacity ? : number;
-        scale ? : number;
-        easing ? : string;
-        container ? : any;
-        mobile ? : boolean;
-        reset ? : boolean;
-        useDelay ? : string;
-        viewFactor ? : number;
-        viewOffset ? : ScrollRevealPositionObject;
-        beforeReveal ? (domEl: HTMLElement | NodeListOf<Element>): void;
-        afterReveal ? (domEl: HTMLElement | NodeListOf<Element>): void;
-        beforeReset ? (domEl: HTMLElement | NodeListOf<Element>): void;
-        afterReset ? (domEl: HTMLElement | NodeListOf<Element>): void;
+        origin?: string;
+        distance?: string;
+        duration?: number;
+        delay?: number;
+        interval?: number;
+        rotate?: ScrollRevealRotateObject;
+        opacity?: number;
+        scale?: number;
+        easing?: string;
+        container?: any;
+        mobile?: boolean;
+        reset?: boolean;
+        useDelay?: string;
+        viewFactor?: number;
+        viewOffset?: ScrollRevealPositionObject;
+        beforeReveal?(domEl: HTMLElement | NodeListOf<Element>): void;
+        afterReveal?(domEl: HTMLElement | NodeListOf<Element>): void;
+        beforeReset?(domEl: HTMLElement | NodeListOf<Element>): void;
+        afterReset?(domEl: HTMLElement | NodeListOf<Element>): void;
     }
-
 
     interface ScrollRevealObject {
         (): ScrollRevealObject;
         (options: ScrollRevealObjectOptions): ScrollRevealObject;
         reveal(selector: string | HTMLElement | NodeListOf<Element>): ScrollRevealObject;
         reveal(selector: string | HTMLElement | NodeListOf<Element>, interval: number): ScrollRevealObject;
-        reveal(selector: string | HTMLElement | NodeListOf<Element>, options: ScrollRevealObjectOptions): ScrollRevealObject;
-        reveal(selector: string | HTMLElement | NodeListOf<Element>, options: ScrollRevealObjectOptions, interval: number): ScrollRevealObject;
+        reveal(
+            selector: string | HTMLElement | NodeListOf<Element>,
+            options: ScrollRevealObjectOptions,
+        ): ScrollRevealObject;
+        reveal(
+            selector: string | HTMLElement | NodeListOf<Element>,
+            options: ScrollRevealObjectOptions,
+            interval: number,
+        ): ScrollRevealObject;
 
         sync(): void;
     }

--- a/types/scrollreveal/scrollreveal-tests.ts
+++ b/types/scrollreveal/scrollreveal-tests.ts
@@ -1,72 +1,70 @@
-//Tests from https://github.com/jlmakes/scrollreveal.js
+// Tests from https://github.com/jlmakes/scrollreveal.js
 
-//1.2
+// 1.2
 var sr = ScrollReveal();
 sr.reveal('.foo');
 sr.reveal('.bar');
 
-//1.3
+// 1.3
 sr = ScrollReveal().reveal('.foo, .bar');
 
-//2.1
+// 2.1
 sr = ScrollReveal({ reset: true });
 sr.reveal('.foo', { duration: 200 });
 
-//3.1
+// 3.1
 sr = ScrollReveal({ duration: 2000 });
 sr.reveal('.box', 50);
 
 sr = ScrollReveal();
 sr.reveal('.box', { duration: 2000 }, 50);
 
-//3.2
-var fooReveal  = {
-  delay    : 200,
-  distance : '90px',
-  easing   : 'ease-in-out',
-  rotate   : { z: 10 },
-  scale    : 1.1
+// 3.2
+var fooReveal = {
+    delay: 200,
+    distance: '90px',
+    easing: 'ease-in-out',
+    rotate: { z: 10 },
+    scale: 1.1,
 };
 
 sr = ScrollReveal();
 sr.reveal('.foo', fooReveal);
 sr.reveal('#chocolate', { delay: 500, scale: 0.9 });
 
-//3.3
+// 3.3
 sr.reveal(document.getElementById('foo'));
 sr.reveal(document.querySelectorAll('.bar'));
 
-//3.4
+// 3.4
 sr = ScrollReveal();
 var fooContainer = document.getElementById('fooContainer');
 sr.reveal('.foo', { container: fooContainer });
 sr.reveal('.bar', { container: '#barContainer' });
 
-//3.5
-
+// 3.5
 fooContainer = document.getElementById('fooContainer');
 
 sr = ScrollReveal();
 sr.reveal('.foo', { container: fooContainer });
 var xmlhttp = new XMLHttpRequest();
 xmlhttp.onreadystatechange = function() {
-  if (xmlhttp.readyState == XMLHttpRequest.DONE) {
-    if (xmlhttp.status == 200) {
+    if (xmlhttp.readyState == XMLHttpRequest.DONE) {
+        if (xmlhttp.status == 200) {
+            // Turn our response into HTML...
+            var content = document.createElement('div');
+            content.innerHTML = xmlhttp.responseText;
 
-      // Turn our response into HTML...
-      var content = document.createElement('div');
-      content.innerHTML = xmlhttp.responseText;
+            // Add each element to the DOM...
+            for (var i = 0; i < content.childNodes.length; i++) {
+                fooContainer.appendChild(content.childNodes[i]);
+            }
 
-      // Add each element to the DOM...
-      for (var i = 0; i < content.childNodes.length; i++) {
-        fooContainer.appendChild(content.childNodes[ i ]);
-      };
-
-      // Finally!
-      sr.sync();
+            // Finally!
+            sr.sync();
+        }
     }
-  }
-}
+};
 
 xmlhttp.open('GET', 'ajax.html', true);
 xmlhttp.send();
@@ -74,11 +72,11 @@ xmlhttp.send();
 sr.reveal('#one-matching-element', {
     beforeReveal: (element: HTMLElement) => {
         // ...
-    }
+    },
 });
 
 sr.reveal('.many-matching-elements', {
     beforeReveal: (element: NodeListOf<HTMLElement>) => {
         // ...
-    }
+    },
 });

--- a/types/scrollreveal/scrollreveal-tests.ts
+++ b/types/scrollreveal/scrollreveal-tests.ts
@@ -70,3 +70,15 @@ xmlhttp.onreadystatechange = function() {
 
 xmlhttp.open('GET', 'ajax.html', true);
 xmlhttp.send();
+
+sr.reveal('#one-matching-element', {
+    beforeReveal: (element: HTMLElement) => {
+        // ...
+    }
+});
+
+sr.reveal('.many-matching-elements', {
+    beforeReveal: (element: NodeListOf<HTMLElement>) => {
+        // ...
+    }
+});


### PR DESCRIPTION
I am changing the type definitions to use union types instead of overloads for the methods, because TypeScript was selecting the wrong overloaded method. I guess the issue was that TypeScript cannot always figure out what overload to choose if they are too similar, so it was choosing the last one instead of the one that matched my code. Using union types instead solved the issue.

I also formatted the files using Prettier, since this seems to be recommended in the readme. I hope the maintainer is okay with this.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://scrollrevealjs.org/api/reveal.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.