### PR TITLE
feat: add @rdfjs/formats-common

### DIFF
--- a/types/rdfjs__formats-common/index.d.ts
+++ b/types/rdfjs__formats-common/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for @rdfjs/formats-common 2.0
+// Project: https://github.com/rdfjs-base/formats-common
+// Definitions by: tpluscode <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { SinkMap } from '@rdfjs/sink-map';
+import { Stream } from 'rdf-js';
+import { EventEmitter } from 'events';
+
+declare const formats: {
+    parsers: SinkMap<EventEmitter, Stream>;
+    serializers: SinkMap<Stream, EventEmitter>;
+};
+
+export = formats;

--- a/types/rdfjs__formats-common/rdfjs__formats-common-tests.ts
+++ b/types/rdfjs__formats-common/rdfjs__formats-common-tests.ts
@@ -1,0 +1,6 @@
+import formats = require('@rdfjs/formats-common');
+import { Sink, Stream } from 'rdf-js';
+import { EventEmitter } from 'events';
+
+const parsers: Sink<EventEmitter, Stream> = formats.parsers;
+const serializers: Sink<Stream, EventEmitter> = formats.serializers;

--- a/types/rdfjs__formats-common/tsconfig.json
+++ b/types/rdfjs__formats-common/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@rdfjs/formats-common": [
+                "rdfjs__formats-common"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "rdfjs__formats-common-tests.ts"
+    ]
+}

--- a/types/rdfjs__formats-common/tslint.json
+++ b/types/rdfjs__formats-common/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
