### PR TITLE
fix(victory): refine `innerRadius` definition. Closes #41685

### DIFF
--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -108,6 +108,8 @@ declare module 'victory' {
     type StringOrNumberOrCallback = string | number | VictoryStringOrNumberCallback;
     type NumberOrCallback = number | VictoryNumberCallback;
 
+    type SliceNumberOrCallback<T, P = null> = number | ((props: Omit<T, P>) => number);
+
     type VictoryStyleObject = { [K in keyof React.CSSProperties]: StringOrNumberOrCallback };
     /**
      * Style interface used in components/themeing
@@ -2936,11 +2938,12 @@ declare module 'victory' {
          */
         radius?: number;
         /**
-         * When creating a donut chart, this prop determines the number of pixels between
-         * the center of the chart and the inner edge of a donut. When this prop is set to zero
-         * a regular pie chart is rendered.
+         * The `innerRadius` prop determines the number of pixels between the center of the chart
+         * and the inner edge of a donut chart. When this prop is set to zero a regular pie chart is rendered.
+         * When this prop is given as a function, `innerRadius` will be evaluated for each slice
+         * of the pie with the props corresponding to that slice
          */
-        innerRadius?: number;
+        innerRadius?: number | ((props: VictorySliceProps) => number);
         /**
          * Set the cornerRadius for every dataComponent (Slice by default) within VictoryPie
          */
@@ -3017,5 +3020,71 @@ declare module 'victory' {
          * The groupComponent prop takes a component instance which will be used to create a group element for VictoryPortal to render its child component into. This prop defaults to a <g> tag.
          */
         groupComponent?: React.ReactElement;
+    }
+
+    export interface VictorySliceProps extends VictoryCommonProps {
+        /**
+         * the corner radius to apply to this slice.
+         * When this prop is given as a function
+         * it will be called with the rest of the props supplied to Slice.
+         */
+        cornerRadius?: SliceNumberOrCallback<VictorySliceProps, 'cornerRadius'>;
+        /**
+         * the data point corresponding to this slice
+         */
+        datum?: object;
+        /**
+         * the inner radius of the slice.
+         * When this prop is given as a function
+         * it will be called with datum and active.
+         */
+        innerRadius?: number | ((props: {
+            active?: boolean,
+            datum?: object,
+        }) => number);
+        /**
+         * the angular padding to add to the slice.
+         * When this prop is given as a function it will be called with
+         * the rest of the props supplied to Slice.
+         */
+        padAngle?: SliceNumberOrCallback<VictorySliceProps, 'padAngle'>;
+        /**
+         * the rendered path element
+         * @default pathComponent={<Path/>}
+         */
+        pathComponent?: React.ReactElement;
+        /**
+         * a function that calculates the path of a given slice.
+         * When given, this prop will be called with the slice object
+         */
+        pathFunction?: (props: VictorySliceProps) => string;
+        /**
+         * the outer radius of the slice.
+         * When this prop is given as a function it will be called with
+         * the rest of the props supplied to Slice.
+         */
+        radius?: SliceNumberOrCallback<VictorySliceProps, 'radius'>;
+        /**
+         * an object specifying the `startAngle`, `endAngle`, `padAngle`,
+         * and `data` of the slice
+         */
+        slice: {
+            startAngle?: number;
+            endAngle?: number;
+            padAngle?: number;
+            data?: any[];
+        };
+        /**
+         * the end angle the slice.
+         * When this prop is given as a function it will be called
+         * with the rest of the props supplied to Slice.
+         */
+        sliceEndAngle?: SliceNumberOrCallback<VictorySliceProps, 'sliceEndAngle'>;
+        /**
+         * the start angle the slice.
+         * When this prop is given as a function it will be called
+         * with the rest of the props supplied to Slice
+         */
+        sliceStartAngle?: SliceNumberOrCallback<VictorySliceProps, 'sliceStartAngle'>;
     }
 }

--- a/types/victory/victory-tests.tsx
+++ b/types/victory/victory-tests.tsx
@@ -25,6 +25,7 @@ import {
     VictoryClipContainer,
     VictoryPortal,
     VictoryStringOrNumberCallback,
+    VictorySliceProps,
 } from 'victory';
 
 const commonData1 = [
@@ -661,6 +662,7 @@ test = (
             { animal: 'Bird', pet: 15, wild: 40 },
         ]}
         x={'animal'}
+        innerRadius={(props: VictorySliceProps) => 2 }
         y={data => data.pet + data.wild}
     />
 );
@@ -959,4 +961,22 @@ const fullTheme: RecursiveRequired<Required<VictoryThemeDefinition>> = {
         padding: 0,
         width: 0,
     },
+};
+
+// Slice.props
+const sliceProps: VictorySliceProps = {
+    cornerRadius: props => props.cornerRadius, // $ExpectError
+    datum: { x: 'Cat', y: 62 },
+    innerRadius: props => props.innerRadius, // $ExpectError
+    padAngle: props => props.padAngle, // $ExpectError
+    pathFunction: sliceProps => 'M1,1',
+    radius: props => props.radius, // $ExpectError
+    slice: {
+        data: [],
+        endAngle: 0,
+        padAngle: 0,
+        startAngle: 0,
+    },
+    sliceEndAngle: props => props.sliceEndAngle, // $ExpectError
+    sliceStartAngle: props => props.slieStartAngle, // $ExpectError
 };


### PR DESCRIPTION
- VictoryPie.innerRadius
https://formidable.com/open-source/victory/docs/victory-pie#innerradius

/cc @mikecsmith

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://formidable.com/open-source/victory/docs/victory-pie#innerradius
