### PR TITLE
[Cesium] Fix 1.66 header and Material translucent option type

### DIFF
--- a/types/cesium/index.d.ts
+++ b/types/cesium/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for cesium 1.65
+// Type definitions for cesium 1.66
 // Project: http://cesiumjs.org
 // Definitions by: Aigars Zeiza <https://github.com/Zuzon>
 //                 Harry Nicholls <https://github.com/hnipps>
@@ -3867,7 +3867,7 @@ declare namespace Cesium {
         static PolylineOutlineType: string;
         constructor(options?: {
             strict?: boolean;
-            translucent?: boolean;
+            translucent?: boolean | ((material: Material) => boolean);
             fabric: any;
             minificationFilter?: TextureMinificationFilter;
             magnificationFilter?: TextureMagnificationFilter;


### PR DESCRIPTION
PR #42113 updated the typings to match version 1.66, but did not update the header number. Additionally, the PR incorrectly set the type for the `translucent` option in the `Material` constructor: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42113/files#diff-1d8d1ddef633ea30e07b80cfec6b7da6R3870