### PR TITLE
yup: Revert "required is not nullable (#41789)"

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -93,7 +93,7 @@ export interface MixedSchema<T = any> extends Schema<T> {
     nullable(isNullable?: true): MixedSchema<T | null>;
     nullable(isNullable: false): MixedSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): MixedSchema<T>;
-    required(message?: TestOptionsMessage): MixedSchema<Exclude<T, null | undefined>>;
+    required(message?: TestOptionsMessage): MixedSchema<Exclude<T, undefined>>;
     notRequired(): MixedSchema<T | undefined>;
     concat(schema: this): this;
     concat<U>(schema: MixedSchema<U>): MixedSchema<T | U>;
@@ -123,7 +123,7 @@ export interface StringSchema<T extends string | null | undefined = string> exte
     nullable(isNullable?: true): StringSchema<T | null>;
     nullable(isNullable: false): StringSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): StringSchema<T>;
-    required(message?: TestOptionsMessage): StringSchema<Exclude<T, null | undefined>>;
+    required(message?: TestOptionsMessage): StringSchema<Exclude<T, undefined>>;
     notRequired(): StringSchema<T | undefined>;
 }
 
@@ -145,7 +145,7 @@ export interface NumberSchema<T extends number | null | undefined = number> exte
     nullable(isNullable?: true): NumberSchema<T | null>;
     nullable(isNullable: false): NumberSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): NumberSchema<T>;
-    required(message?: TestOptionsMessage): NumberSchema<Exclude<T, null | undefined>>;
+    required(message?: TestOptionsMessage): NumberSchema<Exclude<T, undefined>>;
     notRequired(): NumberSchema<T | undefined>;
 }
 
@@ -158,7 +158,7 @@ export interface BooleanSchema<T extends boolean | null | undefined = boolean> e
     nullable(isNullable?: true): BooleanSchema<T | null>;
     nullable(isNullable: false): BooleanSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): BooleanSchema<T>;
-    required(message?: TestOptionsMessage): BooleanSchema<Exclude<T, null | undefined>>;
+    required(message?: TestOptionsMessage): BooleanSchema<Exclude<T, undefined>>;
     notRequired(): BooleanSchema<T | undefined>;
 }
 
@@ -173,7 +173,7 @@ export interface DateSchema<T extends Date | null | undefined = Date> extends Sc
     nullable(isNullable?: true): DateSchema<T | null>;
     nullable(isNullable: false): DateSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): DateSchema<T>;
-    required(message?: TestOptionsMessage): DateSchema<Exclude<T, null | undefined>>;
+    required(message?: TestOptionsMessage): DateSchema<Exclude<T, undefined>>;
     notRequired(): DateSchema<T | undefined>;
 }
 
@@ -258,7 +258,7 @@ export interface ObjectSchema<T extends object | null | undefined = object> exte
     nullable(isNullable?: true): ObjectSchema<T | null>;
     nullable(isNullable: false): ObjectSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): ObjectSchema<T>;
-    required(message?: TestOptionsMessage): ObjectSchema<Exclude<T, null | undefined>>;
+    required(message?: TestOptionsMessage): ObjectSchema<Exclude<T, undefined>>;
     notRequired(): ObjectSchema<T | undefined>;
     concat(schema: this): this;
     concat<U extends object>(schema: ObjectSchema<U>): ObjectSchema<T & U>;
@@ -291,7 +291,7 @@ export interface TestContext {
     parent: any;
     schema: Schema<any>;
     resolve: (value: any) => any;
-    createError: (params?: { path?: string; message?: string; params?: object }) => ValidationError;
+    createError: (params?: { path?: string; message?: string, params?: object }) => ValidationError;
 }
 
 export interface ValidateOptions {

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -636,7 +636,8 @@ const definitionBC: yup.ObjectSchemaDefinition<BC> = {
 };
 const combinedSchema = yup.object(definitionAB).shape(definitionBC); // $ExpectType ObjectSchema<Shape<AB, BC>>
 
-const schemaWithoutNumberField = {
+// $ExpectError
+yup.object<MyInterface>({
     stringField: yup.string().required(),
     subFields: yup
         .object({
@@ -644,13 +645,10 @@ const schemaWithoutNumberField = {
         })
         .required(),
     arrayField: yup.array(yup.string()).required(),
-};
+});
 
 // $ExpectError
-yup.object<MyInterface>(schemaWithoutNumberField);
-
-const schemaWithWrongType = {
-    stringField: yup.number().required(),
+yup.object<MyInterface>({ stringField: yup.number().required(),
     numberField: yup.number().required(),
     subFields: yup
         .object({
@@ -658,22 +656,17 @@ const schemaWithWrongType = {
         })
         .required(),
     arrayField: yup.array(yup.string()).required(),
-};
+});
 
 // $ExpectError
-yup.object<MyInterface>(schemaWithWrongType);
-
-const schemaWithoutSubtype = {
+yup.object<MyInterface>({
     stringField: yup.string().required(),
     numberField: yup.number().required(),
     arrayField: yup.array(yup.string()).required(),
-};
+});
 
 // $ExpectError
-yup.object<MyInterface>(schemaWithoutSubtype);
-
-const schemaWithWrongSubtype = {
-    subFields: yup
+yup.object<MyInterface>({ subFields: yup
         .object({
             testField: yup.number().required(),
         })
@@ -681,10 +674,7 @@ const schemaWithWrongSubtype = {
     stringField: yup.string().required(),
     numberField: yup.number().required(),
     arrayField: yup.array(yup.string()).required(),
-};
-
-// $ExpectError
-yup.object<MyInterface>(schemaWithWrongSubtype);
+});
 
 enum Gender {
     Male = 'Male',
@@ -704,13 +694,7 @@ const personSchema = yup.object({
         .nullable()
         .notRequired()
         .min(new Date(1900, 0, 1)),
-    // $ExpectType StringSchema<string | null>
-    canBeNull: yup.string().nullable(true),
-    // $ExpectType StringSchema<string>
-    requiredNullable: yup
-        .string()
-        .nullable()
-        .required(),
+    canBeNull: yup.string().nullable(true), // $ExpectType StringSchema<string | null>
     isAlive: yup
         .boolean()
         .nullable()
@@ -736,7 +720,6 @@ type Person = yup.InferType<typeof personSchema>;
 //     email?: string | null | undefined;
 //     birthDate?: Date | null | undefined;
 //     canBeNull: string | null;
-//     requiredNullable: string;
 //     isAlive: boolean | null | undefined;
 //     mustBeAString: string;
 //     children?: string[] | null | undefined;
@@ -746,7 +729,6 @@ const minimalPerson: Person = {
     firstName: '',
     gender: Gender.Female,
     canBeNull: null,
-    requiredNullable: '',
     mustBeAString: '',
 };
 
@@ -756,7 +738,6 @@ const person: Person = {
     email: null,
     birthDate: null,
     canBeNull: null,
-    requiredNullable: '',
     isAlive: null,
     mustBeAString: '',
     children: null,


### PR DESCRIPTION
This reverts commit 0a32b87d146dc3efe1ef47e82e0b02bf89248b5a.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41789

```ts
const validationSchema = Yup.object().shape({
  title: Yup.string()
    .nullable()
    .required('Title is required')
});

type ValidationSchema = InferType<typeof validationSchema>;
```

If `ValidationSchema` is supposed to reflect the type of the schema, then `string | null` is correct. An object described by the schema, can certainly have a null value. The schema will say that it is invalid, but it's a perfectly valid value from a typing perspective.

If you wanted the type of the field to be `string` then define it as `Yup.string().required()`.

See comments on original MR for additional reasons why this causes issues.