### PR TITLE
Don't require latest version of cypress to use the types in cypress-image-snapshot

### DIFF
--- a/types/cypress-image-snapshot/index.d.ts
+++ b/types/cypress-image-snapshot/index.d.ts
@@ -3,11 +3,18 @@
 // Definitions by: Alex Kessock <https://github.com/Keysox>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="Cypress" />
-
 export interface Options
     extends Partial<
-        Cypress.ScreenshotOptions & {
+        {
+            blackout: string[];
+            capture: 'runner' | 'viewport' | 'fullPage';
+            clip: { x: number; y: number; width: number; height: number };
+            disableTimersAndAnimations: boolean;
+            padding: number | [number] | [number, number] | [number, number, number] | [number, number, number, number];
+            scale: boolean;
+            beforeScreenshot(doc: Document): void;
+            afterScreenshot(doc: Document): void;
+        } & {
             customDiffConfig?: {
                 readonly threshold?: number;
                 readonly includeAA?: boolean;

--- a/types/cypress-image-snapshot/package.json
+++ b/types/cypress-image-snapshot/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "cypress": "^3.8.3"
-    }
-}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Fixes the following error: `Conflicting definitions for 'cypress' found at 'node_modules/cypress/types/index.d.ts'`
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.