### PR TITLE
dlv: Make it possible to use numbers in key

### DIFF
--- a/types/dlv/dlv-tests.ts
+++ b/types/dlv/dlv-tests.ts
@@ -1,20 +1,24 @@
 import dlv = require('dlv');
 
 const obj = {
-	undef: undefined,
-	zero: 0,
-	one: 1,
-	n: null,
-	f: false,
-	a: {
-		two: 2,
-		b: {
-			three: 3,
-			c: {
-				four: 4
-			}
-		}
-	}
+    undef: undefined,
+    zero: 0,
+    one: 1,
+    n: null,
+    f: false,
+    a: {
+        two: 2,
+        b: {
+            three: 3,
+            c: {
+                four: 4,
+            },
+        },
+    },
+    array: [
+        ['a', 'b'],
+        ['c', 'd'],
+    ],
 };
 
 // Test without defaults
@@ -31,6 +35,8 @@ dlv(obj, 'n');
 dlv(obj, 'n.badkey');
 dlv(obj, 'f');
 dlv(obj, 'f.badkey');
+dlv(obj, ['array', 0, 1]);
+dlv(obj, ['array', 1, 1]);
 
 // Test defaults
 dlv(obj, '', 'foo');

--- a/types/dlv/index.d.ts
+++ b/types/dlv/index.d.ts
@@ -10,4 +10,4 @@
  * undefined
  */
 export = dlv;
-declare function dlv(object: object, key: string | string[], defaultValue?: any): any;
+declare function dlv(object: object, key: string | Array<string | number>, defaultValue?: any): any;


### PR DESCRIPTION
`dlv` also makes it possible to traverse arrays, so it should be valid to have a key of the following format: `['array', 0, 1]`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/developit/dlv/blob/3212139c05647ffe3f1b095acd46afa2f5f635dd/index.js#L4
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
