### PR TITLE
feat(browserslist): update to version 4.8

### DIFF
--- a/types/browserslist/browserslist-tests.ts
+++ b/types/browserslist/browserslist-tests.ts
@@ -1,25 +1,35 @@
-import browserslist from "browserslist";
-import BrowserslistError from "browserslist/error";
+import browserslist from 'browserslist';
+import BrowserslistError from 'browserslist/error';
 
 browserslist(); // $ExpectType string[]
-browserslist(""); // $ExpectType string[]
-browserslist([""]); // $ExpectType string[]
+browserslist(''); // $ExpectType string[]
+browserslist(['']); // $ExpectType string[]
 
 const opts: browserslist.Options[] = [
     {},
-    { path: "" },
-    { env: "" },
-    { stats: { "": { "": 0 } } },
-    { config: "" },
+    { path: '' },
+    { env: '' },
+    { stats: { '': { '': 0 } } },
+    { config: '' },
     { ignoreUnknownVersions: false },
-    { dangerousExtend: false }
+    { dangerousExtend: false },
+    { mobileToDesktop: true },
 ];
 for (const opt of opts) {
-    browserslist("", opt); // $ExpectType string[]
-    browserslist([""], opt); // $ExpectType string[]
+    browserslist('', opt); // $ExpectType string[]
+    browserslist([''], opt); // $ExpectType string[]
 }
 
-browserslist.coverage([""]); // $ExpectType number
-browserslist.coverage([""], { "": { "": 0 } }); // $ExpectType number
+const stats: browserslist.Stats = {};
+
+browserslist.coverage(['']); // $ExpectType number
+browserslist.coverage([''], { '': { '': 0 } }); // $ExpectType number
+
+browserslist.coverage(browserslist('> 1%')); // $ExpectType number
+browserslist.coverage(browserslist('> 1% in US'), 'US'); // $ExpectType number
+browserslist.coverage(browserslist('> 1% in US'), 'my stats'); // $ExpectType number
+browserslist.coverage(browserslist('> 1% in my stats', { stats }), stats); // $ExpectType number
+
+browserslist.clearCaches(); // $ExpectType void
 
 new BrowserslistError('error'); // $ExpectType BrowserslistError

--- a/types/browserslist/index.d.ts
+++ b/types/browserslist/index.d.ts
@@ -1,15 +1,27 @@
-// Type definitions for browserslist 4.4
+// Type definitions for browserslist 4.8
 // Project: https://github.com/browserslist/browserslist#readme
 // Definitions by: Dave Cardwell <https://github.com/davecardwell>
 //                 Andrew Leedham <https://github.com/AndrewLeedham>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
 declare namespace browserslist {
+    /** statistics from `Browserslist` files */
+    type MyStats = 'my stats';
+    /**
+     * Which statistics should be used.
+     * Country code or custom statistics.
+     * Pass `"my stats"` to load statistics
+     * from `Browserslist` files
+     */
+    type StatsOptions = string | MyStats | Stats;
+
     interface Browserslist {
         (queries?: string | ReadonlyArray<string>, opts?: Options): string[];
 
-        coverage: (browsers: ReadonlyArray<string>, stats?: Stats) => number;
+        /** Return browsers market coverage */
+        coverage: (browsers: ReadonlyArray<string>, stats?: StatsOptions) => number;
 
         clearCaches: () => void;
     }
@@ -21,12 +33,20 @@ declare namespace browserslist {
     }
 
     interface Options {
+        /** file or a directory path to look for config file */
         path?: string;
+        /** what environment section use from config */
         env?: string;
+        /** custom usage statistics data */
         stats?: Stats;
+        /** path to config if you want to set it manually */
         config?: string;
+        /** do not throw on direct query (like ie 12). */
         ignoreUnknownVersions?: boolean;
+        /** Disable security checks for extend query.  */
         dangerousExtend?: boolean;
+        /** Use desktop browsers if Can I Use doesn’t have data about this mobile version */
+        mobileToDesktop?: boolean;
     }
 }
 


### PR DESCRIPTION
- missing `mobileToDesktop` option
- correct coverage stats options to support string literals for country
code and 'my stats'
- tests coverage expanded

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the pacage modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/browserslist/browserslist#js-api
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.