### PR TITLE
[@types/react-table] Fix SortByFn<D> is needlessly restrictive

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -733,7 +733,7 @@ export interface UseSortByColumnProps<D extends object> {
     isSortedDesc: boolean | undefined;
 }
 
-export type SortByFn<D extends object> = (rowA: Row<D>, rowB: Row<D>, columnId: IdType<D>) => 0 | 1 | -1;
+export type SortByFn<D extends object> = (rowA: Row<D>, rowB: Row<D>, columnId: IdType<D>) => number;
 
 export type DefaultSortTypes = 'alphanumeric' | 'datetime' | 'basic';
 


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort

There is nothing about `Array.sort()` that says numbers must be strictly, `-1 | 0 | 1`, it just specifies less-than / equal / greater than zero. Relaxing the restriction makes it play nicer with existing sorting libs.
