### PR TITLE
[@pollyjs] Add missing adapter and persister packages

### DIFF
--- a/types/pollyjs__adapter-puppeteer/index.d.ts
+++ b/types/pollyjs__adapter-puppeteer/index.d.ts
@@ -6,4 +6,6 @@
 
 import Adapter from '@pollyjs/adapter';
 
-export default class PuppeteerAdapter extends Adapter {}
+declare class PuppeteerAdapter extends Adapter {}
+
+export = PuppeteerAdapter;

--- a/types/pollyjs__adapter-puppeteer/index.d.ts
+++ b/types/pollyjs__adapter-puppeteer/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for @pollyjs/adapter-puppeteer 4.0
+// Project: https://github.com/netflix/pollyjs/tree/master/packages/@pollyjs/adapter-puppeteer
+// Definitions by: offirgolan <https://github.com/offirgolan>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import Adapter from '@pollyjs/adapter';
+
+export default class PuppeteerAdapter extends Adapter {}

--- a/types/pollyjs__adapter-puppeteer/pollyjs__adapter-puppeteer-tests.ts
+++ b/types/pollyjs__adapter-puppeteer/pollyjs__adapter-puppeteer-tests.ts
@@ -1,0 +1,8 @@
+import PuppeteerAdapter from '@pollyjs/adapter-puppeteer';
+import { Polly } from '@pollyjs/core';
+
+Polly.register(PuppeteerAdapter);
+
+new Polly('<recording>', {
+    adapters: ['puppeteer', PuppeteerAdapter],
+});

--- a/types/pollyjs__adapter-puppeteer/tsconfig.json
+++ b/types/pollyjs__adapter-puppeteer/tsconfig.json
@@ -1,0 +1,40 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": [
+			"es6"
+		],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictNullChecks": true,
+		"strictFunctionTypes": true,
+		"baseUrl": "../",
+		"typeRoots": [
+			"../"
+		],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true,
+		"paths": {
+			"@pollyjs/core": [
+				"pollyjs__core"
+			],
+			"@pollyjs/adapter": [
+				"pollyjs__adapter"
+			],
+			"@pollyjs/adapter-puppeteer": [
+				"pollyjs__adapter-puppeteer"
+			],
+			"@pollyjs/persister": [
+				"pollyjs__persister"
+			],
+			"@pollyjs/utils": [
+				"pollyjs__utils"
+			]
+		}
+	},
+	"files": [
+		"index.d.ts",
+		"pollyjs__adapter-puppeteer-tests.ts"
+	]
+}

--- a/types/pollyjs__adapter-puppeteer/tsconfig.json
+++ b/types/pollyjs__adapter-puppeteer/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": [
 			"es6"
 		],
+		"esModuleInterop": true,
 		"noImplicitAny": true,
 		"noImplicitThis": true,
 		"strictNullChecks": true,

--- a/types/pollyjs__adapter-puppeteer/tslint.json
+++ b/types/pollyjs__adapter-puppeteer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pollyjs__persister-local-storage/index.d.ts
+++ b/types/pollyjs__persister-local-storage/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for @pollyjs/persister-local-storage 4.0
+// Project: https://github.com/netflix/pollyjs/tree/master/packages/@pollyjs/persister-local-storage
+// Definitions by: offirgolan <https://github.com/offirgolan>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import Persister from '@pollyjs/persister';
+
+export default class LocalStoragePersister extends Persister {}

--- a/types/pollyjs__persister-local-storage/index.d.ts
+++ b/types/pollyjs__persister-local-storage/index.d.ts
@@ -6,4 +6,6 @@
 
 import Persister from '@pollyjs/persister';
 
-export default class LocalStoragePersister extends Persister {}
+declare class LocalStoragePersister extends Persister {}
+
+export = LocalStoragePersister;

--- a/types/pollyjs__persister-local-storage/pollyjs__persister-local-storage-tests.ts
+++ b/types/pollyjs__persister-local-storage/pollyjs__persister-local-storage-tests.ts
@@ -1,0 +1,8 @@
+import LocalStoragePersister from '@pollyjs/persister-local-storage';
+import { Polly } from '@pollyjs/core';
+
+Polly.register(LocalStoragePersister);
+
+new Polly('<recording>', {
+    persister: LocalStoragePersister,
+});

--- a/types/pollyjs__persister-local-storage/tsconfig.json
+++ b/types/pollyjs__persister-local-storage/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": [
             "es6"
         ],
+        "esModuleInterop": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,

--- a/types/pollyjs__persister-local-storage/tsconfig.json
+++ b/types/pollyjs__persister-local-storage/tsconfig.json
@@ -1,0 +1,41 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@pollyjs/persister": [
+                "pollyjs__persister"
+            ],
+            "@pollyjs/persister-local-storage": [
+                "pollyjs__persister-local-storage"
+            ],
+            "@pollyjs/core": [
+                "pollyjs__core"
+            ],
+            "@pollyjs/utils": [
+                "pollyjs__utils"
+            ],
+            "@pollyjs/adapter": [
+                "pollyjs__adapter"
+            ]
+        }
+
+    },
+    "files": [
+        "index.d.ts",
+        "pollyjs__persister-local-storage-tests.ts"
+    ]
+}

--- a/types/pollyjs__persister-local-storage/tslint.json
+++ b/types/pollyjs__persister-local-storage/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pollyjs__persister-rest/index.d.ts
+++ b/types/pollyjs__persister-rest/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for @pollyjs/persister-rest 4.0
+// Project: https://github.com/netflix/pollyjs/tree/master/packages/@pollyjs/persister-rest
+// Definitions by: offirgolan <https://github.com/offirgolan>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import Persister from '@pollyjs/persister';
+
+export default class RESTPersister extends Persister {}

--- a/types/pollyjs__persister-rest/index.d.ts
+++ b/types/pollyjs__persister-rest/index.d.ts
@@ -6,4 +6,6 @@
 
 import Persister from '@pollyjs/persister';
 
-export default class RESTPersister extends Persister {}
+declare class RESTPersister extends Persister {}
+
+export = RESTPersister;

--- a/types/pollyjs__persister-rest/pollyjs__persister-rest-tests.ts
+++ b/types/pollyjs__persister-rest/pollyjs__persister-rest-tests.ts
@@ -1,0 +1,8 @@
+import RESTPersister from '@pollyjs/persister-rest';
+import { Polly } from '@pollyjs/core';
+
+Polly.register(RESTPersister);
+
+new Polly('<recording>', {
+    persister: RESTPersister,
+});

--- a/types/pollyjs__persister-rest/tsconfig.json
+++ b/types/pollyjs__persister-rest/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": [
             "es6"
         ],
+        "esModuleInterop": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,

--- a/types/pollyjs__persister-rest/tsconfig.json
+++ b/types/pollyjs__persister-rest/tsconfig.json
@@ -1,0 +1,41 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@pollyjs/persister": [
+                "pollyjs__persister"
+            ],
+            "@pollyjs/persister-rest": [
+                "pollyjs__persister-rest"
+            ],
+            "@pollyjs/core": [
+                "pollyjs__core"
+            ],
+            "@pollyjs/utils": [
+                "pollyjs__utils"
+            ],
+            "@pollyjs/adapter": [
+                "pollyjs__adapter"
+            ]
+        }
+
+    },
+    "files": [
+        "index.d.ts",
+        "pollyjs__persister-rest-tests.ts"
+    ]
+}

--- a/types/pollyjs__persister-rest/tslint.json
+++ b/types/pollyjs__persister-rest/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.