### PR TITLE
feat(react): exclude number from keyof JSX.IntrinsicElements

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -115,7 +115,7 @@ declare namespace React {
     interface ReactComponentElement<
         T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
         P = Pick<ComponentProps<T>, Exclude<keyof ComponentProps<T>, 'key' | 'ref'>>
-    > extends ReactElement<P, T> { }
+    > extends ReactElement<P, Exclude<T, number>> { }
 
     /**
      * @deprecated Please use `FunctionComponentElement`


### PR DESCRIPTION
It's required to exclude `number` type from `keyof JSX.IntrinsicElements` because of the case when `JSX.IntrinsicElements` has some additional declarations with indexer type, for example

```
declare namespace JSX {
    interface IntrinsicElements extends JSX.IntrinsicElements {
        [name: string]: SomeJSXElementType;
    }
}
```

Thank you!

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: the context is in the Pull Request description
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
