### PR TITLE
feat(auth0-js): missing v9 implementation

### DIFF
--- a/types/auth0-js/auth0-js-tests.ts
+++ b/types/auth0-js/auth0-js-tests.ts
@@ -163,11 +163,14 @@ webAuth.client.login({
     scope: 'read:order write:order',
 }, (err, authResult) => {/*Auth tokens in the result or an error*/});
 
-webAuth.popup.buildPopupHandler();
+webAuth.popup.buildPopupHandler(); // $ExpectError
 webAuth.popup.preload({});
-webAuth.popup.authorize({ domain: "", redirectUri: "", responseType: "code" }, (err, data) => {
+webAuth.popup.authorize({ domain: "", redirectUri: "", responseType: "code" }, (err, result) => {
     if (err) /* handle error */ return;
-    // do something with data
+    // do something with results
+    if (result) {
+        // ...
+    }
 });
 webAuth.popup.loginWithCredentials({}, (err, data) => {
     if (err) /* handle error */ return;
@@ -286,4 +289,9 @@ management.patchUserMetadata('asd', {role: 'admin'}, (err, user) => {
     if (!err && user.email_verified) return; // do something
 });
 
-management.linkUser('asd', 'eqwe', (err, user) => {});
+// tslint:disable-next-line: prefer-const
+let user: auth0.Auth0UserProfile;
+management.patchUserAttributes(); // $ExpectError
+management.patchUserAttributes('...'); // $ExpectError
+management.patchUserAttributes('...', {}); // $ExpectError
+management.patchUserAttributes('auth0|123', user, (err, user) => {}); // $ExpectType void

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -140,12 +140,17 @@ export class Management {
     getUser(userId: string, callback: Auth0Callback<Auth0UserProfile>): void;
 
     /**
-     * Updates the user metdata. It will patch the user metdata with the attributes sent.
+     * Updates the user metadata. It will patch the user metadata with the attributes sent.
      * https://auth0.com/docs/api/management/v2#!/Users/patch_users_by_id
      *
      */
     patchUserMetadata(userId: string, userMetadata: any, callback: Auth0Callback<Auth0UserProfile>): void;
-
+    /**
+     * Updates the user attributes.
+     * It will patch the root attributes that the server allows it.
+     * {@link https://auth0.com/docs/api/management/v2#!/Users/patch_users_by_id}
+     */
+    patchUserAttributes(userId: string, user: Auth0UserProfile, callback: Auth0Callback<Auth0UserProfile>): void;
     /**
      * Link two users. https://auth0.com/docs/api/management/v2#!/Users/post_identities
      *
@@ -333,9 +338,8 @@ export class Popup {
 
     /**
      * Returns a new instance of the popup handler
-     *
      */
-    buildPopupHandler(): any;
+    private buildPopupHandler(): any;
 
     /**
      * Initializes the popup window and returns the instance to be used later in order to avoid being blocked by the browser.
@@ -411,7 +415,7 @@ export class Popup {
             /** determines if Auth0 should render the relay page or not and the caller is responsible of handling the response. */
             owp?: boolean,
         },
-        callback: Auth0Callback<any>,
+        callback: Auth0Callback<Auth0Result>,
     ): void;
 
     /**
@@ -521,7 +525,7 @@ export interface AuthOptions {
     audience?: string;
     /**
      * maximum elapsed time in seconds since the last time the user
-     * was actively authenticatedby the authorization server.
+     * was actively authenticated by the authorization server.
      */
     maxAge?: number;
     leeway?: number;
@@ -588,6 +592,30 @@ export interface Auth0Error {
     original?: any;
     statusCode?: number;
     statusText?: string;
+}
+
+/**
+ * result of the Auth request.
+ * If there is no token available, this value will be null.
+ */
+export interface Auth0Result {
+    /**
+     * token that allows access to the specified resource server (identified by the audience parameter
+     * or by default Auth0's /userinfo endpoint)
+     */
+    accessToken?: string;
+    /** number of seconds until the access token expires */
+    expiresIn?: number;
+    /** token that identifies the user */
+    idToken?: string;
+    /**
+     * token that can be used to get new access tokens from Auth0.
+     * Note that not all Auth0 Applications can request them
+     * or the resource server might not allow them.
+     */
+    refreshToken?: string;
+    /** values that you receive back on the authentication response */
+    appState?: any;
 }
 
 export type Auth0ParseHashError = Auth0Error & {


### PR DESCRIPTION
- `patchUserAttributes`
- remove `buildPopupHandler` private method
- authentication callback options typed as `Auth0Result`
- typed results for Popup.authorize
- minor typos

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/auth0/auth0.js/blob/073fd0335ff95148a5f8b54455b4a4038e48fa6d/src/web-auth/popup.js#L31
https://auth0.github.io/auth0.js/global.html#authorizeCallback
https://auth0.com/docs/libraries/auth0js/v9#webauth-popup-authorize-