### PR TITLE
Changed definition of IncomingMessage

### DIFF
--- a/types/connect/index.d.ts
+++ b/types/connect/index.d.ts
@@ -18,7 +18,7 @@ declare function createServer(): createServer.Server;
 declare namespace createServer {
     export type ServerHandle = HandleFunction | http.Server;
 
-    export class IncomingMessage extends http.IncomingMessage {
+    export interface IncomingMessage extends http.IncomingMessage {
         originalUrl?: http.IncomingMessage["url"];
     }
 


### PR DESCRIPTION
TYPES/CONNECT: Changed definition of IncomingMessage from 'class' to 'interface'.
Fixed bug `Cannot extend an interface 'http.IncomingMessage'. Did you mean 'implements'?` from angular build.