### PR TITLE
fix(styled-system__css): zIndex not being handled from theme as a string

### DIFF
--- a/types/styled-system__css/index.d.ts
+++ b/types/styled-system__css/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/styled-system/styled-system
 // Definitions by: Sebastian Sebald <https://github.com/sebald>
 //                 Bartosz Szewczyk <https://github.com/sztobar>
+//                 Ryan Dowling <https://github.com/RyanTheAllmighty>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
@@ -332,6 +333,18 @@ interface OverwriteCSSProperties {
      * @see https://developer.mozilla.org/docs/Web/CSS/font-weight
      */
     fontWeight?: CSS.FontWeightProperty | string;
+    /**
+     * The **`z-index`** CSS property sets the z-order of a positioned element and its descendants or flex items. Overlapping elements with a larger z-index cover those with a smaller one.
+     *
+     * **Initial value**: `auto`
+     *
+     * | Chrome | Firefox | Safari |  Edge  |  IE   |
+     * | :----: | :-----: | :----: | :----: | :---: |
+     * | **1**  |  **1**  | **1**  | **12** | **4** |
+     *
+     * @see https://developer.mozilla.org/docs/Web/CSS/z-index
+     */
+    zIndex?: CSS.ZIndexProperty | string;
 }
 
 /**
@@ -340,7 +353,7 @@ interface OverwriteCSSProperties {
  * theme function or nested) in `SystemCssProperties`.
  */
 interface AllSystemCSSProperties
-    extends Omit<CSSProperties, 'boxShadow' | 'fontWeight'>,
+    extends Omit<CSSProperties, 'boxShadow' | 'fontWeight' | 'zIndex'>,
         AliasesCSSProperties,
         OverwriteCSSProperties {}
 

--- a/types/styled-system__css/styled-system__css-tests.ts
+++ b/types/styled-system__css/styled-system__css-tests.ts
@@ -15,6 +15,9 @@ const theme = {
     fontWeights: {
         bold: 600,
     },
+    zIndicies: {
+        base: 100,
+    }
 };
 
 export const themeWithVariants: Theme = {
@@ -238,3 +241,8 @@ css({
 })({
     breakpoints: ['32em', '40em'],
 });
+
+// handles theme string values for zIndex
+css({
+    zIndex: 'base',
+})(theme);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/styled-system/styled-system/blob/master/packages/css/src/index.js#L103

---

`zIndicies` was added to @styled-system/css back in version 2.0.0, the types do not account for the fact that zIndex css property can now take a string which is read from the theme.