### PR TITLE
fix(mailgun-js): missing option

### DIFF
--- a/types/mailgun-js/index.d.ts
+++ b/types/mailgun-js/index.d.ts
@@ -94,6 +94,7 @@ declare namespace Mailgun {
             inline?: AttachmentData | ReadonlyArray<AttachmentData>;
 
             // Mailgun options
+            'o:testmode'?: 'yes' | 'no' | 'true' | 'false' | 'True' | 'False';
             'o:tag'?: string | string[];
             'o:deliverytime'?: string;
             'o:dkim'?: 'yes' | 'no' | boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://documentation.mailgun.com/en/latest/user_manual.html#tracking-messages
====> Note: I tested using a boolean and it did not work localy. Looks only only a `string` was expected. IDK if the other flags taking `boolean`s in the type description are working.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
