### PR TITLE
[stripe-v3] add missing mandate argument to createSource

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -13,6 +13,7 @@
 //                 Krishna Pravin <https://github.com/KrishnaPravin>
 //                 Hiroshi Ioka <https://github.com/hirochachacha>
 //                 Austin Turner <https://github.com/paustint>
+//                 Kevin Soltysiak <https://github.com/ksol>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var Stripe: stripe.StripeStatic;
@@ -180,6 +181,34 @@ declare namespace stripe {
         phone?: string;
     }
 
+    interface OfflineAcceptanceMandate {
+        contact_email: string;
+    }
+
+    interface OnlineAcceptanceMandate {
+        date: number;
+        ip: string;
+        user_agent: string;
+    }
+
+    interface SourceMandateAcceptance {
+        date: number;
+        status: 'accepted' | 'refused';
+        ip?: string;
+        offline?: OfflineAcceptanceMandate;
+        online?: OnlineAcceptanceMandate;
+        type?: 'online'| 'offline';
+        user_agent?: string;
+    }
+
+    interface SourceMandate {
+        acceptance?: SourceMandateAcceptance;
+        amount?: number;
+        currency?: string;
+        interval?: 'one_time' | 'scheduled' | 'variable';
+        notification_method?: 'email' | 'manual' | 'none';
+    }
+
     interface SourceOptions {
         type: string;
         flow?: 'redirect' | 'receiver' | 'code_verification' | 'none';
@@ -189,6 +218,7 @@ declare namespace stripe {
         currency?: string;
         amount?: number;
         owner?: OwnerInfo;
+        mandate?: SourceMandate;
         metadata?: {};
         statement_descriptor?: string;
         redirect?: {

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -129,6 +129,22 @@ describe("Stripe elements", () => {
         card.destroy();
     });
 
+    it("should create an iban source wit a mandate", () => {
+        stripe.createSource({
+            type: 'sepa_debit',
+            sepa_debit: {
+                iban: 'some iban',
+            },
+            owner: {
+                name: 'some holder',
+            },
+            mandate: {
+                notification_method: 'email',
+            },
+            currency: 'eur',
+        });
+    });
+
     it("should create an iban element", () => {
         elements.create('iban', {
             supportedCountries: ['SEPA'],

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -129,8 +129,8 @@ describe("Stripe elements", () => {
         card.destroy();
     });
 
-    it("should create an iban source wit a mandate", () => {
-        stripe.createSource({
+    it("should create an iban source with a mandate", () => {
+        const options: stripe.SourceOptions = {
             type: 'sepa_debit',
             sepa_debit: {
                 iban: 'some iban',
@@ -142,7 +142,9 @@ describe("Stripe elements", () => {
                 notification_method: 'email',
             },
             currency: 'eur',
-        });
+        };
+
+        stripe.createSource(options);
     });
 
     it("should create an iban element", () => {


### PR DESCRIPTION
I noticed a parameter was not referenced, so after a few days with it in my codebase, I decided to try making a PR.

Said parameter is `mandate` for creating a source (probably only useful when the source is a `sepa_debit`. Relevant docs:
- https://stripe.com/docs/js/tokens_sources/create_source
- https://stripe.com/docs/api/sources/create

I hope I got it all right, thanks for your time !
---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
