### PR TITLE
Bump redux dependency version

### DIFF
--- a/types/redux-mock-store/index.d.ts
+++ b/types/redux-mock-store/index.d.ts
@@ -1,5 +1,5 @@
-// Type definitions for Redux Mock Store 1.0.0
-// Project: https://github.com/arnaudbenard/redux-mock-store
+// Type definitions for Redux Mock Store 1.0.2
+// Project: https://github.com/dmitry-zaets/redux-mock-store
 // Definitions by: Marian Palkus <https://github.com/MarianPalkus>, Cap3 <http://www.cap3.de>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 // TypeScript Version: 2.3

--- a/types/redux-mock-store/package.json
+++ b/types/redux-mock-store/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "redux": "^4.0.0"
+        "redux": "^4.0.5"
     }
 }


### PR DESCRIPTION
Redux dependency should be updated to 4.0.5 in order to fix the arisen type conflicts.