### PR TITLE
Add typings for `json-ptr@1.2`

### DIFF
--- a/types/json-ptr/index.d.ts
+++ b/types/json-ptr/index.d.ts
@@ -1,0 +1,104 @@
+// Type definitions for json-ptr 1.2
+// Project: https://github.com/flitbit/json-ptr
+// Definitions by: Trey Brisbane <https://github.com/treybrisbane>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.4
+
+declare namespace JsonPointer {
+    type PathSegments = readonly string[];
+
+    type JsonStringPointer = string;
+    type UriFragmentIdentifierPointer = string;
+    type Pointer = JsonStringPointer | UriFragmentIdentifierPointer;
+
+    interface JsonStringPointerListItem {
+        readonly pointer: JsonStringPointer;
+        readonly value: unknown;
+    }
+
+    interface UriFragmentIdentifierPointerListItem {
+        readonly fragmentId: UriFragmentIdentifierPointer;
+        readonly value: unknown;
+    }
+
+    class JsonReference {
+        readonly $ref: UriFragmentIdentifierPointer;
+
+        constructor(pointer: JsonPointer | PathSegments | Pointer);
+
+        static isReference(value: unknown): value is JsonReference;
+
+        resolve(target: unknown): unknown;
+    }
+}
+
+declare class JsonPointer {
+    static readonly JsonPointer: typeof JsonPointer;
+    readonly path: JsonPointer.PathSegments;
+    readonly pointer: JsonPointer.JsonStringPointer;
+    readonly uriFragmentIdentifier: JsonPointer.UriFragmentIdentifierPointer;
+
+    constructor(pointer: JsonPointer.PathSegments | JsonPointer.Pointer);
+
+    static create(pointer: JsonPointer.PathSegments | JsonPointer.Pointer): JsonPointer;
+
+    static has(target: unknown, pointer: JsonPointer.Pointer): boolean;
+
+    static get(target: unknown, pointer: JsonPointer.Pointer): unknown;
+
+    static set(target: unknown, pointer: JsonPointer.Pointer, value: unknown, force?: boolean): unknown;
+
+    static list<FragmentId extends boolean = false>(
+        target: unknown,
+        fragmentId?: FragmentId,
+    ): ReadonlyArray<
+        FragmentId extends true
+            ? JsonPointer.UriFragmentIdentifierPointerListItem
+            : JsonPointer.JsonStringPointerListItem
+    >;
+
+    static flatten<FragmentId extends boolean = false>(
+        target: unknown,
+        fragmentId?: FragmentId,
+    ): Record<FragmentId extends true ? JsonPointer.UriFragmentIdentifierPointer : JsonPointer.JsonStringPointer, unknown>;
+
+    static map<FragmentId extends boolean = false>(
+        target: unknown,
+        fragmentId?: FragmentId,
+    ): Map<FragmentId extends true ? JsonPointer.UriFragmentIdentifierPointer : JsonPointer.JsonStringPointer, unknown>;
+
+    static visit<Cycle extends boolean = false>(
+        target: unknown,
+        visitor: (
+            pointer: JsonPointer.JsonStringPointer,
+            value: Cycle extends true ? unknown | JsonPointer.JsonReference : unknown,
+        ) => void,
+        cycle?: Cycle,
+    ): void;
+
+    static decode(pointer: JsonPointer.Pointer): JsonPointer.PathSegments;
+
+    static decodePointer(pointer: JsonPointer.JsonStringPointer): JsonPointer.PathSegments;
+
+    static encodePointer(path: JsonPointer.PathSegments): JsonPointer.JsonStringPointer;
+
+    static decodeUriFragmentIdentifier(pointer: JsonPointer.UriFragmentIdentifierPointer): JsonPointer.PathSegments;
+
+    static encodeUriFragmentIdentifier(path: JsonPointer.PathSegments): JsonPointer.UriFragmentIdentifierPointer;
+
+    static isReference(value: unknown): value is JsonPointer.JsonReference;
+
+    static noConflict(): typeof JsonPointer;
+
+    has(target: unknown): boolean;
+
+    get(target: unknown): unknown;
+
+    set(target: unknown, value: unknown, force?: boolean): unknown;
+
+    concat(target: JsonPointer | JsonPointer.PathSegments | JsonPointer.Pointer): JsonPointer;
+}
+
+export = JsonPointer;
+
+export as namespace JsonPointer;

--- a/types/json-ptr/json-ptr-tests.ts
+++ b/types/json-ptr/json-ptr-tests.ts
@@ -1,0 +1,52 @@
+import JsonPointer = require('json-ptr');
+
+// JsonPointer static
+const JsonPointer1: typeof JsonPointer = JsonPointer.JsonPointer;
+const JsonReference1: typeof JsonPointer.JsonReference = JsonPointer.JsonReference;
+const create1: JsonPointer = JsonPointer.create('');
+const staticHas1: boolean = JsonPointer.has({}, '');
+const staticGet1: unknown = JsonPointer.get({}, '');
+const staticSet1: unknown = JsonPointer.set({}, '', undefined);
+const staticSet2: unknown = JsonPointer.set({}, '', undefined, false);
+const staticSet3: unknown = JsonPointer.set({}, '', undefined, true);
+const list1: readonly JsonPointer.JsonStringPointerListItem[] = JsonPointer.list({});
+const list2: readonly JsonPointer.JsonStringPointerListItem[] = JsonPointer.list({}, false);
+const list3: readonly JsonPointer.UriFragmentIdentifierPointerListItem[] = JsonPointer.list({}, true);
+const flatten1: Record<JsonPointer.JsonStringPointer, unknown> = JsonPointer.flatten({});
+const flatten2: Record<JsonPointer.JsonStringPointer, unknown> = JsonPointer.flatten({}, false);
+const flatten3: Record<JsonPointer.UriFragmentIdentifierPointer, unknown> = JsonPointer.flatten({}, true);
+const map1: Map<JsonPointer.JsonStringPointer, unknown> = JsonPointer.map({});
+const map2: Map<JsonPointer.JsonStringPointer, unknown> = JsonPointer.map({}, false);
+const map3: Map<JsonPointer.UriFragmentIdentifierPointer, unknown> = JsonPointer.map({}, true);
+JsonPointer.visit({}, (pointer: JsonPointer.JsonStringPointer, value: unknown) => {
+});
+JsonPointer.visit({}, (pointer: JsonPointer.JsonStringPointer, value: unknown) => {
+}, false);
+JsonPointer.visit({}, (pointer: JsonPointer.JsonStringPointer, value: unknown | JsonPointer.JsonReference) => {
+}, true);
+const decode1: JsonPointer.PathSegments = JsonPointer.decode('');
+const decodePointer1: JsonPointer.PathSegments = JsonPointer.decodePointer('');
+const encodePointer1: JsonPointer.JsonStringPointer = JsonPointer.encodePointer([]);
+const decodeUriFragmentIdentifier1: JsonPointer.PathSegments = JsonPointer.decodeUriFragmentIdentifier('');
+const encodeUriFragmentIdentifier1: JsonPointer.UriFragmentIdentifierPointer = JsonPointer.encodeUriFragmentIdentifier([]);
+const jsonPointerIsReference1: boolean = JsonPointer.isReference({});
+const noConflict1: typeof JsonPointer = JsonPointer.noConflict();
+
+// JsonReference static
+const jsonReferenceIsReference1: boolean = JsonPointer.JsonReference.isReference({});
+
+// JsonPointer instance
+const jsonPointer: JsonPointer = new JsonPointer('');
+const path1: JsonPointer.PathSegments = jsonPointer.path;
+const pointer1: JsonPointer.JsonStringPointer = jsonPointer.pointer;
+const uriFragmentIdentifier1: JsonPointer.JsonStringPointer = jsonPointer.uriFragmentIdentifier;
+const instanceHas1: boolean = jsonPointer.has({});
+const instanceGet1: unknown = jsonPointer.get({});
+const instanceSet1: unknown = jsonPointer.set({}, undefined);
+const instanceSet2: unknown = jsonPointer.set({}, undefined, false);
+const instanceSet3: unknown = jsonPointer.set({}, undefined, true);
+
+// JsonReference instance
+const jsonReference: JsonPointer.JsonReference = new JsonPointer.JsonReference(jsonPointer);
+const $ref1: JsonPointer.UriFragmentIdentifierPointer = jsonReference.$ref;
+const resolve1: unknown = jsonReference.resolve({});

--- a/types/json-ptr/tsconfig.json
+++ b/types/json-ptr/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "baseUrl": "../",
+        "forceConsistentCasingInFileNames": true,
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "typeRoots": [
+            "../"
+        ],
+        "types": []
+    },
+    "files": [
+        "index.d.ts",
+        "json-ptr-tests.ts"
+    ]
+}

--- a/types/json-ptr/tslint.json
+++ b/types/json-ptr/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.