### PR TITLE
chore: use pretty-format types directly in jest typings

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -526,49 +526,7 @@ declare namespace jest {
         message: () => string;
     }
 
-    interface SnapshotSerializerOptions {
-        callToJSON?: boolean;
-        edgeSpacing?: string;
-        spacing?: string;
-        escapeRegex?: boolean;
-        highlight?: boolean;
-        indent?: number;
-        maxDepth?: number;
-        min?: boolean;
-        plugins?: SnapshotSerializerPlugin[];
-        printFunctionName?: boolean;
-        theme?: SnapshotSerializerOptionsTheme;
-
-        // see https://github.com/facebook/jest/blob/e56103cf142d2e87542ddfb6bd892bcee262c0e6/types/PrettyFormat.js
-    }
-    interface SnapshotSerializerOptionsTheme {
-        comment?: string;
-        content?: string;
-        prop?: string;
-        tag?: string;
-        value?: string;
-    }
-    interface SnapshotSerializerColor {
-        close: string;
-        open: string;
-    }
-    interface SnapshotSerializerColors {
-        comment: SnapshotSerializerColor;
-        content: SnapshotSerializerColor;
-        prop: SnapshotSerializerColor;
-        tag: SnapshotSerializerColor;
-        value: SnapshotSerializerColor;
-    }
-    interface SnapshotSerializerPlugin {
-        print(
-            val: any,
-            serialize: (val: any) => string,
-            indent: (str: string) => string,
-            opts: SnapshotSerializerOptions,
-            colors: SnapshotSerializerColors
-        ): string;
-        test(val: any): boolean;
-    }
+    type SnapshotSerializerPlugin = import('pretty-format').Plugin;
 
     interface InverseAsymmetricMatchers {
         /**

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -622,64 +622,57 @@ expect.addSnapshotSerializer({
 });
 
 expect.addSnapshotSerializer({
-    print(value, serialize, indent, opts, colors) {
+    serialize(value, config, indentation, depth, refs, printer) {
         let result = '';
 
-        if (opts.callToJSON !== undefined && opts.callToJSON) {
+        if (config.callToJSON !== undefined && config.callToJSON) {
             result += ' ';
         }
 
-        result += opts.edgeSpacing;
-        result += opts.spacing;
+        result += config.spacingInner;
+        result += config.spacingOuter;
 
-        if (opts.escapeRegex !== undefined && opts.escapeRegex) {
+        if (config.escapeRegex !== undefined && config.escapeRegex) {
             result += ' ';
         }
 
-        if (opts.indent !== undefined) {
-            for (let i = 0; i < opts.indent; i += 1) {
-                result += '\t';
-            }
+        if (indentation !== undefined) {
+            result += indentation;
         }
 
-        if (opts.maxDepth !== undefined) {
-            result = result.substring(0, opts.maxDepth);
+        if (config.maxDepth !== undefined) {
+            result = result.substring(0, config.maxDepth);
         }
 
-        if (opts.min !== undefined && opts.min) {
+        if (config.min !== undefined && config.min) {
             result += ' ';
         }
 
-        if (opts.plugins !== undefined) {
-            for (const plugin of opts.plugins) {
+        if (config.plugins !== undefined) {
+            for (const plugin of config.plugins) {
                 expect.addSnapshotSerializer(plugin);
             }
         }
 
-        if (opts.printFunctionName !== undefined && opts.printFunctionName) {
+        if (config.printFunctionName !== undefined && config.printFunctionName) {
             result += ' ';
         }
 
-        if (opts.theme) {
-            if (opts.theme.comment !== undefined) {
-                result += opts.theme.comment;
-            }
+        return result;
+    },
+    test: (value: {}) => value === value,
+});
 
-            if (opts.theme.content !== undefined) {
-                result += opts.theme.content;
-            }
+// old API
+expect.addSnapshotSerializer({
+    print(value, serialize, indent, opts, colors) {
+        let result = '';
 
-            if (opts.theme.prop !== undefined) {
-                result += opts.theme.prop;
-            }
+        result += opts.edgeSpacing;
+        result += opts.spacing;
 
-            if (opts.theme.tag !== undefined) {
-                result += opts.theme.tag;
-            }
-
-            if (opts.theme.value !== undefined) {
-                result += opts.theme.value;
-            }
+        if (opts.min !== undefined && opts.min) {
+            result += ' ';
         }
 
         for (const color of [colors.comment, colors.content, colors.prop, colors.tag, colors.value]) {

--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "jest-diff": "^25.1.0"
+        "jest-diff": "^25.1.0",
+        "pretty-format": "^25.1.0"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jest/blob/084508290f4a90b28c3190021d3358ab1f753c3f/packages/pretty-format/src/types.ts#L86-L115
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.