### PR TITLE
Add type definition for non npm package amap-js-api-transfer

### DIFF
--- a/types/amap-js-api-transfer/amap-js-api-transfer-tests.ts
+++ b/types/amap-js-api-transfer/amap-js-api-transfer-tests.ts
@@ -1,0 +1,371 @@
+declare const map: AMap.Map;
+declare const lnglat: AMap.LngLat;
+declare const lnglatTuple: [number, number];
+
+// $ExpectError
+new AMap.Transfer();
+// $ExpectType Transfer
+new AMap.Transfer({
+    city: 'city'
+});
+// $ExpectType Transfer
+const transfer = new AMap.Transfer({
+    city: 'city1',
+    policy: AMap.TransferPolicy.LEAST_TIME,
+    nightflag: true,
+    cityd: 'city2',
+    extensions: 'base',
+    map,
+    panel: 'panel',
+    hideMarkers: false,
+    isOutline: true,
+    outlineColor: 'green',
+    autoFitView: true
+});
+
+// $ExpectType void
+transfer.search(lnglat, lnglat);
+// $ExpectType void
+transfer.search(lnglatTuple, lnglatTuple);
+// $ExpectType void
+transfer.search(lnglat, lnglat, (status, result) => {
+    const temp: 'complete' | 'no_data' | 'error' = status;
+    if (typeof result !== 'string') {
+        // $ExpectType SearchResultBase
+        result;
+        // $ExpectType LngLat
+        result.destination;
+        // $ExpectType Poi | undefined
+        result.end;
+        if (result.end) {
+            const end = result.end;
+            // $ExpectType LngLat
+            end.location;
+            // $ExpectType string
+            end.name;
+            // $ExpectType "start" | "end"
+            end.type;
+        }
+        // $ExpectType string
+        result.info;
+        // $ExpectType LngLat
+        result.origin;
+        // $ExpectType TransferPlan[]
+        result.plans;
+        {
+            const plan = result.plans[0];
+            // $ExpectType number
+            plan.cost;
+            // $ExpectType number
+            plan.distance;
+            // $ExpectType boolean
+            plan.nightLine;
+            // $ExpectType LngLat[]
+            plan.path;
+            // $ExpectType number
+            plan.railway_distance;
+            // $ExpectType Segment[]
+            plan.segments;
+            const segments = plan.segments[0];
+            switch (segments.transit_mode) {
+                case 'WALK':
+                    // $ExpectType number
+                    segments.distance;
+                    // $ExpectType string
+                    segments.instruction;
+                    // $ExpectType number
+                    segments.time;
+                    // $ExpectType WalkDetails
+                    const walkDetails = segments.transit;
+                    {
+                        // $ExpectType LngLat
+                        walkDetails.destination;
+                        // $ExpectType LngLat
+                        walkDetails.origin;
+                        // $ExpectType LngLat[]
+                        walkDetails.path;
+                        // $ExpectType WalkStep[]
+                        walkDetails.steps;
+                        const walkStep = walkDetails.steps[0];
+                        if (walkStep) {
+                            // $ExpectType string
+                            walkStep.action;
+                            // $ExpectType string
+                            walkStep.assist_action;
+                            // $ExpectType number
+                            walkStep.distance;
+                            // $ExpectType string
+                            walkStep.instruction;
+                            // $ExpectType LngLat[]
+                            walkStep.path;
+                            // $ExpectType string
+                            walkStep.road;
+                            // $ExpectType number
+                            walkStep.time;
+                        }
+                    }
+                    // $ExpectType "WALK"
+                    segments.transit_mode;
+                    break;
+                case 'TAXI':
+                    // $ExpectType number
+                    segments.distance;
+                    // $ExpectType string
+                    segments.instruction;
+                    // $ExpectType number
+                    segments.time;
+                    // $ExpectType string
+                    segments.instruction;
+                    // $ExpectType TaxiDetails
+                    const taxiDetails = segments.transit;
+                    {
+                        // $ExpectType LngLat
+                        taxiDetails.destination;
+                        // $ExpectType number
+                        taxiDetails.distance;
+                        // $ExpectType LngLat
+                        taxiDetails.origin;
+                        // $ExpectType string
+                        taxiDetails.sname;
+                        // $ExpectType number
+                        taxiDetails.time;
+                        // $ExpectType string
+                        taxiDetails.tname;
+                    }
+                    // $ExpectType "TAXI"
+                    segments.transit_mode;
+                    break;
+                case 'RAILWAY':
+                    // $ExpectType number
+                    segments.distance;
+                    // $ExpectType string
+                    segments.instruction;
+                    // $ExpectType number
+                    segments.time;
+                    // $ExpectType RailwayDetails
+                    const railwayDetails = segments.transit;
+                    {
+                        // $ExpectType RailStop
+                        const arrivalStop = railwayDetails.arrival_stop;
+                        {
+                            // $ExpectType string
+                            arrivalStop.adcode;
+                            // $ExpectType string
+                            arrivalStop.id;
+                            // $ExpectType LngLat
+                            arrivalStop.location;
+                            // $ExpectType string
+                            arrivalStop.name;
+                            // $ExpectType RailwaySegment | undefined
+                            arrivalStop.segment;
+                            // $ExpectType number
+                            arrivalStop.time;
+                        }
+                        // $ExpectType RailStop
+                        railwayDetails.departure_stop;
+                        // $ExpectType number
+                        railwayDetails.distance;
+                        // $ExpectType string
+                        railwayDetails.id;
+                        // $ExpectType string
+                        railwayDetails.name;
+                        // $ExpectType Space[]
+                        railwayDetails.spaces;
+                        {
+                            const space = railwayDetails.spaces[0];
+                            // $ExpectType number
+                            space.cost;
+                            // $ExpectType string | never[]
+                            space.type;
+                        }
+                        // $ExpectType number
+                        railwayDetails.time;
+                        // $ExpectType string
+                        railwayDetails.trip;
+                        // $ExpectType string
+                        railwayDetails.type;
+
+                        if ('alters' in railwayDetails) {
+                            // $ExpectType Alter[]
+                            railwayDetails.alters;
+                            {
+                                const alter = railwayDetails.alters[0];
+                                // $ExpectType string
+                                alter.id;
+                                // $ExpectType string
+                                alter.name;
+                            }
+                            railwayDetails.alters;
+                            // $ExpectType number
+                            railwayDetails.via_num;
+                            // $ExpectType ViaStop[]
+                            railwayDetails.via_stops;
+                            {
+                                const viaStop = railwayDetails.via_stops[0];
+                                // $ExpectType string
+                                viaStop.id;
+                                // $ExpectType LngLat
+                                viaStop.location;
+                                // $ExpectType string
+                                viaStop.name;
+                                // $ExpectType number
+                                viaStop.time;
+                                // $ExpectType number
+                                viaStop.wait;
+                            }
+                        }
+                    }
+                    // $ExpectType "RAILWAY"
+                    segments.transit_mode;
+                    break;
+                case 'SUBWAY':
+                case 'METRO_RAIL':
+                case 'BUS':
+                    // $ExpectType number
+                    segments.distance;
+                    // $ExpectType string
+                    segments.instruction;
+                    // $ExpectType number
+                    segments.time;
+                    // $ExpectType TransitDetails
+                    const transitDetail = segments.transit;
+                    {
+                        // $ExpectType SubwayEntrance | undefined
+                        const exit = transitDetail.exit;
+                        if (exit) {
+                            // $ExpectType LngLat
+                            exit.location;
+                            // $ExpectType string
+                            exit.name;
+                        }
+                        // $ExpectType SubwayEntrance | undefined
+                        transitDetail.entrance;
+                        // $ExpectType TransitLine[]
+                        transitDetail.lines;
+                        {
+                            const line = transitDetail.lines[0];
+                            // $ExpectType string | never[]
+                            line.etime;
+                            // $ExpectType string
+                            line.id;
+                            // $ExpectType string
+                            line.name;
+                            // $ExpectType string | never[]
+                            line.stime;
+                            // $ExpectType string
+                            line.type;
+                        }
+                        // $ExpectType Stop
+                        const offStation = transitDetail.off_station;
+                        {
+                            // $ExpectType string
+                            offStation.id;
+                            // $ExpectType LngLat
+                            offStation.location;
+                            // $ExpectType string
+                            offStation.name;
+                            // $ExpectType TransitSegment | undefined
+                            offStation.segment;
+                        }
+                        // $ExpectType Stop
+                        transitDetail.on_station;
+                        // $ExpectType LngLat[]
+                        transitDetail.path;
+                        // $ExpectType number
+                        transitDetail.via_num;
+                        // $ExpectType Stop[]
+                        transitDetail.via_stops;
+                        {
+                            const viaStop = transitDetail.via_stops[0];
+                            // $ExpectType string
+                            viaStop.id;
+                            // $ExpectType LngLat
+                            viaStop.location;
+                            // $ExpectType string
+                            viaStop.name;
+                        }
+                    }
+                    // $ExpectType "SUBWAY" | "METRO_RAIL" | "BUS"
+                    segments.transit_mode;
+                    break;
+                default:
+                    // $ExpectType never
+                    segments;
+            }
+            // $ExpectType number
+            plan.taxi_distance;
+            // $ExpectType number
+            plan.time;
+            // $ExpectType number
+            plan.transit_distance;
+            // $ExpectType number
+            plan.walking_distance;
+        }
+        // $ExpectType Poi | undefined
+        result.start;
+        // $ExpectType number
+        result.taxi_cost;
+    } else {
+        // $ExpectType string
+        result;
+    }
+});
+
+// $ExpectType void
+transfer.search([{ keyword: 'origin' }, { keyword: 'destination' }], (status, result) => {
+    const temp: 'complete' | 'no_data' | 'error' = status;
+    if (typeof result !== 'string') {
+        // $ExpectType SearchResultExt
+        result;
+        // $ExpectType PoiExt
+        result.start;
+        // $ExpectType string
+        result.originName;
+        // $ExpectType PoiExt
+        result.end;
+        // $ExpectType string
+        result.destinationName;
+    } else {
+        // $ExpectType string
+        result;
+    }
+});
+
+transfer.on('complete', (event: AMap.Transfer.EventMap['complete']) => {
+    // $ExpectType "complete"
+    event.type;
+    if ('info' in event) {
+        // $ExpectType string
+        event.info;
+        // $ExpectType LngLat
+        event.origin;
+        // $ExpectType LngLat
+        event.destination;
+        // $ExpectType number
+        event.taxi_cost;
+        // $ExpectType TransferPlan[]
+        event.plans;
+    }
+    if ('originName' in event) {
+        // $ExpectType PoiExt
+        event.start;
+        // $ExpectType PoiExt
+        event.end;
+        // $ExpectType string
+        event.originName;
+        // $ExpectType string
+        event.destinationName;
+    } else {
+        // $ExpectType Poi | undefined
+        event.start;
+        // $ExpectType Poi | undefined
+        event.end;
+    }
+});
+
+transfer.on('error', (event: AMap.Transfer.EventMap['error']) => {
+    // $ExpectType "error"
+    event.type;
+    // $ExpectType string
+    event.info;
+});

--- a/types/amap-js-api-transfer/index.d.ts
+++ b/types/amap-js-api-transfer/index.d.ts
@@ -1,0 +1,609 @@
+// Type definitions for non-npm package amap-js-api-transfer 1.4
+// Project: https://lbs.amap.com/api/javascript-api/reference/route-search#m_AMap.Transfer
+// Definitions by: breeze9527 <https://github.com/breeze9527>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+/// <reference types="amap-js-api" />
+/// <reference types="amap-js-api-place-search" />
+
+declare namespace AMap {
+    enum TransferPolicy {
+        /**
+         * 最快捷模式
+         */
+        LEAST_TIME = 0,
+        /**
+         * 最经济模式
+         */
+        LEAST_FEE = 1,
+        /**
+         * 最少换乘模式
+         */
+        LEAST_TRANSFER = 2,
+        /**
+         * 最少步行模式
+         */
+        LEAST_WALK = 3,
+        /**
+         * 最舒适模式
+         */
+        MOST_COMFORT = 4,
+        /**
+         * 不乘地铁模式
+         */
+        NO_SUBWAY = 5
+    }
+
+    namespace Transfer {
+        interface EventMap {
+            error: Event<'error', { info: string }>;
+            complete: Event<'complete', SearchResult>;
+        }
+        interface Options {
+            /**
+             * 公交换乘的城市，支持城市名称、城市区号、电话区号，此项为必填
+             */
+            city: string;
+            /**
+             * 公交换乘策略
+             */
+            policy?: TransferPolicy;
+            /**
+             * 是否计算夜班车，默认为不计算
+             */
+            nightflag?: boolean;
+            /**
+             * 终点城市，跨城公交路径规划时为必填参数
+             */
+            cityd?: string;
+            /**
+             * 返回结果控制, 默认值: base
+             * base:返回基本信息
+             * all:返回全部信息
+             */
+            extensions?: 'all' | 'base';
+            /**
+             * AMap.Map对象, 展现结果的地图实例
+             */
+            map?: Map;
+            /**
+             * 结果列表的HTML容器id或容器元素
+             */
+            panel?: string;
+            /**
+             * 设置是否隐藏路径规划的起始点图标
+             */
+            hideMarkers?: boolean;
+            /**
+             * 使用map属性时，绘制的规划线路是否显示描边。默认为true
+             */
+            isOutline?: boolean;
+            /**
+             * 使用map属性时，绘制的规划线路的描边颜色。默认为'white'
+             */
+            outlineColor?: string;
+            /**
+             * 用于控制在路径规划结束后，是否自动调整地图视野使绘制的路线处于视口的可见范围
+             */
+            autoFitView?: boolean;
+
+            // internal
+            showDir?: boolean;
+        }
+        interface SearchPoint {
+            /**
+             * 关键词
+             */
+            keyword: string;
+        }
+        interface SegmentCommon {
+            /**
+             * 此换乘段预期用时，单位：秒
+             */
+            time: number;
+            /**
+             * 此换乘段的文字描述
+             */
+            instruction: string;
+            /**
+             * 此换乘段距离
+             */
+            distance: number;
+        }
+        interface WalkStep {
+            /**
+             * 步行子路段描述
+             */
+            instruction: string;
+            /**
+             * 道路
+             */
+            road: string;
+            /**
+             * 步行子路段距离，单位：米
+             */
+            distance: number;
+            /**
+             * 步行子路段预计使用时间，单位：秒
+             */
+            time: number;
+            /**
+             * 步行子路段坐标集合
+             */
+            path: LngLat[];
+            /**
+             * 本步行子路段完成后动作
+             */
+            action: string;
+            /**
+             * 步行子路段完成后辅助动作，一般为到达某个公交站点或目的地时返回
+             */
+            assist_action: string;
+        }
+        interface WalkDetails {
+            /**
+             * 此换乘段的步行起点
+             */
+            origin: LngLat;
+            /**
+             * 此换乘段的步行终点
+             */
+            destination: LngLat;
+            /**
+             * 此换乘段坐标集合
+             */
+            path: LngLat[];
+            /**
+             * 步行子路段WalkStep列表
+             */
+            steps: WalkStep[];
+        }
+        interface WalkSegment extends SegmentCommon {
+            /**
+             * 换乘动作类型
+             */
+            transit_mode: 'WALK';
+            /**
+             * 此换乘段导航信息
+             */
+            transit: WalkDetails;
+        }
+        interface TaxiDetails {
+            /**
+             * 耗时，单位：秒
+             */
+            time: number;
+            /**
+             * 该方案的总距离，单位：米
+             */
+            distance: number;
+            /**
+             * 打车起点坐标
+             */
+            origin: LngLat;
+            /**
+             * 打车终点坐标
+             */
+            destination: LngLat;
+            /**
+             * 起点名称
+             */
+            sname: string;
+            /**
+             * 终点名称
+             */
+            tname: string;
+        }
+        interface TaxiSegment extends SegmentCommon {
+            /**
+             * 换乘动作类型
+             */
+            transit_mode: 'TAXI';
+            /**
+             * 此换乘段导航信息
+             */
+            transit: TaxiDetails;
+        }
+        interface Stop {
+            /**
+             * 公交站点名称
+             */
+            name: string;
+            /**
+             * 公交站点ID
+             */
+            id: string;
+            /**
+             * 站点经纬度信息
+             */
+            location: LngLat;
+            segment?: TransitSegment;
+        }
+        interface TransitLine {
+            /**
+             * 公交路线名
+             */
+            name: string;
+            /**
+             * 公交路线ID
+             */
+            id: string;
+            /**
+             * 公交类型
+             */
+            type: string;
+            /**
+             * 公交路线首班车时间
+             */
+            stime: string | never[];
+            /**
+             * 公交路线末班车时间
+             */
+            etime: string | never[];
+        }
+        interface SubwayEntrance {
+            /**
+             * 地铁口名称
+             */
+            name: string;
+            /**
+             * 地铁口经纬度坐标
+             */
+            location: LngLat;
+        }
+        interface TransitDetails {
+            /**
+             * 此换乘段的上车站
+             */
+            on_station: Stop;
+            /**
+             * 此换乘段的下车站
+             */
+            off_station: Stop;
+            /**
+             * 此换乘段公交部分（上车站-下车站）坐标集合
+             */
+            path: LngLat[];
+            /**
+             * 途径公交站点数（不包括上车站和下车站）
+             */
+            via_num: number;
+            /**
+             * 途径公交站点集合（不包括上车站和下车站）
+             */
+            via_stops: Stop[];
+            /**
+             * 此换乘段公交路线
+             */
+            lines: TransitLine[];
+            /**
+             * 地铁站入口
+             */
+            entrance?: SubwayEntrance;
+            /**
+             * 地铁站出口
+             */
+            exit?: SubwayEntrance;
+        }
+        interface TransitSegment extends SegmentCommon {
+            /**
+             * 换乘动作类型
+             */
+            transit_mode: 'SUBWAY' | 'METRO_RAIL' | 'BUS';
+            /**
+             * 此换乘段导航信息
+             */
+            transit: TransitDetails;
+        }
+        interface RailStop {
+            /**
+             * 上、下车站点所在城市的adcode
+             */
+            adcode: string;
+            /**
+             * 上、下车站点ID
+             */
+            id: string;
+            /**
+             * 上、下站点经纬度信息
+             */
+            location: LngLat;
+            /**
+             * 上、下车站点名称
+             */
+            name: string;
+            /**
+             * 上下车点发车时间
+             */
+            time: number;
+            wait?: number;
+            segment?: RailwaySegment;
+        }
+        interface Space {
+            /**
+             * 仓位编码，参考仓位级别表
+             */
+            type: string | never[];
+            /**
+             * 仓位费用
+             */
+            cost: number;
+        }
+        interface RailwayDetailsBase {
+            /**
+             * 线路id编码
+             */
+            id: string;
+            /**
+             * 线路名称
+             */
+            name: string;
+            /**
+             * 线路车次号
+             */
+            trip: string;
+            /**
+             * 线路车次类型，参考火车路线类型列表
+             */
+            type: string;
+            /**
+             * 该换乘段的行车总距离
+             */
+            distance: number;
+            /**
+             * 该线路车段耗时
+             */
+            time: number;
+            /**
+             * 火车始发站信息
+             */
+            departure_stop: RailStop;
+            /**
+             * 火车到站信息
+             */
+            arrival_stop: RailStop;
+            /**
+             * 仓位及价格信息
+             */
+            spaces: Space[];
+        }
+        interface Alter {
+            /**
+             * 备选方案ID
+             */
+            id: string;
+            /**
+             * 备选线路名称
+             */
+            name: string;
+        }
+        interface ViaStop {
+            /**
+             * 途径车站点ID
+             */
+            id: string;
+            /**
+             * 站点经纬度信息
+             */
+            location: LngLat;
+            /**
+             * 途径车站点名称
+             */
+            name: string;
+            /**
+             * 途径站点的进站时间，如大于24:00,则表示跨天
+             */
+            time: number;
+            /**
+             * 途径站点的停靠时间，单位：分钟
+             */
+            wait: number;
+        }
+        interface RailwayDetailsExt extends RailwayDetailsBase {
+            /**
+             * 途经站点信息
+             */
+            via_stops: ViaStop[];
+            /**
+             * 途经站点数量
+             */
+            via_num: number;
+            /**
+             * 聚合的备选方案
+             */
+            alters: Alter[];
+        }
+        type RailwayDetails = RailwayDetailsBase | RailwayDetailsExt;
+        interface RailwaySegment extends SegmentCommon {
+            /**
+             * 换乘动作类型
+             */
+            transit_mode: 'RAILWAY';
+            /**
+             * 此换乘段导航信息
+             */
+            transit: RailwayDetails;
+        }
+        type Segment = WalkSegment | TaxiSegment | TransitSegment | RailwaySegment;
+        interface TransferPlan {
+            /**
+             * 此换乘方案价格，单位：元
+             */
+            cost: number;
+            /**
+             * 预期时间，单位：秒
+             */
+            time: number;
+            /**
+             * 是否夜间线路
+             */
+            nightLine: boolean;
+            /**
+             * 换乘路段列表，以每次换乘动结束作为分段点，将整个换乘方案分隔成若干 Segment（换乘路段）
+             */
+            segments: Segment[];
+            /**
+             * 此方案公交行驶距离，单位：米
+             */
+            transit_distance: number;
+            /**
+             * 此方案火车行驶距离，单位：米
+             */
+            railway_distance: number;
+            /**
+             * 此方案总步行距离，单位：米
+             */
+            walking_distance: number;
+            /**
+             * 此方案出租车行驶距离，单位：米
+             */
+            taxi_distance: number;
+            /**
+             * 此换乘方案全程距离，单位：米
+             */
+            distance: number;
+            /**
+             * 此换乘方案的路径坐标集合
+             */
+            path: LngLat[];
+        }
+        interface Poi {
+            location: LngLat;
+            name: string;
+            type: 'start' | 'end';
+        }
+        interface SearchResultCommon {
+            /**
+             * 成功状态说明
+             */
+            info: string;
+            /**
+             * 公交换乘起点坐标
+             */
+            origin: LngLat;
+            /**
+             * 公交换乘终点坐标
+             */
+            destination: LngLat;
+            /**
+             * 出租车费用，单位：元
+             */
+            taxi_cost: number;
+            /**
+             * 换乘方案列表
+             */
+            plans: TransferPlan[];
+        }
+        interface SearchResultBase extends SearchResultCommon {
+            /**
+             * 公交换乘起点
+             */
+            start?: Poi;
+            /**
+             * 公交换乘终点
+             */
+            end?: Poi;
+        }
+        interface SearchResultExt extends SearchResultCommon {
+            /**
+             * 公交换乘起点
+             */
+            start: PlaceSearch.PoiExt;
+            /**
+             * 公交换乘终点
+             */
+            end: PlaceSearch.PoiExt;
+            /**
+             * 公交换乘起点名称
+             */
+            originName: string;
+            /**
+             * 公交换乘终点名称
+             */
+            destinationName: string;
+        }
+
+        type SearchResult = SearchResultBase | SearchResultExt;
+        type SearchStatus = 'complete' | 'error' | 'no_data';
+    }
+
+    class Transfer extends EventEmitter {
+        /**
+         * 公交换乘服务
+         * @param options 构造函数选项
+         */
+        constructor(options: Transfer.Options);
+        /**
+         * 根据起点和终点坐标，进行公交换乘查询
+         * @param origin 起点坐标
+         * @param destination 终点坐标
+         * @param callback 查询回调
+         */
+        search(
+            origin: LocationValue,
+            destination: LocationValue,
+            callback?: (status: Transfer.SearchStatus, result: string | Transfer.SearchResultBase) => void
+        ): void;
+        /**
+         * 根据起点和终点坐标，进行公交换乘查询
+         * @param path 路径名称关键字
+         * @param callback 路径回调
+         */
+        search(
+            path: [Transfer.SearchPoint, Transfer.SearchPoint],
+            callback?: (status: Transfer.SearchStatus, result: string | Transfer.SearchResultExt) => void
+        ): void;
+        /**
+         * 设置公交换乘策略
+         * @param policy 公交换乘策略
+         */
+        setPolicy(policy?: TransferPolicy): void;
+        /**
+         * 设置公交换乘查询的城市
+         * @param city  城市名称、城市区号、电话区号
+         */
+        setCity(city?: string): void;
+        /**
+         * 设置公交换乘查询的城市
+         * @param city  城市名称、城市区号、电话区号
+         */
+        setCityd(city?: string): void;
+        /**
+         * 设置公交路径规划出发时间
+         * @param time 时间
+         * @param date 日期
+         */
+        leaveAt(time?: string, date?: string): void;
+        /**
+         * 清除结果显示
+         */
+        clear(): void;
+        /**
+         * 唤起高德地图客户端公交路径规划
+         * @param obj 唤起参数
+         */
+        searchOnAMAP(obj: {
+            /**
+             * 起点坐标
+             */
+            origin: LocationValue,
+            /**
+             * 起点名称
+             */
+            originName?: string,
+            /**
+             * 终点坐标
+             */
+            destination: LocationValue,
+            /**
+             * 终点名称
+             */
+            destinationName?: string
+        }): void;
+
+        // internal
+        open(): void;
+        close(): void;
+    }
+}

--- a/types/amap-js-api-transfer/tsconfig.json
+++ b/types/amap-js-api-transfer/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "amap-js-api-transfer-tests.ts"
+    ]
+}

--- a/types/amap-js-api-transfer/tslint.json
+++ b/types/amap-js-api-transfer/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
