### PR TITLE
feat: Add typings for file-size

### DIFF
--- a/types/file-size/file-size-tests.ts
+++ b/types/file-size/file-size-tests.ts
@@ -1,0 +1,10 @@
+import fileSize = require("file-size");
+
+const fz = fileSize(14235235);
+
+fz.fixed; // $ExpectType number
+fz.spacer; // $ExpectType string
+
+fz.human(); // $ExpectType string
+fz.calculate(); // $ExpectType Calculated
+fz.to("KB"); // $ExpectType string

--- a/types/file-size/index.d.ts
+++ b/types/file-size/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for file-size 1.0
+// Project: https://github.com/Nijikokun/file-size
+// Definitions by: Richie Bendall <https://github.com/Richienb>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+interface Options {
+    fixed?: number;
+    spacer?: string;
+}
+
+type Spec = "si" | "iec" | "jedec";
+
+type Unit = "B" | "KB" | "MB" | "GB" | "TB" | "PB" | "EB" | "ZB" | "YB";
+
+interface Bits {
+    result: number;
+    fixed: string;
+}
+
+interface Calculated {
+    suffix: string;
+    magnitude: number;
+    result: number;
+    fixed: string;
+    bits: Bits;
+}
+
+interface Result {
+    human(spec?: Spec): string;
+    to(unit: Unit, spec?: Spec): string;
+    calculate(spec?: Spec): Calculated;
+}
+
+declare function fileSize<T extends Options>(bytes: number, options?: T): Required<T> & Result;
+
+export as namespace filesize;
+
+export = fileSize;

--- a/types/file-size/tsconfig.json
+++ b/types/file-size/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "file-size-tests.ts"
+    ]
+}

--- a/types/file-size/tslint.json
+++ b/types/file-size/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
