### PR TITLE
[@types/hapi__joi]: fixes #41805 This expression is not callable...

### DIFF
--- a/types/hapi__joi/hapi__joi-tests.ts
+++ b/types/hapi__joi/hapi__joi-tests.ts
@@ -966,6 +966,14 @@ schema = Joi.link(str);
     const _objectTypeTest: { key: string } = Joi.object<{ key: string }>({ key: Joi.string() }).validate({}).value;
     const _dateTypeTest: Date = Joi.date().validate(new Date()).value;
     const _alternativeType: number | string = Joi.alternatives<number | string>(Joi.number(), Joi.string()).validate(1).value;
+    const _anySchema: any = (Joi.object<{ key: string }>({ key: Joi.string() }) as Joi.Schema).validate({}).value;
+    const _anySchema2Type: number = (Joi.number() as Joi.Schema).validate<number>({}).value;
+
+    const _schemaToCompile = Joi.object({
+        name: Joi.string(),
+    });
+    const _compiledResult: { name: string } = Joi.compile(_schemaToCompile).validate({ name: 'test' }).value;
+    const _compiledResult2: { name: string } = Joi.compile(_schemaToCompile).validate<{ name: string }>({ name: 'test' }).value;
 }
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---

--- a/types/hapi__joi/index.d.ts
+++ b/types/hapi__joi/index.d.ts
@@ -663,18 +663,7 @@ declare namespace Joi {
         [key in keyof TSchema]?: SchemaLike | SchemaLike[];
     };
 
-    type Schema = AnySchema
-        | ArraySchema
-        | AlternativesSchema
-        | BinarySchema
-        | BooleanSchema
-        | DateSchema
-        | FunctionSchema
-        | NumberSchema
-        | ObjectSchema
-        | StringSchema
-        | LinkSchema
-        | SymbolSchema;
+    type Schema = AnySchema;
 
     type SchemaFunction = (schema: Schema) => Schema;
 


### PR DESCRIPTION
`.validate`/`.validateAsync` was not callable from a Schema because it
had conflicting type declaration since `Schema.validate` was made up of
all `AnySchema` children which have been narrowed to their type.

Modifying `type Schema` to only be `AnySchema` still includes all
its `AnySchema`'s children as possibilities but removed the confusion
around `.validate` and return type.

I've added extra tests for this issue.

What do you think? Is this a good fix or a revert to 16.0.6's code is better? 

I would have liked to know why `type Schema` was defined that way and if it had a purpose but it looks like the file was added instead of moved when the namespace changed, and i'm unable to find the old one to look at the commit history 
____

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41805
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
