### PR TITLE
[emscripten] Delete Math interface and fix locateFile()

### DIFF
--- a/types/emscripten/emscripten-tests.ts
+++ b/types/emscripten/emscripten-tests.ts
@@ -1,3 +1,5 @@
+/// <reference types="emscripten" />
+
 /// Extending Module
 // This requires -s "EXTRA_EXPORTED_RUNTIME_METHODS=['cwrap','ccall','getValue','setvalue']"
 // in emcc compilation flags
@@ -25,7 +27,7 @@ function ModuleTest(): void {
         [{name: "func-name", kind: "function"}],
         (module: WebAssembly.Module) => {}
     );
-    const memFile: string = Module.locateFile("http://www.example.org/file.mem");
+    const memFile: string = Module.locateFile("file.mem", "http://www.example.org/");
     Module.onCustomMessage(new MessageEvent("TestType"));
 
     Module.print = (text) => alert('stdout: ' + text);

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -83,7 +83,7 @@ interface EmscriptenModule {
         imports: Emscripten.WebAssemblyImports,
         successCallback: (module: WebAssembly.Module) => void
     ): Emscripten.WebAssemblyExports;
-    locateFile(url: string): string;
+    locateFile(url: string, scriptDirectory: string): string;
     onCustomMessage(event: MessageEvent): void;
 
     // USE_TYPED_ARRAYS == 1

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -220,10 +220,6 @@ declare namespace FS {
     function createDataFile(parent: string | FSNode, name: string, data: ArrayBufferView, canRead: boolean, canWrite: boolean, canOwn: boolean): FSNode;
 }
 
-interface Math {
-    imul(a: number, b: number): number;
-}
-
 declare var MEMFS: Emscripten.FileSystemType;
 declare var NODEFS: Emscripten.FileSystemType;
 declare var IDBFS: Emscripten.FileSystemType;


### PR DESCRIPTION
`@types/emscripten` have `Math` interface with `Math.imul` function. This function is already a part of `lib.es2015.core.d.ts` so this should not be defined here.

Also, this fixes Emscripten.locateFile().

See: 
* https://github.com/microsoft/TypeScript/blob/master/lib/lib.es2015.core.d.ts#L112
* https://github.com/emscripten-core/emscripten/blob/1e7843784cdf8ed608feebc55bdc246074cc12cb/src/shell.js#L108

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
* https://github.com/microsoft/TypeScript/blob/master/lib/lib.es2015.core.d.ts#L112
* https://github.com/emscripten-core/emscripten/blob/1e7843784cdf8ed608feebc55bdc246074cc12cb/src/shell.js#L108
* https://github.com/emscripten-core/emscripten/issues/10271

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/definitelytyped/definitelytyped/42140)
<!-- Reviewable:end -->
