### PR TITLE
Rewrite (thereby fix) types for express-session

### DIFF
--- a/types/connect-azuretables/index.d.ts
+++ b/types/connect-azuretables/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mike-goodwin/connect-azuretables
 // Definitions by: Mikael Brevik <https://github.com/mikaelbr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 import * as express from 'express';
 import * as session from 'express-session';
@@ -18,7 +18,7 @@ declare namespace connectAzureTable {
     interface AzureTableStore extends session.Store {
         startBackgroundCleanUp(): void;
         cleanUp(): void;
-        update(method: 'SET' | 'TOUCH', sid: string, session: Express.SessionData, callback?: (err: any) => void): void;
+        update(method: 'SET' | 'TOUCH', sid: string, session: SessionData, callback?: (err: any) => void): void;
     }
     interface AzureTableStoreOptions {
         logger?: (message: string) => void;

--- a/types/connect-pg-simple/index.d.ts
+++ b/types/connect-pg-simple/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/voxpelli/node-connect-pg-simple#readme
 // Definitions by: Pasi Eronen <https://github.com/pasieronen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 3.0
 
 import { RequestHandler } from "express";
 import { Store, SessionOptions } from "express-session";

--- a/types/connect-redis/index.d.ts
+++ b/types/connect-redis/index.d.ts
@@ -4,7 +4,7 @@
 //				   Seth Butler <https://github.com/sbutler2901>
 //                 Jip Sterk <https://github.com/JipSterk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 /// <reference types="express" />
 /// <reference types="express-session" />

--- a/types/express-session/tslint.json
+++ b/types/express-session/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "prefer-method-signature": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: These changes have been discussed and reviewed by the package maintainer in https://github.com/expressjs/session/pull/656
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


### This PR is a complete rewrite, because the current definitions are simply wrong
The exact changelog (including some of the reasons why the current definitions are wrong) is listed in https://github.com/expressjs/session/pull/656.
The original package maintainer @dougwilson has already reviewed these definitions and confirmed that they are correct.

Although I haven't thoroughly tested it, I'd be surprised if this rewrite would not be a breaking change. However, these fixes are desperately needed because the current definitions are pretty much unusable.
This issue has also been noticed in https://github.com/JLuboff/connect-mssql-v2/issues/10.

Unfortunately this fix will most likely break downstream definitions. I have already [comitted to updating the definitions for `express-mysql-session`](https://github.com/chill117/express-mysql-session/pull/93) because I'm using it myself, but the other session stores will (probably) need to be updated as well. I noticed @JLuboff and @bradtaniguchi were also having troubles with the current definitions, perhaps they can shine some light on how their session store would be affected by this?


### As for the definitions themselves
When I wrote these definitions (months ago), I had to declare the `SessionData` interface in the global scope to make declaration merging work. This feels wrong though, was this (and is this still) actually required or did I miss something?

I couldn't run prettier (probably due to outdated documentation), but I 'manually' formatted my definitions to use 4 space indentation.
There's also still one weird lint error left that I don't understand:
```
The types for express-session specify 'export default' but the source does not mention 'default' anywhere.
```

Finally, I had to raise the TS-version to 3.0. Is this a problem?

In the long run I'd prefer integrating these definitions into `express-session` itself, but as discussed in https://github.com/expressjs/session/pull/656 this'll have to wait until the v2 release.

This PR (temporarily) closes #35194 and almost certainly fixes #18529, #18527 and #16480.