### PR TITLE
[google-maps-react] Fix InfoWindow Types

### DIFF
--- a/types/google-maps-react/google-maps-react-tests.tsx
+++ b/types/google-maps-react/google-maps-react-tests.tsx
@@ -1,4 +1,4 @@
-import { GoogleAPI, Map, Marker, MapProps, GoogleApiWrapper } from 'google-maps-react';
+import { GoogleAPI, Map, Marker, MapProps, GoogleApiWrapper, InfoWindow } from 'google-maps-react';
 import * as React from 'react';
 
 interface Location {
@@ -56,7 +56,11 @@ class MapContainer extends React.Component<Props> {
         position={ hit._geoloc }
         title={ hit.title }
         key={ hit.id }
-      />;
+      >
+        <InfoWindow>
+          <p>Test</p>
+        </InfoWindow>
+      </Marker>;
     });
   }
 }

--- a/types/google-maps-react/index.d.ts
+++ b/types/google-maps-react/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/fullstackreact/google-maps-react#readme
 // Definitions by: Gordon Burgett <https://github.com/gburgett>
 //                 Justin Powell <https://github.com/jpowell>
+//                 Paito Anderson <https://github.com/PaitoAnderson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -103,12 +104,15 @@ export class HeatMap extends React.Component<any, any> {
 }
 
 export interface InfoWindowProps extends Partial<google.maps.InfoWindowOptions> {
-  google: typeof google;
-  map: google.maps.Map;
-  marker: google.maps.Marker;
+  google?: typeof google;
+  map?: google.maps.Map;
+  marker?: google.maps.Marker;
 
   mapCenter?: google.maps.LatLng | google.maps.LatLngLiteral;
   visible?: boolean;
+
+  onOpen?: () => void;
+  onClose?: () => void;
 }
 
 export class InfoWindow<P extends InfoWindowProps = InfoWindowProps, S = any> extends React.Component<P, S> {

--- a/types/google-maps-react/index.d.ts
+++ b/types/google-maps-react/index.d.ts
@@ -4,7 +4,7 @@
 //                 Justin Powell <https://github.com/jpowell>
 //                 Paito Anderson <https://github.com/PaitoAnderson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 import 'googlemaps';
 import * as React from 'react';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
```
Error: Errors in typescript@2.8 for external dependencies:
../googlemaps/index.d.ts(63,25): error TS1122: A tuple type element list cannot be empty.
../googlemaps/index.d.ts(72,25): error TS1122: A tuple type element list cannot be empty.
../googlemaps/index.d.ts(94,15): error TS1122: A tuple type element list cannot be empty.
../googlemaps/index.d.ts(100,18): error TS1122: A tuple type element list cannot be empty.
../googlemaps/index.d.ts(106,20): error TS1122: A tuple type element list cannot be empty.
../googlemaps/index.d.ts(115,26): error TS1122: A tuple type element list cannot be empty.
../googlemaps/index.d.ts(121,15): error TS1122: A tuple type element list cannot be empty.
../googlemaps/index.d.ts(130,28): error TS1122: A tuple type element list cannot be empty.
../googlemaps/index.d.ts(155,29): error TS1122: A tuple type element list cannot be empty.
../googlemaps/index.d.ts(167,22): error TS1122: A tuple type element list cannot be empty.
../googlemaps/index.d.ts(176,23): error TS1122: A tuple type element list cannot be empty.
../googlemaps/index.d.ts(185,23): error TS1122: A tuple type element list cannot be empty.
../googlemaps/index.d.ts(3308,76): error TS2370: A rest parameter must be of an array type.
```
Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/fullstackreact/google-maps-react/blob/master/src/components/InfoWindow.js#L106
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

