### PR TITLE
Fix socketcluster-client and socketcluster-server type definitions

### DIFF
--- a/types/socketcluster-client/lib/clientsocket.d.ts
+++ b/types/socketcluster-client/lib/clientsocket.d.ts
@@ -412,8 +412,8 @@ declare namespace AGClientSocket {
     }
 
     interface SubscribeStateChangeData extends SubscribeData {
-        oldState: AGChannel.ChannelState;
-        newState: AGChannel.ChannelState;
+        oldChannelState: AGChannel.ChannelState;
+        newChannelState: AGChannel.ChannelState;
     }
 
     interface SubscribeData {

--- a/types/socketcluster-client/socketcluster-client-tests.ts
+++ b/types/socketcluster-client/socketcluster-client-tests.ts
@@ -84,6 +84,23 @@ socket.transmitPublish('myChannel', 'This is a message');
     authStatus.isAuthenticated;
 })();
 
+(async () => {
+    // tslint:disable-next-line: await-promise Bug in tslint: https://github.com/palantir/tslint/issues/3997
+    for await (const event of socket.listener('subscribeStateChange')) {
+        // $ExpectType string
+        event.channel;
+
+        // $ExpectType ChannelState
+        event.oldChannelState;
+
+        // $ExpectType ChannelState
+        event.newChannelState;
+
+        // $ExpectType SubscribeOptions
+        event.subscriptionOptions;
+    }
+})();
+
 const mostOptions = {
     path: '/socketcluster/',
     port: 8000,

--- a/types/socketcluster-server/server.d.ts
+++ b/types/socketcluster-server/server.d.ts
@@ -198,7 +198,7 @@ declare namespace AGServer {
 
         // Can be 1 or 2. Version 1 is for maximum backwards
         // compatibility with SocketCluster clients.
-        protocolVersion: 1 | 2;
+        protocolVersion?: 1 | 2;
 
         // In milliseconds - If the socket handshake hasn't been
         // completed before this timeout is reached, the new

--- a/types/socketcluster-server/socketcluster-server-tests.ts
+++ b/types/socketcluster-server/socketcluster-server-tests.ts
@@ -41,3 +41,5 @@ agServer = socketClusterServer.attach(httpServer, {
     protocolVersion: 1,
     path: '/socketcluster/',
 });
+
+agServer = socketClusterServer.attach(httpServer, {});


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/SocketCluster/socketcluster-client/blob/master/lib/clientsocket.js#L849 https://github.com/SocketCluster/socketcluster-server/blob/master/server.js#L36
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
