### PR TITLE
[googlemaps] add id prop to AutocompletePrediction / QueryAutocompletePrediction

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -3536,6 +3536,7 @@ declare namespace google.maps {
 
         interface AutocompletePrediction {
             description: string;
+            id: string;
             matched_substrings: PredictionSubstring[];
             place_id: string;
             reference: string;
@@ -3768,6 +3769,7 @@ declare namespace google.maps {
 
         interface QueryAutocompletePrediction {
             description: string;
+            id?: string;
             matched_substrings: PredictionSubstring[];
             place_id: string;
             terms: PredictionTerm[];


### PR DESCRIPTION
There is `id` property in AutocompletePrediction / QueryAutocompletePrediction objects (AutocompleteService response). You can find it in the [documentation](https://developers.google.com/places/web-service/autocomplete#place_autocomplete_responses) and in real responses.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/places/web-service/autocomplete#place_autocomplete_responses
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
