### PR TITLE
[@types/hapi-pino] Update hapi-pino to 6.4

### DIFF
--- a/types/hapi-pino/hapi-pino-tests.ts
+++ b/types/hapi-pino/hapi-pino-tests.ts
@@ -58,6 +58,7 @@ function example2() {
                 remove: true,
             },
             logRequestStart: true,
+            logRequestComplete: true,
             prettyPrint: {
                 levelFirst: true,
                 colorize: true,
@@ -80,5 +81,16 @@ function example3() {
             debug: 'debug',
         },
         redact: ['test.property'],
+    });
+}
+
+function example4() {
+    server.register({
+        plugin: HapiPino,
+        options: {
+            logRequestStart: (req: Request) => req.path !== '/ping',
+            logRequestComplete: (req: Request) => req.path !== '/ping',
+            getChildBindings: (req: Request) => ({}),
+        },
     });
 }

--- a/types/hapi-pino/index.d.ts
+++ b/types/hapi-pino/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for hapi-pino 6.3
+// Type definitions for hapi-pino 6.4
 // Project: https://github.com/pinojs/hapi-pino#readme
 // Definitions by: Rodrigo Saboya <https://github.com/saboya>
 //                 Todd Bealmear <https://github.com/todd>
@@ -30,7 +30,8 @@ declare namespace HapiPino {
     interface Options {
         logPayload?: boolean;
         logRouteTags?: boolean;
-        logRequestStart?: boolean;
+        logRequestStart?: boolean | ((req: Request) => boolean);
+        logRequestComplete?: boolean | ((req: Request) => boolean);
         stream?: NodeJS.WriteStream;
         prettyPrint?: boolean | pino.PrettyOptions;
         tags?: { [key in pino.Level]?: string };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/hapi-pino/commit/e947ac5fab8bb747e5887518ef7fe1322d29adbd
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.