### PR TITLE
[kd-tree-javascript] Add typings for kd-tree-javascript

### DIFF
--- a/types/kd-tree-javascript/index.d.ts
+++ b/types/kd-tree-javascript/index.d.ts
@@ -1,0 +1,30 @@
+// Type definitions for kd-tree-javascript 1.0
+// Project: https://github.com/ubilabs/kd-tree-javascript#readme
+// Definitions by: Cooper Bills <https://github.com/coopeyb>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export class kdTree<T> {
+    // Create a new tree from a list of points, a distance function, and a
+    // list of dimensions.
+    constructor(points: T[], distance: (a: T, b: T) => number, dimensions: Array<keyof T>);
+
+    // Query the nearest *count* neighbors to a point, with an optional
+    // maximal search distance.
+    // Result is an array with *count* elements.
+    // Each element is an array with two components: the searched point and
+    // the distance to it.
+    nearest(point: T, count: number, maxDistance?: number): Array<[T, number]>;
+
+    // Insert a new point into the tree.  Must be consistent with previous
+    // contents.
+    insert(point: T): void;
+
+    // Remove a point from the tree by reference.
+    remove(point: T): void;
+
+    // Get an approximation of how unbalanced the tree is.
+    // The higher this number, the worse query performance will be.
+    // It indicates how many times worse it is than the optimal tree.
+    // Minimum is 1. Unreliable for small trees.
+    balanceFactor(): number;
+}

--- a/types/kd-tree-javascript/kd-tree-javascript-tests.ts
+++ b/types/kd-tree-javascript/kd-tree-javascript-tests.ts
@@ -1,0 +1,32 @@
+import { kdTree } from 'kd-tree-javascript';
+
+const points = [
+    { x: 1, y: 2 },
+    { x: 3, y: 4 },
+    { x: 5, y: 6 },
+    { x: 7, y: 8 },
+];
+
+const distance = (a: { x: number; y: number }, b: { x: number; y: number }) => {
+    return Math.pow(a.x - b.x, 2) + Math.pow(a.y - b.y, 2);
+};
+
+const tree = new kdTree(points, distance, ['x', 'y']); // $ExpectType kdTree<{ x: number; y: number; }>
+
+tree.nearest({ x: 5, y: 5 }, 2); // $ExpectType [{ x: number; y: number; }, number][]
+
+tree.balanceFactor(); // $ExpectType number
+
+tree.insert({ x: 1, y: 2 }); // $ExpectType void
+
+tree.remove({ x: 1, y: 2 }); // $ExpectType void
+
+new kdTree(points, distance, ['x', 'wrongField']); // $ExpectError
+
+tree.nearest({ x: 5, notY: 5 }, 2); // $ExpectError
+
+const wrongDistanceComparison = (a: { notX: number; notY: number }, b: { notX: number; notY: number }) => {
+    return Math.pow(a.notX - b.notX, 2) + Math.pow(a.notY - b.notY, 2);
+};
+
+new kdTree(points, wrongDistanceComparison, ['x', 'y']); // $ExpectError

--- a/types/kd-tree-javascript/tsconfig.json
+++ b/types/kd-tree-javascript/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "kd-tree-javascript-tests.ts"
+    ]
+}

--- a/types/kd-tree-javascript/tslint.json
+++ b/types/kd-tree-javascript/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

