### PR TITLE
wordpress__data: Add unsubscribe return to subscribe

### DIFF
--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -18,10 +18,29 @@ export { Action, combineReducers };
 //
 export type SelectorMap = Record<string, <T = unknown>(...args: readonly any[]) => T>;
 export type DispatcherMap = Record<string, <T = void>(...args: readonly any[]) => T>;
-export type Subscriber = (callback: () => void) => void;
+
+/**
+ * Subscribe to any changes to the store
+ *
+ * @param callback Will be invoked whenever there are any updates to the store.
+ * @returns        A callback that can be invoked to unsubscribe.
+ *
+ * @example
+ *
+ * const unsubscribe = subscribe( () => {
+ *     // You could use this opportunity to test whether the derived result of a
+ *     // selector has subsequently changed as the result of a state update.
+ * } );
+ *
+ * // Later, if necessary...
+ * unsubscribe();
+ *
+ */
+export type Subscriber = (callback: () => void) => () => void;
 
 export function dispatch(key: string): DispatcherMap;
 export function select(key: string): SelectorMap;
+
 export const subscribe: Subscriber;
 
 //

--- a/types/wordpress__data/wordpress__data-tests.tsx
+++ b/types/wordpress__data/wordpress__data-tests.tsx
@@ -3,6 +3,9 @@ import * as data from '@wordpress/data';
 data.select('core/block-editor').isTyping<boolean>();
 data.dispatch('core/block-editor').resetBlocks('');
 
+const unsubscribe = data.subscribe(() => console.log('Store was updated.'));
+unsubscribe();
+
 data.use(data.plugins.persistence, { storage: window.localStorage });
 
 interface FooBar {


### PR DESCRIPTION
The `subscribe` functions in `@wordpress/data` return an `unsubscribe` callback to unsubscribe.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.wordpress.org/block-editor/packages/packages-data/#subscribe