### PR TITLE
fix(carbon-components-react): `title` prop of the AccordionItem. Closes #41811

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+    AccordionItem,
     DataTable,
     DataTableHeader,
     DataTableRow,
@@ -9,6 +10,24 @@ import {
     TableRow,
 } from 'carbon-components-react';
 import Link from 'carbon-components-react/lib/components/UIShell/Link';
+
+// AccordionItem
+const titleNode = (
+    <h2 className="TitleClass">
+        <img src="some_image.png" alt="Something" />A heading
+    </h2>
+);
+const accordionItemOne = (
+    <AccordionItem title={titleNode} className="extra-class">
+        Lorem ipsum.
+    </AccordionItem>
+);
+const accordionTitle = 'Hello World!';
+const accordionItemTwo = (
+    <AccordionItem title={accordionTitle} className="extra-class">
+        Lorem ipsum.
+    </AccordionItem>
+);
 
 interface Row1 extends DataTableRow {
     rowProp: string;

--- a/types/carbon-components-react/lib/components/Accordion/AccordionItem.d.ts
+++ b/types/carbon-components-react/lib/components/Accordion/AccordionItem.d.ts
@@ -8,10 +8,12 @@ export interface HeadingClickData {
     isOpen: boolean;
 }
 
-export interface AccordionItemProps extends InheritedProps {
+export interface AccordionItemProps extends Omit<React.HTMLProps<InheritedProps>, "title"> {
     onHeadingClick?(data: HeadingClickData): void,
     open?: boolean,
     renderExpando?: React.ReactNode,
+    /** The accordion title. */
+    title?: React.ReactNode;
 }
 
 declare class AccordionItem extends React.Component<AccordionItemProps> { }

--- a/types/carbon-components-react/lib/components/Accordion/AccordionItem.d.ts
+++ b/types/carbon-components-react/lib/components/Accordion/AccordionItem.d.ts
@@ -8,7 +8,7 @@ export interface HeadingClickData {
     isOpen: boolean;
 }
 
-export interface AccordionItemProps extends Omit<React.HTMLProps<InheritedProps>, "title"> {
+export interface AccordionItemProps extends Omit<InheritedProps, "title"> {
     onHeadingClick?(data: HeadingClickData): void,
     open?: boolean,
     renderExpando?: React.ReactNode,


### PR DESCRIPTION
- redeclare `title` property to supports React.Node

Thanks!

FYI: omit for:
> type 'ReactNode' is not assignable to type 'string'

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon-components-react/blob/master/src/components/AccordionItem/AccordionItem.js#L36