### PR TITLE
express-serve-static-core-tests: Update `req.is` to match the actual function in express

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -9,6 +9,8 @@ app.listen(3000, (err: any) => {
 app.get('/:foo', req => {
     req.params.foo; // $ExpectType string
     req.params[0]; // $ExpectType string
+    // $ExpectType string | false | null
+    req.is(['application/json', 'application/xml']);
 });
 
 // Params can used as an array

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -11,6 +11,10 @@ app.get('/:foo', req => {
     req.params[0]; // $ExpectType string
     // $ExpectType string | false | null
     req.is(['application/json', 'application/xml']);
+    // $ExpectType string | false | null
+    req.is('audio/wav');
+    // $ExpectError
+    req.is(1);
 });
 
 // Params can used as an array

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -7,6 +7,7 @@
 //                 Sami Jaber <https://github.com/samijaber>
 //                 aereal <https://github.com/aereal>
 //                 Jose Luis Leon <https://github.com/JoseLion>
+//                 David Stephens <https://github.com/dwrss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -368,7 +369,7 @@ export interface Request<P extends Params = ParamsDictionary, ResBody = any, Req
      *      req.is('html');
      *      // => false
      */
-    is(type: string): string | false;
+    is(type: string | string[]): string | false | null;
 
     /**
      * Return the protocol string "http" or "https"


### PR DESCRIPTION
The parameters can be a string or an array and return type can be null.
This is described in the JSDoc for the function:
https://github.com/expressjs/express/blob/e1b45ebd050b6f06aa38cda5aaf0c21708b0c71e/lib/request.js#L273

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/express/blob/e1b45ebd050b6f06aa38cda5aaf0c21708b0c71e/lib/request.js#L273