### PR TITLE
feat: add @rdfjs/sink-map

### DIFF
--- a/types/rdfjs__sink-map/index.d.ts
+++ b/types/rdfjs__sink-map/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for @rdfjs/sink-map 1.0
+// Project: https://github.com/rdfjs-base/sink-map
+// Definitions by: tpluscode <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { EventEmitter } from 'events';
+import { Sink } from 'rdf-js';
+
+declare namespace SinkMap {
+    interface SinkMap<InputStream extends EventEmitter, OutputStream extends EventEmitter> extends Map<string, Sink<InputStream, OutputStream>> {
+        import(mediaType: string, input: InputStream, options?: any): OutputStream | null;
+    }
+}
+
+declare class SinkMap<InputStream extends EventEmitter, OutputStream extends EventEmitter> extends Map<string, Sink<InputStream, OutputStream>> implements SinkMap<InputStream, OutputStream> {
+    import(mediaType: string, input: InputStream, options?: any): OutputStream | null;
+}
+
+export = SinkMap;

--- a/types/rdfjs__sink-map/rdfjs__sink-map-tests.ts
+++ b/types/rdfjs__sink-map/rdfjs__sink-map-tests.ts
@@ -1,0 +1,20 @@
+import SinkMap = require('@rdfjs/sink-map');
+import { Stream, Sink } from 'rdf-js';
+
+const parsers: SinkMap<NodeJS.ReadableStream, Stream> = new SinkMap<NodeJS.ReadableStream, Stream>();
+
+function createSinkMap(): SinkMap<NodeJS.ReadableStream, Stream> {
+    const parser: Sink<NodeJS.ReadableStream, Stream> = <any> {};
+    return new SinkMap<NodeJS.ReadableStream, Stream>([
+        ['text/turtle', parser]
+    ]);
+}
+
+function castToMap(): Map<string, Sink<NodeJS.ReadableStream, Stream>> {
+    return parsers;
+}
+
+function importing(): Stream | null {
+    const input: NodeJS.ReadableStream = <any> {};
+    return parsers.import('text/turtle', input);
+}

--- a/types/rdfjs__sink-map/tsconfig.json
+++ b/types/rdfjs__sink-map/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@rdfjs/sink-map": [
+                "rdfjs__sink-map"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "rdfjs__sink-map-tests.ts"
+    ]
+}

--- a/types/rdfjs__sink-map/tslint.json
+++ b/types/rdfjs__sink-map/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.