### PR TITLE
[duo_web_sdk] Add new typing for duo_web_sdk

### DIFF
--- a/types/duo_web_sdk/duo_web_sdk-tests.ts
+++ b/types/duo_web_sdk/duo_web_sdk-tests.ts
@@ -17,4 +17,5 @@ Duo.init({
 
 Duo._onReady(() => {});
 Duo._parseSigRequest("sig");
-Duo._isDuoMessageEvent(new MessageEvent("event"));
+Duo._isDuoMessage(new MessageEvent("event"));
+Duo._doPostBack("response");

--- a/types/duo_web_sdk/duo_web_sdk-tests.ts
+++ b/types/duo_web_sdk/duo_web_sdk-tests.ts
@@ -1,0 +1,20 @@
+import * as Duo from "duo_web_sdk";
+
+Duo.init({
+    host: "http://example.com",
+    sig_request: "sig_request",
+    iframe: "iframe_id",
+    iframeContainer: "container_id",
+    iframeAttributes: {
+      title: "title",
+      height: "200px",
+      width: "200px",
+    },
+    post_action: "/post_destination",
+    post_argument: "post_argument",
+    submit_callback: (duo_form: HTMLFormElement) => duo_form,
+});
+
+Duo._onReady(() => {});
+Duo._parseSigRequest("sig");
+Duo._isDuoMessageEvent(new MessageEvent("event"));

--- a/types/duo_web_sdk/index.d.ts
+++ b/types/duo_web_sdk/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for non-npm package duo_web_sdk-browser 2.7
+// Project: https://github.com/duosecurity/duo_web_sdk
+// Definitions by: Low Heok Hong <https://github.com/lhhong>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace Duo;
+
+export interface InitOptions {
+    host: string;
+    sig_request: string;
+    iframe?: string | HTMLIFrameElement;
+    iframeContainer?: string | HTMLElement;
+    iframeAttributes?: object;
+    post_action?: string;
+    post_argument?: string;
+    submit_callback?: (duo_form: HTMLFormElement) => void;
+}
+
+export interface ParsedSig {
+    sigRequest: string;
+    duoSig: string;
+    appSig: string;
+}
+
+export function init(options: InitOptions): void;
+
+export function _onReady(callback: () => void): void;
+export function _parseSigRequest(sig: string): ParsedSig;
+export function _isDuoMessageEvent(event: MessageEvent): boolean;

--- a/types/duo_web_sdk/index.d.ts
+++ b/types/duo_web_sdk/index.d.ts
@@ -26,4 +26,5 @@ export function init(options: InitOptions): void;
 
 export function _onReady(callback: () => void): void;
 export function _parseSigRequest(sig: string): ParsedSig;
-export function _isDuoMessageEvent(event: MessageEvent): boolean;
+export function _isDuoMessage(event: MessageEvent): boolean;
+export function _doPostBack(response: string): void;

--- a/types/duo_web_sdk/tsconfig.json
+++ b/types/duo_web_sdk/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "duo_web_sdk-tests.ts"
+    ]
+}

--- a/types/duo_web_sdk/tslint.json
+++ b/types/duo_web_sdk/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
