### PR TITLE
dhtmlxscheduler - parsing method added

### DIFF
--- a/types/dhtmlxscheduler/index.d.ts
+++ b/types/dhtmlxscheduler/index.d.ts
@@ -243,6 +243,12 @@ interface SchedulerTemplates {
 	quick_info_title(start: Date, end: Date, event: any): string;
 
 	/**
+     * specifies the date string before events parse and load methods
+     * @param start the date string before assigned to event
+    */
+	parse_date(date: string): string;
+
+	/**
 	 * specifies the drop-down time selector in the lightbox
 	*/
 	time_picker(): string;
@@ -1212,7 +1218,7 @@ interface SchedulerStatic {
 	 * @param config the configuration object of the timespan to mark/block
 	*/
 	addMarkedTimespan(config: any): number;
-	
+
 	/**
 	 * adds a new keyboard shortcut
 	 * @param shortcut the key name or the name of keys combination for a shortcut (shortcut syntax)
@@ -1566,7 +1572,7 @@ interface SchedulerStatic {
 	 * @param type (<i>'json', 'xml', 'ical'</i>) the data type. The default value - <i>'xml'</i>
 	*/
 	parse(data: any, type?: string): void;
-	
+
 	/**
 	 * removes a keyboard shortcut
 	 * @param shortcut the key name or the name of keys combination for a shortcut (shortcut syntax)


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.dhtmlx.com/scheduler/api__scheduler_parse_date_template.html