### PR TITLE
Added jquery-deferred types

### DIFF
--- a/types/jquery-deferred/index.d.ts
+++ b/types/jquery-deferred/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for jquery-deferred 0.3
+// Project: https://github.com/zzdhidden/node-jquery-deferred
+// Definitions by: TekuConcept <https://github.com/TekuConcept>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as jquery from './lib';
+
+export default jquery;

--- a/types/jquery-deferred/jquery-deferred-tests.ts
+++ b/types/jquery-deferred/jquery-deferred-tests.ts
@@ -1,0 +1,26 @@
+/// <reference types="node" />
+import $ from 'jquery-deferred';
+
+function wait(timeout: number): () => void {
+    return (): $.JQueryPromise => {
+        const deferred = $.Deferred();
+        setTimeout(() => deferred.resolve(), timeout);
+        return deferred.promise();
+    };
+}
+
+let start: $.JQueryDeferred;
+
+start = $.Deferred();
+start
+.then(wait(5))
+.then(wait(25))
+.done(() => console.log('waited for 30 ms'));
+start.resolve();
+
+start = $.Deferred();
+start
+.then(wait(60))
+.then(() => $.Deferred().reject().promise())
+.fail(() => console.log('failed after 60 ms'));
+start.resolve();

--- a/types/jquery-deferred/lib/index.d.ts
+++ b/types/jquery-deferred/lib/index.d.ts
@@ -1,0 +1,55 @@
+// Utilities
+export function type(obj: any): string;
+export function isArray(obj: any): boolean;
+export function isFunction(obj: any): boolean;
+export function isPlainObject(obj: any): boolean;
+export function noop(): any;
+export function each(collection: any, callback: (indexInArray: any, valueOfElement: any) => any): any;
+export function extend(target: any, ...objs: any[]): object;
+export function extend(deep: boolean, target: any, ...objs: any[]): object;
+
+// Interface for the JQuery callback
+export interface JQueryCallback {
+    add(...callbacks: any[]): any;
+    disable(): any;
+    disabled(): boolean;
+    empty(): any;
+    fire(...arguments: any[]): any;
+    fired(): boolean;
+    fireWith(context: any, ...args: any[]): any;
+    has(callback: any): boolean;
+    lock(): any;
+    locked(): boolean;
+    remove(...callbacks: any[]): any;
+}
+
+// Interface for the JQuery promise, part of callbacks
+export interface JQueryPromise {
+    state(): string;
+    always(...alwaysCallbacks: any[]): JQueryDeferred;
+    then(doneCallbacks: any, failCallbacks?: any, progressCallbacks?: any): JQueryDeferred;
+    done(...doneCallbacks: any[]): JQueryDeferred;
+    fail(...failCallbacks: any[]): JQueryDeferred;
+    pipe(doneFilter?: (x: any) => any, failFilter?: (x: any) => any, progressFilter?: (x: any) => any): JQueryPromise;
+    promise(): JQueryPromise;
+}
+
+// Interface for the JQuery deferred, part of callbacks
+export interface JQueryDeferred extends JQueryPromise {
+    notify(...args: any[]): JQueryDeferred;
+    notifyWith(context: any, ...args: any[]): JQueryDeferred;
+    progress(...progressCallbacks: any[]): JQueryDeferred;
+    reject(...args: any[]): JQueryDeferred;
+    rejectWith(context: any, ...args: any[]): JQueryDeferred;
+    resolve(...args: any[]): JQueryDeferred;
+    resolveWith(context: any, ...args: any[]): JQueryDeferred;
+}
+
+// Callbacks
+export function Callbacks(flags: any): JQueryCallback;
+
+// Deferred
+export function Deferred(beforeStart?: (deferred: JQueryDeferred) => any): JQueryDeferred;
+
+// Helpers
+export function when(...deferreds: any[]): JQueryPromise;

--- a/types/jquery-deferred/tsconfig.json
+++ b/types/jquery-deferred/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jquery-deferred-tests.ts"
+    ]
+}

--- a/types/jquery-deferred/tslint.json
+++ b/types/jquery-deferred/tslint.json
@@ -1,7 +1,1 @@
-{
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "indent": [true, "spaces", 4],
-        "eofline": true
-    }
-}
+{ "extends": "dtslint/dt.json" }

--- a/types/jquery-deferred/tslint.json
+++ b/types/jquery-deferred/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "indent": [true, "spaces", 4],
+        "eofline": true
+    }
+}


### PR DESCRIPTION
Adding a new definition:
- [x] The package does not already provide its own types.
- [x] This is for an NPM package and matches the respective package name.
- [x] `tslint.json` is present and it doesn't have any additional or disabling rules. Just content as `{ "extends": "dtslint/dt.json" }`.
- [x] `tsconfig.json` does have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.