### PR TITLE
Change koa-ejs ctx.render 'properties' values type to 'any' from 'string'

### DIFF
--- a/types/koa-ejs/index.d.ts
+++ b/types/koa-ejs/index.d.ts
@@ -8,7 +8,8 @@ import * as Koa from "koa";
 
 declare module "Koa" {
   interface ExtendableContext {
-    render: (template: string, properties?: {[name: string]: string}) => Promise<string>;
+    /** Properties values can be of any format; e.g. string, number, boolean, or even nested objects of these types */
+    render: (template: string, properties?: {[name: string]: any}) => Promise<string>;
   }
 }
 


### PR DESCRIPTION
Change koa-ejs ctx.render properties type to 'any' to allow for nested objects and other types than 'string'.

v4.2.1 introduced the ctx.render types, but incorrectly sets the second argument to type { [key: string]: string }. Whilst the keys should be strings, the values can be booleans, numbers, nested objects and more.
____________________________________________________

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/ejs/blob/master/example/app.js (you can see on L36-38 users property is an array of objects).
