### PR TITLE
@pusher/chatkit-client - Added Promise<PusherRoom> return type to currentUser.subscribeToRoomMultipart

### DIFF
--- a/types/pusher__chatkit-client/currentuser.d.ts
+++ b/types/pusher__chatkit-client/currentuser.d.ts
@@ -94,7 +94,7 @@ export interface CurrentUser {
     getJoinableRooms: () => Promise<PusherRoom[]>;
     joinRoom: (params: RoomIdParams) => Promise<PusherRoom>;
     leaveRoom: (params: RoomIdParams) => Promise<PusherRoom>;
-    subscribeToRoomMultipart: (params: RoomSubcriptionParams) => Promise<void>;
+    subscribeToRoomMultipart: (params: RoomSubcriptionParams) => Promise<PusherRoom>;
     sendSimpleMessage: (params: SendSimpleMessageParams) => Promise<number>;
     sendMultipartMessage: (params: SendMultipartMessageParams) => Promise<number>;
     isTypingIn: (params: RoomIdParams) => Promise<void>;

--- a/types/pusher__chatkit-client/pusher__chatkit-client-tests.ts
+++ b/types/pusher__chatkit-client/pusher__chatkit-client-tests.ts
@@ -48,7 +48,7 @@ async function test_connecting() {
     });
 
     // Subscribe to room with no params
-    await currentUser.subscribeToRoomMultipart({
+    const subscribedRoom = await currentUser.subscribeToRoomMultipart({
         roomId: room.id,
     });
 
@@ -86,4 +86,6 @@ async function test_connecting() {
     await currentUser.removeUserFromRoom({ userId: 'keith', roomId: room.id });
     await currentUser.isTypingIn({ roomId: room.id });
     await currentUser.deleteRoom({ roomId: room.id });
+
+    subscribedRoom.users.forEach(user => user.name);
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

subscribeToRoomMultipart returns a Promise resolving to the chat room after successful subscription.

https://github.com/pusher/chatkit-client-js/blob/e9a650c2c8beffc0f34b6fb3db4f1e2adf2b5347/src/current-user.js#L434

- [X] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~ 
**No version change**
- [X] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~ 
**Not needed**
