### PR TITLE
fix `setSelection` type definition in `types/codemirror`

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -6,6 +6,7 @@
 //                 rileymiller <https://github.com/rileymiller>
 //                 toddself <https://github.com/toddself>
 //                 ysulyma <https://github.com/ysulyma>
+//                 azoson <https://github.com/azoson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 
@@ -642,7 +643,7 @@ declare namespace CodeMirror {
         setCursor(pos: CodeMirror.Position | number, ch?: number, options?: { bias?: number, origin?: string, scroll?: boolean }): void;
 
         /** Set a single selection range. anchor and head should be {line, ch} objects. head defaults to anchor when not given. */
-        setSelection(anchor: CodeMirror.Position, head: CodeMirror.Position, options?: { bias?: number, origin?: string, scroll?: boolean }): void;
+        setSelection(anchor: CodeMirror.Position, head?: CodeMirror.Position, options?: { bias?: number, origin?: string, scroll?: boolean }): void;
 
         /** Sets a new set of selections. There must be at least one selection in the given array. When primary is a
         number, it determines which selection is the primary one. When it is not given, the primary index is taken from
@@ -1345,7 +1346,7 @@ declare namespace CodeMirror {
 
         /** When multiple selections are present, this deselects all but the primary selection. */
         singleSelection(cm: CodeMirror.Editor): void;
-        
+
         /** Emacs-style line killing. Deletes the part of the line after the cursor. If that consists only of whitespace, the newline at the end of the line is also deleted. */
         killLine(cm: CodeMirror.Editor): void;
 


### PR DESCRIPTION
The second argument `head` defaults to `anchor` (the first argument). (please see [this link](https://codemirror.net/doc/manual.html#setSelection) or a screenshot below)
Thus `head` is an optional argument.

![image](https://user-images.githubusercontent.com/13480946/72808271-932d3680-3c9c-11ea-8713-07d835fce40b.png)


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://codemirror.net/doc/manual.html#setSelection>>