### PR TITLE
[ramda] Make R.tryCatch type safe

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1937,7 +1937,7 @@ export function trim(str: string): string;
  * function and returns its result. Note that for effective composition with this function, both the tryer and
  * catcher functions must return the same type of results.
  */
-export function tryCatch<T>(tryer: (...args: readonly any[]) => T, catcher: (...args: readonly any[]) => T): (...args: readonly any[]) => T;
+export function tryCatch<F extends (...args: readonly any[]) => any, E = ReturnType<F>>(tryer: F, catcher: (error: any, ...args: _.F.Parameters<F>) => E): (F | (() => E));
 
 /**
  * Gives a single-word string description of the (native) type of a value, returning such answers as 'Object',

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -710,11 +710,15 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    const x          = R.prop("x");
-    const a: boolean  = R.tryCatch<boolean>(R.prop("x"), R.F)({x: true}); // => true
-    const a1: boolean = R.tryCatch(R.prop<"x", true>("x"), R.F)({x: true}); // => true
-    const b: boolean = R.tryCatch<boolean>(R.prop("x"), R.F)(null);      // => false
-    const c: boolean = R.tryCatch<boolean>(R.and, R.F)(true, true);      // => true
+    const f1 = R.tryCatch((x: number) => x, R.F); // $ExpectType ((x: number) => number) | (() => boolean)
+    const f2 = R.tryCatch(<T>(x: T) => x, R.F); // $ExpectType (() => boolean) | (<T>(x: T) => T)
+    const s1 = R.tryCatch((x: number) => x, R.F)(5); // $ExpectType number | boolean
+    const a1 = R.tryCatch(R.prop("x"), R.F)({x: true}); // $ExpectType boolean
+    const a2 = R.tryCatch(R.prop<"x", true>("x"), R.F)({x: true}); // $ExpectType boolean
+    const a3 = R.tryCatch(R.prop("x"), R.F)({x: 13}); // $ExpectType number | boolean
+    const b = R.tryCatch(R.prop("x"), R.F)(null); // $ExpectError
+    // Curried function call
+    const c = R.tryCatch(R.and, R.always(undefined))(true); // $ExpectType ((val2: any) => boolean) | undefined
 };
 
 () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I've tried to make `R.tryCatch` more type safe since current typings return a function that always takes `any[]` as arguments. 
I think I finally got it, it seems to work even with curried and generic functions. However using generic functions works only on TS 3.7 and next, so I guess it's not possible to merge it for a while. I'm not sure if it can be fixed on lower versions.

I'm opening the PR anyway to leave a mark and prevent others from duplicating this work and coming to the same conclusion :slightly_smiling_face: 