### PR TITLE
Add @types for ntlm-client

### DIFF
--- a/types/ntlm-client/index.d.ts
+++ b/types/ntlm-client/index.d.ts
@@ -23,10 +23,7 @@ interface NtlmType2 {
     };
 }
 
-declare namespace ntlm {
-    function createType1Message(workstation: string, domain: string): string;
-    function decodeType2Message(type1Message: string): NtlmType2;
-    function createType3Message(type2Message: NtlmType2, username: string, password: string, workstation: string, domain: string): string;
-}
-
-export { ntlm };
+declare function createType1Message(workstation: string, domain: string): string;
+declare function decodeType2Message(type1Message: string): NtlmType2;
+declare function createType3Message(type2Message: NtlmType2, username: string, password: string, workstation: string, domain: string): string;
+export { createType1Message, decodeType2Message, createType3Message };

--- a/types/ntlm-client/index.d.ts
+++ b/types/ntlm-client/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Manuel Borrajo <https://github.com/borrajo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import "node";
+/// <reference types="node"/>
 
 interface NtlmType2 {
     flags: number;

--- a/types/ntlm-client/index.d.ts
+++ b/types/ntlm-client/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for ntlm-client 0.1
+// Project: https://github.com/clncln1/node-ntlm-client
+// Definitions by: Manuel Borrajo <https://github.com/borrajo>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import "node";
+
+interface NtlmType2 {
+    flags: number;
+    encoding: string;
+    version: number;
+    challenge: Buffer;
+    targetName: string;
+    targetInfo: {
+        parsed: {
+            DOMAIN: string;
+            SERVER: string;
+            DNS: string;
+            FQDN: string;
+            PARENT_DNS: string;
+        },
+        buffer: Buffer;
+    };
+}
+
+declare namespace ntlm {
+    function createType1Message(workstation: string, domain: string): string;
+    function decodeType2Message(type1Message: string): NtlmType2;
+    function createType3Message(type2Message: NtlmType2, username: string, password: string, workstation: string, domain: string): string;
+}
+
+export { ntlm };

--- a/types/ntlm-client/ntlm-client-tests.ts
+++ b/types/ntlm-client/ntlm-client-tests.ts
@@ -1,4 +1,4 @@
-import { ntlm } from 'ntlm-client';
+import ntlm = require('ntlm-client');
 
 const type2 = {
   flags: 0,

--- a/types/ntlm-client/ntlm-client-tests.ts
+++ b/types/ntlm-client/ntlm-client-tests.ts
@@ -1,0 +1,28 @@
+import { ntlm } from 'ntlm-client';
+
+const type2 = {
+  flags: 0,
+  encoding: '',
+  version: 3,
+  challenge: new Buffer(''),
+  targetName: '',
+  targetInfo: {
+    parsed: {
+      DOMAIN: '',
+      SERVER: '',
+      DNS: '',
+      FQDN: '',
+      PARENT_DNS: '',
+    },
+    buffer: new Buffer(''),
+  }
+};
+
+// $ExpectType string
+ntlm.createType1Message('', '');
+
+// $ExpectType string
+ntlm.createType3Message(type2, '', '', '', '');
+
+// $ExpectType NtlmType2
+ntlm.decodeType2Message('');

--- a/types/ntlm-client/tsconfig.json
+++ b/types/ntlm-client/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [
+        ],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ntlm-client-tests.ts"
+    ]
+}

--- a/types/ntlm-client/tslint.json
+++ b/types/ntlm-client/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
