### PR TITLE
bull - add missing whenCurrentJobsFinished typings

### DIFF
--- a/types/bull/bull-tests.tsx
+++ b/types/bull/bull-tests.tsx
@@ -165,6 +165,11 @@ videoQueue.add({ video: 'http://example.com/video1.mov' }, { jobId: 1 })
     // error
 });
 
+pdfQueue.whenCurrentJobsFinished()
+.then(() => {
+    // Jobs finished
+});
+
 //////////////////////////////////////////////////////////////////////////////////
 //
 // Typed Event Handlers

--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for bull 3.10
+// Type definitions for bull 3.12
 // Project: https://github.com/OptimalBits/bull
 // Definitions by: Bruno Grieder <https://github.com/bgrieder>
 //                 Cameron Crothers <https://github.com/JProgrammer>

--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -17,6 +17,7 @@
 //                 DoYoung Ha <https://github.com/hados99>
 //                 Borys Kupar <https://github.com/borys-kupar>
 //                 Remko Klein <https://github.com/remko79>
+//                 Levi Bostian <https://github.com/levibostian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -846,6 +847,11 @@ declare namespace Bull {
      * @param list String with all redis clients
      */
     parseClientList(list: string): Redis.Redis[];
+
+    /**
+     * Returns a promise that resolves when active jobs are finished
+     */
+    whenCurrentJobsFinished(): Promise<void>;
   }
 
   type EventCallback = () => void;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OptimalBits/bull/blob/29d0bae9c239af804406648ff1347936a6e8afd1/lib/queue.js#L1181
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

The function `whenCurrentJobsFinished()` was missing. This PR adds it. 