### PR TITLE
[configs-overload]: add configs-overload type defenition

### DIFF
--- a/types/configs-overload/configs-overload-tests.ts
+++ b/types/configs-overload/configs-overload-tests.ts
@@ -1,0 +1,8 @@
+import configsOverload from 'configs-overload';
+
+configsOverload();
+configsOverload('./configs');
+configsOverload('./configs', {});
+configsOverload('./configs', { defaultEnv: 'default' });
+configsOverload('./configs', { env: 'production' });
+configsOverload('./configs', { defaultEnv: 'default', env: 'production' });

--- a/types/configs-overload/index.d.ts
+++ b/types/configs-overload/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for configs-overload 0.2
+// Project: https://github.com/floatdrop/configs-overload
+// Definitions by: Anton Drobot <https://github.com/anton-drobot>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface ConfigsOverloadOptions {
+    defaultEnv?: string;
+    env?: string;
+}
+
+export interface ExtendableConfig {
+    [key: string]: any;
+}
+
+export default function configsOverload(configsDirectory?: string, options?: ConfigsOverloadOptions): ExtendableConfig;

--- a/types/configs-overload/tsconfig.json
+++ b/types/configs-overload/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "configs-overload-tests.ts"
+    ]
+}

--- a/types/configs-overload/tslint.json
+++ b/types/configs-overload/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.