### PR TITLE
[@types/plupload] Enable import

### DIFF
--- a/types/plupload/index.d.ts
+++ b/types/plupload/index.d.ts
@@ -770,5 +770,5 @@ declare namespace plupload {
 }
 
 declare module 'plupload' {
-    export default plupload
+    export = plupload;
 }

--- a/types/plupload/index.d.ts
+++ b/types/plupload/index.d.ts
@@ -768,3 +768,7 @@ declare namespace plupload {
      */
     function addFileFilter(name: string, cb: Function): void;
 }
+
+declare module 'plupload' {
+    export default plupload
+}


### PR DESCRIPTION
fix `'@types/plupload/index.d.ts is not a module` when import as a module like `import plupload from 'plupload'`

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
