### PR TITLE
feat(async): `retry` method definition update. Closes #41767

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -222,14 +222,26 @@ export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks
 export function autoInject<E = Error>(tasks: any, callback?: AsyncResultCallback<any, E>): void;
 
 export function retry<T, E = Error>(
-    opts: number | {
-        times: number,
-        interval: number | ((retryCount: number) => number),
-        errorFilter?: (error: Error) => boolean
-    },
-    task: (callback: AsyncResultCallback<T, E>, results: any) => void,
-    callback: AsyncResultCallback<any, E>
-    ): void;
+    opts?:
+        | number
+        | {
+              times?: number;
+              interval?: number | ((retryCount: number) => number);
+              errorFilter?: (error: Error) => boolean;
+          },
+    task?: (callback: AsyncResultCallback<T, E>, results: any) => void,
+): Promise<void>;
+export function retry<T, E = Error>(
+    opts?:
+        | number
+        | {
+              times?: number;
+              interval?: number | ((retryCount: number) => number);
+              errorFilter?: (error: Error) => boolean;
+          },
+    task?: (callback: AsyncResultCallback<T, E>, results: any) => void,
+    callback?: AsyncResultCallback<any, E>,
+): void;
 
 export function retryable<T, E = Error>(opts: number | {times: number, interval: number}, task: AsyncFunction<T, E>): AsyncFunction<T, E>;
 export function apply<E = Error>(fn: Function, ...args: any[]): AsyncFunction<any, E>;

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -312,10 +312,31 @@ async.auto<A>({
     (err, results) => { console.log('finished auto'); }
 );
 
-async.retry(3, (callback, results) => { }, (err, result) => { });
-async.retry({ times: 3, interval: 200 }, (callback, results) => { }, (err, result) => { });
-async.retry({ times: 3, interval: (retryCount) => 200 * retryCount }, (callback, results) => { }, (err, result) => { });
-async.retry({ times: 3, interval: 200, errorFilter: (err) => true }, (callback, results) => { }, (err, result) => { });
+async.retry(); // $ExpectType Promise<void>
+async.retry(3); // $ExpectType Promise<void>
+// $ExpectType Promise<void>
+async.retry(
+    3,
+    (callback, results) => {},
+);
+// $ExpectType void
+async.retry(
+    { times: 3, interval: 200 },
+    (callback, results) => {},
+    (err, result) => {},
+);
+// $ExpectType void
+async.retry(
+    { times: 3, interval: retryCount => 200 * retryCount },
+    (callback, results) => {},
+    (err, result) => {},
+);
+// $ExpectType void
+async.retry(
+    { times: 3, interval: 200, errorFilter: err => true },
+    (callback, results) => {},
+    (err, result) => {},
+);
 
 async.parallel([
         (callback: (err: Error, val: string) => void) => { },


### PR DESCRIPTION
- support for optional parameters
- support for differnet return depending on invocation params

See #41767 
Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://caolan.github.io/async/v3/docs.html#retry