### PR TITLE
Add period to LibratoConfig for librato-node

### DIFF
--- a/types/librato-node/index.d.ts
+++ b/types/librato-node/index.d.ts
@@ -26,6 +26,7 @@ export interface LibratoConfig {
     prefix?: string;
     source?: string;
     requestOptions?: LibratoRequestOptions;
+    period?: number;
     simulate?: false;
 }
 

--- a/types/librato-node/librato-node-tests.ts
+++ b/types/librato-node/librato-node-tests.ts
@@ -26,6 +26,7 @@ librato.configure({
         method: 'POST',
         uri: 'https://foo.com',
     },
+    period: 5000,
     simulate: false,
 });
 


### PR DESCRIPTION
I think the `period` option was forgotten in the initial release.


#### Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/goodeggs/librato-node/blob/master/src/librato.coffee#L15
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
