### PR TITLE
[pouchdb-find] Add missing field to PouchDB.Find.FindResponse 

### DIFF
--- a/types/pouchdb-find/index.d.ts
+++ b/types/pouchdb-find/index.d.ts
@@ -102,6 +102,7 @@ declare namespace PouchDB {
 
         interface FindResponse<Content extends {}> {
             docs: Array<Core.ExistingDocument<Content>>;
+            warning?: string;
         }
 
         interface CreateIndexOptions {


### PR DESCRIPTION
> You may also want to pay attention to the "warning" value included in your results set, indicating that there was no index that matched the given query.

https://pouchdb.com/guides/mango-queries.html

