### PR TITLE
chore: use Jest's own configuration types

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 24.9
+// Type definitions for Jest 25.1
 // Project: https://jestjs.io/
 // Definitions by: Asana (https://asana.com)
 //                 Ivo Stratev <https://github.com/NoHomey>
@@ -29,6 +29,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
+/// <reference types="@jest/types" />
 /// <reference types="jest-diff" />
 
 declare var beforeAll: jest.Lifecycle;
@@ -1553,257 +1554,6 @@ declare namespace jest {
     type Runtime = any; // import Runtime from 'jest-runtime';
     type Script = any; // import {Script} from 'vm';
 
-    // Config
-
-    type Path = string;
-    type Glob = string;
-
-    interface HasteConfig {
-        defaultPlatform?: Maybe<string>;
-        hasteImplModulePath?: string;
-        platforms?: string[];
-        providesModuleNodeModules: string[];
-    }
-
-    type ReporterConfig = [string, object];
-
-    type ConfigGlobals = object;
-
-    type SnapshotUpdateState = 'all' | 'new' | 'none';
-
-    interface DefaultOptions {
-        automock: boolean;
-        bail: boolean;
-        browser: boolean;
-        cache: boolean;
-        cacheDirectory: Path;
-        changedFilesWithAncestor: boolean;
-        clearMocks: boolean;
-        collectCoverage: boolean;
-        collectCoverageFrom: Maybe<string[]>;
-        coverageDirectory: Maybe<string>;
-        coveragePathIgnorePatterns: string[];
-        coverageReporters: string[];
-        coverageThreshold: Maybe<{ global: { [key: string]: number } }>;
-        errorOnDeprecated: boolean;
-        expand: boolean;
-        filter: Maybe<Path>;
-        forceCoverageMatch: Glob[];
-        globals: ConfigGlobals;
-        globalSetup: Maybe<string>;
-        globalTeardown: Maybe<string>;
-        haste: HasteConfig;
-        detectLeaks: boolean;
-        detectOpenHandles: boolean;
-        moduleDirectories: string[];
-        moduleFileExtensions: string[];
-        moduleNameMapper: { [key: string]: string };
-        modulePathIgnorePatterns: string[];
-        noStackTrace: boolean;
-        notify: boolean;
-        notifyMode: string;
-        preset: Maybe<string>;
-        projects: Maybe<Array<string | ProjectConfig>>;
-        resetMocks: boolean;
-        resetModules: boolean;
-        resolver: Maybe<Path>;
-        restoreMocks: boolean;
-        rootDir: Maybe<Path>;
-        roots: Maybe<Path[]>;
-        runner: string;
-        runTestsByPath: boolean;
-        setupFiles: Path[];
-        setupTestFrameworkScriptFile: Maybe<Path>;
-        skipFilter: boolean;
-        snapshotSerializers: Path[];
-        testEnvironment: string;
-        testEnvironmentOptions: object;
-        testFailureExitCode: string | number;
-        testLocationInResults: boolean;
-        testMatch: Glob[];
-        testPathIgnorePatterns: string[];
-        testRegex: string;
-        testResultsProcessor: Maybe<string>;
-        testRunner: Maybe<string>;
-        testURL: string;
-        timers: 'real' | 'fake';
-        transform: Maybe<{ [key: string]: string }>;
-        transformIgnorePatterns: Glob[];
-        watchPathIgnorePatterns: string[];
-        useStderr: boolean;
-        verbose: Maybe<boolean>;
-        watch: boolean;
-        watchman: boolean;
-    }
-
-    interface InitialOptions {
-        automock?: boolean;
-        bail?: boolean;
-        browser?: boolean;
-        cache?: boolean;
-        cacheDirectory?: Path;
-        clearMocks?: boolean;
-        changedFilesWithAncestor?: boolean;
-        changedSince?: string;
-        collectCoverage?: boolean;
-        collectCoverageFrom?: Glob[];
-        collectCoverageOnlyFrom?: { [key: string]: boolean };
-        coverageDirectory?: string;
-        coveragePathIgnorePatterns?: string[];
-        coverageReporters?: string[];
-        coverageThreshold?: { global: { [key: string]: number } };
-        detectLeaks?: boolean;
-        detectOpenHandles?: boolean;
-        displayName?: string;
-        expand?: boolean;
-        filter?: Path;
-        findRelatedTests?: boolean;
-        forceCoverageMatch?: Glob[];
-        forceExit?: boolean;
-        json?: boolean;
-        globals?: ConfigGlobals;
-        globalSetup?: Maybe<string>;
-        globalTeardown?: Maybe<string>;
-        haste?: HasteConfig;
-        reporters?: Array<ReporterConfig | string>;
-        logHeapUsage?: boolean;
-        lastCommit?: boolean;
-        listTests?: boolean;
-        mapCoverage?: boolean;
-        moduleDirectories?: string[];
-        moduleFileExtensions?: string[];
-        moduleLoader?: Path;
-        moduleNameMapper?: { [key: string]: string };
-        modulePathIgnorePatterns?: string[];
-        modulePaths?: string[];
-        name?: string;
-        noStackTrace?: boolean;
-        notify?: boolean;
-        notifyMode?: string;
-        onlyChanged?: boolean;
-        outputFile?: Path;
-        passWithNoTests?: boolean;
-        preprocessorIgnorePatterns?: Glob[];
-        preset?: Maybe<string>;
-        projects?: Glob[];
-        replname?: Maybe<string>;
-        resetMocks?: boolean;
-        resetModules?: boolean;
-        resolver?: Maybe<Path>;
-        restoreMocks?: boolean;
-        rootDir?: Path;
-        roots?: Path[];
-        runner?: string;
-        runTestsByPath?: boolean;
-        scriptPreprocessor?: string;
-        setupFiles?: Path[];
-        setupFilesAfterEnv?: Path[];
-        setupTestFrameworkScriptFile?: Path;
-        silent?: boolean;
-        skipFilter?: boolean;
-        skipNodeResolution?: boolean;
-        snapshotSerializers?: Path[];
-        errorOnDeprecated?: boolean;
-        testEnvironment?: string;
-        testEnvironmentOptions?: object;
-        testFailureExitCode?: string | number;
-        testLocationInResults?: boolean;
-        testMatch?: Glob[];
-        testNamePattern?: string;
-        testPathDirs?: Path[];
-        testPathIgnorePatterns?: string[];
-        testRegex?: string;
-        testResultsProcessor?: Maybe<string>;
-        testRunner?: string;
-        testURL?: string;
-        timers?: 'real' | 'fake';
-        transform?: { [key: string]: string };
-        transformIgnorePatterns?: Glob[];
-        watchPathIgnorePatterns?: string[];
-        unmockedModulePathPatterns?: string[];
-        updateSnapshot?: boolean;
-        useStderr?: boolean;
-        verbose?: Maybe<boolean>;
-        watch?: boolean;
-        watchAll?: boolean;
-        watchman?: boolean;
-        watchPlugins?: string[];
-    }
-
-    interface GlobalConfig {
-        bail: boolean;
-        collectCoverage: boolean;
-        collectCoverageFrom: Glob[];
-        collectCoverageOnlyFrom: Maybe<{ [key: string]: boolean }>;
-        coverageDirectory: string;
-        coverageReporters: string[];
-        coverageThreshold: { global: { [key: string]: number } };
-        expand: boolean;
-        forceExit: boolean;
-        logHeapUsage: boolean;
-        mapCoverage: boolean;
-        noStackTrace: boolean;
-        notify: boolean;
-        projects: Glob[];
-        replname: Maybe<string>;
-        reporters: ReporterConfig[];
-        rootDir: Path;
-        silent: boolean;
-        testNamePattern: string;
-        testPathPattern: string;
-        testResultsProcessor: Maybe<string>;
-        updateSnapshot: SnapshotUpdateState;
-        useStderr: boolean;
-        verbose: Maybe<boolean>;
-        watch: boolean;
-        watchman: boolean;
-    }
-
-    interface ProjectConfig {
-        automock: boolean;
-        browser: boolean;
-        cache: boolean;
-        cacheDirectory: Path;
-        clearMocks: boolean;
-        coveragePathIgnorePatterns: string[];
-        cwd: Path;
-        detectLeaks: boolean;
-        displayName: Maybe<string>;
-        forceCoverageMatch: Glob[];
-        globals: ConfigGlobals;
-        haste: HasteConfig;
-        moduleDirectories: string[];
-        moduleFileExtensions: string[];
-        moduleLoader: Path;
-        moduleNameMapper: Array<[string, string]>;
-        modulePathIgnorePatterns: string[];
-        modulePaths: string[];
-        name: string;
-        resetMocks: boolean;
-        resetModules: boolean;
-        resolver: Maybe<Path>;
-        rootDir: Path;
-        roots: Path[];
-        runner: string;
-        setupFiles: Path[];
-        setupTestFrameworkScriptFile: Path;
-        skipNodeResolution: boolean;
-        snapshotSerializers: Path[];
-        testEnvironment: string;
-        testEnvironmentOptions: object;
-        testLocationInResults: boolean;
-        testMatch: Glob[];
-        testPathIgnorePatterns: string[];
-        testRegex: string;
-        testRunner: string;
-        testURL: string;
-        timers: 'real' | 'fake';
-        transform: Array<[string, Path]>;
-        transformIgnorePatterns: Glob[];
-        unmockedModulePathPatterns: Maybe<string[]>;
-        watchPathIgnorePatterns: string[];
-    }
-
     // Console
 
     type LogMessage = string;
@@ -1818,7 +1568,7 @@ declare namespace jest {
     // Context
 
     interface Context {
-        config: ProjectConfig;
+        config: import('@jest/types').Config.ProjectConfig;
         hasteFS: HasteFS;
         moduleMap: ModuleMap;
         resolver: HasteResolver;
@@ -2005,7 +1755,7 @@ declare namespace jest {
     interface Test {
         context: Context;
         duration?: number;
-        path: Path;
+        path: import('@jest/types').Config.Path;
     }
 
     // tslint:disable-next-line:no-empty-interface
@@ -2019,8 +1769,8 @@ declare namespace jest {
     }
 
     type TestFramework = (
-        globalConfig: GlobalConfig,
-        config: ProjectConfig,
+        globalConfig: import('@jest/types').Config.GlobalConfig,
+        config: import('@jest/types').Config.ProjectConfig,
         environment: Environment,
         runtime: Runtime,
         testPath: string
@@ -2041,12 +1791,12 @@ declare namespace jest {
         canInstrument?: boolean;
         createTransformer?(options: any): Transformer;
 
-        getCacheKey?(fileData: string, filePath: Path, configStr: string, options: TransformOptions): string;
+        getCacheKey?(fileData: string, filePath: import('@jest/types').Config.Path, configStr: string, options: TransformOptions): string;
 
         process(
             sourceText: string,
-            sourcePath: Path,
-            config: ProjectConfig,
+            sourcePath: import('@jest/types').Config.Path,
+            config: import('@jest/types').Config.ProjectConfig,
             options?: TransformOptions
         ): string | TransformedSource;
     }

--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "jest-diff": "^24.3.0"
+        "@jest/types": "^25.1.0",
+        "jest-diff": "^25.1.0"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jest/blob/895136f3f4be9155f1b60b55e77b8c285feb6a73/packages/jest-types/src/Config.ts
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This has the same error as #41838, help appreciated 🙂 