### PR TITLE
[xml-flow] Add xml-flow@1.0.4 definition 

### DIFF
--- a/types/xml-flow/index.d.ts
+++ b/types/xml-flow/index.d.ts
@@ -2,6 +2,9 @@
 // Project: https://github.com/matthewmatician/xml-flow
 // Definitions by: Nazar Rohozhuk <https://github.com/kodexxx>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.1
+
+/// <reference types="node" />
 
 import { Readable } from 'stream';
 import { EventEmitter } from 'events';

--- a/types/xml-flow/index.d.ts
+++ b/types/xml-flow/index.d.ts
@@ -1,0 +1,112 @@
+// Type definitions for xml-flow 1.0
+// Project: https://github.com/matthewmatician/xml-flow
+// Definitions by: Nazar Rohozhuk <https://github.com/kodexxx>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Readable } from 'stream';
+import { EventEmitter } from 'events';
+
+declare enum FlowConstants {
+    NEVER = -1,
+    SOMETIMES = 0,
+    ALWAYS = 1
+}
+
+declare interface FlowOptions {
+    /**
+     * Unknown entities will fail in strict mode, and in loose mode, will pass through unmolested.
+     *
+     * @default false
+     */
+    strict?: boolean;
+
+    /**
+     * When not in strict mode, all tags are lowercased, or uppercased when set to false.
+     *
+     * @default true
+     */
+    lowercase?: boolean;
+
+    /**
+     * Whether or not to trim leading and trailing whitespace from text
+     *
+     * @default true
+     */
+    trim?: boolean;
+
+    /**
+     * Turns all whitespace into a single space
+     *
+     * @default true
+     */
+    normalize?: boolean;
+
+    /**
+     * When set to ALWAYS, All subtags and text are stored in the $markup property with their original order preserved.
+     * When set to NEVER, all subtags are collected as separate properties.
+     * When set to SOMETIMES, markup is preserved only when subtags have non-contiguous repetition.
+     *
+     * @default flow.SOMETIMES
+     */
+    preserveMarkup?: FlowConstants;
+
+    /**
+     * Whether to drop empty $attrs, pull properties out of the $attrs when there are no subtags,
+     * or to only use a String instead of an object when $text is the only property.
+     *
+     * @default true
+     */
+    simplifyNodes?: boolean;
+
+    /**
+     * When set to ALWAYS, All subtags and text are enclosed in arrays, even if there's only one found.
+     * When set to NEVER, only the first instance of a subtag or text node are kept.
+     * When set to SOMETIMES, arrays are used only when multiple items are found.
+     * NOTE: When set to NEVER, preserveMarkup is ignored.
+     *
+     * @default flow.SOMETIMES
+     */
+    useArrays?: FlowConstants;
+
+    /**
+     * Appends CDATA text to other nearby text instead of putting it into its own $cdata property.
+     * NOTE: If you plan to run the toXml() function on data that has CDATA in it, you might.
+     * Consider a more robust escape function than what is provided. See below for more information.
+     * @default false
+     */
+    cdataAsText?: boolean;
+}
+
+declare interface FlowToXmlOptions {
+    /**
+     * How to indent tags for pretty-printing, use ' ' for two-spaces, or '\t' for tabs.
+     * If no indent value is provided, output will not be pretty-printed.
+     */
+    indent?: string;
+
+    /**
+     * Whether to self close tags (like <br/> instead of <br></br>) whenever possible.
+     *
+     * @default true
+     */
+    selfClosing?: boolean;
+
+    /**
+     * Optionally provide an escape function for all text, to prevent malformed XML.
+     * As a default, a very simplistic escape function has been provided.
+     * You can provide a more robust escape function that suits your needs.
+     */
+    escape?: (s: string) => string;
+}
+
+declare namespace flow {
+    const NEVER = FlowConstants.NEVER;
+    const SOMETIMES = FlowConstants.SOMETIMES;
+    const ALWAYS = FlowConstants.ALWAYS;
+
+    function toXml(obj: any, opts?: FlowToXmlOptions): string;
+}
+
+declare function flow(stream: Readable, options?: FlowOptions): EventEmitter;
+
+export default flow;

--- a/types/xml-flow/tsconfig.json
+++ b/types/xml-flow/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "xml-flow-tests.ts"
+    ]
+}

--- a/types/xml-flow/tslint.json
+++ b/types/xml-flow/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "strict-export-declare-modifiers": false,
+        "no-redundant-jsdoc": false
+    }
+}

--- a/types/xml-flow/xml-flow-tests.ts
+++ b/types/xml-flow/xml-flow-tests.ts
@@ -1,0 +1,9 @@
+import xmlFlow from 'xml-flow';
+
+import { Readable } from 'stream';
+import { EventEmitter } from 'events';
+
+const readable = Readable.from(['<hello>world</hello>']);
+
+xmlFlow(readable); // $ExpectType EventEmitter
+xmlFlow.toXml({ hello: "world" }); // $ExpectType string


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
