### PR TITLE
[chai] Remove my name from the contributors

### DIFF
--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -10,7 +10,6 @@
 //                 Gintautas Miselis <https://github.com/Naktibalda>
 //                 Satana Charuwichitratana <https://github.com/micksatana>
 //                 Erik Schierboom <https://github.com/ErikSchierboom>
-//                 Rebecca Turner <https://github.com/9999years>
 //                 Bogdan Paranytsia <https://github.com/bparan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0


### PR DESCRIPTION
Given that `@types/chai` is [being used by Palantir to attempt genocide](https://icebreaker.dev/), I don't feel comfortable being listed as a contributor. Remove my name from the list of authors.