### PR TITLE
[parse] Add overload for Parse.Cloud.define

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -1107,6 +1107,10 @@ namespace Parse {
         function afterFind(arg1: any, func?: (request: AfterFindRequest) => any): void;
         function beforeLogin(func?: (request: TriggerRequest) => any): void;
         function define(name: string, func: (request: FunctionRequest) => any): void;
+        function define<T extends () => any>(
+            name: string,
+            func: (request: FunctionRequest<{}>) => Promise<ReturnType<T>> | ReturnType<T>
+        ): void;
         function define<T extends (
             param: { [P in keyof Parameters<T>[0]]: Parameters<T>[0][P] }
         ) => any>(

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -570,6 +570,11 @@ async function test_cloud_functions() {
         request.params.anything;
     });
 
+    Parse.Cloud.define<() => void>('AFunc', request => {
+        // $ExpectType {}
+        request.params;
+    });
+
     Parse.Cloud.define<(params: { something: string }) => number>('AFunc', (request) => {
         // $ExpectType { something: string; }
         request.params;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <http://parseplatform.org/Parse-SDK-JS/api/2.10.0/>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

-----

Previously, `Parse.Cloud.define<() => void>(request => {})` would result in `request.params` being typed as `undefined`. This PR instead causes it to be `{}` in that situation, which is more accurate.
