### PR TITLE
[redux-form] Add additional params to ValidateCallback type

### DIFF
--- a/types/redux-form/lib/reduxForm.d.ts
+++ b/types/redux-form/lib/reduxForm.d.ts
@@ -37,6 +37,8 @@ export interface ValidateCallback<FormData, P, ErrorType> {
     nextProps: P & InjectedFormProps<FormData, P, ErrorType>;
     props: P & InjectedFormProps<FormData, P, ErrorType>;
     initialRender: boolean;
+    lastFieldValidatorKeys: string[];
+    fieldValidatorKeys: string[];
     structure: any;
 }
 

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -242,7 +242,16 @@ const testFormWithChangeFunctionDecorator = reduxForm<TestFormData, TestFormComp
 
 type TestProps = {} & InjectedFormProps<TestFormData>;
 const Test = reduxForm<TestFormData>({
-    form : "test"
+    form : "test",
+    shouldError: ({
+        values,
+        nextProps,
+        props,
+        initialRender,
+        lastFieldValidatorKeys,
+        fieldValidatorKeys,
+        structure
+    }) => true,
 })(
     class Test extends React.Component<TestProps> {
         handleSubmitForm = (values: Partial<TestFormData>, dispatch: Dispatch<any>, props: {}) => {};


### PR DESCRIPTION
Adds a couple missing fields to the `redux-form` `ValidateCallback` type. This change is based off of the [flow types in the codebase](https://github.com/redux-form/redux-form/blob/ca8184418fde8f45833c5d386d97ca29715737d2/src/defaultShouldError.js#L5-L13).

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/redux-form/redux-form/blob/ca8184418fde8f45833c5d386d97ca29715737d2/src/defaultShouldError.js#L5-L13
