### PR TITLE
Unwrap promises

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -234,7 +234,7 @@ export interface JSEvalable<A = any> {
     evaluate<T extends EvaluateFn<A>>(
       pageFunction: T,
       ...args: SerializableOrJSHandle[],
-    ): Promise<EvaluateFnReturnType<T>>;
+    ): Promise<EvaluateFnReturnType<T> extends PromiseLike<infer U> ? U : EvaluateFnReturnType<T>>;
     /**
      * The only difference between `evaluate` and `evaluateHandle` is that `evaluateHandle` returns in-page object (`JSHandle`).
      * If the function, passed to the `evaluateHandle`, returns a `Promise`, then `evaluateHandle` would wait for the

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -550,8 +550,9 @@ puppeteer.launch().then(async browser => {
 (async () => {
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
-  const s = await page.evaluate(() => Promise.resolve(document.body.innerHTML));
-  console.log('body html has length', s.length);
+  await page.evaluate(() => Promise.resolve(document.body.innerHTML)).then(s => {
+    console.log('body html has length', s.length);
+  });
 });
 
 // JSHandle.jsonValue produces compatible type

--- a/types/puppeteer/v1/index.d.ts
+++ b/types/puppeteer/v1/index.d.ts
@@ -234,7 +234,7 @@ export interface JSEvalable<A = any> {
     evaluate<T extends EvaluateFn<A>>(
       pageFunction: T,
       ...args: SerializableOrJSHandle[],
-    ): Promise<EvaluateFnReturnType<T>>;
+    ): Promise<EvaluateFnReturnType<T> extends PromiseLike<infer U> ? U : EvaluateFnReturnType<T>>;
     /**
      * The only difference between `evaluate` and `evaluateHandle` is that `evaluateHandle` returns in-page object (`JSHandle`).
      * If the function, passed to the `evaluateHandle`, returns a `Promise`, then `evaluateHandle` would wait for the

--- a/types/puppeteer/v1/puppeteer-tests.ts
+++ b/types/puppeteer/v1/puppeteer-tests.ts
@@ -549,8 +549,9 @@ puppeteer.launch().then(async browser => {
 (async () => {
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
-  const s = await page.evaluate(() => Promise.resolve(document.body.innerHTML));
-  console.log('body html has length', s.length);
+  await page.evaluate(() => Promise.resolve(document.body.innerHTML)).then(s => {
+    console.log('body html has length', s.length);
+  });
 });
 
 // JSHandle.jsonValue produces compatible type

--- a/types/task-worklet/index.d.ts
+++ b/types/task-worklet/index.d.ts
@@ -18,7 +18,7 @@ declare namespace TaskQueue {
     interface Task<T = any> {
         id: number;
         state: State;
-        result: Promise<T>;
+        result: Promise<T extends PromiseLike<infer U> ? U : T>;
     }
 
     type State =

--- a/types/task-worklet/task-worklet-tests.ts
+++ b/types/task-worklet/task-worklet-tests.ts
@@ -14,7 +14,9 @@ queue.addModule('/fetcher-worklet.js');                               // $Expect
 const task = queue.postTask('fetch', 'https://example.com');          // $ExpectType Task
 
 async () => {
-  const result = await task.result;                                   // $ExpectType any
+  await task.result.then(result => {
+    result;                                                           // $ExpectType any
+  });
   const id = task.id;                                                 // $ExpectType number
   const state = task.state;                                           // $ExpectType State
 };

--- a/types/task-worklet/ts3.1/index.d.ts
+++ b/types/task-worklet/ts3.1/index.d.ts
@@ -16,7 +16,7 @@ interface TaskDescriptor {
 export interface Task<T = unknown> {
     id: number;
     state: State;
-    result: Promise<T>;
+    result: Promise<T extends PromiseLike<infer U> ? U : T>;
 }
 
 export type State =

--- a/types/task-worklet/ts3.1/task-worklet-tests.ts
+++ b/types/task-worklet/ts3.1/task-worklet-tests.ts
@@ -14,7 +14,9 @@ queue.addModule('/fetcher-worklet.js');                               // $Expect
 const task = queue.postTask<Fetcher>('fetch', 'https://example.com'); // $ExpectType Task<Promise<Response>>
 
 async () => {
-  const result = await task.result;                                   // $ExpectType Response
+  await task.result.then(result => {
+    result;                                                           // $ExpectType Response
+  });
   const id = task.id;                                                 // $ExpectType number
   const state = task.state;                                           // $ExpectType State
 };


### PR DESCRIPTION
```TypeScript
// even through a double promise.
(async () => {
  const browser = await puppeteer.launch();
  const page = await browser.newPage();
  await page.evaluate(() => Promise.resolve(document.body.innerHTML)).then(s => {
    console.log('body html has length', s.length);
  });
});
```

### Before

`page.evaluate()` returned a `Promise<Promise<string>>` :x:
```
Error in puppeteer
Error: /home/travis/build/DefinitelyTyped/DefinitelyTyped/types/puppeteer/puppeteer-tests.ts:554:43
ERROR: 554:43  expect  TypeScript@next compile error: 
Property 'length' does not exist on type 'Promise<string>'.
ERROR: 626:10  expect  TypeScript@next compile error: 
```

### After

It returns a `Promise<string>` :heavy_check_mark:

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- ~[ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- ~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~