### PR TITLE
chrome: Adds `chrome.devtools.panels.themeName`.

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2091,6 +2091,12 @@ declare namespace chrome.devtools.panels {
      * function() {...};
      */
     export function openResource(url: string, lineNumber: number, callback: () => void): void;
+
+    /**
+     * @since Chrome 59.
+     * The name of the color theme set in user's DevTools settings.
+     */
+    export var themeName: 'default'|'dark';
 }
 
 ////////////////////


### PR DESCRIPTION
Official API definition: https://developer.chrome.com/extensions/devtools_panels#property-themeName

Apparently Chrome extensions don't get the `prefers-color-scheme` media query and instead need to use this value. It can only be `"dark"` or `"default"` (even when users explicitly set their theme to `"light"`).

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)

N/A, I don't think there is an effective way to test this since the property only exists within a Chrome extension. I don't see other tests covering `chrome.devtools.panels.*`. Let me know if there is a means of testing this.

I did test this in my extension directly and it seems to be working just fine. I also manually verified that even when setting DevTools theme explicitly to "Light theme" it still outputs the value `"default"` 🤷‍♂️.

- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:

https://bugs.chromium.org/p/chromium/issues/detail?id=608869
https://developer.chrome.com/extensions/devtools_panels#property-themeName

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

`themeName` was added in Chrome 59, but later versions already exist. This PR is just correcting a missed property.
