### PR TITLE
[mongoose-autopopulate] added new type definitions

### DIFF
--- a/types/mongoose-autopopulate/index.d.ts
+++ b/types/mongoose-autopopulate/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for mongoose-autopopulate 0.10
+// Project: https://github.com/mongodb-js/mongoose-autopopulate
+// Definitions by: Ranjit Singh <https://github.com/rann91>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import { Schema } from 'mongoose';
+
+declare function mongooseAutoPopulate(schema: Schema): void;
+
+export default mongooseAutoPopulate;

--- a/types/mongoose-autopopulate/mongoose-autopopulate-tests.ts
+++ b/types/mongoose-autopopulate/mongoose-autopopulate-tests.ts
@@ -1,0 +1,8 @@
+import { Schema } from 'mongoose';
+import mongooseAutoPopulate from 'mongoose-autopopulate';
+
+const schema = new Schema({
+    test: { type: String },
+});
+
+schema.plugin(mongooseAutoPopulate);

--- a/types/mongoose-autopopulate/tsconfig.json
+++ b/types/mongoose-autopopulate/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mongoose-autopopulate-tests.ts"
+    ]
+}

--- a/types/mongoose-autopopulate/tslint.json
+++ b/types/mongoose-autopopulate/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ x ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ x ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ x ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ x ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ x ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ x ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
