### PR TITLE
Add koaBunyanLogger.timeContext(opts) to koa-bunyan-logger

### DIFF
--- a/types/koa-bunyan-logger/index.d.ts
+++ b/types/koa-bunyan-logger/index.d.ts
@@ -39,8 +39,14 @@ declare namespace koaBunyanLogger {
         ignorePath?: string[];
     }
 
+    interface TimeContextOptions {
+        logLevel?: string;
+        updateLogFields?: (fields: any) => any;
+    }
+
     function requestLogger(opts?: RequestLoggerOptions): Middleware;
     function requestIdContext(opts?: RequestIdContextOptions): Middleware;
+    function timeContext(opts?: TimeContextOptions): Middleware;
 }
 
 // Extend the Koa context to add the logger..

--- a/types/koa-bunyan-logger/koa-bunyan-logger-tests.ts
+++ b/types/koa-bunyan-logger/koa-bunyan-logger-tests.ts
@@ -6,6 +6,20 @@ app.use(koaBunyanLogger());
 app.use(koaBunyanLogger.requestIdContext());
 app.use(koaBunyanLogger.requestLogger());
 app.use(koaBunyanLogger.requestLogger({ ignorePath: ['/ping'] }));
+app.use(koaBunyanLogger.timeContext());
+app.use(
+    koaBunyanLogger.timeContext({
+        logLevel: 'warn',
+        updateLogFields(fields) {
+            return {
+                request_trace: {
+                    name: fields.label,
+                    time: fields.duration,
+                },
+            };
+        },
+    }),
+);
 
 app.use(async (ctx, next) => {
     ctx.log.info('Got a request from %s for %s', ctx.request.ip, ctx.path);


### PR DESCRIPTION
https://github.com/koajs/bunyan-logger#koabunyanloggertimecontextopts

> koaBunyanLogger.timeContext(opts)
> Adds time(label) and timeEnd(label) methods to the koa context, which records the time between the time() and timeEnd() calls for a given label.
> 
> Calls to time() and timeEnd() can be nested or interleaved as long as they're balanced for each label.
> 
> Options:
> 
> logLevel: name of log level to use; defaults to 'trace'
> updateLogFields: function which will be called with arguments (fields) in koa context; can update fields or return a new object.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/bunyan-logger#koabunyanloggertimecontextopts
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
