### PR TITLE
Add path for @testing-library/cypress/add-commands

### DIFF
--- a/types/testing-library__cypress/OTHER_FILES.txt
+++ b/types/testing-library__cypress/OTHER_FILES.txt
@@ -1,0 +1,1 @@
+add-commands.d.ts

--- a/types/testing-library__cypress/add-commands.d.ts
+++ b/types/testing-library__cypress/add-commands.d.ts
@@ -1,0 +1,2 @@
+// Allow `import '@testing-library/cypress/add-commands'` from a `cypress/commands.ts` file
+import './'

--- a/types/testing-library__cypress/testing-library__cypress-tests.ts
+++ b/types/testing-library__cypress/testing-library__cypress-tests.ts
@@ -1,5 +1,6 @@
 /// <reference types="Cypress" />
 import { configure } from '@testing-library/cypress';
+import '@testing-library/cypress/add-commands';
 
 configure({ testIdAttribute: 'data-myown-testid' });
 

--- a/types/testing-library__cypress/tsconfig.json
+++ b/types/testing-library__cypress/tsconfig.json
@@ -27,7 +27,6 @@
     },
     "files": [
         "index.d.ts",
-        "add-commands.d.ts",
         "testing-library__cypress-tests.ts"
     ]
 }

--- a/types/testing-library__cypress/tsconfig.json
+++ b/types/testing-library__cypress/tsconfig.json
@@ -27,6 +27,7 @@
     },
     "files": [
         "index.d.ts",
+        "add-commands.d.ts",
         "testing-library__cypress-tests.ts"
     ]
 }


### PR DESCRIPTION
Some Cypress projects use Typescript for the `commands` file. If this is the case, the path `@testing-library/cypress/add-commands` doesn't exist and requires the index file to be added to the `types` property in the `tsconfig`. This change lowers the friction for those using Typescript for their commands file.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/testing-library/cypress-testing-library/issues/102
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.