### PR TITLE
fix(google__maps): sessiontoken in PlaceAutocomplete is optional

### DIFF
--- a/types/google__maps/index.d.ts
+++ b/types/google__maps/index.d.ts
@@ -3003,7 +3003,7 @@ export interface PlaceAutocompleteRequest {
      * [session](https://developers.google.com/places/web-service/autocomplete#session_tokens) for billing purposes.
      * If this parameter is omitted from an autocomplete request, the request is billed independently
      */
-    sessiontoken: string;
+    sessiontoken?: string;
     /**
      * The position, in the input term, of the last character that the service uses to match predictions.
      * For example, if the input is 'Google' and the `offset` is 3, the service will match on 'Goo'.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
- https://developers.google.com/places/web-service/autocomplete (look for `sessiontoken`)

--- 

Hi team,

As the doc and description of this property suggest, `sessiontoken` is an optional parameter.

Closes #42151

Best regards,
