### PR TITLE
Fix Jest Matchers type

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -727,7 +727,7 @@ declare namespace jest {
         not: T
     };
     // should be R extends void|Promise<void> but getting dtslint error
-    interface Matchers<R, T = void> {
+    interface Matchers<R, T = {}> {
         /**
          * Ensures the last call to a mock function was provided specific args.
          *

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -727,7 +727,7 @@ declare namespace jest {
         not: T
     };
     // should be R extends void|Promise<void> but getting dtslint error
-    interface Matchers<R, T> {
+    interface Matchers<R, T = void> {
         /**
          * Ensures the last call to a mock function was provided specific args.
          *


### PR DESCRIPTION
This PR addresses the `Matchers<R>` -> `Matchers<R, T>` change in #39243

The above change is not inline with the types of `Jest` [see code here](https://github.com/facebook/jest/blob/master/packages/expect/src/types.ts#L87) and has broken any libraries extending Jest's `expect` (see: https://github.com/jest-community/jest-extended/issues/234).

The change in this PR adds a default to the new `T` type parameter of `void` which means that other libraries that extend `expect` can write their matchers in terms of `Matchers<R>` or `Matchers<R, T>` (should they need the `T`).

cc/ @tonyhallett



- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jest/blob/master/packages/expect/src/types.ts#L87
