### PR TITLE
 feat(multer): pre-v1 dead code removal 

### DIFF
--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for multer 1.4
 // Project: https://github.com/expressjs/multer
 // Definitions by: jt000 <https://github.com/jt000>
-//                 vilicvane <https://vilic.github.io/>
+//                 vilicvane <https://github.com/vilic>
 //                 David Broder-Rodgers <https://github.com/DavidBR-SW>
 //                 Michael Ledin <https://github.com/mxl>
 //                 HyunSeob Lee <https://github.com/hyunseob>
@@ -11,7 +11,6 @@
 // TypeScript Version: 2.8
 
 import { Request, RequestHandler } from 'express';
-import { Readable } from 'stream';
 
 declare global {
     namespace Express {
@@ -40,8 +39,6 @@ declare global {
                 path: string;
                 /** `MemoryStorage` A Buffer containing the entire file. */
                 buffer: Buffer;
-                /** A readable stream of this file. */
-                stream: Readable;
             }
         }
 

--- a/types/multer/tslint.json
+++ b/types/multer/tslint.json
@@ -1,8 +1,1 @@
-{
-	"extends": "dtslint/dt.json",
-	"rules": {
-		// TODO
-		"npm-naming": false,
-        "dt-header": false
-	}
-}
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
It seems the 'stream' property of the multer file was removed:
https://git.io/Jv3KM
and was never part of v1 version:
https://git.io/Jv3K9

Also:
- udpate linting config to latest one
- fix linting errors in TD header

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://git.io/Jv3KM
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.