### PR TITLE
Add types package for winston-loggly-bulk

### DIFF
--- a/types/winston-loggly-bulk/index.d.ts
+++ b/types/winston-loggly-bulk/index.d.ts
@@ -6,14 +6,14 @@
 /// <reference types="node" />
 
 import { Url } from 'url';
-import Transport = require('winston-transport');
+import TransportStream = require('winston-transport');
 
 export interface BufferOptions {
     size: number;
     retriesInMilliseconds: number;
 }
 
-export interface LogglyOptions extends Transport.TransportStreamOptions {
+export interface LogglyOptions extends TransportStream.TransportStreamOptions {
     auth?: {
         username: string;
         password: string;
@@ -30,8 +30,26 @@ export interface LogglyOptions extends Transport.TransportStreamOptions {
     token: string;
 }
 
-export class Loggly extends Transport {
+export class Loggly {
     constructor(options?: LogglyOptions);
+
+    extend(destination: any, source: any): any;
+
+    extractContext(obj: any): any;
+
+    formatQuery(query: any): any;
+
+    formatResults(results: any, _options: any): any;
+
+    log(meta: any, callback: any): any;
+
+    loglify(obj: any): any;
+
+    query(options: any, callback: any): any;
+
+    sanitizeLogs(logs: any): any;
+
+    stream(maybeOptions: any): any;
 }
 
 export function flushLogsAndExit(): void;

--- a/types/winston-loggly-bulk/index.d.ts
+++ b/types/winston-loggly-bulk/index.d.ts
@@ -30,7 +30,7 @@ export interface LogglyOptions extends TransportStream.TransportStreamOptions {
     token: string;
 }
 
-export class Loggly {
+export class Loggly extends TransportStream {
     constructor(options?: LogglyOptions);
 
     extend(destination: any, source: any): any;

--- a/types/winston-loggly-bulk/index.d.ts
+++ b/types/winston-loggly-bulk/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for winston-loggly-bulk 3.0.1
+// Project: https://github.com/loggly/winston-loggly-bulk
+// Definitions by: Simcha Wood <https://github.com/SimchaWood>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Url } from 'url';
+import Transport from 'winston-transport';
+
+export namespace Loggly {
+    interface BufferOptions {
+        size: number;
+        retriesInMilliseconds: number;
+    }
+
+    interface LogglyOptions extends Transport.TransportStreamOptions {
+        auth?: {
+            username: string;
+            password: string;
+        } | null;
+        bufferOptions?: BufferOptions;
+        isBulk?: boolean;
+        json?: boolean;
+        networkErrorOnConsole?: boolean;
+        proxy?: null | string | Url;
+        stripColors?: boolean;
+        subdomain: string;
+        tags?: string[];
+        timestamp?: boolean;
+        token: string;
+    }
+}
+
+export class Loggly {
+    constructor(options?: Loggly.LogglyOptions);
+}
+
+export function flushLogsAndExit(): void;
+
+export {};

--- a/types/winston-loggly-bulk/index.d.ts
+++ b/types/winston-loggly-bulk/index.d.ts
@@ -30,7 +30,7 @@ export namespace Loggly {
     }
 }
 
-export class Loggly {
+export class Loggly extends Transport {
     constructor(options?: Loggly.LogglyOptions);
 }
 

--- a/types/winston-loggly-bulk/index.d.ts
+++ b/types/winston-loggly-bulk/index.d.ts
@@ -1,39 +1,37 @@
-// Type definitions for winston-loggly-bulk 3.0.1
+// Type definitions for winston-loggly-bulk 3.0
 // Project: https://github.com/loggly/winston-loggly-bulk
 // Definitions by: Simcha Wood <https://github.com/SimchaWood>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
 import { Url } from 'url';
-import Transport from 'winston-transport';
+import Transport = require('winston-transport');
 
-export namespace Loggly {
-    interface BufferOptions {
-        size: number;
-        retriesInMilliseconds: number;
-    }
+export interface BufferOptions {
+    size: number;
+    retriesInMilliseconds: number;
+}
 
-    interface LogglyOptions extends Transport.TransportStreamOptions {
-        auth?: {
-            username: string;
-            password: string;
-        } | null;
-        bufferOptions?: BufferOptions;
-        isBulk?: boolean;
-        json?: boolean;
-        networkErrorOnConsole?: boolean;
-        proxy?: null | string | Url;
-        stripColors?: boolean;
-        subdomain: string;
-        tags?: string[];
-        timestamp?: boolean;
-        token: string;
-    }
+export interface LogglyOptions extends Transport.TransportStreamOptions {
+    auth?: {
+        username: string;
+        password: string;
+    } | null;
+    bufferOptions?: BufferOptions;
+    isBulk?: boolean;
+    json?: boolean;
+    networkErrorOnConsole?: boolean;
+    proxy?: null | string | Url;
+    stripColors?: boolean;
+    subdomain: string;
+    tags?: string[];
+    timestamp?: boolean;
+    token: string;
 }
 
 export class Loggly extends Transport {
-    constructor(options?: Loggly.LogglyOptions);
+    constructor(options?: LogglyOptions);
 }
 
 export function flushLogsAndExit(): void;
-
-export {};

--- a/types/winston-loggly-bulk/package.json
+++ b/types/winston-loggly-bulk/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "winston-transport": "^4.2.0"
+        "winston": "^3.0.0",
+        "winston-loggly-bulk": "^3.0.1"
     }
 }

--- a/types/winston-loggly-bulk/package.json
+++ b/types/winston-loggly-bulk/package.json
@@ -1,7 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "winston": "^3.0.0",
-        "winston-loggly-bulk": "^3.0.1"
+        "winston": "^3.0.0"
     }
 }

--- a/types/winston-loggly-bulk/package.json
+++ b/types/winston-loggly-bulk/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "winston-transport": "^4.2.0"
+    }
+}

--- a/types/winston-loggly-bulk/tsconfig.json
+++ b/types/winston-loggly-bulk/tsconfig.json
@@ -7,11 +7,8 @@
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
-        "baseUrl": "../",
-        "typeRoots": ["../"],
-        "types": [],
+        "baseUrl": ".",
+        "paths": { "winston-loggly-bulk": ["."]},
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "files": ["index.d.ts", "winston-loggly-bulk-tests.ts"]
+    }
 }

--- a/types/winston-loggly-bulk/tsconfig.json
+++ b/types/winston-loggly-bulk/tsconfig.json
@@ -7,8 +7,11 @@
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
-        "baseUrl": ".",
-        "paths": { "winston-loggly-bulk": ["."]},
-        "noEmit": true,
-    }
+        "forceConsistentCasingInFileNames": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true
+    },
+    "files": ["index.d.ts", "winston-loggly-bulk-tests.ts"]
 }

--- a/types/winston-loggly-bulk/tsconfig.json
+++ b/types/winston-loggly-bulk/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "esModuleInterop": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "winston-loggly-bulk-tests.ts"]
+}

--- a/types/winston-loggly-bulk/tslint.json
+++ b/types/winston-loggly-bulk/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-unnecessary-class": ["allow-constructor-only"]
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/winston-loggly-bulk/tslint.json
+++ b/types/winston-loggly-bulk/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-unnecessary-class": ["allow-constructor-only"]
+    }
+}

--- a/types/winston-loggly-bulk/winston-loggly-bulk-tests.ts
+++ b/types/winston-loggly-bulk/winston-loggly-bulk-tests.ts
@@ -1,0 +1,25 @@
+import { Loggly, flushLogsAndExit } from 'winston-loggly-bulk';
+
+const loggly = new Loggly({
+    auth: {
+        username: 'user',
+        password: 'guest',
+    },
+    bufferOptions: {
+        size: 500,
+        retriesInMilliseconds: 30000,
+    },
+    isBulk: false,
+    json: true,
+    networkErrorOnConsole: false,
+    proxy: 'www.example.com',
+    stripColors: true,
+    subdomain: 'my_subdomain',
+    tags: ['NodeJS'],
+    timestamp: true,
+    token: 'mysupersecrettoken',
+});
+
+loggly; // $ExpectType Loggly
+
+flushLogsAndExit(); // $ExpectType void


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). [Ran `tsc` and ]

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.