### PR TITLE
Allow other expected values to be nested in jasmine.objectContaining

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -263,7 +263,7 @@ declare namespace jasmine {
 
     function arrayContaining<T>(sample: ArrayLike<T>): ArrayContaining<T>;
     function arrayWithExactContents<T>(sample: ArrayLike<T>): ArrayContaining<T>;
-    function objectContaining<T>(sample: Partial<T>): ObjectContaining<T>;
+    function objectContaining<T>(sample: {[K in keyof T]?: ExpectedRecursive<T[K]>}): ObjectContaining<T>;
 
     function setDefaultSpyStrategy(and: SpyAnd): void;
     function createSpy(name?: string, originalFn?: Function): Spy;

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1025,6 +1025,37 @@ describe("jasmine.objectContaining", () => {
         });
     });
 
+    it("other expected can be nested in jasmine.objectContaining", () => {
+        interface nestedFooType {
+            nested: {
+                a: number;
+                b: number;
+                bar: string;
+            };
+            other: {
+                c: number;
+                d: string;
+            };
+        }
+
+        const nestedFoo: nestedFooType = {
+            nested: {
+                a: 1,
+                b: 2,
+                bar: 's',
+            },
+            other: {
+                c: 5,
+                d: 't',
+            },
+        };
+
+        expect(nestedFoo).toEqual(jasmine.objectContaining({
+            nested: jasmine.objectContaining({ b: 2 }),
+            other: jasmine.any(Object),
+        }));
+    });
+
     describe("when used with a spy", () => {
         it("is useful for comparing arguments", () => {
             const callback = jasmine.createSpy('callback');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jasmine/jasmine/blob/8d53f4d202f86a11cbd3496469a1c5afd10cb836/spec/core/asymmetric_equality/ObjectContainingSpec.js#L49

