### PR TITLE
fix(@hapi/joi): fix extend typings

### DIFF
--- a/types/hapi__joi/hapi__joi-tests.ts
+++ b/types/hapi__joi/hapi__joi-tests.ts
@@ -1012,11 +1012,18 @@ const Joi3 = Joi.extend({
         asd: {
             args: [
                 {
-                    name: 'allowFalse'
+                    name: 'allowFalse',
+                    ref: true,
+                    assert: Joi.boolean(),
                 }
             ],
-            method(allowFalse) {
-                this.$_createError(str, {}, {}, {}, {});
+            method(allowFalse: boolean) {
+                return this.$_addRule({
+                    name: 'asd',
+                    args: {
+                        allowFalse,
+                    }
+                });
             },
             validate(value: boolean, helpers, params, options) {
                 if (value || params.allowFalse && !value) {

--- a/types/hapi__joi/index.d.ts
+++ b/types/hapi__joi/index.d.ts
@@ -679,6 +679,13 @@ declare namespace Joi {
 
     type SchemaFunction = (schema: Schema) => Schema;
 
+    interface AddRuleOptions {
+        name: string;
+        args?: {
+            [key: string]: any;
+        };
+    }
+
     interface SchemaInternals {
         /**
          * Parent schema object.
@@ -693,7 +700,7 @@ declare namespace Joi {
         /**
          * Adds a rule to current validation schema.
          */
-        $_addRule(rule: string | ExtensionRule): Schema;
+        $_addRule(rule: string | AddRuleOptions): Schema;
 
         /**
          * Internally compiles schema.
@@ -1756,7 +1763,7 @@ declare namespace Joi {
     interface RuleArgs {
         name: string;
         ref?: boolean;
-        assert?: (value: any) => boolean;
+        assert?: ((value: any) => boolean) | AnySchema;
         message?: string;
 
         /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/joi/blob/47d29ecf5a0493ddf12f1b5e44fe401a8c45617c/lib/types/string.js#L163
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

These functions are not very well documented (if at all).
