### PR TITLE
@types/node: http2: Add protocol option to http2.connect

### DIFF
--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -440,6 +440,7 @@ declare module "http2" {
     export interface ClientSessionOptions extends SessionOptions {
         maxReservedRemoteStreams?: number;
         createConnection?: (authority: url.URL, option: SessionOptions) => stream.Duplex;
+        protocol?: 'http:' | 'https:';
     }
 
     export interface ServerSessionOptions extends SessionOptions {

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -350,6 +350,7 @@ import { URL } from 'url';
         maxSendHeaderBlockLength: 0,
         paddingStrategy: 0,
         peerMaxConcurrentStreams: 0,
+        protocol: 'https:',
         selectPadding: (frameLen: number, maxFrameLen: number) => 0,
         settings
     };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: the option is read at https://github.com/nodejs/node/blob/70c32a6d190e2b5d7b9ff9d5b6a459d14e8b7d59/lib/internal/http2/core.js#L3010 and checked at https://github.com/nodejs/node/blob/70c32a6d190e2b5d7b9ff9d5b6a459d14e8b7d59/lib/internal/http2/core.js#L3028-L3036

I am unsure about restricting the option so strongly. On one hand, in the code path that checks the value, any value other than those two results in an error being thrown. On the other hand, there is a code path that does not check the value at all, so technically in that case any value is allowed.
