### PR TITLE
Add redisURL option in RedisStoreOptions type

### DIFF
--- a/types/rate-limit-redis/index.d.ts
+++ b/types/rate-limit-redis/index.d.ts
@@ -12,6 +12,7 @@ interface RedisStoreOptions {
     prefix?: string;
     resetExpiryOnChange?: boolean;
     client?: RedisClient;
+    redisURL?: string;
 }
 
 declare function RedisStore(options?: RedisStoreOptions): Store;

--- a/types/rate-limit-redis/index.d.ts
+++ b/types/rate-limit-redis/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for rate-limit-redis 1.6
 // Project: https://github.com/wyattjoh/rate-limit-redis#readme
 // Definitions by: Chris Suich <https://github.com/csuich2>
+//                 Nicolas Torres <https://github.com/noclat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 

--- a/types/rate-limit-redis/package.json
+++ b/types/rate-limit-redis/package.json
@@ -1,6 +1,8 @@
 {
     "private": true,
     "dependencies": {
-        "express-rate-limit": ">=3.4.0"
+        "express-rate-limit": ">=3.4.0",
+        "rate-limit-redis": "^1.7.0",
+        "redis": "^3.0.2"
     }
 }

--- a/types/rate-limit-redis/rate-limit-redis-tests.ts
+++ b/types/rate-limit-redis/rate-limit-redis-tests.ts
@@ -26,3 +26,8 @@ store = RedisStore({
 store = RedisStore({
     client: new RedisClient({}),
 });
+
+// $ExpectType Store
+store = RedisStore({
+    redisURL: 'redis://localhost:6379',
+});


### PR DESCRIPTION
`redisURL` Store option type was missing, but the option exists both in [documentation](https://github.com/wyattjoh/rate-limit-redis) and [code](https://github.com/wyattjoh/rate-limit-redis/blob/master/lib/redis-store.js#L10).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [documentation](https://github.com/wyattjoh/rate-limit-redis) and [code](https://github.com/wyattjoh/rate-limit-redis/blob/master/lib/redis-store.js#L10)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.