### PR TITLE
Adding es6-set-proptypes npm package.

### DIFF
--- a/types/es6-set-proptypes/es6-set-proptypes-tests.ts
+++ b/types/es6-set-proptypes/es6-set-proptypes-tests.ts
@@ -1,0 +1,10 @@
+import * as setType from 'es6-set-proptypes';
+import * as PropTypes from "prop-types";
+
+interface SetProps {
+    names: Set<string>;
+}
+
+const propTypes: PropTypes.ValidationMap<SetProps> = {
+    names: setType.isRequired,
+};

--- a/types/es6-set-proptypes/index.d.ts
+++ b/types/es6-set-proptypes/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for es6-set-proptypes 1.0
+// Project: https://github.com/andrewbranch/es6-set-proptypes#readme
+// Definitions by: Cyrille <https://github.com/zozoens31>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import { Requireable } from 'prop-types';
+
+declare const setType: Requireable<Set<any>>;
+
+export = setType;

--- a/types/es6-set-proptypes/tsconfig.json
+++ b/types/es6-set-proptypes/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "es6-set-proptypes-tests.ts"
+    ]
+}

--- a/types/es6-set-proptypes/tslint.json
+++ b/types/es6-set-proptypes/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/definitelytyped/definitelytyped/41613)
<!-- Reviewable:end -->
