### PR TITLE
[jwplayer] Add missing method signatures for JWPlayer.off()

### DIFF
--- a/types/jwplayer/index.d.ts
+++ b/types/jwplayer/index.d.ts
@@ -349,6 +349,8 @@ declare namespace jwplayer {
         once<TEvent extends keyof EventParams>(event: TEvent, callback: EventCallback<EventParams[TEvent]>): void;
         once(event: NoParamEvent, callback: () => void): void;
         off(event: keyof EventParams | NoParamEvent): void;
+        off(event: NoParamEvent, callback: () => void): void;
+        off<TEvent extends keyof EventParams>(event: TEvent, callback: EventCallback<EventParams[TEvent]>): void;
         trigger<TEvent extends keyof EventParams>(event: TEvent, args: EventParams[TEvent]): void;
         trigger(event: NoParamEvent): void;
         pause(state?: boolean): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.jwplayer.com/jwplayer/docs/jw8-reference#section-event-listening-with-the-jw-player-api
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

<hr />

This PR adds extra call signatures for the `off()` method which can be used in two ways:
1. to remove all event listeners for a given event 
2. to remove a specific event listener for a given event

The signature for removing _all_ listeners was already present, but the signatures for removing a specific listener were missing.
