### PR TITLE
fix(d3-transition): fix interrupt return type for selection interface

### DIFF
--- a/types/d3-transition/d3-transition-tests.ts
+++ b/types/d3-transition/d3-transition-tests.ts
@@ -516,5 +516,11 @@ updateTransitionActive = d3Transition.active<SVGCircleElement, CircleDatum, SVGS
 
 // interrupt(...) ----------------------------------------------------------
 
-d3Transition.interrupt(topTransition.selection().node());
-d3Transition.interrupt(topTransition.selection().node(), 'top');
+const topSelection = topTransition.selection();
+const topNode = topSelection.node();
+
+d3Transition.interrupt(topNode);
+d3Transition.interrupt(topNode, 'top');
+
+// test selection interrupt
+topSelection.interrupt().selectAll('*').interrupt();

--- a/types/d3-transition/index.d.ts
+++ b/types/d3-transition/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for D3JS d3-transition module 1.1
 // Project: https://github.com/d3/d3-transition/, https://d3js.org/d3-transition
-// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+//                 Alex Ford <https://github.com/gustavderdrache>
+//                 Boris Yankov <https://github.com/borisyankov>
+//                 Robert Moura <https://github.com/robertmoura>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -31,7 +34,7 @@ declare module 'd3-selection' {
          *
          * @param name Name of the transition.
          */
-        interrupt(name?: string): Transition<GElement, Datum, PElement, PDatum>;
+        interrupt(name?: string): this;
         /**
          * Returns a new transition on the given selection with the specified name. If a name is not specified, null is used.
          * The new transition is only exclusive with other transitions of the same name.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-transition#selection_interrupt
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
---
Small change to align the `interrupt` function with the d3 spec. It should returns the current selection to allow multiple interrupts like so: `selection.interrupt().selectAll('*').interrupt();` (example from the [documentation](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request)).