### PR TITLE
fix(sharedb): correct sharedb.DB.getOps so it has nullable arguments

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/share/sharedb
 // Definitions by: Steve Oney <https://github.com/soney>
 //                 Eric Hwang <https://github.com/ericyhwang>
+//                 Peter Xu <https://github.com/pxpeterxu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -65,8 +65,8 @@ declare namespace sharedb {
         commit(collection: string, id: string, op: Op, snapshot: any, options: any, callback: (...args: any[]) => any): void;
         getSnapshot(collection: string, id: string, fields: any, options: any, callback: (...args: any[]) => any): void;
         getSnapshotBulk(collection: string, ids: string, fields: any, options: any, callback: (...args: any[]) => any): void;
-        getOps(collection: string, id: string, from: number, to: number, options: any, callback: (...args: any[]) => any): void;
-        getOpsToSnapshot(collection: string, id: string, from: number, snapshot: number, options: any, callback: (...args: any[]) => any): void;
+        getOps(collection: string, id: string, from: number | null, to: number | null, options: any, callback: (...args: any[]) => any): void;
+        getOpsToSnapshot(collection: string, id: string, from: number | null, snapshot: number, options: any, callback: (...args: any[]) => any): void;
         getOpsBulk(collection: string, fromMap: any, toMap: any, options: any, callback: (...args: any[]) => any): void;
         getCommittedOpVersion(collection: string, id: string, snapshot: any, op: any, options: any, callback: (...args: any[]) => any): void;
         query: DBQueryMethod;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -40,6 +40,11 @@ const backend = new ShareDB({
     extraDbs: {myDb: new CustomExtraDb()}
 });
 console.log(backend.db);
+
+// getOps allows for `from` and `to` to both be `null`:
+// https://github.com/share/sharedb/blob/960f5d152f6a8051ed2dcb00a57681a3ebbd7dc2/README.md#getops
+backend.db.getOps('someCollection', 'someId', null, null, {}, () => {});
+
 console.log(backend.pubsub);
 console.log(backend.extraDbs);
 


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/share/sharedb#getops
  - Usage in tests: https://github.com/share/sharedb/blob/8de47b6dc2f4ff2c2c2cbaac08665593cebaa386/test/db.js#L76

**Details**

sharedb.DB.getOps was typed as taking `from` and `to` as always being `numbers`, when in fact, either of them could be `null`:

- If `from` is null, it means we should get ops from the beginning of time
- If `to` is null, it means we should get ops up to the latest

This is documented in [docs](https://github.com/share/sharedb#getops) and in [tests](https://github.com/share/sharedb/blob/8de47b6dc2f4ff2c2c2cbaac08665593cebaa386/test/db.js#L76)

I've edited `getOps` and `getOpsToSnapshot`, and added a test for `getOps`