### PR TITLE
[braintree] Fix the type of the account updater webhook notification

### DIFF
--- a/types/braintree/braintree-tests.ts
+++ b/types/braintree/braintree-tests.ts
@@ -123,9 +123,26 @@ const gateway: BraintreeGateway = new braintree.BraintreeGateway({
     const notification = await gateway.webhookNotification.parse(sampleResponse.bt_signature, sampleResponse.bt_payload).catch(console.error);
     if (!notification) return;
 
-    // this should cause the type of `notification` to be narrowed to `SubscriptionNotification`
+    // this should cause the type of `notification` to be narrowed to `PaymentMethodNotification`
     if (notification.kind !== kind) return;
 
     const metadata = notification.revokedPaymentMethodMetadata;
     if (!metadata.revokedPaymentMethod) return;
+})();
+
+(async () => {
+    const kind: WebhookNotificationKind = 'account_updater_daily_report';
+    const subscriptionId = '123456';
+
+    const sampleResponse = await gateway.webhookTesting.sampleNotification(kind, subscriptionId).catch(console.error);
+    if (!sampleResponse) return;
+
+    const notification = await gateway.webhookNotification.parse(sampleResponse.bt_signature, sampleResponse.bt_payload).catch(console.error);
+    if (!notification) return;
+
+    // this should cause the type of `notification` to be narrowed to `AccountUpdaterNotification`
+    if (notification.kind !== kind) return;
+
+    const reportUrl = notification.accountUpdaterDailyReport.reportUrl;
+    if (!reportUrl) return;
 })();

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -828,6 +828,14 @@ declare namespace braintree {
         | 'SamsungPayCard';
 
     /**
+     * Account Updater
+     */
+    export class AccountUpdaterDailyReport {
+        reportDate: Date;
+        reportUrl: string;
+    }
+
+    /**
      * Webhooks
      */
 
@@ -868,8 +876,7 @@ declare namespace braintree {
 
     export interface AccountUpdaterNotification extends BaseWebhookNotification {
         kind: AccountUpdaterNotificationKind;
-        reportDate: Date;
-        reportUrl: string;
+        accountUpdaterDailyReport: AccountUpdaterDailyReport;
     }
 
     export interface PaymentMethodNotification extends BaseWebhookNotification {


### PR DESCRIPTION
The Braintree documentation for the [Account Updater](https://developers.braintreepayments.com/reference/general/webhooks/account-updater/node) webhook states that `reportDate` and `reportUrl` are top-level properties of the webhook object, but using the Braintree SDK's `sampleNotification` function reveals that a different data structure is returned.
```
{
  "timestamp": "2020-02-13T16:01:05Z",
  "kind": "account_updater_daily_report",
  "subject": {
    "accountUpdaterDailyReport": {
      "reportDate": "2016-01-14",
      "reportUrl": "link-to-csv-report"
    }
  },
  "accountUpdaterDailyReport": {
    "reportDate": "2016-01-14",
    "reportUrl": "link-to-csv-report"
  }
}
```
I have confirmed with Braintree support that this is correct:
```I am assured by our internal SDK Engineers that what you are encountering is in fact not a bug. The webhook notification class will translate the webhook to the specific type of object necessary. That is why you see a WebhookNotification object with an accountUpdaterDailyReport parameter that is the class AccountUpdaterDailyReport​.```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

