### PR TITLE
[passport-microsoft] Add Types for passport-microsoft

### DIFF
--- a/types/passport-microsoft/index.d.ts
+++ b/types/passport-microsoft/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for passport-microsoft 0.0
+// Project: https://github.com/seanfisher/passport-microsoft#readme
+// Definitions by: Eitan Levi <https://github.com/skrud>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+import * as oauth2 from 'passport-oauth2';
+
+// Disable automatic exporting
+export {};
+
+// The passport-microsoft library provides defaults for these fields, so they become optional
+// when calling the constructor. (No need to export this).
+type OptionalOptionParameters = 'authorizationURL' | 'tokenURL' | 'scopeSeparator' | 'customHeaders';
+
+export type MicrosoftStrategyOptions = Omit<oauth2.StrategyOptions, OptionalOptionParameters> & Partial<oauth2.StrategyOptions>;
+export type MicrosoftStrategyOptionsWithRequest = Omit<oauth2.StrategyOptionsWithRequest, OptionalOptionParameters> & Partial<oauth2.StrategyOptionsWithRequest>;
+
+export class Strategy extends oauth2.Strategy {
+    constructor(options: MicrosoftStrategyOptions, verify: oauth2.VerifyFunction);
+    constructor(options: MicrosoftStrategyOptionsWithRequest, verify: oauth2.VerifyFunctionWithRequest);
+}

--- a/types/passport-microsoft/passport-microsoft-tests.ts
+++ b/types/passport-microsoft/passport-microsoft-tests.ts
@@ -1,0 +1,26 @@
+import passport = require('passport');
+import { Strategy as MicrosoftStrategy } from 'passport-microsoft';
+
+// Just some test model.
+const User = {
+    findOrCreate(
+        id: string,
+        provider: string,
+        callback: (err: any, user: any) => void
+    ): void {
+        callback(null, { username: "arnold" });
+    }
+};
+
+passport.use(new MicrosoftStrategy(
+    {
+        clientID: 'thisIsMyClientId',
+        clientSecret: 'thisIsMyClientSecret'
+    },
+    (accessToken: string, refreshToken: string, profile: passport.Profile, done: (error: any, user?: any) => void) => {
+        User.findOrCreate(profile.id, profile.provider, (err, user) => {
+            if (err) { done(err); return; }
+            done(null, user);
+        });
+    }
+));

--- a/types/passport-microsoft/tsconfig.json
+++ b/types/passport-microsoft/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "passport-microsoft-tests.ts"
+    ]
+}

--- a/types/passport-microsoft/tslint.json
+++ b/types/passport-microsoft/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This adds types for the passport-microsoft package, which is a library
for authenticating with Microsoft's GraphQL API over OAuth2 using
    PassportJs.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
