### PR TITLE
chore: use `expect`'s own `MatcherState` for matchers

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -454,69 +454,13 @@ declare namespace jest {
 
     type EqualityTester = (a: any, b: any) => boolean | undefined;
 
-    interface MatcherUtils {
-        readonly isNot: boolean;
-        readonly dontThrow: () => void;
-        readonly promise: string;
-        readonly assertionCalls: number;
-        readonly expectedAssertionsNumber: number | null;
-        readonly isExpectingAssertions: boolean;
-        readonly suppressedErrors: any[];
-        readonly expand: boolean;
-        readonly testPath: string;
-        readonly currentTestName: string;
-        utils: {
-            readonly EXPECTED_COLOR: MatcherColorFn;
-            readonly RECEIVED_COLOR: MatcherColorFn;
-            readonly INVERTED_COLOR: MatcherColorFn;
-            readonly BOLD_WEIGHT: MatcherColorFn;
-            readonly DIM_COLOR: MatcherColorFn;
-            readonly SUGGEST_TO_CONTAIN_EQUAL: string;
-            diff(a: any, b: any, options?: import("jest-diff").DiffOptions): string | null;
-            ensureActualIsNumber(actual: any, matcherName: string, options?: MatcherHintOptions): void;
-            ensureExpectedIsNumber(actual: any, matcherName: string, options?: MatcherHintOptions): void;
-            ensureNoExpected(actual: any, matcherName: string, options?: MatcherHintOptions): void;
-            ensureNumbers(actual: any, expected: any, matcherName: string, options?: MatcherHintOptions): void;
-            ensureExpectedIsNonNegativeInteger(expected: any, matcherName: string, options?: MatcherHintOptions): void;
-            matcherHint(
-                matcherName: string,
-                received?: string,
-                expected?: string,
-                options?: MatcherHintOptions
-            ): string;
-            matcherErrorMessage(
-              hint: string,
-              generic: string,
-              specific: string
-            ): string;
-            pluralize(word: string, count: number): string;
-            printReceived(object: any): string;
-            printExpected(value: any): string;
-            printWithType(name: string, value: any, print: (value: any) => string): string;
-            stringify(object: {}, maxDepth?: number): string;
-            highlightTrailingWhitespace(text: string): string;
-
-            printDiffOrStringify(expected: any, received: any, expectedLabel: string, receivedLabel: string, expand: boolean): string;
-
-            getLabelPrinter(...strings: string[]): PrintLabel;
-
-            iterableEquality: EqualityTester;
-            subsetEquality: EqualityTester;
-        };
-        /**
-         *  This is a deep-equality function that will return true if two objects have the same values (recursively).
-         */
-        equals(a: any, b: any, customTesters?: EqualityTester[], strictCheck?: boolean): boolean;
-        [other: string]: any;
-    }
-
     interface ExpectExtendMap {
         [key: string]: CustomMatcher;
     }
 
-    type MatcherContext = MatcherUtils & Readonly<MatcherState>;
+    type MatcherState = import("expect").MatcherState;
     type CustomMatcher = (
-        this: MatcherContext,
+        this: MatcherState,
         received: any,
         ...actual: any[]
     ) => CustomMatcherResult | Promise<CustomMatcherResult>;
@@ -561,15 +505,6 @@ declare namespace jest {
          * `expect.stringContaining`.
          */
         stringContaining(str: string): any;
-    }
-    interface MatcherState {
-        assertionCalls: number;
-        currentTestName: string;
-        expand: boolean;
-        expectedAssertionsNumber: number;
-        isExpectingAssertions?: boolean;
-        suppressedErrors: Error[];
-        testPath: string;
     }
     /**
      * The `expect` function is used every time you want to test a value.

--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "jest-diff": "^25.1.0",
+        "expect": "^25.1.0",
         "pretty-format": "^25.1.0"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jest/blob/895136f3f4be9155f1b60b55e77b8c285feb6a73/packages/expect/src/types.ts#L31-L53
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.