### PR TITLE
aws-lambda: Make Handle.callback optional

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -1115,7 +1115,7 @@ export interface LexResult {
 export type Handler<TEvent = any, TResult = any> = (
     event: TEvent,
     context: Context,
-    callback: Callback<TResult>,
+    callback?: Callback<TResult>,
 ) => void | Promise<TResult>;
 
 /**


### PR DESCRIPTION
The comment itself already says it's optional. Just updating type to reflect that.
