### PR TITLE
[@types/object-fit-images] added new type definitions

### DIFF
--- a/types/object-fit-images/index.d.ts
+++ b/types/object-fit-images/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for object-fit-images 3.2
+// Project: https://github.com/bfred-it/object-fit-images#readme
+// Definitions by: Ranjit Singh <https://github.com/rann91>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function objectFillImages(
+    images: string | HTMLElement | HTMLElement[] | NodeList | null,
+    options?: { watchMQ: boolean },
+): void;
+
+export default objectFillImages;

--- a/types/object-fit-images/index.d.ts
+++ b/types/object-fit-images/index.d.ts
@@ -3,9 +3,11 @@
 // Definitions by: Ranjit Singh <https://github.com/rann91>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+export as namespace objectFillImages;
+
+export = objectFillImages;
+
 declare function objectFillImages(
     images: string | HTMLElement | HTMLElement[] | NodeList | null,
-    options?: { watchMQ: boolean },
+    options?: { watchMQ?: boolean; skipTest?: boolean },
 ): void;
-
-export default objectFillImages;

--- a/types/object-fit-images/object-fit-images-tests.ts
+++ b/types/object-fit-images/object-fit-images-tests.ts
@@ -1,5 +1,3 @@
-import objectFillImages from 'object-fit-images';
-
 const img = document.createElement('img');
 img.setAttribute('src', 'https://i.picsum.photos/id/565/536/354.jpg');
 

--- a/types/object-fit-images/object-fit-images-tests.ts
+++ b/types/object-fit-images/object-fit-images-tests.ts
@@ -1,0 +1,8 @@
+import objectFillImages from 'object-fit-images';
+
+const img = document.createElement('img');
+img.setAttribute('src', 'https://i.picsum.photos/id/565/536/354.jpg');
+
+document.appendChild(img);
+
+objectFillImages(img);

--- a/types/object-fit-images/tsconfig.json
+++ b/types/object-fit-images/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "object-fit-images-tests.ts"
+    ]
+}

--- a/types/object-fit-images/tslint.json
+++ b/types/object-fit-images/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/object-hash/tsconfig.json
+++ b/types/object-hash/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/object-hash/tsconfig.json
+++ b/types/object-hash/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
+        "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ x ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ x ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ x ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ x ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ x ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ x ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
