### PR TITLE
[braintree] Move webhook notifications to their own types

### DIFF
--- a/types/braintree/braintree-tests.ts
+++ b/types/braintree/braintree-tests.ts
@@ -108,6 +108,6 @@ const gateway: BraintreeGateway = new braintree.BraintreeGateway({
     const notificationResponse = await gateway.webhookNotification.parse(sampleResponse.bt_signature, sampleResponse.bt_payload).catch(console.error);
     if (!notificationResponse) return;
 
-    const notification: SubscriptionNotification = <SubscriptionNotification> notificationResponse;
+    const notification: SubscriptionNotification = notificationResponse as SubscriptionNotification;
     const subscription = notification.subscription;
 })();

--- a/types/braintree/braintree-tests.ts
+++ b/types/braintree/braintree-tests.ts
@@ -14,9 +14,8 @@ import {
     PaymentMethod,
     PaymentMethodNonce,
     Transaction,
-    SampleNotification,
-    WebhookNotification,
     WebhookNotificationKind,
+    SubscriptionNotification,
 } from 'braintree';
 
 /**
@@ -109,5 +108,6 @@ const gateway: BraintreeGateway = new braintree.BraintreeGateway({
     const notificationResponse = await gateway.webhookNotification.parse(sampleResponse.bt_signature, sampleResponse.bt_payload).catch(console.error);
     if (!notificationResponse) return;
 
-    const notification: WebhookNotification = notificationResponse;
+    const notification: SubscriptionNotification = <SubscriptionNotification> notificationResponse;
+    const subscription = notification.subscription;
 })();

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -843,6 +843,8 @@ declare namespace braintree {
         merchantAccount?: MerchantAccount;
         transaction?: Transaction;
         dispute?: Dispute;
+        reportDate?: Date;
+        reportUrl?: string;
     }
 
     export type WebhookNotificationKind =

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -836,15 +836,34 @@ declare namespace braintree {
         bt_payload: string;
     }
 
-    export class WebhookNotification {
+    export abstract class WebhookNotification {
         kind: WebhookNotificationKind;
         timestamp: Date;
-        subscription?: Subscription;
-        merchantAccount?: MerchantAccount;
-        transaction?: Transaction;
-        dispute?: Dispute;
-        reportDate?: Date;
-        reportUrl?: string;
+    }
+
+    export class TransactionNotification extends WebhookNotification {
+        transaction: Transaction;
+    }
+
+    export class SubMerchantAccountApprovedNotification extends WebhookNotification {
+        merchantAccount: MerchantAccount;
+    }
+
+    export class SubMerchantAccountDeclinedNotification extends WebhookNotification {
+        merchantAccount: MerchantAccount;
+    }
+
+    export class SubscriptionNotification extends WebhookNotification {
+        subscription: Subscription;
+    }
+
+    export class DisputeNotification extends WebhookNotification {
+        dispute: Dispute;
+    }
+
+    export class AccountUpdaterNotification extends WebhookNotification {
+        reportDate: Date;
+        reportUrl: string;
     }
 
     export type WebhookNotificationKind =


### PR DESCRIPTION
This PR refactors the existing `WebhookNotification` class into a type for each kind of notification with the appropriate attributes.

It also adds a type for the account-updater webhook: 
 https://developers.braintreepayments.com/reference/general/webhooks/account-updater/node#attributes

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
