### PR TITLE
feat(autoprefixer): update to 9.7

### DIFF
--- a/types/autoprefixer/autoprefixer-tests.ts
+++ b/types/autoprefixer/autoprefixer-tests.ts
@@ -6,7 +6,6 @@ const ap1: Transformer = autoprefixer();
 
 // Default options
 const ap2: Transformer = autoprefixer({
-    browsers: [],
     overrideBrowserslist: [],
     env: 'test',
     cascade: true,
@@ -19,19 +18,15 @@ const ap2: Transformer = autoprefixer({
     ignoreUnknownVersions: false,
 });
 
+autoprefixer.info(); // $ExpectedType () => void
+autoprefixer.data; // $ExpectType { browsers: any; prefixes: any; }
+autoprefixer.defaults; // $ExpectedType string
+
 // Using environment map in "overrideBrowserslist"
 const ap3: Transformer = autoprefixer({
     overrideBrowserslist: {
-        production: [
-            '> 1%',
-            'ie 10',
-        ],
-        modern: [
-            'last 1 chrome version',
-            'last 1 firefox version',
-        ],
-        ssr: [
-            'node 12',
-        ],
+        production: ['> 1%', 'ie 10'],
+        modern: ['last 1 chrome version', 'last 1 firefox version'],
+        ssr: ['node 12'],
     },
 });

--- a/types/autoprefixer/index.d.ts
+++ b/types/autoprefixer/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for autoprefixer 9.6
+// Type definitions for autoprefixer 9.7
 // Project: https://github.com/postcss/autoprefixer
 // Definitions by: Armando Meziat <https://github.com/odnamrataizem>
 //                 murt <https://github.com/murt>
 //                 Slava Fomin II <https://github.com/slavafomin>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
@@ -10,23 +11,46 @@ import { Plugin } from 'postcss';
 import { Stats } from 'browserslist';
 
 declare namespace autoprefixer {
-    type BrowserslistTarget = (string | string[] | { [key: string]: string[]; });
+    type BrowserslistTarget = string | string[] | { [key: string]: string[] };
 
     interface Options {
+        /** environment for `Browserslist` */
         env?: string;
+        /** should Autoprefixer use Visual Cascade, if CSS is uncompressed */
         cascade?: boolean;
+        /** should Autoprefixer add prefixes. */
         add?: boolean;
+        /** should Autoprefixer [remove outdated] prefixes */
         remove?: boolean;
+        /** should Autoprefixer add prefixes for @supports parameters. */
         supports?: boolean;
+        /** should Autoprefixer add prefixes for flexbox properties */
         flexbox?: boolean | 'no-2009';
+        /** should Autoprefixer add IE 10-11 prefixes for Grid Layout properties */
         grid?: false | 'autoplace' | 'no-autoplace';
+        /** custom usage statistics for > 10% in my stats browsers query */
         stats?: Stats;
+        /** @deprecated Replace Autoprefixer `browsers` option to `Browserslist` config */
         browsers?: string[] | string;
+        /** list of queries for target browsers */
         overrideBrowserslist?: BrowserslistTarget;
+        /** do not raise error on unknown browser version in `Browserslist` config. */
         ignoreUnknownVersions?: boolean;
     }
 
-    type Autoprefixer = Plugin<Options>;
+    interface ExportedAPI {
+        /** Autoprefixer data */
+        data: {
+            browsers: any;
+            prefixes: any;
+        };
+        /** Autoprefixer default browsers */
+        defaults: any;
+        /** Inspect with default Autoprefixer */
+        info(): void;
+    }
+
+    type Autoprefixer = Plugin<Options> & ExportedAPI;
 }
 
 declare const autoprefixer: autoprefixer.Autoprefixer;


### PR DESCRIPTION
- mark `browsers` option as @deprecated
- add docs to properties
- expose public exports from module for:
autoprefixer.info method
autoprefixer.data property
autoprefixer.defaults property
- clenaup

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/postcss/autoprefixer/blob/master/lib/autoprefixer.js#L140-L153
https://github.com/postcss/autoprefixer#debug
https://github.com/postcss/autoprefixer/releases/tag/9.6.0 (`browsers`)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.