### PR TITLE
[react-query] Fix specificity of paginated function overload

### DIFF
--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -7,18 +7,18 @@
 
 import { ComponentType } from 'react';
 
+// overloaded useQuery function with pagination
+export function useQuery<TResult, TVariables extends object>(
+    queryKey: QueryKey<TVariables>,
+    queryFn: QueryFunction<TResult, TVariables>,
+    options: QueryOptionsPaginated<TResult>
+): QueryResultPaginated<TResult, TVariables>;
+
 export function useQuery<TResult, TVariables extends object>(
     queryKey: QueryKey<TVariables>,
     queryFn: QueryFunction<TResult, TVariables>,
     options?: QueryOptions<TResult>
 ): QueryResult<TResult, TVariables>;
-
-// overloaded useQuery function with pagination
-export function useQuery<TResult, TVariables extends object>(
-    queryKey: QueryKey<TVariables>,
-    queryFn: QueryFunction<TResult, TVariables>,
-    options?: QueryOptionsPaginated<TResult>
-): QueryResultPaginated<TResult, TVariables>;
 
 export type QueryKey<TVariables> = string | [string, TVariables] | false | null | QueryKeyFunction<TVariables>;
 export type QueryKeyFunction<TVariables> = () => string | [string, TVariables] | false | null;

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -38,6 +38,7 @@ queryNested.data; // $ExpectType number | null
 
 // Paginated mode
 const queryPaginated = useQuery('key', () => Promise.resolve({data: [1, 2, 3], next: true}), {
+    refetchInterval: 1000,
     paginated: true,
     getCanFetchMore: (lastPage, allPages) => lastPage.next
 });


### PR DESCRIPTION
If options can be assigned to both the paginated and non-paginated overloads, the non-paginated overload was taking precedence. Function overloads should be ordered from most-specific to least-specific so the correct one is picked.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/functions.html#overloads

