### PR TITLE
[chart.js] Add types of `ChartPoint`, `ChartData.labels`.

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -1,4 +1,5 @@
 import { BorderWidth, Chart, Point, ChartColor } from 'chart.js';
+import moment = require('moment');
 
 // alternative:
 // import chartjs = require('chart.js');
@@ -409,3 +410,27 @@ if (doughnutChart.getDatasetMeta(0).data.length > 0) {
     console.log(doughnutChartView.x);
     console.log(doughnutChartView.y);
 }
+
+// Time Cartesian Axis
+const timeAxisChartData: Chart.ChartData = {
+    datasets: [{
+        data: [
+            { x: new Date(), y: 1 },
+            { y: new Date(), t: 1 },
+            { t: new Date(), y: 1 },
+            { x: moment(), y: 1 },
+            { y: moment(), t: 1 },
+            { t: moment(), y: 1 },
+        ]
+    }]
+};
+
+// Labels
+const timeLabelsChartData: Chart.ChartData = {
+    labels: [
+        'a', 'b', 'c',
+        1, 2, 3,
+        new Date(), new Date(), new Date(),
+        moment(), moment(), moment(),
+    ],
+};

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -26,6 +26,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
+import { Moment } from 'moment';
+
 declare class Chart {
     static readonly Chart: typeof Chart;
     constructor(
@@ -227,10 +229,10 @@ declare namespace Chart {
     }
 
     interface ChartPoint {
-        x?: number | string | Date;
-        y?: number | string | Date;
+        x?: number | string | Date | Moment;
+        y?: number | string | Date | Moment;
         r?: number;
-        t?: number | string | Date;
+        t?: number | string | Date | Moment;
     }
 
     interface ChartConfiguration {
@@ -241,7 +243,7 @@ declare namespace Chart {
     }
 
     interface ChartData {
-        labels?: Array<string | string[]>;
+        labels?: Array<string | string[] | number | number[] | Date | Date[] | Moment | Moment[]>;
         datasets?: ChartDataSets[];
     }
 

--- a/types/chart.js/package.json
+++ b/types/chart.js/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "moment": "^2.10.2"
+    }
+}


### PR DESCRIPTION
`Moment` can be specified for chartpoint in addition to `number`, `string` and `Date`.
Also specify it in labels.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  * https://github.com/chartjs/Chart.js/blob/v2.9.3/test/specs/scale.time.tests.js#L134  
  * https://www.chartjs.org/samples/latest/scales/time/line.html - source
  * https://www.chartjs.org/docs/latest/axes/cartesian/time.html#date-adapters  
    > By default, Chart.js includes an adapter for **Moment.js** .
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

