### PR TITLE
[ioredis] add missing `unlink` to Pipeline

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -811,6 +811,8 @@ declare namespace IORedis {
 
         del(...keys: KeyType[]): Pipeline;
 
+        unlink(...keys: KeyType[]): Pipeline;
+        
         exists(...keys: KeyType[]): Pipeline;
 
         setbit(key: KeyType, offset: number, value: ValueType, callback?: (err: Error, res: number) => void): Pipeline;

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -812,7 +812,7 @@ declare namespace IORedis {
         del(...keys: KeyType[]): Pipeline;
 
         unlink(...keys: KeyType[]): Pipeline;
-        
+
         exists(...keys: KeyType[]): Pipeline;
 
         setbit(key: KeyType, offset: number, value: ValueType, callback?: (err: Error, res: number) => void): Pipeline;


### PR DESCRIPTION
The method is available in the Pipeline in the same way as the rest of the redis commands (https://github.com/luin/ioredis/blob/master/lib/pipeline.ts).

This is the original issue about the missing method: https://github.com/luin/ioredis/issues/1001

The `unlink` method is available in the pipeline object. I am using it in my lib https://github.com/eturino/ioredis-del-by-pattern.ts/blob/master/src/run-with-pipeline.ts#L41 which is tested with a real redis client.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
  - no tests affected here.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
  - run it successfully in local repo

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/luin/ioredis/blob/master/lib/pipeline.ts>, <https://github.com/luin/ioredis/issues/1001>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
