### PR TITLE
Definitions to "pdf-image" package

### DIFF
--- a/types/pdf-image/index.d.ts
+++ b/types/pdf-image/index.d.ts
@@ -1,0 +1,300 @@
+// Type definitions for pdf-image 2.0
+// Project: https://github.com/mooz/node-pdf-image#readme
+// Definitions by: NickLatkovich <https://github.com/nicklatkovich>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.1
+
+export type ConvertOptionKey =
+    | '-adaptive-blur'
+    | '-adaptive-resize'
+    | '-adaptive-sharpen'
+    | '-adjoin'
+    | '-affine'
+    | '-alpha'
+    | '-annotate'
+    | '-antialias'
+    | '-append'
+    | '-authenticate'
+    | '-auto-gamma'
+    | '-auto-level'
+    | '-auto-orient'
+    | '-auto-threshold'
+    | '-background'
+    | '-bench'
+    | '-bias'
+    | '-black-threshold'
+    | '-blue-primary'
+    | '-blue-shift'
+    | '-blur'
+    | '-border'
+    | '-bordercolor'
+    | '-brightness-contrast'
+    | '-canny'
+    | '-caption'
+    | '-cdl'
+    | '-channel'
+    | '-charcoal'
+    | '-chop'
+    | '-clahe'
+    | '-clamp'
+    | '-clip'
+    | '-clip-mask'
+    | '-clip-path'
+    | '-clone'
+    | '-clut'
+    | '-connected-components'
+    | '-contrast-stretch'
+    | '-coalesce'
+    | '-colorize'
+    | '-color-matrix'
+    | '-colors'
+    | '-colorspace'
+    | '-combine'
+    | '-comment'
+    | '-compare'
+    | '-complexoperator'
+    | '-compose'
+    | '-composite'
+    | '-compress'
+    | '-contrast'
+    | '-convolve'
+    | '-copy'
+    | '-crop'
+    | '-cycle'
+    | '-decipher'
+    | '-debug'
+    | '-define'
+    | '-deconstruct'
+    | '-delay'
+    | '-delete'
+    | '-density'
+    | '-depth'
+    | '-despeckle'
+    | '-direction'
+    | '-display'
+    | '-dispose'
+    | '-distribute-cache'
+    | '-distort'
+    | '-dither'
+    | '-draw'
+    | '-duplicate'
+    | '-edge'
+    | '-emboss'
+    | '-encipher'
+    | '-encoding'
+    | '-endian'
+    | '-enhance'
+    | '-equalize'
+    | '-evaluate'
+    | '-evaluate-sequence'
+    | '-extent'
+    | '-extract'
+    | '-family'
+    | '-features'
+    | '-fft'
+    | '-fill'
+    | '-filter'
+    | '-flatten'
+    | '-flip'
+    | '-floodfill'
+    | '-flop'
+    | '-font'
+    | '-format'
+    | '-frame'
+    | '-function'
+    | '-fuzz'
+    | '-fx'
+    | '-gamma'
+    | '-gaussian-blur'
+    | '-geometry'
+    | '-gravity'
+    | '-grayscale'
+    | '-green-primary'
+    | '-help'
+    | '-hough-lines'
+    | '-identify'
+    | '-ift'
+    | '-implode'
+    | '-insert'
+    | '-intensity'
+    | '-intent'
+    | '-interlace'
+    | '-interline-spacing'
+    | '-interpolate'
+    | '-interword-spacing'
+    | '-kerning'
+    | '-kmeans'
+    | '-kuwahara'
+    | '-label'
+    | '-lat'
+    | '-layers'
+    | '-level'
+    | '-limit'
+    | '-linear-stretch'
+    | '-liquid-rescale'
+    | '-list'
+    | '-log'
+    | '-loop'
+    | '-mattecolor'
+    | '-median'
+    | '-mean-shift'
+    | '-metric'
+    | '-mode'
+    | '-modulate'
+    | '-moments'
+    | '-monitor'
+    | '-monochrome'
+    | '-morph'
+    | '-morphology'
+    | '-motion-blur'
+    | '-negate'
+    | '-noise'
+    | '-normalize'
+    | '-opaque'
+    | '-ordered-dither'
+    | '-orient'
+    | '-page'
+    | '-paint'
+    | '-perceptible'
+    | '-ping'
+    | '-pointsize'
+    | '-polaroid'
+    | '-poly'
+    | '-posterize'
+    | '-precision'
+    | '-preview'
+    | '-print'
+    | '-process'
+    | '-profile'
+    | '-quality'
+    | '-quantize'
+    | '-quiet'
+    | '-radial-blur'
+    | '-raise'
+    | '-random-threshold'
+    | '-range-threshold'
+    | '-read-mask'
+    | '-red-primary'
+    | '-regard-warnings'
+    | '-region'
+    | '-remap'
+    | '-render'
+    | '-repage'
+    | '-resample'
+    | '-resize'
+    | '-respect-parentheses'
+    | '-roll'
+    | '-rotate'
+    | '-sample'
+    | '-sampling-factor'
+    | '-scale'
+    | '-scene'
+    | '-seed'
+    | '-segment'
+    | '-selective-blur'
+    | '-separate'
+    | '-sepia-tone'
+    | '-set'
+    | '-shade'
+    | '-shadow'
+    | '-sharpen'
+    | '-shave'
+    | '-shear'
+    | '-sigmoidal-contrast'
+    | '-smush'
+    | '-size'
+    | '-sketch'
+    | '-solarize'
+    | '-splice'
+    | '-spread'
+    | '-statistic'
+    | '-strip'
+    | '-stroke'
+    | '-strokewidth'
+    | '-stretch'
+    | '-style'
+    | '-swap'
+    | '-swirl'
+    | '-synchronize'
+    | '-taint'
+    | '-texture'
+    | '-threshold'
+    | '-thumbnail'
+    | '-tile'
+    | '-tile-offset'
+    | '-tint'
+    | '-transform'
+    | '-transparent'
+    | '-transparent-color'
+    | '-transpose'
+    | '-transverse'
+    | '-treedepth'
+    | '-trim'
+    | '-type'
+    | '-undercolor'
+    | '-unique-colors'
+    | '-units'
+    | '-unsharp'
+    | '-verbose'
+    | '-version'
+    | '-view'
+    | '-vignette'
+    | '-virtual-pixel'
+    | '-wave'
+    | '-wavelet-denoise'
+    | '-weight'
+    | '-white-point'
+    | '-white-threshold'
+    | '-write'
+    | '-write-mask';
+
+export type ConvertOptions = { [key in ConvertOptionKey]?: string };
+
+export interface Options {
+    pdfFileBaseName?: string;
+    convertOptions?: ConvertOptions;
+    convertExtension?: string;
+    graphicsMagick?: boolean;
+    outputDirectory?: string;
+}
+
+export type OptionalSpread<CombinedImage extends boolean> = CombinedImage extends true
+    ? [Options & { combinedImage: CombinedImage }]
+    : [] | [Options & { combinedImage?: CombinedImage }];
+
+export interface PDFInfo {
+    Creator: string;
+    Producer: string;
+    CreationDate: string;
+    Tagged: string;
+    UserProperties: string;
+    Suspects: string;
+    Form: string;
+    JavaScript: string;
+    Pages: string;
+    Encrypted: string;
+    'Page size': string;
+    'Page rot': string;
+    'File size': string;
+    Optimized: string;
+    'PDF version': string;
+    [key: string]: string;
+}
+
+export class PDFImage<CombinedImage extends boolean = false> {
+    constructor(path: string, ...options: OptionalSpread<CombinedImage>);
+    combineImages(imagePaths: string[]): Promise<string>;
+    constructCombineCommandForFile(imagePaths: string[]): string;
+    constructConvertCommandForPage(pageNumber: number): string;
+    constructConvertOptions(): string;
+    constructGetInfoCommand(): string;
+    convertFile(): Promise<CombinedImage extends true ? string : string[]>;
+    convertPage(pageNumber: number): Promise<string>;
+    getInfo(): Promise<PDFInfo>;
+    getOutputImagePathForFile(): string;
+    getOutputImagePathForPage(pageNumber: number): string;
+    parseGetInfoCommandOutput(output: string): { [key: string]: string };
+    setConvertExtension(convertExtension?: string): void;
+    setConvertOptions(convertOptions?: ConvertOptions): void;
+    setPdfFileBaseName(pdfFileBaseName?: string): void;
+}

--- a/types/pdf-image/index.d.ts
+++ b/types/pdf-image/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mooz/node-pdf-image#readme
 // Definitions by: NickLatkovich <https://github.com/nicklatkovich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.1
+// Minimum TypeScript Version: 3.4
 
 export type ConvertOptionKey =
     | '-adaptive-blur'
@@ -283,8 +283,8 @@ export interface PDFInfo {
 
 export class PDFImage<CombinedImage extends boolean = false> {
     constructor(path: string, ...options: OptionalSpread<CombinedImage>);
-    combineImages(imagePaths: string[]): Promise<string>;
-    constructCombineCommandForFile(imagePaths: string[]): string;
+    combineImages(imagePaths: readonly string[]): Promise<string>;
+    constructCombineCommandForFile(imagePaths: readonly string[]): string;
     constructConvertCommandForPage(pageNumber: number): string;
     constructConvertOptions(): string;
     constructGetInfoCommand(): string;
@@ -295,6 +295,6 @@ export class PDFImage<CombinedImage extends boolean = false> {
     getOutputImagePathForPage(pageNumber: number): string;
     parseGetInfoCommandOutput(output: string): { [key: string]: string };
     setConvertExtension(convertExtension?: string): void;
-    setConvertOptions(convertOptions?: ConvertOptions): void;
+    setConvertOptions(convertOptions?: Readonly<ConvertOptions>): void;
     setPdfFileBaseName(pdfFileBaseName?: string): void;
 }

--- a/types/pdf-image/pdf-image-tests.ts
+++ b/types/pdf-image/pdf-image-tests.ts
@@ -1,0 +1,21 @@
+import { PDFImage } from 'pdf-image';
+
+// $ExpectType PDFImage<false>
+new PDFImage('path');
+
+// $ExpectType Promise<string[]>
+new PDFImage('path').convertFile();
+
+// $ExpectType Promise<string>
+new PDFImage('path', { combinedImage: true }).convertFile();
+
+// $ExpectType Promise<string | string[]>
+new PDFImage<boolean>('path', { combinedImage: true }).convertFile();
+
+// $ExpectError
+new PDFImage<false>('path', { combinedImage: true });
+
+new PDFImage('path', { convertOptions: { "-adaptive-blur": '' } });
+
+// $ExpectError
+new PDFImage('path', { convertOptions: { invalidOptionKey: '' } });

--- a/types/pdf-image/tsconfig.json
+++ b/types/pdf-image/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "pdf-image-tests.ts"
+    ]
+}

--- a/types/pdf-image/tslint.json
+++ b/types/pdf-image/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.