### PR TITLE
[emscripten] Fix and improvements for 1.39.5

### DIFF
--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -34,6 +34,26 @@ declare namespace Emscripten {
 }
 
 interface EmscriptenModule {
+    /**
+     * Initializes an EmscriptenModule object and returns it. The initialized
+     * obejct will be passed to then(). Works only when -s MODULARIZE=1 is
+     * enabled. This is default exported function when -s EXPORT_ES6=1 is
+     * enabled.
+     * https://emscripten.org/docs/getting_started/FAQ.html#how-can-i-tell-when-the-page-is-fully-loaded-and-it-is-safe-to-call-compiled-functions
+     * @param moduleOverrides Properties of an initialized module to override.
+     */
+    (moduleOverrides?: Partial<this>): this;
+    /**
+     * Promise-like then() inteface.
+     * WRANGING: Emscripten's then() is not really promise-based 'thenable'.
+     * Don't try to use it with Promise.resolve() or in an async function
+     * without deleting delete Module["then"] in the callback.
+     * https://github.com/kripken/emscripten/issues/5820
+     * Works only when -s MODULARIZE=1 is enabled.
+     * @param callback A callback chained from Module() with an Module instance.
+     */
+    then(callback: (module: this) => void): this;
+
     print(str: string): void;
     printErr(str: string): void;
     arguments: string[];

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -85,8 +85,6 @@ interface EmscriptenModule {
     locateFile(url: string): string;
     onCustomMessage(event: MessageEvent): void;
 
-    Runtime: any;
-
     // USE_TYPED_ARRAYS == 1
     HEAP: Int32Array;
     IHEAP: Int32Array;

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -81,20 +81,6 @@ interface EmscriptenModule {
 
     Runtime: any;
 
-    ccall(ident: string, returnType: Emscripten.ValueType | null, argTypes: Emscripten.ValueType[], args: Emscripten.TypeCompatibleWithC[], opts?: Emscripten.CCallOpts): any;
-    cwrap(ident: string, returnType: Emscripten.ValueType | null, argTypes: Emscripten.ValueType[], opts?: Emscripten.CCallOpts): (...args: any[]) => any;
-
-    setValue(ptr: number, value: any, type: string, noSafe?: boolean): void;
-    getValue(ptr: number, type: string, noSafe?: boolean): number;
-
-    ALLOC_NORMAL: number;
-    ALLOC_STACK: number;
-    ALLOC_STATIC: number;
-    ALLOC_DYNAMIC: number;
-    ALLOC_NONE: number;
-
-    allocate(slab: any, types: string | string[], allocator: number, ptr: number): number;
-
     // USE_TYPED_ARRAYS == 1
     HEAP: Int32Array;
     IHEAP: Int32Array;
@@ -119,16 +105,6 @@ interface EmscriptenModule {
     addOnPreMain(cb: () => any): void;
     addOnExit(cb: () => any): void;
     addOnPostRun(cb: () => any): void;
-
-    // Tools
-    intArrayFromString(stringy: string, dontAddNull?: boolean, length?: number): number[];
-    intArrayToString(array: number[]): string;
-    writeStringToMemory(str: string, buffer: number, dontAddNull: boolean): void;
-    writeArrayToMemory(array: number[], buffer: number): void;
-    writeAsciiToMemory(str: string, buffer: number, dontAddNull: boolean): void;
-
-    addRunDependency(id: any): void;
-    removeRunDependency(id: any): void;
 
     preloadedImages: any;
     preloadedAudios: any;
@@ -236,9 +212,35 @@ declare namespace FS {
         canRead: boolean, canWrite: boolean, onload?: () => void, onerror?: () => void, dontCreateFile?: boolean, canOwn?: boolean): void;
 }
 
+interface Math {
+    imul(a: number, b: number): number;
+}
+
 declare var MEMFS: Emscripten.FileSystemType;
 declare var NODEFS: Emscripten.FileSystemType;
 declare var IDBFS: Emscripten.FileSystemType;
+
+// Below runtime function/variable declarations are exportable by
+// -s EXTRA_EXPORTED_RUNTIME_METHODS. You can extend or merge
+// EmscriptenModule interface to add runtime functions.
+//
+// For example, by using -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall']"
+// You can access ccall() via Module["ccall"]. In this case, you should
+// extend EmscriptenModule to pass the compiler check like the following:
+//
+// interface YourOwnEmscriptenModule extends EmscriptenModule {
+//     ccall: typeof ccall;
+// }
+//
+// See: https://emscripten.org/docs/getting_started/FAQ.html#why-do-i-get-typeerror-module-something-is-not-a-function
+
+declare function ccall(ident: string, returnType: Emscripten.ValueType | null, argTypes: Emscripten.ValueType[], args: Emscripten.TypeCompatibleWithC[], opts?: Emscripten.CCallOpts): any;
+declare function cwrap(ident: string, returnType: Emscripten.ValueType | null, argTypes: Emscripten.ValueType[], opts?: Emscripten.CCallOpts): (...args: any[]) => any;
+
+declare function setValue(ptr: number, value: any, type: string, noSafe?: boolean): void;
+declare function getValue(ptr: number, type: string, noSafe?: boolean): number;
+
+declare function allocate(slab: any, types: string | string[], allocator: number, ptr: number): number;
 
 declare function UTF8ToString(ptr: number, maxBytesToRead?: number): string;
 declare function stringToUTF8(str: string, outPtr: number, maxBytesToRead?: number): void;
@@ -251,6 +253,17 @@ declare function UTF32ToString(ptr: number): string;
 declare function stringToUTF32(str: string, outPtr: number, maxBytesToRead?: number): void;
 declare function lengthBytesUTF32(str: string): number;
 
-interface Math {
-    imul(a: number, b: number): number;
-}
+declare function intArrayFromString(stringy: string, dontAddNull?: boolean, length?: number): number[];
+declare function intArrayToString(array: number[]): string;
+declare function writeStringToMemory(str: string, buffer: number, dontAddNull: boolean): void;
+declare function writeArrayToMemory(array: number[], buffer: number): void;
+declare function writeAsciiToMemory(str: string, buffer: number, dontAddNull: boolean): void;
+
+declare function addRunDependency(id: any): void;
+declare function removeRunDependency(id: any): void;
+
+declare var ALLOC_NORMAL: number;
+declare var ALLOC_STACK: number;
+declare var ALLOC_STATIC: number;
+declare var ALLOC_DYNAMIC: number;
+declare var ALLOC_NONE: number;

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -14,8 +14,14 @@ declare namespace Emscripten {
     interface FileSystemType {
     }
     type EnvironmentType = "WEB" | "NODE" | "SHELL" | "WORKER";
-    type ValueType = "number" | "string" | "array" | "boolean";
+
+    type JSType = "number" | "string" | "array" | "boolean";
     type TypeCompatibleWithC = number | string | any[] | boolean;
+
+    type CIntType = 'i8' | 'i16' | 'i32' | 'i64';
+    type CFloatType = 'float' | 'double';
+    type CPointerType = 'i8*' | 'i16*' | 'i32*' | 'i64*' | 'float*' | 'double*' | '*';
+    type CType =  CIntType | CFloatType | CPointerType;
 
     type WebAssemblyImports =  Array<{
         name: string;
@@ -237,13 +243,13 @@ declare var IDBFS: Emscripten.FileSystemType;
 //
 // See: https://emscripten.org/docs/getting_started/FAQ.html#why-do-i-get-typeerror-module-something-is-not-a-function
 
-declare function ccall(ident: string, returnType: Emscripten.ValueType | null, argTypes: Emscripten.ValueType[], args: Emscripten.TypeCompatibleWithC[], opts?: Emscripten.CCallOpts): any;
-declare function cwrap(ident: string, returnType: Emscripten.ValueType | null, argTypes: Emscripten.ValueType[], opts?: Emscripten.CCallOpts): (...args: any[]) => any;
+declare function ccall(ident: string, returnType: Emscripten.JSType | null, argTypes: Emscripten.JSType[], args: Emscripten.TypeCompatibleWithC[], opts?: Emscripten.CCallOpts): any;
+declare function cwrap(ident: string, returnType: Emscripten.JSType | null, argTypes: Emscripten.JSType[], opts?: Emscripten.CCallOpts): (...args: any[]) => any;
 
-declare function setValue(ptr: number, value: any, type: string, noSafe?: boolean): void;
-declare function getValue(ptr: number, type: string, noSafe?: boolean): number;
+declare function setValue(ptr: number, value: any, type: Emscripten.CType, noSafe?: boolean): void;
+declare function getValue(ptr: number, type: Emscripten.CType, noSafe?: boolean): number;
 
-declare function allocate(slab: any, types: string | string[], allocator: number, ptr: number): number;
+declare function allocate(slab: number[] | ArrayBufferView | number, types: Emscripten.CType | Emscripten.CType[], allocator: number, ptr?: number): number;
 
 declare function stackAlloc(size: number): number;
 declare function stackSave(): number;

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Emscripten 1.38.33
+// Type definitions for Emscripten 1.39.5
 // Project: http://kripken.github.io/emscripten-site/index.html
 // Definitions by: Kensuke Matsuzaki <https://github.com/zakki>
 //                 Periklis Tsirakidis <https://github.com/periklis>

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://kripken.github.io/emscripten-site/index.html
 // Definitions by: Kensuke Matsuzaki <https://github.com/zakki>
 //                 Periklis Tsirakidis <https://github.com/periklis>
+//                 Bumsik Kim <https://github.com/kbumsik>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -193,7 +193,9 @@ declare namespace FS {
     function allocate(stream: FSStream, offset: number, length: number): void;
     function mmap(stream: FSStream, buffer: ArrayBufferView, offset: number, length: number, position: number, prot: number, flags: number): any;
     function ioctl(stream: FSStream, cmd: any, arg: any): any;
-    function readFile(path: string, opts?: { encoding?: "binary" | "utf8"; flags?: string }): string | Uint8Array;
+    function readFile(path: string, opts: { encoding: "binary", flags?: string }): Uint8Array;
+    function readFile(path: string, opts: { encoding: "utf8", flags?: string }): string;
+    function readFile(path: string, opts?: { flags?: string }): Uint8Array;
     function writeFile(path: string, data: string | ArrayBufferView, opts?: { flags?: string }): void;
 
     //
@@ -210,6 +212,7 @@ declare namespace FS {
     function createLazyFile(parent: string | FSNode, name: string, url: string, canRead: boolean, canWrite: boolean): FSNode;
     function createPreloadedFile(parent: string | FSNode, name: string, url: string,
         canRead: boolean, canWrite: boolean, onload?: () => void, onerror?: () => void, dontCreateFile?: boolean, canOwn?: boolean): void;
+    function createDataFile(parent: string | FSNode, name: string, data: ArrayBufferView, canRead: boolean, canWrite: boolean): FSNode;
 }
 
 interface Math {

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -242,10 +242,15 @@ declare function getValue(ptr: number, type: string, noSafe?: boolean): number;
 
 declare function allocate(slab: any, types: string | string[], allocator: number, ptr: number): number;
 
+declare function stackAlloc(size: number): number;
+declare function stackSave(): number;
+declare function stackRestore(ptr: number): void;
+
 declare function UTF8ToString(ptr: number, maxBytesToRead?: number): string;
 declare function stringToUTF8(str: string, outPtr: number, maxBytesToRead?: number): void;
 declare function lengthBytesUTF8(str: string): number;
 declare function allocateUTF8(str: string): number;
+declare function allocateUTF8OnStack(str: string): number;
 declare function UTF16ToString(ptr: number): string;
 declare function stringToUTF16(str: string, outPtr: number, maxBytesToRead?: number): void;
 declare function lengthBytesUTF16(str: string): number;
@@ -261,6 +266,9 @@ declare function writeAsciiToMemory(str: string, buffer: number, dontAddNull: bo
 
 declare function addRunDependency(id: any): void;
 declare function removeRunDependency(id: any): void;
+
+declare function addFunction(func: () => any, signature?: string): number;
+declare function removeFunction(funcPtr: number): void;
 
 declare var ALLOC_NORMAL: number;
 declare var ALLOC_STACK: number;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * https://emscripten.org/docs/getting_started/FAQ.html#how-can-i-tell-when-the-page-is-fully-loaded-and-it-is-safe-to-call-compiled-functions
  * https://github.com/emscripten-core/emscripten/blob/79523944931f526c4b1c2a92e1a826475c987a2b/src/settings.js#L674-L685
  * https://emscripten.org/docs/getting_started/FAQ.html#why-does-runtime-no-longer-exist-why-do-i-get-an-error-trying-to-access-runtime-something
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/definitelytyped/definitelytyped/41621)
<!-- Reviewable:end -->
