### PR TITLE
[react-aria-menubutton] Add definition for the render prop

### DIFF
--- a/types/react-aria-menubutton/index.d.ts
+++ b/types/react-aria-menubutton/index.d.ts
@@ -85,6 +85,7 @@ export interface MenuProps<T extends HTMLElement>
 	 * The HTML tag for this element. Default: 'span'.
 	 */
 	tag?: T["tagName"];
+	children: JSX.Element | (({ isOpen }: { isOpen: boolean }) => JSX.Element);
 }
 
 /**

--- a/types/react-aria-menubutton/react-aria-menubutton-tests.tsx
+++ b/types/react-aria-menubutton/react-aria-menubutton-tests.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+
 import {
-	closeMenu,
-	openMenu,
-	Wrapper,
 	Button,
 	Menu,
-	MenuItem
+	MenuItem,
+	Wrapper,
+	closeMenu,
+	openMenu
 } from "react-aria-menubutton";
 
 const menuItemWords = ["foo", "bar", "baz"];
@@ -136,3 +137,17 @@ class ObjectMenuItem extends React.Component {
 }
 
 ReactDOM.render(<ObjectMenuItem />, document.body);
+
+class MenuWithRenderProp extends React.Component {
+	render() {
+		return (
+			<Menu>
+				{({ isOpen }) => (
+					<ul>
+						<li><MenuItem>Foo</MenuItem></li>
+					</ul>
+				)}
+			</Menu>
+		);
+	}
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/davidtheclark/react-aria-menubutton/blob/5b88ff9459b8c1f6543186ae2c98a8dca7a30868/README.md#L311-L314
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
ackages.json`.
