### PR TITLE
[styled-components] Add missing react-native components

### DIFF
--- a/types/styled-components/native.d.ts
+++ b/types/styled-components/native.d.ts
@@ -58,7 +58,7 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     T
   >;
   ActivityIndicatorIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ActivityIndicatorIOS,
+    typeof ReactNative.ActivityIndicator,
     T
   >;
   Button: ReactNativeThemedStyledFunction<
@@ -87,10 +87,6 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
   >;
   ListView: ReactNativeThemedStyledFunction<
     typeof ReactNative.ListView,
-    T
-  >;
-  MapView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.MapView,
     T
   >;
   Modal: ReactNativeThemedStyledFunction<
@@ -129,6 +125,10 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     typeof ReactNative.Slider,
     T
   >;
+  SliderIOS: ReactNativeThemedStyledFunction<	
+    typeof ReactNative.Slider,	
+    T	
+  >;
   SnapshotViewIOS: ReactNativeThemedStyledFunction<
     typeof ReactNative.SnapshotViewIOS,
     T
@@ -158,7 +158,7 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     T
   >;
   SwitchAndroid: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SwitchAndroid,
+    typeof ReactNative.Switch,
     T
   >;
   SwitchIOS: ReactNativeThemedStyledFunction<

--- a/types/styled-components/native.d.ts
+++ b/types/styled-components/native.d.ts
@@ -58,7 +58,11 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     T
   >;
   ActivityIndicatorIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ActivityIndicator,
+    typeof ReactNative.ActivityIndicatorIOS,
+    T
+  >;
+  ART: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ART,
     T
   >;
   Button: ReactNativeThemedStyledFunction<
@@ -81,12 +85,24 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     typeof ReactNative.ImageBackground,
     T
   >;
+  ImageEditor: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ImageEditor,
+    T
+  >;
+  ImageStore: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ImageStore,
+    T
+  >;
   KeyboardAvoidingView: ReactNativeThemedStyledFunction<
     typeof ReactNative.KeyboardAvoidingView,
     T
   >;
   ListView: ReactNativeThemedStyledFunction<
     typeof ReactNative.ListView,
+    T
+  >;
+  MapView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.MapView,
     T
   >;
   Modal: ReactNativeThemedStyledFunction<
@@ -126,7 +142,7 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     T
   >;
   SliderIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Slider,
+    typeof ReactNative.SliderIOS,
     T
   >;
   SnapshotViewIOS: ReactNativeThemedStyledFunction<
@@ -158,7 +174,7 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     T
   >;
   SwitchAndroid: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Switch,
+    typeof ReactNative.SwitchAndroid,
     T
   >;
   SwitchIOS: ReactNativeThemedStyledFunction<
@@ -177,8 +193,16 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     typeof ReactNative.TextInput,
     T
   >;
+  ToastAndroid: ReactNativeThemedStyledFunction<
+    typeof ReactNative.ToastAndroid,
+    T
+  >;
   ToolbarAndroid: ReactNativeThemedStyledFunction<
     typeof ReactNative.ToolbarAndroid,
+    T
+  >;
+  Touchable: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Touchable,
     T
   >;
   TouchableHighlight: ReactNativeThemedStyledFunction<
@@ -205,6 +229,22 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     typeof ReactNative.ViewPagerAndroid,
     T
   >;
+  WebView: ReactNativeThemedStyledFunction<
+    typeof ReactNative.WebView,
+    T
+  >;
+  FlatList: ReactNativeThemedStyledFunction<
+    typeof ReactNative.FlatList,
+    T
+  >;
+  SectionList: ReactNativeThemedStyledFunction<
+    typeof ReactNative.SectionList,
+    T
+  >;
+  VirtualizedList: ReactNativeThemedStyledFunction<
+    typeof ReactNative.VirtualizedList,
+    T
+   >;
 }
 
 export interface ReactNativeThemedStyledComponentsModule<

--- a/types/styled-components/native.d.ts
+++ b/types/styled-components/native.d.ts
@@ -61,10 +61,6 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     typeof ReactNative.ActivityIndicatorIOS,
     T
   >;
-  ART: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ART,
-    T
-  >;
   Button: ReactNativeThemedStyledFunction<
     typeof ReactNative.Button,
     T
@@ -83,14 +79,6 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
   >;
   ImageBackground: ReactNativeThemedStyledFunction<
     typeof ReactNative.ImageBackground,
-    T
-  >;
-  ImageEditor: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ImageEditor,
-    T
-  >;
-  ImageStore: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ImageStore,
     T
   >;
   KeyboardAvoidingView: ReactNativeThemedStyledFunction<
@@ -141,10 +129,6 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     typeof ReactNative.Slider,
     T
   >;
-  SliderIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SliderIOS,
-    T
-  >;
   SnapshotViewIOS: ReactNativeThemedStyledFunction<
     typeof ReactNative.SnapshotViewIOS,
     T
@@ -193,16 +177,8 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     typeof ReactNative.TextInput,
     T
   >;
-  ToastAndroid: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ToastAndroid,
-    T
-  >;
   ToolbarAndroid: ReactNativeThemedStyledFunction<
     typeof ReactNative.ToolbarAndroid,
-    T
-  >;
-  Touchable: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Touchable,
     T
   >;
   TouchableHighlight: ReactNativeThemedStyledFunction<
@@ -229,10 +205,6 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     typeof ReactNative.ViewPagerAndroid,
     T
   >;
-  WebView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.WebView,
-    T
-  >;
   FlatList: ReactNativeThemedStyledFunction<
     typeof ReactNative.FlatList,
     T
@@ -241,10 +213,6 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     typeof ReactNative.SectionList,
     T
   >;
-  VirtualizedList: ReactNativeThemedStyledFunction<
-    typeof ReactNative.VirtualizedList,
-    T
-   >;
 }
 
 export interface ReactNativeThemedStyledComponentsModule<

--- a/types/styled-components/native.d.ts
+++ b/types/styled-components/native.d.ts
@@ -125,9 +125,9 @@ export interface ReactNativeStyledInterface<T extends object> extends ReactNativ
     typeof ReactNative.Slider,
     T
   >;
-  SliderIOS: ReactNativeThemedStyledFunction<	
-    typeof ReactNative.Slider,	
-    T	
+  SliderIOS: ReactNativeThemedStyledFunction<
+    typeof ReactNative.Slider,
+    T
   >;
   SnapshotViewIOS: ReactNativeThemedStyledFunction<
     typeof ReactNative.SnapshotViewIOS,


### PR DESCRIPTION
Some react-native components that are included in styled-components was missing from the `ReactNativeStyledInterface`. I added them by applying the following regex:
```
s/\(.*\)/  \1: ReactNativeThemedStyledFunction<\r    typeof ReactNative.\1,\r    T\r  >;/
```
to the string `aliases` from here:

https://github.com/styled-components/styled-components/blob/43f6fbe1d999452d76e6c3a4c458ec153f5f1401/packages/styled-components/src/native/index.js#L23-L29.

Or is there a reason that they shouldn't be included?

**Edit:** For most of them, the answer was yes, they failed to typecheck. But there are two new components that I think should be included.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/styled-components/styled-components/blob/43f6fbe1d999452d76e6c3a4c458ec153f5f1401/packages/styled-components/src/native/index.js#L23-L29

