### PR TITLE
fix: stub out the Context class

### DIFF
--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -206,6 +206,6 @@ multipleLiterals = clownface({ dataset }).node([ 'a', 10, false ]);
 const multipleMixedTerms: clownface.SafeClownface<Dataset> = clownface({ dataset }).node([ 'a', node, null ]);
 
 // .context
-const ctxTerm: Literal = fromSingleArrayLiteral._context.term;
-const ctxGraph: Quad_Graph | undefined = fromSingleArrayLiteral._context.graph;
-const ctxDataset: Dataset = fromSingleArrayLiteral._context.dataset;
+const ctxTerm: Literal = fromSingleArrayLiteral._context[0].term;
+const ctxGraph: Quad_Graph | undefined = fromSingleArrayLiteral._context[0].graph;
+const ctxDataset: Dataset = fromSingleArrayLiteral._context[0].dataset;

--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -1,4 +1,4 @@
-import { Term, NamedNode, Dataset, Literal, DatasetCore, BlankNode } from 'rdf-js';
+import { Term, NamedNode, Dataset, Literal, DatasetCore, BlankNode, Quad_Graph } from 'rdf-js';
 import Clownface = require('clownface/lib/Clownface');
 import clownface = require('clownface');
 
@@ -204,3 +204,8 @@ let multipleLiterals: clownface.SafeClownface<Dataset, Literal> = safeCf.literal
 multipleLiterals = clownface({ dataset }).node([ 'a', 10, false ]);
 
 const multipleMixedTerms: clownface.SafeClownface<Dataset> = clownface({ dataset }).node([ 'a', node, null ]);
+
+// .context
+const ctxTerm: Literal = fromSingleArrayLiteral._context.term;
+const ctxGraph: Quad_Graph | undefined = fromSingleArrayLiteral._context.graph;
+const ctxDataset: Dataset = fromSingleArrayLiteral._context.dataset;

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -50,7 +50,7 @@ declare namespace clownface {
         readonly values: string[];
         readonly dataset: D;
         readonly datasets: D[];
-        readonly _context: Context<D, T>;
+        readonly _context: Array<Context<D, T>>;
         list(): Iterable<SingleContextClownface<D>>;
         toArray(): Array<Clownface<D, T>>;
         filter(cb: (quad: Clownface<D, T>) => boolean): Clownface<D, T>;

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -109,6 +109,7 @@ declare namespace clownface {
         readonly terms: [T];
         readonly value: string;
         readonly values: [string];
+        readonly _context: [Context<D, T>];
     }
 }
 

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -5,6 +5,7 @@
 // TypeScript Version: 2.3
 
 import { Term, DatasetCore, Quad_Graph, NamedNode, BlankNode, Literal } from 'rdf-js';
+import { Context } from './lib/Context';
 
 declare namespace clownface {
     type TermOrClownface = Clownface | Term;
@@ -49,7 +50,7 @@ declare namespace clownface {
         readonly values: string[];
         readonly dataset: D;
         readonly datasets: D[];
-        readonly _context: any;
+        readonly _context: Context<D, T>;
         list(): Iterable<SingleContextClownface<D>>;
         toArray(): Array<Clownface<D, T>>;
         filter(cb: (quad: Clownface<D, T>) => boolean): Clownface<D, T>;

--- a/types/clownface/lib/Clownface.d.ts
+++ b/types/clownface/lib/Clownface.d.ts
@@ -15,6 +15,7 @@ import {
     SingleContextClownface,
     SingleOrOneElementArray
 } from '..';
+import { Context } from './Context';
 
 declare class Clownface<D extends DatasetCore = DatasetCore, T extends Term = Term> implements ClownfaceContract<D, T> {
     constructor(options: ClownfaceInit & Partial<WithSingleTerm<T> | WithTerms<T>> & Partial<WithSingleValue | WithValues>);
@@ -24,7 +25,7 @@ declare class Clownface<D extends DatasetCore = DatasetCore, T extends Term = Te
     readonly values: string[];
     readonly dataset: D;
     readonly datasets: D[];
-    readonly _context: any;
+    readonly _context: Context<D, T>;
     list(): Iterable<SingleContextClownface<D>>;
     toArray(): Array<Clownface<D, T>>;
     filter(cb: (quad: Clownface<D, T>) => boolean): Clownface<D, T>;

--- a/types/clownface/lib/Clownface.d.ts
+++ b/types/clownface/lib/Clownface.d.ts
@@ -25,7 +25,7 @@ declare class Clownface<D extends DatasetCore = DatasetCore, T extends Term = Te
     readonly values: string[];
     readonly dataset: D;
     readonly datasets: D[];
-    readonly _context: Context<D, T>;
+    readonly _context: Array<Context<D, T>>;
     list(): Iterable<SingleContextClownface<D>>;
     toArray(): Array<Clownface<D, T>>;
     filter(cb: (quad: Clownface<D, T>) => boolean): Clownface<D, T>;

--- a/types/clownface/lib/Context.d.ts
+++ b/types/clownface/lib/Context.d.ts
@@ -1,0 +1,18 @@
+import { DatasetCore, Quad_Graph, Term } from 'rdf-js';
+
+declare namespace Context {
+    interface Context<D extends DatasetCore, T extends Term> {
+        dataset: D;
+        graph?: Quad_Graph;
+        term: T;
+    }
+}
+
+declare class Context<D extends DatasetCore, T extends Term> implements Context.Context<D, T> {
+    constructor(dataset: D, graph: Quad_Graph | undefined, value: any);
+    dataset: D;
+    graph?: Quad_Graph;
+    term: T;
+}
+
+export = Context;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/rdf-ext/clownface/blob/master/lib/Context.js>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.