### PR TITLE
[iobroker] Add definitions for the integrated objects and states cache

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -455,6 +455,12 @@ declare global {
 
             /** if true, stateChange will be called with an id that has no namespace, e.g. "state" instead of "adapter.0.state". Default: false */
             noNamespace?: boolean;
+
+            /** If true, the adapter will have a property `oObjects` that contains a live cache of the adapter's objects */
+            objects?: boolean;
+
+            /** If true, the adapter will have a property `oStates` that contains a live cache of the adapter's states */
+            states?: boolean;
         } // end interface AdapterOptions
 
         // tslint:disable-next-line:no-empty-interface
@@ -489,6 +495,19 @@ declare global {
             version: any;
             /** if the adapter is connected to the host */
             connected: boolean;
+
+            /**
+             * Contains a live cache of the adapter's objects.
+             *
+             * NOTE: This is only defined if the adapter was initialized with the option `objects: true`.
+             */
+            oObjects?: Record<string, ioBroker.Object>;
+            /**
+             * Contains a live cache of the adapter's states.
+             *
+             * NOTE: This is only defined if the adapter was initialized with the option `states: true`.
+             */
+            oStates?: Record<string, State>;
 
             /*	===============================
                 Functions defined in adapter.js

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -302,6 +302,9 @@ adapter.states.getStates();
 // $ExpectError
 adapter.objects.getObjectView();
 
+adapter.oObjects && adapter.oObjects["foo"]._id.toString();
+adapter.oStates && adapter.oStates["foo"].val;
+
 // Repro from https://github.com/ioBroker/adapter-core/issues/3
 const repro1: ioBroker.ObjectChangeHandler = (id, obj) => {
     if (!obj || !obj.common) return;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ioBroker/ioBroker.js-controller/blob/07e31d4f33d8a9e957e9120a9d409e001d91089a/lib/adapter.js#L11-L12
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.