### PR TITLE
[rsocket-core] export rsocket error

### DIFF
--- a/types/rsocket-core/RSocketFrame.d.ts
+++ b/types/rsocket-core/RSocketFrame.d.ts
@@ -91,6 +91,7 @@ export function isLease(flags: number): boolean;
  */
 export function isResumePositionFrameType(type: number): boolean;
 export function getFrameTypeName(type: number): string;
+/** Metadata about the error for use in introspecting at runtime. */
 export interface ErrorSource {
     /** The error code returned by the server. */
     code: number;
@@ -99,14 +100,10 @@ export interface ErrorSource {
     /** The error string returned by the server. */
     message: string;
 }
-export class RSocketError extends Error {
-    /** Metadata about the error for use in introspecting at runtime. */
-    source: ErrorSource;
-}
 /**
  * Constructs an Error object given the contents of an error frame.
  */
-export function createErrorFromFrame(frame: ErrorFrame): RSocketError;
+export function createErrorFromFrame(frame: ErrorFrame): Error & { source: ErrorSource };
 /**
  * Given a RSocket error code, returns a human-readable explanation of that
  * code, following the names used in the protocol specification.

--- a/types/rsocket-core/index.d.ts
+++ b/types/rsocket-core/index.d.ts
@@ -33,6 +33,7 @@ export {
     MAX_RESUME_LENGTH,
     MAX_STREAM_ID,
     MAX_VERSION,
+    ErrorSource,
     createErrorFromFrame,
     getErrorCodeExplanation,
     isComplete,


### PR DESCRIPTION
This PR is a follow-up for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42155. I forgot to export the introduced types in `index.d.ts`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
