### PR TITLE
Revert "`history`: switch default `LocationState` generic from `any` to `unknown`"

### DIFF
--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -9,8 +9,6 @@ let input = { value: "" };
 {
     let history = createBrowserHistory<{ some: 'state' }>();
 
-    history.location.state; // $ExpectType { some: "state"; }
-
     // Listen for changes to the current location. The
     // listener is called once immediately.
     let unlisten = history.listen(function (location) {
@@ -116,8 +114,7 @@ let input = { value: "" };
 }
 
 {
-    const anything: any = {};
-    const eventTarget: EventTarget = anything;
+    let eventTarget: EventTarget;
     DOMUtils.addEventListener(eventTarget, 'onload', function (event) { event.preventDefault(); });
     DOMUtils.removeEventListener(eventTarget, 'onload', function (event) { event.preventDefault(); });
     DOMUtils.getConfirmation('confirm?', (result) => console.log(result));
@@ -127,10 +124,4 @@ let input = { value: "" };
 {
     let supportsDOM = ExecutionEnvironment.canUseDOM;
     let isExtraneousPopstateEvent = DOMUtils.isExtraneousPopstateEvent;
-}
-
-{
-    const anything: any = {};
-    const history: History = anything;
-    history.location.state; // $ExpectType PoorMansUnknown
 }

--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -49,10 +49,7 @@ export namespace History {
       location: Location<S>,
       action: Action,
     ) => void;
-    // The value type here is a "poor man's `unknown`". When these types support TypeScript
-    // 3.0+, we can replace this with `unknown`.
-    type PoorMansUnknown = {} | null | undefined;
-    export type LocationState = PoorMansUnknown;
+    export type LocationState = any;
     export type Path = string;
     export type Pathname = string;
     export type Search = string;

--- a/types/history/tsconfig.json
+++ b/types/history/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
+        "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/react-router/test/examples-from-react-router-website/Auth.tsx
+++ b/types/react-router/test/examples-from-react-router-website/Auth.tsx
@@ -8,7 +8,6 @@ import {
   Redirect,
   withRouter
 } from 'react-router-dom';
-import { StaticContext } from 'react-router';
 
 ////////////////////////////////////////////////////////////
 // 1. Click the public page
@@ -69,9 +68,7 @@ const PrivateRoute: React.SFC<RouteProps> = ({ component, ...rest }) => (
 const Public: React.SFC<RouteComponentProps> = () => <h3>Public</h3>;
 const Protected: React.SFC<RouteComponentProps> = () => <h3>Protected</h3>;
 
-type Props = RouteComponentProps<{}, StaticContext, { from: { pathname: string; }; }>;
-
-class Login extends React.Component<Props, {redirectToReferrer: boolean}> {
+class Login extends React.Component<RouteComponentProps, {redirectToReferrer: boolean}> {
   state = {
     redirectToReferrer: false
   };

--- a/types/react-router/test/examples-from-react-router-website/ModalGallery.tsx
+++ b/types/react-router/test/examples-from-react-router-website/ModalGallery.tsx
@@ -6,7 +6,6 @@ import {
   Route,
   Link
 } from 'react-router-dom';
-import { StaticContext } from 'react-router';
 
 // This example shows how to render two different screens
 // (or the same screen in a different context) at the same url,
@@ -17,9 +16,7 @@ import { StaticContext } from 'react-router';
 // are the same as before but now we see them inside a modal
 // on top of the old screen.
 
-type Props = RouteComponentProps<{}, StaticContext, { modal: boolean }>;
-
-class ModalSwitch extends React.Component<Props> {
+class ModalSwitch extends React.Component<RouteComponentProps> {
   // We can pass a location to <Switch/> that will tell it to
   // ignore the router's current location and use the location
   // prop instead.
@@ -34,7 +31,7 @@ class ModalSwitch extends React.Component<Props> {
   // is still `/` even though its `/images/2`.
   previousLocation = this.props.location;
 
-  componentWillUpdate(nextProps: Props) {
+  componentWillUpdate(nextProps: RouteComponentProps) {
     const { location } = this.props;
     // set previousLocation if props.location is not modal
     if (


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#41580 to fix https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41674

CC @johnnyreilly @OliverJAsh @fr3gu