### PR TITLE
[@types/react-native] Fix: Animated Components are always any type

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8474,7 +8474,7 @@ export namespace Animated {
     /**
      * Make any React component Animatable.  Used to create `Animated.View`, etc.
      */
-    export function createAnimatedComponent<T>(component: React.FC<T> | typeof React.Component): AnimatedComponent<T>;
+    export function createAnimatedComponent<T extends React.FC | typeof React.Component>(component: T): AnimatedComponent<T>;
 
     /**
      * Animated variants of the basic native views. Accepts Animated.Value for

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8470,9 +8470,14 @@ export namespace Animated {
 
     export type ComponentProps<T> = T extends React.ComponentType<infer P> | React.Component<infer P> ? P : never;
 
-    export type WithAnimatedValue<T> = T extends object ? {
-        [K in keyof T]?: WithAnimatedValue<T[K]>;
-    } : T extends (infer P)[] ? WithAnimatedValue<P>[] : T | Value | AnimatedInterpolation;
+    export interface WithAnimatedValue<T>
+      extends ThisType<
+        T extends object
+          ? { [K in keyof T]?: WithAnimatedValue<T[K]> }
+          : T extends (infer P)[]
+          ? WithAnimatedValue<P>[]
+          : T | Animated.Value | Animated.AnimatedInterpolation
+        > {}
 
     export type AnimatedProps<T> = {
         [key in keyof T]: WithAnimatedValue<T[key]>;

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8469,7 +8469,15 @@ export namespace Animated {
 
     export type ComponentProps<T> = T extends React.ComponentType<infer P> | React.Component<infer P> ? P : never;
 
-    export interface AnimatedComponent<T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>> extends React.FC<ComponentProps<T>> {
+    export type WithAnimatedValue<T> = T extends Object ? {
+        [K in keyof T]: WithAnimatedValue<T[K]>;
+    } : T | Value;
+
+    export type AnimatedProps<T> = {
+        [key in keyof T]: WithAnimatedValue<T[key]>;
+    }
+
+    export interface AnimatedComponent<T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>> extends React.FC<AnimatedProps<ComponentProps<T>>> {
         getNode: () => T;
     }
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8469,7 +8469,7 @@ export namespace Animated {
 
     export type ComponentProps<T> = T extends React.ComponentType<infer P> | React.Component<infer P> ? P : never;
 
-    export interface AnimatedComponent<T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>> extends React.FC<ComponentProps<T>>{
+    export interface AnimatedComponent<T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>> extends React.FC<ComponentProps<T>> {
         getNode: () => T;
     }
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8467,7 +8467,7 @@ export namespace Animated {
      */
     export function event<T>(argMapping: Array<Mapping | null>, config?: EventConfig<T>): (...args: any[]) => void;
 
-    export interface AnimatedComponent<T extends React.FC | typeof React.Component> extends React.FC<T['props']> {
+    export interface AnimatedComponent<T extends React.ComponentType> extends React.FC<T['props']> {
       getNode: () => T;
     }
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -32,8 +32,7 @@
 //                 Kelvin Chu <https://github.com/RageBill>
 //                 Daiki Ihara <https://github.com/sasurau4>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.7
-// Minimum TypeScript Version: 3.7
+// TypeScript Version: 2.8
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3994,7 +3994,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     removeClippedSubviews?: boolean;
 }
 
-export class FlatList<ItemT> extends React.Component<FlatListProps<ItemT>> {
+export class FlatList<ItemT = any> extends React.Component<FlatListProps<ItemT>> {
     /**
      * Exports some data, e.g. for perf investigations or analytics.
      */
@@ -4222,7 +4222,7 @@ export interface SectionListScrollParams {
     viewPosition?: number;
 }
 
-export class SectionList<SectionT> extends React.Component<SectionListProps<SectionT>> {
+export class SectionList<SectionT = any> extends React.Component<SectionListProps<SectionT>> {
     /**
      * Scrolls to the item at the specified sectionIndex and itemIndex (within the section)
      * positioned in the viewable area such that viewPosition 0 places it at the top
@@ -8467,21 +8467,25 @@ export namespace Animated {
      */
     export function event<T>(argMapping: Array<Mapping | null>, config?: EventConfig<T>): (...args: any[]) => void;
 
+    export interface AnimatedComponent<T extends React.FC | typeof React.Component> extends React.FC<T['props']> {
+      getNode: () => T;
+    }
+
     /**
      * Make any React component Animatable.  Used to create `Animated.View`, etc.
      */
-    export function createAnimatedComponent(component: any): any;
+    export function createAnimatedComponent<T>(component: React.FC<T> | typeof React.Component): AnimatedComponent<T>;
 
     /**
      * Animated variants of the basic native views. Accepts Animated.Value for
      * props and style.
      */
-    export const View: any;
-    export const Image: any;
-    export const Text: any;
-    export const ScrollView: any;
-    export const FlatList: any;
-    export const SectionList: any;
+    export const View: AnimatedComponent<View>;
+    export const Image: AnimatedComponent<Image>;
+    export const Text: AnimatedComponent<Text>;
+    export const ScrollView: AnimatedComponent<ScrollView>;
+    export const FlatList: AnimatedComponent<FlatList>;
+    export const SectionList: AnimatedComponent<SectionList>;
 }
 
 // tslint:disable-next-line:interface-name

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8467,14 +8467,16 @@ export namespace Animated {
      */
     export function event<T>(argMapping: Array<Mapping | null>, config?: EventConfig<T>): (...args: any[]) => void;
 
-    export interface AnimatedComponent<T extends React.ComponentType> extends React.FC<T['props']> {
-      getNode: () => T;
+    export type ComponentProps<T> = T extends React.ComponentType<infer P> | React.Component<infer P> ? P : never;
+
+    export interface AnimatedComponent<T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>> extends React.FC<ComponentProps<T>>{
+        getNode: () => T;
     }
 
     /**
      * Make any React component Animatable.  Used to create `Animated.View`, etc.
      */
-    export function createAnimatedComponent<T extends React.ComponentType>(component: T): AnimatedComponent<T>;
+    export function createAnimatedComponent<T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>>(component: T): AnimatedComponent<InstanceType<T>>;
 
     /**
      * Animated variants of the basic native views. Accepts Animated.Value for

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8471,7 +8471,7 @@ export namespace Animated {
 
     export type WithAnimatedValue<T> = T extends Object ? {
         [K in keyof T]: WithAnimatedValue<T[K]>;
-    } : T | Value;
+    } : T extends Array<infer P> ? WithAnimatedValue<P>[] : T | Value;
 
     export type AnimatedProps<T> = {
         [key in keyof T]: WithAnimatedValue<T[key]>;

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8476,7 +8476,7 @@ export namespace Animated {
     /**
      * Make any React component Animatable.  Used to create `Animated.View`, etc.
      */
-    export function createAnimatedComponent<T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>>(component: T): AnimatedComponent<T extends React.FunctionComponent<ComponentProps<T>> ? T : InstanceType<T>>;
+    export function createAnimatedComponent<T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>>(component: T): AnimatedComponent<T extends React.ComponentClass<ComponentProps<T>> ? InstanceType<T> : T>;
 
     /**
      * Animated variants of the basic native views. Accepts Animated.Value for

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -32,7 +32,7 @@
 //                 Kelvin Chu <https://github.com/RageBill>
 //                 Daiki Ihara <https://github.com/sasurau4>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.7
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8478,9 +8478,7 @@ export namespace Animated {
           : T | Animated.Value | Animated.AnimatedInterpolation
         > {}
 
-    export type AnimatedProps<T> = {
-        [key in keyof T]: WithAnimatedValue<T[key]>;
-    }
+    export type AnimatedProps<T> = { [key in keyof T]: WithAnimatedValue<T[key]> };
 
     export interface AnimatedComponent<T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>> extends React.FC<AnimatedProps<ComponentProps<T>>> {
         getNode: () => T;

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8476,7 +8476,7 @@ export namespace Animated {
     /**
      * Make any React component Animatable.  Used to create `Animated.View`, etc.
      */
-    export function createAnimatedComponent<T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>>(component: T): AnimatedComponent<InstanceType<T>>;
+    export function createAnimatedComponent<T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>>(component: T): AnimatedComponent<T extends React.FunctionComponent<ComponentProps<T>> ? T : InstanceType<T>>;
 
     /**
      * Animated variants of the basic native views. Accepts Animated.Value for

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -33,6 +33,7 @@
 //                 Daiki Ihara <https://github.com/sasurau4>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
+// Minimum TypeScript Version: 3.7
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8469,9 +8469,9 @@ export namespace Animated {
 
     export type ComponentProps<T> = T extends React.ComponentType<infer P> | React.Component<infer P> ? P : never;
 
-    export type WithAnimatedValue<T> = T extends Object ? {
-        [K in keyof T]: WithAnimatedValue<T[K]>;
-    } : T extends Array<infer P> ? WithAnimatedValue<P>[] : T | Value;
+    export type WithAnimatedValue<T> = T extends object ? {
+        [K in keyof T]?: WithAnimatedValue<T[K]>;
+    } : T extends (infer P)[] ? WithAnimatedValue<P>[] : T | Value | AnimatedInterpolation;
 
     export type AnimatedProps<T> = {
         [key in keyof T]: WithAnimatedValue<T[key]>;

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8474,7 +8474,7 @@ export namespace Animated {
     /**
      * Make any React component Animatable.  Used to create `Animated.View`, etc.
      */
-    export function createAnimatedComponent<T extends React.FC | typeof React.Component>(component: T): AnimatedComponent<T>;
+    export function createAnimatedComponent<T extends React.ComponentType>(component: T): AnimatedComponent<T>;
 
     /**
      * Animated variants of the basic native views. Accepts Animated.Value for

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8475,7 +8475,7 @@ export namespace Animated {
           ? { [K in keyof T]?: WithAnimatedValue<T[K]> }
           : T extends (infer P)[]
           ? WithAnimatedValue<P>[]
-          : T | Animated.Value | Animated.AnimatedInterpolation
+          : T | Value | AnimatedInterpolation
         > {}
 
     export type AnimatedProps<T> = { [key in keyof T]: WithAnimatedValue<T[key]> };

--- a/types/react-native/test/animated.tsx
+++ b/types/react-native/test/animated.tsx
@@ -84,7 +84,7 @@ function TestAnimatedAPI() {
                 ]}
             />
 
-            <Animated.Image style={position.getTranslateTransform()} />
+            <Animated.Image style={position.getTranslateTransform()} source={{uri: 'https://picsum.photos/200'}} />
         </View>
     );
 }


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

Closes #40424