### PR TITLE
[rsocket-core] Add rsocket error types

### DIFF
--- a/types/rsocket-core/RSocketFrame.d.ts
+++ b/types/rsocket-core/RSocketFrame.d.ts
@@ -91,16 +91,22 @@ export function isLease(flags: number): boolean;
  */
 export function isResumePositionFrameType(type: number): boolean;
 export function getFrameTypeName(type: number): string;
+export interface ErrorSource {
+    /** The error code returned by the server. */
+    code: number;
+    /** Human-readable explanation of the code (this value is not standardized and may change). */
+    explanation: string;
+    /** The error string returned by the server. */
+    message: string;
+}
+export class RSocketError extends Error {
+    /** Metadata about the error for use in introspecting at runtime. */
+    source: ErrorSource;
+}
 /**
- * Constructs an Error object given the contents of an error frame. The
- * `source` property contains metadata about the error for use in introspecting
- * the error at runtime:
- * - `error.source.code: number`: the error code returned by the server.
- * - `error.source.explanation: string`: human-readable explanation of the code
- *   (this value is not standardized and may change).
- * - `error.source.message: string`: the error string returned by the server.
+ * Constructs an Error object given the contents of an error frame.
  */
-export function createErrorFromFrame(frame: ErrorFrame): Error;
+export function createErrorFromFrame(frame: ErrorFrame): RSocketError;
 /**
  * Given a RSocket error code, returns a human-readable explanation of that
  * code, following the names used in the protocol specification.


### PR DESCRIPTION
This PR adds typings to [RSocketFrame.js#L182-L195](https://github.com/rsocket/rsocket-js/blob/ca619ef3027a993ae2d52c3031c6ca5115dd259c/packages/rsocket-core/src/RSocketFrame.js#L182-L195) so that it's possible to introspect the error in runtime, and in particular observe the rsocket error code. The error codes are important for the applications that rely on custom [error codes](https://github.com/rsocket/rsocket/blob/master/Protocol.md#error-frame-0x0b). 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
