### PR TITLE
[ldapjs] Correct version for ldapjs type definitions

### DIFF
--- a/types/ldapjs/index.d.ts
+++ b/types/ldapjs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ldapjs
+// Type definitions for ldapjs 1.0
 // Project: http://ldapjs.org
 // Definitions by: Charles Villemure <https://github.com/cvillemure>, Peter Kooijmans <https://github.com/peterkooijmans>, Pablo Moleri <https://github.com/pmoleri>, Michael Scott-Nelson <https://github.com/mscottnelson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -52,15 +52,15 @@ export interface ClientOptions {
 
 export interface SearchOptions {
 	/** Defaults to base */
-	scope?: "base" | "one" | "sub"; 
-	/**  Defaults to (objectclass=*) */ 
-	filter?: string | Filter; 
+	scope?: "base" | "one" | "sub";
+	/**  Defaults to (objectclass=*) */
+	filter?: string | Filter;
 	/** Defaults to the empty set, which means all attributes */
-	attributes?: string | string[];  
-	/** Defaults to 0 (unlimited) */ 
-	sizeLimit?: number; 
-	/** Timeout in seconds. Defaults to 10. Lots of servers will ignore this! */ 
-	timeLimit?: number; 
+	attributes?: string | string[];
+	/** Defaults to 0 (unlimited) */
+	sizeLimit?: number;
+	/** Timeout in seconds. Defaults to 10. Lots of servers will ignore this! */
+	timeLimit?: number;
 	derefAliases?: number;
 	typesOnly?: boolean;
 	paged?: boolean | {
@@ -297,7 +297,7 @@ export interface Server extends EventEmitter {
 	/**
 	 * Unix Domain Socket
 	 * Start a UNIX socket server listening for connections on the given path.
-	 * This function is asynchronous. The last parameter callback will be called when the server has been bound. 
+	 * This function is asynchronous. The last parameter callback will be called when the server has been bound.
 	 */
 	listen(path: string): void;
 	listen(path: string, callback: any): void;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] ~~Test the change in your own code. (Compile and run.)~~
- [ ] ~~Add or edit tests to reflect the change. (Run with `npm test`.)~~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- ~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~

Description:
- Add missing version number for type definitions.
- Remove trailing spaces (automatic per .editorconfig).