### PR TITLE
fix(carbon-components-react) Updated DataTableCustomSelectionProps accordingly to the Element's props

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import {
     AccordionItem,
-    DataTable, DataTableCustomRenderProps,
+    DataTable,
+    DataTableCustomRenderProps,
     DataTableHeader,
     DataTableRow,
     Table,
@@ -171,11 +172,11 @@ interface T5RowType extends DataTableRow {
     col1: number;
     col2: number;
 }
-const t5RowItems: Array<T5RowType> = [
+const t5RowItems: T5RowType[] = [
     { id: "row0", col1: 0, col2: 0},
     { id: "row1", col1: 1, col2: 1},
 ];
-const t5Headers: Array<DataTableHeader> = [
+const t5Headers: DataTableHeader[] = [
     {key: 'col1', header: 'First column'},
     {key: 'col2', header: 'Second column'}
 ];

--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {
     AccordionItem,
-    DataTable,
+    DataTable, DataTableCustomRenderProps,
     DataTableHeader,
     DataTableRow,
     Table,
@@ -164,6 +164,63 @@ const t4 = (
             let b = rowProps.someRandomRowProp;
             return <div />;
         }}
+    />
+);
+// RenderProps are compatible with sub-elements
+interface T5RowType extends DataTableRow {
+    col1: number;
+    col2: number;
+}
+const t5RowItems: Array<T5RowType> = [
+    { id: "row0", col1: 0, col2: 0},
+    { id: "row1", col1: 1, col2: 1},
+];
+const t5Headers: Array<DataTableHeader> = [
+    {key: 'col1', header: 'First column'},
+    {key: 'col2', header: 'Second column'}
+];
+const t5 = (
+    <DataTable
+        rows={t5RowItems}
+        headers={t5Headers}
+        render={(renderProps: DataTableCustomRenderProps<T5RowType>) => (
+            <DataTable.TableContainer>
+                <DataTable.Table {...renderProps.getTableProps()}>
+                    <DataTable.TableHead>
+                        <DataTable.TableRow>
+                            <DataTable.TableSelectAll
+                                {...renderProps.getSelectionProps()}
+                            />
+                            {renderProps.headers.map(header => (
+                                <DataTable.TableHeader
+                                    {...renderProps.getHeaderProps({ header })}
+                                >
+                                    {header.header}
+                                </DataTable.TableHeader>
+                            ))}
+                            <DataTable.TableHeader />
+                        </DataTable.TableRow>
+                    </DataTable.TableHead>
+                    <DataTable.TableBody>
+                        {renderProps.rows.map(row => (
+                            <React.Fragment key={row.id}>
+                                <DataTable.TableRow {...renderProps.getRowProps({ row })}>
+                                    <DataTable.TableSelectRow
+                                        {...renderProps.getSelectionProps({ row })}
+                                    />
+                                    {row.cells.map(cell => (
+                                        <DataTable.TableCell key={cell.id}>
+                                            {cell.value}
+                                        </DataTable.TableCell>
+                                    ))}
+                                    <DataTable.TableCell key={`options${row.id}`} />
+                                </DataTable.TableRow>
+                            </React.Fragment>
+                        ))}
+                    </DataTable.TableBody>
+                </DataTable.Table>
+            </DataTable.TableContainer>
+        )}
     />
 );
 

--- a/types/carbon-components-react/lib/components/DataTable/DataTable.d.ts
+++ b/types/carbon-components-react/lib/components/DataTable/DataTable.d.ts
@@ -70,13 +70,13 @@ export interface DataTableCustomSelectionData<R extends DataTableRow = DataTable
 
 export interface DataTableCustomSelectionProps<R extends DataTableRow = DataTableRow> {
     ariaLabel?: string,
-    checked: R extends never ? boolean : R["isSelected"],
+    checked: R extends never ? boolean : NonNullable<R["isSelected"]>,
     disabled: R extends never ? never : R["disabled"],
     id: string,
     indeterminate: R extends never ? boolean : never,
     name: string,
     onSelect(event: React.MouseEvent<HTMLElement>): void,
-    radio: R extends never ? never : (Extract<DataTableProps["radio"], true> | null),
+    radio?: R extends never ? never : (Extract<DataTableProps["radio"], boolean>),
 }
 
 // endregion Row Types


### PR DESCRIPTION
The issue can be reproduced [here](https://codesandbox.io/s/sleepy-silence-8wk9d?fontsize=14&hidenavigation=1&theme=dark) at line 52, once the `radio` will be fixed, `checked` will crash.

The PR fixes two issues on the prop generation for DataTableRow.

* The prop `checked`: R["isSelected"] can lead to `undefined`.
* The prop `radio`: The type was misleading.
  * Since the prop is not mandatory ([see here](https://github.com/carbon-design-system/carbon/blob/v10.6.4/packages/react/src/components/DataTable/TableSelectRow.js#L78)), I changed it to optional.
  * The method `Extract` expects the second argument property to be a type and not a value, it led to some compilation issues.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I could not provide an URL for this.
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>