### PR TITLE
fix(defaults): Limit function definition to module scope

### DIFF
--- a/types/defaults/index.d.ts
+++ b/types/defaults/index.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: Ibtihel CHNAB <https://github.com/IbtihelCHNAB>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function defaults(options: any, defaultOptions: any): any;
-
 declare module "defaults" {
+  function defaults(options: any, defaultOptions: any): any;
+
   export = defaults;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

This fixes an issue where the `defaults` function is declared globally even though it's only available when imported as a module.

Before:
Types and no errors when not imported
![defaults-scope-before](https://user-images.githubusercontent.com/9935648/74206101-d0973b00-4c2e-11ea-8bf7-a9ee2734fb79.png)

After:
Error when module not imported (as expected)
![defaults-scope-after-1](https://user-images.githubusercontent.com/9935648/74206159-f7ee0800-4c2e-11ea-8dd4-d76fc9cbd7ef.png)

Types available when module is imported (as expected)
![defaults-scope-after-2](https://user-images.githubusercontent.com/9935648/74206163-fae8f880-4c2e-11ea-89b1-258c0dbd8498.png)

Note: If this is a common issue, perhaps we could consider adding a note about it to the "Common mistakes" documentation.