### PR TITLE
`react-router`: Add missing history state props

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -46,11 +46,11 @@ export interface MemoryRouterProps {
 
 export class MemoryRouter extends React.Component<MemoryRouterProps, any> {}
 
-export interface PromptProps {
-    message: string | ((location: H.Location) => string | boolean);
+export interface PromptProps<S = H.LocationState> {
+    message: string | ((location: H.Location<S>) => string | boolean);
     when?: boolean;
 }
-export class Prompt extends React.Component<PromptProps, any> {}
+export class Prompt<S = H.LocationState> extends React.Component<PromptProps<S>, any> {}
 
 export interface RedirectProps {
     to: H.LocationDescriptor;
@@ -78,7 +78,7 @@ export interface RouteComponentProps<
 }
 
 export interface RouteChildrenProps<Params extends { [K in keyof Params]?: string } = {}, S = H.LocationState> {
-    history: H.History;
+    history: H.History<S>;
     location: H.Location<S>;
     match: match<Params> | null;
 }


### PR DESCRIPTION
This is required to fix https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41674#issuecomment-576169158

Please fill in this template.

- [*] Use a meaningful title for the pull request. Include the name of the package modified.
- [*] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
