### PR TITLE
redux-first-router: expose `selectLocationState` function

### DIFF
--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -9,6 +9,7 @@
 //                 geirsagberg <https://github.com/geirsagberg>
 //                 Harry Hedger <https://github.com/hedgerh>
 //                 Adam Rich <https://github.com/adam1658>
+//                 Karl-Aksel Puulmann <https://github.com/macobo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -371,3 +372,5 @@ export function scrollBehavior(): ScrollBehavior | void;
 export function setKind(action: Action, kind: string): Action;
 
 export function updateScroll(): void;
+
+export function selectLocationState<TState = any>(state: TState): LocationState;


### PR DESCRIPTION
Implementation: https://github.com/faceyspacey/redux-first-router/blob/a8f3bb3995089f1a9355ca596ce20987e10ee572/src/connectRoutes.js#L156

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/faceyspacey/redux-first-router/blob/a8f3bb3995089f1a9355ca596ce20987e10ee572/src/connectRoutes.js#L156
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.