### PR TITLE
[swagger-ui-react] Update types to be in sync with the version 3.25.0 of swagger-ui-react

### DIFF
--- a/types/swagger-ui-react/index.d.ts
+++ b/types/swagger-ui-react/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for swagger-ui-react 3.23
 // Project: https://github.com/swagger-api/swagger-ui#readme
 // Definitions by: viki.green <https://github.com/VictoriaGreen93>
+//                 Mendes <https://github.com/fernando-msj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -14,13 +15,19 @@ interface Response {
 }
 type System = any;
 
+type PluginGenerator = (system: System) => object;
+
+type Plugin = object | PluginGenerator;
+
 export interface SwaggerUIProps {
     spec?: object;
     url?: string;
     onComplete?: (system: System) => void;
     requestInterceptor?: (req: Request) => Request | Promise<Request>;
     responseInterceptor?: (res: Response) => Response | Promise<Response>;
-    docExpansion: 'list' | 'full' | 'none';
+    docExpansion?: 'list' | 'full' | 'none';
+    defaultModelExpandDepth?: number;
+    plugins?: Plugin[];
 }
 
 declare class SwaggerUI extends React.PureComponent<SwaggerUIProps> {}

--- a/types/swagger-ui-react/swagger-ui-react-tests.tsx
+++ b/types/swagger-ui-react/swagger-ui-react-tests.tsx
@@ -9,5 +9,13 @@ import SwaggerUI from 'swagger-ui-react';
       console.log(request);
       return request;
     }}
+    defaultModelExpandDepth={-1}
+    plugins={[
+        {
+            components: {
+                OperationTag: () => null,
+            },
+        },
+    ]}
   />
 </div>;


### PR DESCRIPTION
#### Changes:
* Makes `docExpansion` optional as it in fact isn't required.
* Adds optional `defaultModelExpandDepth` of type `number`.
* Adds optional `plugins`.

See the docs for [swagger-ui-react](https://www.npmjs.com/package/swagger-ui-react);

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.