### PR TITLE
@types/eslint - adding optional data argument to Formatter type

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -514,7 +514,26 @@ let formatter: CLIEngine.Formatter;
 formatter = cli.getFormatter('codeframe');
 formatter = cli.getFormatter();
 
+let data: CLIEngine.LintResultData;
+let meta: Rule.RuleMetaData = {
+    type: "suggestion",
+    docs: {
+        description: "disallow unnecessary semicolons",
+        category: "Possible Errors",
+        recommended: true,
+        url: "https://eslint.org/docs/rules/no-extra-semi"
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+        unexpected: "Unnecessary semicolon."
+    }
+}
+
+data = {rulesMeta: {"no-extra-semi": meta}};
+
 formatter(cliReport.results);
+formatter(cliReport.results, data);
 
 CLIEngine.getErrorResults(cliReport.results);
 

--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -515,7 +515,7 @@ formatter = cli.getFormatter('codeframe');
 formatter = cli.getFormatter();
 
 let data: CLIEngine.LintResultData;
-let meta: Rule.RuleMetaData = {
+const meta: Rule.RuleMetaData = {
     type: "suggestion",
     docs: {
         description: "disallow unnecessary semicolons",
@@ -528,7 +528,7 @@ let meta: Rule.RuleMetaData = {
     messages: {
         unexpected: "Unnecessary semicolon."
     }
-}
+};
 
 data = {rulesMeta: {"no-extra-semi": meta}};
 

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -538,6 +538,12 @@ export namespace CLIEngine {
         source?: string;
     }
 
+    interface LintResultData {
+        rulesMeta : {
+            [ruleId: string]: Rule.RuleMetaData;
+        }
+    }
+
     interface LintReport {
         results: LintResult[];
         errorCount: number;
@@ -546,7 +552,7 @@ export namespace CLIEngine {
         fixableWarningCount: number;
     }
 
-    type Formatter = (results: LintResult[]) => string;
+    type Formatter = (results: LintResult[], data?: LintResultData) => string;
 }
 
 //#endregion

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -539,9 +539,9 @@ export namespace CLIEngine {
     }
 
     interface LintResultData {
-        rulesMeta : {
+        rulesMeta: {
             [ruleId: string]: Rule.RuleMetaData;
-        }
+        };
     }
 
     interface LintReport {

--- a/types/eslint/package.json
+++ b/types/eslint/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "types": "./index.d.ts",
+    "types": "index",
     "typesVersions": {
         ">=3.1.0-0": {
             "*": [

--- a/types/eslint/package.json
+++ b/types/eslint/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "types": "index",
+    "types": "./index.d.ts",
     "typesVersions": {
         ">=3.1.0-0": {
             "*": [

--- a/types/eslint/ts3.1/eslint-tests.ts
+++ b/types/eslint/ts3.1/eslint-tests.ts
@@ -514,7 +514,26 @@ let formatter: CLIEngine.Formatter;
 formatter = cli.getFormatter('codeframe');
 formatter = cli.getFormatter();
 
+let data: CLIEngine.LintResultData;
+let meta: Rule.RuleMetaData = {
+    type: "suggestion",
+    docs: {
+        description: "disallow unnecessary semicolons",
+        category: "Possible Errors",
+        recommended: true,
+        url: "https://eslint.org/docs/rules/no-extra-semi"
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+        unexpected: "Unnecessary semicolon."
+    }
+}
+
+data = {rulesMeta: {"no-extra-semi": meta}};
+
 formatter(cliReport.results);
+formatter(cliReport.results, data);
 
 CLIEngine.getErrorResults(cliReport.results);
 

--- a/types/eslint/ts3.1/eslint-tests.ts
+++ b/types/eslint/ts3.1/eslint-tests.ts
@@ -515,7 +515,7 @@ formatter = cli.getFormatter('codeframe');
 formatter = cli.getFormatter();
 
 let data: CLIEngine.LintResultData;
-let meta: Rule.RuleMetaData = {
+const meta: Rule.RuleMetaData = {
     type: "suggestion",
     docs: {
         description: "disallow unnecessary semicolons",
@@ -528,7 +528,7 @@ let meta: Rule.RuleMetaData = {
     messages: {
         unexpected: "Unnecessary semicolon."
     }
-}
+};
 
 data = {rulesMeta: {"no-extra-semi": meta}};
 

--- a/types/eslint/ts3.1/index.d.ts
+++ b/types/eslint/ts3.1/index.d.ts
@@ -534,6 +534,12 @@ export namespace CLIEngine {
         source?: string;
     }
 
+    interface LintResultData {
+        rulesMeta : {
+            [ruleId: string]: Rule.RuleMetaData;
+        }
+    }
+
     interface LintReport {
         results: LintResult[];
         errorCount: number;
@@ -542,7 +548,7 @@ export namespace CLIEngine {
         fixableWarningCount: number;
     }
 
-    type Formatter = (results: LintResult[]) => string;
+    type Formatter = (results: LintResult[], data?: LintResultData) => string;
 }
 
 //#endregion

--- a/types/eslint/ts3.1/index.d.ts
+++ b/types/eslint/ts3.1/index.d.ts
@@ -535,9 +535,9 @@ export namespace CLIEngine {
     }
 
     interface LintResultData {
-        rulesMeta : {
+        rulesMeta: {
             [ruleId: string]: Rule.RuleMetaData;
-        }
+        };
     }
 
     interface LintReport {

--- a/types/eslint/ts3.1/index.d.ts
+++ b/types/eslint/ts3.1/index.d.ts
@@ -1,5 +1,3 @@
-// TypeScript Version: 3.1
-
 /// <reference path="helpers.d.ts" />
 
 import { JSONSchema4 } from 'json-schema';

--- a/types/eslint/ts3.1/index.d.ts
+++ b/types/eslint/ts3.1/index.d.ts
@@ -1,4 +1,4 @@
-// Minimum TypeScript Version: 3.1
+// TypeScript Version: 3.1
 
 /// <reference path="helpers.d.ts" />
 

--- a/types/eslint/ts3.1/index.d.ts
+++ b/types/eslint/ts3.1/index.d.ts
@@ -1,3 +1,5 @@
+// Minimum TypeScript Version: 3.1
+
 /// <reference path="helpers.d.ts" />
 
 import { JSONSchema4 } from 'json-schema';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://eslint.org/docs/developer-guide/working-with-custom-formatters#the-data-argument
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

