### PR TITLE
[WIP] [@types/redux-form] fixed definitions of FormErrors and FormWarnings

### DIFF
--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -31,7 +31,7 @@ export interface ErrorOther<T = string> {
 
 export type FormErrors<FormData = {}, T = string> = {
     [P in keyof FormData]?: FormData[P] extends Array<infer Pi>
-        ? Array<FormErrors<Pi>> | ErrorOther<T>
+        ? Array<ReactElement | T | FormErrors<Pi>> | T[] | ErrorOther<T>
         : ReactElement | T | FormErrors<FormData[P]>;
 } & ErrorOther<T>;
 
@@ -41,7 +41,7 @@ export interface WarningOther<T = void> {
 
 export type FormWarnings<FormData = {}, T = string> = {
     [P in keyof FormData]?: FormData[P] extends Array<infer Pi>
-        ? Array<FormWarnings<Pi>> | WarningOther<T>
+        ? Array<ReactElement | T | FormWarnings<Pi>> | WarningOther<T>
         : ReactElement | T | FormWarnings<FormData[P]>;
 } & WarningOther<T>;
 

--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -15,6 +15,7 @@
 //                 Walter Barbagallo <https://github.com/bwlt>
 //                 Kota Marusue <https://github.com/mrsekut>
 //                 Adam Bouqdib <https://github.com/abemedia>
+//                 Allis Tauri <https://github.com/allista>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 import {

--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -30,9 +30,9 @@ export interface ErrorOther<T = string> {
 }
 
 export type FormErrors<FormData = {}, T = string> = {
-  [P in keyof FormData]?: FormData[P] extends Array<infer Pi>
-    ? FormErrors<Pi>[] | ErrorOther<T>
-    : ReactElement | T | FormErrors<FormData[P]>;
+    [P in keyof FormData]?: FormData[P] extends Array<infer Pi>
+        ? Array<FormErrors<Pi>> | ErrorOther<T>
+        : ReactElement | T | FormErrors<FormData[P]>;
 } & ErrorOther<T>;
 
 export interface WarningOther<T = void> {
@@ -40,11 +40,10 @@ export interface WarningOther<T = void> {
 }
 
 export type FormWarnings<FormData = {}, T = string> = {
-  [P in keyof FormData]?: FormData[P] extends Array<infer Pi>
-    ? FormWarnings<Pi>[] | WarningOther<T>
-    : ReactElement | T | FormWarnings<FormData[P]>;
+    [P in keyof FormData]?: FormData[P] extends Array<infer Pi>
+        ? Array<FormWarnings<Pi>> | WarningOther<T>
+        : ReactElement | T | FormWarnings<FormData[P]>;
 } & WarningOther<T>;
-
 
 export interface RegisteredFieldState {
     name: string;

--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -30,16 +30,21 @@ export interface ErrorOther<T = string> {
 }
 
 export type FormErrors<FormData = {}, T = string> = {
-    [P in keyof FormData]?: ReactElement | T;
+  [P in keyof FormData]?: FormData[P] extends Array<infer Pi>
+    ? FormErrors<Pi>[] | ErrorOther<T>
+    : ReactElement | T | FormErrors<FormData[P]>;
 } & ErrorOther<T>;
 
 export interface WarningOther<T = void> {
     _warning?: T;
 }
 
-export type FormWarnings<FormData = {}, T = void> = {
-    [P in keyof FormData]?: ReactElement | string | WarningOther<T>;
-};
+export type FormWarnings<FormData = {}, T = string> = {
+  [P in keyof FormData]?: FormData[P] extends Array<infer Pi>
+    ? FormWarnings<Pi>[] | WarningOther<T>
+    : ReactElement | T | FormWarnings<FormData[P]>;
+} & WarningOther<T>;
+
 
 export interface RegisteredFieldState {
     name: string;

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -486,3 +486,62 @@ class TestFormComponent2 extends React.Component<TestFormComponentProps & Inject
         return null;
     }
 }
+
+// Test SubmissionError with recursive error format
+interface ComplexTestFormData {
+    myField: {
+        subfield1: any;
+        subfield2: any;
+    };
+    arrayField: any[];
+    arrayField2: any[];
+}
+
+new LibSubmissionError<ComplexTestFormData>({
+    _error: 'Form-level error',
+    myField: {
+        subfield1: 'Subfield1 error',
+        subfield2: { _error: 'Subfield2 error' }
+    },
+    arrayField: ['arrayField[0] error', 'arrayField[1] error'],
+    arrayField2: { _error: 'Common error for all arrayField2 instances' }
+});
+
+new SubmissionError({
+    _error: 'Form-level error',
+    myField: {
+        subfield1: 'Subfield1 error',
+        subfield2: { _error: 'Subfield2 error' }
+    },
+    arrayField: ['arrayField[0] error', 'arrayField[1] error'],
+    arrayField2: { _error: 'Common error for all arrayField2 instances' }
+});
+
+// Test forms with recursive error format.
+const HandleSubmitTestForm3 = reduxForm<ComplexTestFormData>({
+    form: 'test',
+})((props: InjectedFormProps<ComplexTestFormData>) => <form onSubmit={props.handleSubmit} />);
+
+class HandleSubmitTest3 extends React.Component {
+    handleSubmit = (values: Partial<ComplexTestFormData>, dispatch: Dispatch<any>, props: {}) => {};
+    render() {
+        return <HandleSubmitTestForm3 onSubmit={this.handleSubmit} />;
+    }
+}
+
+type InjectedProps3 = InjectedFormProps<ComplexTestFormData, TestFormComponentProps>;
+class TestFormComponent3 extends React.Component<TestFormComponentProps & InjectedProps3> {
+    render() {
+        const { error, initialValues, handleSubmit } = this.props;
+        handleSubmit(values => ({
+            _error: 'Form-level error',
+            myField: {
+                subfield1: 'Subfield1 error',
+                subfield2: { _error: 'Subfield2 error' }
+            },
+            arrayField: ['arrayField[0] error', 'arrayField[1] error'],
+            arrayField2: { _error: 'Common error for all arrayField2 instances' }
+        }));
+        return null;
+    }
+}


### PR DESCRIPTION
According to the current redux-form code:
https://github.com/redux-form/redux-form/blob/master/src/ConnectedField.js#L48
Both `FormErrors` and `FormWarnings` are defined identically and recursively to conform with the dot-and-brackets notation of Field names.

E.g. Field name `users[3].addresses[5].zipcode` produces the following structure of the field value in the store:
```js
{
  users: [
    //...
    {
      addresses: [
        //...
        {
          zipcode: 123123
        }
      ]
    }
  ]
```

And corresponding errors/warnings object should be able to reflect this structure.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/redux-form/redux-form/blob/master/src/ConnectedField.js#L48
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
