### PR TITLE
[angular-aria] Add types for AngularJS $aria service

### DIFF
--- a/types/angular-aria/angular-aria-tests.ts
+++ b/types/angular-aria/angular-aria-tests.ts
@@ -1,5 +1,5 @@
 function testConfig($aria: angular.aria.IAriaService): void {
-    // $ExpectType void
+    // $ExpectType boolean
     $aria.config('tabindex');
 
     // $ExpectError

--- a/types/angular-aria/angular-aria-tests.ts
+++ b/types/angular-aria/angular-aria-tests.ts
@@ -1,0 +1,7 @@
+function testConfig($aria: angular.aria.IAriaService): void {
+    // $ExpectType void
+    $aria.config('tabindex');
+
+    // $ExpectError
+    $aria.config('unknown-string');
+}

--- a/types/angular-aria/index.d.ts
+++ b/types/angular-aria/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://angularjs.org, https://docs.angularjs.org/api/ngAria
 // Definitions by: Chives <https://github.com/chivesrs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 import * as angular from 'angular';
 

--- a/types/angular-aria/index.d.ts
+++ b/types/angular-aria/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for angular-aria 1.7
+// Project: http://angularjs.org, https://docs.angularjs.org/api/ngAria
+// Definitions by: Chives <https://github.com/chivesrs>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as angular from 'angular';
+
+declare module 'angular' {
+    namespace aria {
+        type IAriaAttribute = 'ariaHidden'|'ariaChecked'|'ariaReadonly'|'ariaDisabled'|'ariaRequired'|'ariaInvalid'|'ariaValue'|'tabindex'|'bindKeydown'|'bindRoleForClick';
+
+        /**
+         * $aria service.
+         */
+        interface IAriaService {
+            config(attribute: IAriaAttribute): boolean;
+        }
+    }
+}

--- a/types/angular-aria/tsconfig.json
+++ b/types/angular-aria/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
+            "dom",
             "es6"
         ],
         "noImplicitAny": true,

--- a/types/angular-aria/tsconfig.json
+++ b/types/angular-aria/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "angular-aria-tests.ts"
+    ]
+}

--- a/types/angular-aria/tslint.json
+++ b/types/angular-aria/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/angular-aria/tslint.json
+++ b/types/angular-aria/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "interface-name": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

The `tslint.json` is explicitly modified to disable interface naming rules. The reason for this is that AngularJS typings follow the pattern listed [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/angular/README.md#services-and-other-injectables).

Regarding documentation on the actual types, see:
https://docs.angularjs.org/api/ngAria
https://docs.angularjs.org/guide/accessibility
https://github.com/angular/angular.js/blob/master/src/ngAria/aria.js#L97
https://docs.angularjs.org/api/ngAria/provider/$ariaProvider#config
https://github.com/angular/angular.js/blob/master/src/ngAria/aria.js#L205

Also try some sample code:
```
s = document.createElement('script'); s.src = "https://ajax.googleapis.com/ajax/libs/angularjs/1.7.9/angular-aria.js"; document.getElementsByTagName('head')[0].appendChild(s);

i = angular.injector(); i.loadNewModules(['ngAria']); aria = i.get('$aria'); console.log(aria); console.log(aria.config('tabindex')); console.log(aria.config('ariaInvalid'));
```

Paste into https://angularjs.org in the JS console. First line loads `ngAria` script (it's not built into main AngularJS, but it is a core library), second line instantiates the service and uses it.

/cc @peterblazejewicz