### PR TITLE
Fix focused typing to match onFocusChange

### DIFF
--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -152,7 +152,7 @@ declare namespace ReactDates {
 
         // required props for a functional interactive SingleDatePicker
         date: momentPropTypes.momentObj | null;
-        focused: boolean;
+        focused: boolean | null;
 
         onDateChange: (date: momentPropTypes.momentObj | null) => void;
         onFocusChange: (arg: { focused: boolean | null }) => void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


This PR changes the `focused` prop typing to match the argument in `onFocusChange`. If these are not typed the same the linter will throw an error.