### PR TITLE
[WIP] feat(angular-aria): definition for AngularJS ngAria

### DIFF
--- a/types/angular-aria/angular-aria-tests.ts
+++ b/types/angular-aria/angular-aria-tests.ts
@@ -1,0 +1,16 @@
+const app = angular.module('testModule', ['ngAria']);
+
+app.config(($ariaProvider: angular.aria.IAriaProvider) => {
+    $ariaProvider.config({
+        ariaChecked: true,
+        ariaDisabled: true,
+        ariaHidden: true,
+        ariaInvalid: true,
+        ariaReadonly: true,
+        ariaRequired: true,
+        ariaValue: true,
+        bindKeydown: true,
+        bindRoleForClick: true,
+        tabindex: true,
+    });
+});

--- a/types/angular-aria/index.d.ts
+++ b/types/angular-aria/index.d.ts
@@ -1,0 +1,67 @@
+// Type definitions for angular-aria 1.7
+// Project: http://angularjs.org
+// Definitions by: chivesrs <https://github.com/chivesrs>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="angular" />
+
+// `ngAria` string
+declare const exportedString: 'ngAria';
+export default exportedString;
+
+// re-export aliases for shorter syntax
+export type IAriaOptions = angular.aria.IAriaOptions;
+export type IAriaProvider = angular.aria.IAriaProvider;
+
+declare module 'angular' {
+    /**
+     * ngAria module (angular-aria.js)
+     * see {@link https://docs.angularjs.org/api/ngAria/service/$aria}
+     */
+    namespace aria {
+        /**
+         * AriaProvider
+         * Used for configuring the ARIA attributes injected and managed by ngAria.
+         * see {@link https://docs.angularjs.org/api/ngAria/provider/$ariaProvider}
+         */
+        // tslint:disable-next-line interface-name
+        interface IAriaProvider {
+            /** Enables/disables various ARIA attributes */
+            config(config: IAriaOptions): void;
+        }
+
+        /**
+         * see {@link https://docs.angularjs.org/api/ngAria/provider/$ariaProvider}
+         */
+        // tslint:disable-next-line interface-name
+        interface IAriaOptions {
+            /** Enables/disables aria-hidden tags */
+            ariaHidden?: boolean;
+            /** Enables/disables aria-checked tags */
+            ariaChecked?: boolean;
+            /** Enables/disables aria-readonly tags */
+            ariaReadonly?: boolean;
+            /** Enables/disables aria-disabled tags */
+            ariaDisabled?: boolean;
+            /** Enables/disables aria-required tags */
+            ariaRequired?: boolean;
+            /** Enables/disables aria-invalid tags */
+            ariaInvalid?: boolean;
+            /** Enables/disables aria-valuemin, aria-valuemax and aria-valuenow tags */
+            ariaValue?: boolean;
+            /** Enables/disables tabindex tags */
+            tabindex?: boolean;
+            /**
+             * Enables/disables keyboard event binding on non-interactive elements
+             * (such as `div` or `li`) using ng-click, making them more accessible to users of assistive technologies
+             */
+            bindKeydown?: boolean;
+            /**
+             * Adds `role=button` to non-interactive elements
+             * (such as `div` or `li`) using ng-click, making them more accessible to users of assistive technologies
+             */
+            bindRoleForClick?: boolean;
+        }
+    }
+}

--- a/types/angular-aria/tsconfig.json
+++ b/types/angular-aria/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "angular-aria-tests.ts"
+    ]
+}

--- a/types/angular-aria/tslint.json
+++ b/types/angular-aria/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- type defintion
- tests
- configuration

Note that TSLint rules contains single exclusion based on established
convention of naming AngularJS interfaces with names prefixed with 'I'.

https://docs.angularjs.org/api/ngAria#module-installation

/cc @chivesrs

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.