### PR TITLE
Fixing get() result for `ssh2-sftp-client`

### DIFF
--- a/types/email-templates/index.d.ts
+++ b/types/email-templates/index.d.ts
@@ -22,14 +22,20 @@ import StreamTransport = require('nodemailer/lib/stream-transport');
 // too and calls createTransport if given a non-function, thus a lot
 // of different types accepted for transport
 type NodeMailerTransportOptions =
-    Mail |
-    SMTPPool | SMTPPool.Options |
-    SendmailTransport | SendmailTransport.Options |
-    StreamTransport | StreamTransport.Options |
-    JSONTransport | JSONTransport.Options |
-    SESTransport | SESTransport.Options |
-    SMTPTransport | SMTPTransport.Options |
-    string;
+    | Mail
+    | SMTPPool
+    | SMTPPool.Options
+    | SendmailTransport
+    | SendmailTransport.Options
+    | StreamTransport
+    | StreamTransport.Options
+    | JSONTransport
+    | JSONTransport.Options
+    | SESTransport
+    | SESTransport.Options
+    | SMTPTransport
+    | SMTPTransport.Options
+    | string;
 
 // No typedef for https://github.com/niftylettuce/preview-email
 interface PreviewEmailOpts {
@@ -76,7 +82,7 @@ interface View {
     /**
      * View root. Defaults to the current working directory's "emails" folder via path.resolve('emails')
      */
-    root: string;
+    root?: string;
 
     options?: ViewOptions;
 }
@@ -101,7 +107,7 @@ interface EmailConfig<T = any> {
     /**
      * Preview the email
      */
-    preview?: boolean|PreviewEmailOpts;
+    preview?: boolean | PreviewEmailOpts;
     /**
      * Set to object to configure and Enable <https://github.com/ladjs/il8n>
      */
@@ -119,12 +125,12 @@ interface EmailConfig<T = any> {
      *
      * configuration object for html-to-text
      */
-    htmlToText?: HtmlToTextOptions|false;
+    htmlToText?: HtmlToTextOptions | false;
     /**
      * You can pass an option to prefix subject lines with a string
      * env === 'production' ? false : `[${env.toUpperCase()}] `; // <--- HERE
      */
-    subjectPrefix?: string|false;
+    subjectPrefix?: string | false;
     /**
      * <https://github.com/Automattic/juice>
      */
@@ -158,7 +164,7 @@ declare class EmailTemplate<T = any> {
      *   shorthand use of `juiceResources` with the config
      *   mainly for custom renders like from a database).
      */
-    juiceResources(html: string): Promise<string> ;
+    juiceResources(html: string): Promise<string>;
     /**
      *
      * @param view The Html pug to render
@@ -176,7 +182,7 @@ declare namespace EmailTemplate {
      *   shorthand use of `juiceResources` with the config
      *   mainly for custom renders like from a database).
      */
-    function juiceResources(html: string): Promise<string> ;
+    function juiceResources(html: string): Promise<string>;
 
     /**
      *

--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -31,7 +31,7 @@ declare class sftp {
         path: string,
         dst?: string | NodeJS.WritableStream,
         options?: ssh2Stream.TransferOptions,
-    ): Promise<string | NodeJS.WritableStream | Buffer>;
+    ): Promise<string | NodeJS.ReadableStream | Buffer>;
 
     fastGet(remoteFilePath: string, localPath: string, options?: ssh2Stream.TransferOptions): Promise<string>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.npmjs.com/package/ssh2-sftp-client#getpath-dst-options--stringstreambuffer>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
