### PR TITLE
create type defs for box-node-sdk

### DIFF
--- a/types/box-node-sdk/box-node-sdk-tests.ts
+++ b/types/box-node-sdk/box-node-sdk-tests.ts
@@ -1,0 +1,74 @@
+import * as boxNodeSdk from 'box-node-sdk';
+
+const results: boxNodeSdk.SearchResults = {
+  total_count: 1,
+  entries: [
+    {
+      type: 'file',
+      id: '12345',
+      file_version: {
+          type: 'file_version',
+          id: '123456',
+          sha1: '1234567890'
+      },
+      sequence_id: '0',
+      etag: '0',
+      sha1: '12345678',
+      name: 'test.dwg',
+      description: '',
+      size: 123,
+      path_collection: {
+          total_count: 2,
+          entries: [
+              {
+                  type: 'folder',
+                  id: '0',
+                  sequence_id: null,
+                  etag: null,
+                  name: 'All Files'
+              },
+              {
+                  type: 'folder',
+                  id: '1',
+                  sequence_id: '0',
+                  etag: '0',
+                  name: 'Folder 01'
+              }
+          ]
+      },
+      created_at: '2020-01-03T13:09:01-08:00',
+      modified_at: '2020-01-03T13:09:01-08:00',
+      trashed_at: null,
+      purged_at: null,
+      content_created_at: '2020-01-03T13:08:56-08:00',
+      content_modified_at: '2019-12-11T13:36:25-08:00',
+      created_by: {
+          type: 'user',
+          id: '1',
+          name: 'User1',
+          login: 'user1@test.com'
+      },
+      modified_by: {
+          type: 'user',
+          id: '1',
+          name: 'User1',
+          login: 'user1@test.com'
+      },
+      owned_by: {
+          type: 'user',
+          id: '1',
+          name: 'User1',
+          login: 'user1@test.com'
+      },
+      shared_link: null,
+      parent: {
+          type: 'folder',
+          id: '1',
+          sequence_id: '0',
+          etag: '0',
+          name: 'Folder 01'
+      },
+      item_status: 'active'
+    }
+  ]
+};

--- a/types/box-node-sdk/index.d.ts
+++ b/types/box-node-sdk/index.d.ts
@@ -1,0 +1,119 @@
+// Type definitions for box-node-sdk 1.30
+// Project: https://github.com/box/box-node-sdk#readme
+// Definitions by: theodore-koch <https://github.com/theodore-koch>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface SearchResults {
+    total_count: number;
+    limit?: number;
+    offset?: number;
+    order?: {
+        by: string;
+        direction: string;
+    };
+    entries: Array<File | Folder | WebLink>;
+}
+
+export interface WebLink {
+    type: 'web_link';
+    id: string;
+    sequence_id: string;
+    etag: string;
+    sha1: string;
+    name: string;
+    url: string;
+    shared_link: SharedLink | null;
+    path_collection: PathCollection;
+}
+
+export interface SharedLink {
+    access: 'open' | 'company' | 'collaborators';
+    download_count: number;
+    download_url: string;
+    effective_access: 'open' | 'company' | 'collaborators';
+    effective_permission: 'can_download' | 'can_preview';
+    is_password_enabled: boolean;
+    permissions: {
+        can_download: boolean;
+        can_preview: boolean;
+    };
+    preview_count: number;
+    unshared_at: string;
+    url: string;
+    vanity_url: string;
+}
+
+export interface PathCollection {
+    total_count: number;
+    entries: Path[];
+}
+
+export interface Folder {
+    type: 'folder';
+    id: string;
+    sequence_id: string;
+    etag: string;
+    sha1: string;
+    name: string;
+    size: number;
+    description: string;
+    path_collection: PathCollection;
+}
+
+export interface File {
+    type: 'file';
+    id: string;
+    file_version: {
+        type: string;
+        id: string;
+        sha1: string;
+    } | null;
+    sequence_id: string;
+    etag: string;
+    sha1: string;
+    name: string;
+    description: string;
+    size: number;
+    path_collection: PathCollection;
+    created_at: string | null;
+    modified_at: string;
+    trashed_at: string | null;
+    purged_at: string | null;
+    content_created_at: string;
+    content_modified_at: string;
+    created_by: {
+        type: 'user';
+        id: string;
+        name: string;
+        login: string;
+    };
+    modified_by: {
+        type: 'user';
+        id: string;
+        name: string;
+        login: string;
+    };
+    owned_by: {
+        type: 'user';
+        id: string;
+        name: string;
+        login: string;
+    };
+    shared_link: string | null;
+    parent: {
+        type: 'folder';
+        id: string;
+        sequence_id: string;
+        etag: string;
+        name: string;
+    } | null;
+    item_status: string;
+}
+
+export interface Path {
+    type: 'folder';
+    id: string;
+    sequence_id: string | null;
+    etag: string | null;
+    name: string;
+}

--- a/types/box-node-sdk/tsconfig.json
+++ b/types/box-node-sdk/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "box-node-sdk-tests.ts"
+    ]
+}

--- a/types/box-node-sdk/tslint.json
+++ b/types/box-node-sdk/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
