### PR TITLE
fix(lodash): allow readonly tuple in fromPairs

### DIFF
--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -512,12 +512,14 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType LoDashExplicitWrapper<number
 {
     const twoDimensionalArray: string[][] | null | undefined = anything;
     const numberTupleArray: Array<[string, number]> | null | undefined = anything;
+    const readonlyTuple: ReadonlyArray<number> =  [];
 
     _.fromPairs(twoDimensionalArray); // $ExpectType Dictionary<any>
     _.fromPairs(numberTupleArray); // $ExpectType Dictionary<number>
     _(twoDimensionalArray).fromPairs(); // $ExpectType LoDashImplicitWrapper<Dictionary<any>>
     _.chain(twoDimensionalArray).fromPairs(); // $ExpectType LoDashExplicitWrapper<Dictionary<any>>
     fp.fromPairs(numberTupleArray); // $ExpectType Dictionary<number>
+    _.fromPairs(readonlyTuple);
 }
 
 // _.head


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

