### PR TITLE
[brotli-webpack-plugin] Add definition

### DIFF
--- a/types/brotli-webpack-plugin/brotli-webpack-plugin-tests.ts
+++ b/types/brotli-webpack-plugin/brotli-webpack-plugin-tests.ts
@@ -1,0 +1,22 @@
+import * as webpack from 'webpack';
+import BrotliWebpackPlugin = require('brotli-webpack-plugin');
+
+new BrotliWebpackPlugin(); // $ExpectType BrotliWebpackPlugin
+
+const optionsEmpty: BrotliWebpackPlugin.Options = {};
+
+const optionsFull: BrotliWebpackPlugin.Options = {
+    asset: '[path].br[query]',
+    test: /\.js$/,
+    threshold: 1024,
+    minRatio: 0.9,
+    deleteOriginalAssets: true,
+};
+
+const config: webpack.Configuration = {
+    plugins: [
+        new BrotliWebpackPlugin(),
+        new BrotliWebpackPlugin(optionsEmpty),
+        new BrotliWebpackPlugin(optionsFull),
+    ]
+};

--- a/types/brotli-webpack-plugin/index.d.ts
+++ b/types/brotli-webpack-plugin/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for brotli-webpack-plugin 1.1
+// Project: https://github.com/mynameiswhm/brotli-webpack-plugin
+// Definitions by: Karol Majewski <https://github.com/karol-majewski>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+import * as webpack from 'webpack';
+
+declare class BrotliWebpackPlugin extends webpack.Plugin {
+  constructor(options?: BrotliWebpackPlugin.Options);
+}
+
+declare namespace BrotliWebpackPlugin {
+  interface Options {
+    /**
+     * The target asset name. Defaults to `'[path].br[query]'`.
+     *
+     * - `[file]` is replaced with the original asset file name.
+     * - `[fileWithoutExt]` is replaced with the file name minus its extension, e.g. the `style` of `style.css`.
+     * - `[ext]` is replaced with the file name extension, e.g. the `css` of `style.css`.
+     * - `[path]` is replaced with the path of the original asset.
+     * - `[query]` is replaced with the query.
+     */
+    asset?: string;
+    /**
+     * All assets matching this RegExp are processed. Defaults to every asset.
+     */
+    test?: RegExp;
+    /**
+     * Only assets bigger than this size (in bytes) are processed. Defaults to `0`.
+     */
+    threshold?: number;
+    /**
+     * Only assets that compress better that this ratio are processed. Defaults to `0.8`.
+     */
+    minRatio?: number;
+    /**
+     * Remove original files that were compressed with brotli. Default: `false`.
+     */
+    deleteOriginalAssets?: boolean;
+  }
+}
+
+export = BrotliWebpackPlugin;

--- a/types/brotli-webpack-plugin/tsconfig.json
+++ b/types/brotli-webpack-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "brotli-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/brotli-webpack-plugin/tslint.json
+++ b/types/brotli-webpack-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Definitions and JSDoc based on https://www.npmjs.com/package/brotli-webpack-plugin.
