### PR TITLE
react-native: add some missing props for TextInput

### DIFF
--- a/types/react-native-popup-dialog/react-native-popup-dialog-tests.tsx
+++ b/types/react-native-popup-dialog/react-native-popup-dialog-tests.tsx
@@ -89,7 +89,7 @@ class Test extends React.Component<any> {
                 <DialogContent>
 
                 </DialogContent>
-                ></Dialog>
+                </Dialog>
             </View>);
     }
 }

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -991,6 +991,21 @@ export interface TextInputIOSProps {
     keyboardAppearance?: 'default' | 'light' | 'dark';
 
     /**
+     * Provide rules for your password.
+     * For example, say you want to require a password with at least eight characters consisting of a mix of uppercase and lowercase letters, at least one number, and at most two consecutive characters.
+     * "required: upper; required: lower; required: digit; max-consecutive: 2; minlength: 8;"
+     */
+    passwordRules?: string;
+    
+    /**
+     * If `true`, allows TextInput to pass touch events to the parent component.
+     * This allows components to be swipeable from the TextInput on iOS,
+     * as is the case on Android by default.
+     * If `false`, TextInput always asks to handle the input (except when disabled).
+     */
+    rejectResponderTermination?: boolean;
+
+    /**
      * See DocumentSelectionState.js, some state that is responsible for maintaining selection information for a document
      */
     selectionState?: DocumentSelectionState;
@@ -1075,10 +1090,13 @@ export interface TextInputIOSProps {
     | 'newPassword'
     | 'oneTimeCode';
 
+
     /**
      * If false, scrolling of the text view will be disabled. The default value is true. Only works with multiline={true}
      */
     scrollEnabled?: boolean;
+
+
 }
 
 /**

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -995,7 +995,7 @@ export interface TextInputIOSProps {
      * For example, say you want to require a password with at least eight characters consisting of a mix of uppercase and lowercase letters, at least one number, and at most two consecutive characters.
      * "required: upper; required: lower; required: digit; max-consecutive: 2; minlength: 8;"
      */
-    passwordRules?: string;
+    passwordRules?: string | null;
     
     /**
      * If `true`, allows TextInput to pass touch events to the parent component.
@@ -1003,7 +1003,7 @@ export interface TextInputIOSProps {
      * as is the case on Android by default.
      * If `false`, TextInput always asks to handle the input (except when disabled).
      */
-    rejectResponderTermination?: boolean;
+    rejectResponderTermination?: boolean | null;
 
     /**
      * See DocumentSelectionState.js, some state that is responsible for maintaining selection information for a document
@@ -1090,13 +1090,10 @@ export interface TextInputIOSProps {
     | 'newPassword'
     | 'oneTimeCode';
 
-
     /**
      * If false, scrolling of the text view will be disabled. The default value is true. Only works with multiline={true}
      */
     scrollEnabled?: boolean;
-
-
 }
 
 /**

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -996,7 +996,7 @@ export interface TextInputIOSProps {
      * "required: upper; required: lower; required: digit; max-consecutive: 2; minlength: 8;"
      */
     passwordRules?: string | null;
-    
+
     /**
      * If `true`, allows TextInput to pass touch events to the parent component.
      * This allows components to be swipeable from the TextInput on iOS,


### PR DESCRIPTION
Added `passwordRules` and `rejectResponderTermination` props for `TextInput` both props are for iOS.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/master/Libraries/Components/TextInput/TextInput.js#L270-L285
