### PR TITLE
feat(karma-remap-coverage): type definition for v0.1

### DIFF
--- a/types/karma-remap-coverage/index.d.ts
+++ b/types/karma-remap-coverage/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for karma-remap-coverage 0.1
+// Project: https://github.com/sshev/karma-remap-coverage#readme
+// Definitions by: Piotr Błażejewicz (Peter Blazejewicz) <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.2
+
+/// <reference types="karma-coverage" />
+
+import 'karma';
+
+declare module 'karma' {
+    interface ConfigOptions {
+        /**
+         * Key-value pairs where key is report type and value - path to file/dir where to save it.
+         * Reporters like `text-summary`, `text-lcov` and `teamcity` can print out to console as well
+         * - in this case just provide any falsy value instead of path.
+         *
+         * @example
+         * ```ts
+         * 'text-summary': null, // to show summary in console
+         * html: './coverage/html',
+         * ```
+         *
+         * {@link https://github.com/sshev/karma-remap-coverage#remapcoveragereporter-format }
+         */
+        remapCoverageReporter?: KarmaRemapCoverageReporter;
+    }
+
+    // remapped reporter types to key-value pairs
+    type KarmaRemapCoverageReporter = Partial<Record<ReporterType, string | null | undefined>>;
+}

--- a/types/karma-remap-coverage/karma-remap-coverage-tests.ts
+++ b/types/karma-remap-coverage/karma-remap-coverage-tests.ts
@@ -1,0 +1,28 @@
+import { Config } from 'karma';
+
+module.exports = (config: Config) =>
+    config.set({
+        files: ['./entry-module.spec.ts'],
+        preprocessors: {
+            './entry-module.spec.ts': ['webpack', 'sourcemap'],
+            './entry-module.ts': ['coverage'],
+        },
+        // add both "karma-coverage" and "karma-remap-coverage" reporters
+        reporters: ['progress', 'coverage', 'remap-coverage'],
+
+        // save interim raw coverage report in memory
+        coverageReporter: {
+            type: 'in-memory',
+        },
+
+        // define where to save final remaped coverage reports
+        remapCoverageReporter: {
+            'text-summary': null,
+            lcov: undefined,
+            html: './coverage/html',
+            cobertura: './coverage/cobertura.xml',
+        },
+
+        // make sure both reporter plugins are loaded
+        plugins: ['karma-coverage', 'karma-remap-coverage'],
+    });

--- a/types/karma-remap-coverage/tsconfig.json
+++ b/types/karma-remap-coverage/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "karma-remap-coverage-tests.ts"
+    ]
+}

--- a/types/karma-remap-coverage/tslint.json
+++ b/types/karma-remap-coverage/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- type definition
- tests

Thanks!

https://github.com/sshev/karma-remap-coverage#readme

Used e.g.:
https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/template/template/karma.conf.js#L22

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. 
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.