### PR TITLE
use union type instead of intersection type

### DIFF
--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -12176,7 +12176,7 @@ declare namespace Office {
          * {@link Office.MessageCompose | MessageCompose}, {@link Office.MessageRead | MessageRead},
          * {@link Office.AppointmentCompose | AppointmentCompose}, {@link Office.AppointmentRead | AppointmentRead}
          */
-        item: Item & ItemCompose & ItemRead & MessageRead & MessageCompose & AppointmentRead & AppointmentCompose;
+        item: Item | ItemCompose | ItemRead | MessageRead | MessageCompose | AppointmentRead | AppointmentCompose;
         /**
          * Gets an object that provides methods to manage the categories master list associated with a mailbox.
          *


### PR DESCRIPTION
item can be one of given type not all at once


