### PR TITLE
[css-font-loading-module] Add FontFaceSet to WorkerGlobalScope

### DIFF
--- a/types/css-font-loading-module/css-font-loading-module-tests.ts
+++ b/types/css-font-loading-module/css-font-loading-module-tests.ts
@@ -10,7 +10,12 @@ font.loaded.then((fontFace: FontFace) => {
     fontFace.display;
 }, (fontFace: FontFace) => {});
 
-const a: boolean = document.fonts.check("12px Example");
-const b: boolean = document.fonts.check("12px Example", "ß");
-const c: Promise<FontFace[]> = document.fonts.load("12px MyFont", "ß").then();
-const d: Promise<typeof document.fonts> = document.fonts.ready.then();
+const workerContext: WorkerGlobalScope = undefined;
+
+const contexts = [document, workerContext];
+contexts.forEach(context => {
+    const a: boolean = context.fonts.check("12px Example");
+    const b: boolean = context.fonts.check("12px Example", "ß");
+    const c: Promise<FontFace[]> = context.fonts.load("12px MyFont", "ß").then();
+    const d: Promise<typeof context.fonts> = context.fonts.ready.then();
+});

--- a/types/css-font-loading-module/index.d.ts
+++ b/types/css-font-loading-module/index.d.ts
@@ -58,4 +58,8 @@ declare global {
     interface Document {
         fonts: FontFaceSet;
     }
+
+    interface WorkerGlobalScope {
+        fonts: FontFaceSet;
+    }
 }


### PR DESCRIPTION
**css-font-loading-module** is missing type support for `FontFaceSet` on `WorkerGlobalScope`, which has the same implementation as on `Document`. https://drafts.csswg.org/css-font-loading/#font-face-source

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://drafts.csswg.org/css-font-loading/#font-face-source