### PR TITLE
[basic-auth] Add http2.Http2ServerRequest type to the auth() parameter

### DIFF
--- a/types/basic-auth/index.d.ts
+++ b/types/basic-auth/index.d.ts
@@ -1,14 +1,15 @@
 // Type definitions for basic-auth 1.1
 // Project: https://github.com/jshttp/basic-auth
-// Definitions by: Clément Bourgeois <https://github.com/moonpyk>, Vesa Poikajärvi <https://github.com/vesse>
+// Definitions by: Clément Bourgeois <https://github.com/moonpyk>, Vesa Poikajärvi <https://github.com/vesse>, Ryo Ota <https://github.com/nwtgck>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
 import * as http from 'http';
+import * as http2 from 'http2';
 
 // See https://github.com/jshttp/basic-auth/blob/v1.1.0/index.js#L49
-declare function auth(req: http.IncomingMessage): auth.BasicAuthResult | undefined;
+declare function auth(req: http.IncomingMessage | http2.Http2ServerRequest): auth.BasicAuthResult | undefined;
 
 declare namespace auth {
     interface BasicAuthResult {


### PR DESCRIPTION
Hi, 

This PR allows users to use HTTP/2 requests. `http2.Http2ServerRequest.headers` is a `IncomingHttpHeaders`, which is the same header type HTTP/1 request has. basic-auth access to `req.headers.authorization`, so basic-auth supports `http2.Http2ServerRequest` request too.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/jshttp/basic-auth/blob/e8a29f94dc7c05b5858b08090386338af010ce49/index.js#L81-L92>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
