### PR TITLE
[rdf-js] Add generics to BaseQuad and formalise Triple

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -100,8 +100,6 @@ export class Quad extends BaseQuad implements RDF.Quad {
     toJSON(): string;
 }
 
-export class Triple extends Quad implements RDF.Triple {}
-
 export namespace DataFactory {
     function namedNode(value: string): NamedNode;
     function blankNode(value?: string): BlankNode;
@@ -110,8 +108,8 @@ export namespace DataFactory {
     function defaultGraph(): DefaultGraph;
     function quad(subject: RDF.Quad_Subject, predicate: RDF.Quad_Predicate, object: RDF.Quad_Object, graph?: RDF.Quad_Graph): Quad;
     function quad<Q_In extends RDF.BaseQuad = RDF.Quad, Q_Out extends BaseQuad = Quad>(subject: Q_In['subject'], predicate: Q_In['predicate'], object: Q_In['object'], graph?: Q_In['graph']): Q_Out;
-    function triple(subject: RDF.Quad_Subject, predicate: RDF.Quad_Predicate, object: RDF.Quad_Object): Quad;
-    function triple<Q_In extends RDF.BaseQuad = RDF.Quad, Q_Out extends BaseQuad = Quad>(subject: Q_In['subject'], predicate: Q_In['predicate'], object: Q_In['object']): Q_Out;
+    function triple(subject: RDF.Quad_Subject, predicate: RDF.Quad_Predicate, object: RDF.Quad_Object): RDF.Triple<Quad>;
+    function triple<Q_In extends RDF.BaseQuad = RDF.Quad, Q_Out extends BaseQuad = Quad>(subject: Q_In['subject'], predicate: Q_In['predicate'], object: Q_In['object']): RDF.Triple<Q_Out>;
 }
 
 export type ErrorCallback = (err: Error, result: any) => void;

--- a/types/rdf-data-model/index.d.ts
+++ b/types/rdf-data-model/index.d.ts
@@ -12,5 +12,5 @@ export function blankNode(value?: string): RDF.BlankNode;
 export function literal(value: string, languageOrDatatype?: string | RDF.NamedNode): RDF.Literal;
 export function variable(value: string): RDF.Variable;
 export function defaultGraph(): RDF.DefaultGraph;
-export function triple(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term): RDF.Quad;
+export function triple(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term): RDF.Triple;
 export function quad(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term, graph?: RDF.Term): RDF.Quad;

--- a/types/rdf-data-model/rdf-data-model-tests.ts
+++ b/types/rdf-data-model/rdf-data-model-tests.ts
@@ -17,6 +17,6 @@ function test_datafactory() {
     const defaultGraph2: RDF.DefaultGraph = DataFactory.defaultGraph();
 
     const term: RDF.Term = <any> {};
-    const triple: RDF.Quad = DataFactory.triple(term, term, term);
+    const triple: RDF.Triple = DataFactory.triple(term, term, term);
     const quad: RDF.Quad = DataFactory.quad(term, term, term, term);
 }

--- a/types/rdf-ext/lib/DataFactory.d.ts
+++ b/types/rdf-ext/lib/DataFactory.d.ts
@@ -1,4 +1,4 @@
-import { DataFactory, Sink, NamedNode, BaseQuad, Quad, Stream, Quad_Subject, Quad_Predicate, Quad_Object, Quad_Graph } from 'rdf-js';
+import { DataFactory, Sink, NamedNode, BaseQuad, Quad, Triple, Stream, Quad_Subject, Quad_Predicate, Quad_Object, Quad_Graph } from 'rdf-js';
 import BlankNodeExt = require("./BlankNode");
 import LiteralExt = require("./Literal");
 import NamedNodeExt = require("./NamedNode");
@@ -29,7 +29,7 @@ declare class DataFactoryExt implements DataFactory<QuadExt> {
   static literal(value: string, languageOrDatatype?: string | NamedNode): LiteralExt;
   static variable(value: string): VariableExt;
   static defaultGraph(): DefaultGraphExt;
-  static triple(subject: Quad_Subject, predicate: Quad_Predicate, object: Quad_Object): QuadExt;
+  static triple(subject: Quad_Subject, predicate: Quad_Predicate, object: Quad_Object): Triple<QuadExt>;
   static quad(subject: Quad_Subject, predicate: Quad_Predicate, object: Quad_Object, graph?: Quad_Graph): QuadExt;
   static graph(quads?: any): Dataset;
   static prefixMap(prefixes: Prefixes): PrefixMap;
@@ -40,7 +40,7 @@ declare class DataFactoryExt implements DataFactory<QuadExt> {
   literal(value: string, languageOrDatatype?: string | NamedNode): LiteralExt;
   namedNode(value: string): NamedNode;
   quad(subject: Quad_Subject, predicate: Quad_Predicate, object: Quad_Object, graph?: Quad_Graph): QuadExt;
-  triple(subject: Quad_Subject, predicate: Quad_Predicate, object: Quad_Object): QuadExt;
+  triple(subject: Quad_Subject, predicate: Quad_Predicate, object: Quad_Object): Triple<QuadExt>;
   variable(value: string): VariableExt;
 }
 

--- a/types/rdf-ext/rdf-ext-tests.ts
+++ b/types/rdf-ext/rdf-ext-tests.ts
@@ -1,5 +1,5 @@
 import rdf = require('rdf-ext');
-import { Literal, Quad, Dataset, NamedNode, Stream, Sink, DataFactory, DatasetFactory } from 'rdf-js';
+import { Literal, Quad, Triple, Dataset, NamedNode, Stream, Sink, DataFactory, DatasetFactory } from 'rdf-js';
 import QuadExt = require('rdf-ext/lib/Quad');
 import DataFactoryExt = require('rdf-ext/lib/DataFactory');
 import DatasetExt = require('rdf-ext/lib/Dataset');
@@ -172,7 +172,7 @@ function static_Quad_fromBaseTerms(): Quad {
     return rdf.quad(subject, predicate, object, graph);
 }
 
-function static_Triple_fromBaseTerms(): Quad {
+function static_Triple_fromBaseTerms(): Triple {
     const subject: NamedNode = <any> {};
     const predicate: NamedNode = <any> {};
     const object: NamedNode = <any> {};
@@ -190,7 +190,7 @@ function instance_Quad_fromBaseTerms(): Quad {
     return factory.quad(subject, predicate, object, graph);
 }
 
-function instance_Triple_fromBaseTerms(): Quad {
+function instance_Triple_fromBaseTerms(): Triple {
     const factory: DataFactoryExt = <any> {};
     const subject: NamedNode = <any> {};
     const predicate: NamedNode = <any> {};
@@ -219,12 +219,12 @@ function graph_noParams_returnsDataset(): boolean {
 }
 
 function graph_initWithTriples(): Dataset {
-    const triple1 = rdf.quad(
+    const triple1 = rdf.triple(
         rdf.namedNode('http://example.org/subject'),
         rdf.namedNode('http://example.org/predicate'),
         rdf.literal('object1'));
 
-    const triple2 = rdf.quad(
+    const triple2 = rdf.triple(
         rdf.namedNode('http://example.org/subject'),
         rdf.namedNode('http://example.org/predicate'),
         rdf.literal('object2'));

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -174,27 +174,27 @@ export type Quad_Graph = DefaultGraph | NamedNode | BlankNode | Variable;
 /**
  * An RDF quad, taking any Term in its positions, containing the subject, predicate, object and graph terms.
  */
-export interface BaseQuad {
+export interface BaseQuad<S extends Term = Term, P extends Term = Term, O extends Term = Term, G extends Term = Term> {
   /**
    * The subject.
    * @see Quad_Subject
    */
-  subject: Term;
+  subject: S;
   /**
    * The predicate.
    * @see Quad_Predicate
    */
-  predicate: Term;
+  predicate: P;
   /**
    * The object.
    * @see Quad_Object
    */
-  object: Term;
+  object: O;
   /**
    * The named graph.
    * @see Quad_Graph
    */
-  graph: Term;
+  graph: G;
 
   /**
    * @param other The term to compare with.
@@ -206,42 +206,13 @@ export interface BaseQuad {
 /**
  * An RDF quad, containing the subject, predicate, object and graph terms.
  */
-export interface Quad extends BaseQuad {
-    /**
-     * The subject.
-     * @see Quad_Subject
-     */
-    subject: Quad_Subject;
-    /**
-     * The predicate.
-     * @see Quad_Predicate
-     */
-    predicate: Quad_Predicate;
-    /**
-     * The object.
-     * @see Quad_Object
-     */
-    object: Quad_Object;
-    /**
-     * The named graph.
-     * @see Quad_Graph
-     */
-    graph: Quad_Graph;
-
-    /**
-     * @param other The term to compare with.
-     * @return True if and only if the argument is a) of the same type b) has all components equal.
-     */
-    equals(other: BaseQuad): boolean;
-}
+export interface Quad<S extends Quad_Subject = Quad_Subject, P extends Quad_Predicate = Quad_Predicate,
+  O extends Quad_Object = Quad_Object, G extends Quad_Graph = Quad_Graph> extends BaseQuad<S, P, O, G> {}
 
 /**
  * An RDF triple, containing the subject, predicate, object terms.
- *
- * Triple is an alias of Quad.
  */
-// tslint:disable-next-line no-empty-interface
-export interface Triple extends Quad {}
+export type Triple<Q extends BaseQuad = Quad> = Q & { graph: DefaultGraph };
 
 /**
  * A factory for instantiating RDF terms, triples and quads.
@@ -297,7 +268,7 @@ export interface DataFactory<Q extends BaseQuad = Quad> {
      * @see Triple
      * @see DefaultGraph
      */
-    triple(subject: Q['subject'], predicate: Q['predicate'], object: Q['object']): Q;
+    triple(subject: Q['subject'], predicate: Q['predicate'], object: Q['object']): Triple<Q>;
 
     /**
      * @param subject   The quad subject term.

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -1,5 +1,6 @@
 import { BlankNode, DataFactory, Dataset, DatasetCore, DatasetCoreFactory, DatasetFactory, DefaultGraph, Literal,
-  NamedNode, Quad, BaseQuad, Sink, Source, Store, Stream, Triple, Term, Variable, Quad_Graph } from "rdf-js";
+  NamedNode, Quad, BaseQuad, Sink, Source, Store, Stream, Triple, Term, Variable, Quad_Subject, Quad_Predicate,
+  Quad_Object, Quad_Graph } from "rdf-js";
 import { EventEmitter } from "events";
 
 function test_terms() {
@@ -50,19 +51,19 @@ function test_terms() {
 
 function test_quads() {
     const quad: Quad = <any> {};
-    const s1: Term = quad.subject;
-    const p1: Term = quad.predicate;
-    const o1: Term = quad.object;
-    const g1: Term = quad.graph;
-    quad.equals(quad);
+    const s1: Quad_Subject = quad.subject;
+    const p1: Quad_Predicate = quad.predicate;
+    const o1: Quad_Object = quad.object;
+    const g1: Quad_Graph = quad.graph;
+    const e1: boolean = quad.equals(quad);
 
-    const triple: Triple = quad;
-    const s2: Term = triple.subject;
-    const p2: Term = triple.predicate;
-    const o2: Term = triple.object;
-    const g2: Term = triple.graph;
-    triple.equals(quad);
-    quad.equals(triple);
+    const triple: Triple = <any> {};
+    const s2: Quad_Subject = triple.subject;
+    const p2: Quad_Predicate = triple.predicate;
+    const o2: Quad_Object = triple.object;
+    const g2: DefaultGraph = triple.graph;
+    const e2: boolean = triple.equals(quad);
+    const e3: boolean = quad.equals(triple);
 }
 
 function test_datafactory() {
@@ -80,17 +81,21 @@ function test_datafactory() {
     const variable: Variable = dataFactory.variable ? dataFactory.variable('v1') : <any> {};
 
     const term: NamedNode = <any> {};
-    const triple: Quad = dataFactory.triple(term, term, term);
     interface QuadBnode extends BaseQuad {
       subject: Term;
       predicate: Term;
       object: Term;
       graph: Term;
+      foo: Term;
     }
 
     const quadBnodeFactory: DataFactory<QuadBnode> = <any> {};
     const quad = quadBnodeFactory.quad(literal1, blankNode1, term, term);
-    const hasBnode = quad.predicate.termType === "BlankNode";
+    const triple: Triple<QuadBnode> = quadBnodeFactory.triple(term, term, term);
+    const hasBnode1 = quad.predicate.termType === "BlankNode";
+    const hasBnode2 = triple.predicate.termType === "BlankNode";
+    const tripleGraph: DefaultGraph = triple.graph;
+    const tripleExtra: Term = triple.foo;
 }
 
 function test_stream() {
@@ -147,7 +152,7 @@ function test_datasetcore() {
 
     const dataset1: DatasetCore = datasetCoreFactory1.dataset();
     const dataset2: DatasetCore = datasetCoreFactory1.dataset([quad, quad]);
-    const dataset3: DatasetCore<QuadBnode, QuadBnode> = datasetCoreFactory2.dataset([quadBnode, quad]);
+    const dataset3: DatasetCore<QuadBnode> = datasetCoreFactory2.dataset([quadBnode, quad]);
 
     const dataset2Size: number = dataset2.size;
     const dataset2Add: DatasetCore = dataset2.add(quad);


### PR DESCRIPTION
In draft while I'm experimenting, but this adds generics to `BaseQuad`, and makes `Triple` a real triple (that is, `graph` _has_ to be `DefaultGraph`).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: n/a
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.