### PR TITLE
Update sjcl types to v1.0.8

### DIFF
--- a/types/sjcl/index.d.ts
+++ b/types/sjcl/index.d.ts
@@ -38,16 +38,14 @@ declare namespace sjcl {
 
         /// Returns true if "this" and "that" are equal.  Calls fullReduce().
         /// Equality test is in constant time.
-        equals(that: number): boolean;
-        equals(that: BigNumber): boolean;
+        equals(that: BigNumber | number): boolean;
 
         /// Get the i'th limb of this, zero if i is too large.
         getLimb(index: number): number;
 
         /// Constant time comparison function.
         /// Returns 1 if this >= that, or zero otherwise.
-        greaterEquals(that: number): boolean;
-        greaterEquals(that: BigNumber): boolean;
+        greaterEquals(that: BigNumber | number): boolean;
 
         /// Convert to a hex string.
         toString(): string;
@@ -82,9 +80,7 @@ declare namespace sjcl {
         square(): BigNumber;
 
         /// this ^ n.  Uses square-and-multiply.  Normalizes and reduces.
-        power(n: number): BigNumber;
-        power(n: BigNumber): BigNumber;
-        power(a: number[]): BigNumber;
+        power(n: BigNumber | number[] | number): BigNumber;
 
         /// this * that mod N
         mulmod: TypeHelpers.BigNumberTrinaryOperator;
@@ -118,9 +114,7 @@ declare namespace sjcl {
 
     interface BigNumberStatic {
         new (): BigNumber;
-        new (n: string): BigNumber;
-        new (n: number): BigNumber;
-        new (n: BigNumber): BigNumber;
+        new (n: BigNumber | number | string): BigNumber;
 
         fromBits(bits: BitArray): BigNumber;
         random: TypeHelpers.Bind1<number>;
@@ -151,9 +145,7 @@ declare namespace sjcl {
 
     interface PseudoMersennePrimeStatic extends BigNumberStatic {
         new (): PseudoMersennePrime;
-        new (n: string): PseudoMersennePrime;
-        new (n: number): PseudoMersennePrime;
-        new (n: BigNumber): PseudoMersennePrime;
+        new (n: BigNumber | number | string): PseudoMersennePrime;
     }
 
     // ________________________________________________________________________
@@ -224,15 +216,13 @@ declare namespace sjcl {
 
     interface SjclHash {
         reset(): SjclHash;
-        update(data: string): SjclHash;
-        update(data: BitArray): SjclHash;
+        update(data: BitArray | string): SjclHash;
         finalize(): BitArray;
     }
 
     interface SjclHashStatic {
         new (hash?: SjclHash): SjclHash;
-        hash(data: string): BitArray;
-        hash(data: BitArray): BitArray;
+        hash(data: BitArray | string): BitArray;
     }
 
     interface SjclHashes {
@@ -338,36 +328,24 @@ declare namespace sjcl {
     }
 
     interface SjclMisc {
-        pbkdf2(password: string, salt: string, count?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
-        pbkdf2(password: BitArray, salt: string, count?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
-        pbkdf2(password: BitArray, salt: BitArray, count?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
-        pbkdf2(password: string, salt: BitArray, count?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
+        pbkdf2(password: BitArray | string, salt: BitArray | string, count?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
         hmac: SjclHMACStatic;
         cachedPbkdf2(password: string, obj?: PBKDF2Params): {
             key: BitArray;
             salt: BitArray;
         };
-        hkdf(ikm: BitArray, keyBitLength: number, salt: string, info: string, Hash?: SjclHashStatic): BitArray;
-        hkdf(ikm: BitArray, keyBitLength: number, salt: BitArray, info: string, Hash?: SjclHashStatic): BitArray;
-        hkdf(ikm: BitArray, keyBitLength: number, salt: BitArray, info: BitArray, Hash?: SjclHashStatic): BitArray;
-        hkdf(ikm: BitArray, keyBitLength: number, salt: string, info: BitArray, Hash?: SjclHashStatic): BitArray;
-        scrypt(password: string, salt: string, N?: number, r?: number, p?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
-        scrypt(password: BitArray, salt: string, N?: number, r?: number, p?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
-        scrypt(password: BitArray, salt: BitArray, N?: number, r?: number, p?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
-        scrypt(password: string, salt: BitArray, N?: number, r?: number, p?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
+        hkdf(ikm: BitArray, keyBitLength: number, salt: BitArray | string, info: BitArray | string, Hash?: SjclHashStatic): BitArray;
+        scrypt(password: BitArray | string, salt: BitArray | string, N?: number, r?: number, p?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
     }
 
     class SjclPRFFamily {
-        encrypt(data: string): BitArray;
-        encrypt(data: BitArray): BitArray;
+        encrypt(data: BitArray | string): BitArray;
     }
 
     interface SjclHMAC extends SjclPRFFamily {
-        mac(data: string): BitArray;
-        mac(data: BitArray): BitArray;
+        mac(data: BitArray | string): BitArray;
         reset(): void;
-        update(data: string): void;
-        update(data: BitArray): void;
+        update(data: BitArray | string): void;
         digest(): BitArray;
     }
 
@@ -446,8 +424,7 @@ declare namespace sjcl {
     }
 
     interface SjclKeysGenerator<P extends SjclECCPublicKey, S extends SjclECCSecretKey> {
-        (curve: SjclEllipticalCurve, paranoia: number, sec?: BigNumber): SjclKeyPair<P, S>;
-        (curve: number, paranoia: number, sec?: BigNumber): SjclKeyPair<P, S>;
+        (curve: SjclEllipticalCurve | number, paranoia: number, sec?: BigNumber): SjclKeyPair<P, S>;
     }
 
     interface SjclECCKeyPairData {
@@ -475,8 +452,7 @@ declare namespace sjcl {
     }
 
     interface SjclECCPublicKeyFactory<T extends SjclECCPublicKey> {
-        new (curve: SjclEllipticalCurve, point: SjclEllipticalPoint): T;
-        new (curve: SjclEllipticalCurve, point: BitArray): T;
+        new (curve: SjclEllipticalCurve, point: SjclEllipticalPoint | BitArray): T;
     }
 
     interface SjclECCSecretKeyFactory<T extends SjclECCSecretKey> {
@@ -527,9 +503,7 @@ declare namespace sjcl {
     interface SjclRandom {
         randomWords(nwords: number, paranoia?: number): BitArray;
         setDefaultParanoia(paranoia: number, allowZeroParanoia: string): void;
-        addEntropy(data: number, estimatedEntropy: number, source: string): void;
-        addEntropy(data: number[], estimatedEntropy: number, source: string): void;
-        addEntropy(data: string, estimatedEntropy: number, source: string): void;
+        addEntropy(data: number | number[] | string, estimatedEntropy: number, source: string): void;
         isReady(paranoia?: number): boolean;
         getProgress(paranoia?: number): number;
         startCollectors(): void;
@@ -556,8 +530,7 @@ declare namespace sjcl {
     interface SjclSecureRemotePassword {
         makeVerifier(username: string, password: string, salt: BitArray, group: SjclSRPGroup): BitArray;
         makeX(username: string, password: string, salt: BitArray): BitArray;
-        knownGroup(i: string): SjclSRPGroup;
-        knownGroup(i: number): SjclSRPGroup;
+        knownGroup(i: number | string): SjclSRPGroup;
     }
 
     // ________________________________________________________________________
@@ -592,16 +565,11 @@ declare namespace sjcl {
     }
 
     interface SjclConvenienceEncryptor {
-        (password: string, plaintext: string, params?: SjclCipherEncryptParams, rp?: SjclCipherEncrypted): SjclCipherEncrypted;
-        (password: BitArray, plaintext: string, params?: SjclCipherEncryptParams, rp?: SjclCipherEncrypted): SjclCipherEncrypted;
-        (password: SjclElGamalPublicKey, plaintext: string, params?: SjclCipherEncryptParams, rp?: SjclCipherEncrypted): SjclCipherEncrypted;
+        (password: SjclElGamalPublicKey | BitArray | string, plaintext: string, params?: SjclCipherEncryptParams, rp?: SjclCipherEncrypted): SjclCipherEncrypted;
     }
 
     interface SjclConvenienceDecryptor {
-        (password: string, ciphertext: SjclCipherEncrypted, params?: SjclCipherDecryptParams, rp?: SjclCipherDecrypted): string;
-        (password: string, ciphertext: string, params?: SjclCipherDecryptParams, rp?: SjclCipherDecrypted): string;
-        (password: BitArray, ciphertext: SjclCipherEncrypted, params?: SjclCipherDecryptParams, rp?: SjclCipherDecrypted): string;
-        (password: SjclElGamalSecretKey, ciphertext: SjclCipherEncrypted, params?: SjclCipherDecryptParams, rp?: SjclCipherDecrypted): string;
+        (password: SjclElGamalSecretKey | BitArray | string, ciphertext: SjclCipherEncrypted | string, params?: SjclCipherDecryptParams, rp?: SjclCipherDecrypted): string;
     }
 
     interface SjclJson {

--- a/types/sjcl/index.d.ts
+++ b/types/sjcl/index.d.ts
@@ -22,8 +22,8 @@ declare namespace sjcl {
     export var prng: SjclRandomStatic;
     export var keyexchange: SjclKeyExchange;
     export var json: SjclJson;
-    export var encrypt: SjclConveninceEncryptor;
-    export var decrypt: SjclConveninceDecryptor;
+    export var encrypt: SjclConvenienceEncryptor;
+    export var decrypt: SjclConvenienceDecryptor;
 
     // ________________________________________________________________________
 
@@ -332,18 +332,18 @@ declare namespace sjcl {
 
     // ________________________________________________________________________
 
-    interface Pbkdf2Params {
+    interface PBKDF2Params {
         iter?: number;
         salt?: BitArray;
     }
 
     interface SjclMisc {
-        pbkdf2(password: string, salt: string, count?: number, length?: number, Prff?: SjclPseudorandomFunctionFamilyStatic): BitArray;
-        pbkdf2(password: BitArray, salt: string, count?: number, length?: number, Prff?: SjclPseudorandomFunctionFamilyStatic): BitArray;
-        pbkdf2(password: BitArray, salt: BitArray, count?: number, length?: number, Prff?: SjclPseudorandomFunctionFamilyStatic): BitArray;
-        pbkdf2(password: string, salt: BitArray, count?: number, length?: number, Prff?: SjclPseudorandomFunctionFamilyStatic): BitArray;
-        hmac: SjclHmacStatic;
-        cachedPbkdf2(password: string, obj?: Pbkdf2Params): {
+        pbkdf2(password: string, salt: string, count?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
+        pbkdf2(password: BitArray, salt: string, count?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
+        pbkdf2(password: BitArray, salt: BitArray, count?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
+        pbkdf2(password: string, salt: BitArray, count?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
+        hmac: SjclHMACStatic;
+        cachedPbkdf2(password: string, obj?: PBKDF2Params): {
             key: BitArray;
             salt: BitArray;
         };
@@ -351,18 +351,18 @@ declare namespace sjcl {
         hkdf(ikm: BitArray, keyBitLength: number, salt: BitArray, info: string, Hash?: SjclHashStatic): BitArray;
         hkdf(ikm: BitArray, keyBitLength: number, salt: BitArray, info: BitArray, Hash?: SjclHashStatic): BitArray;
         hkdf(ikm: BitArray, keyBitLength: number, salt: string, info: BitArray, Hash?: SjclHashStatic): BitArray;
-        scrypt(password: string, salt: string, N?: number, r?: number, p?: number, length?: number, Prff?: SjclPseudorandomFunctionFamilyStatic): BitArray;
-        scrypt(password: BitArray, salt: string, N?: number, r?: number, p?: number, length?: number, Prff?: SjclPseudorandomFunctionFamilyStatic): BitArray;
-        scrypt(password: BitArray, salt: BitArray, N?: number, r?: number, p?: number, length?: number, Prff?: SjclPseudorandomFunctionFamilyStatic): BitArray;
-        scrypt(password: string, salt: BitArray, N?: number, r?: number, p?: number, length?: number, Prff?: SjclPseudorandomFunctionFamilyStatic): BitArray;
+        scrypt(password: string, salt: string, N?: number, r?: number, p?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
+        scrypt(password: BitArray, salt: string, N?: number, r?: number, p?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
+        scrypt(password: BitArray, salt: BitArray, N?: number, r?: number, p?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
+        scrypt(password: string, salt: BitArray, N?: number, r?: number, p?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
     }
 
-    class SjclPseudorandomFunctionFamily {
+    class SjclPRFFamily {
         encrypt(data: string): BitArray;
         encrypt(data: BitArray): BitArray;
     }
 
-    interface SjclHmac extends SjclPseudorandomFunctionFamily {
+    interface SjclHMAC extends SjclPRFFamily {
         mac(data: string): BitArray;
         mac(data: BitArray): BitArray;
         reset(): void;
@@ -371,12 +371,12 @@ declare namespace sjcl {
         digest(): BitArray;
     }
 
-    interface SjclPseudorandomFunctionFamilyStatic {
-        new (key: BitArray): SjclPseudorandomFunctionFamily;
+    interface SjclPRFFamilyStatic {
+        new (key: BitArray): SjclPRFFamily;
     }
 
-    interface SjclHmacStatic {
-        new (key: BitArray, Hash?: SjclHashStatic): SjclHmac;
+    interface SjclHMACStatic {
+        new (key: BitArray, Hash?: SjclHashStatic): SjclHMAC;
     }
 
     // ________________________________________________________________________
@@ -400,7 +400,7 @@ declare namespace sjcl {
         deserialize(key: SjclECCKeyPairData): SjclECCSecretKey;
         basicKey: SjclECCBasic;
         elGamal: SjclElGamal;
-        ecdsa: SjclEcdsa;
+        ecdsa: SjclECDSA;
     }
 
     interface SjclEllipticalPoint {
@@ -508,18 +508,18 @@ declare namespace sjcl {
         generateKeys: SjclKeysGenerator<SjclElGamalPublicKey, SjclElGamalSecretKey>;
     }
 
-    class SjclEcdsaPublicKey extends SjclECCPublicKey {
+    class SjclECDSAPublicKey extends SjclECCPublicKey {
         verify(hash: BitArray, rs: BitArray, fakeLegacyVersion: boolean): boolean;
     }
 
-    class SjclEcdsaSecretKey extends SjclECCSecretKey {
+    class SjclECDSASecretKey extends SjclECCSecretKey {
         sign(hash: BitArray, paranoia: number, fakeLegacyVersion: boolean, fixedKForTesting?: BigNumber): BitArray;
     }
 
-    interface SjclEcdsa {
-        publicKey: SjclECCPublicKeyFactory<SjclEcdsaPublicKey>;
-        secretKey: SjclECCSecretKeyFactory<SjclEcdsaSecretKey>;
-        generateKeys: SjclKeysGenerator<SjclEcdsaPublicKey, SjclEcdsaSecretKey>;
+    interface SjclECDSA {
+        publicKey: SjclECCPublicKeyFactory<SjclECDSAPublicKey>;
+        secretKey: SjclECCSecretKeyFactory<SjclECDSASecretKey>;
+        generateKeys: SjclKeysGenerator<SjclECDSAPublicKey, SjclECDSASecretKey>;
     }
 
     // ________________________________________________________________________
@@ -545,7 +545,7 @@ declare namespace sjcl {
     // ________________________________________________________________________
 
     interface SjclKeyExchange {
-        srp: SecureRemotePassword;
+        srp: SjclSecureRemotePassword;
     }
 
     interface SjclSRPGroup {
@@ -553,7 +553,7 @@ declare namespace sjcl {
         g: BigNumber;
     }
 
-    interface SecureRemotePassword {
+    interface SjclSecureRemotePassword {
         makeVerifier(username: string, password: string, salt: BitArray, group: SjclSRPGroup): BitArray;
         makeX(username: string, password: string, salt: BitArray): BitArray;
         knownGroup(i: string): SjclSRPGroup;
@@ -591,13 +591,13 @@ declare namespace sjcl {
         key: BitArray;
     }
 
-    interface SjclConveninceEncryptor {
+    interface SjclConvenienceEncryptor {
         (password: string, plaintext: string, params?: SjclCipherEncryptParams, rp?: SjclCipherEncrypted): SjclCipherEncrypted;
         (password: BitArray, plaintext: string, params?: SjclCipherEncryptParams, rp?: SjclCipherEncrypted): SjclCipherEncrypted;
         (password: SjclElGamalPublicKey, plaintext: string, params?: SjclCipherEncryptParams, rp?: SjclCipherEncrypted): SjclCipherEncrypted;
     }
 
-    interface SjclConveninceDecryptor {
+    interface SjclConvenienceDecryptor {
         (password: string, ciphertext: SjclCipherEncrypted, params?: SjclCipherDecryptParams, rp?: SjclCipherDecrypted): string;
         (password: string, ciphertext: string, params?: SjclCipherDecryptParams, rp?: SjclCipherDecrypted): string;
         (password: BitArray, ciphertext: SjclCipherEncrypted, params?: SjclCipherDecryptParams, rp?: SjclCipherDecrypted): string;
@@ -605,8 +605,8 @@ declare namespace sjcl {
     }
 
     interface SjclJson {
-        encrypt: SjclConveninceEncryptor;
-        decrypt: SjclConveninceDecryptor;
+        encrypt: SjclConvenienceEncryptor;
+        decrypt: SjclConvenienceDecryptor;
         encode(obj: Object): string;
         decode(obj: string): Object;
     }

--- a/types/sjcl/index.d.ts
+++ b/types/sjcl/index.d.ts
@@ -7,7 +7,6 @@ export = sjcl;
 export as namespace sjcl;
 
 declare namespace sjcl {
-
     export var arrayBuffer: SjclArrayBufferModes;
     export var bn: BigNumberStatic;
     export var bitArray: BitArrayStatic;
@@ -150,8 +149,7 @@ declare namespace sjcl {
 
     // ________________________________________________________________________
 
-    interface BitArray extends Array<number> {
-    }
+    interface BitArray extends Array<number> {}
 
     interface BitArrayStatic {
         /// Array slices in units of bits.
@@ -161,7 +159,7 @@ declare namespace sjcl {
         extract(a: BitArray, bstart: number, blength: number): number;
 
         /// Concatenate two bit arrays.
-        concat(a1: BitArray, a2: BitArray): BitArray
+        concat(a1: BitArray, a2: BitArray): BitArray;
 
         /// Find the length of an array of bits.
         bitLength(a: BitArray): number;
@@ -283,8 +281,23 @@ declare namespace sjcl {
     interface SjclArrayBufferCCMMode {
         compat_encrypt(prf: SjclCipher, plaintext: BitArray, iv: BitArray, adata?: BitArray, tlen?: number): BitArray;
         compat_decrypt(prf: SjclCipher, ciphertext: BitArray, iv: BitArray, adata?: BitArray, tlen?: number): BitArray;
-        encrypt(prf: SjclCipher, plaintext_buffer: ArrayBuffer, iv: BitArray, adata?: ArrayBuffer, tlen?: number, ol?: number): ArrayBuffer;
-        decrypt(prf: SjclCipher, ciphertext_buffer: ArrayBuffer, iv: BitArray, tag: BitArray, adata?: ArrayBuffer, tlen?: number, ol?: number): ArrayBuffer;
+        encrypt(
+            prf: SjclCipher,
+            plaintext_buffer: ArrayBuffer,
+            iv: BitArray,
+            adata?: ArrayBuffer,
+            tlen?: number,
+            ol?: number,
+        ): ArrayBuffer;
+        decrypt(
+            prf: SjclCipher,
+            ciphertext_buffer: ArrayBuffer,
+            iv: BitArray,
+            tag: BitArray,
+            adata?: ArrayBuffer,
+            tlen?: number,
+            ol?: number,
+        ): ArrayBuffer;
     }
 
     interface SjclCCMMode {
@@ -295,8 +308,22 @@ declare namespace sjcl {
     }
 
     interface SjclOCB2Mode {
-        encrypt(prf: SjclCipher, plaintext: BitArray, iv: BitArray, adata?: BitArray, tlen?: number, premac?: boolean): BitArray;
-        decrypt(prf: SjclCipher, ciphertext: BitArray, iv: BitArray, adata?: BitArray, tlen?: number, premac?: boolean): BitArray;
+        encrypt(
+            prf: SjclCipher,
+            plaintext: BitArray,
+            iv: BitArray,
+            adata?: BitArray,
+            tlen?: number,
+            premac?: boolean,
+        ): BitArray;
+        decrypt(
+            prf: SjclCipher,
+            ciphertext: BitArray,
+            iv: BitArray,
+            adata?: BitArray,
+            tlen?: number,
+            premac?: boolean,
+        ): BitArray;
         pmac(prf: SjclCipher, adata: BitArray): number[];
     }
 
@@ -306,8 +333,20 @@ declare namespace sjcl {
     }
 
     interface SjclOCB2ProgressiveMode {
-        createEncryptor(prp: SjclCipher, iv: BitArray, adata?: BitArray, tlen?: number, premac?: boolean): SjclOCB2ProgressiveProcessor;
-        createDecryptor(prp: SjclCipher, iv: BitArray, adata?: BitArray, tlen?: number, premac?: boolean): SjclOCB2ProgressiveProcessor;
+        createEncryptor(
+            prp: SjclCipher,
+            iv: BitArray,
+            adata?: BitArray,
+            tlen?: number,
+            premac?: boolean,
+        ): SjclOCB2ProgressiveProcessor;
+        createDecryptor(
+            prp: SjclCipher,
+            iv: BitArray,
+            adata?: BitArray,
+            tlen?: number,
+            premac?: boolean,
+        ): SjclOCB2ProgressiveProcessor;
     }
 
     interface SjclCBCMode {
@@ -328,14 +367,37 @@ declare namespace sjcl {
     }
 
     interface SjclMisc {
-        pbkdf2(password: BitArray | string, salt: BitArray | string, count?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
+        pbkdf2(
+            password: BitArray | string,
+            salt: BitArray | string,
+            count?: number,
+            length?: number,
+            Prff?: SjclPRFFamilyStatic,
+        ): BitArray;
         hmac: SjclHMACStatic;
-        cachedPbkdf2(password: string, obj?: PBKDF2Params): {
+        cachedPbkdf2(
+            password: string,
+            obj?: PBKDF2Params,
+        ): {
             key: BitArray;
             salt: BitArray;
         };
-        hkdf(ikm: BitArray, keyBitLength: number, salt: BitArray | string, info: BitArray | string, Hash?: SjclHashStatic): BitArray;
-        scrypt(password: BitArray | string, salt: BitArray | string, N?: number, r?: number, p?: number, length?: number, Prff?: SjclPRFFamilyStatic): BitArray;
+        hkdf(
+            ikm: BitArray,
+            keyBitLength: number,
+            salt: BitArray | string,
+            info: BitArray | string,
+            Hash?: SjclHashStatic,
+        ): BitArray;
+        scrypt(
+            password: BitArray | string,
+            salt: BitArray | string,
+            N?: number,
+            r?: number,
+            p?: number,
+            length?: number,
+            Prff?: SjclPRFFamilyStatic,
+        ): BitArray;
     }
 
     class SjclPRFFamily {
@@ -400,7 +462,12 @@ declare namespace sjcl {
         doubl(): SjclPointJacobian;
         toAffine(): SjclEllipticalPoint;
         mult(k: BigNumber, affine: SjclEllipticalPoint): SjclPointJacobian;
-        mult2(k1: BigNumber, affine: SjclEllipticalPoint, k2: BigNumber, affine2: SjclEllipticalPoint): SjclPointJacobian;
+        mult2(
+            k1: BigNumber,
+            affine: SjclEllipticalPoint,
+            k2: BigNumber,
+            affine2: SjclEllipticalPoint,
+        ): SjclPointJacobian;
         negate(): SjclPointJacobian;
         isValid(): boolean;
     }
@@ -415,7 +482,14 @@ declare namespace sjcl {
     }
 
     interface SjclEllipticalCurveStatic {
-        new (Field: BigNumber, r: BigNumber, a: BigNumber, b: BigNumber, x: BigNumber, y: BigNumber): SjclEllipticalCurve;
+        new (
+            Field: BigNumber,
+            r: BigNumber,
+            a: BigNumber,
+            b: BigNumber,
+            x: BigNumber,
+            y: BigNumber,
+        ): SjclEllipticalCurve;
     }
 
     interface SjclKeyPair<P extends SjclECCPublicKey, S extends SjclECCSecretKey> {
@@ -466,7 +540,9 @@ declare namespace sjcl {
     }
 
     class SjclElGamalPublicKey extends SjclECCPublicKey {
-        kem(paranoia: number): {
+        kem(
+            paranoia: number,
+        ): {
             key: BitArray;
             tag: BitArray;
         };
@@ -565,11 +641,21 @@ declare namespace sjcl {
     }
 
     interface SjclConvenienceEncryptor {
-        (password: SjclElGamalPublicKey | BitArray | string, plaintext: string, params?: SjclCipherEncryptParams, rp?: SjclCipherEncrypted): SjclCipherEncrypted;
+        (
+            password: SjclElGamalPublicKey | BitArray | string,
+            plaintext: string,
+            params?: SjclCipherEncryptParams,
+            rp?: SjclCipherEncrypted,
+        ): SjclCipherEncrypted;
     }
 
     interface SjclConvenienceDecryptor {
-        (password: SjclElGamalSecretKey | BitArray | string, ciphertext: SjclCipherEncrypted | string, params?: SjclCipherDecryptParams, rp?: SjclCipherDecrypted): string;
+        (
+            password: SjclElGamalSecretKey | BitArray | string,
+            ciphertext: SjclCipherEncrypted | string,
+            params?: SjclCipherDecryptParams,
+            rp?: SjclCipherDecrypted,
+        ): string;
     }
 
     interface SjclJson {
@@ -586,17 +672,14 @@ declare namespace sjcl {
             (value: T): BigNumber;
         }
 
-        interface BigNumberBinaryOperator extends One<number>, One<string>, One<BigNumber> {
-        }
+        interface BigNumberBinaryOperator extends One<number>, One<string>, One<BigNumber> {}
 
         interface Two<T1, T2> {
             (x: T1, N: T2): BigNumber;
         }
 
-        interface Bind1<T> extends Two<number, T>, Two<string, T>, Two<BigNumber, T> {
-        }
+        interface Bind1<T> extends Two<number, T>, Two<string, T>, Two<BigNumber, T> {}
 
-        interface BigNumberTrinaryOperator extends Bind1<number>, Bind1<string>, Bind1<BigNumber> {
-        }
+        interface BigNumberTrinaryOperator extends Bind1<number>, Bind1<string>, Bind1<BigNumber> {}
     }
 }

--- a/types/sjcl/sjcl-tests.ts
+++ b/types/sjcl/sjcl-tests.ts
@@ -1,10 +1,12 @@
 import sjcl = require("sjcl"); 
 
-var b: boolean;
-var n: number;
-var s: string;
-var bn: sjcl.BigNumber;
-var ba: sjcl.BitArray;
+let b: boolean;
+let n: number;
+let s: string;
+let bn: sjcl.BigNumber;
+let ba: sjcl.BitArray;
+let ab: ArrayBuffer;
+let ret: any;
 
 function testBigNumber() {
     bn = new sjcl.bn();
@@ -63,6 +65,16 @@ function testBigNumber() {
     bn = bn.powermod(bn, 0);
     bn = bn.powermod(bn, "0");
     bn = bn.powermod(bn, bn);
+
+    bn = bn.montpowermod(0, 0);
+    bn = bn.montpowermod(0, "0");
+    bn = bn.montpowermod(0, bn);
+    bn = bn.montpowermod("0", 0);
+    bn = bn.montpowermod("0", "0");
+    bn = bn.montpowermod("0", bn);
+    bn = bn.montpowermod(bn, 0);
+    bn = bn.montpowermod(bn, "0");
+    bn = bn.montpowermod(bn, bn);
 
     bn = bn.copy();
 
@@ -125,9 +137,17 @@ function testBitArray() {
     ba = sjcl.bitArray._shiftRight(ba, 0);
     ba = sjcl.bitArray._shiftRight(ba, 0, 0);
     ba = sjcl.bitArray._shiftRight(ba, 0, 0, ba);
+
+    ba = sjcl.bitArray.byteswapM(ba);
 }
 
 function testCodecs() {
+    s = sjcl.codec.base32.fromBits(ba);
+    ba = sjcl.codec.base32.toBits(s);
+
+    s = sjcl.codec.base32hex.fromBits(ba);
+    ba = sjcl.codec.base32hex.toBits(s);
+
     s = sjcl.codec.base64.fromBits(ba);
     ba = sjcl.codec.base64.toBits(s);
 
@@ -140,12 +160,19 @@ function testCodecs() {
     s = sjcl.codec.utf8String.fromBits(ba);
     ba = sjcl.codec.utf8String.toBits(s);
 
-    var bytes: number[] = sjcl.codec.bytes.fromBits(ba);
+    s = sjcl.codec.z85.fromBits(ba);
+    ba = sjcl.codec.z85.toBits(s);
+
+    ab = sjcl.codec.arrayBuffer.fromBits(ba);
+    ba = sjcl.codec.arrayBuffer.toBits(ab);
+    sjcl.codec.arrayBuffer.hexDumpBuffer(ab);
+
+    const bytes: number[] = sjcl.codec.bytes.fromBits(ba);
     ba = sjcl.codec.bytes.toBits(bytes);
 }
 
 function testHashes() {
-    var hash: sjcl.SjclHash;
+    let hash: sjcl.SjclHash;
     ba = hash.reset().update("xxx").update(ba).finalize();
 
     hash = new sjcl.hash.sha1();
@@ -162,29 +189,91 @@ function testHashes() {
     hash = new sjcl.hash.sha512(hash);
     ba = sjcl.hash.sha512.hash(ba);
     ba = sjcl.hash.sha512.hash("xxx");
+
+    hash = new sjcl.hash.ripemd160();
+    hash = new sjcl.hash.ripemd160(hash);
+    ba = sjcl.hash.ripemd160.hash(ba);
+    ba = sjcl.hash.ripemd160.hash("xxx");
 }
 
-function testSymetric() {
-    var aes = new sjcl.cipher.aes([0, 0, 0, 0]);
+function testSymmetric() {
+    const aes = new sjcl.cipher.aes([0, 0, 0, 0]);
+    const iv: sjcl.BitArray = [...ba];
 
-    ba = sjcl.mode.cbc.encrypt(aes, ba, ba);
-    ba = sjcl.mode.cbc.encrypt(aes, ba, ba, ba);
+    // CBC
+    ba = sjcl.mode.cbc.encrypt(aes, ba, iv);
+    ba = sjcl.mode.cbc.decrypt(aes, ba, iv);
 
-    ba = sjcl.mode.gcm.encrypt(aes, ba, ba);
-    ba = sjcl.mode.gcm.encrypt(aes, ba, ba, ba);
-    ba = sjcl.mode.gcm.encrypt(aes, ba, ba, ba, 128);
+    ba = sjcl.mode.cbc.encrypt(aes, ba, iv, ba);
+    ba = sjcl.mode.cbc.decrypt(aes, ba, iv, ba);
 
-    ba = sjcl.mode.ccm.encrypt(aes, ba, ba);
-    ba = sjcl.mode.ccm.encrypt(aes, ba, ba, ba);
-    ba = sjcl.mode.ccm.encrypt(aes, ba, ba, ba, 128);
+    // CTR
+    ba = sjcl.mode.ctr.encrypt(aes, ba, iv);
+    ba = sjcl.mode.ctr.decrypt(aes, ba, iv);
 
-    ba = sjcl.mode.ocb2.encrypt(aes, ba, ba);
-    ba = sjcl.mode.ocb2.encrypt(aes, ba, ba, ba);
-    ba = sjcl.mode.ocb2.encrypt(aes, ba, ba, ba, 128);
-    ba = sjcl.mode.ocb2.encrypt(aes, ba, ba, ba, 128, false);
+    ba = sjcl.mode.ctr.encrypt(aes, ba, iv, ba);
+    ba = sjcl.mode.ctr.decrypt(aes, ba, iv, ba);
+
+    // GCM
+    ba = sjcl.mode.gcm.encrypt(aes, ba, iv);
+    ba = sjcl.mode.gcm.decrypt(aes, ba, iv);
+
+    ba = sjcl.mode.gcm.encrypt(aes, ba, iv, ba);
+    ba = sjcl.mode.gcm.decrypt(aes, ba, iv, ba);
+
+    ba = sjcl.mode.gcm.encrypt(aes, ba, iv, ba, 128);
+    ba = sjcl.mode.gcm.decrypt(aes, ba, iv, ba, 128);
+
+    // CCM
+    ba = sjcl.mode.ccm.encrypt(aes, ba, iv);
+    ba = sjcl.mode.ccm.decrypt(aes, ba, iv);
+
+    ba = sjcl.mode.ccm.encrypt(aes, ba, iv, ba);
+    ba = sjcl.mode.ccm.decrypt(aes, ba, iv, ba);
+
+    ba = sjcl.mode.ccm.encrypt(aes, ba, iv, ba, 128);
+    ba = sjcl.mode.ccm.decrypt(aes, ba, iv, ba, 128);
+
+    // CCM with ArrayBuffer
+    ba = sjcl.arrayBuffer.ccm.compat_encrypt(aes, ba, iv);
+    ba = sjcl.arrayBuffer.ccm.compat_decrypt(aes, ba, iv);
+
+    ba = sjcl.arrayBuffer.ccm.compat_encrypt(aes, ba, iv, ba);
+    ba = sjcl.arrayBuffer.ccm.compat_decrypt(aes, ba, iv, ba);
+
+    ba = sjcl.arrayBuffer.ccm.compat_encrypt(aes, ba, iv, ba, 128);
+    ba = sjcl.arrayBuffer.ccm.compat_decrypt(aes, ba, iv, ba, 128);
+
+    // OCB2
+    ba = sjcl.mode.ocb2.encrypt(aes, ba, iv);
+    ba = sjcl.mode.ocb2.decrypt(aes, ba, iv);
+
+    ba = sjcl.mode.ocb2.encrypt(aes, ba, iv, ba);
+    ba = sjcl.mode.ocb2.decrypt(aes, ba, iv, ba);
+
+    ba = sjcl.mode.ocb2.encrypt(aes, ba, iv, ba, 128);
+    ba = sjcl.mode.ocb2.decrypt(aes, ba, iv, ba, 128);
+
+    ba = sjcl.mode.ocb2.encrypt(aes, ba, iv, ba, 128, false);
+    ba = sjcl.mode.ocb2.decrypt(aes, ba, iv, ba, 128, false);
+
+    // OCB2 Progressive
+    let ocb2pEnc = sjcl.mode.ocb2progressive.createEncryptor(aes, iv);
+    ocb2pEnc = sjcl.mode.ocb2progressive.createEncryptor(aes, iv, ba);
+    ocb2pEnc = sjcl.mode.ocb2progressive.createEncryptor(aes, iv, ba, 128);
+    ocb2pEnc = sjcl.mode.ocb2progressive.createEncryptor(aes, iv, ba, 128, false);
+    ba = ocb2pEnc.process(ba);
+    ba = ocb2pEnc.finalize();
+
+    let ocb2pDec = sjcl.mode.ocb2progressive.createDecryptor(aes, iv);
+    ocb2pDec = sjcl.mode.ocb2progressive.createDecryptor(aes, iv, ba);
+    ocb2pDec = sjcl.mode.ocb2progressive.createDecryptor(aes, iv, ba, 128);
+    ocb2pDec = sjcl.mode.ocb2progressive.createDecryptor(aes, iv, ba, 128, false);
+    ba = ocb2pDec.process(ba);
+    ba = ocb2pDec.finalize();
 }
 
-function testHmacPbdkf2() {
+function testHMACPBDKF2() {
     ba = sjcl.misc.pbkdf2("xxx", "xxx");
     ba = sjcl.misc.pbkdf2("xxx", "xxx", 1000);
     ba = sjcl.misc.pbkdf2("xxx", "xxx", 1000, 12);
@@ -205,7 +294,7 @@ function testHmacPbdkf2() {
     ba = sjcl.misc.pbkdf2(ba, ba, 1000, 12);
     ba = sjcl.misc.pbkdf2(ba, ba, 1000, 12, sjcl.misc.hmac);
 
-    var hmac: sjcl.SjclHmac;
+    let hmac: sjcl.SjclHMAC;
     hmac = new sjcl.misc.hmac(ba);
     hmac = new sjcl.misc.hmac(ba, sjcl.hash.sha512);
 
@@ -223,13 +312,117 @@ function testHmacPbdkf2() {
     ba = hmac.digest();
 }
 
+function testHKDF() {
+    ba = sjcl.misc.hkdf(ba, 128, "xxx", "xxx");
+    ba = sjcl.misc.hkdf(ba, 128, "xxx", "xxx", sjcl.hash.sha256);
+
+    ba = sjcl.misc.hkdf(ba, 128, ba, "xxx");
+    ba = sjcl.misc.hkdf(ba, 128, ba, "xxx", sjcl.hash.sha256);
+
+    ba = sjcl.misc.hkdf(ba, 128, "xxx", ba);
+    ba = sjcl.misc.hkdf(ba, 128, "xxx", ba, sjcl.hash.sha256);
+
+    ba = sjcl.misc.hkdf(ba, 128, ba, ba);
+    ba = sjcl.misc.hkdf(ba, 128, ba, ba, sjcl.hash.sha256);
+}
+
+function testScrypt() {
+    ba = sjcl.misc.scrypt("xxx", "xxx");
+    ba = sjcl.misc.scrypt("xxx", "xxx", 16384);
+    ba = sjcl.misc.scrypt("xxx", "xxx", 16384, 8);
+    ba = sjcl.misc.scrypt("xxx", "xxx", 16384, 8, 1);
+    ba = sjcl.misc.scrypt("xxx", "xxx", 16384, 8, 1, 128);
+    ba = sjcl.misc.scrypt("xxx", "xxx", 16384, 8, 1, 128, sjcl.misc.hmac);
+
+    ba = sjcl.misc.scrypt(ba, "xxx");
+    ba = sjcl.misc.scrypt(ba, "xxx", 16384);
+    ba = sjcl.misc.scrypt(ba, "xxx", 16384, 8);
+    ba = sjcl.misc.scrypt(ba, "xxx", 16384, 8, 1);
+    ba = sjcl.misc.scrypt(ba, "xxx", 16384, 8, 1, 128);
+    ba = sjcl.misc.scrypt(ba, "xxx", 16384, 8, 1, 128, sjcl.misc.hmac);
+
+    ba = sjcl.misc.scrypt("xxx", ba);
+    ba = sjcl.misc.scrypt("xxx", ba, 16384);
+    ba = sjcl.misc.scrypt("xxx", ba, 16384, 8);
+    ba = sjcl.misc.scrypt("xxx", ba, 16384, 8, 1);
+    ba = sjcl.misc.scrypt("xxx", ba, 16384, 8, 1, 128);
+    ba = sjcl.misc.scrypt("xxx", ba, 16384, 8, 1, 128, sjcl.misc.hmac);
+
+    ba = sjcl.misc.scrypt(ba, ba);
+    ba = sjcl.misc.scrypt(ba, ba, 16384);
+    ba = sjcl.misc.scrypt(ba, ba, 16384, 8);
+    ba = sjcl.misc.scrypt(ba, ba, 16384, 8, 1);
+    ba = sjcl.misc.scrypt(ba, ba, 16384, 8, 1, 128);
+    ba = sjcl.misc.scrypt(ba, ba, 16384, 8, 1, 128, sjcl.misc.hmac);
+}
+
 function testECC() {
-    var keys = sjcl.ecc.elGamal.generateKeys(192, 0);
+    ret = sjcl.ecc.curveName(sjcl.ecc.curves.c192);
+    ret = sjcl.ecc.curveName(sjcl.ecc.curves.c224);
+    ret = sjcl.ecc.curveName(sjcl.ecc.curves.c256);
+    ret = sjcl.ecc.curveName(sjcl.ecc.curves.c384);
+    ret = sjcl.ecc.curveName(sjcl.ecc.curves.c521);
+    ret = sjcl.ecc.curveName(sjcl.ecc.curves.k192);
+    ret = sjcl.ecc.curveName(sjcl.ecc.curves.k224);
+    ret = sjcl.ecc.curveName(sjcl.ecc.curves.k256);
+}
 
-    var ciphertext = sjcl.encrypt(keys.pub, "hello world");
-    var plaintext = sjcl.decrypt(keys.sec, ciphertext);
+function testECCElGamal() {
+    ret = new sjcl.ecc.elGamal.publicKey(
+        sjcl.ecc.curves.c192,
+        new sjcl.ecc.point(sjcl.ecc.curves.c192)
+    );
+    ret = new sjcl.ecc.elGamal.secretKey(
+        sjcl.ecc.curves.c192,
+        new sjcl.bn(2)
+    );
 
-    // TODO: Maybe deeper testing required. Let me know
+    const keys = sjcl.ecc.elGamal.generateKeys(192, 0);
+
+    const ciphertext = sjcl.encrypt(keys.pub, "hello world");
+    ret = sjcl.decrypt(keys.sec, ciphertext);
+
+    const kem = keys.pub.kem(10);
+    ret = keys.sec.unkem(kem.tag);
+
+    ret = keys.pub.serialize();
+    ret = sjcl.ecc.deserialize(ret);
+    ret = keys.pub.get();
+    ret = keys.pub.getType();
+
+    ret = keys.sec.serialize();
+    ret = sjcl.ecc.deserialize(ret);
+    ret = keys.sec.get();
+    ret = keys.sec.getType();
+    ret = keys.sec.dh(keys.pub);
+    ret = keys.sec.dhJavaEc(keys.pub);
+}
+
+function testECCECDSA() {
+    ret = new sjcl.ecc.ecdsa.publicKey(
+        sjcl.ecc.curves.c192,
+        new sjcl.ecc.point(sjcl.ecc.curves.c192)
+    );
+    ret = new sjcl.ecc.ecdsa.secretKey(
+        sjcl.ecc.curves.c192,
+        new sjcl.bn(2)
+    );
+
+    const keys = sjcl.ecc.ecdsa.generateKeys(192, 0);
+
+    let signature = keys.sec.sign(ba, 10, false);
+    signature = keys.sec.sign(ba, 10, false, new sjcl.bn(128));
+    ret = keys.pub.verify(ba, signature, false);
+
+    ret = keys.pub.serialize();
+    ret = sjcl.ecc.deserialize(ret);
+    ret = keys.pub.get();
+    ret = keys.pub.getType();
+
+    ret = keys.sec.serialize();
+    ret = sjcl.ecc.deserialize(ret);
+    ret = keys.sec.get();
+    ret = keys.sec.getType();
 }
 
 function testRandom() {
@@ -237,28 +430,27 @@ function testRandom() {
     ba = sjcl.random.randomWords(8);
     ba = sjcl.random.randomWords(8, 6);
 
-    var rnd = new sjcl.prng(1);
+    const rnd = new sjcl.prng(1);
     ba = rnd.randomWords(16);
     ba = rnd.randomWords(16, 6);
 }
 
 function testSRP() {
-    var group = sjcl.keyexchange.srp.knownGroup(1024);
+    const group = sjcl.keyexchange.srp.knownGroup(1024);
     ba = sjcl.codec.hex.toBits(s);
     ba = sjcl.keyexchange.srp.makeX(s, s, ba);
     ba = sjcl.keyexchange.srp.makeVerifier(s, s, ba, group);
 }
 
-function testConvenince() {
-    var x: sjcl.SjclCipherEncrypted;
+function testConvenience() {
+    let x: sjcl.SjclCipherEncrypted;
     x = sjcl.encrypt("xxx", "text");
     s = sjcl.decrypt(ba, x);
 
     x = sjcl.encrypt("xxx", "text", { iv: ba, salt: ba });
     s = sjcl.decrypt(ba, x, { iv: ba, salt: ba });
 
-    var y: sjcl.SjclCipherDecrypted;
-
+    let y: sjcl.SjclCipherDecrypted;
     sjcl.encrypt("xxx", "text", { iv: ba, salt: ba, mode: "gcm" }, x);
     s = sjcl.decrypt(ba, x, { iv: ba, salt: ba, mode: "gcm" }, y);
 

--- a/types/sjcl/sjcl-tests.ts
+++ b/types/sjcl/sjcl-tests.ts
@@ -173,7 +173,11 @@ function testCodecs() {
 
 function testHashes() {
     let hash: sjcl.SjclHash;
-    ba = hash.reset().update("xxx").update(ba).finalize();
+    ba = hash
+        .reset()
+        .update("xxx")
+        .update(ba)
+        .finalize();
 
     hash = new sjcl.hash.sha1();
     hash = new sjcl.hash.sha1(hash);
@@ -368,14 +372,8 @@ function testECC() {
 }
 
 function testECCElGamal() {
-    ret = new sjcl.ecc.elGamal.publicKey(
-        sjcl.ecc.curves.c192,
-        new sjcl.ecc.point(sjcl.ecc.curves.c192)
-    );
-    ret = new sjcl.ecc.elGamal.secretKey(
-        sjcl.ecc.curves.c192,
-        new sjcl.bn(2)
-    );
+    ret = new sjcl.ecc.elGamal.publicKey(sjcl.ecc.curves.c192, new sjcl.ecc.point(sjcl.ecc.curves.c192));
+    ret = new sjcl.ecc.elGamal.secretKey(sjcl.ecc.curves.c192, new sjcl.bn(2));
 
     const keys = sjcl.ecc.elGamal.generateKeys(192, 0);
 
@@ -399,14 +397,8 @@ function testECCElGamal() {
 }
 
 function testECCECDSA() {
-    ret = new sjcl.ecc.ecdsa.publicKey(
-        sjcl.ecc.curves.c192,
-        new sjcl.ecc.point(sjcl.ecc.curves.c192)
-    );
-    ret = new sjcl.ecc.ecdsa.secretKey(
-        sjcl.ecc.curves.c192,
-        new sjcl.bn(2)
-    );
+    ret = new sjcl.ecc.ecdsa.publicKey(sjcl.ecc.curves.c192, new sjcl.ecc.point(sjcl.ecc.curves.c192));
+    ret = new sjcl.ecc.ecdsa.secretKey(sjcl.ecc.curves.c192, new sjcl.bn(2));
 
     const keys = sjcl.ecc.ecdsa.generateKeys(192, 0);
 


### PR DESCRIPTION
Lib url:
https://github.com/bitwiseshiftleft/sjcl/releases/tag/1.0.8

This is a long overdue update of sjcl types. Some types are still not tested thoroughly, but I've added test cases for all new additions, except `ArrayBuffer` based CCM, because I can't find enough documentation explaining how the parameters should be supplied (the `sjcl.arraybuffer.ccm` namespace is documented very sparsely and has typos in the library itself).

Notes:
- Changed long class names that included `PseudorandomFunction` to `PRF`
- Fixed typo in `Convenience`
- Did not include public functions from `sjcl.misc.scrypt` namespace, as they lack documentation (`salsa20Core`, `blockMix`, `ROMix`, etc.)
- Renamed method arguments from `prp` to `prf` to correctly correspond to the JS method signature ("pseudo-random function"), with the exception of `sjcl.mode.ocb2progressive` (`SjclOCB2ProgressiveMode`). Not sure if those were replicated with a typo, or were intentional, please shed some light if anyone has an idea.

PR Checklist:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

PR Specific:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header
- [x] If you are making substantial changes, consider adding a tslint.json containing { "extends": "dtslint/dt.json" }. If for reason the any rule need to be disabled, disable it for that line using // tslint:disable-next-line [ruleName] and not for whole package so that the need for disabling can be reviewed.

(edited description formatting)