### PR TITLE
[@types/victory] Add singleQuadrantDomainPadding type to victory

### DIFF
--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Victory 33.2
+// Type definitions for Victory 33.1
 // Project: https://github.com/FormidableLabs/victory, https://formidable.com/open-source/victory
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 //                 snerks <https://github.com/snerks>

--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Victory 33.1
+// Type definitions for Victory 33.2
 // Project: https://github.com/FormidableLabs/victory, https://formidable.com/open-source/victory
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 //                 snerks <https://github.com/snerks>
@@ -1375,6 +1375,20 @@ declare module 'victory' {
                   x?: ScalePropType | D3Scale;
                   y?: ScalePropType | D3Scale;
               };
+        /**
+         * By default `domainPadding` is coerced to existing quadrants. This means that if a given domain only
+         * includes positive values, no amount of padding applied by `domainPadding` will result in a domain with
+         * negative values. This is the desired behavior in most cases. For users that need to apply padding without
+         * regard to quadrant, the `singleQuadrantDomainPadding` prop may be used. This prop may be given as a boolean
+         * or an object with boolean values specified for "x" and/or "y". When this prop is false (or false for a given
+         * dimension), padding will be applied without regard to quadrant. If this prop is not specified,
+         * `domainPadding` will be coerced to existing quadrants.
+         *
+         * *note:* The `x` value supplied to the `singleQuadrantDomainPadding` prop refers to the *independent* variable,
+         * and the `y` value refers to the *dependent* variable. This may cause confusion in horizontal charts, as the
+         * independent variable will corresponds to the y axis.
+         */
+        singleQuadrantDomainPadding?: boolean | { x?: boolean; y?: boolean };
         /**
          * The standalone prop determines whether the component will render a standalone svg
          * or a <g> tag that will be included in an external svg. Set standalone to false to

--- a/types/victory/victory-tests.tsx
+++ b/types/victory/victory-tests.tsx
@@ -980,3 +980,8 @@ const sliceProps: VictorySliceProps = {
     sliceEndAngle: props => props.sliceEndAngle, // $ExpectError
     sliceStartAngle: props => props.slieStartAngle, // $ExpectError
 };
+
+// singleQuadrantDomainPadding test
+test = <VictoryArea singleQuadrantDomainPadding={true} />
+test = <VictoryArea singleQuadrantDomainPadding={{ x: true }} />
+test = <VictoryArea singleQuadrantDomainPadding={5} /> // $ExpectError

--- a/types/victory/victory-tests.tsx
+++ b/types/victory/victory-tests.tsx
@@ -982,6 +982,6 @@ const sliceProps: VictorySliceProps = {
 };
 
 // singleQuadrantDomainPadding test
-test = <VictoryArea singleQuadrantDomainPadding={true} />
-test = <VictoryArea singleQuadrantDomainPadding={{ x: true }} />
-test = <VictoryArea singleQuadrantDomainPadding={5} /> // $ExpectError
+test = <VictoryArea singleQuadrantDomainPadding={true} />;
+test = <VictoryArea singleQuadrantDomainPadding={{ x: true }} />;
+test = <VictoryArea singleQuadrantDomainPadding={5} />; // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [singlequadrantdomainpadding](https://formidable.com/open-source/victory/docs/common-props#singlequadrantdomainpadding)

Also closes #38991 