### PR TITLE
Update rdf-transform-triple-to-quad tests

### DIFF
--- a/types/rdf-transform-triple-to-quad/rdf-transform-triple-to-quad-tests.ts
+++ b/types/rdf-transform-triple-to-quad/rdf-transform-triple-to-quad-tests.ts
@@ -5,7 +5,7 @@ import { Readable, EventEmitter } from 'stream';
 const inputStream: Stream & Readable = <any> {};
 const graph: NamedNode = <any> {};
 const factory: DataFactory = <any> {};
-const sink: Sink = <any> {};
+const sink: Sink<Stream, Stream> = <any> {};
 
 const transformedStream1: TripleToQuadTransform = inputStream.pipe(new TripleToQuadTransform());
 const transformedStream2: Stream = inputStream.pipe(new TripleToQuadTransform(graph));


### PR DESCRIPTION
The PR that adds rdf-transform-triple-to-quad conflicts with the
recent change to rdf-js, but both were merged about the same time, so CI
didn't catch the conflict.