### PR TITLE
Add types for semver-utils

### DIFF
--- a/types/semver-utils/index.d.ts
+++ b/types/semver-utils/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for semver-utils 1.1
+// Project: https://git.coolaj86.com/coolaj86/semver-utils.js
+// Definitions by: Jamie Magee <https://github.com/JamieMagee>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface SemVer {
+    semver?: string;
+    version?: string;
+    major?: string;
+    minor?: string;
+    patch?: string;
+    release?: string;
+    build?: string;
+    operator?: string;
+}
+
+export function parse(version: string): SemVer;
+export function stringify(version: SemVer): string;
+export function parseRange(range: string): SemVer[];
+export function stringifyRange(version: SemVer[]): string;

--- a/types/semver-utils/semver-utils-tests.ts
+++ b/types/semver-utils/semver-utils-tests.ts
@@ -1,0 +1,10 @@
+import { stringify, SemVer, parse } from 'semver-utils';
+
+const version: SemVer = {
+    major: '1',
+    minor: '0',
+    patch: '0',
+};
+
+stringify(version); // $ExpectType string
+parse('1.0.0'); // $ExpectType SemVer

--- a/types/semver-utils/tsconfig.json
+++ b/types/semver-utils/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "semver-utils-tests.ts"
+    ]
+}

--- a/types/semver-utils/tslint.json
+++ b/types/semver-utils/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.