### PR TITLE
[chrome] Match chrome.tabCapture.CaptureOptions with IDL definition

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8,6 +8,7 @@
 //                 MatCarlson <https://github.com/MatCarlson>
 //                 ekinsol <https://github.com/ekinsol>
 //                 Thierry Régagnon <https://github.com/tregagnon>
+//                 Brian Wilson <https://github.com/echoabstract>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -6883,15 +6884,20 @@ declare namespace chrome.tabCapture {
         fullscreen: boolean;
     }
 
+    export interface MediaStreamConstraint {
+        mandatory: object;
+        optional?: object;
+    }
+
     export interface CaptureOptions {
         /** Optional. */
         audio?: boolean;
         /** Optional. */
         video?: boolean;
         /** Optional. */
-        audioConstraints?: MediaStreamConstraints;
+        audioConstraints?: MediaStreamConstraint;
         /** Optional. */
-        videoConstraints?: MediaStreamConstraints;
+        videoConstraints?: MediaStreamConstraint;
     }
 
     export interface CaptureStatusChangedEvent extends chrome.events.Event<(info: CaptureInfo) => void> { }

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -326,6 +326,42 @@ function testOptionsPage() {
   });
 }
 
+// https://developer.chrome.com/extensions/tabCapture#type-CaptureOptions
+function testTabCaptureOptions() {
+    // Constraints based on:
+    // https://github.com/muaz-khan/WebRTC-Experiment/blob/master/Chrome-Extensions/tabCapture/tab-capturing.js
+
+    const resolutions = {
+        maxWidth: 1920,
+        maxHeight: 1080,
+    };
+
+    const constraints: chrome.tabCapture.CaptureOptions = {
+        audio: true,
+        video: true,
+        audioConstraints: {
+            mandatory: {
+                chromeMediaSource: 'tab',
+                echoCancellation: true
+            }
+        },
+        videoConstraints: {
+            mandatory: {
+                chromeMediaSource: 'tab',
+                maxWidth: resolutions.maxWidth,
+                maxHeight: resolutions.maxHeight,
+                minFrameRate: 30,
+                minAspectRatio: 1.77
+            }
+        }
+    };
+
+    let constraints2: chrome.tabCapture.CaptureOptions;
+    constraints2 = constraints;
+}
+
+
+
 // https://developer.chrome.com/extensions/debugger
 function testDebugger() {
 	chrome.debugger.attach({tabId: 123}, '1.23', () => {


### PR DESCRIPTION
In both the documentation and the IDL for tabCapture chrome uses
the confusing name `MediaStreamConstraint` which is not similar to
the actual `MediaStreamConstraints` browser type.  In the IDL the
documentation claims (incorrectly) that it's MediaTrackConstraints,
but there are additional undocumented supported fields so the type
ends up as `Object`:

See:

https://chromium.googlesource.com/chromium/src/+/b79156a434f215444989be10c007a1a992280108/chrome/common/extensions/api/tab_capture.idl#27

NOTE: This should be a non-breaking change as the `object` type is less strict and the previous definition would not work with current chrome.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://chromium.googlesource.com/chromium/src/+/b79156a434f215444989be10c007a1a992280108/chrome/common/extensions/api/tab_capture.idl#27
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
