### PR TITLE
Fix value `Cookies` used in place of a type in @types/koa

### DIFF
--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -716,7 +716,7 @@ declare namespace Application {
         req: IncomingMessage;
         res: ServerResponse;
         originalUrl: string;
-        cookies: Cookies;
+        cookies: typeof Cookies;
         accept: accepts.Accepts;
         /**
          * To bypass Koa's built-in response handling, you may explicitly set `ctx.respond = false;`


### PR DESCRIPTION
Fixes error TS2749: 'Cookies' refers to a value, but is being used as a type here.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [n/a] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [n/a] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.