### PR TITLE
Remove version from react-dom as it doesn't exist.

### DIFF
--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -26,7 +26,6 @@ export function unmountComponentAtNode(container: Element): boolean;
 
 export function createPortal(children: ReactNode, container: Element, key?: null | string): ReactPortal;
 
-export const version: string;
 export const render: Renderer;
 export const hydrate: Renderer;
 


### PR DESCRIPTION
Removing the `version` property from react-dom client entry as it doesn't exist and it hasn't been there since version 16.0.0.
https://github.com/facebook/react/pull/15780

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/pull/15780
