### PR TITLE
fix(carbon-components-react) Added onChange in FileUploader

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -6,6 +6,7 @@ import {
     DataTableHeader,
     DataTableRow,
     Dropdown,
+    FileUploader,
     NumberInput,
     Slider,
     Tab,
@@ -394,5 +395,12 @@ const numberInput = (
     <NumberInput
         id="my-id"
         value={12}
+    />
+);
+
+// FileUploader
+const fileUploaderHasOnChange = (
+    <FileUploader
+        onChange={(e) => {} }
     />
 );

--- a/types/carbon-components-react/lib/components/FileUploader/FileUploader.d.ts
+++ b/types/carbon-components-react/lib/components/FileUploader/FileUploader.d.ts
@@ -56,7 +56,9 @@ interface FileUploaderInheritedProps extends
     Omit<ReactLabelAttr, "onChange">,
     EmbeddedIconProps,
     SharedProps
-{ }
+{
+    onChange?(event: React.ChangeEvent<HTMLInputElement>): void,
+}
 
 export interface FileUploaderProps extends FileUploaderInheritedProps {
     buttonLabel?: string,


### PR DESCRIPTION
Added the `onChange` attribute for `FileUploader`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/carbon-design-system/carbon/blob/v10.6.4/packages/react/src/components/FileUploader/FileUploader.js#L192>>

