### PR TITLE
yargs: Add 'sort-commands' option to `parserConfiguration`

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -427,7 +427,10 @@ declare namespace yargs {
         parsed: DetailedArguments | false;
 
         /** Allows to configure advanced yargs features. */
-        parserConfiguration(configuration: Partial<Configuration>): Argv<T>;
+        parserConfiguration(configuration: Partial<Configuration & {
+            /** Sort commands alphabetically. Default is `false` */
+            'sort-commands': boolean;
+        }>): Argv<T>;
 
         /**
          * Similar to `config()`, indicates that yargs should interpret the object from the specified key in package.json as a configuration object.

--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -30,6 +30,11 @@ import { DetailedArguments, Configuration } from 'yargs-parser';
 declare namespace yargs {
     type BuilderCallback<T, R> = ((args: Argv<T>) => Argv<R>) | ((args: Argv<T>) => void);
 
+    type ParserConfigurationOptions = Configuration & {
+        /** Sort commands alphabetically. Default is `false` */
+        'sort-commands': boolean;
+    };
+
     /**
      * The type parameter `T` is the expected shape of the parsed options.
      * `Arguments<T>` is those options plus `_` and `$0`, and an indexer falling
@@ -427,10 +432,7 @@ declare namespace yargs {
         parsed: DetailedArguments | false;
 
         /** Allows to configure advanced yargs features. */
-        parserConfiguration(configuration: Partial<Configuration & {
-            /** Sort commands alphabetically. Default is `false` */
-            'sort-commands': boolean;
-        }>): Argv<T>;
+        parserConfiguration(configuration: Partial<ParserConfigurationOptions>): Argv<T>;
 
         /**
          * Similar to `config()`, indicates that yargs should interpret the object from the specified key in package.json as a configuration object.

--- a/types/yargs/v13/index.d.ts
+++ b/types/yargs/v13/index.d.ts
@@ -421,7 +421,10 @@ declare namespace yargs {
         parsed: DetailedArguments | false;
 
         /** Allows to configure advanced yargs features. */
-        parserConfiguration(configuration: Partial<Configuration>): Argv<T>;
+        parserConfiguration(configuration: Partial<Configuration & {
+            /** Sort commands alphabetically. Default is `false` */
+            'sort-commands': boolean;
+        }>): Argv<T>;
 
         /**
          * Similar to `config()`, indicates that yargs should interpret the object from the specified key in package.json as a configuration object.

--- a/types/yargs/v13/index.d.ts
+++ b/types/yargs/v13/index.d.ts
@@ -30,6 +30,11 @@ import { DetailedArguments, Configuration } from 'yargs-parser';
 declare namespace yargs {
     type BuilderCallback<T, R> = ((args: Argv<T>) => Argv<R>) | ((args: Argv<T>) => void);
 
+    type ParserConfigurationOptions = Configuration & {
+        /** Sort commands alphabetically. Default is `false` */
+        'sort-commands': boolean;
+    };
+
     /**
      * The type parameter `T` is the expected shape of the parsed options.
      * `Arguments<T>` is those options plus `_` and `$0`, and an indexer falling
@@ -421,10 +426,7 @@ declare namespace yargs {
         parsed: DetailedArguments | false;
 
         /** Allows to configure advanced yargs features. */
-        parserConfiguration(configuration: Partial<Configuration & {
-            /** Sort commands alphabetically. Default is `false` */
-            'sort-commands': boolean;
-        }>): Argv<T>;
+        parserConfiguration(configuration: Partial<ParserConfigurationOptions>): Argv<T>;
 
         /**
          * Similar to `config()`, indicates that yargs should interpret the object from the specified key in package.json as a configuration object.

--- a/types/yargs/v13/yargs-tests.ts
+++ b/types/yargs/v13/yargs-tests.ts
@@ -734,6 +734,7 @@ function Argv$parserConfiguration() {
         'populate--': false,
         'set-placeholder-key': false,
         'short-option-groups': false,
+        'sort-commands': true,
     }).parse();
 
     const argv2 = yargs.parserConfiguration({

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -734,6 +734,7 @@ function Argv$parserConfiguration() {
         'populate--': false,
         'set-placeholder-key': false,
         'short-option-groups': false,
+        'sort-commands': true,
     }).parse();
 
     const argv2 = yargs.parserConfiguration({


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
 
- http://yargs.js.org/docs/#api-parserconfigurationobj
- https://github.com/yargs/yargs/blob/05324b426025f7bc52b0caeb0794dd61abdd6845/docs/api.md#parserconfigurationobj
- https://github.com/yargs/yargs/blob/63b3dd31a455d428902220c1992ae930e18aff5c/lib/usage.js#L209

Although it looks as if this belongs in `yargs-parser`, it's handled directly in `yargs` (see last code link)