### PR TITLE
[redis-info] Add base types

### DIFF
--- a/types/redis-info/index.d.ts
+++ b/types/redis-info/index.d.ts
@@ -72,7 +72,7 @@ export interface MemoryInfo {
     lazyfree_pending_objects: string;
 }
 
-export type PersistenceInfo = {
+export interface BasePersistenceInfo {
     rdb_changes_since_last_save: string;
     rdb_bgsave_in_progress: Flag;
     rdb_last_save_time: string;
@@ -87,7 +87,10 @@ export type PersistenceInfo = {
     aof_last_bgrewrite_status: string;
     aof_last_write_status: string;
     aof_last_cow_size: string;
-} & (PersistenceAOFOnInfo | PersistenceAOFOffInfo) &
+}
+
+export type PersistenceInfo = BasePersistenceInfo &
+    (PersistenceAOFOnInfo | PersistenceAOFOffInfo) &
     (PersistenceLoadingOnInfo | PersistenceLoadingOffInfo);
 
 export interface PersistenceAOFOnInfo {
@@ -147,7 +150,7 @@ export interface Stats {
     active_defrag_key_misses: string;
 }
 
-export type ReplicationInfo = {
+export interface BaseReplicationInfo {
     connected_slaves: string;
     master_replid: string;
     master_replid2: string;
@@ -157,13 +160,15 @@ export type ReplicationInfo = {
     repl_backlog_size: string;
     repl_backlog_first_byte_offset: string;
     repl_backlog_histlen: string;
-} & (ReplicationMasterInfo | ReplicationReplicaInfo);
+}
+
+export type ReplicationInfo = BaseReplicationInfo & (ReplicationMasterInfo | ReplicationReplicaInfo);
 
 export interface ReplicationMasterInfo {
     role: 'master';
 }
 
-export type ReplicationReplicaInfo = {
+export interface BaseReplicationReplicaInfo {
     role: 'slave';
     master_host: string;
     master_port: string;
@@ -173,7 +178,10 @@ export type ReplicationReplicaInfo = {
     slave_read_only: Flag;
     connected_slaves: string;
     min_slaves_good_slaves: string;
-} & (ReplicationReplicaSyncOnInfo | ReplicationReplicaSyncOffInfo) &
+}
+
+export type ReplicationReplicaInfo = BaseReplicationReplicaInfo &
+    (ReplicationReplicaSyncOnInfo | ReplicationReplicaSyncOffInfo) &
     (ReplicationReplicaLinkUpInfo | ReplicationReplicaLinkDownInfo);
 
 export interface ReplicationReplicaSyncOnInfo {
@@ -186,12 +194,17 @@ export interface ReplicationReplicaSyncOffInfo {
     master_sync_in_progress: Flag.OFF;
 }
 
+export enum LinkStatus {
+    UP = 'up',
+    DOWN = 'down',
+}
+
 export interface ReplicationReplicaLinkUpInfo {
-    master_link_status: 'up';
+    master_link_status: LinkStatus.UP;
 }
 
 export interface ReplicationReplicaLinkDownInfo {
-    master_link_status: 'down';
+    master_link_status: LinkStatus.DOWN;
     master_link_down_since_seconds: string;
 }
 
@@ -222,13 +235,8 @@ export interface GeneralStats {
     };
 }
 
-export type RedisInfo = GeneralStats &
-    ServerInfo &
-    ClientsInfo &
-    MemoryInfo &
-    PersistenceInfo &
-    Stats &
-    ReplicationInfo &
-    CPUInfo;
+export type RedisInfo = Readonly<
+    GeneralStats & ServerInfo & ClientsInfo & MemoryInfo & PersistenceInfo & Stats & ReplicationInfo & CPUInfo
+>;
 
 export function parse(info: string): RedisInfo;

--- a/types/redis-info/index.d.ts
+++ b/types/redis-info/index.d.ts
@@ -1,0 +1,234 @@
+// Type definitions for redis-info 3.0
+// Project: https://github.com/FGRibreau/node-redis-info#readme
+// Definitions by: Yurick Hauschild <https://github.com/Yurickh>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export enum Flag {
+    ON = '1',
+    OFF = '0',
+}
+
+export interface ServerInfo {
+    redis_version: string;
+    redis_git_sha1: string;
+    redis_git_dirty: Flag;
+    redis_build_id: string;
+    redis_mode: 'standalone' | 'sentinel' | 'cluster';
+    os: string;
+    arch_bits: '32' | '64';
+    multiplexing_api: string;
+    atomicvar_api: string;
+    gcc_version: string;
+    process_id: string;
+    run_id: string;
+    tcp_port: string;
+    uptime_in_seconds: string;
+    uptime_in_days: string;
+    hz: string;
+    lru_clock: string;
+    executable: string;
+    config_file: string;
+}
+
+export interface ClientsInfo {
+    connected_clients: string;
+    client_longest_output_list: string;
+    client_biggest_input_buf: string;
+    blocked_clients: string;
+}
+
+export interface MemoryInfo {
+    used_memory: string;
+    used_memory_human: string;
+    used_memory_rss: string;
+    used_memory_rss_human: string;
+    used_memory_peak: string;
+    used_memory_peak_human: string;
+    used_memory_peak_perc: string;
+    used_memory_overhead: string;
+    used_memory_startup: string;
+    used_memory_dataset: string;
+    used_memory_dataset_perc: string;
+    allocator_allocated: string;
+    allocator_active: string;
+    allocator_resident: string;
+    total_system_memory: string;
+    total_system_memory_human: string;
+    used_memory_lua: string;
+    used_memory_lua_human: string;
+    maxmemory: string;
+    maxmemory_human: string;
+    maxmemory_policy: string;
+    allocator_frag_ratio: string;
+    allocator_frag_bytes: string;
+    allocator_rss_ratio: string;
+    allocator_rss_bytes: string;
+    rss_overhead_ratio: string;
+    rss_overhead_bytes: string;
+    mem_fragmentation_ratio: string;
+    mem_fragmentation_bytes: string;
+    mem_allocator: string;
+    active_defrag_running: Flag;
+    lazyfree_pending_objects: string;
+}
+
+export type PersistenceInfo = {
+    rdb_changes_since_last_save: string;
+    rdb_bgsave_in_progress: Flag;
+    rdb_last_save_time: string;
+    rdb_last_bgsave_status: string;
+    rdb_last_bgsave_time_sec: string;
+    rdb_current_bgsave_time_sec: string;
+    rdb_last_cow_size: string;
+    aof_rewrite_in_progress: Flag;
+    aof_rewrite_scheduled: Flag;
+    aof_last_rewrite_time_sec: string;
+    aof_current_rewrite_time_sec: string;
+    aof_last_bgrewrite_status: string;
+    aof_last_write_status: string;
+    aof_last_cow_size: string;
+} & (PersistenceAOFOnInfo | PersistenceAOFOffInfo) &
+    (PersistenceLoadingOnInfo | PersistenceLoadingOffInfo);
+
+export interface PersistenceAOFOnInfo {
+    aof_enabled: Flag.ON;
+    aof_current_size: string;
+    aof_base_size: string;
+    aof_pending_rewrite: Flag;
+    aof_buffer_length: string;
+    aof_rewrite_buffer_length: string;
+    aof_pending_bio_fsync: string;
+    aof_delayed_fsync: string;
+}
+
+export interface PersistenceAOFOffInfo {
+    aof_enabled: Flag.OFF;
+}
+
+export interface PersistenceLoadingOnInfo {
+    loading: Flag.ON;
+    loading_start_time: string;
+    loading_total_bytes: string;
+    loading_loaded_bytes: string;
+    loading_loaded_perc: string;
+    loading_eta_seconds: string;
+}
+
+export interface PersistenceLoadingOffInfo {
+    loading: Flag.OFF;
+}
+
+export interface Stats {
+    total_connections_received: string;
+    total_commands_processed: string;
+    instantaneous_ops_per_sec: string;
+    total_net_input_bytes: string;
+    total_net_output_bytes: string;
+    instantaneous_input_kbps: string;
+    instantaneous_output_kbps: string;
+    rejected_connections: string;
+    sync_full: string;
+    sync_partial_ok: string;
+    sync_partial_err: string;
+    expired_keys: string;
+    expired_stale_perc: string;
+    expired_time_cap_reached_count: string;
+    evicted_keys: string;
+    keyspace_hits: string;
+    keyspace_misses: string;
+    pubsub_channels: string;
+    pubsub_patterns: string;
+    latest_fork_usec: string;
+    migrate_cached_sockets: string;
+    slave_expires_tracked_keys: string;
+    active_defrag_hits: string;
+    active_defrag_misses: string;
+    active_defrag_key_hits: string;
+    active_defrag_key_misses: string;
+}
+
+export type ReplicationInfo = {
+    connected_slaves: string;
+    master_replid: string;
+    master_replid2: string;
+    master_repl_offset: string;
+    second_repl_offset: string;
+    repl_backlog_active: Flag;
+    repl_backlog_size: string;
+    repl_backlog_first_byte_offset: string;
+    repl_backlog_histlen: string;
+} & (ReplicationMasterInfo | ReplicationReplicaInfo);
+
+export interface ReplicationMasterInfo {
+    role: 'master';
+}
+
+export type ReplicationReplicaInfo = {
+    role: 'slave';
+    master_host: string;
+    master_port: string;
+    master_last_io_seconds_ago: string;
+    slave_repl_offset: string;
+    slave_priority: string;
+    slave_read_only: Flag;
+    connected_slaves: string;
+    min_slaves_good_slaves: string;
+} & (ReplicationReplicaSyncOnInfo | ReplicationReplicaSyncOffInfo) &
+    (ReplicationReplicaLinkUpInfo | ReplicationReplicaLinkDownInfo);
+
+export interface ReplicationReplicaSyncOnInfo {
+    master_sync_in_progress: Flag.ON;
+    master_sync_left_bytes: string;
+    master_sync_last_io_seconds_ago: string;
+}
+
+export interface ReplicationReplicaSyncOffInfo {
+    master_sync_in_progress: Flag.OFF;
+}
+
+export interface ReplicationReplicaLinkUpInfo {
+    master_link_status: 'up';
+}
+
+export interface ReplicationReplicaLinkDownInfo {
+    master_link_status: 'down';
+    master_link_down_since_seconds: string;
+}
+
+export interface CPUInfo {
+    used_cpu_sys: string;
+    used_cpu_user: string;
+    used_cpu_sys_children: string;
+    used_cpu_user_children: string;
+}
+
+export interface ClusterInfo {
+    cluster_enabled: Flag;
+}
+
+export interface GeneralStats {
+    databases: {
+        [index: number]: {
+            keys: number;
+            expires: number;
+        };
+    };
+    commands: {
+        [command: string]: {
+            calls: number;
+            usec: number;
+            usec_per_call: number;
+        };
+    };
+}
+
+export type RedisInfo = GeneralStats &
+    ServerInfo &
+    ClientsInfo &
+    MemoryInfo &
+    PersistenceInfo &
+    Stats &
+    ReplicationInfo &
+    CPUInfo;
+
+export function parse(info: string): RedisInfo;

--- a/types/redis-info/redis-info-tests.ts
+++ b/types/redis-info/redis-info-tests.ts
@@ -1,0 +1,33 @@
+import * as redisInfo from 'redis-info';
+
+const info = redisInfo.parse('');
+
+if (info.role === 'master') {
+    info.master_host; // $ExpectError
+} else {
+    info.master_host;
+
+    if (info.master_sync_in_progress === redisInfo.Flag.OFF) {
+        info.master_sync_left_bytes; // $ExpectError
+    } else {
+        info.master_sync_left_bytes;
+    }
+
+    if (info.master_link_status === redisInfo.LinkStatus.UP) {
+        info.master_link_down_since_seconds; // $ExpectError
+    } else {
+        info.master_link_down_since_seconds;
+    }
+}
+
+if (info.aof_enabled === redisInfo.Flag.OFF) {
+    info.aof_pending_rewrite; // $ExpectError
+} else {
+    info.aof_pending_rewrite;
+}
+
+if (info.loading === redisInfo.Flag.OFF) {
+    info.loading_start_time; // $ExpectError
+} else {
+    info.loading_start_time;
+}

--- a/types/redis-info/tsconfig.json
+++ b/types/redis-info/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "redis-info-tests.ts"]
+}

--- a/types/redis-info/tslint.json
+++ b/types/redis-info/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adds typings to the [redis-info](https://github.com/FGRibreau/node-redis-info) package.

As I'm not a heavy user of redis myself, it would be great to have someone that's more used to the common pitfalls of the return of `redis> INFO` reviewing these types.

## Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
