### PR TITLE
fix nodegit repository.getReferences() param error

### DIFF
--- a/types/nodegit/repository.d.ts
+++ b/types/nodegit/repository.d.ts
@@ -103,7 +103,7 @@ export class Repository {
     /**
      * Lookup references for a repository.
      */
-    getReferences(type: Reference.TYPE): Promise<Reference[]>;
+    getReferences(): Promise<Reference[]>;
     /**
      * Lookup reference names for a repository.
      */


### PR DESCRIPTION
since the method `repository.getReferences()` has been migrated to use underlying cpp method and the single type parameter is removed, but the ts type definition hasn't been updated, this pr is to update the ts type definition to remove the unnecessary params. More details:
https://github.com/nodegit/nodegit/commit/adcc5c520aae1a3351d9c463ee0ae7a207e666d1
https://github.com/nodegit/nodegit/blob/v0.26.0/lib/repository.js#L353
https://github.com/nodegit/nodegit/blob/v0.26.0/lib/repository.js#L1266

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
