### PR TITLE
New property "registerChild" for the react-virtualized package was added about a week ago

### DIFF
--- a/types/react-virtualized/dist/es/CellMeasurer.d.ts
+++ b/types/react-virtualized/dist/es/CellMeasurer.d.ts
@@ -46,9 +46,14 @@ export type MeasuredCellParent = {
     recomputeGridSize?: (cell: CellPosition) => void;
 };
 
+export type CellMeasurerChildProps = {
+    measure: () => void,
+    registerChild?: (element: Element) => void
+}
+
 export type CellMeasurerProps = {
     cache: CellMeasurerCacheInterface;
-    children: ((props: { measure: () => void }) => React.ReactNode) | React.ReactNode;
+    children: ((props: CellMeasurerChildProps) => React.ReactNode) | React.ReactNode;
     columnIndex?: number;
     index?: number;
     parent: MeasuredCellParent;


### PR DESCRIPTION
The property registerChild was added to CellMeasurer about a week ago.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/bvaughn/react-virtualized/commit/dc9e2dd4fb942f8d62cc790912096880b7ce0e2b>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
