### PR TITLE
[react-native]: add message to WebSocketCloseEvent.

### DIFF
--- a/types/react-native/globals.d.ts
+++ b/types/react-native/globals.d.ts
@@ -282,6 +282,7 @@ interface WebSocketErrorEvent extends Event {
 interface WebSocketCloseEvent extends Event {
     code?: number;
     reason?: string;
+    message?: string;
 }
 
 interface WebSocket extends EventTarget {


### PR DESCRIPTION
There are two occasions for WebSocketCloseEvent to fire, 1) the websocket directly closes, or 2) the websocket closes when an error has occurred.

The current definition only covers for case 1 while misses case 2.

See definition for case 2 [here](https://github.com/facebook/react-native/blob/master/Libraries/WebSocket/WebSocket.js#L268).

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).