### PR TITLE
[rehype-react] Add Fragment option, update which options are optional

### DIFF
--- a/types/rehype-react/index.d.ts
+++ b/types/rehype-react/index.d.ts
@@ -8,6 +8,7 @@ import * as React from "react";
 
 interface Options {
     createElement: typeof React.createElement;
+    Fragment: React.ComponentType<{ children?: React.ReactNode }>;
     components: {
         [tagName: string]: React.ComponentType<any>;
     };

--- a/types/rehype-react/index.d.ts
+++ b/types/rehype-react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for rehype-react 3.1
+// Type definitions for rehype-react 4.0
 // Project: https://github.com/rhysd/rehype-react
 // Definitions by: Adrian Kremer <https://github.com/adriankremer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/rehype-react/index.d.ts
+++ b/types/rehype-react/index.d.ts
@@ -8,8 +8,8 @@ import * as React from "react";
 
 interface Options {
     createElement: typeof React.createElement;
-    Fragment: React.ComponentType<{ children?: React.ReactNode }>;
-    components: {
+    Fragment?: React.ComponentType<{ children?: React.ReactNode }>;
+    components?: {
         [tagName: string]: React.ComponentType<any>;
     };
     prefix?: string;

--- a/types/rehype-react/rehype-react-tests.tsx
+++ b/types/rehype-react/rehype-react-tests.tsx
@@ -8,6 +8,7 @@ const htmlAst = {
 
 const { Compiler: compile } = new RehypeReact({
     createElement: React.createElement,
+    Fragment: React.Fragment,
     components: {
         button: () => {
             return <button />;


### PR DESCRIPTION
Brings the typings up to date with the newest version of `rehype-react`. This mostly involves adding the new `Fragment` option.

Also updates some options to be optional; only the `createElement` option is actually required, as all other options have sensible defaults.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [link to official documentation](https://github.com/rehypejs/rehype-react#api), [link to source code indicating which options are optional](https://github.com/rehypejs/rehype-react/blob/621ab0d3304a4c00110d979f5045f8d7524d6555/index.js#L12-L15)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
