### PR TITLE
fix(clownface): in and out can be called without parameters

### DIFF
--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -117,6 +117,7 @@ cf = cf.has([predicate, predicate], 'Stuart');
 cf = cf.has(predicate, [literal, literal]);
 
 // .in
+cf = cf.in();
 cf = cf.in(node);
 cf = cf.in([node, node]);
 cf = cf.in(cf.node(node));
@@ -150,6 +151,7 @@ cf = cf.node('example', { datatype: node.value });
 cf = cf.node('example', { datatype: node });
 
 // .out
+cf = cf.out();
 cf = cf.out(node);
 cf = cf.out([node, node]);
 cf = cf.out(cf.node([node, node]));

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -77,8 +77,8 @@ declare namespace clownface {
         namedNode(values: Array<string | NamedNode>): SafeClownface<D, NamedNode>;
 
         // tslint:disable:no-unnecessary-generics
-        in<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
-        out<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
+        in<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
+        out<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
 
         has<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTermsOrLiterals): SafeClownface<D, X>;
 

--- a/types/clownface/lib/Clownface.d.ts
+++ b/types/clownface/lib/Clownface.d.ts
@@ -51,8 +51,8 @@ declare class Clownface<D extends DatasetCore = DatasetCore, T extends Term = Te
     namedNode(values: Array<string | NamedNode>): SafeClownface<D, NamedNode>;
 
     // tslint:disable:no-unnecessary-generics
-    in<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
-    out<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
+    in<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
+    out<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
 
     has<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTermsOrLiterals): SafeClownface<D, X>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.