### PR TITLE
[redis] Fix type definition for RedisClient, Multi

### DIFF
--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -11,6 +11,7 @@
 //                 Stanislav Dzhus <https://github.com/blablapolicja>
 //                 Jake Ferrante <https://github.com/ferrantejake>
 //                 Adebayo Opesanya <https://github.com/OpesanyaAdebayo>
+//                 Alexis Tabaksyurov <https://github.com/f3nrir92>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Imported from: https://github.com/types/npm-redis
@@ -1179,7 +1180,7 @@ export interface Commands<R> {
 
 export const RedisClient: new (options: ClientOpts) => RedisClient;
 
-export interface RedisClient extends Commands<boolean>, EventEmitter {
+export interface RedisClient extends Commands<any>, EventEmitter {
     connected: boolean;
     command_queue_length: number;
     offline_queue_length: number;
@@ -1209,10 +1210,10 @@ export interface RedisClient extends Commands<boolean>, EventEmitter {
 
     duplicate(options?: ClientOpts, cb?: Callback<RedisClient>): RedisClient;
 
-    sendCommand(command: string, cb?: Callback<any>): boolean;
-    sendCommand(command: string, args?: any[], cb?: Callback<any>): boolean;
-    send_command(command: string, cb?: Callback<any>): boolean;
-    send_command(command: string, args?: any[], cb?: Callback<any>): boolean;
+    sendCommand(command: string, cb?: Callback<any>): any;
+    sendCommand(command: string, args?: any[], cb?: Callback<any>): any;
+    send_command(command: string, cb?: Callback<any>): any;
+    send_command(command: string, args?: any[], cb?: Callback<any>): any;
 
     addCommand(command: string): void;
     add_command(command: string): void;
@@ -1230,11 +1231,11 @@ export interface RedisClient extends Commands<boolean>, EventEmitter {
 export const Multi: new () => Multi;
 
 export interface Multi extends Commands<Multi> {
-    exec(cb?: Callback<any[]>): boolean;
-    EXEC(cb?: Callback<any[]>): boolean;
+    exec(cb?: Callback<any[]>): any;
+    EXEC(cb?: Callback<any[]>): any;
 
-    exec_atomic(cb?: Callback<any[]>): boolean;
-    EXEC_ATOMIC(cb?: Callback<any[]>): boolean;
+    exec_atomic(cb?: Callback<any[]>): any;
+    EXEC_ATOMIC(cb?: Callback<any[]>): any;
 }
 
 export let debug_mode: boolean;


### PR DESCRIPTION
Solves #32365.

Changed return type to `any` as suggested in #37064


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #32365
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.