### PR TITLE
refactor: update type definitions for react-router-tabs

### DIFF
--- a/types/react-router-tabs/index.d.ts
+++ b/types/react-router-tabs/index.d.ts
@@ -25,6 +25,6 @@ export interface RoutedTabsProps {
     children?: ReactNode;
 }
 
-export const NavTab: React.FC<NavTabProps>;
+export const NavTab: ComponentType<NavTabProps>;
 
 export const RoutedTabs: ComponentType<RoutedTabsProps>;

--- a/types/react-router-tabs/index.d.ts
+++ b/types/react-router-tabs/index.d.ts
@@ -4,18 +4,16 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Route, Link, RouteProps, LinkProps, NavLinkProps } from 'react-router-dom';
-import { ReactNode } from 'react';
+import { ReactNode, ComponentType } from 'react';
 
 export type AriaCurrent = 'page' | 'step' | 'location' | 'date' | 'time' | 'true';
 
 export interface NavTabProps extends NavLinkProps {
-    activeStyle?: React.CSSProperties;
     style?: React.CSSProperties;
     disabled?: boolean;
     allowClickOnActive?: boolean;
     'aria-current'?: AriaCurrent;
 }
-
 export interface RoutedTabsProps {
     startPathWith?: string;
     className?: string;
@@ -29,4 +27,4 @@ export interface RoutedTabsProps {
 
 export const NavTab: React.FC<NavTabProps>;
 
-export const RoutedTabs: React.FC<RoutedTabsProps>;
+export const RoutedTabs: ComponentType<RoutedTabsProps>;

--- a/types/react-router-tabs/index.d.ts
+++ b/types/react-router-tabs/index.d.ts
@@ -3,22 +3,17 @@
 // Definitions by: Joakim Unge <https://github.com/joakimunge>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Route, Link, RouteProps } from 'react-router-dom';
+import { Route, Link, RouteProps, LinkProps, NavLinkProps } from 'react-router-dom';
 import { ReactNode } from 'react';
 
 export type AriaCurrent = 'page' | 'step' | 'location' | 'date' | 'time' | 'true';
 
-export interface NavTabProps {
-    to: string | object;
-    replace?: boolean;
-    exact?: boolean;
-    strict?: boolean;
-    activeClassName?: string;
-    className?: string;
-    activeStyle?: object;
-    style?: object;
-    'aria-current'?: AriaCurrent;
+export interface NavTabProps extends NavLinkProps {
+    activeStyle?: React.CSSProperties;
+    style?: React.CSSProperties;
     disabled?: boolean;
+    allowClickOnActive?: boolean;
+    'aria-current'?: AriaCurrent;
 }
 
 export interface RoutedTabsProps {
@@ -32,5 +27,6 @@ export interface RoutedTabsProps {
     children?: ReactNode;
 }
 
-export function NavTab(props: NavTabProps): Route;
-export function RoutedTabs(props: RoutedTabsProps): ReactNode;
+export const NavTab: React.FC<NavTabProps>;
+
+export const RoutedTabs: React.FC<RoutedTabsProps>;

--- a/types/react-router-tabs/react-router-tabs-tests.ts
+++ b/types/react-router-tabs/react-router-tabs-tests.ts
@@ -1,4 +1,0 @@
-import { NavTab, RoutedTabs } from 'react-router-tabs';
-
-NavTab({ to: 'path' }); // $ExpectType Route<RouteProps>
-RoutedTabs({}); // $ExpectType ReactNode

--- a/types/react-router-tabs/react-router-tabs-tests.tsx
+++ b/types/react-router-tabs/react-router-tabs-tests.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+import { NavTab, RoutedTabs } from 'react-router-tabs';
+
+const NavTabTest: React.FC = () => {
+    return (
+        <div>
+            <NavTab to="/home">Home</NavTab>
+        </div>
+    );
+};
+
+const RoutedTabsTest: React.FC = () => {
+    return (
+        <RoutedTabs startPathWith="/testbed">
+            <NavTab to="/home">Home</NavTab>
+            <NavTab to="/about">About</NavTab>
+            <NavTab to="/contact">Contact</NavTab>
+        </RoutedTabs>
+    );
+};
+
+export { NavTabTest, RoutedTabsTest };

--- a/types/react-router-tabs/tsconfig.json
+++ b/types/react-router-tabs/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": ["es6"],
+        "jsx": "react",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
@@ -12,5 +13,5 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": ["index.d.ts", "react-router-tabs-tests.ts"]
+    "files": ["index.d.ts", "react-router-tabs-tests.tsx"]
 }


### PR DESCRIPTION
Updates some invalid type definitions for react-router-tabs which were merged this morning.

https://github.com/chacestew/react-router-tabs

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
