### PR TITLE
[cheerio] Remove my name from the contributors

### DIFF
--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -8,7 +8,6 @@
 //                 Chennakrishna <https://github.com/chennakrishna8>
 //                 AzSiAz <https://github.com/AzSiAz>
 //                 Ryo Ota <https://github.com/nwtgck>
-//                 Rebecca Turner <https://github.com/9999years>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />


### PR DESCRIPTION
Given that `@types/cheerio` is [being used by Palantir to attempt genocide](https://icebreaker.dev/), I don't feel comfortable being listed as a contributor. Remove my name from the list of authors.