### PR TITLE
Add types for yawn-yaml

### DIFF
--- a/types/yawn-yaml/cjs/index.d.ts
+++ b/types/yawn-yaml/cjs/index.d.ts
@@ -2,6 +2,6 @@ export default class YAWN {
     constructor(content: string);
     json: any;
     yaml: string;
-    getRemark(path: string): any;
+    getRemark(path: string): string;
     setRemark(path: string, remark: string): boolean;
 }

--- a/types/yawn-yaml/cjs/index.d.ts
+++ b/types/yawn-yaml/cjs/index.d.ts
@@ -1,0 +1,7 @@
+export default class YAWN {
+    constructor(content: string);
+    json: any;
+    yaml: string;
+    getRemark(path: string): any;
+    setRemark(path: string, remark: string): boolean;
+}

--- a/types/yawn-yaml/index.d.ts
+++ b/types/yawn-yaml/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for yawn-yaml 1.4
+// Project: https://github.com/mohsen1/yawn#readme
+// Definitions by: Jamie Magee <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+export default class YAWN {
+    constructor(content: string);
+    json: any;
+    yaml: string;
+    getRemark(path: string): any;
+    setRemark(path: string, remark: string): boolean;
+}

--- a/types/yawn-yaml/index.d.ts
+++ b/types/yawn-yaml/index.d.ts
@@ -1,11 +1,11 @@
 // Type definitions for yawn-yaml 1.4
-// Project: https://github.com/mohsen1/yawn#readme
-// Definitions by: Jamie Magee <https://github.com/me>
+// Project: https://github.com/mohsen1/yawn-yaml#readme
+// Definitions by: Jamie Magee <https://github.com/JamieMagee>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 export default class YAWN {
     constructor(content: string);
     json: any;
     yaml: string;
-    getRemark(path: string): any;
+    getRemark(path: string): string;
     setRemark(path: string, remark: string): boolean;
 }

--- a/types/yawn-yaml/tsconfig.json
+++ b/types/yawn-yaml/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "yawn-yaml-tests.ts"
+    ]
+}

--- a/types/yawn-yaml/tslint.json
+++ b/types/yawn-yaml/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/yawn-yaml/yawn-yaml-tests.ts
+++ b/types/yawn-yaml/yawn-yaml-tests.ts
@@ -1,0 +1,7 @@
+import YAML from 'yawn-yaml/cjs';
+
+const yaml = new YAML(''); // $ExpectType YAWN
+yaml.json; // $ExpectType any
+yaml.yaml; // $ExpectType string
+yaml.getRemark(''); // $ExpectType any
+yaml.setRemark('', ''); // $ExpectType boolean

--- a/types/yawn-yaml/yawn-yaml-tests.ts
+++ b/types/yawn-yaml/yawn-yaml-tests.ts
@@ -3,5 +3,5 @@ import YAML from 'yawn-yaml/cjs';
 const yaml = new YAML(''); // $ExpectType YAWN
 yaml.json; // $ExpectType any
 yaml.yaml; // $ExpectType string
-yaml.getRemark(''); // $ExpectType any
+yaml.getRemark(''); // $ExpectType string
 yaml.setRemark('', ''); // $ExpectType boolean


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

