### PR TITLE
[ssh2] Make more arguments undefined unions

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -249,7 +249,7 @@ export class Client extends events.EventEmitter {
      * @param options Options for the command.
      * @param callback The callback to execute when the command has completed.
      */
-    exec(command: string, options: ExecOptions, callback: (err: Error, channel: ClientChannel) => void): boolean;
+    exec(command: string, options: ExecOptions, callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
 
     /**
      * Executes a command on the server.
@@ -259,7 +259,7 @@ export class Client extends events.EventEmitter {
      * @param command The command to execute.
      * @param callback The callback to execute when the command has completed.
      */
-    exec(command: string, callback: (err: Error, channel: ClientChannel) => void): boolean;
+    exec(command: string, callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
 
     /**
      * Starts an interactive shell session on the server.
@@ -270,7 +270,7 @@ export class Client extends events.EventEmitter {
      * @param options Options for the command.
      * @param callback The callback to execute when the channel has been created.
      */
-    shell(window: PseudoTtyOptions | false, options: ShellOptions, callback: (err: Error, channel: ClientChannel) => void): boolean;
+    shell(window: PseudoTtyOptions | false, options: ShellOptions, callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
 
     /**
      * Starts an interactive shell session on the server.
@@ -280,7 +280,7 @@ export class Client extends events.EventEmitter {
      * @param window Either an object containing containing pseudo-tty settings, `false` to suppress creation of a pseudo-tty.
      * @param callback The callback to execute when the channel has been created.
      */
-    shell(window: PseudoTtyOptions | false, callback: (err: Error, channel: ClientChannel) => void): boolean;
+    shell(window: PseudoTtyOptions | false, callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
 
     /**
      * Starts an interactive shell session on the server.
@@ -290,7 +290,7 @@ export class Client extends events.EventEmitter {
      * @param options Options for the command.
      * @param callback The callback to execute when the channel has been created.
      */
-    shell(options: ShellOptions, callback: (err: Error, channel: ClientChannel) => void): boolean;
+    shell(options: ShellOptions, callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
 
     /**
      * Starts an interactive shell session on the server.
@@ -299,7 +299,7 @@ export class Client extends events.EventEmitter {
      *
      * @param callback The callback to execute when the channel has been created.
      */
-    shell(callback: (err: Error, channel: ClientChannel) => void): boolean;
+    shell(callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
 
     /**
      * Bind to `remoteAddr` on `remotePort` on the server and forward incoming TCP connections.
@@ -320,7 +320,7 @@ export class Client extends events.EventEmitter {
      * @param remotePort The remote port to bind on the server. If this value is `0`, the actual bound port is provided to `callback`.
      * @param callback An optional callback that is invoked when the remote address is bound.
      */
-    forwardIn(remoteAddr: string, remotePort: number, callback?: (err: Error, bindPort: number) => void): boolean;
+    forwardIn(remoteAddr: string, remotePort: number, callback?: (err: Error | undefined, bindPort: number) => void): boolean;
 
     /**
      * Unbind from `remoteAddr` on `remotePort` on the server and stop forwarding incoming TCP
@@ -332,7 +332,7 @@ export class Client extends events.EventEmitter {
      * @param remotePort The remote port to unbind on the server.
      * @param callback An optional callback that is invoked when the remote address is unbound.
      */
-    unforwardIn(remoteAddr: string, remotePort: number, callback?: (err: Error) => void): boolean;
+    unforwardIn(remoteAddr: string, remotePort: number, callback?: (err: Error | undefined) => void): boolean;
 
     /**
      * Open a connection with `srcIP` and `srcPort` as the originating address and port and
@@ -346,7 +346,7 @@ export class Client extends events.EventEmitter {
      * @param dstPort The destination port.
      * @param callback The callback that is invoked when the address is bound.
      */
-    forwardOut(srcIP: string, srcPort: number, dstIP: string, dstPort: number, callback: (err: Error, channel: ClientChannel) => void): boolean;
+    forwardOut(srcIP: string, srcPort: number, dstIP: string, dstPort: number, callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
 
     /**
      * Starts an SFTP session.
@@ -355,7 +355,7 @@ export class Client extends events.EventEmitter {
      *
      * @param callback The callback that is invoked when the SFTP session has started.
      */
-    sftp(callback: (err: Error, sftp: SFTPWrapper) => void): boolean;
+    sftp(callback: (err: Error | undefined, sftp: SFTPWrapper) => void): boolean;
 
     /**
      * Invokes `subsystem` on the server.
@@ -365,7 +365,7 @@ export class Client extends events.EventEmitter {
      * @param subsystem The subsystem to start on the server.
      * @param callback The callback that is invoked when the subsystem has started.
      */
-    subsys(subsystem: string, callback: (err: Error, channel: ClientChannel) => void): boolean;
+    subsys(subsystem: string, callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
 
     /**
      * Disconnects the socket.
@@ -383,7 +383,7 @@ export class Client extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    openssh_noMoreSessions(callback?: (err: Error) => void): boolean;
+    openssh_noMoreSessions(callback?: (err: Error | undefined) => void): boolean;
 
     /**
      * OpenSSH extension that binds to a UNIX domain socket at `socketPath` on the server and
@@ -391,7 +391,7 @@ export class Client extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    openssh_forwardInStreamLocal(socketPath: string, callback?: (err: Error) => void): boolean;
+    openssh_forwardInStreamLocal(socketPath: string, callback?: (err: Error | undefined) => void): boolean;
 
     /**
      * OpenSSH extension that unbinds from a UNIX domain socket at `socketPath` on the server
@@ -399,7 +399,7 @@ export class Client extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    openssh_unforwardInStreamLocal(socketPath: string, callback?: (err: Error) => void): boolean;
+    openssh_unforwardInStreamLocal(socketPath: string, callback?: (err: Error | undefined) => void): boolean;
 
     /**
      * OpenSSH extension that opens a connection to a UNIX domain socket at `socketPath` on
@@ -407,7 +407,7 @@ export class Client extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    openssh_forwardOutStreamLocal(socketPath: string, callback?: (err: Error, channel: ClientChannel) => void): boolean;
+    openssh_forwardOutStreamLocal(socketPath: string, callback?: (err: Error | undefined, channel: ClientChannel) => void): boolean;
 }
 
 export interface ConnectConfig {
@@ -697,7 +697,7 @@ export class Server extends events.EventEmitter {
     /**
      * Asynchronously get the number of concurrent connections on the server.
      */
-    getConnections(callback: (err: Error, count: number) => void): void;
+    getConnections(callback: (err: Error | undefined, count: number) => void): void;
 
     /**
      * Stops the server from accepting new connections and keeps existing connections. This
@@ -708,7 +708,7 @@ export class Server extends events.EventEmitter {
      *      Unlike that event, it will be called with an `Error` as its only argument if the
      *      server was not open when it was closed.
      */
-    close(callback?: (err: Error) => void): this;
+    close(callback?: (err: Error | undefined) => void): this;
 
     /**
      * Opposite of `unref`, calling `ref` on a previously unrefd server will not let the
@@ -791,18 +791,18 @@ export interface Connection extends events.EventEmitter {
      * Emitted when the client has sent a global request for name.
      * If info.bindPort === 0, you should pass the chosen port to accept so that the client will know what port was bound.
      */
-    on(event: "request", listener: (accept: (chosenPort?: number) => void, reject: () => void, name: "tcpip-forward" | "cancel-tcpip-forward", info: TcpipBindInfo) => void): this;
+    on(event: "request", listener: (accept: ((chosenPort?: number) => void) | undefined, reject: (() => void) | undefined, name: "tcpip-forward" | "cancel-tcpip-forward", info: TcpipBindInfo) => void): this;
 
     /**
      * Emitted when the client has sent a global request for name.
      */
-    on(event: "request", listener: (accept: () => void, reject: () => void, name: "streamlocal-forward@openssh.com" | "cancel-streamlocal-forward@openssh.com", info: SocketBindInfo) => void): this;
+    on(event: "request", listener: (accept: (() => void) | undefined, reject: () => void, name: "streamlocal-forward@openssh.com" | "cancel-streamlocal-forward@openssh.com", info: SocketBindInfo) => void): this;
 
     /**
      * Emitted when the client has sent a global request for name.
      * If info.bindPort === 0, you should pass the chosen port to accept so that the client will know what port was bound.
      */
-    on(event: "request", listener: (accept: (chosenPort?: number) => void, reject: () => void, name: string, info: TcpipBindInfo | SocketBindInfo) => void): this;
+    on(event: "request", listener: (accept: ((chosenPort?: number) => void) | undefined, reject: (() => void) | undefined, name: string, info: TcpipBindInfo | SocketBindInfo) => void): this;
 
     /**
      * Emitted when the client has finished rekeying (either client or server initiated).
@@ -848,7 +848,7 @@ export interface Connection extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    x11(originAddr: string, originPort: number, callback: (err: Error, channel: ServerChannel) => void): boolean;
+    x11(originAddr: string, originPort: number, callback: (err: Error | undefined, channel: ServerChannel) => void): boolean;
 
     /**
      * Alert the client of an incoming TCP connection on `boundAddr` on port `boundPort` from
@@ -856,7 +856,7 @@ export interface Connection extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    forwardOut(boundAddr: string, boundPort: number, remoteAddr: string, remotePort: number, callback: (err: Error, channel: ServerChannel) => void): boolean;
+    forwardOut(boundAddr: string, boundPort: number, remoteAddr: string, remotePort: number, callback: (err: Error | undefined, channel: ServerChannel) => void): boolean;
 
     /**
      * Initiates a rekeying with the client.
@@ -865,7 +865,7 @@ export interface Connection extends events.EventEmitter {
      *
      * @param callback An optional callback added as a one-time handler for the `rekey` event.
      */
-    rekey(callback?: (err: Error) => void): boolean;
+    rekey(callback?: (err: Error | undefined) => void): boolean;
 
     /**
      * Alert the client of an incoming UNIX domain socket connection on socketPath.
@@ -906,7 +906,7 @@ export interface AuthContextBase extends events.EventEmitter {
     /**
      * Emitted when the client aborts the authentication request.
      */
-    on(event: "abort", listener: (err: Error) => void): this;
+    on(event: "abort", listener: () => void): this;
 
     on(event: string | symbol, listener: Function): this;
 }
@@ -1022,58 +1022,60 @@ export interface SocketBindInfo {
     socketPath: string;
 }
 
+type SessionAcceptReject = (() => boolean) | undefined
+
 export interface Session extends events.EventEmitter {
     // Session events
 
     /**
      * Emitted when the client requested allocation of a pseudo-TTY for this session.
      */
-    on(event: "pty", listener: (accept: () => boolean, reject: () => boolean, info: PseudoTtyInfo) => void): this;
+    on(event: "pty", listener: (accept: SessionAcceptReject, reject: SessionAcceptReject, info: PseudoTtyInfo) => void): this;
 
     /**
      * Emitted when the client reported a change in window dimensions during this session.
      */
-    on(event: "window-change", listener: (accept: () => boolean, reject: () => boolean, info: WindowChangeInfo) => void): this;
+    on(event: "window-change", listener: (accept: SessionAcceptReject, reject: SessionAcceptReject, info: WindowChangeInfo) => void): this;
 
     /**
      * Emitted when the client requested X11 forwarding.
      */
-    on(event: "x11", listener: (accept: () => boolean, reject: () => boolean, info: X11Info) => void): this;
+    on(event: "x11", listener: (accept: SessionAcceptReject, reject: SessionAcceptReject, info: X11Info) => void): this;
 
     /**
      * Emitted when the client requested an environment variable to be set for this session.
      */
-    on(event: "env", listener: (accept: () => boolean, reject: () => boolean, info: SetEnvInfo) => void): this;
+    on(event: "env", listener: (accept: SessionAcceptReject, reject: SessionAcceptReject, info: SetEnvInfo) => void): this;
 
     /**
      * Emitted when the client has sent a POSIX signal.
      */
-    on(event: "signal", listener: (accept: () => boolean, reject: () => boolean, info: SignalInfo) => void): this;
+    on(event: "signal", listener: (accept: SessionAcceptReject, reject: SessionAcceptReject, info: SignalInfo) => void): this;
 
     /**
      * Emitted when the client has requested incoming ssh-agent requests be forwarded to them.
      */
-    on(event: "auth-agent", listener: (accept: () => boolean, reject: () => boolean) => void): this;
+    on(event: "auth-agent", listener: (accept: SessionAcceptReject, reject: SessionAcceptReject) => void): this;
 
     /**
      * Emitted when the client has requested an interactive shell.
      */
-    on(event: "shell", listener: (accept: () => ServerChannel, reject: () => boolean) => void): this;
+    on(event: "shell", listener: (accept: SessionAcceptReject, reject: SessionAcceptReject) => void): this;
 
     /**
      * Emitted when the client has requested execution of a command string.
      */
-    on(event: "exec", listener: (accept: () => ServerChannel, reject: () => boolean, info: ExecInfo) => void): this;
+    on(event: "exec", listener: (accept: SessionAcceptReject, reject: SessionAcceptReject, info: ExecInfo) => void): this;
 
     /**
      * Emitted when the client has requested the SFTP subsystem.
      */
-    on(event: "sftp", listener: (accept: () => SFTPStream, reject: () => boolean) => void): this;
+    on(event: "sftp", listener: (accept: SessionAcceptReject, reject: SessionAcceptReject) => void): this;
 
     /**
      * Emitted when the client has requested an arbitrary subsystem.
      */
-    on(event: "subsystem", listener: (accept: () => ServerChannel, reject: () => boolean, info: SubsystemInfo) => void): this;
+    on(event: "subsystem", listener: (accept: SessionAcceptReject, reject: SessionAcceptReject, info: SubsystemInfo) => void): this;
 
     /**
      * Emitted when the session has closed.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    * For accept and reject undefineds, see https://github.com/mscdex/ssh2#connection-events where accept and reject are typed "mixed".
    * For error callbacks, while the Readme types them as `Error`, their [code examples](https://github.com/mscdex/ssh2/tree/master#execute-uptime-on-a-server) have conditional checks for the errors, and the [code itself](https://github.com/mscdex/ssh2/blob/master/lib/client.js#L852) passes undefined for many of the callbacks

---

In my projects, I use the [`no-unnecessary-condition`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md) lint rule, and the current type definitions trigger that every time I check for an error or an accept method. Likewise, this would allow you to write unsafe code if you call `accept` or access the error object without first checking it.