### PR TITLE
yup: required fields is not nullable

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -93,7 +93,7 @@ export interface MixedSchema<T = any> extends Schema<T> {
     nullable(isNullable?: true): MixedSchema<T | null>;
     nullable(isNullable: false): MixedSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): MixedSchema<T>;
-    required(message?: TestOptionsMessage): MixedSchema<Exclude<T, undefined>>;
+    required(message?: TestOptionsMessage): MixedSchema<Exclude<T, null | undefined>>;
     notRequired(): MixedSchema<T | undefined>;
     concat(schema: this): this;
     concat<U>(schema: MixedSchema<U>): MixedSchema<T | U>;
@@ -123,7 +123,7 @@ export interface StringSchema<T extends string | null | undefined = string> exte
     nullable(isNullable?: true): StringSchema<T | null>;
     nullable(isNullable: false): StringSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): StringSchema<T>;
-    required(message?: TestOptionsMessage): StringSchema<Exclude<T, undefined>>;
+    required(message?: TestOptionsMessage): StringSchema<Exclude<T, null | undefined>>;
     notRequired(): StringSchema<T | undefined>;
 }
 
@@ -145,7 +145,7 @@ export interface NumberSchema<T extends number | null | undefined = number> exte
     nullable(isNullable?: true): NumberSchema<T | null>;
     nullable(isNullable: false): NumberSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): NumberSchema<T>;
-    required(message?: TestOptionsMessage): NumberSchema<Exclude<T, undefined>>;
+    required(message?: TestOptionsMessage): NumberSchema<Exclude<T, null | undefined>>;
     notRequired(): NumberSchema<T | undefined>;
 }
 
@@ -158,7 +158,7 @@ export interface BooleanSchema<T extends boolean | null | undefined = boolean> e
     nullable(isNullable?: true): BooleanSchema<T | null>;
     nullable(isNullable: false): BooleanSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): BooleanSchema<T>;
-    required(message?: TestOptionsMessage): BooleanSchema<Exclude<T, undefined>>;
+    required(message?: TestOptionsMessage): BooleanSchema<Exclude<T, null | undefined>>;
     notRequired(): BooleanSchema<T | undefined>;
 }
 
@@ -173,7 +173,7 @@ export interface DateSchema<T extends Date | null | undefined = Date> extends Sc
     nullable(isNullable?: true): DateSchema<T | null>;
     nullable(isNullable: false): DateSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): DateSchema<T>;
-    required(message?: TestOptionsMessage): DateSchema<Exclude<T, undefined>>;
+    required(message?: TestOptionsMessage): DateSchema<Exclude<T, null | undefined>>;
     notRequired(): DateSchema<T | undefined>;
 }
 
@@ -258,7 +258,7 @@ export interface ObjectSchema<T extends object | null | undefined = object> exte
     nullable(isNullable?: true): ObjectSchema<T | null>;
     nullable(isNullable: false): ObjectSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): ObjectSchema<T>;
-    required(message?: TestOptionsMessage): ObjectSchema<Exclude<T, undefined>>;
+    required(message?: TestOptionsMessage): ObjectSchema<Exclude<T, null | undefined>>;
     notRequired(): ObjectSchema<T | undefined>;
     concat(schema: this): this;
     concat<U extends object>(schema: ObjectSchema<U>): ObjectSchema<T & U>;
@@ -291,7 +291,7 @@ export interface TestContext {
     parent: any;
     schema: Schema<any>;
     resolve: (value: any) => any;
-    createError: (params?: { path?: string; message?: string, params?: object }) => ValidationError;
+    createError: (params?: { path?: string; message?: string; params?: object }) => ValidationError;
 }
 
 export interface ValidateOptions {

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -636,8 +636,7 @@ const definitionBC: yup.ObjectSchemaDefinition<BC> = {
 };
 const combinedSchema = yup.object(definitionAB).shape(definitionBC); // $ExpectType ObjectSchema<Shape<AB, BC>>
 
-// $ExpectError
-yup.object<MyInterface>({
+const schemaWithoutNumberField = {
     stringField: yup.string().required(),
     subFields: yup
         .object({
@@ -645,10 +644,13 @@ yup.object<MyInterface>({
         })
         .required(),
     arrayField: yup.array(yup.string()).required(),
-});
+};
 
 // $ExpectError
-yup.object<MyInterface>({ stringField: yup.number().required(),
+yup.object<MyInterface>(schemaWithoutNumberField);
+
+const schemaWithWrongType = {
+    stringField: yup.number().required(),
     numberField: yup.number().required(),
     subFields: yup
         .object({
@@ -656,17 +658,22 @@ yup.object<MyInterface>({ stringField: yup.number().required(),
         })
         .required(),
     arrayField: yup.array(yup.string()).required(),
-});
+};
 
 // $ExpectError
-yup.object<MyInterface>({
+yup.object<MyInterface>(schemaWithWrongType);
+
+const schemaWithoutSubtype = {
     stringField: yup.string().required(),
     numberField: yup.number().required(),
     arrayField: yup.array(yup.string()).required(),
-});
+};
 
 // $ExpectError
-yup.object<MyInterface>({ subFields: yup
+yup.object<MyInterface>(schemaWithoutSubtype);
+
+const schemaWithWrongSubtype = {
+    subFields: yup
         .object({
             testField: yup.number().required(),
         })
@@ -674,7 +681,10 @@ yup.object<MyInterface>({ subFields: yup
     stringField: yup.string().required(),
     numberField: yup.number().required(),
     arrayField: yup.array(yup.string()).required(),
-});
+};
+
+// $ExpectError
+yup.object<MyInterface>(schemaWithWrongSubtype);
 
 enum Gender {
     Male = 'Male',
@@ -694,7 +704,13 @@ const personSchema = yup.object({
         .nullable()
         .notRequired()
         .min(new Date(1900, 0, 1)),
-    canBeNull: yup.string().nullable(true), // $ExpectType StringSchema<string | null>
+    // $ExpectType StringSchema<string | null>
+    canBeNull: yup.string().nullable(true),
+    // $ExpectType StringSchema<string>
+    requiredNullable: yup
+        .string()
+        .nullable()
+        .required(),
     isAlive: yup
         .boolean()
         .nullable()
@@ -720,6 +736,7 @@ type Person = yup.InferType<typeof personSchema>;
 //     email?: string | null | undefined;
 //     birthDate?: Date | null | undefined;
 //     canBeNull: string | null;
+//     requiredNullable: string;
 //     isAlive: boolean | null | undefined;
 //     mustBeAString: string;
 //     children?: string[] | null | undefined;
@@ -729,6 +746,7 @@ const minimalPerson: Person = {
     firstName: '',
     gender: Gender.Female,
     canBeNull: null,
+    requiredNullable: '',
     mustBeAString: '',
 };
 
@@ -738,6 +756,7 @@ const person: Person = {
     email: null,
     birthDate: null,
     canBeNull: null,
+    requiredNullable: '',
     isAlive: null,
     mustBeAString: '',
     children: null,


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [link to source code](https://github.com/jquense/yup/blob/820f910fabcb5333986dded0b2443a77e7fd43ff/src/mixed.js#L336)

required fields never return null after validation:
```
return value != null;
```

so `null` should be excluded from types 