### PR TITLE
later - next() can return single date

### DIFF
--- a/types/later/index.d.ts
+++ b/types/later/index.d.ts
@@ -158,7 +158,7 @@ declare namespace later {
          * @param dateFrom: The earliest a valid range can occur
          * @param dateTo: The latest a valid range can occur
          */
-        nextRange(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[];
+        nextRange(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[] | Date;
 
         /**
          * Finds the previous valid instance or instances of the current schedule,
@@ -170,7 +170,7 @@ declare namespace later {
          * @param dateFrom: The earliest a valid instance can occur
          * @param dateTo: The latest a valid instance can occur
          */
-        prev(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[];
+        prev(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[] | Date;
 
         /**
          * Finds the previous valid range or ranges of the current schedule,
@@ -182,7 +182,7 @@ declare namespace later {
          * @param dateFrom: The earliest a valid range can occur
          * @param dateTo: The latest a valid range can occur
          */
-        prevRange(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[];
+        prevRange(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[] | Date;
     }
 
     interface RecurrenceBuilder extends ScheduleData {

--- a/types/later/index.d.ts
+++ b/types/later/index.d.ts
@@ -146,7 +146,7 @@ declare namespace later {
          * @param dateFrom: The earliest a valid instance can occur
          * @param dateTo: The latest a valid instance can occur
          */
-        next(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[];
+        next(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[] | Date;
 
         /**
          * Finds the next valid range or ranges of the current schedule,

--- a/types/later/later-tests.ts
+++ b/types/later/later-tests.ts
@@ -594,12 +594,12 @@ function LaterTest_CalculateOccurences() {
     // calculate the next 10 occurrences of a recur schedule
     const recurSched = later.parse.recur().last().dayOfMonth();
 
-    next = <Date[]>later.schedule(recurSched).next(10);
+    next = <Date[]> later.schedule(recurSched).next(10);
 
     // calculate the previous occurrence starting from March 21, 2013
     const cronSched = later.parse.cron('0 0/5 14,18 * * ?');
 
-    next = <Date[]>later.schedule(cronSched).prev(1, new Date(2013, 2, 21));
+    next = <Date[]> later.schedule(cronSched).prev(1, new Date(2013, 2, 21));
 }
 
 function LaterTest_ExecuteCodeUsingSchedule() {

--- a/types/later/later-tests.ts
+++ b/types/later/later-tests.ts
@@ -594,12 +594,12 @@ function LaterTest_CalculateOccurences() {
     // calculate the next 10 occurrences of a recur schedule
     const recurSched = later.parse.recur().last().dayOfMonth();
 
-    next = later.schedule(recurSched).next(10);
+    next = <Date[]>later.schedule(recurSched).next(10);
 
     // calculate the previous occurrence starting from March 21, 2013
     const cronSched = later.parse.cron('0 0/5 14,18 * * ?');
 
-    next = later.schedule(cronSched).prev(1, new Date(2013, 2, 21));
+    next = <Date[]>later.schedule(cronSched).prev(1, new Date(2013, 2, 21));
 }
 
 function LaterTest_ExecuteCodeUsingSchedule() {


### PR DESCRIPTION
Here's the code that implements the type:
https://github.com/bunkat/later/blob/c5b45ef076d7a2c175c27427e5af22b29a0cc241/src/core/schedule.js#L125

If there's only one value, it returns a single, but the typing says it will always return an array.

This template below is a bit daunting for right now, will try to circle back to it later.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
