### PR TITLE
fix FilterQuery when use RootQuerySelector

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1386,7 +1386,7 @@ export type Condition<T> = MongoAltQuery<T> | QuerySelector<MongoAltQuery<T>>;
 
 export type FilterQuery<T> = {
     [P in keyof T]?: Condition<T[P]>;
-} &
+} |
     RootQuerySelector<T>;
 
 /** http://docs.mongodb.org/manual/reference/command/collStats/ */


### PR DESCRIPTION
The following code is supposed to compile.
```javascript
const queries:Array<FilterQuery<ReturnType>> = [];
const condition :RootQuerySelector<ReturnType> = { $or: queries};
const result = await collection.find<ReturnType>(condition).toArray();
```
But getting the following error:
```
No overload matches this call.
  Overload 1 of 2, '(query?: FilterQuery<ReturnType>): Cursor<ReturnType>', gave the following error.
    Argument of type 'RootQuerySelector<ReturnType>' is not assignable to parameter of type 'FilterQuery<ReturnType>'.
      Type 'RootQuerySelector<ReturnType>' is not assignable to type '{ [P in keyof ReturnType]?: Condition<ReturnType[P]>; }'.
  Overload 2 of 2, '(query: FilterQuery<ReturnType>, options?: FindOneOptions): Cursor<ReturnType>', gave the following error.
    Argument of type 'RootQuerySelector<ReturnType>' is not assignable to parameter of type 'FilterQuery<ReturnType>'.
      Type 'RootQuerySelector<ReturnType>' is not assignable to type '{ [P in keyof ReturnType]?: Condition<ReturnType[P]>; }'.ts(2769)
```