### PR TITLE
feat(node): Add Buffer.from(object) override

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -244,7 +244,7 @@ declare class Buffer extends Uint8Array {
      * A `TypeError` will be thrown if {obj} has not mentioned methods or is not of other type appropriate for `Buffer.from()` variants.
      * @param obj An object supporting `Symbol.toPrimitive` or `valueOf()`.
      */
-    static from(obj: object, byteOffset?: number, length?: number): Buffer;
+    static from(obj: { valueOf(): string | object } | { [Symbol.toPrimitive](hint: 'string'): string }, byteOffset?: number, length?: number): Buffer;
     /**
      * Creates a new Buffer containing the given JavaScript string {str}.
      * If provided, the {encoding} parameter identifies the character encoding.

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -240,6 +240,12 @@ declare class Buffer extends Uint8Array {
     static from(data: number[]): Buffer;
     static from(data: Uint8Array): Buffer;
     /**
+     * Creates a new buffer containing the coerced value of an object
+     * A `TypeError` will be thrown if {obj} has not mentioned methods or is not of other type appropriate for `Buffer.from()` variants.
+     * @param obj An object supporting `Symbol.toPrimitive` or `valueOf()`.
+     */
+    static from(obj: object, byteOffset?: number, length?: number): Buffer;
+    /**
      * Creates a new Buffer containing the given JavaScript string {str}.
      * If provided, the {encoding} parameter identifies the character encoding.
      * If not provided, {encoding} defaults to 'utf8'.

--- a/types/node/test/global.ts
+++ b/types/node/test/global.ts
@@ -50,3 +50,12 @@ const a: NodeJS.TypedArray = new Buffer(123);
     writableFinished = writable.writableFinished;
     writable.destroyed;
 }
+
+{
+  const obj = {
+    valueOf() {
+      return 'hello';
+    }
+  };
+  Buffer.from(obj);
+}

--- a/types/node/v10/globals.d.ts
+++ b/types/node/v10/globals.d.ts
@@ -355,7 +355,7 @@ declare const Buffer: {
      * A `TypeError` will be thrown if {obj} has not mentioned methods or is not of other type appropriate for `Buffer.from()` variants.
      * @param obj An object supporting `Symbol.toPrimitive` or `valueOf()`.
      */
-    from(obj: object, byteOffset?: number, length?: number): Buffer;
+    from(obj: { valueOf(): string | object } | { [Symbol.toPrimitive](hint: 'string'): string }, byteOffset?: number, length?: number): Buffer;
     /**
      * Creates a new Buffer containing the given JavaScript string {str}.
      * If provided, the {encoding} parameter identifies the character encoding.

--- a/types/node/v10/globals.d.ts
+++ b/types/node/v10/globals.d.ts
@@ -351,6 +351,12 @@ declare const Buffer: {
     from(data: any[]): Buffer;
     from(data: Uint8Array): Buffer;
     /**
+     * Creates a new buffer containing the coerced value of an object
+     * A `TypeError` will be thrown if {obj} has not mentioned methods or is not of other type appropriate for `Buffer.from()` variants.
+     * @param obj An object supporting `Symbol.toPrimitive` or `valueOf()`.
+     */
+    from(obj: object, byteOffset?: number, length?: number): Buffer;
+    /**
      * Creates a new Buffer containing the given JavaScript string {str}.
      * If provided, the {encoding} parameter identifies the character encoding.
      * If not provided, {encoding} defaults to 'utf8'.

--- a/types/node/v11/globals.d.ts
+++ b/types/node/v11/globals.d.ts
@@ -367,7 +367,7 @@ declare const Buffer: {
      * A `TypeError` will be thrown if {obj} has not mentioned methods or is not of other type appropriate for `Buffer.from()` variants.
      * @param obj An object supporting `Symbol.toPrimitive` or `valueOf()`.
      */
-    from(obj: object, byteOffset?: number, length?: number): Buffer;
+    from(obj: { valueOf(): string | object } | { [Symbol.toPrimitive](hint: 'string'): string }, byteOffset?: number, length?: number): Buffer;
     /**
      * Creates a new Buffer containing the given JavaScript string {str}.
      * If provided, the {encoding} parameter identifies the character encoding.

--- a/types/node/v11/globals.d.ts
+++ b/types/node/v11/globals.d.ts
@@ -363,6 +363,12 @@ declare const Buffer: {
     from(data: number[]): Buffer;
     from(data: Uint8Array): Buffer;
     /**
+     * Creates a new buffer containing the coerced value of an object
+     * A `TypeError` will be thrown if {obj} has not mentioned methods or is not of other type appropriate for `Buffer.from()` variants.
+     * @param obj An object supporting `Symbol.toPrimitive` or `valueOf()`.
+     */
+    from(obj: object, byteOffset?: number, length?: number): Buffer;
+    /**
      * Creates a new Buffer containing the given JavaScript string {str}.
      * If provided, the {encoding} parameter identifies the character encoding.
      * If not provided, {encoding} defaults to 'utf8'.

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -315,7 +315,7 @@ declare class Buffer extends Uint8Array {
      * A `TypeError` will be thrown if {obj} has not mentioned methods or is not of other type appropriate for `Buffer.from()` variants.
      * @param obj An object supporting `Symbol.toPrimitive` or `valueOf()`.
      */
-    static from(obj: object, byteOffset?: number, length?: number): Buffer;
+    static from(obj: { valueOf(): string | object } | { [Symbol.toPrimitive](hint: 'string'): string }, byteOffset?: number, length?: number): Buffer;
     /**
      * Creates a new Buffer containing the given JavaScript string {str}.
      * If provided, the {encoding} parameter identifies the character encoding.

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -311,6 +311,12 @@ declare class Buffer extends Uint8Array {
     static from(data: number[]): Buffer;
     static from(data: Uint8Array): Buffer;
     /**
+     * Creates a new buffer containing the coerced value of an object
+     * A `TypeError` will be thrown if {obj} has not mentioned methods or is not of other type appropriate for `Buffer.from()` variants.
+     * @param obj An object supporting `Symbol.toPrimitive` or `valueOf()`.
+     */
+    static from(obj: object, byteOffset?: number, length?: number): Buffer;
+    /**
      * Creates a new Buffer containing the given JavaScript string {str}.
      * If provided, the {encoding} parameter identifies the character encoding.
      * If not provided, {encoding} defaults to 'utf8'.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_object_offsetorencoding_length
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.