### PR TITLE
fix(d3-axis): Allow use of scales with toString property

### DIFF
--- a/types/d3-axis/d3-axis-tests.ts
+++ b/types/d3-axis/d3-axis-tests.ts
@@ -35,6 +35,7 @@ let num: number;
 let axisScaleNumber: d3Axis.AxisScale<number>;
 let axisScaleDate: d3Axis.AxisScale<Date>;
 let axisScaleString: d3Axis.AxisScale<string>;
+let axisScaleToString: d3Axis.AxisScale<{ toString(): string }>;
 
 // --------------------------------------------------------------------------
 // Test AxisScale Helper Interface
@@ -47,6 +48,7 @@ axisScaleNumber = scaleBand<number>();
 axisScaleNumber = scalePoint<number>();
 axisScaleString = scaleBand();
 axisScaleString = scalePoint();
+axisScaleToString = scaleBand<{ toString(): string }>();
 
 // --------------------------------------------------------------------------
 // Test AxisContainerElement
@@ -69,7 +71,7 @@ containerElement = canvas; // fails, incompatible type
 let topAxis: d3Axis.Axis<number | { valueOf(): number }> = d3Axis.axisTop(scaleLinear());
 let rightAxis: d3Axis.Axis<Date> = d3Axis.axisRight<Date>(scaleTime());
 let bottomAxis: d3Axis.Axis<string> = d3Axis.axisBottom(scaleOrdinal<number>());
-let leftAxis: d3Axis.Axis<number | { valueOf(): number }> = d3Axis.axisLeft(scaleLinear<number>());
+let leftAxis: d3Axis.Axis<{ toString(): string }> = d3Axis.axisLeft(scaleBand<{ toString(): string }>());
 
 // --------------------------------------------------------------------------
 // Test Configure Axis
@@ -77,8 +79,8 @@ let leftAxis: d3Axis.Axis<number | { valueOf(): number }> = d3Axis.axisLeft(scal
 
 // scale(...) ----------------------------------------------------------------
 
-leftAxis = leftAxis.scale(scalePow());
-const powerScale: ScalePower<number, number> = leftAxis.scale<ScalePower<number, number>>();
+topAxis = topAxis.scale(scalePow());
+const powerScale: ScalePower<number, number> = topAxis.scale<ScalePower<number, number>>();
 
 bottomAxis = bottomAxis.scale(scaleOrdinal<number>());
 // $ExpectError

--- a/types/d3-axis/index.d.ts
+++ b/types/d3-axis/index.d.ts
@@ -4,6 +4,7 @@
 //                 Alex Ford <https://github.com/gustavderdrache>
 //                 Boris Yankov <https://github.com/borisyankov>
 //                 denisname <https://github.com/denisname>
+//                 Robert Moura <https://github.com/robertmoura>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -18,7 +19,7 @@ import { Selection, TransitionLike } from 'd3-selection';
 /**
  * A helper type to alias elements which can serve as a domain for an axis.
  */
-export type AxisDomain = number | string | Date | { valueOf(): number};
+export type AxisDomain = { toString(): string } | number | { valueOf(): number};
 
 /**
  * A helper interface to describe the minimal contract to be met by a time interval


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
---
Changing an existing definition
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-axis#axisTop
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
---
I've changed the axis domain to allow any scale that has a `toString` domain to create an axis. This helps with previous typings for scales like the [ordinal scale](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/d3-scale/index.d.ts#L1451). For example this was an error: 
```typescript
const bandScale = d3.scaleBand<{ toString(): string }>();

d3.axisLeft(bandScale); // Error here
```