### PR TITLE
[global-npm] Add types for global-npm

### DIFF
--- a/types/global-npm/global-npm-tests.ts
+++ b/types/global-npm/global-npm-tests.ts
@@ -1,0 +1,18 @@
+import npm = require('global-npm');
+
+const installPath: string = npm.GLOBAL_NPM_PATH;
+const binPath: string = npm.GLOBAL_NPM_BIN;
+
+const list: string[] = npm.fullList;
+
+npm.globalDir;
+npm.globalBin;
+
+npm.load({ loglevel: 'silent' }, () => {
+    npm.commands.install(['typescript'], () => {});
+
+    npm.commands.view(['typescript'], true, () => {});
+
+    // $ExpectError
+    npm.commands.install('typescript', () => {});
+});

--- a/types/global-npm/index.d.ts
+++ b/types/global-npm/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for global-npm 0.4
+// Project: https://github.com/dracupid/global-npm#readme
+// Definitions by: Waseem Dahman <https://github.com/wsmd>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="npm" />
+
+import * as NPM from 'npm';
+
+interface GlobalNPM {
+    GLOBAL_NPM_PATH: string;
+    GLOBAL_NPM_BIN: string;
+}
+
+declare var globalNPM: GlobalNPM & typeof NPM;
+export = globalNPM;

--- a/types/global-npm/index.d.ts
+++ b/types/global-npm/index.d.ts
@@ -1,9 +1,7 @@
 // Type definitions for global-npm 0.4
-// Project: https://github.com/dracupid/global-npm#readme
+// Project: https://github.com/dracupid/global-npm
 // Definitions by: Waseem Dahman <https://github.com/wsmd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-/// <reference types="npm" />
 
 import * as NPM from 'npm';
 

--- a/types/global-npm/tsconfig.json
+++ b/types/global-npm/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "global-npm-tests.ts"
+    ]
+}

--- a/types/global-npm/tslint.json
+++ b/types/global-npm/tslint.json
@@ -1,6 +1,1 @@
-{
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-reference-import": false
-    }
-}
+{ "extends": "dtslint/dt.json" }

--- a/types/global-npm/tslint.json
+++ b/types/global-npm/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-reference-import": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
