### PR TITLE
fix(node): WritableStream .end() and .destroy() methods should be chainable

### DIFF
--- a/types/adone/glosses/archives.d.ts
+++ b/types/adone/glosses/archives.d.ts
@@ -204,7 +204,7 @@ declare namespace adone {
 
                 finalize(): void;
 
-                destroy(err?: any): void;
+                destroy(err?: any): this;
             }
 
             /**

--- a/types/adone/glosses/collections/buffer_list.d.ts
+++ b/types/adone/glosses/collections/buffer_list.d.ts
@@ -30,8 +30,8 @@ declare namespace adone.collection {
         /**
          * Ends the stream
          */
-        end(chunk?: Buffer | string): void;
-        end(chunk?: () => void): void;
+        end(chunk?: Buffer | string): this;
+        end(chunk?: () => void): this;
 
         /**
          * Returns the byte at the specified index
@@ -80,7 +80,7 @@ declare namespace adone.collection {
         /**
          * Destroys the stream
          */
-        destroy(): void;
+        destroy(): this;
 
         then<T1 = Buffer, T2 = never>(
             onfulfilled?: ((value: Buffer) => T1 | PromiseLike<T1>) | null,

--- a/types/bittorrent-protocol/index.d.ts
+++ b/types/bittorrent-protocol/index.d.ts
@@ -50,7 +50,7 @@ declare namespace BittorrentProtocol {
 
         setTimeout(ms: number, unref?: boolean): void;
 
-        destroy(): void;
+        destroy(): this;
 
         use(ext: ExtensionConstructor): void;
 

--- a/types/bunyan/index.d.ts
+++ b/types/bunyan/index.d.ts
@@ -266,7 +266,7 @@ declare namespace Logger {
         records: any[];
 
         write(record: any): boolean;
-        end(record?: any): void;
+        end(record?: any): this;
         destroy(): void;
         destroySoon(): void;
     }

--- a/types/charm/index.d.ts
+++ b/types/charm/index.d.ts
@@ -19,7 +19,7 @@ declare namespace charm {
 		destroy(): void;
 
 		/** Emit an "end" event downstream. */
-		end(): void;
+		end(): this;
 
 		/**
 		 * Pass along `msg` to the output stream.

--- a/types/ebml/index.d.ts
+++ b/types/ebml/index.d.ts
@@ -230,9 +230,9 @@ export class Decoder extends Transform {
 
     write(chunk: Buffer, encoding?: string, cb?: (error: Error | null | undefined) => void): boolean;
     write(chunk: Buffer, cb?: (error: Error | null | undefined) => void): boolean;
-    end(cb?: () => void): void;
-    end(chunk: Buffer, cb?: () => void): void;
-    end(chunk: Buffer, encoding?: string, cb?: () => void): void;
+    end(cb?: () => void): this;
+    end(chunk: Buffer, cb?: () => void): this;
+    end(chunk: Buffer, encoding?: string, cb?: () => void): this;
 
     // #endregion
 }

--- a/types/hexo-util/index.d.ts
+++ b/types/hexo-util/index.d.ts
@@ -10,7 +10,7 @@ import { Transform } from "stream";
 import { SpawnOptions, StdioOptions } from 'child_process';
 
 export class CacheStream extends Transform {
-    destroy(): void;
+    destroy(): this;
     getCache(): Buffer;
 }
 

--- a/types/iconv/index.d.ts
+++ b/types/iconv/index.d.ts
@@ -23,10 +23,10 @@ declare namespace Iconv {
         // copy from NodeJS.WritableStream for compatibility
         write(buffer: Buffer|string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;
-        end(): void;
-        end(buffer: Buffer, cb?: Function): void;
-        end(str: string, cb?: Function): void;
-        end(str: string, encoding?: string, cb?: Function): void;
+        end(): this;
+        end(buffer: Buffer, cb?: Function): this;
+        end(str: string, cb?: Function): this;
+        end(str: string, encoding?: string, cb?: Function): this;
 
         // copy from stream.Stream
         pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;

--- a/types/list-stream/index.d.ts
+++ b/types/list-stream/index.d.ts
@@ -25,7 +25,7 @@ declare let ListStream: ListStreamConstructor;
 interface ListStream extends Duplex {
     append(chunk: any): void;
     duplicate(): ListStream;
-    end(): void;
+    end(): this;
     get(index: number): any;
     length: number;
 }

--- a/types/minipass/index.d.ts
+++ b/types/minipass/index.d.ts
@@ -24,9 +24,9 @@ declare class MiniPass extends EventEmitter implements NodeJS.WritableStream {
     read(size?: number): any;
     write(chunk: any, cb?: () => void): boolean;
     write(chunk: any, encoding?: string | null, cb?: () => void): boolean;
-    end(cb?: () => void): void;
-    end(chunk: any, cb?: () => void): void;
-    end(chunk: any, encoding?: string | null, cb?: () => void): void;
+    end(cb?: () => void): this;
+    end(chunk: any, cb?: () => void): this;
+    end(chunk: any, encoding?: string | null, cb?: () => void): this;
     resume(): void;
     pause(): void;
     pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;

--- a/types/node-expat/index.d.ts
+++ b/types/node-expat/index.d.ts
@@ -32,15 +32,15 @@ export class Parser extends Stream {
     pause(): void;
     resume(): void;
 
-    destroy(): void;
+    destroy(): this;
 
     destroySoon(): void;
 
     write(data: Buffer | string): boolean;
 
-    end(cb?: () => void): void;
-    end(chunk: any, cb?: () => void): void;
-    end(chunk: any, encoding: string, cb?: () => void): void;
+    end(cb?: () => void): this;
+    end(chunk: any, cb?: () => void): this;
+    end(chunk: any, encoding: string, cb?: () => void): this;
 
     reset(): void;
 

--- a/types/node-expat/tsconfig.json
+++ b/types/node-expat/tsconfig.json
@@ -2,7 +2,10 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es5", "es2015.symbol", "es2015.Iterable", "es2015.Promise"
+            "es5",
+            "ES2015.Symbol.WellKnown",
+            "es2015.Iterable",
+            "es2015.Promise"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/node-expat/tsconfig.json
+++ b/types/node-expat/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es5", "es2015.symbol"
+            "es5", "es2015.symbol", "es2015.Iterable", "es2015.Promise"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -580,9 +580,9 @@ declare namespace NodeJS {
         writable: boolean;
         write(buffer: Uint8Array | string, cb?: (err?: Error | null) => void): boolean;
         write(str: string, encoding?: string, cb?: (err?: Error | null) => void): boolean;
-        end(cb?: () => void): void;
-        end(data: string | Uint8Array, cb?: () => void): void;
-        end(str: string, encoding?: string, cb?: () => void): void;
+        end(cb?: () => void): this;
+        end(data: string | Uint8Array, cb?: () => void): this;
+        end(str: string, encoding?: string, cb?: () => void): this;
     }
 
     interface ReadWriteStream extends ReadableStream, WritableStream { }

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -320,7 +320,7 @@ declare module "http" {
          * Only valid for response obtained from http.ClientRequest.
          */
         statusMessage?: string;
-        destroy(error?: Error): void;
+        destroy(error?: Error): this;
     }
 
     interface AgentOptions {

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -87,9 +87,9 @@ declare module "net" {
         readonly remotePort?: number;
 
         // Extended base methods
-        end(cb?: () => void): void;
-        end(buffer: Uint8Array | string, cb?: () => void): void;
-        end(str: Uint8Array | string, encoding?: string, cb?: () => void): void;
+        end(cb?: () => void): this;
+        end(buffer: Uint8Array | string, cb?: () => void): this;
+        end(str: Uint8Array | string, encoding?: string, cb?: () => void): this;
 
         /**
          * events.EventEmitter

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -42,7 +42,7 @@ declare module "stream" {
             wrap(oldStream: NodeJS.ReadableStream): this;
             push(chunk: any, encoding?: string): boolean;
             _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
-            destroy(error?: Error): void;
+            destroy(error?: Error): this;
 
             /**
              * Event emitter
@@ -135,12 +135,12 @@ declare module "stream" {
             write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
             write(chunk: any, encoding: string, cb?: (error: Error | null | undefined) => void): boolean;
             setDefaultEncoding(encoding: string): this;
-            end(cb?: () => void): void;
-            end(chunk: any, cb?: () => void): void;
-            end(chunk: any, encoding: string, cb?: () => void): void;
+            end(cb?: () => void): this;
+            end(chunk: any, cb?: () => void): this;
+            end(chunk: any, encoding: string, cb?: () => void): this;
             cork(): void;
             uncork(): void;
-            destroy(error?: Error): void;
+            destroy(error?: Error): this;
 
             /**
              * Event emitter
@@ -240,9 +240,9 @@ declare module "stream" {
             write(chunk: any, encoding?: string, cb?: (error: Error | null | undefined) => void): boolean;
             write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
             setDefaultEncoding(encoding: string): this;
-            end(cb?: () => void): void;
-            end(chunk: any, cb?: () => void): void;
-            end(chunk: any, encoding?: string, cb?: () => void): void;
+            end(cb?: () => void): this;
+            end(chunk: any, cb?: () => void): this;
+            end(chunk: any, encoding?: string, cb?: () => void): this;
             cork(): void;
             uncork(): void;
         }

--- a/types/node/test/global.ts
+++ b/types/node/test/global.ts
@@ -49,6 +49,7 @@ const a: NodeJS.TypedArray = new Buffer(123);
     readable.pipe(writable);
     writableFinished = writable.writableFinished;
     writable.destroyed;
+    writable.end().destroy().destroyed;
 }
 
 {

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -230,7 +230,9 @@ import { LookupOneOptions } from 'dns';
 
     bool = _socket.connecting;
     bool = _socket.destroyed;
-    _socket.destroy();
+
+    _socket = _socket.destroy();
+    _socket = _socket.end();
 }
 
 {

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -6,7 +6,7 @@ import { ok as assert } from 'assert';
 
 // Simplified constructors
 function simplified_stream_ctor_test() {
-    new Readable({
+    let _readable: Readable = new Readable({
         read(size) {
             // $ExpectType Readable
             this;
@@ -21,7 +21,23 @@ function simplified_stream_ctor_test() {
         }
     });
 
-    new Writable({
+    _readable.read(1); // $ExpectType any
+    _readable.push('smth'); // $ExpectType boolean
+    _readable.unshift('smth'); // $ExpectType void
+
+    _readable = _readable.setEncoding('utf-8');
+    _readable = _readable.pause();
+    _readable = _readable.resume();
+    _readable = _readable.unpipe();
+    _readable = _readable.wrap(_readable);
+    _readable = _readable.addListener('event', () => {});
+    _readable = _readable.prependListener('event', () => {});
+    _readable = _readable.prependOnceListener('event', () => {});
+    _readable = _readable.removeListener('event', () => {});
+    _readable = _readable.on("event", () => {});
+    _readable = _readable.once("event", () => {});
+
+    let _writable: Writable = new Writable({
         write(chunk, enc, cb) {
             // $ExpectType Writable
             this;
@@ -55,6 +71,21 @@ function simplified_stream_ctor_test() {
             cb;
         }
     });
+
+    _writable.cork(); // $ExpectType void
+    _writable.uncork(); // $ExpectType void
+    _writable.write('some'); // $ExpectType boolean
+    _writable.emit("event"); // $ExpectType boolean
+
+    _writable = _writable.setDefaultEncoding('utf-8');
+    _writable = _writable.end();
+    _writable = _writable.destroy(new Error('err'));
+    _writable = _writable.addListener('event', () => {});
+    _writable = _writable.prependListener('event', () => {});
+    _writable = _writable.prependOnceListener('event', () => {});
+    _writable = _writable.removeListener('event', () => {});
+    _writable = _writable.on("event", () => {});
+    _writable = _writable.once("event", () => {});
 
     new Duplex({
         read(size) {

--- a/types/request/index.d.ts
+++ b/types/request/index.d.ts
@@ -250,14 +250,14 @@ declare namespace request {
 
         write(buffer: Buffer | string, cb?: (err?: Error) => void): boolean;
         write(str: string, encoding?: string, cb?: (err?: Error) => void): boolean;
-        end(cb?: () => void): void;
-        end(chunk: string | Buffer, cb?: () => void): void;
-        end(str: string, encoding?: string, cb?: () => void): void;
+        end(cb?: () => void): this;
+        end(chunk: string | Buffer, cb?: () => void): this;
+        end(str: string, encoding?: string, cb?: () => void): this;
 
         pause(): void;
         resume(): void;
         abort(): void;
-        destroy(): void;
+        destroy(): this;
         toJSON(): RequestAsJSON;
 
         // several of the CoreOptions are copied onto the request instance

--- a/types/simple-peer/index.d.ts
+++ b/types/simple-peer/index.d.ts
@@ -83,7 +83,7 @@ declare namespace SimplePeer {
         // destroy(onclose?: () => void): void;
         // https://nodejs.org/api/stream.html#stream_writable_destroy_error
         // https://nodejs.org/api/stream.html#stream_readable_destroy_error
-        destroy(error?: Error): void;
+        destroy(error?: Error): this;
 
         // methods which are not documented
         readonly bufferSize: number;

--- a/types/simple-websocket/index.d.ts
+++ b/types/simple-websocket/index.d.ts
@@ -26,7 +26,7 @@ declare class Socket extends Duplex {
   send(chunk: any): void;
 
   /** Destroy and cleanup this websocket connection */
-  destroy(err?: Error): void;
+  destroy(err?: Error): this;
 }
 
 export = Socket;

--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -66,7 +66,7 @@ export interface Channel extends stream.Duplex {
     /**
      * Shuts down the channel on this side.
      */
-    destroy(): void;
+    destroy(): this;
 }
 
 export interface ClientChannel extends Channel {

--- a/types/tar/index.d.ts
+++ b/types/tar/index.d.ts
@@ -61,7 +61,7 @@ export interface PackStream extends NodeJS.ReadWriteStream {
 
     addGlobal(props: HeaderProperties): void;
     add(stream: stream.Stream): boolean;
-    destroy(): void;
+    destroy(): this;
 
     _process(): void;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

* NodeJs doc ref: https://nodejs.org/api/stream.html#stream_writable_end_chunk_encoding_callback
* NodeJs code refs: 
  * https://github.com/nodejs/node/blob/master/lib/_stream_writable.js#L613
  * https://github.com/nodejs/node/blob/master/lib/_stream_writable.js#L807

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

