### PR TITLE
[camunda-external-task-client-js] add missing func def

### DIFF
--- a/types/camunda-external-task-client-js/camunda-external-task-client-js-tests.ts
+++ b/types/camunda-external-task-client-js/camunda-external-task-client-js-tests.ts
@@ -1,5 +1,47 @@
-import { Client, Variables } from 'camunda-external-task-client-js';
+import { Client, HandlerArgs, Task, TaskService, TopicSubscription, Variables } from 'camunda-external-task-client-js';
 
 new Client({ baseUrl: '' }); // $ExpectType Client
 new Variables(); // $ExpectType Variables
 new Variables().set('a', 42).getAllTyped(); // $ExpectType TypedValue[]
+
+const client: Client = new Client({ baseUrl: '' }); // $ExpectType Client
+client.on('subscribe', (topic: string, topicSubscription: TopicSubscription) => {});
+client.on('unsubscribe', (topic: string, topicSubscription: TopicSubscription) => {});
+
+client.on('poll:start', () => {});
+client.on('poll:stop', () => {});
+
+client.on('poll:success', (tasks: Task[]) => {});
+
+client.on('complete:success', (task: Task) => {});
+client.on('handleFailure:success', (task: Task) => {});
+client.on('handleBpmnError:success', (task: Task) => {});
+client.on('extendLock:success', (task: Task) => {});
+client.on('unlock:success', (task: Task) => {});
+
+client.on('handleFailure:error', (task: Task, error: any) => {});
+client.on('handleBpmnError:error', (task: Task, error: any) => {});
+client.on('extendLock:error', (task: Task, error: any) => {});
+client.on('unlock:error', (task: Task, error: any) => {});
+
+client.on('complete:error', (error: any) => {});
+client.on('poll:error', (error: any) => {});
+
+client.start();
+client.stop();
+client.subscribe('', {}, (args: HandlerArgs) => {
+    const task: Task = args.task;
+    const taskService: TaskService = args.taskService;
+    task.businessKey;
+    task.processInstanceId;
+    task.id;
+    task.executionId;
+    task.activityId;
+    task.activityInstanceId;
+    task.tenantId;
+    task.topicName;
+    task.workerId;
+
+    taskService.handleFailure(task, {});
+    taskService.complete(task);
+});

--- a/types/camunda-external-task-client-js/index.d.ts
+++ b/types/camunda-external-task-client-js/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for camunda-external-task-client-js 1.2
+// Type definitions for camunda-external-task-client-js 1.3
 // Project: https://github.com/camunda/camunda-external-task-client-js#readme
 // Definitions by: MacRusher <https://github.com/MacRusher>
+//                 DoYoung Ha <https://github.com/hados99>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -10,6 +11,13 @@ export class Client {
     stop(): void;
     subscribe(topic: string, options: SubscribeOptions, handler: Handler): TopicSubscription;
     subscribe(topic: string, handler: Handler): TopicSubscription;
+
+    on(name: TopicEvent, callback: (topic: string, topicSubscription: TopicSubscription) => void): void;
+    on(name: PollEvent, callback: () => void): void;
+    on(name: SuccessWithTasksEvent, callback: (tasks: Task[]) => void): void;
+    on(name: SuccessWithTaskEvent, callback: (task: Task) => void): void;
+    on(name: ErrorWithTaskEvent, callback: (task: Task, error: any) => void): void;
+    on(name: ErrorEvent, callback: (error: any) => void): void;
 }
 
 export interface ClientConfig {
@@ -113,5 +121,12 @@ export type Logger = Middleware & {
     success(text: string): void;
     error(text: string): void;
 };
+
+export type TopicEvent = "subscribe" | "unsubscribe";
+export type PollEvent = "poll:start" | "poll:stop";
+export type SuccessWithTasksEvent = "poll:success";
+export type SuccessWithTaskEvent = "complete:success" | "handleFailure:success" | "handleBpmnError:success" | "extendLock:success" | "unlock:success";
+export type ErrorWithTaskEvent = "handleFailure:error" | "handleBpmnError:error" | "extendLock:error" | "unlock:error";
+export type ErrorEvent = "poll:error" | "complete:error";
 
 export const logger: Logger;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/camunda/camunda-external-task-client-js/blob/master/docs/handler.md
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
