### PR TITLE
ssh2-sftp-client: fix get method dest parameter

### DIFF
--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -8,6 +8,7 @@
 //                 Taylor Herron <https://github.com/gbhmt>
 //                 Lane Goldberg <https://github.com/builtbylane>
 //                 Lorenzo Adinolfi <https://github.com/loru88>
+//                 Sam Galizia <https://github.com/sgalizia>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as ssh2 from 'ssh2';
@@ -18,19 +19,27 @@ export = sftp;
 declare class sftp {
     connect(options: ssh2.ConnectConfig): Promise<ssh2.SFTPWrapper>;
 
-    list(remoteFilePath: string, pattern?: string|RegExp): Promise<sftp.FileInfo[]>;
+    list(remoteFilePath: string, pattern?: string | RegExp): Promise<sftp.FileInfo[]>;
 
-    exists(remotePath: string): Promise<false | "d" | "-" | "l">;
+    exists(remotePath: string): Promise<false | 'd' | '-' | 'l'>;
 
     stat(remotePath: string): Promise<sftp.FileStats>;
 
     realPath(remotePath: string): Promise<string>;
 
-    get(path: string, dst?: string | NodeJS.ReadableStream, options?: ssh2Stream.TransferOptions): Promise<string | NodeJS.ReadableStream | Buffer>;
+    get(
+        path: string,
+        dst?: string | NodeJS.WritableStream,
+        options?: ssh2Stream.TransferOptions,
+    ): Promise<string | NodeJS.WritableStream | Buffer>;
 
     fastGet(remoteFilePath: string, localPath: string, options?: ssh2Stream.TransferOptions): Promise<string>;
 
-    put(input: string | Buffer | NodeJS.ReadableStream, remoteFilePath: string, options?: ssh2Stream.TransferOptions): Promise<string>;
+    put(
+        input: string | Buffer | NodeJS.ReadableStream,
+        remoteFilePath: string,
+        options?: ssh2Stream.TransferOptions,
+    ): Promise<string>;
 
     fastPut(localPath: string, remoteFilePath: string, options?: ssh2Stream.TransferOptions): Promise<string>;
 
@@ -46,7 +55,11 @@ declare class sftp {
 
     chmod(remotePath: string, mode: number | string): Promise<string>;
 
-    append(input: Buffer | NodeJS.ReadableStream, remotePath: string, options?: ssh2Stream.TransferOptions): Promise<string>;
+    append(
+        input: Buffer | NodeJS.ReadableStream,
+        remotePath: string,
+        options?: ssh2Stream.TransferOptions,
+    ): Promise<string>;
 
     end(): Promise<void>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.npmjs.com/package/ssh2-sftp-client#getpath-dst-options--stringstreambuffer>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
