### PR TITLE
codemirror: add missing LineWidgetOptions properties

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -820,6 +820,15 @@ declare namespace CodeMirror {
         above?: boolean;
         /** When true, will cause the widget to be rendered even if the line it is associated with is hidden. */
         showIfHidden?: boolean;
+        /** Determines whether the editor will capture mouse and drag events occurring in this widget. 
+        Default is false—the events will be left alone for the default browser handler, or specific handlers on the widget, to capture. */
+        handleMouseEvents?: boolean;
+        /** By default, the widget is added below other widgets for the line. 
+        This option can be used to place it at a different position (zero for the top, N to put it after the Nth other widget). 
+        Note that this only has effect once, when the widget is created. */
+        insertAt?: number;
+        /** Add an extra CSS class name to the wrapper element created for the widget. */
+        className?: string;
     }
 
     interface EditorChange {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://codemirror.net/doc/manual.html (see doc.addLineWidget and read the supported options)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
