### PR TITLE
[umzug] fix: support array of migrations as input

### DIFF
--- a/types/umzug/index.d.ts
+++ b/types/umzug/index.d.ts
@@ -211,6 +211,8 @@ declare namespace umzug {
     }
 
     interface Migration {
+        file: string;
+        
         migration(): Promise<any>;
         up(): Promise<any>;
         down(): Promise<any>;

--- a/types/umzug/index.d.ts
+++ b/types/umzug/index.d.ts
@@ -174,7 +174,7 @@ declare namespace umzug {
         /**
          * Options for defined migration
          */
-        migrations?: MigrationOptions;
+        migrations?: MigrationOptions | Migration[];
 
     }
 

--- a/types/umzug/index.d.ts
+++ b/types/umzug/index.d.ts
@@ -213,6 +213,11 @@ declare namespace umzug {
     interface Migration {
         path: string;
         file: string;
+
+        migration(): Promise<any>;
+        up(): Promise<any>;
+        down(): Promise<any>;
+        testFileName(needle:string): boolean;
     }
 
     interface Umzug extends EventEmitter {

--- a/types/umzug/index.d.ts
+++ b/types/umzug/index.d.ts
@@ -211,9 +211,6 @@ declare namespace umzug {
     }
 
     interface Migration {
-        path: string;
-        file: string;
-
         migration(): Promise<any>;
         up(): Promise<any>;
         down(): Promise<any>;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sequelize/umzug/blob/master/src/index.js#L65
https://github.com/sequelize/umzug/blob/master/test/fixtures/index.js#L61
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
