### PR TITLE
mixpanel-browser: Add transport support

### DIFF
--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mixpanel-browser 2.23
+// Type definitions for mixpanel-browser 2.33
 // Project: https://github.com/mixpanel/mixpanel-js
 // Definitions by: Carlos López <https://github.com/karlos1337>
 //                 Ricardo Rodrigues <https://github.com/RicardoRodrigues>
@@ -12,6 +12,10 @@ export type PushItem = Array<string | Dict>;
 export type Query = string | Element | Element[];
 
 export interface Dict {[key: string]: any; }
+
+export interface RequestOptions {
+  transport?: "xhr" | "sendBeacon";
+}
 
 export interface XhrHeadersDef {[header: string]: any; }
 
@@ -124,7 +128,7 @@ export function register_once(props: Dict, default_value?: any, days?: number): 
 export function reset(): void;
 export function set_config(config: Partial<Config>): void;
 export function time_event(event_name: string): void;
-export function track(event_name: string, properties?: Dict, callback?: () => void): void;
+export function track(event_name: string, properties?: Dict, options?: RequestOptions, callback?: () => void): void;
 export function track_forms(query: Query, event_name: string, properties?: Dict | (() => void)): void;
 export function track_links(query: Query, event_name: string, properties?: Dict | (() => void)): void;
 export function unregister(property: string): void;

--- a/types/mixpanel-browser/mixpanel-browser-tests.ts
+++ b/types/mixpanel-browser/mixpanel-browser-tests.ts
@@ -9,6 +9,7 @@ mixpanel.track_links('#nav', 'Clicked Nav Link');
 mixpanel.track_forms('#register', 'Created Account');
 mixpanel.time_event('Registered');
 mixpanel.track('Registered', {Gender: 'Male', Age: 21});
+mixpanel.track('Left page', {duration_seconds: 35}, {transport: 'sendBeacon'});
 mixpanel.register({Gender: 'Female'});
 mixpanel.register({
   Email: 'jdoe@example.com',


### PR DESCRIPTION
Adds request options to `mixpanel-browser`'s types. See mixpanel's [documentation](https://developer.mixpanel.com/docs/javascript-full-api-reference#section-mixpanel-track) for details.
Even though this is was released in a minor version, this is actually a breaking change