### PR TITLE
angular-material: Missing IPanelAnimation.duration

### DIFF
--- a/types/angular-material/index.d.ts
+++ b/types/angular-material/index.d.ts
@@ -462,6 +462,7 @@ declare module 'angular' {
             openFrom(from: string | Element | Event | { top: number, left: number }): IPanelAnimation;
             closeTo(to: string | Element | { top: number, left: number }): IPanelAnimation;
             withAnimation(cssClass: string | { open: string, close: string }): IPanelAnimation;
+            duration(duration: number | { open: number, close: number }): IPanelAnimation;
         }
 
         interface IPanelService {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://material.angularjs.org/HEAD/api/type/MdPanelAnimation#mdpanelanimation-duration-duration
https://github.com/angular/material/blob/0b83a2cbfd527a171fef2d0ffef038ff8a8dd674/src/components/panel/panel.js#L3274
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
