### PR TITLE
@wordpress/components: Add isDismissible prop to <Modal>

### DIFF
--- a/types/wordpress__components/modal/index.d.ts
+++ b/types/wordpress__components/modal/index.d.ts
@@ -46,8 +46,15 @@ declare namespace Modal {
          * If this property is set to false, the modal will not display a close
          * icon and cannot be dismissed.
          * @defaultValue true
+         * @deprecated Use isDismissible
          */
         isDismissable?: boolean;
+        /**
+         * If this property is set to false, the modal will not display a close
+         * icon and cannot be dismissed.
+         * @defaultValue true
+         */
+        isDismissible?: boolean;
         /**
          * If this property is added, it will an additional class name to the
          * modal overlay div.

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -407,7 +407,7 @@ const kbshortcuts = {
 //
 // modal
 //
-<C.Modal title="This is my modal" onRequestClose={() => console.log('closing modal')}>
+<C.Modal title="This is my modal" isDismissible={true} onRequestClose={() => console.log('closing modal')}>
     <button onClick={() => console.log('clicked')}>My custom close button</button>
 </C.Modal>;
 


### PR DESCRIPTION
The isDismissible spelling has replaced isDismissable (with an "a"). I left the old spelling in the type definitions to avoid breaking builds, however it has been marked as deprecated in the JSDoc.

Added a test for the prop in wordpress__components-tests.tsx.

The new spelling is in version 8.5, so no need to bump the type definition version.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Public docs: https://developer.wordpress.org/block-editor/components/modal/#isdismissible
  - PR that made the change: WordPress/gutenberg#17689
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

