### PR TITLE
types/n3: Fix incorrect callback param types on N3Store.forSubjects (etc)

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -215,13 +215,13 @@ export interface N3Store<Q_RDF extends RDF.BaseQuad = RDF.Quad, Q_N3 extends Bas
     every(callback: QuadPredicate<Q_N3>, subject: OTerm, predicate: OTerm, object: OTerm, graph: OTerm): boolean;
     some(callback: QuadPredicate<Q_N3>, subject: OTerm, predicate: OTerm, object: OTerm, graph: OTerm): boolean;
     getSubjects(predicate: OTerm, object: OTerm, graph: OTerm): Array<Q_N3['subject']>;
-    forSubjects(callback: QuadCallback<Q_N3>, predicate: OTerm, object: OTerm, graph: OTerm): void;
+    forSubjects(callback: (result: Q_N3['subject']) => void, predicate: OTerm, object: OTerm, graph: OTerm): void;
     getPredicates(subject: OTerm, object: OTerm, graph: OTerm): Array<Q_N3['predicate']>;
-    forPredicates(callback: QuadCallback<Q_N3>, subject: OTerm, object: OTerm, graph: OTerm): void;
+    forPredicates(callback: (result: Q_N3['predicate']) => void, subject: OTerm, object: OTerm, graph: OTerm): void;
     getObjects(subject: OTerm, predicate: OTerm, graph: OTerm): Array<Q_N3['object']>;
-    forObjects(callback: QuadCallback<Q_N3>, subject: OTerm, predicate: OTerm, graph: OTerm): void;
+    forObjects(callback: (result: Q_N3['object']) => void, subject: OTerm, predicate: OTerm, graph: OTerm): void;
     getGraphs(subject: OTerm, predicate: OTerm, object: OTerm): Array<Q_N3['graph']>;
-    forGraphs(callback: QuadCallback<Q_N3>, subject: OTerm, predicate: OTerm, object: OTerm): void;
+    forGraphs(callback: (result: Q_N3['graph']) => void, subject: OTerm, predicate: OTerm, object: OTerm): void;
     createBlankNode(suggestedName?: string): BlankNode;
 }
 export interface StoreConstructor {

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -217,6 +217,22 @@ function test_doc_storing() {
     storeGeneralized.addQuad(N3.DataFactory.namedNode('http://ex.org/Pluto'), N3.DataFactory.blankNode(), N3.DataFactory.namedNode('http://ex.org/Dog'));
 }
 
+function test_store_queries() {
+    const store: N3.N3Store = new N3.Store();
+
+    const subjs: N3.Quad_Subject[] = store.getSubjects(null, null, null);
+    store.forSubjects((subj: N3.Quad_Subject) => {}, null, null, null);
+
+    const preds: N3.Quad_Predicate[] = store.getPredicates(null, null, null);
+    store.forPredicates((subj: N3.Quad_Predicate) => {}, null, null, null);
+
+    const objs: N3.Quad_Object[] = store.getObjects(null, null, null);
+    store.forObjects((subj: N3.Quad_Object) => {}, null, null, null);
+
+    const graphs: N3.Quad_Graph[] = store.getGraphs(null, null, null);
+    store.forGraphs((subj: N3.Quad_Graph) => {}, null, null, null);
+}
+
 function test_doc_utility() {
     const N3Util = N3.Util;
     N3Util.isNamedNode(N3.DataFactory.namedNode('http://example.org/cartoons#Mickey')); // true


### PR DESCRIPTION
Now they callback with the same type that N3Store.getSubjects/etc returned.

See https://github.com/rdfjs/N3.js/blob/master/src/N3Store.js#L521 for how getSubjects uses forSubjects internally. The callback param (s) is the returned array element type.
