### PR TITLE
Update react-simple-maps geography type from object to any

### DIFF
--- a/types/react-simple-maps/index.d.ts
+++ b/types/react-simple-maps/index.d.ts
@@ -84,7 +84,7 @@ export interface ZoomableGroupProps extends React.SVGAttributes<SVGGElement> {
 }
 
 interface GeographiesChildrenArgument {
-    geographies: object[];
+    geographies: any[];
     path: GeoPath;
     projection: GeoProjection;
 }
@@ -97,7 +97,7 @@ export interface GeographiesProps extends React.SVGAttributes<SVGGElement> {
 
 export interface GeographyProps
     extends Pick<React.SVGProps<SVGPathElement>, Exclude<keyof React.SVGProps<SVGPathElement>, 'style'>> {
-    geography?: object;
+    geography?: any;
     style?: {
         default?: React.CSSProperties;
         hover?: React.CSSProperties;

--- a/types/react-simple-maps/index.d.ts
+++ b/types/react-simple-maps/index.d.ts
@@ -84,7 +84,7 @@ export interface ZoomableGroupProps extends React.SVGAttributes<SVGGElement> {
 }
 
 interface GeographiesChildrenArgument {
-    geographies: any[];
+    geographies: unknown[];
     path: GeoPath;
     projection: GeoProjection;
 }
@@ -97,7 +97,7 @@ export interface GeographiesProps extends React.SVGAttributes<SVGGElement> {
 
 export interface GeographyProps
     extends Pick<React.SVGProps<SVGPathElement>, Exclude<keyof React.SVGProps<SVGPathElement>, 'style'>> {
-    geography?: any;
+    geography?: unknown;
     style?: {
         default?: React.CSSProperties;
         hover?: React.CSSProperties;

--- a/types/react-simple-maps/index.d.ts
+++ b/types/react-simple-maps/index.d.ts
@@ -84,7 +84,7 @@ export interface ZoomableGroupProps extends React.SVGAttributes<SVGGElement> {
 }
 
 interface GeographiesChildrenArgument {
-    geographies: unknown[];
+    geographies: any[];
     path: GeoPath;
     projection: GeoProjection;
 }
@@ -97,7 +97,7 @@ export interface GeographiesProps extends React.SVGAttributes<SVGGElement> {
 
 export interface GeographyProps
     extends Pick<React.SVGProps<SVGPathElement>, Exclude<keyof React.SVGProps<SVGPathElement>, 'style'>> {
-    geography?: unknown;
+    geography?: any;
     style?: {
         default?: React.CSSProperties;
         hover?: React.CSSProperties;


### PR DESCRIPTION
the object type is too restrictive, forcing people to use any in their code. The geography prop comes through as a very complex object, and using the object type prevents you from using it properly. If we want to allow any geography type (I am not sure if they vary by map, but I assume they would), we should type it as any, not as object.

That being said, I would happily contribute my type definition for geography if it is the same across all maps provided.

A quote straight from your common mistakes document:
> Using the types Function and Object is almost never a good idea. In 99% of cases it's possible to specify a more specific type. Examples are (x: number) => number for functions and { x: number, y: number } for objects. If there is no certainty at all about the type, any is the right choice, not Object. If the only known fact about the type is that it's some object, use the type object, not Object or { [key: string]: any }.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).