### PR TITLE
@chromecast-caf-receiver - Update LoggerLevel to ENUM

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -12,7 +12,14 @@ export import messages = messages;
 
 export type HTMLMediaElement = any;
 export as namespace framework;
-export type LoggerLevel = 'DEBUG' | 'VERBOSE' | 'INFO' | 'WARNING' | 'ERROR' | 'NONE';
+export enum LoggerLevel {
+    DEBUG = '0',
+    ERROR = '1000',
+    INFO = '800',
+    NONE = '1500',
+    VERBOSE = '500',
+    WARNING = '900'
+}
 
 export enum ContentProtection {
     NONE = 'none',

--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -13,12 +13,12 @@ export import messages = messages;
 export type HTMLMediaElement = any;
 export as namespace framework;
 export enum LoggerLevel {
-    DEBUG = '0',
-    ERROR = '1000',
-    INFO = '800',
-    NONE = '1500',
-    VERBOSE = '500',
-    WARNING = '900'
+    DEBUG = 0,
+    VERBOSE = 500,
+    INFO = 800,
+    WARNING = 900,
+    ERROR = 1000,
+    NONE = 1500
 }
 
 export enum ContentProtection {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.html#.LoggerLevel

OBS: In the documentation the numbers are not mentioned, but it says that the type is numeric. Typing "cast.framework.LoggerLevel" in the console can be proved.