### PR TITLE
[braintree] Adds typing for PaymentMethod webhook

### DIFF
--- a/types/braintree/braintree-tests.ts
+++ b/types/braintree/braintree-tests.ts
@@ -15,7 +15,6 @@ import {
     PaymentMethodNonce,
     Transaction,
     WebhookNotificationKind,
-    SubscriptionNotification,
 } from 'braintree';
 
 /**
@@ -112,4 +111,21 @@ const gateway: BraintreeGateway = new braintree.BraintreeGateway({
     if (notification.kind !== kind) return;
 
     const subscription = notification.subscription;
+})();
+
+(async () => {
+    const kind: WebhookNotificationKind = 'payment_method_revoked_by_customer';
+    const subscriptionId = '123456';
+
+    const sampleResponse = await gateway.webhookTesting.sampleNotification(kind, subscriptionId).catch(console.error);
+    if (!sampleResponse) return;
+
+    const notification = await gateway.webhookNotification.parse(sampleResponse.bt_signature, sampleResponse.bt_payload).catch(console.error);
+    if (!notification) return;
+
+    // this should cause the type of `notification` to be narrowed to `SubscriptionNotification`
+    if (notification.kind !== kind) return;
+
+    const metadata = notification.revokedPaymentMethodMetadata;
+    if (!metadata.revokedPaymentMethod) return;
 })();

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -872,13 +872,23 @@ declare namespace braintree {
         reportUrl: string;
     }
 
+    export interface PaymentMethodNotification extends BaseWebhookNotification {
+        kind: PaymentMethodNotificationKind;
+        revokedPaymentMethodMetadata: {
+            token: string;
+            customerId: string;
+            revokedPaymentMethod: PaymentMethod;
+        };
+    }
+
     export type WebhookNotification =
         | TransactionNotification
         | SubMerchantAccountApprovedNotification
         | SubMerchantAccountDeclinedNotification
         | SubscriptionNotification
         | DisputeNotification
-        | AccountUpdaterNotification;
+        | AccountUpdaterNotification
+        | PaymentMethodNotification;
 
     export type AccountUpdaterNotificationKind =
         | 'account_updater_daily_report';
@@ -908,6 +918,9 @@ declare namespace braintree {
         | 'transaction_settled'
         | 'transaction_settlement_declined';
 
+    export type PaymentMethodNotificationKind =
+        | 'payment_method_revoked_by_customer';
+
     export type WebhookNotificationKind =
         | AccountUpdaterNotificationKind
         | DisputeNotificationKind
@@ -915,6 +928,7 @@ declare namespace braintree {
         | SubMerchantAccountApprovedNotificationKind
         | SubMerchantAccountDeclinedNotificationKind
         | TransactionNotificationKind
+        | PaymentMethodNotificationKind
         | 'check'
         | 'connected_merchant_paypal_status_changed'
         | 'connected_merchant_status_transitioned'
@@ -926,7 +940,6 @@ declare namespace braintree {
         | 'partner_merchant_connected'
         | 'partner_merchant_disconnected'
         | 'partner_merchant_declined'
-        | 'payment_method_revoked_by_customer'
         | 'oauth_access_revoked'
         | 'recipient_updated_granted_payment_method';
 


### PR DESCRIPTION
Adds typing for the Payment Method webhook:

https://developers.braintreepayments.com/reference/general/webhooks/payment-method/node#revoked_payment_method_metadata

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
