### PR TITLE
express-fileupload: Fixed typing of 'responseOnLimit' from boolean to string

### DIFF
--- a/types/express-fileupload/express-fileupload-tests.ts
+++ b/types/express-fileupload/express-fileupload-tests.ts
@@ -39,7 +39,7 @@ app.use(fileUpload({ safeFileNames: true }));
 app.use(fileUpload({ safeFileNames: true, preserveExtension: true }));
 app.use(fileUpload({ safeFileNames: true, preserveExtension: 2 }));
 app.use(fileUpload({ abortOnLimit: true }));
-app.use(fileUpload({ responseOnLimit: true }));
+app.use(fileUpload({ responseOnLimit: 'Size Limit reached' }));
 app.use(fileUpload({ limitHandler: true }));
 app.use(
     fileUpload({

--- a/types/express-fileupload/index.d.ts
+++ b/types/express-fileupload/index.d.ts
@@ -74,7 +74,7 @@ declare namespace fileUpload {
         /**
          * Response which will be send to client if file size limit exceeded when `abortOnLimit` set to `true`.
          */
-        responseOnLimit?: boolean;
+        responseOnLimit?: string;
         /**
          * User defined limit handler which will be invoked if the file is bigger than configured limits.
          */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/richardgirges/express-fileupload/blob/master/lib/index.js
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
