### PR TITLE
Add bresenham lib types

### DIFF
--- a/types/bresenham/bresenham-tests.ts
+++ b/types/bresenham/bresenham-tests.ts
@@ -1,0 +1,12 @@
+import bresenham = require('bresenham');
+import generatorFn = require('bresenham/generator');
+
+// $ExpectType Point[]
+bresenham(0, 0, 10, 12);
+
+// $ExpectType void
+bresenham(0, 0, 10, 12, (x: number, y: number) => {
+});
+
+// $ExpectType Generator<Point, any, unknown>
+generatorFn(0, 0, 10, 12);

--- a/types/bresenham/generator.d.ts
+++ b/types/bresenham/generator.d.ts
@@ -1,0 +1,11 @@
+interface Point {
+    x: number;
+    y: number;
+}
+
+declare function generator(
+    x0: number, y0: number,
+    x1: number, y1: number
+): Generator<Point>;
+
+export = generator;

--- a/types/bresenham/index.d.ts
+++ b/types/bresenham/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for bresenham 0.0
+// Project: https://github.com/madbence/node-bresenham
+// Definitions by: Richard <https://github.com/Chnapy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.6
+
+interface Point {
+    x: number;
+    y: number;
+}
+
+declare function bresenham(
+    x0: number, y0: number,
+    x1: number, y1: number
+): Point[];
+declare function bresenham(
+    x0: number, y0: number,
+    x1: number, y1: number,
+    fn: (x: number, y: number) => void
+): void;
+
+export = bresenham;

--- a/types/bresenham/tsconfig.json
+++ b/types/bresenham/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "bresenham-tests.ts"
+    ]
+}

--- a/types/bresenham/tslint.json
+++ b/types/bresenham/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
