### PR TITLE
Add options argument to nodejs.streams.finished

### DIFF
--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -267,9 +267,15 @@ declare module "stream" {
 
         class PassThrough extends Transform { }
 
+        interface FinishedOptions {
+            error?: boolean;
+            readable?: boolean;
+            writable?: boolean;
+        }
+        function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, options: FinishedOptions, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;
         function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;
         namespace finished {
-            function __promisify__(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream): Promise<void>;
+            function __promisify__(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, options?: FinishedOptions): Promise<void>;
         }
 
         function pipeline<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: T, callback?: (err: NodeJS.ErrnoException | null) => void): T;

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -163,7 +163,10 @@ function simplified_stream_ctor_test() {
 }
 
 function streamPipelineFinished() {
-    const cancel = finished(process.stdin, (err?: Error | null) => {});
+    let cancel = finished(process.stdin, (err?: Error | null) => {});
+    cancel();
+
+    cancel = finished(process.stdin, { readable: false }, (err?: Error | null) => {});
     cancel();
 
     pipeline(process.stdin, process.stdout, (err?: Error | null) => {});
@@ -172,6 +175,7 @@ function streamPipelineFinished() {
 async function asyncStreamPipelineFinished() {
     const fin = promisify(finished);
     await fin(process.stdin);
+    await fin(process.stdin, { readable: false });
 
     const pipe = promisify(pipeline);
     await pipe(process.stdin, process.stdout);


### PR DESCRIPTION
This optional argument allows ignoring the writable/readable/error components of a stream.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/stream.html#stream_stream_finished_stream_options_callback
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
