### PR TITLE
[iobroker] objects and states in the cache may be undefined

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ioBroker/ioBroker, http://iobroker.net
 // Definitions by: AlCalzone <https://github.com/AlCalzone>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.2
+// TypeScript Version: 3.6
 
 // Note: This is not the definition for the package `iobroker`,
 // which is just an installer, not a library.
@@ -501,13 +501,13 @@ declare global {
              *
              * NOTE: This is only defined if the adapter was initialized with the option `objects: true`.
              */
-            oObjects?: Record<string, ioBroker.Object>;
+            oObjects?: Record<string, ioBroker.Object | undefined>;
             /**
              * Contains a live cache of the adapter's states.
              *
              * NOTE: This is only defined if the adapter was initialized with the option `states: true`.
              */
-            oStates?: Record<string, State>;
+            oStates?: Record<string, ioBroker.State | undefined>;
 
             /*	===============================
                 Functions defined in adapter.js

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -306,8 +306,8 @@ adapter.states.getStates();
 // $ExpectError
 adapter.objects.getObjectView();
 
-adapter.oObjects && adapter.oObjects["foo"]._id.toString();
-adapter.oStates && adapter.oStates["foo"].val;
+adapter.oObjects && adapter.oObjects["foo"] && adapter.oObjects["foo"]._id.toString();
+adapter.oStates && adapter.oStates["foo"] && adapter.oStates["foo"].val;
 
 // Repro from https://github.com/ioBroker/adapter-core/issues/3
 const repro1: ioBroker.ObjectChangeHandler = (id, obj) => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


#41753 added the definitions for the cache but missed the fact that not every object or state must be in there. This PR fixes that mistake.