### PR TITLE
mongodb: fix typo in the comment for auth option

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -296,7 +296,7 @@ export interface MongoClientOptions extends
     appname?: string;
 
     /**
-     * Authentifikation credentials
+     * Authentication credentials
      */
     auth?: {
         /**


### PR DESCRIPTION
It's just a typo