### PR TITLE
feat(multer): refine filter function callback

### DIFF
--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -164,6 +164,16 @@ declare namespace multer {
         field?: string;
     }
 
+    /**
+     * a function to control which files should be uploaded and which should be skipped
+     * pass a boolean to indicate if the file should be accepted
+     * pass an error if something goes wrong
+     */
+    interface FileFilterCallback {
+        (error: Error): void;
+        (error: null, acceptFile: boolean): void;
+     }
+
     /** Options for initializing a Multer instance. */
     interface Options {
         /**
@@ -208,12 +218,12 @@ declare namespace multer {
          *
          * @param req The Express `Request` object.
          * @param file Object containing information about the processed file.
-         * @param callback Callback to accept or deny the file.
+         * @param callback  a function to control which files should be uploaded and which should be skipped.
          */
         fileFilter?(
             req: Request,
             file: Express.Multer.File,
-            callback: (error: Error | null, acceptFile: boolean) => void
+            callback: FileFilterCallback,
         ): void;
     }
 

--- a/types/multer/multer-tests.ts
+++ b/types/multer/multer-tests.ts
@@ -4,8 +4,10 @@ import multer = require('multer');
 const upload = multer({
     dest: 'uploads/',
     fileFilter: (req, file, cb) => {
+        cb(null, false);
         cb(null, true);
-    }
+        cb(new Error(`I don't have a clue!`));
+    },
 });
 
 const app = express();


### PR DESCRIPTION
The callback function should allow single parameter of type Error only
or two params, first being null, other boolean.
This fixes the problem:
https://www.npmjs.com/package/multer#filefilter

- implmentation
- tests

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/multer#filefilter