### PR TITLE
Add types for serviceworker-webpack-plugin

### DIFF
--- a/types/serviceworker-webpack-plugin/index.d.ts
+++ b/types/serviceworker-webpack-plugin/index.d.ts
@@ -11,7 +11,11 @@ export interface ServiceWorkerOption {
     jsonStats?: Stats.ToJsonOutput;
 }
 
-export interface ServiceWorkerWebpackPluginOptions<T = Pick<ServiceWorkerOption, 'assets'>> {
+export interface ServiceWorkerDefaultOption {
+    assets: string[];
+}
+
+export interface ServiceWorkerWebpackPluginOptions<T = ServiceWorkerDefaultOption> {
     /**
      * Path to the actual service worker implementation.
      */
@@ -63,6 +67,6 @@ export interface ServiceWorkerWebpackPluginOptions<T = Pick<ServiceWorkerOption,
     minimize?: boolean;
 }
 
-export default class ServiceWorkerWebpackPlugin extends Plugin {
-    constructor(options: ServiceWorkerWebpackPluginOptions);
+export default class ServiceWorkerWebpackPlugin<T = ServiceWorkerDefaultOption> extends Plugin {
+    constructor(options: ServiceWorkerWebpackPluginOptions<T>);
 }

--- a/types/serviceworker-webpack-plugin/index.d.ts
+++ b/types/serviceworker-webpack-plugin/index.d.ts
@@ -5,68 +5,72 @@
 
 import { Plugin, Stats } from 'webpack';
 
-export interface ServiceWorkerOption {
-    assets: string[];
-
-    jsonStats?: Stats.ToJsonOutput;
+declare class ServiceWorkerWebpackPlugin<T = ServiceWorkerWebpackPlugin.ServiceWorkerDefaultOption> extends Plugin {
+    constructor(options: ServiceWorkerWebpackPlugin.ServiceWorkerWebpackPluginOptions<T>);
 }
 
-export interface ServiceWorkerDefaultOption {
-    assets: string[];
+declare namespace ServiceWorkerWebpackPlugin {
+    interface ServiceWorkerOption {
+        assets: string[];
+
+        jsonStats?: Stats.ToJsonOutput;
+    }
+
+    interface ServiceWorkerDefaultOption {
+        assets: string[];
+    }
+
+    interface ServiceWorkerWebpackPluginOptions<T = ServiceWorkerDefaultOption> {
+        /**
+         * Path to the actual service worker implementation.
+         */
+        entry: string;
+
+        /**
+         * Relative (from the webpack's config output.path) output path for emitted script.
+         *
+         * @default 'sw.js'
+         */
+        filename?: string;
+
+        /**
+         * Exclude matched assets from being added to the `serviceWorkerOption.assets` variable. (Blacklist)
+         *
+         * @default ['**\/.*', '**\/*.map']
+         */
+        excludes?: string[];
+
+        /**
+         * Include matched assets added to the `serviceWorkerOption.assets` variable. (Whitelist)
+         *
+         * @default ['**\/*']
+         */
+        includes?: string[];
+
+        /**
+         * Specifies the public URL address of the output files when referenced in a browser. We use this value to load the service worker over the network.
+         *
+         * @default '/'
+         */
+        publicPath?: string;
+
+        /**
+         * This callback function can be used to inject statically generated service worker.
+         */
+        template?: (serviceWorkerOption: T) => Promise<void>;
+
+        /**
+         * This callback function receives a raw `serviceWorkerOption` argument. The `jsonStats` key contains all the webpack build information.
+         */
+        transformOptions?: (serviceWorkerOption: ServiceWorkerOption) => T;
+
+        /**
+         * Whether to minimize output.
+         *
+         * @default process.env.NODE_ENV === 'production'
+         */
+        minimize?: boolean;
+    }
 }
 
-export interface ServiceWorkerWebpackPluginOptions<T = ServiceWorkerDefaultOption> {
-    /**
-     * Path to the actual service worker implementation.
-     */
-    entry: string;
-
-    /**
-     * Relative (from the webpack's config output.path) output path for emitted script.
-     *
-     * @default 'sw.js'
-     */
-    filename?: string;
-
-    /**
-     * Exclude matched assets from being added to the `serviceWorkerOption.assets` variable. (Blacklist)
-     *
-     * @default ['**\/.*', '**\/*.map']
-     */
-    excludes?: string[];
-
-    /**
-     * Include matched assets added to the `serviceWorkerOption.assets` variable. (Whitelist)
-     *
-     * @default ['**\/*']
-     */
-    includes?: string[];
-
-    /**
-     * Specifies the public URL address of the output files when referenced in a browser. We use this value to load the service worker over the network.
-     *
-     * @default '/'
-     */
-    publicPath?: string;
-
-    /**
-     * This callback function can be used to inject statically generated service worker.
-     */
-    template?: (serviceWorkerOption: T) => Promise<void>;
-
-    /**
-     * This callback function receives a raw `serviceWorkerOption` argument. The `jsonStats` key contains all the webpack build information.
-     */
-    transformOptions?: (serviceWorkerOption: ServiceWorkerOption) => T;
-
-    /**
-     * Whether to minimize output.
-     *
-     * @default process.env.NODE_ENV === 'production'
-     */
-    minimize?: boolean;
-}
-
-export default class ServiceWorkerWebpackPlugin<T = ServiceWorkerDefaultOption> extends Plugin {
-    constructor(options: ServiceWorkerWebpackPluginOptions<T>);
-}
+export = ServiceWorkerWebpackPlugin;

--- a/types/serviceworker-webpack-plugin/index.d.ts
+++ b/types/serviceworker-webpack-plugin/index.d.ts
@@ -1,0 +1,68 @@
+// Type definitions for serviceworker-webpack-plugin 1.0
+// Project: https://github.com/oliviertassinari/serviceworker-webpack-plugin#readme
+// Definitions by: Remco Haszing <https://github.com/remcohaszing>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Plugin, Stats } from 'webpack';
+
+export interface ServiceWorkerOption {
+    assets: string[];
+
+    jsonStats?: Stats.ToJsonOutput;
+}
+
+export interface ServiceWorkerWebpackPluginOptions<T = Pick<ServiceWorkerOption, 'assets'>> {
+    /**
+     * Path to the actual service worker implementation.
+     */
+    entry: string;
+
+    /**
+     * Relative (from the webpack's config output.path) output path for emitted script.
+     *
+     * @default 'sw.js'
+     */
+    filename?: string;
+
+    /**
+     * Exclude matched assets from being added to the `serviceWorkerOption.assets` variable. (Blacklist)
+     *
+     * @default ['**\/.*', '**\/*.map']
+     */
+    excludes?: string[];
+
+    /**
+     * Include matched assets added to the `serviceWorkerOption.assets` variable. (Whitelist)
+     *
+     * @default ['**\/*']
+     */
+    includes?: string[];
+
+    /**
+     * Specifies the public URL address of the output files when referenced in a browser. We use this value to load the service worker over the network.
+     *
+     * @default '/'
+     */
+    publicPath?: string;
+
+    /**
+     * This callback function can be used to inject statically generated service worker.
+     */
+    template?: (serviceWorkerOption: T) => Promise<void>;
+
+    /**
+     * This callback function receives a raw `serviceWorkerOption` argument. The `jsonStats` key contains all the webpack build information.
+     */
+    transformOptions?: (serviceWorkerOption: ServiceWorkerOption) => T;
+
+    /**
+     * Whether to minimize output.
+     *
+     * @default process.env.NODE_ENV === 'production'
+     */
+    minimize?: boolean;
+}
+
+export default class ServiceWorkerWebpackPlugin extends Plugin {
+    constructor(options: ServiceWorkerWebpackPluginOptions);
+}

--- a/types/serviceworker-webpack-plugin/lib/runtime.d.ts
+++ b/types/serviceworker-webpack-plugin/lib/runtime.d.ts
@@ -1,12 +1,7 @@
-// Type definitions for serviceworker-webpack-plugin 1.0
-// Project: https://github.com/oliviertassinari/serviceworker-webpack-plugin#readme
-// Definitions by: Remco Haszing <https://github.com/remcohaszing>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-declare interface Runtime {
+export interface ServiceWorkerWebpackPluginRuntime {
     register(options?: RegistrationOptions): Promise<ServiceWorkerRegistration>;
 }
 
-declare const runtime: Runtime;
+declare const runtime: ServiceWorkerWebpackPluginRuntime;
 
 export default runtime;

--- a/types/serviceworker-webpack-plugin/lib/runtime.d.ts
+++ b/types/serviceworker-webpack-plugin/lib/runtime.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for serviceworker-webpack-plugin 1.0
+// Project: https://github.com/oliviertassinari/serviceworker-webpack-plugin#readme
+// Definitions by: Remco Haszing <https://github.com/remcohaszing>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare interface Runtime {
+    register(options?: RegistrationOptions): Promise<ServiceWorkerRegistration>;
+}
+
+declare const runtime: Runtime;
+
+export default runtime;

--- a/types/serviceworker-webpack-plugin/serviceworker-webpack-plugin-tests.ts
+++ b/types/serviceworker-webpack-plugin/serviceworker-webpack-plugin-tests.ts
@@ -1,4 +1,4 @@
-import ServiceWorkerWebpackPlugin from 'serviceworker-webpack-plugin';
+import * as ServiceWorkerWebpackPlugin from 'serviceworker-webpack-plugin';
 import runtime from 'serviceworker-webpack-plugin/lib/runtime';
 
 new ServiceWorkerWebpackPlugin({

--- a/types/serviceworker-webpack-plugin/serviceworker-webpack-plugin-tests.ts
+++ b/types/serviceworker-webpack-plugin/serviceworker-webpack-plugin-tests.ts
@@ -1,4 +1,47 @@
+import ServiceWorkerWebpackPlugin from 'serviceworker-webpack-plugin';
 import runtime from 'serviceworker-webpack-plugin/lib/runtime';
+
+new ServiceWorkerWebpackPlugin({
+    entry: 'foo',
+});
+
+new ServiceWorkerWebpackPlugin({
+    entry: 'foo',
+    filename: 'bar',
+    excludes: ['**'],
+    includes: ['**'],
+    async template(options) {
+        console.log(options.assets);
+    },
+    transformOptions({ assets }) {
+        return { assets };
+    },
+    minimize: true,
+});
+
+new ServiceWorkerWebpackPlugin({
+    entry: 'foo',
+    filename: 'bar',
+    excludes: ['**'],
+    includes: ['**'],
+    async template(options) {
+        console.log(options.assets);
+    },
+    transformOptions({ assets }) {
+        return { assets };
+    },
+    minimize: true,
+});
+
+new ServiceWorkerWebpackPlugin<number>({
+    entry: 'foo',
+    async template(options) {
+        console.log(options * options);
+    },
+    transformOptions() {
+        return 42;
+    },
+});
 
 runtime.register().then(registration => {
     registration.pushManager;

--- a/types/serviceworker-webpack-plugin/serviceworker-webpack-plugin-tests.ts
+++ b/types/serviceworker-webpack-plugin/serviceworker-webpack-plugin-tests.ts
@@ -1,0 +1,9 @@
+import runtime from 'serviceworker-webpack-plugin/lib/runtime';
+
+runtime.register().then(registration => {
+    registration.pushManager;
+});
+
+runtime.register({ scope: '' }).then(registration => {
+    registration.pushManager;
+});

--- a/types/serviceworker-webpack-plugin/tsconfig.json
+++ b/types/serviceworker-webpack-plugin/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "dom",
+            "es6",
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "lib/runtime.d.ts",
+        "serviceworker-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/serviceworker-webpack-plugin/tsconfig.json
+++ b/types/serviceworker-webpack-plugin/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "lib": [
             "dom",
-            "es6",
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
@@ -18,7 +18,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "lib/runtime.d.ts",
+        "index.d.ts",
         "serviceworker-webpack-plugin-tests.ts"
     ]
 }

--- a/types/serviceworker-webpack-plugin/tslint.json
+++ b/types/serviceworker-webpack-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
These type definitions are for the injected code, not for the plugin itself.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.