### PR TITLE
[@babel/core] Add missing merge options

### DIFF
--- a/types/babel__core/babel__core-tests.ts
+++ b/types/babel__core/babel__core-tests.ts
@@ -58,6 +58,30 @@ checkOptions({ caller: { name: '', tomato: true } });
 checkOptions({ rootMode: 'upward-optional' });
 // $ExpectError
 checkOptions({ rootMode: 'potato' });
+checkOptions({ exclude: '../node_modules' });
+// $ExpectError
+checkOptions({ exclude: 256 });
+checkOptions({ include: [/node_modules/, new RegExp('bower_components')] });
+// $ExpectError
+checkOptions({ include: [null] });
+checkOptions({ test: (fileName) => fileName ? fileName.endsWith('mjs') : false });
+// $ExpectError
+checkOptions({ test: (fileName) => fileName && fileName.endsWith('mjs') });
+checkOptions({
+    overrides: [
+        {
+            test: /^.*\.m?js$/,
+            compact: true,
+        }
+    ]
+});
+checkOptions({
+    overrides: {
+        // $ExpectError
+        test: /^.*\.m?js$/,
+        compact: true,
+    }
+});
 
 // $ExpectError
 checkConfigFunction(() => {});

--- a/types/babel__core/index.d.ts
+++ b/types/babel__core/index.d.ts
@@ -97,6 +97,11 @@ export interface TransformOptions {
     envName?: string;
 
     /**
+     * If any of patterns match, the current configuration object is considered inactive and is ignored during config processing.
+     */
+    exclude?: MatchPattern | MatchPattern[];
+
+    /**
      * Enable code generation
      *
      * Default: `true`
@@ -190,6 +195,11 @@ export interface TransformOptions {
     ignore?: string[] | null;
 
     /**
+     * This option is a synonym for "test"
+     */
+    include?: MatchPattern | MatchPattern[];
+
+    /**
      * A source map object that the output source map will be based on
      *
      * Default: `null`
@@ -231,6 +241,12 @@ export interface TransformOptions {
      * Default: `null`
      */
     only?: string | RegExp | Array<string | RegExp> | null;
+
+    /**
+     * Allows users to provide an array of options that will be merged into the current configuration one at a time.
+     * This feature is best used alongside the "test"/"include"/"exclude" options to provide conditions for which an override should apply
+     */
+    overrides?: TransformOptions[];
 
     /**
      * An object containing the options to be passed down to the babel parser, @babel/parser
@@ -298,6 +314,11 @@ export interface TransformOptions {
     sourceType?: "script" | "module" | "unambiguous" | null;
 
     /**
+     * If all patterns fail to match, the current configuration object is considered inactive and is ignored during config processing.
+     */
+    test?: MatchPattern | MatchPattern[];
+
+    /**
      * An optional callback that can be used to wrap visitor methods. **NOTE**: This is useful for things like introspection, and not really needed for implementing anything. Called as
      * `wrapPluginVisitorMethod(pluginAlias, visitorType, callback)`.
      */
@@ -313,6 +334,13 @@ export interface TransformCaller {
 }
 
 export type FileResultCallback = (err: Error | null, result: BabelFileResult | null) => any;
+
+export interface MatchPatternContext {
+    envName: string;
+    dirname: string;
+    caller: TransformCaller | undefined;
+}
+export type MatchPattern = string | RegExp | ((filename: string | undefined, context: MatchPatternContext) => boolean);
 
 /**
  * Transforms the passed in code. Calling a callback with an object with the generated code, source map, and AST.


### PR DESCRIPTION
This PR adds the following merging options:

- [exclude](https://babeljs.io/docs/en/options#exclude)
- [include](https://babeljs.io/docs/en/options#include)
- [test](https://babeljs.io/docs/en/options#test)
- [overrides](https://babeljs.io/docs/en/options#overrides)

`MatchPattern` function declaration in this PR is based on the [source code](https://github.com/babel/babel/blob/779f00b8e9ce568ece4859501dd79682798c7fbf/packages/babel-core/src/config/config-chain.js#L698-L700) and a bit different from the one in the [docs](https://babeljs.io/docs/en/options#matchpattern). There is an [opened PR](https://github.com/babel/website/pull/2168) for the documentation update.
