### PR TITLE
feat(karma-junit-reporter): type definition for JUnit reporter

### DIFF
--- a/types/karma-junit-reporter/index.d.ts
+++ b/types/karma-junit-reporter/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for karma-junit-reporter 2.0
+// Project: https://github.com/karma-runner/karma-junit-reporter#readme
+// Definitions by: Piotr Błażejewicz (Peter Blazejewicz) <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.2
+
+import 'karma';
+
+declare module 'karma' {
+    interface ConfigOptions {
+        junitReporter?: JUnitReporterConfiguration;
+    }
+
+    interface JUnitReporterConfiguration {
+        /** results will be saved as $outputDir/$browserName.xml */
+        outputDir?: string;
+        /** if included, results will be saved as $outputDir/$browserName/$outputFile */
+        outputFile?: string;
+        /** suite will become the package name attribute in xml testsuite element */
+        suite?: string;
+        /** add browser name to report and classes names */
+        useBrowserName?: boolean;
+        /** function (browser, result) to customize the name attribute in xml testcase element */
+        nameFormatter?: (browser: any, result: any) => string;
+        /** function (browser, result) to customize the classname attribute in xml testcase element */
+        classNameFormatter?: (browser: any, result: any) => string;
+        /** key value pair of properties to add to the <properties> section of the report */
+        properties?: {
+            [key: string]: any;
+        };
+        /** use '1' if reporting to be per SonarQube 6.2 XML format */
+        xmlVersion?: number | null;
+    }
+}

--- a/types/karma-junit-reporter/karma-junit-reporter-tests.ts
+++ b/types/karma-junit-reporter/karma-junit-reporter-tests.ts
@@ -1,0 +1,36 @@
+import karma = require('karma');
+
+// See https://github.com/karma-runner/karma-coverage/blob/v1.1.2/README.md#basic
+module.exports = (config: karma.Config) => {
+    config.set({
+        files: ['src/**/*.js', 'test/**/*.js'],
+
+        // coverage reporter generates the coverage
+        reporters: ['progress', 'coverage', 'junit'],
+
+        preprocessors: {
+            // source files, that you wanna generate coverage for
+            // do not include tests or libraries
+            // (these files will be instrumented by Istanbul)
+            'src/**/*.js': ['coverage'],
+        },
+
+        // the default configuration
+        junitReporter: {
+            outputDir: 'junit',
+            outputFile: 'test-resutls.xml',
+            suite: 'tests',
+            useBrowserName: true,
+            nameFormatter: (browser, result) => {
+                return browser.id + '-browser';
+            },
+            classNameFormatter: (browser, result) => {
+                return browser.name + '-class';
+            },
+            properties: {
+                isValid: true,
+            },
+            xmlVersion: 1,
+        },
+    });
+};

--- a/types/karma-junit-reporter/tsconfig.json
+++ b/types/karma-junit-reporter/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "karma-junit-reporter-tests.ts"
+    ]
+}

--- a/types/karma-junit-reporter/tslint.json
+++ b/types/karma-junit-reporter/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- new type definition covering v2 of `karma-junit-reporter`
- tests based on documented api

Thanks!

https://github.com/karma-runner/karma-junit-reporter#readme

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.