### PR TITLE
Fix iso-3166-2 typings as it can return null

### DIFF
--- a/types/iso-3166-2/index.d.ts
+++ b/types/iso-3166-2/index.d.ts
@@ -1,9 +1,7 @@
-// Type definitions for iso-3166-2 0.6
+// Type definitions for iso-3166-2 1.0
 // Project: https://github.com/olahol/iso-3166-2.js
-// Definitions by: Matt Rollins <https://github.com/sicilica>
+// Definitions by: Matt Rollins <https://github.com/sicilica>, Emily Klassen <https://github.com/forivall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-export type InfoOrEmptyRecord<T> = T | {};
 
 export namespace CountryInfo {
     interface Partial {
@@ -40,9 +38,9 @@ export namespace SubdivisionInfo {
 }
 export type SubdivisionInfo = SubdivisionInfo.Full;
 
-export function subdivision(countryCodeOrFullSubdivisionCode: string, subdivisionCodeOrName?: string): InfoOrEmptyRecord<SubdivisionInfo>;
+export function subdivision(countryCodeOrFullSubdivisionCode: string, subdivisionCodeOrName?: string): SubdivisionInfo | null;
 
-export function country(countryCodeOrName: string): InfoOrEmptyRecord<CountryInfo>;
+export function country(countryCodeOrName: string): CountryInfo | null;
 
 export const data: CountryInfo.Map;
 

--- a/types/iso-3166-2/iso-3166-2-tests.ts
+++ b/types/iso-3166-2/iso-3166-2-tests.ts
@@ -1,28 +1,25 @@
 import * as iso3166 from "iso-3166-2";
 
-// subdivision() and country() return {} on failure, which is nearly impossible to separate from a valid response in TypeScript;
-// until a PR can be accepted on the original repo, this workaround makes accessing the original type possible.
-function wrap<T>(rawResult: T|{}): T|null {
-	if (Object.keys(rawResult).length)
-		return rawResult as T;
-	else
-		return null;
-}
-
 iso3166.subdivision("SE-O");
 iso3166.subdivision("US-IN");
 
 iso3166.subdivision("SWE", "O");
 iso3166.subdivision("US", "Indiana");
 
-const indiana = wrap(iso3166.subdivision("US-IN"));
+const indiana = iso3166.subdivision("US-IN");
 if (indiana) {
-	const name: string = indiana.name;
-	const type: string = indiana.type;
-	const code: string = indiana.code;
-	const regionCode: string = indiana.regionCode;
-	const countryCode: string = indiana.countryCode;
-	const countryName: string = indiana.countryName;
+    // $ExpectType string
+    indiana.name;
+    // $ExpectType string
+    indiana.type;
+    // $ExpectType string
+    indiana.code;
+    // $ExpectType string
+    indiana.regionCode;
+    // $ExpectType string
+    indiana.countryCode;
+    // $ExpectType string
+    indiana.countryName;
 }
 
 iso3166.country("US");
@@ -32,19 +29,25 @@ iso3166.country("SWE");
 iso3166.country("United States");
 iso3166.country("Sweden");
 
-const sweden = wrap(iso3166.country("SE"));
+const sweden = iso3166.country("SE");
 if (sweden) {
-	const name: string = sweden.name;
-	const subNameO: string = sweden.sub["SE-O"].name;
-	const code: string = sweden.code;
+    // $ExpectType string
+    sweden.name;
+    // $ExpectType string
+    sweden.sub["SE-O"].name;
+    // $ExpectType string
+	sweden.code;
 }
 
 const unitedStates = iso3166.data["US"];
 {
-	const name: string = unitedStates.name;
-	const subNameIN: string = unitedStates.sub["US-IN"].name;
+    // $ExpectType string
+    unitedStates.name;
+    // $ExpectType string
+	unitedStates.sub["US-IN"].name;
 }
 
 const alpha3 = "SWE";
 const alpha2 = "SE";
+// $ExpectType boolean
 const codesWork = (alpha2 === iso3166.codes[alpha3]);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/olahol/iso-3166-2.js#examples
    > ```js
    > > iso3166.subdivision("UN-1");
    > null
    > ```
    I discovered an issue because i encountered [this problem](https://github.com/olahol/iso-3166-2.js/issues/22) in the wild, and this module actually returns `null`.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
