### PR TITLE
[chroma-js] Add `mode` param to `valid()`

### DIFF
--- a/types/chroma-js/chroma-js-tests.ts
+++ b/types/chroma-js/chroma-js-tests.ts
@@ -11,6 +11,7 @@ function test_chroma() {
     chroma.valid({});
     chroma.valid(null);
     chroma.valid(undefined);
+    chroma.valid('000', 'hex');
 
     chroma(0xff3399);
     chroma(0xff, 0x33, 0x99);

--- a/types/chroma-js/index.d.ts
+++ b/types/chroma-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Chroma.js 1.4
+// Type definitions for Chroma.js 2.0
 // Project: https://github.com/gka/chroma.js
 // Definitions by: Sebastian Brückner <https://github.com/invliD>, Marcin Pacholec <https://github.com/mpacholec>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/chroma-js/index.d.ts
+++ b/types/chroma-js/index.d.ts
@@ -62,7 +62,7 @@ declare namespace chroma {
          */
         hex(color: string): Color;
 
-        valid(color: any): boolean;
+        valid(color: any, mode?: string): boolean;
 
         hsl(h: number, s: number, l: number): Color;
 


### PR DESCRIPTION
Adds the second (optional) parameter to `chroma.valid`.
`chroma.valid` was not introduced until `v2.0.1` so I updated the version, as well.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gka/chroma.js/blob/master/src/utils/valid.js#L5 https://github.com/gka/chroma.js/blob/master/src/Color.js#L15-L16
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
~~- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
