### PR TITLE
[angular-aria] Add types for $ariaProvider

### DIFF
--- a/types/angular-aria/angular-aria-tests.ts
+++ b/types/angular-aria/angular-aria-tests.ts
@@ -1,4 +1,15 @@
-function testConfig($aria: angular.aria.IAriaService): void {
+function testProvider($ariaProvider: angular.aria.IAriaProvider): void {
+    // $ExpectType void
+    $ariaProvider.config({ariaHidden: true});
+
+    // $ExpectError
+    $ariaProvider.config({ariaDisabled: 44});
+
+    // $ExpectError
+    $ariaProvider.config({unknownkey: false});
+}
+
+function testService($aria: angular.aria.IAriaService): void {
     // $ExpectType boolean
     $aria.config('tabindex');
 

--- a/types/angular-aria/angular-aria-tests.ts
+++ b/types/angular-aria/angular-aria-tests.ts
@@ -2,6 +2,9 @@ function testProvider($ariaProvider: angular.aria.IAriaProvider): void {
     // $ExpectType void
     $ariaProvider.config({ariaHidden: true});
 
+    // $ExpectType void
+    $ariaProvider.config({ariaChecked: true, ariaReadonly: false});
+
     // $ExpectError
     $ariaProvider.config({ariaDisabled: 44});
 

--- a/types/angular-aria/index.d.ts
+++ b/types/angular-aria/index.d.ts
@@ -10,8 +10,19 @@ declare module 'angular' {
     namespace aria {
         type IAriaAttribute = 'ariaHidden'|'ariaChecked'|'ariaReadonly'|'ariaDisabled'|'ariaRequired'|'ariaInvalid'|'ariaValue'|'tabindex'|'bindKeydown'|'bindRoleForClick';
 
+        type IAriaProviderOptions = {
+            [key in IAriaAttribute]?: boolean;
+        };
+
         /**
-         * $aria service.
+         * $ariaProvider (https://docs.angularjs.org/api/ngAria/provider/$ariaProvider).
+         */
+        interface IAriaProvider {
+            config(config: IAriaProviderOptions): void;
+        }
+
+        /**
+         * $aria service (https://docs.angularjs.org/api/ngAria/service/$aria).
          */
         interface IAriaService {
             config(attribute: IAriaAttribute): boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.angularjs.org/api/ngAria/provider/$ariaProvider
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

/cc @peterblazejewicz
PR manually forked from #42133.