### PR TITLE
[braintree] Use discriminated union for WebhookNotifications

### DIFF
--- a/types/braintree/braintree-tests.ts
+++ b/types/braintree/braintree-tests.ts
@@ -105,9 +105,11 @@ const gateway: BraintreeGateway = new braintree.BraintreeGateway({
     const sampleResponse = await gateway.webhookTesting.sampleNotification(kind, subscriptionId).catch(console.error);
     if (!sampleResponse) return;
 
-    const notificationResponse = await gateway.webhookNotification.parse(sampleResponse.bt_signature, sampleResponse.bt_payload).catch(console.error);
-    if (!notificationResponse) return;
+    const notification = await gateway.webhookNotification.parse(sampleResponse.bt_signature, sampleResponse.bt_payload).catch(console.error);
+    if (!notification) return;
 
-    const notification: SubscriptionNotification = notificationResponse as SubscriptionNotification;
+    // this should cause the type of `notification` to be narrowed to `SubscriptionNotification`
+    if (notification.kind !== kind) return;
+
     const subscription = notification.subscription;
 })();

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -831,40 +831,64 @@ declare namespace braintree {
      * Webhooks
      */
 
-    export class SampleNotification {
+    export interface SampleNotification {
         bt_signature: string;
         bt_payload: string;
     }
 
-    export abstract class WebhookNotification {
-        kind: WebhookNotificationKind;
+    export interface BaseWebhookNotification {
+        kind: string;
         timestamp: Date;
     }
 
-    export class TransactionNotification extends WebhookNotification {
+    export interface TransactionNotification extends BaseWebhookNotification {
+        kind: 'transaction_disbursed'
+            | 'transaction_settled'
+            | 'transaction_settlement_declined';
         transaction: Transaction;
     }
 
-    export class SubMerchantAccountApprovedNotification extends WebhookNotification {
+    export interface SubMerchantAccountApprovedNotification extends BaseWebhookNotification {
+        kind: 'sub_merchant_account_approved';
         merchantAccount: MerchantAccount;
     }
 
-    export class SubMerchantAccountDeclinedNotification extends WebhookNotification {
+    export interface SubMerchantAccountDeclinedNotification extends BaseWebhookNotification {
+        kind: 'sub_merchant_account_declined';
         merchantAccount: MerchantAccount;
     }
 
-    export class SubscriptionNotification extends WebhookNotification {
+    export interface SubscriptionNotification extends BaseWebhookNotification {
+        kind: 'subscription_canceled'
+            | 'subscription_charged_successfully'
+            | 'subscription_charged_unsuccessfully'
+            | 'subscription_expired'
+            | 'subscription_trial_ended'
+            | 'subscription_went_active'
+            | 'subscription_went_past_due';
         subscription: Subscription;
     }
 
-    export class DisputeNotification extends WebhookNotification {
+    export interface DisputeNotification extends BaseWebhookNotification {
+        kind: 'dispute_opened'
+            | 'dispute_lost'
+            | 'dispute_won';
         dispute: Dispute;
     }
 
-    export class AccountUpdaterNotification extends WebhookNotification {
+    export interface AccountUpdaterNotification extends BaseWebhookNotification {
+        kind: 'account_updater_daily_report';
         reportDate: Date;
         reportUrl: string;
     }
+
+    export type WebhookNotification =
+        TransactionNotification
+        | SubMerchantAccountApprovedNotification
+        | SubMerchantAccountDeclinedNotification
+        | SubscriptionNotification
+        | DisputeNotification
+        | AccountUpdaterNotification;
 
     export type WebhookNotificationKind =
         | 'account_updater_daily_report'

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -895,7 +895,7 @@ declare namespace braintree {
         | 'subscription_expired'
         | 'subscription_trial_ended'
         | 'subscription_went_active'
-        | 'subscription_went_past_due'
+        | 'subscription_went_past_due';
 
     export type SubMerchantAccountApprovedNotificationKind =
         | 'sub_merchant_account_approved';

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -837,7 +837,7 @@ declare namespace braintree {
     }
 
     export interface BaseWebhookNotification {
-        kind: string;
+        kind: WebhookNotificationKind;
         timestamp: Date;
     }
 

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -842,64 +842,84 @@ declare namespace braintree {
     }
 
     export interface TransactionNotification extends BaseWebhookNotification {
-        kind: 'transaction_disbursed'
-            | 'transaction_settled'
-            | 'transaction_settlement_declined';
+        kind: TransactionNotificationKind;
         transaction: Transaction;
     }
 
     export interface SubMerchantAccountApprovedNotification extends BaseWebhookNotification {
-        kind: 'sub_merchant_account_approved';
+        kind: SubMerchantAccountApprovedNotificationKind;
         merchantAccount: MerchantAccount;
     }
 
     export interface SubMerchantAccountDeclinedNotification extends BaseWebhookNotification {
-        kind: 'sub_merchant_account_declined';
+        kind: SubMerchantAccountDeclinedNotificationKind;
         merchantAccount: MerchantAccount;
     }
 
     export interface SubscriptionNotification extends BaseWebhookNotification {
-        kind: 'subscription_canceled'
-            | 'subscription_charged_successfully'
-            | 'subscription_charged_unsuccessfully'
-            | 'subscription_expired'
-            | 'subscription_trial_ended'
-            | 'subscription_went_active'
-            | 'subscription_went_past_due';
+        kind: SubscriptionNotificationKind;
         subscription: Subscription;
     }
 
     export interface DisputeNotification extends BaseWebhookNotification {
-        kind: 'dispute_opened'
-            | 'dispute_lost'
-            | 'dispute_won';
+        kind: DisputeNotificationKind;
         dispute: Dispute;
     }
 
     export interface AccountUpdaterNotification extends BaseWebhookNotification {
-        kind: 'account_updater_daily_report';
+        kind: AccountUpdaterNotificationKind;
         reportDate: Date;
         reportUrl: string;
     }
 
     export type WebhookNotification =
-        TransactionNotification
+        | TransactionNotification
         | SubMerchantAccountApprovedNotification
         | SubMerchantAccountDeclinedNotification
         | SubscriptionNotification
         | DisputeNotification
         | AccountUpdaterNotification;
 
+    export type AccountUpdaterNotificationKind =
+        | 'account_updater_daily_report';
+
+    export type DisputeNotificationKind =
+        | 'dispute_opened'
+        | 'dispute_lost'
+        | 'dispute_won';
+
+    export type SubscriptionNotificationKind =
+        | 'subscription_canceled'
+        | 'subscription_charged_successfully'
+        | 'subscription_charged_unsuccessfully'
+        | 'subscription_expired'
+        | 'subscription_trial_ended'
+        | 'subscription_went_active'
+        | 'subscription_went_past_due'
+
+    export type SubMerchantAccountApprovedNotificationKind =
+        | 'sub_merchant_account_approved';
+
+    export type SubMerchantAccountDeclinedNotificationKind =
+        | 'sub_merchant_account_declined';
+
+    export type TransactionNotificationKind =
+        | 'transaction_disbursed'
+        | 'transaction_settled'
+        | 'transaction_settlement_declined';
+
     export type WebhookNotificationKind =
-        | 'account_updater_daily_report'
+        | AccountUpdaterNotificationKind
+        | DisputeNotificationKind
+        | SubscriptionNotificationKind
+        | SubMerchantAccountApprovedNotificationKind
+        | SubMerchantAccountDeclinedNotificationKind
+        | TransactionNotificationKind
         | 'check'
         | 'connected_merchant_paypal_status_changed'
         | 'connected_merchant_status_transitioned'
         | 'disbursement'
         | 'disbursement_exception'
-        | 'dispute_opened'
-        | 'dispute_lost'
-        | 'dispute_won'
         | 'grantor_updated_granted_payment_method'
         | 'granted_payment_method_revoked'
         | 'local_payment_completed'
@@ -908,19 +928,7 @@ declare namespace braintree {
         | 'partner_merchant_declined'
         | 'payment_method_revoked_by_customer'
         | 'oauth_access_revoked'
-        | 'recipient_updated_granted_payment_method'
-        | 'subscription_canceled'
-        | 'subscription_charged_successfully'
-        | 'subscription_charged_unsuccessfully'
-        | 'subscription_expired'
-        | 'subscription_trial_ended'
-        | 'subscription_went_active'
-        | 'subscription_went_past_due'
-        | 'sub_merchant_account_approved'
-        | 'sub_merchant_account_declined'
-        | 'transaction_disbursed'
-        | 'transaction_settled'
-        | 'transaction_settlement_declined';
+        | 'recipient_updated_granted_payment_method';
 
     /**
      * Plan


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~

### Summary of Change

This changes the `WebhookNotification` types to know their own values for the `kind` property, so that the compiler can automatically infer types from it as a [discriminated union](https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions).

This also requires changing the notification types to be interfaces instead of classes, and changing `WebhookNotification` to be a union type instead of an abstract class.

Result: A guard on the returned `notification.kind` will now have the effect of narrowing the type of `notification` itself, so that explicit casts aren’t always necessary. See the test for a demonstration.