### PR TITLE
[@types/fabric] Update types/fabric from fabric v3.5.0 to v3.6

### DIFF
--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -2237,7 +2237,7 @@ export class Ellipse {
 }
 interface IGroupOptions extends IObjectOptions {
 	/**
-	 * Indicates if click events should also check for subtargets
+	 * Indicates if click, mouseover, mouseout events & hoverCursor should also check for subtargets
 	 * @type Boolean
 	 */
 	subTargetCheck?: boolean;

--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -1879,6 +1879,14 @@ interface ICanvasOptions extends IStaticCanvasOptions {
 	 * @default
 	 */
 	fireMiddleClick?: boolean;
+
+	/**
+	 * Keep track of the subTargets for Mouse Events
+	 * @type {Array.<fabric.Object>}
+	 * @since 3.6.0
+	 * @default
+	 */
+	targets?: Object[];
 }
 export interface Canvas extends StaticCanvas { }
 export interface Canvas extends ICanvasOptions { }

--- a/types/fabric/index.d.ts
+++ b/types/fabric/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for FabricJS 3.5
+// Type definitions for FabricJS 3.6
 // Project: http://fabricjs.com/
 // Definitions by: Oliver Klemencic <https://github.com/oklemencic>
 //                 Joseph Livecchi <https://github.com/joewashear007>
@@ -11,6 +11,7 @@
 //                 Glenn Gartner <https://github.com/glenngartner>
 //                 Codertx <https://github.com/codertx>
 //                 Mike Moore <https://github.com/mike667>
+//                 Natalie Marleny <https://github.com/nataliemarleny>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 export import fabric = require("./fabric-impl");

--- a/types/fabric/test/index.ts
+++ b/types/fabric/test/index.ts
@@ -2,6 +2,7 @@ function sample1() {
   const canvas = new fabric.Canvas('c', {
     hoverCursor: 'pointer',
     selection: false,
+    targets: []
   });
 
   canvas.on('object:moving', (e: fabric.IEvent) => {


### PR DESCRIPTION
Small update - feedback welcome.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/fabricjs/fabric.js/compare/v3.5.0...v3.6.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [not substantial changes] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
