### PR TITLE
Bump ts-toolbelt to ^6.1.11

### DIFF
--- a/types/ramda/package.json
+++ b/types/ramda/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "ts-toolbelt": "^4.12.0"
+        "ts-toolbelt": "^6.1.11"
     }
 }


### PR DESCRIPTION
Bump ts-toolbelt to ^6.1.11 in order to support Typescript 3.7

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/pirix-gh/ts-toolbelt#-compatibility](https://github.com/pirix-gh/ts-toolbelt#-compatibility)