### PR TITLE
[mjml-react] Move extensions and utils to correct location

### DIFF
--- a/types/mjml-react/extensions/index.d.ts
+++ b/types/mjml-react/extensions/index.d.ts
@@ -1,0 +1,6 @@
+import * as React from 'react';
+
+export class MjmlComment extends React.Component<{ children: string }> { }
+export class MjmlConditionalComment extends React.Component<{ children: string; condition: string }> { }
+export class MjmlTrackingPixel extends React.Component<{ src: string }> { }
+export class MjmlYahooStyle extends React.Component<{ children: string }> { }

--- a/types/mjml-react/index.d.ts
+++ b/types/mjml-react/index.d.ts
@@ -6,24 +6,6 @@
 
 import * as React from 'react';
 
-export namespace extensions {
-    class MjmlComment extends React.Component<{ children: string }> { }
-    class MjmlConditionalComment extends React.Component<{ children: string; condition: string }> { }
-    class MjmlTrackingPixel extends React.Component<{ src: string }> { }
-    class MjmlYahooStyle extends React.Component<{ children: string }> { }
-}
-
-export namespace utils {
-    function namedEntityToHexCode(html: string): string;
-    function fixConditionalComment(html: string, havingContent: string, newCondition: string): string;
-    function useHttps(url?: string): string | undefined;
-    function toMobileFontSize(sizeWithUnit: string): number;
-    function addQueryParams(url: string, params: { [key: string]: any }): string;
-
-    type TextAlignment = 'left' | 'right' | 'center' | 'justify' | 'inherit';
-    function getTextAlign(value: string, fallback?: TextAlignment): TextAlignment;
-}
-
 export function renderToMjml(email: React.ReactElement): string;
 
 export interface Mjml2HtmlOptions {

--- a/types/mjml-react/mjml-react-tests.tsx
+++ b/types/mjml-react/mjml-react-tests.tsx
@@ -12,6 +12,22 @@ import {
     MjmlImage
 } from 'mjml-react';
 
+import {
+    MjmlComment,
+    MjmlConditionalComment,
+    MjmlTrackingPixel,
+    MjmlYahooStyle
+} from 'mjml-react/extensions';
+
+import {
+    addQueryParams,
+    fixConditionalComment,
+    getTextAlign,
+    namedEntityToHexCode,
+    toMobileFontSize,
+    useHttps
+} from 'mjml-react/utils';
+
 function renderOutTestEmail() {
     // $ExpectType { html: string; errors: Error[]; }
     const result = render((

--- a/types/mjml-react/utils/index.d.ts
+++ b/types/mjml-react/utils/index.d.ts
@@ -1,0 +1,8 @@
+export function namedEntityToHexCode(html: string): string;
+export function fixConditionalComment(html: string, havingContent: string, newCondition: string): string;
+export function useHttps(url?: string): string | undefined;
+export function toMobileFontSize(sizeWithUnit: string): number;
+export function addQueryParams(url: string, params: { [key: string]: any }): string;
+
+export type TextAlignment = 'left' | 'right' | 'center' | 'justify' | 'inherit';
+export function getTextAlign(value: string, fallback?: TextAlignment): TextAlignment;


### PR DESCRIPTION
Fixes extensions and utils imports
```ts
import {} from 'mjml-react/extensions';
import {} from 'mjml-react/utils';
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wix-incubator/mjml-react#extensions
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
