### PR TITLE
Highland: convert spaces to tabs and add tslint rule

### DIFF
--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -47,23 +47,23 @@ var anyArrStream: Highland.Stream<any[]>;
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 interface Foo {
-  foo(): string;
+	foo(): string;
 }
 interface Bar {
-  bar(): string;
+	bar(): string;
 }
 interface Baz {
-  foo: string;
-  bar: number;
-  baz: boolean;
+	foo: string;
+	bar: number;
+	baz: boolean;
 }
 
 interface StrFooArrMap {
-  [key: string]: Foo[];
+	[key: string]: Foo[];
 }
 
 interface StrBarArrMap {
-  [key: string]: Bar[];
+	[key: string]: Bar[];
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -137,24 +137,24 @@ fooStream = streamRedirect.to;
 fooStream = _<Foo>();
 fooStream = _(fooArr);
 fooStream = _<Foo>((push, next) => {
-  push(null, foo);
-  push(err);
-  next();
+	push(null, foo);
+	push(err);
+	next();
 });
 
 fooStream = _(fooStream);
 fooStream = _<Foo>(readable);
 fooStream = _<Foo>(readable, (r, cb) => {
-    return;
+		return;
 });
 fooStream = _<Foo>(readable, (r, cb) => {
-    return () => { return; }
+		return () => { return; }
 });
 fooStream = _<Foo>(readable, (r, cb) => {
-    return { continueOnError: true };
+		return { continueOnError: true };
 });
 fooStream = _<Foo>(readable, (r, cb) => {
-    return { onDestroy: () => { return; } };
+		return { onDestroy: () => { return; } };
 });
 fooStream = _<Foo>(str, emitter);
 fooStream = _<Foo>(str, emitter, num);
@@ -201,22 +201,22 @@ fooArrStream = fooStream.collect();
 fooStream = fooStream.compact();
 
 barStream = fooStream.consume(
-  (
-    err: Error,
-    x: Foo | Highland.Nil,
-    push: (err: Error, value?: Bar | Highland.Nil) => void,
-    next: () => void
-  ) => {
-    push(err);
-    push(null, bar);
-    next();
-  }
+	(
+		err: Error,
+		x: Foo | Highland.Nil,
+		push: (err: Error, value?: Bar | Highland.Nil) => void,
+		next: () => void
+	) => {
+		push(err);
+		push(null, bar);
+		next();
+	}
 );
 
 barStream = fooStream.consume<Bar>((err, x, push, next) => {
-  push(err);
-  push(null, bar);
-  next();
+	push(err);
+	push(null, bar);
+	next();
 });
 
 fooStream = fooStream.debounce(num);
@@ -226,31 +226,31 @@ fooStream = fooStream.doto((x: Foo) => {});
 fooStream = fooStream.drop(2);
 
 fooStream = fooStream.errors(
-  (err: Error, push: (e: Error, x?: Foo) => void) => {
-    push(err);
-    push(null, x);
-    push(null, foo);
-  }
+	(err: Error, push: (e: Error, x?: Foo) => void) => {
+		push(err);
+		push(null, x);
+		push(null, foo);
+	}
 );
 
 fooStream = fooStream.errors((err, push) => {
-  push(err);
-  push(null, x);
-  push(null, foo);
+	push(err);
+	push(null, x);
+	push(null, foo);
 });
 
 fooStream = fooStream.filter((x: Foo) => {
-  return bool;
+	return bool;
 });
 
 fooStream = fooStream.find((x: Foo) => {
-  return bool;
+	return bool;
 });
 
 fooStream = fooStream.findWhere(obj);
 
 strFooArrMapStream = fooStream.group((x: Foo) => {
-  return str;
+	return str;
 });
 strFooArrMapStream = fooStream.group(str);
 
@@ -269,7 +269,7 @@ fooStream = fooStream.last();
 fooStream = fooStream.latest();
 
 barStream = fooStream.map((x: Foo) => {
-  return bar;
+	return bar;
 });
 
 // $ExpectType Stream<Pick<Baz, "foo" | "bar">>
@@ -286,30 +286,30 @@ fooStream = fooStream.ratelimit(3, 1000);
 
 // $ExpectType Stream<Foo>
 fooStream = fooStream.reduce1((memo: Foo, x: Foo) => {
-  return memo;
+	return memo;
 });
 
 // $ExpectType Stream<Bar>
 barStream = fooStream.reduce1((memo: Foo | Bar, x: Foo) => {
-  return bar;
+	return bar;
 });
 
 fooStream = fooStream.reject((x: Foo) => {
-  return bool;
+	return bool;
 });
 
 barStream = fooStream.scan(bar, (memo: Bar, x: Foo) => {
-  return memo;
+	return memo;
 });
 
 // $ExpectType Stream<Foo>
 fooStream = fooStream.scan1((memo: Foo, x: Foo) => {
-  return memo;
+	return memo;
 });
 
 // $ExpectType Stream<Bar>
 barStream = fooStream.scan1((memo: Foo | Bar, x: Foo) => {
-  return bar;
+	return bar;
 });
 
 // $ExpectType Stream<Foo>
@@ -361,15 +361,15 @@ fooStream = fooStream.concat(fooStream);
 fooStream = fooStream.concat(fooArr);
 
 fooStream = fooStream.flatFilter((x: Foo) => {
-  return boolStream;
+	return boolStream;
 });
 
 barStream = fooStream.flatMap((x: Foo) => {
-  return barStream;
+	return barStream;
 });
 
 barStream = fooStream.flatMap((x: Foo) => {
-  return bar;
+	return bar;
 });
 
 barStream = barArrStream.flatten<Bar>();

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -145,7 +145,7 @@ interface HighlandStatic {
 	// UTILS
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  /**
+	/**
 	 * Returns true if `x` is the end of stream marker.
 	 *
 	 * @id isNil
@@ -154,7 +154,7 @@ interface HighlandStatic {
 	 * @param x - the object to test
 	 * @api public
 	 */
-  isNil<R>(x: R | Highland.Nil): x is Highland.Nil;
+	isNil<R>(x: R | Highland.Nil): x is Highland.Nil;
 
 	/**
 	 * Returns true if `x` is a Highland Stream.
@@ -1083,27 +1083,27 @@ declare namespace Highland {
 		 */
 		throttle(ms: number): Stream<R>;
 
-    /**
-     * Filters out all duplicate values from the stream and keeps only the first
-     * occurence of each value, using === to define equality.
-     *
-     * @id uniq
-     * @section Streams
-     * @name Stream.uniq()
-     * @api public
-     */
-    uniq(): Stream<R>;
+		/**
+		 * Filters out all duplicate values from the stream and keeps only the first
+		 * occurence of each value, using === to define equality.
+		 *
+		 * @id uniq
+		 * @section Streams
+		 * @name Stream.uniq()
+		 * @api public
+		 */
+		uniq(): Stream<R>;
 
-    /**
-     * Filters out all duplicate values from the stream and keeps only the first
-     * occurence of each value, using the provided function to define equality.
-     *
-     * @id uniqBy
-     * @section Streams
-     * @name Stream.uniqBy()
-     * @api public
-     */
-    uniqBy(f: (a: R, b: R) => boolean): Stream<R>;
+		/**
+		 * Filters out all duplicate values from the stream and keeps only the first
+		 * occurence of each value, using the provided function to define equality.
+		 *
+		 * @id uniqBy
+		 * @section Streams
+		 * @name Stream.uniqBy()
+		 * @api public
+		 */
+		uniqBy(f: (a: R, b: R) => boolean): Stream<R>;
 
 		/**
 		 * A convenient form of filter, which returns all objects from a Stream
@@ -1156,7 +1156,7 @@ declare namespace Highland {
 		 * Creates a new Stream of values by applying each item in a Stream to an
 		 * iterator function which must return a (possibly empty) Stream. Each
 		 * item on these result Streams are then emitted on a single output Stream.
-		 * 
+		 *
 		 * This transform is functionally equivalent to `.map(f).sequence()`.
 		 *
 		 * @id flatMap
@@ -1214,7 +1214,7 @@ declare namespace Highland {
 		 * // => contents of foo.txt, bar.txt and baz.txt in the order they were read
 		 */
 		merge<U>(this: Stream<Stream<U>>): Stream<U>;
-		
+
 		/**
 		 * Takes a Stream of Streams and merges their values and errors into a
 		 * single new Stream, limitting the number of unpaused streams that can
@@ -1582,28 +1582,28 @@ declare namespace Highland {
 		 */
 		toNodeStream(options?: object): NodeJS.ReadableStream;
 
-    /**
-     * Converts the result of a stream to Promise.
-     *
-     * If the stream contains a single value, it will return
-     * with the single item emitted by the stream (if present).
-     * If the stream is empty, `undefined` will be returned.
-     * If an error is encountered in the stream, this function will stop
-     * consumption and call `cb` with the error.
-     * If the stream contains more than one item, it will stop consumption
-     * and reject with an error.
-     *
-     * @id toPromise
-     * @section Consumption
-     * @name Stream.toPromise(PromiseCtor)
-     * @param {Function} PromiseCtor - Promises/A+ compliant constructor
-     * @api public
-     *
-     * _([1, 2, 3, 4]).collect().toPromise(Promise).then(function (result) {
-     *     // parameter result will be [1,2,3,4]
-     * });
-     */
-    toPromise(PromiseCtor: PromiseConstructor): PromiseLike<R>;
+		/**
+		 * Converts the result of a stream to Promise.
+		 *
+		 * If the stream contains a single value, it will return
+		 * with the single item emitted by the stream (if present).
+		 * If the stream is empty, `undefined` will be returned.
+		 * If an error is encountered in the stream, this function will stop
+		 * consumption and call `cb` with the error.
+		 * If the stream contains more than one item, it will stop consumption
+		 * and reject with an error.
+		 *
+		 * @id toPromise
+		 * @section Consumption
+		 * @name Stream.toPromise(PromiseCtor)
+		 * @param {Function} PromiseCtor - Promises/A+ compliant constructor
+		 * @api public
+		 *
+		 * _([1, 2, 3, 4]).collect().toPromise(Promise).then(function (result) {
+		 *     // parameter result will be [1,2,3,4]
+		 * });
+		 */
+		toPromise(PromiseCtor: PromiseConstructor): PromiseLike<R>;
 	}
 
 	interface PipeableStream<T, R> extends Stream<R> {}
@@ -1612,13 +1612,13 @@ declare namespace Highland {
 		end: boolean
 	}
 
-    type MappingHint = number | string[] | Function;
+		type MappingHint = number | string[] | Function;
 
-    interface CleanupObject {
-        onDestroy?: Function;
-        continueOnError?: boolean;
-    }
-    type OnFinished = (r: NodeJS.ReadableStream, cb: (...args: any[]) => void) => void | Function | CleanupObject;
+		interface CleanupObject {
+				onDestroy?: Function;
+				continueOnError?: boolean;
+		}
+		type OnFinished = (r: NodeJS.ReadableStream, cb: (...args: any[]) => void) => void | Function | CleanupObject;
 }
 
 declare var highland:HighlandStatic;

--- a/types/highland/tslint.json
+++ b/types/highland/tslint.json
@@ -8,6 +8,7 @@
         "callable-types": false,
         "comment-format": false,
         "dt-header": false,
+        "indent": [true, "tabs", 1],
         "npm-naming": false,
         "eofline": false,
         "export-just-namespace": false,


### PR DESCRIPTION
Not a code change. I noticed when reviewing a couple of PRs that the spacing seemed odd. It turns out some code was using spaces and others tabs. I added a dtslint rule to only allow tabs (chosen since that was the majority already) and converted all spaces to tabs.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
