### PR TITLE
Export TestContext type so we can have typed `let { owner } = getCont…

### DIFF
--- a/types/ember__test-helpers/index.d.ts
+++ b/types/ember__test-helpers/index.d.ts
@@ -188,7 +188,7 @@ declare module '@ember/test-helpers/setup-context' {
     import Resolver from '@ember/application/resolver';
 
     export default function<C extends object>(context: C, options?: { resolver?: Resolver }): Promise<C>;
-    export function getContext(): object;
+    export function getContext(): TestContext;
     export function setContext(context: object): void;
     export function unsetContext(): void;
     

--- a/types/ember__test-helpers/index.d.ts
+++ b/types/ember__test-helpers/index.d.ts
@@ -51,7 +51,7 @@ declare module '@ember/test-helpers' {
     // Test Framework APIs
 
     export { setResolver, getResolver } from '@ember/test-helpers/resolver';
-    export { default as setupContext, getContext, setContext, unsetContext } from '@ember/test-helpers/setup-context';
+    export { default as setupContext, getContext, setContext, TestContext, unsetContext } from '@ember/test-helpers/setup-context';
     export { default as teardownContext } from '@ember/test-helpers/teardown-context';
     export { default as setupRenderingContext } from '@ember/test-helpers/setup-rendering-context';
     export { default as teardownRenderingContext } from '@ember/test-helpers/teardown-rendering-context';
@@ -191,6 +191,23 @@ declare module '@ember/test-helpers/setup-context' {
     export function getContext(): object;
     export function setContext(context: object): void;
     export function unsetContext(): void;
+    
+    export interface BaseContext {
+      [key: string]: any;
+    }
+
+    // https://github.com/emberjs/ember-test-helpers/blob/5c4f7025cf530273b7fc240adec04a5a24113c57/addon-test-support/%40ember/test-helpers/setup-context.ts#L21
+    export interface TestContext extends BaseContext {
+      owner: Owner;
+
+      set(key: string, value: any): any;
+      setProperties(hash: { [key: string]: any }): { [key: string]: any };
+      get(key: string): any;
+      getProperties(...args: string[]): Pick<BaseContext, string>;
+
+      pauseTest(): Promise<void>;
+      resumeTest(): Promise<void>;
+    }
 
     export function pauseTest(): Promise<void>;
     export function resumeTest(): void;


### PR DESCRIPTION
This change will prevent 
```ts
  let { owner } = getContext() as any;
```
in addons and apps' test-helpers

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
