### PR TITLE
add NUMBERS to plaid-link ViewNames

### DIFF
--- a/types/plaid-link/index.d.ts
+++ b/types/plaid-link/index.d.ts
@@ -59,6 +59,7 @@ export namespace Plaid {
         | 'EXIT'
         | 'LOADING'
         | 'MFA'
+        | 'NUMBERS'
         | 'RECAPTCHA'
         | 'SELECT_ACCOUNT'
         | 'SELECT_INSTITUTION';


### PR DESCRIPTION

NUMBERS is not listed in [Plaid's documentation](plaid.com/docs/#metadata-view_name), but testing confirmed they send this value when following the Microdeposits path.
