### PR TITLE
[@types/stripe-v3] accept BankAccountOptions on createToken

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -25,7 +25,7 @@ declare namespace stripe {
 
     interface Stripe {
         elements(options?: elements.ElementsCreateOptions): elements.Elements;
-        createToken(element: elements.Element, options?: TokenOptions): Promise<TokenResponse>;
+        createToken(element: elements.Element, options?: TokenOptions | BankAccountTokenOptions): Promise<TokenResponse>;
         createToken(name: 'bank_account', options: BankAccountTokenOptions): Promise<TokenResponse>;
         createToken(name: 'pii', options: PiiTokenOptions): Promise<TokenResponse>;
         createSource(element: elements.Element, options?: { owner?: OwnerInfo }): Promise<SourceResponse>;

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -130,10 +130,39 @@ describe("Stripe elements", () => {
     });
 
     it("should create an iban element", () => {
-        elements.create('iban', {
+        const ibanElement = elements.create('iban', {
             supportedCountries: ['SEPA'],
             placeholderCountry: 'AT'
         });
+        stripe.createToken(ibanElement, {
+            country: 'US',
+            currency: 'USD',
+            routing_number: '110000000',
+            account_number: '110000000',
+            account_holder_name: 'Jane Austen',
+            account_holder_type: 'individual',
+        })
+            .then((result: stripe.TokenResponse) => {
+                console.log(result.token);
+            },
+                (error: stripe.Error) => {
+                    console.error(error);
+                });
+
+        stripe.createToken('bank_account', {
+            country: 'US',
+            currency: 'USD',
+            routing_number: '110000000',
+            account_number: '110000000',
+            account_holder_name: 'Jane Austen',
+            account_holder_type: 'individual',
+        })
+            .then((result: stripe.TokenResponse) => {
+                console.log(result.token);
+            },
+                (error: stripe.Error) => {
+                    console.error(error);
+                });
     });
 
     it("should create an idealBank element", () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ x Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/api/tokens/create_bank_account / https://stripe.com/docs/api/tokens/create_card?lang=node / https://github.com/stripe/stripe-node/blob/e766d366bc070a80498ff14e8cd508ba0abb40b1/types/2019-12-03/Tokens.d.ts#L81

Basically I couldn't find any definition for the string as first parameter version of createToken, but the type of options basically depends on whatever type the Element is.