### PR TITLE
Add nestedKey property to pino config

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -268,6 +268,10 @@ declare namespace P {
          */
         messageKey?: string;
         /**
+         * The string key to place any logged object under.
+         */
+        nestedKey?: string;
+        /**
          * Enables pino.pretty. This is intended for non-production configurations. This may be set to a configuration
          * object as outlined in http://getpino.io/#/docs/API?id=pretty. Default: `false`.
          */

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -177,6 +177,10 @@ const withTimeFn = pino({
     timestamp: pino.stdTimeFunctions.isoTime,
 });
 
+const withNestedKey = pino({
+    nestedKey: 'payload',
+});
+
 // Properties/types imported from pino-std-serializers
 const wrappedErrSerializer = pino.stdSerializers.wrapErrorSerializer((err: pino.SerializedError) => {
   return {...err, newProp: 'foo'};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://getpino.io/#/docs/api?id=nestedkey-string
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
