### PR TITLE
Mongoose: Strongly typed the paths of schema definitions

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -1048,7 +1048,7 @@ declare module "mongoose" {
   /*
    * Intellisense for Schema definitions
    */
-  type SchemaDefinition<T> = {
+  type SchemaDefinition<T = {[x: string]: unknown}> = {
     [path in keyof T]?: SchemaTypeOpts<any> | Schema | SchemaType;
   };
 

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -704,10 +704,10 @@ declare module "mongoose" {
      * the child schema first before passing it into its parent.
      * @event init Emitted after the schema is compiled into a Model.
      */
-    constructor(definition?: SchemaDefinition, options?: SchemaOptions);
+    constructor(definition?: SchemaDefinition<T>, options?: SchemaOptions);
 
     /** Adds key path / schema type pairs to this schema. */
-    add(obj: SchemaDefinition, prefix?: string): void;
+    add(obj: SchemaDefinition<T>, prefix?: string): void;
 
     /** Return a deep copy of this schema */
     clone(): Schema;
@@ -1048,9 +1048,9 @@ declare module "mongoose" {
   /*
    * Intellisense for Schema definitions
    */
-  interface SchemaDefinition {
-    [path: string]: SchemaTypeOpts<any> | Schema | SchemaType;
-  }
+  type SchemaDefinition<T> = {
+    [path in keyof T]: SchemaTypeOpts<any> | Schema | SchemaType;
+  };
 
   /*
    * The standard options available when configuring a schema type:

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -1049,7 +1049,7 @@ declare module "mongoose" {
    * Intellisense for Schema definitions
    */
   type SchemaDefinition<T> = {
-    [path in keyof T]: SchemaTypeOpts<any> | Schema | SchemaType;
+    [path in keyof T]?: SchemaTypeOpts<any> | Schema | SchemaType;
   };
 
   /*

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -620,10 +620,10 @@ new mongoose.Schema({
     type: Number,
     validate: {
       isAsync: true,
-      validator: (val: number, done): void => {
+      validator: (val: number, done: any): void => {
         setImmediate(done, true);
       },
-      message: (props) => `${props.value} is invalid`
+      message: (props: any) => `${props.value} is invalid`
     }
   },
   promiseValidated: {

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -538,7 +538,9 @@ mongoose.Schema.reserved.hasOwnProperty('');
 schema.addListener('e', cb);
 /* practical examples */
 interface Animal {
-  findSimilarTypes(cb: any): Promise<Animal>
+  findSimilarTypes(cb: any): Promise<Animal>;
+  name: string;
+  type: string;
 }
 var animalSchema = new mongoose.Schema<Animal>({
   name: String,


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://mongoosejs.com/docs/guide.html#definition
> Each key in our code blogSchema defines a property in our documents which will be cast to its associated SchemaType. For example, we've defined a property title which will be cast to the String SchemaType and property date which will be cast to a Date SchemaType.