### PR TITLE
Fix a type in mongoose tests

### DIFF
--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -216,7 +216,7 @@ validatorError.stack;
  * https://mongoosejs.com/docs/api.html#mongooseerror_MongooseError.ValidationError
  */
 var doc = <mongoose.Document>{};
-var validationError: mongoose.Error.ValidationError = new mongoose.Error.ValidationError(doc);
+var validationError: mongoose.Error.ValidationError | undefined = new mongoose.Error.ValidationError(doc);
 validationError.name;
 validationError.toString().toLowerCase();
 validationError.inspect();


### PR DESCRIPTION
Previously, Typescript didn't issue strictNullCheck errors on variables with multiple declarations, like

```ts
var x: E
var y: E | undefined
var x = y // TS should error here, but didn't previously

var z: E | undefined = y // TS already errored here
```

Now it does, and mongoose's tests were missing a now-required `undefined`.
