### PR TITLE
Updated type for node-cron, fixed minor typo in test

### DIFF
--- a/types/node-cron/index.d.ts
+++ b/types/node-cron/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: morsic <https://github.com/maximelkin>,
 //                 burtek <https://github.com/burtek>,
 //                 Richard Honor <https://github.com/RMHonor>
+//                 Ata Berk YILMAZ <https://github.com/ataberkylmz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Timezone } from 'tz-offset';
@@ -15,6 +16,7 @@ export interface ScheduledTask {
     start: () => this;
     stop: () => this;
     destroy: () => void;
+    getStatus: () => string;
 }
 
 export interface ScheduleOptions {

--- a/types/node-cron/node-cron-tests.ts
+++ b/types/node-cron/node-cron-tests.ts
@@ -47,8 +47,20 @@ if (valid && !invalid) {
 }
 
 // check timezones are accepted from the string literal
-const tast4 = cron.schedule('* * * * *', () => {
+const task4 = cron.schedule('* * * * *', () => {
     log('will execute every minute until stopped');
 }, { timezone: 'Europe/London' });
 
-tast4.destroy();
+task4.destroy();
+
+const task5 = cron.schedule('* * * * *', () => {
+    log('will execute every minute until stopped');
+});
+
+if (task5.getStatus() === 'scheduled') {
+    task5.destroy();
+}
+
+if (task5.getStatus() === 'destroyed') {
+    log('Task5 is destroyed!');
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/node-cron/node-cron/releases/tag/v2.0.0>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.