### PR TITLE
fix(rdf-ext): merge also accepts quad array

### DIFF
--- a/types/rdf-ext/lib/Dataset.d.ts
+++ b/types/rdf-ext/lib/Dataset.d.ts
@@ -1,14 +1,16 @@
-import { Dataset } from 'rdf-js';
+import { Dataset, DatasetCore, Stream, Quad } from 'rdf-js';
 import { PropType } from './_PropType';
 import QuadExt = require('./Quad');
+import { Readable } from 'stream';
 
 interface DatasetExt extends Dataset {
   readonly length: number;
   toJSON(): Array<ReturnType<PropType<QuadExt, 'toJSON'>>>;
   clone(): this;
   readonly includes: PropType<Dataset, 'has'>;
-  merge(other: Dataset): DatasetExt;
+  merge(other: Dataset | Quad[]): this;
   removeMatches(subject: any, predicate: any, object: any, graph: any): this;
+  toStream(): Stream<QuadExt> & Readable;
 }
 
 export = DatasetExt;

--- a/types/rdf-ext/rdf-ext-tests.ts
+++ b/types/rdf-ext/rdf-ext-tests.ts
@@ -1,5 +1,5 @@
 import rdf = require('rdf-ext');
-import { Literal, Quad, Dataset, NamedNode, Stream, Sink } from 'rdf-js';
+import { Literal, Quad, Dataset, NamedNode, Stream, Sink, DatasetCore } from 'rdf-js';
 import QuadExt = require('rdf-ext/lib/Quad');
 import DataFactoryExt = require('rdf-ext/lib/DataFactory');
 import DatasetExt = require('rdf-ext/lib/Dataset');
@@ -228,8 +228,14 @@ function dataset_empty(): boolean {
     return rdf.dataset().length === 0;
 }
 
-function dataset_merge(): Dataset {
-    return rdf.dataset().merge(rdf.dataset());
+function dataset_merge(): DatasetExt {
+    const other: Dataset = <any> {};
+    return rdf.dataset().merge(other);
+}
+
+function dataset_merge_arrau(): DatasetExt {
+    const other: Quad[] = <any> {};
+    return rdf.dataset().merge(other);
 }
 
 function dataset_clone(): Dataset {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
<img width="659" alt="image" src="https://user-images.githubusercontent.com/588128/72531853-9ffff380-3872-11ea-9143-f6d0054e95f6.png">

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.