### PR TITLE
[sharp] update typings to 0.24

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -717,15 +717,15 @@ declare namespace sharp {
         /** Boolean indicating whether the image is interlaced using a progressive scan */
         isProgressive?: boolean;
         /** Number of pages/frames contained within the image, with support for TIFF, HEIF, PDF, animated GIF and animated WebP */
-        pages: number;
+        pages?: number;
         /** Number of pixels high each page in a multi-page image will be. */
-        pageHeight: number;
+        pageHeight?: number;
         /** Number of times to loop an animated image, zero refers to a continuous loop. */
-        loop: number;
+        loop?: number;
         /** Delay in ms between each page in an animated image, provided as an array of integers. */
-        delay: number[];
+        delay?: number[];
         /**  Number of the primary page in a HEIF image */
-        pagePrimary: number;
+        pagePrimary?: number;
         /** Boolean indicating the presence of an embedded ICC profile */
         hasProfile?: boolean;
         /** Boolean indicating the presence of an alpha transparency channel */
@@ -739,7 +739,7 @@ declare namespace sharp {
         /** Buffer containing raw XMP data, if present */
         xmp?: Buffer;
         /** Buffer containing raw TIFFTAG_PHOTOSHOP data, if present */
-        tifftagPhotoshop: Buffer;
+        tifftagPhotoshop?: Buffer;
     }
 
     interface Stats {

--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sharp 0.23
+// Type definitions for sharp 0.24
 // Project: https://github.com/lovell/sharp
 // Definitions by: François Nguyen <https://github.com/lith-light-g>
 //                 Wooseop Kim <https://github.com/wooseopkim>
@@ -255,6 +255,7 @@ declare namespace sharp {
          * @param limit An integral Number of pixels, zero or false to remove limit, true to use default limit.
          * @throws {Error} Invalid limit
          * @returns A sharp instance that can be used to chain operations
+         * @deprecated since version 0.24.0 - moved to @see sharp.SharpOptions
          */
         limitInputPixels(limit: number | boolean): Sharp;
 
@@ -264,6 +265,7 @@ declare namespace sharp {
          * The default behaviour before function call is false, meaning the libvips access method is not sequential.
          * @param sequentialRead true to enable and false to disable (defaults to true)
          * @returns A sharp instance that can be used to chain operations
+         * @deprecated since version 0.24.0 - moved to @see sharp.SharpOptions
          */
         sequentialRead(sequentialRead?: boolean): Sharp;
 
@@ -635,6 +637,14 @@ declare namespace sharp {
          * (optional, default true)
          */
         failOnError?: boolean;
+        /**
+         * Do not process input images where the number of pixels (width x height) exceeds this limit.
+         * Assumes image dimensions contained in the input metadata can be trusted.
+         * An integral Number of pixels, zero or false to remove limit, true to use default limit of 268402689 (0x3FFF x 0x3FFF). (optional, default 268402689)
+         */
+        limitInputPixels?: number | boolean;
+        /** Set this to true to use sequential rather than random access where possible. This can reduce memory usage and might improve performance on some systems. (optional, default false) */
+        sequentialRead?: boolean;
         /** Number representing the DPI for vector images. (optional, default 72) */
         density?: number;
         /** Number of pages to extract for multi-page input (GIF, TIFF, PDF), use -1 for all pages */
@@ -706,6 +716,16 @@ declare namespace sharp {
         chromaSubsampling: string;
         /** Boolean indicating whether the image is interlaced using a progressive scan */
         isProgressive?: boolean;
+        /** Number of pages/frames contained within the image, with support for TIFF, HEIF, PDF, animated GIF and animated WebP */
+        pages: number;
+        /** Number of pixels high each page in a multi-page image will be. */
+        pageHeight: number;
+        /** Number of times to loop an animated image, zero refers to a continuous loop. */
+        loop: number;
+        /** Delay in ms between each page in an animated image, provided as an array of integers. */
+        delay: number[];
+        /**  Number of the primary page in a HEIF image */
+        pagePrimary: number;
         /** Boolean indicating the presence of an embedded ICC profile */
         hasProfile?: boolean;
         /** Boolean indicating the presence of an alpha transparency channel */
@@ -718,6 +738,8 @@ declare namespace sharp {
         iptc?: Buffer;
         /** Buffer containing raw XMP data, if present */
         xmp?: Buffer;
+        /** Buffer containing raw TIFFTAG_PHOTOSHOP data, if present */
+        tifftagPhotoshop: Buffer;
     }
 
     interface Stats {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - Move `limitInputPixels` and `sequentialRead` to input options, deprecating functions of the same name: https://github.com/lovell/sharp/commit/bd52e93fca3a90794d03c2ee6f020432d2ad2828
   - Expose delay and loop metadata for animated images: https://github.com/lovell/sharp/issues/1905
   - Add missing metadata properties that were omitted in previous typings: https://sharp.pixelplumbing.com/api-input
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
