### PR TITLE
Add definitions for migrate-mongo

### DIFF
--- a/types/migrate-mongo/index.d.ts
+++ b/types/migrate-mongo/index.d.ts
@@ -1,0 +1,101 @@
+// Type definitions for migrate-mongo 7.0
+// Project: https://github.com/seppevs/migrate-mongo#readme
+// Definitions by: Amit Beckenstein <https://github.com/amitbeck>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.1
+
+import * as mongo from 'mongodb';
+
+export function init(): Promise<void>;
+export function create(description: string): Promise<string>;
+export namespace database {
+    function connect(): Promise<{
+        client: mongo.MongoClient;
+        db: mongo.Db & { close: mongo.MongoClient['close'] },
+    }>;
+}
+export namespace config {
+    /**
+     * @internal
+     */
+    const DEFAULT_CONFIG_FILE_NAME: string;
+    /**
+     * @internal
+     */
+    function shouldExist(): Promise<void>;
+    /**
+     * @internal
+     */
+    function shouldNotExist(): Promise<void>;
+    /**
+     * @internal
+     */
+    function getConfigFilename(): string;
+    /**
+     * Read the `migrate-mongo-config.js` file.
+     */
+    function read(): Promise<Config>;
+
+    interface Config {
+        mongodb: {
+            url: Parameters<typeof mongo.MongoClient['connect']>[0];
+            databaseName: mongo.Db['databaseName'];
+            options: mongo.MongoClientOptions;
+        };
+        /**
+         * The migrations dir, can be an relative or absolute path.
+         */
+        migrationsDir?: string;
+        /**
+         * The MongoDB collection where the applied changes are stored.
+         */
+        changelogCollectionName: string;
+    }
+}
+
+/**
+ * Apply all pending migrations.
+ * @example
+ * ```js
+ * const db = await database.connect();
+ * const migrated = await up(db);
+ * migrated.forEach(fileName => console.log('Migrated:', fileName));
+ * ```
+ * If an an error occurred, the promise will reject and won't continue with the rest of the pending migrations.
+ */
+export function up(db: mongo.Db): Promise<string[]>;
+/**
+ * Revert (only) the last applied migration.
+ * @example
+ * ```js
+ * const db = await database.connect();
+ * const migratedDown = await down(db);
+ * migratedDown.forEach(fileName => console.log('Migrated Down:', fileName));
+ * ```
+ */
+export function down(db: mongo.Db): Promise<string[]>;
+export function status(db: mongo.Db): Promise<MigrationStatus[]>;
+
+export interface MigrationStatus {
+    fileName: string;
+    /**
+     * Either "PENDING" or a JSON date.
+     */
+    appliedAt: string;
+}
+
+/**
+ * Type of `up()` and `down()` functions for migration scripts.
+ */
+export type MigrationFunction =
+    | ((db: mongo.Db, client: mongo.MongoClient) => Promise<void>)
+    /**
+     * @deprecated Callbacks are supported for backwards compatibility.
+     * New migration scripts should be written using `Promise`s and/or `async` & `await`. It's easier to read and write.
+     */
+    | ((db: mongo.Db, next: mongo.MongoCallback<mongo.UpdateWriteOpResult>) => void)
+    /**
+     * @deprecated Callbacks are supported for backwards compatibility.
+     * New migration scripts should be written using `Promise`s and/or `async` & `await`. It's easier to read and write.
+     */
+    | ((db: mongo.Db, client: mongo.MongoClient, next: mongo.MongoCallback<mongo.UpdateWriteOpResult>) => void);

--- a/types/migrate-mongo/migrate-mongo-tests.ts
+++ b/types/migrate-mongo/migrate-mongo-tests.ts
@@ -1,0 +1,34 @@
+import { init, create, database, config, up, down, status, MigrationFunction } from 'migrate-mongo';
+import { Db, MongoCallback, MongoClient, UpdateWriteOpResult } from 'mongodb';
+
+const upPromisified: MigrationFunction = async (db: Db, client: MongoClient): Promise<void> => {
+    await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: true}});
+    await db.collection('albums').updateOne({artist: 'The Doors'}, {$set: {stars: 5}});
+};
+const upCallback: MigrationFunction = (db: Db, client: MongoClient, callback: MongoCallback<UpdateWriteOpResult>) => {
+    db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: true}}, callback);
+};
+
+const downPromisified: MigrationFunction = async (db: Db, client: MongoClient): Promise<void> => {
+    await db.collection('albums').updateOne({artist: 'The Doors'}, {$set: {stars: 0}});
+    await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: false}});
+};
+const downCallback: MigrationFunction = (db: Db, client: MongoClient, callback: MongoCallback<UpdateWriteOpResult>) => {
+    db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: false}}, callback);
+};
+
+async function test() {
+    await init();
+    const fileName = await create('blacklist_the_beatles');
+    console.log('Created:', fileName);
+    const { db } = await database.connect();
+    const mongoConnectionSettings = await config.read();
+    const migrated = await up(db);
+    migrated.forEach(fileName => console.log('Migrated:', fileName));
+    const migratedDown = await down(db);
+    migratedDown.forEach(fileName => console.log('Migrated Down:', fileName));
+    const migrationStatus = await status(db);
+    migrationStatus.forEach(({ fileName, appliedAt }) => console.log(fileName, ':', appliedAt));
+    await db.close();
+}
+test();

--- a/types/migrate-mongo/tsconfig.json
+++ b/types/migrate-mongo/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "migrate-mongo-tests.ts"
+    ]
+}

--- a/types/migrate-mongo/tslint.json
+++ b/types/migrate-mongo/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.