### PR TITLE
[fluent-ffmpeg] Update Autopad parameters

### DIFF
--- a/types/fluent-ffmpeg/index.d.ts
+++ b/types/fluent-ffmpeg/index.d.ts
@@ -292,16 +292,16 @@ declare namespace Ffmpeg {
         setAspectRatio(aspect: string | number): FfmpegCommand;
         aspect(aspect: string | number): FfmpegCommand;
         aspectRatio(aspect: string | number): FfmpegCommand;
-        applyAutopadding(pad: boolean, color: string): FfmpegCommand;
-        applyAutoPadding(pad: boolean, color: string): FfmpegCommand;
-        applyAutopad(pad: boolean, color: string): FfmpegCommand;
-        applyAutoPad(pad: boolean, color: string): FfmpegCommand;
-        withAutopadding(pad: boolean, color: string): FfmpegCommand;
-        withAutoPadding(pad: boolean, color: string): FfmpegCommand;
-        withAutopad(pad: boolean, color: string): FfmpegCommand;
-        withAutoPad(pad: boolean, color: string): FfmpegCommand;
-        autoPad(pad: boolean, color: string): FfmpegCommand;
-        autopad(pad: boolean, color: string): FfmpegCommand;
+        applyAutopadding(pad?: boolean, color?: string): FfmpegCommand;
+        applyAutoPadding(pad?: boolean, color?: string): FfmpegCommand;
+        applyAutopad(pad?: boolean, color?: string): FfmpegCommand;
+        applyAutoPad(pad?: boolean, color?: string): FfmpegCommand;
+        withAutopadding(pad?: boolean, color?: string): FfmpegCommand;
+        withAutoPadding(pad?: boolean, color?: string): FfmpegCommand;
+        withAutopad(pad?: boolean, color?: string): FfmpegCommand;
+        withAutoPad(pad?: boolean, color?: string): FfmpegCommand;
+        autoPad(pad?: boolean, color?: string): FfmpegCommand;
+        autopad(pad?: boolean, color?: string): FfmpegCommand;
 
         // options/output
         addOutput(target: string | stream.Writable, pipeopts?: { end?: boolean }): FfmpegCommand;


### PR DESCRIPTION
Updates the parameters for `autopad` (and associated alias's) to allow for all valid parameters.
First, no parameters are explicitly required. Thus the `color` parameter is optional. 
Second, the boolean value is supported for backwards compatibility, and thus optional.
Third, you can specify just the boolean, or just the color, or neither, and the functional will work without issue.
Therefore, we can just make these parameters both optional so I can use `.autopad()` in my code without getting an error message :).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/fluent-ffmpeg/node-fluent-ffmpeg#autopadcolorblack-enable-auto-padding-the-output-video
