### PR TITLE
fix: clownface#list returns iterable and not iterator

### DIFF
--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -12,7 +12,7 @@ let term: Term = <any> {};
 const dataset: Dataset = <any> {};
 const graph: NamedNode = <any> {};
 
-let cf = new Clownface({ dataset });
+let cf: Clownface<Dataset> = new Clownface({ dataset });
 cf = new Clownface({ dataset, graph });
 const typedByTerm: Clownface<DatasetCore, NamedNode> = new Clownface({ dataset, term: node });
 const typedByTerms: Clownface<DatasetCore, NamedNode | BlankNode> = new Clownface({ dataset, term: [node, blankNode] });
@@ -113,7 +113,7 @@ cf = cf.in([node, node]);
 cf = cf.in(cf.node(node));
 
 // .list
-const iterator: Iterator<Term> = cf.list();
+const listNodes: Iterable<clownface.SingleContextClownface<Dataset>> = cf.list();
 
 // .literal
 cf = cf.literal('foo');

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -42,7 +42,7 @@ declare namespace clownface {
         readonly dataset: D;
         readonly datasets: D[];
         readonly _context: any;
-        list(): Iterator<Term>;
+        list(): Iterable<SingleContextClownface<D>>;
         toArray(): Array<Clownface<D, T>>;
         filter(cb: (quad: Clownface<D, T>) => boolean): Clownface<D, T>;
         forEach(cb: (quad: Clownface<D, T>) => void): void;

--- a/types/clownface/lib/Clownface.d.ts
+++ b/types/clownface/lib/Clownface.d.ts
@@ -23,7 +23,7 @@ declare class Clownface<D extends DatasetCore = DatasetCore, T extends Term = Te
     readonly dataset: D;
     readonly datasets: D[];
     readonly _context: any;
-    list(): Iterator<Term>;
+    list(): Iterable<SingleContextClownface<D>>;
     toArray(): Array<Clownface<D, T>>;
     filter(cb: (quad: Clownface<D, T>) => boolean): Clownface<D, T>;
     forEach(cb: (quad: Clownface<D, T>) => void): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/rdf-ext/clownface/blob/master/test/Clownface/list.js#L37-L47>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
