### PR TITLE
fix(estree): declaration should not be undefined

### DIFF
--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -528,7 +528,7 @@ export interface ImportNamespaceSpecifier extends BaseModuleSpecifier {
 
 export interface ExportNamedDeclaration extends BaseModuleDeclaration {
   type: "ExportNamedDeclaration";
-  declaration?: Declaration | null;
+  declaration: Declaration | null;
   specifiers: Array<ExportSpecifier>;
   source?: Literal | null;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
- https://github.com/estree/estree/blob/master/es2015.md#exportnameddeclaration

---

Hi

As specified in the spec of Estress, `declaration` should never be undefined.
Closes #40188

Have a great day,
