### PR TITLE
react-daterange-picker: Fix to Props types to allow onSelect to handle both single and range

### DIFF
--- a/types/react-daterange-picker/index.d.ts
+++ b/types/react-daterange-picker/index.d.ts
@@ -7,14 +7,14 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from "react";
-import * as moment from "moment";
-import * as momentRange from "moment-range";
+import * as React from 'react';
+import * as moment from 'moment';
+import * as momentRange from 'moment-range';
 
-export default class DateRangePicker extends React.Component<Props> { }
+export default class DateRangePicker extends React.Component<Props> {}
 export as namespace ReactDateRangePicker;
 
-export interface Props<T = DateRangePicker> extends React.Props<T> {
+export interface BaseProps<T = DateRangePicker> extends React.Props<T> {
     bemBlock?: string;
     bemNamespace?: string;
     dateStates?: DateState[];
@@ -33,16 +33,26 @@ export interface Props<T = DateRangePicker> extends React.Props<T> {
     numberOfCalendars?: number;
     onHighlightDate?(date: Date): void;
     onHighlightRange?(date: Date): void;
-    onSelect?(value: OnSelectCallbackParam): void;
     onSelectStart?(value: momentRange.MomentRange & typeof moment): void;
     paginationArrowComponent?: React.ComponentClass<PaginationArrowProps> | React.SFC<PaginationArrowProps>;
     selectedLabel?: string;
-    selectionType?: 'single' | 'range';
     singleDateRange?: boolean;
     showLegend?: boolean;
     stateDefinitions?: StateDefinitions;
     value?: (momentRange.MomentRange & typeof moment) | momentRange.DateRange | moment.Moment;
 }
+
+export interface RangeProps<T = DateRangePicker> extends BaseProps<T> {
+    onSelect?(value: OnSelectCallbackParam): void;
+    selectionType?: 'range';
+}
+
+export interface SingleProps<T = DateRangePicker> extends BaseProps<T> {
+    onSelect?(value: moment.Moment): void;
+    selectionType?: 'single';
+}
+
+export type Props<T = DateRangePicker> = RangeProps<T> | SingleProps<T>;
 
 export interface DateState {
     state: string;


### PR DESCRIPTION
Edits the types provided of the react-daterange-picker. The current type definition has a bug which doesn't account for selecting a single date in the onSelect function. This adds types for the onSelect function to handle both range and single date selections.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
* https://github.com/onefinestay/react-daterange-picker/blob/master/src/DateRangePicker.jsx#L53
* https://github.com/onefinestay/react-daterange-picker/blob/master/src/DateRangePicker.jsx#L269-L288
