### PR TITLE
Add missing fields to types in node-telegram-bot-api

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -120,6 +120,7 @@ declare namespace TelegramBot {
     }
 
     interface SendBasicOptions {
+        chat_id?: number | string;
         disable_notification?: boolean;
         reply_to_message_id?: number;
         reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply;

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -127,6 +127,7 @@ declare namespace TelegramBot {
     }
 
     interface SendMessageOptions extends SendBasicOptions {
+        text: string;
         parse_mode?: ParseMode;
         disable_web_page_preview?: boolean;
     }


### PR DESCRIPTION
`chat_id` is required by most of the send methods of Telegram Bot API