### PR TITLE
[rdf-dataset-indexed] Fix data factory type

### DIFF
--- a/types/rdf-dataset-indexed/index.d.ts
+++ b/types/rdf-dataset-indexed/index.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: Chris Wilkinson <https://github.com/thewilkybarkid>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { BaseQuad, DataFactory, DatasetCore, Quad } from 'rdf-js';
+import { BaseQuad, DataFactory, DatasetCore, DatasetCoreFactory, Quad } from 'rdf-js';
 
-declare function datasetFactory<Q extends BaseQuad = Quad>(quads?: Q[], dataFactory?: DataFactory<Q>): DatasetCore<Q>;
+declare function datasetFactory<Q extends BaseQuad = Quad>(quads?: Q[], dataFactory?: DataFactory<Q> & DatasetCoreFactory<Q>): DatasetCore<Q>;
 
 export = datasetFactory;

--- a/types/rdf-dataset-indexed/rdf-dataset-indexed-tests.ts
+++ b/types/rdf-dataset-indexed/rdf-dataset-indexed-tests.ts
@@ -1,12 +1,21 @@
 import datasetFactory = require('rdf-dataset-indexed');
-import { BaseQuad, DataFactory, DatasetCore, Quad } from 'rdf-js';
+import { BaseQuad, DataFactory, DatasetCore, DatasetCoreFactory, Quad, Term } from 'rdf-js';
 
-const dataFactory: DataFactory = {} as any;
+interface QuadBnode extends BaseQuad {
+    subject: Term;
+    predicate: Term;
+    object: Term;
+    graph: Term;
+}
+
+const dataFactory1: DataFactory & DatasetCoreFactory = {} as any;
+const dataFactory2: DataFactory<QuadBnode> & DatasetCoreFactory<QuadBnode> = {} as any;
 const quads1: Quad[] = [] as any;
-const quads2: BaseQuad[] = [] as any;
+const quads2: QuadBnode[] = [] as any;
 
 const test1: DatasetCore = datasetFactory();
 const test2: DatasetCore = datasetFactory(quads1);
-const test3: DatasetCore = datasetFactory(quads1, dataFactory);
-const test4: DatasetCore<BaseQuad> = datasetFactory(quads2);
-const test5: DatasetCore<BaseQuad> = datasetFactory<BaseQuad>(quads2);
+const test3: DatasetCore = datasetFactory(quads1, dataFactory1);
+const test4: DatasetCore<QuadBnode> = datasetFactory(quads2);
+const test5: DatasetCore<QuadBnode> = datasetFactory<QuadBnode>(quads2);
+const test6: DatasetCore<QuadBnode> = datasetFactory<QuadBnode>(quads2, dataFactory2);


### PR DESCRIPTION
Bit surprised, but the data factory is actually meant to be a dataset (core) factory too. Given there's a test for its usage, seems like it really is intended.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rdf-ext/rdf-dataset-indexed/blob/7ea6c12626be211080c25af6c6eb853318474fbc/test/dataset.test.js#L143-L152
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.