### PR TITLE
[uuid] Avoid depending on "node" typings

### DIFF
--- a/types/uuid/index.d.ts
+++ b/types/uuid/index.d.ts
@@ -4,6 +4,7 @@
 //                 Felipe Ochoa <https://github.com/felipeochoa>
 //                 Chris Barth <https://github.com/cjbarth>
 //                 Rauno Viskus <https://github.com/rauno56>
+//                 Linus Unnebäck <https://github.com/LinusU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/uuid/interfaces.d.ts
+++ b/types/uuid/interfaces.d.ts
@@ -1,8 +1,6 @@
-/// <reference types="node" />
-
 // Uses ArrayLike to admit Unit8 and co.
-export type OutputBuffer = ArrayLike<number> | Buffer;
-export type InputBuffer = ArrayLike<number> | Buffer;
+export type OutputBuffer = ArrayLike<number>;
+export type InputBuffer = ArrayLike<number>;
 
 export interface V1Options {
     node?: InputBuffer;

--- a/types/uuid/uuid-tests.ts
+++ b/types/uuid/uuid-tests.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import uuid = require('uuid');
 import v1 = require('uuid/v1');
 import v4 = require('uuid/v4');
@@ -52,3 +54,10 @@ const d: number[] = v5('world', MY_NAMESPACE, [], 0);
 // https://github.com/kelektiv/node-uuid#quickstart---commonjs-recommended
 const e: string = v5('hello.example.com', v5.DNS);
 const f: string = v5('http://example.com/hello', v5.URL);
+
+const g = Buffer.alloc(16);
+v4(null, g); // $ExpectType Buffer
+
+class CustomBuffer extends Uint8Array {}
+const h = new CustomBuffer(10);
+v4(null, h); // $ExpectType CustomBuffer


### PR DESCRIPTION
Fixes https://github.com/uuidjs/uuid/issues/328

-----

There is no code in uuid that specifically depends on `Buffer`, and `Buffer` conforms to `ArrayLike<number>` so we don't need to specifically declare it as accepted ☺️ 

-----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: n/a
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
