### PR TITLE
@types/passport-auth0: Add default export to type definition

### DIFF
--- a/types/passport-auth0/index.d.ts
+++ b/types/passport-auth0/index.d.ts
@@ -55,7 +55,7 @@ export type VerifyFunction = (
     refreshToken: string,
     extraParams: ExtraVerificationParams,
     profile: Profile,
-    done: (error: any, user?: any, info?: any) => void
+    done: (error: any, user?: any, info?: any) => void,
 ) => void;
 
 export type VerifyFunctionWithRequest = (
@@ -63,7 +63,7 @@ export type VerifyFunctionWithRequest = (
     accessToken: string,
     refreshToken: string,
     profile: Profile,
-    done: (error: any, user?: any, info?: any) => void
+    done: (error: any, user?: any, info?: any) => void,
 ) => void;
 
 export class Strategy extends passport.Strategy {

--- a/types/passport-auth0/index.d.ts
+++ b/types/passport-auth0/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: John Umeh <https://github.com/johnbendi>
 //                 Vishnu Sankar <https://github.com/iamvishnusankar>
 //                 Duncan Hall <https://github.com/duncanhall>
+//                 Karl Horky <https://github.com/karlhorky>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/passport-auth0/index.d.ts
+++ b/types/passport-auth0/index.d.ts
@@ -10,70 +10,68 @@
 import passport = require('passport');
 import express = require('express');
 
-declare module 'passport-auth0' {
-    export interface Profile extends passport.Profile {
-        id: string;
-        displayName: string;
-        gender?: string;
-        ageRange?: {
-            min: number;
-            max?: number;
-        };
-        profileUrl?: string;
-        username?: string;
-        birthday: string;
+export interface Profile extends passport.Profile {
+    id: string;
+    displayName: string;
+    gender?: string;
+    ageRange?: {
+        min: number;
+        max?: number;
+    };
+    profileUrl?: string;
+    username?: string;
+    birthday: string;
 
-        _raw: string;
-        _json: any;
-    }
-
-    export interface AuthenticateOptions extends passport.AuthenticateOptions {
-        authType?: string;
-    }
-
-    export interface StrategyOption {
-        clientID: string;
-        clientSecret: string;
-        callbackURL: string;
-        domain: string;
-        scopeSeparator?: string;
-        enableProof?: boolean;
-        profileFields?: string[];
-        state?: boolean;
-    }
-
-    export interface StrategyOptionWithRequest extends StrategyOption {
-        passReqToCallback: true;
-    }
-    export interface ExtraVerificationParams {
-        audience?: string;
-        connection?: string;
-        prompt?: string;
-    }
-
-    export type VerifyFunction = (
-        accessToken: string,
-        refreshToken: string,
-        extraParams: ExtraVerificationParams,
-        profile: Profile,
-        done: (error: any, user?: any, info?: any) => void,
-    ) => void;
-
-    export type VerifyFunctionWithRequest = (
-        req: express.Request,
-        accessToken: string,
-        refreshToken: string,
-        profile: Profile,
-        done: (error: any, user?: any, info?: any) => void,
-    ) => void;
-
-    export class Strategy extends passport.Strategy {
-        constructor(options: StrategyOptionWithRequest, verify: VerifyFunctionWithRequest);
-        constructor(options: StrategyOption, verify: VerifyFunction);
-
-        name: string;
-        authenticate(req: express.Request, options?: object): void;
-    }
-
-    export default Strategy;
+    _raw: string;
+    _json: any;
 }
+
+export interface AuthenticateOptions extends passport.AuthenticateOptions {
+    authType?: string;
+}
+
+export interface StrategyOption {
+    clientID: string;
+    clientSecret: string;
+    callbackURL: string;
+    domain: string;
+    scopeSeparator?: string;
+    enableProof?: boolean;
+    profileFields?: string[];
+    state?: boolean;
+}
+
+export interface StrategyOptionWithRequest extends StrategyOption {
+    passReqToCallback: true;
+}
+export interface ExtraVerificationParams {
+    audience?: string;
+    connection?: string;
+    prompt?: string;
+}
+
+export type VerifyFunction = (
+    accessToken: string,
+    refreshToken: string,
+    extraParams: ExtraVerificationParams,
+    profile: Profile,
+    done: (error: any, user?: any, info?: any) => void,
+) => void;
+
+export type VerifyFunctionWithRequest = (
+    req: express.Request,
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
+    done: (error: any, user?: any, info?: any) => void,
+) => void;
+
+export class Strategy extends passport.Strategy {
+    constructor(options: StrategyOptionWithRequest, verify: VerifyFunctionWithRequest);
+    constructor(options: StrategyOption, verify: VerifyFunction);
+
+    name: string;
+    authenticate(req: express.Request, options?: object): void;
+}
+
+export default Strategy;

--- a/types/passport-auth0/index.d.ts
+++ b/types/passport-auth0/index.d.ts
@@ -72,3 +72,5 @@ export class Strategy extends passport.Strategy {
     name: string;
     authenticate(req: express.Request, options?: object): void;
 }
+
+export = Strategy;

--- a/types/passport-auth0/index.d.ts
+++ b/types/passport-auth0/index.d.ts
@@ -66,7 +66,7 @@ export type VerifyFunctionWithRequest = (
     done: (error: any, user?: any, info?: any) => void,
 ) => void;
 
-declare class Strategy extends passport.Strategy {
+export class Strategy extends passport.Strategy {
     constructor(options: StrategyOptionWithRequest, verify: VerifyFunctionWithRequest);
     constructor(options: StrategyOption, verify: VerifyFunction);
 
@@ -74,4 +74,4 @@ declare class Strategy extends passport.Strategy {
     authenticate(req: express.Request, options?: object): void;
 }
 
-export { Strategy as default,  Strategy };
+export { Strategy as default };

--- a/types/passport-auth0/index.d.ts
+++ b/types/passport-auth0/index.d.ts
@@ -66,7 +66,7 @@ export type VerifyFunctionWithRequest = (
     done: (error: any, user?: any, info?: any) => void,
 ) => void;
 
-class Strategy extends passport.Strategy {
+declare class Strategy extends passport.Strategy {
     constructor(options: StrategyOptionWithRequest, verify: VerifyFunctionWithRequest);
     constructor(options: StrategyOption, verify: VerifyFunction);
 

--- a/types/passport-auth0/index.d.ts
+++ b/types/passport-auth0/index.d.ts
@@ -66,7 +66,7 @@ export type VerifyFunctionWithRequest = (
     done: (error: any, user?: any, info?: any) => void,
 ) => void;
 
-export class Strategy extends passport.Strategy {
+class Strategy extends passport.Strategy {
     constructor(options: StrategyOptionWithRequest, verify: VerifyFunctionWithRequest);
     constructor(options: StrategyOption, verify: VerifyFunction);
 
@@ -74,4 +74,4 @@ export class Strategy extends passport.Strategy {
     authenticate(req: express.Request, options?: object): void;
 }
 
-export = Strategy;
+export { Strategy as default,  Strategy };

--- a/types/passport-auth0/index.d.ts
+++ b/types/passport-auth0/index.d.ts
@@ -74,4 +74,4 @@ export class Strategy extends passport.Strategy {
     authenticate(req: express.Request, options?: object): void;
 }
 
-export { Strategy as default };
+export default Strategy;

--- a/types/passport-auth0/index.d.ts
+++ b/types/passport-auth0/index.d.ts
@@ -10,68 +10,70 @@
 import passport = require('passport');
 import express = require('express');
 
-export interface Profile extends passport.Profile {
-    id: string;
-    displayName: string;
-    gender?: string;
-    ageRange?: {
-        min: number;
-        max?: number;
-    };
-    profileUrl?: string;
-    username?: string;
-    birthday: string;
+declare module 'passport-auth0' {
+    export interface Profile extends passport.Profile {
+        id: string;
+        displayName: string;
+        gender?: string;
+        ageRange?: {
+            min: number;
+            max?: number;
+        };
+        profileUrl?: string;
+        username?: string;
+        birthday: string;
 
-    _raw: string;
-    _json: any;
+        _raw: string;
+        _json: any;
+    }
+
+    export interface AuthenticateOptions extends passport.AuthenticateOptions {
+        authType?: string;
+    }
+
+    export interface StrategyOption {
+        clientID: string;
+        clientSecret: string;
+        callbackURL: string;
+        domain: string;
+        scopeSeparator?: string;
+        enableProof?: boolean;
+        profileFields?: string[];
+        state?: boolean;
+    }
+
+    export interface StrategyOptionWithRequest extends StrategyOption {
+        passReqToCallback: true;
+    }
+    export interface ExtraVerificationParams {
+        audience?: string;
+        connection?: string;
+        prompt?: string;
+    }
+
+    export type VerifyFunction = (
+        accessToken: string,
+        refreshToken: string,
+        extraParams: ExtraVerificationParams,
+        profile: Profile,
+        done: (error: any, user?: any, info?: any) => void,
+    ) => void;
+
+    export type VerifyFunctionWithRequest = (
+        req: express.Request,
+        accessToken: string,
+        refreshToken: string,
+        profile: Profile,
+        done: (error: any, user?: any, info?: any) => void,
+    ) => void;
+
+    export class Strategy extends passport.Strategy {
+        constructor(options: StrategyOptionWithRequest, verify: VerifyFunctionWithRequest);
+        constructor(options: StrategyOption, verify: VerifyFunction);
+
+        name: string;
+        authenticate(req: express.Request, options?: object): void;
+    }
+
+    export default Strategy;
 }
-
-export interface AuthenticateOptions extends passport.AuthenticateOptions {
-    authType?: string;
-}
-
-export interface StrategyOption {
-    clientID: string;
-    clientSecret: string;
-    callbackURL: string;
-    domain: string;
-    scopeSeparator?: string;
-    enableProof?: boolean;
-    profileFields?: string[];
-    state?: boolean;
-}
-
-export interface StrategyOptionWithRequest extends StrategyOption {
-    passReqToCallback: true;
-}
-export interface ExtraVerificationParams {
-    audience?: string;
-    connection?: string;
-    prompt?: string;
-}
-
-export type VerifyFunction = (
-    accessToken: string,
-    refreshToken: string,
-    extraParams: ExtraVerificationParams,
-    profile: Profile,
-    done: (error: any, user?: any, info?: any) => void,
-) => void;
-
-export type VerifyFunctionWithRequest = (
-    req: express.Request,
-    accessToken: string,
-    refreshToken: string,
-    profile: Profile,
-    done: (error: any, user?: any, info?: any) => void,
-) => void;
-
-export class Strategy extends passport.Strategy {
-    constructor(options: StrategyOptionWithRequest, verify: VerifyFunctionWithRequest);
-    constructor(options: StrategyOption, verify: VerifyFunction);
-
-    name: string;
-    authenticate(req: express.Request, options?: object): void;
-}
-
-export default Strategy;

--- a/types/passport-auth0/passport-auth0-tests.ts
+++ b/types/passport-auth0/passport-auth0-tests.ts
@@ -12,7 +12,7 @@ const User = {
     }
 };
 
-passport.use(new auth0.Strategy({
+passport.use(new auth0({
     clientID: process.env.PASSPORT_AUTH0_CLIENT_ID as string,
     clientSecret: process.env.PASSPORT_AUTH0_CLIENT_SECRET as string,
     callbackURL: process.env.PASSPORT_AUTH0_CALLBACK_URL as string,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/passport-auth0/blob/09f18140de08ca9f7dc1549a881e8bd5eee9ffd4/lib/index.js#L187-L190
- ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~

