### PR TITLE
Add ChildNode to union in fireEvent `element` arg

### DIFF
--- a/types/testing-library__dom/events.d.ts
+++ b/types/testing-library__dom/events.d.ts
@@ -83,12 +83,12 @@ export type EventType =
     | 'gotPointerCapture'
     | 'lostPointerCapture';
 
-export type FireFunction = (element: Document | Element | Window, event: Event) => boolean;
+export type FireFunction = (element: Document | Element | Window | ChildNode, event: Event) => boolean;
 export type FireObject = {
-    [K in EventType]: (element: Document | Element | Window, options?: {}) => boolean;
+    [K in EventType]: (element: Document | Element | Window | ChildNode, options?: {}) => boolean;
 };
 export type CreateObject = {
-    [K in EventType]: (element: Document | Element | Window, options?: {}) => Event;
+    [K in EventType]: (element: Document | Element | Window | ChildNode, options?: {}) => Event;
 };
 
 export const createEvent: CreateObject;

--- a/types/testing-library__dom/events.d.ts
+++ b/types/testing-library__dom/events.d.ts
@@ -83,12 +83,12 @@ export type EventType =
     | 'gotPointerCapture'
     | 'lostPointerCapture';
 
-export type FireFunction = (element: Document | Element | Window | ChildNode, event: Event) => boolean;
+export type FireFunction = (element: Document | Element | Window | Node, event: Event) => boolean;
 export type FireObject = {
-    [K in EventType]: (element: Document | Element | Window | ChildNode, options?: {}) => boolean;
+    [K in EventType]: (element: Document | Element | Window | Node, options?: {}) => boolean;
 };
 export type CreateObject = {
-    [K in EventType]: (element: Document | Element | Window | ChildNode, options?: {}) => Event;
+    [K in EventType]: (element: Document | Element | Window | Node, options?: {}) => Event;
 };
 
 export const createEvent: CreateObject;

--- a/types/testing-library__dom/testing-library__dom-tests.ts
+++ b/types/testing-library__dom/testing-library__dom-tests.ts
@@ -51,4 +51,13 @@ function eventTest() {
         location: 'http://www.example.com/?page=1',
         state: { page: 1 },
     });
+
+    // ChildNode
+    const element = document.createElement('div');
+    const child = document.createElement('div');
+    element.appendChild(child);
+    if(!element.firstChild) { // Narrow Type
+        throw new Error(`Can't find firstChild`)
+    }
+    fireEvent.click(element.firstChild);
 }

--- a/types/testing-library__dom/testing-library__dom-tests.ts
+++ b/types/testing-library__dom/testing-library__dom-tests.ts
@@ -52,12 +52,15 @@ function eventTest() {
         state: { page: 1 },
     });
 
-    // ChildNode
+    // HTMLElement
     const element = document.createElement('div');
+    fireEvent.click(getByText(element, 'foo'));
+
+    // ChildNode
     const child = document.createElement('div');
     element.appendChild(child);
-    if(!element.firstChild) { // Narrow Type
-        throw new Error(`Can't find firstChild`)
+    if (!element.firstChild) { // Narrow Type
+        throw new Error(`Can't find firstChild`);
     }
     fireEvent.click(element.firstChild);
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **Please see below....**
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

### It's possible to do the following:

```ts
const { container } = render(<Button />);
fireEvent.click(container.firstChild);
```

`container.firstChild` is a `ChildNode` of which has a declaration of `interface ChildNode extends Node`. The existing union for the `element` argument (`Document | Element | Window`) contains `Element` of which has a declaration of `interface Element extends Node, ...`. So both `Element` and `ChildNode` inherit from `Node`, except `ChildNode` is currently left out in the cold as it's not in the union. Yet, triggering an event on `container.firstChild` works as expected. 

`container.firstChild` is also [recommended](https://testing-library.com/docs/react-testing-library/api#container-1) when used in conjunction with `.toMatchSnapshot()`. Although it's not explicitly recommended in conjunction with `fireEvent`, it can still be used here for similar reasons.

### Why use `container.firstChild`?

Useful when testing a small component in isolation and you want to trigger an event on its root.
