### PR TITLE
Fix new errors from TS@next (3.9)

### DIFF
--- a/types/cleave.js/cleave.js-tests.tsx
+++ b/types/cleave.js/cleave.js-tests.tsx
@@ -36,8 +36,8 @@ const ExampleReact2 = (props: Props) => {
         <CleaveReact
             value="test"
             className="form-control"
-            options={{ phone: true }}
             {...props}
+            options={{ phone: true }}
         />
     );
 };

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -315,7 +315,7 @@ function EventWrapper(props: EventWrapperProps<CalendarEvent>) {
     const { continuesEarlier, event, label, accessors = {}, style } = props;
     return (
         <div style={style}>
-            <div>{continuesEarlier}-{label}-{accessors.title && event && accessors.title(event)}}</div>
+            <div>{continuesEarlier}-{label}-{accessors.title && event && accessors.title(event)}</div>
         </div>
     );
 }
@@ -325,7 +325,7 @@ class Toolbar extends React.Component<ToolbarProps> {
         const { date, label, view } = this.props;
         return (
             <div>
-                <div>{date.toJSON()}-{label}-{view}}</div>
+                <div>{date.toJSON()}-{label}-{view}</div>
             </div>
         );
     }

--- a/types/react-motion/react-motion-tests.tsx
+++ b/types/react-motion/react-motion-tests.tsx
@@ -53,9 +53,7 @@ class TransitionTest extends React.Component {
             <div>
                 {interpolatedItems.map(config => {
                     return (
-                        <div key={config.key}>
-                            style={{ height: config.style['height'] }}
-                            >
+                        <div key={config.key} style={{ height: config.style['height'] as number }}>
                             {config.data}
                         </div>
                     );

--- a/types/react-router/test/examples-from-react-router-website/NoMatch.tsx
+++ b/types/react-router/test/examples-from-react-router-website/NoMatch.tsx
@@ -30,9 +30,9 @@ const NoMatchExample = () => (
 
 const Home = () => (
   <p>
-    A <code>&lt;Switch></code> renders the
-    first child <code>&lt;Route></code> that
-    matches. A <code>&lt;Route></code> with
+    A <code>&lt;Switch&gt;</code> renders the
+    first child <code>&lt;Route&gt;</code> that
+    matches. A <code>&lt;Route&gt;</code> with
     no <code>path</code> always matches.
   </p>
 );


### PR DESCRIPTION
1. Bogus trailing } and > are now detected in JSX.
2. Properties that are overwritten in JSX and object spreads are now detected.

For react-motion, note that the fix correctly started to use a previously unused attribute `style`, which exposes a type error in the tests:

```
config.style: number | OpaqueConfig
```

but the test assigns it to

```
div.style: string | number
```

I squelched the error with a cast to `number`, but probably either the
test or the types are actually wrong.