### PR TITLE
react-imgix: support data attributes as htmlAttributes

### DIFF
--- a/types/react-imgix/index.d.ts
+++ b/types/react-imgix/index.d.ts
@@ -204,7 +204,7 @@ interface AttributeConfig {
   sizes?: string;
 }
 
-type ImgixHTMLAttributes = React.ImgHTMLAttributes<HTMLImageElement> | React.SourceHTMLAttributes<HTMLSourceElement>;
+type ImgixHTMLAttributes = React.ImgHTMLAttributes<HTMLImageElement> | React.SourceHTMLAttributes<HTMLSourceElement> | Record<string, string>;
 
 interface CommonProps {
   className?: string;

--- a/types/react-imgix/react-imgix-tests.tsx
+++ b/types/react-imgix/react-imgix-tests.tsx
@@ -16,6 +16,7 @@ const ImgixTest = () => (
         className="lazyload"
         htmlAttributes={{
             src: '...',
+            'data-testid': 'testid',
         }}
     />
 );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/imgix/react-imgix#htmlattributes--object-1>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
