### PR TITLE
[parse] Fix typo in Parse.Object.save attrs type

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -412,7 +412,7 @@ namespace Parse {
         revert(...keys: Array<Extract<keyof T, string>>): void;
         save<K extends Extract<keyof T, string>>(
             attrs?: (((x: T) => void) extends ((x: Attributes) => void) ? Partial<T> : {
-                [key in K]: T[K];
+                [key in K]: T[key];
             }) | null,
             options?: Object.SaveOptions
         ): Promise<this>;

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -423,7 +423,7 @@ namespace Parse {
         ): Promise<this>;
         set<K extends Extract<keyof T, string>>(
             attrs: ((x: T) => void) extends ((x: Attributes) => void) ? Partial<T> : {
-                [key in K]: T[K];
+                [key in K]: T[key];
             },
             options?: Object.SetOptions
         ): this | false;

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1109,17 +1109,26 @@ function testObject() {
         objTyped.revert('other');
     }
 
-    async function testSave(objUntyped: Parse.Object, objTyped: Parse.Object<{ example: boolean }>) {
+    async function testSave(
+        objUntyped: Parse.Object,
+        objTyped: Parse.Object<{ example: boolean; someString: string }>
+    ) {
         // $ExpectType Object<Attributes>
         await objUntyped.save({ whatever: 100 });
 
         // $ExpectType Object<Attributes>
         await objUntyped.save('whatever', 100);
 
-        // $ExpectType Object<{ example: boolean; }>
+        // $ExpectType Object<{ example: boolean; someString: string; }>
         await objTyped.save({ example: true });
 
-        // $ExpectType Object<{ example: boolean; }>
+        // $ExpectType Object<{ example: boolean; someString: string; }>
+        await objTyped.save({ example: true, someString: 'hello' });
+
+        // $ExpectError
+        await objTyped.save({ example: 'hello', someString: true });
+
+        // $ExpectType Object<{ example: boolean; someString: string; }>
         await objTyped.save('example', true);
 
         // $ExpectError

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1155,6 +1155,12 @@ function testObject() {
         objTyped.set({ example: false });
 
         // $ExpectType false | Object<{ example: boolean; another: number; }>
+        objTyped.set({ example: true, another: 123 });
+
+        // $ExpectError
+        objTyped.set({ example: 123, another: true });
+
+        // $ExpectType false | Object<{ example: boolean; another: number; }>
         objTyped.set('example', true);
 
         // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <http://parseplatform.org/Parse-SDK-JS/api/2.10.0/>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

-----

Fixing a typo:
`[key in K]: T[K];` -> `[key in K]: T[key];`
The `K` type parameter represents the union of all property names while `key` is the particular property name. Each property should be typed according to its own type, not the union of all property types.

The following test case also ensures that this is now correct:
```ts
// objTyped: Parse.Object<{ example: boolean; someString: string }>

// $ExpectError
await objTyped.save({ example: 'hello', someString: true });
```