### PR TITLE
Adds chrome.cast.media.LiveSeekableRange to chrome/chrome-cast and chromecast-caf-sender

### DIFF
--- a/types/chrome/chrome-cast/index.d.ts
+++ b/types/chrome/chrome-cast/index.d.ts
@@ -990,6 +990,7 @@ declare namespace chrome.cast.media {
         customData: Object;
         idleReason: chrome.cast.media.IdleReason;
         items: Array<chrome.cast.media.QueueItem>;
+        liveSeekableRange?: chrome.cast.media.LiveSeekableRange;
         loadingItemId: number;
         media: chrome.cast.media.MediaInfo;
         mediaSessionId: number;
@@ -1260,6 +1261,13 @@ declare namespace chrome.cast.media {
         fontGenericFamily: chrome.cast.media.TextTrackFontGenericFamily;
         fontStyle: chrome.cast.media.TextTrackFontStyle;
         customData: Object;
+    }
+    
+    export class LiveSeekableRange {
+        start?: number;
+        end?: number;
+        isMovingWindow?: boolean;
+        isLiveDone?: boolean;
     }
 }
 

--- a/types/chrome/chrome-cast/index.d.ts
+++ b/types/chrome/chrome-cast/index.d.ts
@@ -1264,6 +1264,17 @@ declare namespace chrome.cast.media {
     }
     
     export class LiveSeekableRange {
+        /**
+         * @constructor
+             * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.LiveSeekableRange
+         */
+        constructor(
+            start?: number,
+            end?: number,
+            isMovingWindow?: boolean,
+            isLiveDone?: boolean
+        );
+        
         start?: number;
         end?: number;
         isMovingWindow?: boolean;

--- a/types/chromecast-caf-sender/index.d.ts
+++ b/types/chromecast-caf-sender/index.d.ts
@@ -75,7 +75,8 @@ declare namespace cast.framework {
     DISPLAY_STATUS_CHANGED = "displayStatusChanged",
     MEDIA_INFO_CHANGED = "mediaInfoChanged",
     IMAGE_URL_CHANGED = "imageUrlChanged",
-    PLAYER_STATE_CHANGED = "playerStateChanged"
+    PLAYER_STATE_CHANGED = "playerStateChanged",
+    LIVE_SEEKABLE_RANGE_CHANGED = "liveSeekableRange"
   }
 
   enum ActiveInputState {

--- a/types/chromecast-caf-sender/index.d.ts
+++ b/types/chromecast-caf-sender/index.d.ts
@@ -236,6 +236,7 @@ declare namespace cast.framework {
     statusText: string;
     title: string;
     displayStatus: string;
+    liveSeekableRange?: chrome.cast.media.LiveSeekableRange;
     mediaInfo?: chrome.cast.media.MediaInfo;
     imageUrl: string | null;
     playerState: chrome.cast.media.PlayerState | null;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.LiveSeekableRange + https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Media#liveSeekableRange + https://developers.google.com/cast/docs/reference/chrome/cast.framework.RemotePlayer#liveSeekableRange
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
