### PR TITLE
[@types/blessed] Fix Blessed typings (allow number and string as well for ListElement)

### DIFF
--- a/types/blessed/index.d.ts
+++ b/types/blessed/index.d.ts
@@ -5,6 +5,7 @@
 //                 Max Brauer <https://github.com/mamachanko>
 //                 Nathan Rajlich <https://github.com/TooTallNate>
 //                 Daniel Berlanga <https://github.com/danikaze>
+//                 Jeff Huijsmans <https://github.com/jeffhuys>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -2335,7 +2336,7 @@ export namespace Widgets {
         /**
          * Removes an item from the list. Child can be an element, index, or string.
          */
-        removeItem(child: BlessedElement): BlessedElement;
+        removeItem(child: BlessedElement | number | string): BlessedElement;
 
         /**
          * Push an item onto the list.
@@ -2360,12 +2361,12 @@ export namespace Widgets {
         /**
          * Inserts an item to the list. Child can be an element, index, or string.
          */
-        insertItem(i: number, child: BlessedElement): void;
+        insertItem(i: number, child: BlessedElement | number | string): void;
 
         /**
          * Returns the item element. Child can be an element, index, or string.
          */
-        getItem(child: BlessedElement): BlessedElement;
+        getItem(child: BlessedElement | number | string): BlessedElement;
 
         /**
          * Set item to content.
@@ -2390,7 +2391,7 @@ export namespace Widgets {
         /**
          * Returns the item index from the list. Child can be an element, index, or string.
          */
-        getItemIndex(child: BlessedElement): number;
+        getItemIndex(child: BlessedElement | number | string): number;
 
         /**
          * Select an index of an item.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing existing definitions.
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chjj/blessed#lists - `removeItem(child)`, `insertItem(child)`, `getItem(child)`, `getItemIndex(child)`. The `child` parameter can be "an element, index, or string".
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This PR fixes a relatively small issue with the typings, where we should be able to supply a `number` or `string`, in addition to `BlessedElement`.
