### PR TITLE
bech32: Fixing parameter types and return types

### DIFF
--- a/types/bech32/bech32-tests.ts
+++ b/types/bech32/bech32-tests.ts
@@ -9,7 +9,7 @@ decoded.prefix;
 decoded.words;
 
 // Test convert from/to words
-const words: Buffer = bech32.toWords(Buffer.from('foobar', 'utf8'));
+const words: number[] = bech32.toWords(Buffer.from('foobar', 'utf8'));
 bech32.fromWords(words);
 
 // Test encode

--- a/types/bech32/index.d.ts
+++ b/types/bech32/index.d.ts
@@ -5,10 +5,10 @@
 
 /// <reference types="node" />
 
-export function decode(str: string, LIMIT?: number): { prefix: string, words: Buffer };
+export function decode(str: string, LIMIT?: number): { prefix: string, words: number[] };
 
-export function encode(prefix: string, words: Buffer, LIMIT?: number): string;
+export function encode(prefix: string, words: ArrayLike<number>, LIMIT?: number): string;
 
-export function fromWords(words: Buffer): Buffer;
+export function fromWords(words: ArrayLike<number>): number[];
 
-export function toWords(bytes: Buffer): Buffer;
+export function toWords(bytes: ArrayLike<number>): number[];


### PR DESCRIPTION
This PR fixes some erroneous and non-exhaustive type definitions for the bech32 package.

* The return type of `decode`, `fromWords` and `toWords` is an array (`number[]`) as seen in the source code of the package: https://github.com/bitcoinjs/bech32/blob/b1845b87ed37f0e4e0cec8efaab505ad996fa556/index.js#L94 and https://github.com/bitcoinjs/bech32/blob/b1845b87ed37f0e4e0cec8efaab505ad996fa556/index.js#L127, _not_ `Buffer`.
* The parameter for `fromWords`, `toWords` and `encode` does actually not have to be a `Buffer`, rather `ArrayLike`, i.e: https://github.com/bitcoinjs/bech32/blob/b1845b87ed37f0e4e0cec8efaab505ad996fa556/index.js#L52

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/bitcoinjs/bech32/blob/master/index.js>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
