### PR TITLE
fix: move heatmapLibrary for google-map-react to props

### DIFF
--- a/types/google-map-react/google-map-react-tests.tsx
+++ b/types/google-map-react/google-map-react-tests.tsx
@@ -28,4 +28,4 @@ const options: MapOptions = {
     ],
 };
 
-<GoogleMapReact center={center} zoom={3} bootstrapURLKeys={client} options={options} />;
+<GoogleMapReact center={center} heatmapLibrary={true} zoom={3} bootstrapURLKeys={client} options={options} />;

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -29,7 +29,6 @@ export interface MapOptions {
   fullscreenControlOptions?: { position: number };
   gestureHandling?: string;
   heading?: number;
-  heatmapLibrary?: boolean;
   keyboardShortcuts?: boolean;
   mapTypeControl?: boolean;
   mapTypeControlOptions?: any;
@@ -122,6 +121,7 @@ export interface Props {
     center?: Coords;
     defaultZoom?: number;
     zoom?: number;
+    heatmapLibrary?: boolean;
     hoverDistance?: number;
     options?: MapOptions | ((maps: Maps) => MapOptions);
     margin?: any[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/google-map-react/google-map-react/blob/master/src/google_map.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Running the lint command results in this error:

```
npm run lint google-map-react 

> definitely-typed@0.0.3 lint /Users/eshortiss/workspaces/js/DefinitelyTyped
> dtslint types "google-map-react"

Error: Errors in typescript@next for external dependencies:
../react/index.d.ts(34,22): error TS2307: Cannot find module 'csstype'.
```
