### PR TITLE
Add graphite module declarations

### DIFF
--- a/types/graphite/graphite-tests.ts
+++ b/types/graphite/graphite-tests.ts
@@ -1,0 +1,75 @@
+import graphite = require('graphite');
+
+interface Metrics {
+    available: number;
+    free: number;
+    total: number;
+}
+
+interface OptionalMetrics {
+    disk?: Metrics;
+    memory?: Metrics;
+}
+
+const memory: Metrics = {
+    available: 30000000,
+    free: 25000000,
+    total: 40000000,
+};
+
+const os: OptionalMetrics = {
+    memory,
+};
+
+const client = graphite.createClient('plaintext://graphite.example.org:2003/');
+
+// Check metric values
+client.write({ foo: 23 });
+client.write({ foo: { bar: { qux: 23 } } });
+// Check interfaces as metric values
+client.write(memory);
+// Check interfaces with optional fields as metric values
+client.write(os);
+// Check nested interfaces as metric values
+client.write({ os: { memory } });
+
+// The following metric values should yield compilation errors, but these are
+// ignored because of the use of the any keyword as type annotation.
+client.write(1);
+client.write('foo');
+client.write(false);
+client.write([]);
+client.write({ foo: 'foo' });
+client.write({ foo: { baz: 'baz' } });
+client.write({ foo: new Date() });
+client.write({ foo: [] });
+
+// Check overloaded arguments
+client.write({ foo: 23 }, (err: any) => {});
+client.write({ foo: 23 }, Date.now(), (err: any) => {});
+
+// Check metric and tag values
+client.writeTagged({ foo: 23 }, { foo: 'baz' });
+client.writeTagged({ foo: { bar: 23 } }, { foo: { bar: 'qux' } });
+
+// Check overloaded arguments
+client.writeTagged({ foo: 23 }, { foo: 'baz' }, (err) => {});
+client.writeTagged({ foo: 23 }, { foo: 'baz' }, Date.now(), (err) => {});
+
+// Check utilities
+
+// Graphite metric values should be numeric, but outside the graphite context
+// flatten can be used to flatten nested object containing any value.
+graphite.flatten({ foo: 23 });
+graphite.flatten({ foo: { bar: 1, baz: '2' }, qux: true });
+graphite.flatten(memory);
+
+// Check other parameters
+graphite.flatten({ foo: 23 }, { baz: 'bar' });
+graphite.flatten({ foo: 23 }, { baz: 'bar' }, 'prefix');
+
+graphite.appendTags({ foo: 23 }, { foo: 'foo' });
+
+// Should yield compilation error when a nested object is provided, but won't
+// happen when using any as the type annotation.
+graphite.appendTags({ foo: { bar: 23 } }, { foo: 'foo' });

--- a/types/graphite/index.d.ts
+++ b/types/graphite/index.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for graphite 0.1
+// Project: https://github.com/felixge/node-graphite
+// Definitions by: Christian Muñoz <https://github.com/ctumolosus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type Callback = (err: any) => void;
+
+interface GraphiteClientProperties {
+    carbon: any;
+}
+
+declare class GraphiteClient {
+    constructor(properties: GraphiteClientProperties);
+    static createClient(dsn: string): GraphiteClient;
+    static flatten(object: any, flat?: any, prefix?: string): any;
+    static appendTags(flatMetrics: any, tags: any): any;
+    write(metrics: any, callback?: Callback): void;
+    write(metrics: any, timestamp?: number, callback?: Callback): void;
+    writeTagged(metrics: any, tags: any, callback?: Callback): void;
+    writeTagged(metrics: any, tags: any, timestamp?: number, callback?: Callback): void;
+    end(): void;
+}
+
+export = GraphiteClient;

--- a/types/graphite/tsconfig.json
+++ b/types/graphite/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "graphite-tests.ts"
+    ]
+}

--- a/types/graphite/tslint.json
+++ b/types/graphite/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
