### PR TITLE
chart.js: Update ChartData to accept both Arrays and ReadonlyArrays

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -411,6 +411,15 @@ if (doughnutChart.getDatasetMeta(0).data.length > 0) {
     console.log(doughnutChartView.y);
 }
 
+// Passing readonly data as ChartData
+const readonlyDataInput: {
+    labels: ReadonlyArray<string>;
+    datasets: ReadonlyArray<{
+        data: number[];
+    }>;
+} = { labels: [], datasets: [] };
+const readonlyData: Chart.ChartData = readonlyDataInput;
+
 // Time Cartesian Axis
 const timeAxisChartData: Chart.ChartData = {
     datasets: [{

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -243,8 +243,8 @@ declare namespace Chart {
     }
 
     interface ChartData {
-        labels?: Array<string | string[] | number | number[] | Date | Date[] | Moment | Moment[]>;
-        datasets?: ChartDataSets[];
+        labels?: ReadonlyArray<string | ReadonlyArray<string> | number | ReadonlyArray<number> | Date | ReadonlyArray<Date> | Moment | ReadonlyArray<Moment>>;
+        datasets?: ReadonlyArray<ChartDataSets>;
     }
 
     interface RadialChartOptions extends ChartOptions {


### PR DESCRIPTION
By changing the types for `ChartData["labels"]` and `ChartData["datasets"]`
to ReadonlyArrays we can pass either ReadonlyArrays or Arrays as ChartData.

This is useful when chart.js is used inside a React component where the
props are readonly.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chartjs/Chart.js/blob/316f0e22449c3b266b56edbce02436b25c84e71a/src/core/core.controller.js#L175
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
