### PR TITLE
react-native: Add WebSocket ready state constants

### DIFF
--- a/types/react-native/globals.d.ts
+++ b/types/react-native/globals.d.ts
@@ -304,4 +304,8 @@ declare var WebSocket: {
             [optionName: string]: any;
         } | null,
     ): WebSocket;
+  readonly CLOSED: number;
+  readonly CLOSING: number;
+  readonly CONNECTING: number;
+  readonly OPEN: number;
 };


### PR DESCRIPTION
Please fill in this template.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/master/Libraries/WebSocket/WebSocket.js#L59-L67
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.