### PR TITLE
[contentstack] Add ContentStack type definitions for 3.8.1

### DIFF
--- a/types/contentstack/contentstack-tests.ts
+++ b/types/contentstack/contentstack-tests.ts
@@ -1,5 +1,6 @@
 import contentstack = require('contentstack');
 
+contentstack.Stack({ api_key: '', access_token: '', environment: ''});
 const stack = contentstack.Stack('api_key', 'access_token', 'environment_name');
 stack.ContentType('content_type');
 

--- a/types/contentstack/contentstack-tests.ts
+++ b/types/contentstack/contentstack-tests.ts
@@ -1,0 +1,168 @@
+import contentstack = require('contentstack');
+
+const stack = contentstack.Stack('api_key', 'access_token', 'environment_name');
+stack.ContentType('content_type');
+
+const query = stack.ContentType('content_type').Query();
+stack
+    .ContentType('content_type')
+    .Query()
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .setCacheProvider({})
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .setCachePolicy(1)
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .language('en-US')
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .addQuery('query', 'foo')
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .includeReference('query')
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .includeReference('query', 'foo')
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .includeReference(['query'])
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .includeReference(['query', 'foo'])
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .includeReferenceContentTypeUID()
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .includeSchema()
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .includeContentType()
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .includeOwner()
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .toJSON()
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .addParam('key', 'value')
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .fetch();
+stack
+    .ContentType('content_type')
+    .Query()
+    .equalTo('key', 'value')
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .where('key', 'value')
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .count()
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .referenceIn('key', query)
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .referenceNotIn('key', query)
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .tags(['some', 'tag'])
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .includeCount()
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .getQuery()
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .regex('key', 'value', 'options')
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .search('search_value')
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .findOne();
+stack
+    .ContentType('content_type')
+    .Query()
+    .greaterThan('key', 'value')
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .greaterThanOrEqualTo('key', 'value')
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .lessThan('key', 'value')
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .lessThanOrEqualTo('key', 'value')
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .notEqualTo('key', 'value')
+    .find();
+stack
+    .ContentType('content_type')
+    .Query()
+    .containedIn('key', 'value')
+    .find();

--- a/types/contentstack/index.d.ts
+++ b/types/contentstack/index.d.ts
@@ -1,0 +1,75 @@
+// Type definitions for contentstack 3.8
+// Project: https://github.com/contentstack/contentstack-javascript
+// Definitions by: Dominic Wroblewski <https://github.com/domness>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.6
+
+export function Stack(api_key: string, access_token: string, environment_name: string): Stack;
+
+export class Stack {
+    constructor(api_key: string, access_token: string, environment_name: string);
+
+    ContentType(uid: string): ContentType;
+}
+
+export class ContentType {
+    constructor();
+
+    Query(): Query;
+}
+
+export class Entry {
+    constructor();
+
+    setCacheProvider(provider: object): Entry;
+    setCachePolicy(policy: number): Entry;
+    includeReference(val: string[]): Entry;
+    includeReference(...val: string[]): Entry;
+    language(language_code: string): Entry;
+    addQuery(key: string, value: string): Entry;
+    includeSchema(): Entry;
+    includeReferenceContentTypeUID(): Entry;
+    includeContentType(): Entry;
+    includeOwner(): Entry;
+    toJSON(): Entry;
+    addParam(key: string, value: any): Entry;
+    fetch(): Promise<any>;
+}
+
+export class Query extends Entry {
+    constructor();
+
+    setCacheProvider(provider: object): Query;
+    setCachePolicy(policy: number): Query;
+    language(language_code: string): Query;
+    addQuery(key: string, value: string): Query;
+    includeReference(val: string[]): Query;
+    includeReference(...val: string[]): Query;
+    includeReferenceContentTypeUID(): Query;
+    includeSchema(): Query;
+    includeContentType(): Query;
+    includeOwner(): Query;
+    toJSON(): Query;
+    addParam(key: string, value: any): Query;
+    fetch(): Promise<any>;
+
+    equalTo(key: string, value: any): Query;
+    where(key: string, value: any): Query;
+    count(): Query;
+    query(query: any): Query;
+    referenceIn(key: string, query: Query): Query;
+    referenceNotIn(key: string, query: Query): Query;
+    tags(value: any[]): Query;
+    includeCount(): Query;
+    getQuery(): Query;
+    regex(key: string, value: any, options: string): Query;
+    search(value: string): Query;
+    find(): Promise<any>;
+    findOne(): Promise<any>;
+    greaterThan(key: string, value: any): Query;
+    greaterThanOrEqualTo(key: string, value: any): Query;
+    lessThan(key: string, value: any): Query;
+    lessThanOrEqualTo(key: string, value: any): Query;
+    notEqualTo(key: string, value: any): Query;
+    containedIn(key: string, value: any): Query;
+}

--- a/types/contentstack/index.d.ts
+++ b/types/contentstack/index.d.ts
@@ -5,8 +5,16 @@
 // TypeScript Version: 3.6
 
 export function Stack(api_key: string, access_token: string, environment_name: string): Stack;
+export function Stack(config: Config): Stack;
+
+export interface Config {
+    api_key: string;
+    access_token: string;
+    environment: string;
+}
 
 export class Stack {
+    constructor(config: Config);
     constructor(api_key: string, access_token: string, environment_name: string);
 
     ContentType(uid: string): ContentType;

--- a/types/contentstack/tsconfig.json
+++ b/types/contentstack/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "contentstack-tests.ts"
+    ]
+}

--- a/types/contentstack/tslint.json
+++ b/types/contentstack/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adds type definitions for ContentStack


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
