### PR TITLE
Improve types of highland filter and toPromise

### DIFF
--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -66,6 +66,11 @@ interface StrBarArrMap {
   [key: string]: Bar[];
 }
 
+declare class MyPromise<T> implements PromiseLike<T> {
+  constructor(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (err: any) => void) => void);
+  then<TResult1 = T, TResult2 = never>(onfulfilled?: (value: T) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>): PromiseLike<TResult1 | TResult2>;
+}
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 var foo: Foo;
@@ -468,18 +473,21 @@ fooStream.toNodeStream();
 fooStream.toNodeStream({objectMode: false});
 fooStream.toNodeStream({objectMode: true});
 
-fooStream.toPromise(Promise)
-  .then((foo: Foo) => foo)
-  .catch((err: any) => { throw err; });
+fooStream.toPromise(Promise).then((foo: Foo) => {})
 
-declare class MyPromise<T> implements PromiseLike<T> {
-  constructor(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (err: any) => void) => void);
-  then<TResult1 = T, TResult2 = never>(onfulfilled?: (value: T) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>): PromiseLike<TResult1 | TResult2>;
-}
+// Type inference for the generic parameter only seems to work with TS 3.5 or above.
+// Rather than bump the required version, I'm not testing type inference here.
 
+// Test that the generic parameter is optional:
+fooStream.toPromise(MyPromise);
+
+// $ExpectType Promise<Foo>
+fooStream.toPromise<Promise<Foo>>(Promise);
 // $ExpectType MyPromise<Foo>
-fooStream.toPromise(MyPromise);  
-  
+fooStream.toPromise<MyPromise<Foo>>(MyPromise);
+// $ExpectError
+fooStream.toPromise<Promise<Foo>>(MyPromise);
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // UTILS
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -463,8 +463,18 @@ fooStream.toNodeStream();
 fooStream.toNodeStream({objectMode: false});
 fooStream.toNodeStream({objectMode: true});
 
-fooStream.toPromise(Promise);
+fooStream.toPromise(Promise)
+  .then((foo: Foo) => foo)
+  .catch((err: any) => { throw err; });
 
+declare class MyPromise<T> implements PromiseLike<T> {
+  constructor(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (err: any) => void) => void);
+  then<TResult1 = T, TResult2 = never>(onfulfilled?: (value: T) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>): PromiseLike<TResult1 | TResult2>;
+}
+
+// $ExpectType MyPromise<Foo>
+fooStream.toPromise(MyPromise);  
+  
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // UTILS
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -53,7 +53,7 @@ interface Bar {
   bar(): string;
 }
 interface Baz {
-  foo: string;
+  foo(): string;
   bar: number;
   baz: boolean;
 }
@@ -106,6 +106,8 @@ var barStreamThen: PromiseLike<Highland.Stream<Bar>>;
 
 var fooIterable: Iterable<Foo>;
 var fooIterator: Iterator<Foo>;
+
+var isBaz: (obj: Foo) => obj is Baz;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -242,6 +244,9 @@ fooStream = fooStream.errors((err, push) => {
 fooStream = fooStream.filter((x: Foo) => {
   return bool;
 });
+
+// $ExpectType Stream<Baz>
+fooStream.filter(isBaz);
 
 fooStream = fooStream.find((x: Foo) => {
   return bool;

--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -250,6 +250,9 @@ fooStream = fooStream.filter((x: Foo) => {
   return bool;
 });
 
+// $ExpectType Stream<number>
+numStream = numStream.filter((n: number) => n < 3);
+
 // $ExpectType Stream<Baz>
 fooStream.filter(isBaz);
 

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -24,6 +24,10 @@ type Flattened<R> = {
 	array: R extends Array<infer U> ? Flattened<U> : never;
 }[R extends Array<any> ? 'array' : R extends Highland.Stream<any> ? 'stream' : 'value'];
 
+// Describes a constructor for a particular promise library
+interface PConstructor<T, P extends PromiseLike<T>> {
+	new(executor: (resolve: (value?: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): P
+}
 /**
  * Highland: the high-level streams library
  *
@@ -1603,7 +1607,7 @@ declare namespace Highland {
      *     // parameter result will be [1,2,3,4]
      * });
      */
-    toPromise(PromiseCtor: PromiseConstructor): PromiseLike<R>;
+    toPromise<P extends PromiseLike<R>>(PromiseCtor: PConstructor<R, P>): P;
 	}
 
 	interface PipeableStream<T, R> extends Stream<R> {}

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -704,6 +704,7 @@ declare namespace Highland {
 		 * @param f - the truth test function
 		 * @api public
 		 */
+		filter<S extends R>(f: (x: R) => x is S): Stream<S>;
 		filter(f: (x: R) => boolean): Stream<R>;
 
 		/**


### PR DESCRIPTION
`toPromise` now returns an instance of the constructor passed to it, instead of just a `PromiseLike<T>`.
`filter` now accepts a type guard, just like the array filter function.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://highlandjs.org/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
