### PR TITLE
[@hapi/b64] Add types for @hapi/b64

### DIFF
--- a/types/hapi__b64/hapi__b64-tests.ts
+++ b/types/hapi__b64/hapi__b64-tests.ts
@@ -1,0 +1,17 @@
+import * as B64 from '@hapi/b64';
+import * as fs from 'fs';
+
+const stream = fs.createReadStream('package.json');
+const encoder = new B64.Encoder();
+const decoder = new B64.Decoder();
+
+stream.pipe(encoder).pipe(process.stdout);
+stream.pipe(decoder).pipe(process.stdout);
+
+B64.decode(Buffer.from('aHR0cHM6Ly9naXRodWIuY29t')); // $ExpectType Buffer
+B64.encode(Buffer.from('https://github.com')); // $ExpectType Buffer
+
+B64.base64urlDecode('aHR0cHM6Ly9naXRodWIuY29t'); // $ExpectType string
+B64.base64urlDecode('aHR0cHM6Ly9naXRodWIuY29t', 'ascii'); // $ExpectType string
+B64.base64urlDecode('aHR0cHM6Ly9naXRodWIuY29t', 'buffer'); // $ExpectType Buffer
+B64.base64urlEncode('https://github.com'); // $ExpectType string

--- a/types/hapi__b64/index.d.ts
+++ b/types/hapi__b64/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for @hapi/b64 5.0
+// Project: https://github.com/hapijs/b64#readme
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types='node' />
+
+import * as stream from 'stream';
+
+export class Decoder extends stream.Transform {}
+export class Encoder extends stream.Transform {}
+
+export function decode(buffer: Buffer): Buffer;
+export function encode(buffer: Buffer): Buffer;
+
+export function base64urlEncode(value: string | Buffer, encoding?: BufferEncoding): string;
+
+export function base64urlDecode(value: string, encoding?: BufferEncoding): string;
+export function base64urlDecode(value: string, encoding: 'buffer'): Buffer;

--- a/types/hapi__b64/tsconfig.json
+++ b/types/hapi__b64/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@hapi/b64": [
+                "hapi__b64"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "hapi__b64-tests.ts"
+    ]
+}

--- a/types/hapi__b64/tslint.json
+++ b/types/hapi__b64/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
