### PR TITLE
feat: types for @rdfjs/to-ntriples

### DIFF
--- a/types/rdfjs__to-ntriples/OTHER_FILES.txt
+++ b/types/rdfjs__to-ntriples/OTHER_FILES.txt
@@ -1,0 +1,5 @@
+lib/blankNode.d.ts
+lib/defaultGraph.d.ts
+lib/literal.d.ts
+lib/namedNode.d.ts
+lib/variable.d.ts

--- a/types/rdfjs__to-ntriples/index.d.ts
+++ b/types/rdfjs__to-ntriples/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for @rdfjs/to-ntriples 1.0
+// Project: https://github.com/rdfjs-base/to-ntriples
+// Definitions by: tpluscode <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.0
+
+import quad = require('./lib/quad');
+import term = require('./lib/term');
+
+declare const toNtriples: {
+    quadToNTriples: typeof quad;
+    termToNTriples: typeof term;
+};
+
+export = toNtriples;

--- a/types/rdfjs__to-ntriples/lib/blankNode.d.ts
+++ b/types/rdfjs__to-ntriples/lib/blankNode.d.ts
@@ -1,0 +1,5 @@
+import { BlankNode } from 'rdf-js';
+
+declare function blankNode(blankNode: BlankNode): string;
+
+export = blankNode;

--- a/types/rdfjs__to-ntriples/lib/defaultGraph.d.ts
+++ b/types/rdfjs__to-ntriples/lib/defaultGraph.d.ts
@@ -1,0 +1,5 @@
+import { DefaultGraph } from 'rdf-js';
+
+declare function defaultGraph(defaultGraph?: DefaultGraph): string;
+
+export = defaultGraph;

--- a/types/rdfjs__to-ntriples/lib/literal.d.ts
+++ b/types/rdfjs__to-ntriples/lib/literal.d.ts
@@ -1,0 +1,5 @@
+import { Literal } from 'rdf-js';
+
+declare function literal(literal: Literal): string;
+
+export = literal;

--- a/types/rdfjs__to-ntriples/lib/namedNode.d.ts
+++ b/types/rdfjs__to-ntriples/lib/namedNode.d.ts
@@ -1,0 +1,5 @@
+import { NamedNode } from 'rdf-js';
+
+declare function namedNode(namedNode: NamedNode): string;
+
+export = namedNode;

--- a/types/rdfjs__to-ntriples/lib/quad.d.ts
+++ b/types/rdfjs__to-ntriples/lib/quad.d.ts
@@ -1,0 +1,5 @@
+import { Quad } from 'rdf-js';
+
+declare function quad(quad: Quad): string;
+
+export = quad;

--- a/types/rdfjs__to-ntriples/lib/term.d.ts
+++ b/types/rdfjs__to-ntriples/lib/term.d.ts
@@ -1,0 +1,6 @@
+import { Term } from 'rdf-js';
+
+declare function term(term: Term): string;
+declare function term(term: unknown): undefined;
+
+export = term;

--- a/types/rdfjs__to-ntriples/lib/variable.d.ts
+++ b/types/rdfjs__to-ntriples/lib/variable.d.ts
@@ -1,0 +1,5 @@
+import { Variable } from 'rdf-js';
+
+declare function variable(variable: Variable): string;
+
+export = variable;

--- a/types/rdfjs__to-ntriples/rdfjs__to-ntriples-tests.ts
+++ b/types/rdfjs__to-ntriples/rdfjs__to-ntriples-tests.ts
@@ -1,0 +1,27 @@
+import * as RDF from 'rdf-js';
+import toNtriples = require('@rdfjs/to-ntriples');
+import blankNode = require('@rdfjs/to-ntriples/lib/blankNode');
+import defaultGraph = require('@rdfjs/to-ntriples/lib/defaultGraph');
+import namedNode = require('@rdfjs/to-ntriples/lib/namedNode');
+import variable = require('@rdfjs/to-ntriples/lib/variable');
+
+const rdfBlankNode: RDF.BlankNode = <any> {};
+const rdfDefaultGraph: RDF.DefaultGraph = <any> {};
+const rdfNamedNode: RDF.NamedNode = <any> {};
+const rdfVariable: RDF.Variable = <any> {};
+const rdfQuad: RDF.Quad = <any> {};
+
+const blankNodeString: string = blankNode(rdfBlankNode);
+let defaultGraphString: string = defaultGraph();
+defaultGraphString = defaultGraph(rdfDefaultGraph);
+const namedNodeString: string = namedNode(rdfNamedNode);
+const variableString: string = variable(rdfVariable);
+const quadString: string = toNtriples.quadToNTriples(rdfQuad);
+
+let termString: string;
+termString = toNtriples.termToNTriples(rdfBlankNode);
+termString = toNtriples.termToNTriples(rdfDefaultGraph);
+termString = toNtriples.termToNTriples(rdfNamedNode);
+termString = toNtriples.termToNTriples(rdfVariable);
+
+const notTermString: undefined = toNtriples.termToNTriples({ termType: 'foo' });

--- a/types/rdfjs__to-ntriples/tsconfig.json
+++ b/types/rdfjs__to-ntriples/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@rdfjs/to-ntriples": [
+                "rdfjs__to-ntriples"
+            ],
+            "@rdfjs/to-ntriples/*": [
+                "rdfjs__to-ntriples/*"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "rdfjs__to-ntriples-tests.ts"
+    ]
+}

--- a/types/rdfjs__to-ntriples/tslint.json
+++ b/types/rdfjs__to-ntriples/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.