### PR TITLE
Fix jest spyOn test for Promises

### DIFF
--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -418,6 +418,13 @@ const spy3Mock = spy3
     .mockReturnThis()
     .mockReturnValue('value')
     .mockReturnValueOnce('value')
+
+var spiedPromiseTarget = {
+    resolvesString() {
+        return Promise.resolve('string')
+    }
+}
+jest.spyOn(spiedPromiseTarget, 'resolvesString')
     .mockResolvedValue('value')
     .mockResolvedValueOnce('value')
     .mockRejectedValue('value')

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -417,13 +417,13 @@ const spy3Mock = spy3
     .mockName('name')
     .mockReturnThis()
     .mockReturnValue('value')
-    .mockReturnValueOnce('value')
+    .mockReturnValueOnce('value');
 
-var spiedPromiseTarget = {
+const spiedPromiseTarget = {
     resolvesString() {
-        return Promise.resolve('string')
+        return Promise.resolve('string');
     }
-}
+};
 jest.spyOn(spiedPromiseTarget, 'resolvesString')
     .mockResolvedValue('value')
     .mockResolvedValueOnce('value')


### PR DESCRIPTION
Before February 8, Typescript stopped issuing errors in long method chains after it encountered one error. Now it continues to give errors
on subsequent methods. This found an error in the jest tests where mockResolvedValue[Once] and moveRejectValue[Once] were being tested on a
non-promise target.

This PR adds a promise-specific test case to fix those errors.

```ts
const spy3Mock = spy3
    .mockImplementation(() => '')
    .mockImplementation()
    // $ExpectError
    .mockImplementation((arg: {}) => arg) // Previously, an error here...
    .mockImplementation((...args: string[]) => args.join('')) // Would disable call resolution errors in
    .mockImplementationOnce(() => '')                         // all
    .mockName('name')                                         // these
    .mockReturnThis()                                         // calls
    .mockReturnValue('value')                                 // here
    .mockReturnValueOnce('value')                             // ...
```