### PR TITLE
fix[react test renderer]  replace deprecated type ReactType

### DIFF
--- a/types/react-test-renderer/index.d.ts
+++ b/types/react-test-renderer/index.d.ts
@@ -5,10 +5,11 @@
 //                 John Reilly <https://github.com/johnnyreilly>
 //                 John Gozde <https://github.com/jgoz>
 //                 Jessica Franco <https://github.com/Jessidhia>
+//                 Dhruv Jain <https://github.com/maddhruv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { ReactElement, ReactType } from "react";
+import { ReactElement, ElementType } from 'react';
 
 // extracted from:
 // - https://github.com/facebook/react/blob/v16.0.0/src/renderers/testing/ReactTestRendererFiberEntry.js
@@ -21,23 +22,23 @@ export interface ReactTestRendererJSON {
 }
 export type ReactTestRendererNode = ReactTestRendererJSON | string;
 export interface ReactTestRendererTree extends ReactTestRendererJSON {
-    nodeType: "component" | "host";
+    nodeType: 'component' | 'host';
     instance: any;
     rendered: null | ReactTestRendererTree;
 }
 export interface ReactTestInstance {
     instance: any;
-    type: ReactType;
+    type: ElementType;
     props: { [propName: string]: any };
     parent: null | ReactTestInstance;
     children: Array<ReactTestInstance | string>;
 
     find(predicate: (node: ReactTestInstance) => boolean): ReactTestInstance;
-    findByType(type: ReactType): ReactTestInstance;
+    findByType(type: ElementType): ReactTestInstance;
     findByProps(props: { [propName: string]: any }): ReactTestInstance;
 
     findAll(predicate: (node: ReactTestInstance) => boolean, options?: { deep: boolean }): ReactTestInstance[];
-    findAllByType(type: ReactType, options?: { deep: boolean }): ReactTestInstance[];
+    findAllByType(type: ElementType, options?: { deep: boolean }): ReactTestInstance[];
     findAllByProps(props: { [propName: string]: any }, options?: { deep: boolean }): ReactTestInstance[];
 }
 export interface ReactTestRenderer {
@@ -85,9 +86,6 @@ export function act(callback: () => void | undefined): DebugPromiseLike;
 // Intentionally doesn't extend PromiseLike<never>.
 // Ideally this should be as hard to accidentally use as possible.
 export interface DebugPromiseLike {
-  // the actual then() in here is 1-ary, but that doesn't count as a PromiseLike.
-  then(
-    onfulfilled: (value: never) => never,
-    onrejected: (reason: never) => never,
-  ): never;
+    // the actual then() in here is 1-ary, but that doesn't count as a PromiseLike.
+    then(onfulfilled: (value: never) => never, onrejected: (reason: never) => never): never;
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -22,7 +22,6 @@
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 Kyle Scully <https://github.com/zieka>
 //                 Cong Zhang <https://github.com/dancerphil>
-//                 Dhruv Jain <https://github.com/maddhruv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -321,7 +320,7 @@ declare namespace React {
         /**
          * **NOTE**: Exotic components are not callable.
          */
-        (props: PropsWithChildren<P>): (ReactElement|null);
+        (props: P): (ReactElement|null);
         readonly $$typeof: symbol;
     }
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -22,6 +22,7 @@
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 Kyle Scully <https://github.com/zieka>
 //                 Cong Zhang <https://github.com/dancerphil>
+//                 Dhruv Jain <https://github.com/maddhruv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -320,7 +321,7 @@ declare namespace React {
         /**
          * **NOTE**: Exotic components are not callable.
          */
-        (props: P): (ReactElement|null);
+        (props: PropsWithChildren<P>): (ReactElement|null);
         readonly $$typeof: symbol;
     }
 


### PR DESCRIPTION
Replaces the deprecated `ReactType` with `ElementType` in `react-test-renderer`
Ref - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L75

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>