### PR TITLE
Updates emscripten types, adding canOwn parameter to createDataFile method

### DIFF
--- a/types/emscripten/emscripten-tests.ts
+++ b/types/emscripten/emscripten-tests.ts
@@ -106,7 +106,7 @@ function FSTest(): void {
     FS.write(wstream, data, 0, data.length, 0);
     FS.close(wstream);
 
-    FS.createDataFile('/', 'dummy2', data, true, true);
+    FS.createDataFile('/', 'dummy2', data, true, true, true);
 
     const lookup = FS.lookupPath("path", { parent: true });
 }

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -217,7 +217,7 @@ declare namespace FS {
     function createLazyFile(parent: string | FSNode, name: string, url: string, canRead: boolean, canWrite: boolean): FSNode;
     function createPreloadedFile(parent: string | FSNode, name: string, url: string,
         canRead: boolean, canWrite: boolean, onload?: () => void, onerror?: () => void, dontCreateFile?: boolean, canOwn?: boolean): void;
-    function createDataFile(parent: string | FSNode, name: string, data: ArrayBufferView, canRead: boolean, canWrite: boolean): FSNode;
+    function createDataFile(parent: string | FSNode, name: string, data: ArrayBufferView, canRead: boolean, canWrite: boolean, canOwn: boolean): FSNode;
 }
 
 interface Math {


### PR DESCRIPTION
Adds `canOwn` parameter to createDataFile File System method.

Please let me know if I should bump the major version. I'm not sure if this is considered a breaking change. There hasn't been a change to this API from emscripten recently, I believe the type declaration for `createDataFile` has just been incorrect.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://emscripten.org/docs/api_reference/advanced-apis.html#FS.createDataFile
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
