### PR TITLE
`eslint`: allow `fix` to return array

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -338,6 +338,17 @@ rule = {
             }
         });
 
+        context.report({
+            message: 'foo',
+            node: AST,
+            fix: ruleFixer => {
+                return [
+                    ruleFixer.insertTextAfter(AST, 'foo'),
+                    ruleFixer.insertTextAfter(TOKEN, 'foo')
+                ];
+            }
+        });
+
         return {
             onCodePathStart(codePath, node) {},
             onCodePathEnd(codePath, node) {},

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -327,7 +327,7 @@ export namespace Rule {
     interface ReportDescriptorOptions {
         data?: { [key: string]: string };
 
-        fix?(fixer: RuleFixer): null | Fix | IterableIterator<Fix>;
+        fix?(fixer: RuleFixer): null | Fix | IterableIterator<Fix> | Fix[];
     }
 
     interface RuleFixer {

--- a/types/eslint/ts3.1/eslint-tests.ts
+++ b/types/eslint/ts3.1/eslint-tests.ts
@@ -338,6 +338,17 @@ rule = {
             }
         });
 
+        context.report({
+            message: 'foo',
+            node: AST,
+            fix: ruleFixer => {
+                return [
+                    ruleFixer.insertTextAfter(AST, 'foo'),
+                    ruleFixer.insertTextAfter(TOKEN, 'foo')
+                ];
+            }
+        });
+
         return {
             onCodePathStart(codePath, node) {},
             onCodePathEnd(codePath, node) {},

--- a/types/eslint/ts3.1/index.d.ts
+++ b/types/eslint/ts3.1/index.d.ts
@@ -320,7 +320,7 @@ export namespace Rule {
     interface ReportDescriptorOptions {
         data?: { [key: string]: string };
 
-        fix?(fixer: RuleFixer): null | Fix | IterableIterator<Fix>;
+        fix?(fixer: RuleFixer): null | Fix | IterableIterator<Fix> | Fix[];
     }
 
     interface RuleFixer {


### PR DESCRIPTION
> The above methods return a fixing object. The fix() function can return the following values:
> 
> - A fixing object.
> - An array which includes fixing objects.
> - An iterable object which enumerates fixing objects. Especially, the fix() function can be a generator.

https://eslint.org/docs/developer-guide/working-with-rules#applying-fixes

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://eslint.org/docs/developer-guide/working-with-rules#applying-fixes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.