### PR TITLE
Describe `Parsimmon.seq` and extend `Parsimmon.seqMap` for `parsimmon`

### DIFF
--- a/types/parsimmon/index.d.ts
+++ b/types/parsimmon/index.d.ts
@@ -6,8 +6,9 @@
 //                 Benny van Reeven <https://github.com/bvanreeven>
 //                 Leonard Thieu <https://github.com/leonard-thieu>
 //                 Jonathan Frere <https://github.com/MrJohz>
+//                 Isaac Huang <https://github.com/caasi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 /**
  * **NOTE:** You probably will never need to use this function. Most parsing
@@ -252,6 +253,8 @@ declare namespace Parsimmon {
 		of<U>(result: U): Parser<U>;
 	}
 
+	type UnParser<T> = T extends Parser<infer U> ? U : never;
+
 	/**
 	 * Alias of `Parsimmon(fn)` for backwards compatibility.
 	 */
@@ -388,7 +391,7 @@ declare namespace Parsimmon {
 	function seq<T, U, V, W, X, Y>(p1: Parser<T>, p2: Parser<U>, p3: Parser<V>, p4: Parser<W>, p5: Parser<X>, p6: Parser<Y>): Parser<[T, U, V, W, X, Y]>;
 	function seq<T, U, V, W, X, Y, Z>(p1: Parser<T>, p2: Parser<U>, p3: Parser<V>, p4: Parser<W>, p5: Parser<X>, p6: Parser<Y>, p7: Parser<Z>): Parser<[T, U, V, W, X, Y, Z]>;
 	function seq<T>(...parsers: Array<Parser<T>>): Parser<T[]>;
-	function seq(...parsers: Array<Parser<any>>): Parser<any[]>;
+	function seq<T extends any[]>(...parsers: T): Parser<UnParser<T>>;
 
 	/**
 	 * Takes the string passed to parser.parse(string) and the error returned from
@@ -413,6 +416,12 @@ declare namespace Parsimmon {
 	function seqMap<T, U, V, W, X, Y, Z, A, B>(
 		p1: Parser<T>, p2: Parser<U>, p3: Parser<V>, p4: Parser<W>, p5: Parser<X>, p6: Parser<Y>, p7: Parser<Z>, p8: Parser<A>,
 		cb: (a1: T, a2: U, a3: V, a4: W, a5: X, a6: Y, a7: Z, a8: A) => B): Parser<B>;
+	function seqMap<T, U, V, W, X, Y, Z, A, B, C>(
+		p1: Parser<T>, p2: Parser<U>, p3: Parser<V>, p4: Parser<W>, p5: Parser<X>, p6: Parser<Y>, p7: Parser<Z>, p8: Parser<A>, p9: Parser<B>,
+		cb: (a1: T, a2: U, a3: V, a4: W, a5: X, a6: Y, a7: Z, a8: A, a9: B) => C): Parser<C>;
+	function seqMap<T, U, V, W, X, Y, Z, A, B, C, D>(
+		p1: Parser<T>, p2: Parser<U>, p3: Parser<V>, p4: Parser<W>, p5: Parser<X>, p6: Parser<Y>, p7: Parser<Z>, p8: Parser<A>, p9: Parser<B>, p10: Parser<C>,
+		cb: (a1: T, a2: U, a3: V, a4: W, a5: X, a6: Y, a7: Z, a8: A, a9: B, a10: C) => D): Parser<D>;
 
 	function seqObj<T, Key extends keyof T = keyof T>(...args: Array<[Key, Parser<T[Key]>] | Parser<any>>): Parser<{ [K in Key]: T[K] }>;
 

--- a/types/parsimmon/parsimmon-tests.ts
+++ b/types/parsimmon/parsimmon-tests.ts
@@ -146,6 +146,7 @@ fooPar = P.succeed(foo);
 fooArrPar = P.seq(fooPar, fooPar);
 const par: Parser<[Bar, Foo, number]> = P.seq(barPar, fooPar, numPar);
 const par2: Parser<number> = P.seq(barPar, fooPar, numPar).map(([a, b, c]: [Bar, Foo, number]) => 42);
+const par3: Parser<[string, string, string, number, string, string, string, number]> = P.seq(fooPar, fooPar, fooPar, numPar, fooPar, fooPar, fooPar, numPar);
 
 interface SeqObj {
 	first: number;
@@ -258,6 +259,19 @@ strPar = P.seqMap(P.digit, (a: string) => 'foo');
 numPar = P.seqMap(P.digit, P.digits, (a: string, b: string) => 42);
 strPar = P.seqMap(P.digit, P.digits, P.letter, (a: string, b: string, c: string) => 'foo');
 strPar = P.seqMap(P.digit, P.digits, P.letter, P.letters.map(Number), (a: string, b: string, c: string, d: number) => 'foo');
+strPar = P.seqMap(
+	P.digit,
+	P.digit,
+	P.digit,
+	P.digit,
+	P.digit.map(Number),
+	P.digit.map(Number),
+	P.digit,
+	P.digit,
+	P.digit,
+	P.digit,
+	(a: string, b: string, c: string, d: string, e: number, f: number, g: string, h: string, i: string, j: string) => 'foo',
+);
 
 strArrPar = P.sepBy(P.string('foo'), P.string('bar'));
 strArrPar = P.sepBy1(P.string('foo'), P.string('bar'));


### PR DESCRIPTION
Use "generic rest parameters" in TypeScript 3.0 to describe `Parsimmon.seq` and extend `Parsimmon.seqMap` to 10 parameters.

Because it's not possible to type `Parsimmon.seqMap` without removing the last parameter type from the generic rest type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html#generic-rest-parameters