### PR TITLE
[react-table] v7: fix getRowId type signature

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -112,7 +112,7 @@ export type UseTableOptions<D extends object> = {
     defaultColumn: Partial<Column<D>>;
     initialRowStateKey: IdType<D>;
     getSubRows: (originalRow: D, relativeIndex: number) => D[];
-    getRowId: (originalRow: D, relativeIndex: number) => IdType<D>;
+    getRowId: (originalRow: D, relativeIndex: number, parent?: Row<D>) => string;
 }>;
 
 export type PropGetter<D extends object, Props, T extends object = never, P = Partial<Props>> =


### PR DESCRIPTION
The signature for `getRowId` was incorrect, this fixes it. See https://github.com/tannerlinsley/react-table/blob/master/docs/api/useTable.md for details.


