### PR TITLE
binary-parser: update to 1.5.0

### DIFF
--- a/types/binary-parser/binary-parser-tests.ts
+++ b/types/binary-parser/binary-parser-tests.ts
@@ -118,3 +118,17 @@ const result = parser6.parse(Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05]));
 result.nested.points[0].x;
 result.nested.points[1].y;
 result.optional.number;
+
+const parser7 = new Parser()
+    // Signed 64-bit integer
+    .int64('a')
+    // Unsigned 64-bit integer
+    .uint64('b')
+    // Signed 64-bit integer (little endian)
+    .int64le('c')
+    // Signed 64-bit integer (big endian)
+    .int64be('d')
+    // Unsigned 64-bit integer (little endian)
+    .uint64le('e')
+    // Unsigned 64-bit integer (big endian)
+    .uint64be('f');

--- a/types/binary-parser/index.d.ts
+++ b/types/binary-parser/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for binary-parser 1.3
+// Type definitions for binary-parser 1.5
 // Project: https://github.com/keichi/binary-parser
 // Definitions by: Benjamin Riggs <https://github.com/riggs>,
 //                 Dolan Miu <https://github.com/dolanmiu>,
-//                 Yu Shimura <https://github.com/yuhr>
+//                 Yu Shimura <https://github.com/yuhr>,
+//                 John Mark Gabriel Caguicla <https://github.com/caguiclajmg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.2
 
 /// <reference types="node" />
 
@@ -29,6 +30,13 @@ export interface Parser<O extends object | undefined = undefined> {
     int32be<N extends string>(name: N, options?: Parser.Options): Parser.Next<O, N, number>;
     uint32le<N extends string>(name: N, options?: Parser.Options): Parser.Next<O, N, number>;
     uint32be<N extends string>(name: N, options?: Parser.Options): Parser.Next<O, N, number>;
+
+    int64<N extends string>(name: N, options?: Parser.Options): Parser.Next<O, N, bigint>;
+    uint64<N extends string>(name: N, options?: Parser.Options): Parser.Next<O, N, bigint>;
+    int64le<N extends string>(name: N, options?: Parser.Options): Parser.Next<O, N, bigint>;
+    int64be<N extends string>(name: N, options?: Parser.Options): Parser.Next<O, N, bigint>;
+    uint64le<N extends string>(name: N, options?: Parser.Options): Parser.Next<O, N, bigint>;
+    uint64be<N extends string>(name: N, options?: Parser.Options): Parser.Next<O, N, bigint>;
 
     bit1<N extends string>(name: N, options?: Parser.Options): Parser.Next<O, N, number>;
     bit2<N extends string>(name: N, options?: Parser.Options): Parser.Next<O, N, number>;
@@ -108,6 +116,8 @@ export interface Parser<O extends object | undefined = undefined> {
     >;
 
     skip(length: number): Parser<O>;
+
+    seek(length: number): Parser<O>;
 
     endianess(endianess: Parser.Endianness): Parser<O>;   /* [sic] */
 


### PR DESCRIPTION
This brings in the new 64-bit integer family of functions and the `seek()` function (which is just a `skip()` alias)

Summary of changes:
- Add 64-bit integer function definitions [u]int64{le, be}
- Bump required TS version to 3.2 due to bigint usage
- Add seek (skip alias)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/keichi/binary-parser/blob/master/README.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
