### PR TITLE
[@testing-library/jest-dom] Add new type for toHaveStyle matcher

### DIFF
--- a/types/testing-library__jest-dom/index.d.ts
+++ b/types/testing-library__jest-dom/index.d.ts
@@ -28,7 +28,7 @@ declare namespace jest {
         toHaveClass(...classNames: string[]): R;
         toHaveFocus(): R;
         toHaveFormValues(expectedValues: Record<string, unknown>): R;
-        toHaveStyle(css: string): R;
+        toHaveStyle(css: string | object): R;
         toHaveTextContent(text: string | RegExp, options?: { normalizeWhitespace: boolean }): R;
         toHaveValue(value?: string | string[] | number): R;
         toBeChecked(): R;

--- a/types/testing-library__jest-dom/index.d.ts
+++ b/types/testing-library__jest-dom/index.d.ts
@@ -28,7 +28,7 @@ declare namespace jest {
         toHaveClass(...classNames: string[]): R;
         toHaveFocus(): R;
         toHaveFormValues(expectedValues: Record<string, unknown>): R;
-        toHaveStyle(css: string | object): R;
+        toHaveStyle(css: string | Record<string, unknown>): R;
         toHaveTextContent(text: string | RegExp, options?: { normalizeWhitespace: boolean }): R;
         toHaveValue(value?: string | string[] | number): R;
         toBeChecked(): R;

--- a/types/testing-library__jest-dom/test/testing-library__jest-dom-global-tests.ts
+++ b/types/testing-library__jest-dom/test/testing-library__jest-dom-global-tests.ts
@@ -22,6 +22,7 @@ expect(element).toHaveClass('cls1', 'cls2', 'cls3', 'cls4');
 expect(element).toHaveFocus();
 expect(element).toHaveFormValues({ foo: 'bar', baz: 1 });
 expect(element).toHaveStyle('display: block');
+expect(element).toHaveStyle({ display: 'block' });
 expect(element).toHaveTextContent('Text');
 expect(element).toHaveTextContent(/Text/);
 expect(element).toHaveTextContent('Text', { normalizeWhitespace: true });

--- a/types/testing-library__jest-dom/test/testing-library__jest-dom-global-tests.ts
+++ b/types/testing-library__jest-dom/test/testing-library__jest-dom-global-tests.ts
@@ -22,7 +22,7 @@ expect(element).toHaveClass('cls1', 'cls2', 'cls3', 'cls4');
 expect(element).toHaveFocus();
 expect(element).toHaveFormValues({ foo: 'bar', baz: 1 });
 expect(element).toHaveStyle('display: block');
-expect(element).toHaveStyle({ display: 'block' });
+expect(element).toHaveStyle({ display: 'block', width: 100 });
 expect(element).toHaveTextContent('Text');
 expect(element).toHaveTextContent(/Text/);
 expect(element).toHaveTextContent('Text', { normalizeWhitespace: true });


### PR DESCRIPTION
Update `toHaveStyle` matcher type according to https://github.com/testing-library/jest-dom/pull/196.