### PR TITLE
Update EventEmitter references again

### DIFF
--- a/types/hexo/index.d.ts
+++ b/types/hexo/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-import EventEmitter = require('events');
+import { EventEmitter } from 'events';
 import moment = require('moment');
 import { ParsedArgs } from 'minimist';
 import Logger = require('bunyan');

--- a/types/socketio-wildcard/index.d.ts
+++ b/types/socketio-wildcard/index.d.ts
@@ -6,10 +6,10 @@
 /// <reference types="socket.io-client" />
 import SocketIO = require("socket.io");
 
-import Events = require("events");
+import { EventEmitter } from "events";
 import Socket = SocketIO.Socket;
 import ClientSocket = SocketIOClient.Socket;
 
 export = sioWildcard;
 
-declare function sioWildcard(emitterCtor?: { prototype: typeof Events.prototype }): (socket: Socket | ClientSocket, next?: (err?: any) => void) => void;
+declare function sioWildcard(emitterCtor?: { prototype: typeof EventEmitter.prototype }): (socket: Socket | ClientSocket, next?: (err?: any) => void) => void;


### PR DESCRIPTION
EventEmitter changed again in
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41353. This PR
fixes the packages that were missed in that PR.