### PR TITLE
[cli-progress] increment can be called without parameters.

### DIFF
--- a/types/cli-progress/cli-progress-tests.ts
+++ b/types/cli-progress/cli-progress-tests.ts
@@ -94,6 +94,8 @@ function test5() {
 function test6() {
     // SingleBar
     const bar2 = new progress.SingleBar({}, progress.Presets.shades_classic);
+    bar2.increment();
+    bar2.increment(10);
 
     // MultiBar
     const multiBar = new progress.MultiBar({}, progress.Presets.shades_classic);

--- a/types/cli-progress/index.d.ts
+++ b/types/cli-progress/index.d.ts
@@ -122,7 +122,7 @@ export class SingleBar {
     getTotal(): any;
 
     /** Increases the current progress value by a specified amount (default +1). Update payload optionally */
-    increment(step: number, payload?: object): void;
+    increment(step?: number, payload?: object): void;
 
     render(): void;
 


### PR DESCRIPTION
> *::increment()*
> Increases the current progress value by a specified amount (default +1). Update payload optionally

Source: https://www.npmjs.com/package/cli-progress#increment