### PR TITLE
signalr: make the second parameter of the Hub.Proxy.off method optional

### DIFF
--- a/types/signalr/index.d.ts
+++ b/types/signalr/index.d.ts
@@ -9,7 +9,7 @@
 
 
 declare namespace SignalR {
-    
+
     const enum ConnectionState {
         Connecting = 0,
         Connected = 1,
@@ -65,9 +65,9 @@ declare namespace SignalR {
             * Removes the callback invocation request from the server hub for the given event name.
             *
             * @param eventName The name of the hub event to unregister the callback for.
-            * @param callback The callback to be invoked.
+            * @param callback [Optional] The callback to unregister. If not provided, all callbacks previously registered under that event name will be unregistered.
             */
-            off(eventName: string, callback: (...msg: any[]) => void): Proxy;
+            off(eventName: string, callback?: (...msg: any[]) => void): Proxy;
             /**
             * Invokes a server hub method with the given arguments.
             *
@@ -178,7 +178,7 @@ declare namespace SignalR {
         protocol: string;
         host: string;
     }
-    
+
     interface ConnectionErrorContext {
         readyState: number;
         responseText: string;

--- a/types/signalr/signalr-tests.ts
+++ b/types/signalr/signalr-tests.ts
@@ -162,6 +162,8 @@ function test_hubs() {
     proxy.on('addMessage', function (msg?) {
         console.log(msg);
     });
+    //the second argument to proxy.off is optional
+    proxy.off('addMessage');
 
     //a listener may have more than 1 parameter, and you should be able to subscribe and unsubscribe
     function listenerWithMoreParams(id: number, anything: string) {


### PR DESCRIPTION
As can be seen here: https://github.com/SignalR/SignalR/blob/master/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.hubs.js#L204
the second parameter to a hub proxy's `off` method is optional.