### PR TITLE
Fix node's assert module resolution in tests

### DIFF
--- a/types/node/tsconfig.json
+++ b/types/node/tsconfig.json
@@ -50,6 +50,9 @@
         "typeRoots": [
             "../"
         ],
+        "paths": {
+            "assert": ["node/assert.d.ts"]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Previously it incorrectly resolved to @types/assert, which is *almost* the same, but a port that necessarily lags a bit, and is compatible with the browser.
