### PR TITLE
In SetFields, take into consideration optional array types.

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1209,9 +1209,9 @@ export type ArrayOperator<Type> = {
 };
 
 export type SetFields<TSchema> = ({
-    readonly [key in KeysOfAType<TSchema, any[]>]?: Unpacked<TSchema[key]> | AddToSetOperators<TSchema[key]>;
+    readonly [key in KeysOfAType<TSchema, any[] | undefined>]?: Unpacked<TSchema[key]> | AddToSetOperators<TSchema[key]>;
 } &
-    NotAcceptedFields<TSchema, any[]>) & {
+    NotAcceptedFields<TSchema, any[] | undefined>) & {
     readonly [key: string]: AddToSetOperators<any> | any;
 };
 

--- a/types/mongodb/test/collection/updateX.ts
+++ b/types/mongodb/test/collection/updateX.ts
@@ -11,6 +11,8 @@ async function run() {
         field2: string;
     }
 
+    type FruitTypes = 'apple' | 'pear';
+
     // test with collection type
     interface TestModel {
         stringField: string;
@@ -19,6 +21,7 @@ async function run() {
         otherDateField: Date;
         oneMoreDateField: Date;
         fruitTags: string[];
+        maybeFruitTags?: FruitTypes[];
         subInterfaceField: SubTestModel;
         subInterfaceArray: SubTestModel[];
     }
@@ -95,6 +98,7 @@ async function run() {
 
     buildUpdateQuery({ $addToSet: { fruitTags: 'stringField' } });
     buildUpdateQuery({ $addToSet: { fruitTags: { $each: ['stringField'] } } });
+    buildUpdateQuery({ $addToSet: { maybeFruitTags: 'apple' } });
     buildUpdateQuery({ $addToSet: { 'dot.notation': 'stringField' } });
     buildUpdateQuery({ $addToSet: { 'dot.notation': { $each: ['stringfield'] } } });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This PR aims to fix this open issue #40381 .
The problem can be summarized by the following example:
```
type Something = {
  optionalArray?: string[];
  normalArray: string[];
  notArray: string;
};

const setFields: SetFields<Something> = {
  // Type 'string' is not assignable to type 'undefined'.ts(2322)
  optionalArray: 'test'
};

// Will have type `type KeysOfSomething = "normalArray" | undefined`
type KeysOfSomething = KeysOfAType<Something, any[]>;
```

The `optionalArray` type is not included as an allowed property by `KeysOfAType`.

A simple solution, and the one in this PR is to replace:
```
KeysOfAType<TSchema, any[]>
```
with
```
KeysOfAType<TSchema, any[] | undefined>
``` 
so as to allow optional types.

Although I'm not sure if this is the best solution since this might also fail for other specific cases. Another approach would be to augment `KeysOfType` (and `KeysOfOtherType`) from:
```
type KeysOfAType<TSchema, Type> = {
  [key in keyof TSchema]: TSchema[key] extends Type ? key : never;
}[keyof TSchema];
```
to
```
type KeysOfAType<TSchema, Type> = {
  [key in keyof TSchema]:
    TSchema[key] extends Type ? key :
    Type extends TSchema[key] ? key :
    never;
}[keyof TSchema];
```
Or something similar, which would check if there's any intersection at all between the types.