### PR TITLE
create types for docx-templates

### DIFF
--- a/types/docx-templates/docx-templates-tests.ts
+++ b/types/docx-templates/docx-templates-tests.ts
@@ -1,4 +1,4 @@
-import createReport from 'docx-templater';
+import createReport from 'docx-templates';
 
 createReport({
     template: 'templates/myTemplate.docx',

--- a/types/docx-templates/docx-templates-tests.ts
+++ b/types/docx-templates/docx-templates-tests.ts
@@ -15,17 +15,19 @@ createReport({
     data: (query: string) => JSON.parse(query),
 });
 
-const buffer1: Buffer = await createReport({
-    output: 'buffer',
-    template: 'templates/myTemplate.docx',
-    data: {},
-});
+async function test() {
+    const buffer1: Buffer = await createReport({
+        output: 'buffer',
+        template: 'templates/myTemplate.docx',
+        data: {},
+    });
 
-const buffer2 = await createReport({
-    output: 'buffer',
-    template: buffer1,
-    data: {},
-});
+    const buffer2 = await createReport({
+        output: 'buffer',
+        template: buffer1,
+        data: {},
+    });
+}
 
 createReport({
     template: 'templates/myTemplate.docx',

--- a/types/docx-templates/docx-templates-tests.ts
+++ b/types/docx-templates/docx-templates-tests.ts
@@ -1,0 +1,41 @@
+import createReport from 'docx-templater';
+
+createReport({
+    template: 'templates/myTemplate.docx',
+    output: 'reports/myReport.docx',
+    data: {
+        name: 'John',
+        surname: 'Appleseed',
+    },
+});
+
+createReport({
+    template: 'templates/myTemplate.docx',
+    output: 'reports/myReport.docx',
+    data: (query: string) => JSON.parse(query),
+});
+
+const buffer1: Buffer = await createReport({
+    output: 'buffer',
+    template: 'templates/myTemplate.docx',
+    data: {},
+});
+
+const buffer2 = await createReport({
+    output: 'buffer',
+    template: buffer1,
+    data: {},
+});
+
+createReport({
+    template: 'templates/myTemplate.docx',
+    output: 'reports/myReport.docx',
+    additionalJsContext: {
+        foo: 'bar',
+        qrCode: async (url: string) => {},
+    },
+    cmdDelimiter: '+++',
+    literalXmlDelimiter: '||',
+    processLineBreaks: true,
+    noSandbox: false,
+});

--- a/types/docx-templates/index.d.ts
+++ b/types/docx-templates/index.d.ts
@@ -2,40 +2,39 @@
 // Project: https://github.com/guigrpa/docx-templates#readme
 // Definitions by: Sebastian Krüger <https://github.com/mathe42>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node" />
 
-declare module 'docx-templates' {
-    function createReport(options: UserOptions<'buffer'>): Promise<Buffer>;
-    function createReport(options: UserOptions<string>): Promise<void>;
+declare function createReport(options: UserOptions<'buffer'>): Promise<Buffer>;
+declare function createReport(options: UserOptions<string>): Promise<void>;
 
-    interface runJSOptions {
-        sandbox: any;
-        ctx: any;
-    }
-
-    interface UserOptions<T> {
-        template: string | ArrayBuffer; // path
-        data?: ReportData | QueryResolver;
-        queryVars?: any;
-        output?: T;
-        cmdDelimiter?: string | [string, string];
-        literalXmlDelimiter?: string;
-        processLineBreaks?: boolean; // true by default
-        noSandbox?: boolean;
-        runJs?: (
-            runJSOptions: runJSOptions,
-        ) => {
-            modifiedSandbox: any;
-            result: any;
-        };
-        additionalJsContext?: any;
-        _probe?: 'JS' | 'XML';
-    }
-
-    type Query = string;
-
-    type QueryResolver = (query?: Query, queryVars?: any) => ReportData | Promise<ReportData>;
-
-    type ReportData = any;
-
-    export default createReport;
+interface runJSOptions {
+    sandbox: any;
+    ctx: any;
 }
+
+interface UserOptions<T> {
+    template: string | ArrayBuffer | Buffer;
+    data?: ReportData | QueryResolver;
+    queryVars?: any;
+    output?: T;
+    cmdDelimiter?: string | [string, string];
+    literalXmlDelimiter?: string;
+    processLineBreaks?: boolean;
+    noSandbox?: boolean;
+    runJs?: (
+        runJSOptions: runJSOptions,
+    ) => {
+        modifiedSandbox: any;
+        result: any;
+    };
+    additionalJsContext?: any;
+    _probe?: 'JS' | 'XML';
+}
+
+type Query = string;
+
+type QueryResolver = (query?: Query, queryVars?: any) => ReportData | Promise<ReportData>;
+
+type ReportData = any;
+
+export default createReport;

--- a/types/docx-templates/index.d.ts
+++ b/types/docx-templates/index.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for docx-templates 3.1
+// Project: https://github.com/guigrpa/docx-templates#readme
+// Definitions by: Sebastian Krüger <https://github.com/mathe42>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'docx-templates' {
+    function createReport(options: UserOptions<'buffer'>): Promise<Buffer>;
+    function createReport(options: UserOptions<string>): Promise<void>;
+
+    interface runJSOptions {
+        sandbox: any;
+        ctx: any;
+    }
+
+    interface UserOptions<T> {
+        template: string | ArrayBuffer; // path
+        data?: ReportData | QueryResolver;
+        queryVars?: any;
+        output?: T;
+        cmdDelimiter?: string | [string, string];
+        literalXmlDelimiter?: string;
+        processLineBreaks?: boolean; // true by default
+        noSandbox?: boolean;
+        runJs?: (
+            runJSOptions: runJSOptions,
+        ) => {
+            modifiedSandbox: any;
+            result: any;
+        };
+        additionalJsContext?: any;
+        _probe?: 'JS' | 'XML';
+    }
+
+    type Query = string;
+
+    type QueryResolver = (query?: Query, queryVars?: any) => ReportData | Promise<ReportData>;
+
+    type ReportData = any;
+
+    export default createReport;
+}

--- a/types/docx-templates/tsconfig.json
+++ b/types/docx-templates/tsconfig.json
@@ -1,14 +1,18 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es6"],
+        "lib": [
+            "es6"
+        ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictFunctionTypes": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
-        "typeRoots": ["../"],
-        "types": ["node"],
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/docx-templates/tsconfig.json
+++ b/types/docx-templates/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": ["node"],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "docx-templates-tests.ts"]
+}

--- a/types/docx-templates/tslint.json
+++ b/types/docx-templates/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.