### PR TITLE
Fix onRangeChange types from CalendarProps

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -268,7 +268,7 @@ export interface CalendarProps<TEvent extends object = Event, TResource extends 
     onDoubleClickEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelectEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelecting?: (range: { start: stringOrDate; end: stringOrDate }) => boolean | undefined | null;
-    onRangeChange?: (range: Date[] | { start: stringOrDate; end: stringOrDate }) => void;
+    onRangeChange?: (range: Date[], view: View) => void;
     selected?: any;
     views?: ViewsProps;
     drilldownView?: View | null;

--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -268,7 +268,7 @@ export interface CalendarProps<TEvent extends object = Event, TResource extends 
     onDoubleClickEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelectEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelecting?: (range: { start: stringOrDate; end: stringOrDate }) => boolean | undefined | null;
-    onRangeChange?: (range: Date[] | { start: stringOrDate; end: stringOrDate }, view: View) => void;
+    onRangeChange?: (range: Date[] | { start: Date; end: Date }, view?: View) => void;
     selected?: any;
     views?: ViewsProps;
     drilldownView?: View | null;

--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -268,7 +268,7 @@ export interface CalendarProps<TEvent extends object = Event, TResource extends 
     onDoubleClickEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelectEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelecting?: (range: { start: stringOrDate; end: stringOrDate }) => boolean | undefined | null;
-    onRangeChange?: (range: Date[], view: View) => void;
+    onRangeChange?: (range: Date[] | { start: stringOrDate; end: stringOrDate }, view: View) => void;
     selected?: any;
     views?: ViewsProps;
     drilldownView?: View | null;

--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -268,7 +268,7 @@ export interface CalendarProps<TEvent extends object = Event, TResource extends 
     onDoubleClickEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelectEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelecting?: (range: { start: stringOrDate; end: stringOrDate }) => boolean | undefined | null;
-    onRangeChange?: (range: Date[] | { start: Date; end: Date }, view?: View) => void;
+    onRangeChange?: (range: Date[] | { start: stringOrDate; end: stringOrDate }, view?: View) => void;
     selected?: any;
     views?: ViewsProps;
     drilldownView?: View | null;

--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -268,7 +268,7 @@ export interface CalendarProps<TEvent extends object = Event, TResource extends 
     onDoubleClickEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelectEvent?: (event: TEvent, e: React.SyntheticEvent<HTMLElement>) => void;
     onSelecting?: (range: { start: stringOrDate; end: stringOrDate }) => boolean | undefined | null;
-    onRangeChange?: (range: Date[] | { start: stringOrDate; end: stringOrDate }, view?: View) => void;
+    onRangeChange?: (range: Date[] | { start: stringOrDate; end: stringOrDate }, view: View | undefined) => void;
     selected?: any;
     views?: ViewsProps;
     drilldownView?: View | null;


### PR DESCRIPTION
The types declaration of onRangeChange function seem to be wrong: typescript returns error if I try to manipulate the returning range array like the following:
```
<BigCalendar
  onRangeChange={
    range => {
      range.map((v, k) => { ... }) // typescript error here
    }
  }
/>
```

Typescript error:
```
Property 'map' does not exist on type 'Date[] | { start: stringOrDate; end: stringOrDate; }'.
Property 'map' does not exist on type '{ start: stringOrDate; end: stringOrDate; }'.
```

Furthermore, if you look at the variables returned by the function with a spread operator, you'll get an array of 2 elements:
[0] => range: Date[]
[1] => view: View