### PR TITLE
[@types/leaflet] add attributionControl property to Map class

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1789,6 +1789,7 @@ export class Map extends Evented {
     stopLocate(): this;
 
     // Properties
+    attributionControl: L.Control.Attribution;
     boxZoom: Handler;
     doubleClickZoom: Handler;
     dragging: Handler;

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -223,6 +223,9 @@ mapPixelBounds = map.getPixelBounds();
 mapPixelBounds = map.getPixelWorldBounds();
 mapPixelBounds = map.getPixelWorldBounds(12);
 
+let attributionContro: L.Control.Attribution;
+attributionControl = map.attributionControl;
+
 let tileLayerOptions: L.TileLayerOptions = {};
 tileLayerOptions = {
 	id: 'mapbox.streets',

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -223,7 +223,7 @@ mapPixelBounds = map.getPixelBounds();
 mapPixelBounds = map.getPixelWorldBounds();
 mapPixelBounds = map.getPixelWorldBounds(12);
 
-let attributionContro: L.Control.Attribution;
+let attributionControl: L.Control.Attribution;
 attributionControl = map.attributionControl;
 
 let tileLayerOptions: L.TileLayerOptions = {};


### PR DESCRIPTION
Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [X ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Leaflet/Leaflet/issues/4514
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

While not yet documented, the attributionControl property is not a private property (no leading underscore at least) and it is scheduled for documentation per the linked github issue.   It is the only way to get a reference to the Attribution that can be created automatically when constructing a Map.