### PR TITLE
fix(js‑yaml): `loadAll(…)` allows `null` as the `iterator` parameter

### DIFF
--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for js-yaml 3.12
 // Project: https://github.com/nodeca/js-yaml
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Sebastian Clausen <https://github.com/sclausen>
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
+//                 Sebastian Clausen <https://github.com/sclausen>
+//                 ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -16,9 +18,9 @@ export class Type {
 	construct(data: any): any;
 	instanceOf: object | null;
 	predicate: ((data: object) => boolean) | null;
-	represent: ((data: object) => any) | { [x: string]: (data: object) => any; } | null;
+	represent: ((data: object) => any) | { [x: string]: (data: object) => any } | null;
 	defaultStyle: string | null;
-	styleAliases: { [x: string]: any; };
+	styleAliases: { [x: string]: any };
 }
 
 /* tslint:disable-next-line:no-unnecessary-class */
@@ -28,12 +30,11 @@ export class Schema implements SchemaDefinition {
 	static create(schemas: Schema[] | Schema, types: Type[] | Type): Schema;
 }
 
-export function safeLoadAll(str: string, iterator?: undefined, opts?: LoadOptions): any[];
-export function safeLoadAll(str: string, iterator: (doc: any) => void, opts?: LoadOptions): undefined;
+export function safeLoadAll(str: string, iterator?: null, opts?: LoadOptions): any[];
+export function safeLoadAll(str: string, iterator: (doc: any) => void, opts?: LoadOptions): void;
 
-export function loadAll(str: string, iterator?: undefined, opts?: LoadOptions): any[];
-
-export function loadAll(str: string, iterator: (doc: any) => void, opts?: LoadOptions): undefined;
+export function loadAll(str: string, iterator?: null, opts?: LoadOptions): any[];
+export function loadAll(str: string, iterator: (doc: any) => void, opts?: LoadOptions): void;
 
 export function safeDump(obj: any, opts?: DumpOptions): string;
 export function dump(obj: any, opts?: DumpOptions): string;
@@ -59,7 +60,7 @@ export interface DumpOptions {
 	/** specifies level of nesting, when to switch from block to flow style for collections. -1 means block style everwhere */
 	flowLevel?: number;
 	/** Each tag may have own set of styles.	- "tag" => "style" map. */
-	styles?: { [x: string]: any; };
+	styles?: { [x: string]: any };
 	/** specifies a schema to use. */
 	schema?: SchemaDefinition;
 	/** if true, sort keys when dumping YAML. If a function, use the function to sort the keys. (default: false) */
@@ -85,7 +86,7 @@ export interface TypeConstructorOptions {
 	predicate?: (data: object) => boolean;
 	represent?: ((data: object) => any) | { [x: string]: (data: object) => any };
 	defaultStyle?: string;
-	styleAliases?: { [x: string]: any; };
+	styleAliases?: { [x: string]: any };
 }
 
 export interface SchemaDefinition {

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -6,9 +6,9 @@ import SchemaDefinition = yaml.SchemaDefinition;
 
 const bool = true;
 const num = 0;
-const str = "";
+const str = '';
 const obj: object = {};
-const map: { [x: string]: any; } = {};
+const map: { [x: string]: any } = {};
 const array: any[] = [];
 const fn: (...args: any[]) => any = () => {};
 const type = new yaml.Type(str);
@@ -16,17 +16,17 @@ const type = new yaml.Type(str);
 const schemaDefinition: SchemaDefinition = {
 	implicit: array,
 	explicit: array,
-	include: array
+	include: array,
 };
 const typeConstructorOptions: TypeConstructorOptions = {
-	kind: "scalar",
+	kind: 'scalar',
 	resolve: fn,
 	construct: fn,
 	instanceOf: obj,
-	predicate: (obj) => false,
+	predicate: obj => false,
 	represent: fn,
 	defaultStyle: str,
-	styleAliases: map
+	styleAliases: map,
 };
 
 const schema: yaml.Schema = new yaml.Schema(schemaDefinition);
@@ -55,40 +55,42 @@ yaml.SAFE_SCHEMA;
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
 loadOpts = {
-	filename: str
+	filename: str,
 };
 loadOpts = {
-	onWarning(e) { e.stack; }
+	onWarning(e) {
+		e.stack;
+	},
 };
 loadOpts = {
-	json: bool
+	json: bool,
 };
 loadOpts = {
-	schema: yaml.DEFAULT_SAFE_SCHEMA
+	schema: yaml.DEFAULT_SAFE_SCHEMA,
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
 dumpOpts = {
-	indent: num
+	indent: num,
 };
 dumpOpts = {
-	noArrayIndent: bool
+	noArrayIndent: bool,
 };
 dumpOpts = {
-	skipInvalid: bool
+	skipInvalid: bool,
 };
 dumpOpts = {
-	flowLevel: num
+	flowLevel: num,
 };
 dumpOpts = {
-	styles: obj
+	styles: obj,
 };
 dumpOpts = {
-	schema: value
+	schema: value,
 };
 dumpOpts = {
-	schema: yaml.DEFAULT_FULL_SCHEMA
+	schema: yaml.DEFAULT_FULL_SCHEMA,
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
@@ -129,31 +131,43 @@ yaml.load(str, loadOpts);
 
 // $ExpectType any[]
 yaml.safeLoadAll(str);
-
-// $ExpectType undefined
-yaml.safeLoadAll(str, (doc) => {
-	value = doc;
-});
-// $ExpectType undefined
-yaml.safeLoadAll(str, (doc) => {
-	value = doc;
-}, loadOpts);
+// $ExpectType any[]
+value = yaml.safeLoadAll(str, null, loadOpts);
 // $ExpectType any[]
 value = yaml.safeLoadAll(str, undefined, loadOpts);
 
-// $ExpectType any[]
-value = yaml.loadAll(str);
-
-// $ExpectType undefined
-yaml.loadAll(str, (doc) => {
+// $ExpectType void
+yaml.safeLoadAll(str, doc => {
 	value = doc;
 });
-// $ExpectType undefined
-yaml.loadAll(str, (doc) => {
-	value = doc;
-}, loadOpts);
+// $ExpectType void
+yaml.safeLoadAll(
+	str,
+	doc => {
+		value = doc;
+	},
+	loadOpts,
+);
+
+// $ExpectType any[]
+value = yaml.loadAll(str);
+// $ExpectType any[]
+value = yaml.loadAll(str, null, loadOpts);
 // $ExpectType any[]
 value = yaml.loadAll(str, undefined, loadOpts);
+
+// $ExpectType void
+yaml.loadAll(str, doc => {
+	value = doc;
+});
+// $ExpectType void
+yaml.loadAll(
+	str,
+	doc => {
+		value = doc;
+	},
+	loadOpts,
+);
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 

--- a/types/js-yaml/tsconfig.json
+++ b/types/js-yaml/tsconfig.json
@@ -1,23 +1,19 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
-        "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
-        "types": [],
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.d.ts",
-        "js-yaml-tests.ts"
-    ]
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": ["es6"],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictNullChecks": true,
+		"strictFunctionTypes": true,
+		"baseUrl": "../",
+		"typeRoots": ["../"],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"js-yaml-tests.ts",
+		"index.d.ts"
+	]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/nodeca/js-yaml/blob/master/lib/js-yaml/loader.js>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

Technically, the&nbsp;type is&nbsp;<code>not&nbsp;Function</code>, but&nbsp;that&nbsp;needs&nbsp;<https://github.com/microsoft/TypeScript/pull/29317> and&nbsp;would also&nbsp;allow incorrectly&nbsp;passing the&nbsp;`options`&nbsp;argument in&nbsp;place of&nbsp;the&nbsp;`iterator`, which&nbsp;is&nbsp;incorrect.