### PR TITLE
update(webpack-node-externals): white list option refined

### DIFF
--- a/types/webpack-node-externals/index.d.ts
+++ b/types/webpack-node-externals/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/liady/webpack-node-externals
 // Definitions by: Matt Traynham <https://github.com/mtraynham>
 //                 Manuel Pogge <https://github.com/MrSpoocy>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -12,9 +13,10 @@ export = webpackNodeExternals;
 declare function webpackNodeExternals(options?: webpackNodeExternals.Options): ExternalsFunctionElement;
 
 declare namespace webpackNodeExternals {
-    type WhitelistOption = string | RegExp;
+    type WhitelistOption = string | RegExp | WhitelistFunctionType;
     type ImportTypeCallback = (moduleName: string) => string;
-
+    /** a function that accepts the module name and returns whether it should be included */
+    type WhitelistFunctionType = (moduleName: string) => boolean;
     interface ModulesFromFileType {
         exclude?: string | string[];
         include?: string | string[];

--- a/types/webpack-node-externals/webpack-node-externals-tests.ts
+++ b/types/webpack-node-externals/webpack-node-externals-tests.ts
@@ -15,9 +15,14 @@ const c: webpack.Configuration = {
     entry: 'test.js',
     externals: [
         webpackNodeExternals({
-            whitelist: ['jquery', 'webpack/hot/dev-server', /^lodash/]
-        })
-    ]
+            whitelist: [
+                'jquery',
+                'webpack/hot/dev-server',
+                /^lodash/,
+                (moduleName: string) => moduleName === 'moduleF',
+            ],
+        }),
+    ],
 };
 const d: webpack.Configuration = {
     entry: 'test.js',
@@ -68,4 +73,28 @@ const h: webpack.Configuration = {
             }
         })
     ]
+};
+const i: webpack.Configuration = {
+    entry: 'test.js',
+    externals: [
+        webpackNodeExternals({
+            includeAbsolutePaths: true,
+        }),
+    ],
+};
+const j: webpack.Configuration = {
+    entry: 'test.js',
+    externals: [
+        webpackNodeExternals({
+            modulesDir: 'node_modules/somepackage/node_modules',
+        }),
+    ],
+};
+const k: webpack.Configuration = {
+    entry: 'test.js',
+    externals: [
+        webpackNodeExternals({
+            binaryDirs: ['.bin', '._bin'],
+        }),
+    ],
 };


### PR DESCRIPTION
This adds support for filter-like function for white-listing modules as
per existing documentation:
https://github.com/liady/webpack-node-externals#optionswhitelist-

- definition change
- tests updated

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/liady/webpack-node-externals#optionswhitelist-