### PR TITLE
elliptic: signatures can be constructed from flexibly encoded DER types

### DIFF
--- a/types/elliptic/elliptic-tests.ts
+++ b/types/elliptic/elliptic-tests.ts
@@ -13,6 +13,8 @@ const signature = key.sign(msgHash);
 // Export DER encoded signature in Array
 const derSign = signature.toDER();
 
+const decodedSignature = new elliptic.ec.Signature(derSign);
+
 // Verify signature
 console.log(key.verify(msgHash, derSign));
 

--- a/types/elliptic/index.d.ts
+++ b/types/elliptic/index.d.ts
@@ -10,7 +10,8 @@ import BN = require("bn.js");
 export const utils: any;
 export const rand: any;
 
-export type BNInput = string | BN | number | Buffer | Uint8Array | number[];
+export type BNInput = string | BN | number | Buffer | Uint8Array | ReadonlyArray<number>;
+export type SignatureInput = ec.Signature | ec.SignatureOptions | Uint8Array | ReadonlyArray<number> | string;
 
 export const version: number;
 
@@ -204,19 +205,19 @@ export class ec {
     ): ec.Signature;
     verify(
         msg: BNInput,
-        signature: ec.Signature | ec.SignatureOptions,
+        signature: SignatureInput,
         key: Buffer | ec.KeyPair,
         enc?: string
     ): boolean;
     recoverPubKey(
         msg: BNInput,
-        signature: ec.Signature | ec.SignatureOptions,
+        signature: SignatureInput,
         j: number,
         enc?: string
     ): any;
     getKeyRecoveryParam(
         e: Error | undefined,
-        signature: ec.Signature | ec.SignatureOptions,
+        signature: SignatureInput,
         Q: BN,
         enc?: string
     ): number;
@@ -266,7 +267,7 @@ export namespace ec {
         sign(msg: BNInput, options?: SignOptions): Signature;
         verify(
             msg: BNInput,
-            signature: Signature | SignatureOptions | string
+            signature: SignatureInput
         ): boolean;
         inspect(): string;
     }
@@ -276,7 +277,7 @@ export namespace ec {
         s: BN;
         recoveryParam: number | null;
 
-        constructor(options: SignatureOptions | Signature, enc?: string);
+        constructor(options: SignatureInput, enc?: string);
 
         toDER(enc?: string | null): any; // ?
     }


### PR DESCRIPTION
signatures can be constructed from DER encodings of anything [toArray](https://github.com/indutny/minimalistic-crypto-utils/blob/master/lib/utils.js#L5) from minimalistic-crypto-utils recognizes, specifically number[], Uint8Array, and (hexadecimal) strings.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/indutny/elliptic/blob/master/lib/elliptic/ec/signature.js#L12