### PR TITLE
[meteor] Fix Mongo.Collection definition

### DIFF
--- a/types/meteor/globals/mongo.d.ts
+++ b/types/meteor/globals/mongo.d.ts
@@ -127,7 +127,7 @@ declare module Mongo {
 
     var Collection: CollectionStatic;
     interface CollectionStatic {
-        new <T>(name: string, options?: {
+        new <T>(name: string | null, options?: {
             connection?: Object | null;
             idGeneration?: string;
             transform?: Function | null;

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -129,7 +129,7 @@ declare module "meteor/mongo" {
 
         var Collection: CollectionStatic;
         interface CollectionStatic {
-            new <T>(name: string, options?: {
+            new <T>(name: string | null, options?: {
                 connection?: Object | null;
                 idGeneration?: string;
                 transform?: Function | null;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
   - **this failed on my machine**

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.meteor.com/api/collections.html#Mongo-Collection

```null``` value for name argument is allowed as per definition seen above. It's not a change, rather a fix as looking through history  it's there for at least 6 years.

https://github.com/meteor/meteor/blame/master/packages/mongo/collection.js#L11-L15
