### PR TITLE
fix(carbon-components-react) Added ref for inputs and textareas

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -360,17 +360,9 @@ const controlledPasswordInputWithRef = (
 );
 
 // NumberInput
-const numberInputWithoutRef = (
+const numberInput = (
     <NumberInput
         id="my-id"
         value={12}
-    />
-);
-
-const numberInputWithRef = (
-    <NumberInput
-        id="my-id"
-        value={12}
-        ref={inputRef}
     />
 );

--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -16,6 +16,7 @@ import {
     TextInput,
 } from 'carbon-components-react';
 import Link from 'carbon-components-react/lib/components/UIShell/Link';
+import NumberInput from './lib/components/NumberInput';
 
 // AccordionItem
 const titleNode = (
@@ -355,5 +356,21 @@ const controlledPasswordInputWithRef = (
         id="my-id"
         ref={inputRef}
         labelText=""
+    />
+);
+
+// NumberInput
+const numberInputWithoutRef = (
+    <NumberInput
+        id="my-id"
+        value={12}
+    />
+);
+
+const numberInputWithRef = (
+    <NumberInput
+        id="my-id"
+        value={12}
+        ref={inputRef}
     />
 );

--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -5,6 +5,7 @@ import {
     DataTableCustomRenderProps,
     DataTableHeader,
     DataTableRow,
+    NumberInput,
     Slider,
     Tab,
     Table,
@@ -16,7 +17,6 @@ import {
     TextInput,
 } from 'carbon-components-react';
 import Link from 'carbon-components-react/lib/components/UIShell/Link';
-import NumberInput from './lib/components/NumberInput';
 
 // AccordionItem
 const titleNode = (

--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -12,6 +12,8 @@ import {
     TableHeader,
     TableRow,
     TooltipDefinition,
+    TextArea,
+    TextInput,
 } from 'carbon-components-react';
 import Link from 'carbon-components-react/lib/components/UIShell/Link';
 
@@ -267,7 +269,7 @@ const uisLinkT5 = (
 
 // TooltipDefinition
 const tooltipDefHasAlign = (
-  <TooltipDefinition tooltipText="my text" align="end" />
+    <TooltipDefinition tooltipText="my text" align="end" />
 );
 
 const tooltipDefHasTriggerClassName = (
@@ -293,5 +295,65 @@ const SliderHasOnChange = (
         min={10}
         value={5}
         onChange={(newValue) => newValue.value}
+    />
+);
+
+// TextArea
+const textAreaWithDefaultRef = (
+    <TextArea labelText=""/>
+);
+
+const HtmlTextAreaRef = React.createRef<HTMLTextAreaElement>();
+const textAreaWithRef = (
+    <TextArea
+        ref={HtmlTextAreaRef}
+        labelText=""
+    />
+);
+
+// TextInput
+const inputWithoutRef = (
+    <TextInput
+        id="my-id"
+        labelText=""
+    />
+);
+
+const passwordInputWithoutRef = (
+    <TextInput.PasswordInput
+        id="my-id"
+        labelText=""
+    />
+);
+
+const controlledPasswordInputWithoutRef = (
+    <TextInput.ControlledPasswordInput
+        id="my-id"
+        labelText=""
+    />
+);
+
+const inputRef = React.createRef<HTMLInputElement>();
+const inputWithRef = (
+    <TextInput
+        id="my-id"
+        ref={inputRef}
+        labelText=""
+    />
+);
+
+const passwordInputWithRef = (
+    <TextInput.PasswordInput
+        id="my-id"
+        ref={inputRef}
+        labelText=""
+    />
+);
+
+const controlledPasswordInputWithRef = (
+    <TextInput.ControlledPasswordInput
+        id="my-id"
+        ref={inputRef}
+        labelText=""
     />
 );

--- a/types/carbon-components-react/lib/components/NumberInput/NumberInput.d.ts
+++ b/types/carbon-components-react/lib/components/NumberInput/NumberInput.d.ts
@@ -23,6 +23,6 @@ export interface NumberInputProps extends InheritedProps {
     isMobile?: boolean,
 }
 
-declare const NumberInput: React.RefForwardingComponent<HTMLInputElement, NumberInputProps>;
+declare class NumberInput extends React.Component<NumberInputProps> { }
 
 export default NumberInput;

--- a/types/carbon-components-react/lib/components/NumberInput/NumberInput.d.ts
+++ b/types/carbon-components-react/lib/components/NumberInput/NumberInput.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { EmbeddedIconProps, InternationalProps, ReactInputAttr, RequiresIdProps, ThemeProps, ValidityProps } from "../../../typings/shared";
+import { EmbeddedIconProps, InternationalProps, ReactInputAttr, RequiresIdProps, ThemeProps, ValidityProps, RefForwardingProps } from "../../../typings/shared";
 
 type ExcludedAttributes = "aria-label" | "id" | "ref";
 export type NumberInputTranslationKey = "decrement.number" | "increment.number";
@@ -9,7 +9,8 @@ interface InheritedProps extends
     InternationalProps<NumberInputTranslationKey>,
     RequiresIdProps,
     ThemeProps,
-    ValidityProps
+    ValidityProps,
+    RefForwardingProps<HTMLInputElement>
 {
     value: number,
 }

--- a/types/carbon-components-react/lib/components/TextArea/TextArea.d.ts
+++ b/types/carbon-components-react/lib/components/TextArea/TextArea.d.ts
@@ -1,14 +1,15 @@
 import * as React from "react";
-import { ThemeProps, ValidityProps } from "../../../typings/shared";
+import { RefForwardingProps, ThemeProps, ValidityProps } from "../../../typings/shared";
 
 type ExcludedAttributes = "aria-invalid" | "aria-describedby" | "defaultValue" | "value";
-interface InheritedProps extends
+interface InheritedProps<E extends HTMLTextAreaElement = HTMLTextAreaElement> extends
     Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, ExcludedAttributes>,
     ThemeProps,
-    ValidityProps
+    ValidityProps,
+    RefForwardingProps<HTMLTextAreaElement>
 { }
 
-export interface TextAreaProps extends InheritedProps {
+export interface TextAreaProps<E extends HTMLTextAreaElement = HTMLTextAreaElement> extends InheritedProps<E> {
     defaultValue?: string | number,
     helperText?: React.ReactNode,
     hideLabel?: boolean,
@@ -16,6 +17,7 @@ export interface TextAreaProps extends InheritedProps {
     value?: string | number,
 }
 
-declare const TextArea: React.RefForwardingComponent<HTMLTextAreaElement, TextAreaProps>;
+interface TextArea extends React.RefForwardingComponent<HTMLTextAreaElement, TextAreaProps> {}
 
+declare const TextArea: TextArea;
 export default TextArea;

--- a/types/carbon-components-react/lib/components/TextArea/TextArea.d.ts
+++ b/types/carbon-components-react/lib/components/TextArea/TextArea.d.ts
@@ -2,14 +2,14 @@ import * as React from "react";
 import { RefForwardingProps, ThemeProps, ValidityProps } from "../../../typings/shared";
 
 type ExcludedAttributes = "aria-invalid" | "aria-describedby" | "defaultValue" | "value";
-interface InheritedProps<E extends HTMLTextAreaElement = HTMLTextAreaElement> extends
+interface InheritedProps extends
     Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, ExcludedAttributes>,
     ThemeProps,
     ValidityProps,
     RefForwardingProps<HTMLTextAreaElement>
 { }
 
-export interface TextAreaProps<E extends HTMLTextAreaElement = HTMLTextAreaElement> extends InheritedProps<E> {
+export interface TextAreaProps extends InheritedProps {
     defaultValue?: string | number,
     helperText?: React.ReactNode,
     hideLabel?: boolean,

--- a/types/carbon-components-react/lib/components/TextArea/TextArea.d.ts
+++ b/types/carbon-components-react/lib/components/TextArea/TextArea.d.ts
@@ -17,7 +17,6 @@ export interface TextAreaProps extends InheritedProps {
     value?: string | number,
 }
 
-interface TextArea extends React.RefForwardingComponent<HTMLTextAreaElement, TextAreaProps> {}
+declare const TextArea: React.RefForwardingComponent<HTMLTextAreaElement, TextAreaProps>;
 
-declare const TextArea: TextArea;
 export default TextArea;

--- a/types/carbon-components-react/lib/components/TextInput/ControlledPasswordInput.d.ts
+++ b/types/carbon-components-react/lib/components/TextInput/ControlledPasswordInput.d.ts
@@ -1,11 +1,11 @@
 import * as React from "react";
-import { EmbeddedTooltipProps } from "../../../typings/shared";
+import { EmbeddedTooltipProps, RefForwardingProps } from "../../../typings/shared";
 import { TextInputInheritedProps } from "./props";
 
 interface InheritedProps extends TextInputInheritedProps, EmbeddedTooltipProps { }
 
 export interface ControlledPasswordInputProps extends InheritedProps { }
 
-declare const ControlledPasswordInput: React.RefForwardingComponent<HTMLInputElement, ControlledPasswordInputProps>;
+interface ControlledPasswordInput extends React.RefForwardingComponent<HTMLInputElement, ControlledPasswordInputProps> {}
 
 export default ControlledPasswordInput;

--- a/types/carbon-components-react/lib/components/TextInput/ControlledPasswordInput.d.ts
+++ b/types/carbon-components-react/lib/components/TextInput/ControlledPasswordInput.d.ts
@@ -6,6 +6,6 @@ interface InheritedProps extends TextInputInheritedProps, EmbeddedTooltipProps {
 
 export interface ControlledPasswordInputProps extends InheritedProps { }
 
-interface ControlledPasswordInput extends React.RefForwardingComponent<HTMLInputElement, ControlledPasswordInputProps> {}
+declare const ControlledPasswordInput: React.RefForwardingComponent<HTMLInputElement, ControlledPasswordInputProps>;
 
 export default ControlledPasswordInput;

--- a/types/carbon-components-react/lib/components/TextInput/PasswordInput.d.ts
+++ b/types/carbon-components-react/lib/components/TextInput/PasswordInput.d.ts
@@ -6,6 +6,6 @@ interface InheritedProps extends TextInputInheritedProps, EmbeddedTooltipProps {
 
 export interface PasswordInputProps extends InheritedProps { }
 
-interface PasswordInput extends React.RefForwardingComponent<HTMLInputElement, PasswordInputProps> {}
+declare const PasswordInput: React.RefForwardingComponent<HTMLInputElement, PasswordInputProps>;
 
 export default PasswordInput;

--- a/types/carbon-components-react/lib/components/TextInput/PasswordInput.d.ts
+++ b/types/carbon-components-react/lib/components/TextInput/PasswordInput.d.ts
@@ -6,6 +6,6 @@ interface InheritedProps extends TextInputInheritedProps, EmbeddedTooltipProps {
 
 export interface PasswordInputProps extends InheritedProps { }
 
-declare const PasswordInput: React.FC<PasswordInputProps>;
+interface PasswordInput extends React.RefForwardingComponent<HTMLInputElement, PasswordInputProps> {}
 
 export default PasswordInput;

--- a/types/carbon-components-react/lib/components/TextInput/TextInput.d.ts
+++ b/types/carbon-components-react/lib/components/TextInput/TextInput.d.ts
@@ -6,8 +6,8 @@ import { TextInputInheritedProps } from "./props";
 export interface TextInputProps extends TextInputInheritedProps { }
 
 interface TextInputFC extends React.RefForwardingComponent<HTMLInputElement, TextInputProps> {
-    readonly ControlledPasswordInput: typeof ControlledPasswordInput,
-    readonly PasswordInput: typeof PasswordInput,
+    readonly ControlledPasswordInput: ControlledPasswordInput,
+    readonly PasswordInput: PasswordInput,
 }
 
 declare const TextInput: TextInputFC;

--- a/types/carbon-components-react/lib/components/TextInput/TextInput.d.ts
+++ b/types/carbon-components-react/lib/components/TextInput/TextInput.d.ts
@@ -6,8 +6,8 @@ import { TextInputInheritedProps } from "./props";
 export interface TextInputProps extends TextInputInheritedProps { }
 
 interface TextInputFC extends React.RefForwardingComponent<HTMLInputElement, TextInputProps> {
-    readonly ControlledPasswordInput: ControlledPasswordInput,
-    readonly PasswordInput: PasswordInput,
+    readonly ControlledPasswordInput: typeof ControlledPasswordInput,
+    readonly PasswordInput: typeof PasswordInput,
 }
 
 declare const TextInput: TextInputFC;

--- a/types/carbon-components-react/lib/components/TextInput/props.d.ts
+++ b/types/carbon-components-react/lib/components/TextInput/props.d.ts
@@ -1,12 +1,13 @@
 import * as React from "react";
-import { ReactInputAttr, RequiresIdProps, ThemeProps, ValidityProps } from "../../../typings/shared";
+import { ReactInputAttr, RequiresIdProps, ThemeProps, ValidityProps, RefForwardingProps } from "../../../typings/shared";
 
 type ExcludedAttributes = "aria-describedby" | "aria-invalid" | "defaultValue" | "id" | "value";
 export interface TextInputInheritedProps extends
     Omit<ReactInputAttr, ExcludedAttributes>,
     RequiresIdProps,
     ThemeProps,
-    ValidityProps
+    ValidityProps,
+    RefForwardingProps<HTMLInputElement>
 {
     defaultValue?: TextInputInheritedProps["value"],
     helperText?: React.ReactNode,

--- a/types/carbon-components-react/typings/shared.d.ts
+++ b/types/carbon-components-react/typings/shared.d.ts
@@ -71,3 +71,7 @@ export interface SideNavSharedProps {
 export interface SideNavSizingProps {
     large?: boolean;
 }
+
+export interface RefForwardingProps<T = HTMLElement> {
+    ref?: React.RefObject<T>;
+}


### PR DESCRIPTION
Added the support of `ref` for `TextInput` and `TextArea`.
Removed the `RefForwadding` for `NumberInput`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [TextInput](https://github.com/carbon-design-system/carbon/blob/v10.6.4/packages/react/src/components/TextInput/TextInput.js)
  - [TextArea](https://github.com/carbon-design-system/carbon/blob/v10.6.4/packages/react/src/components/TextArea/TextArea.js)
  - [NumberInput](https://github.com/carbon-design-system/carbon/blob/v10.6.4/packages/react/src/components/NumberInput/NumberInput.js)