### PR TITLE
fix(fs-extra): missing `createSymlink`

### DIFF
--- a/types/fs-extra/fs-extra-tests.ts
+++ b/types/fs-extra/fs-extra-tests.ts
@@ -235,3 +235,7 @@ fs.mkdtemp("foo");
 fs.copyFile("src", "dest").then();
 fs.copyFile("src", "dest", fs.constants.COPYFILE_EXCL).then();
 fs.copyFile("src", "dest", errorCallback);
+
+fs.createSymlink("src", "dest", "dir").then();
+fs.createSymlink("src", "dest", "file").then();
+fs.createSymlink("src", "dest", "dir", errorCallback);

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for fs-extra 8.0
+// Type definitions for fs-extra 8.1
 // Project: https://github.com/jprichardson/node-fs-extra
 // Definitions by: Alan Agius <https://github.com/alan-agius4>,
 //                 midknight41 <https://github.com/midknight41>,
@@ -7,6 +7,7 @@
 //                 Justin Rockwood <https://github.com/jrockwood>,
 //                 Sang Dang <https://github.com/sangdth>,
 //                 Florian Keller <https://github.com/ffflorian>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -34,6 +35,10 @@ export function moveSync(src: string, dest: string, options?: MoveOptions): void
 export function createFile(file: string): Promise<void>;
 export function createFile(file: string, callback: (err: Error) => void): void;
 export function createFileSync(file: string): void;
+
+export function createSymlink(src: string, dest: string, type: SymlinkType): Promise<void>;
+export function createSymlink(src: string, dest: string, type: SymlinkType, callback?: (err: Error) => void): void;
+export function createSymlinkSync(src: string, dest: string, type: SymlinkType): void;
 
 export function ensureDir(path: string, options?: EnsureOptions | number): Promise<void>;
 export function ensureDir(path: string, options?: EnsureOptions | number, callback?: (err: Error) => void): void;


### PR DESCRIPTION
Missed:
- `createSymlink`
- `createSymlinkSync`

see: jprichardson/node-fs-extra#758
see: cucumber/cucumber-js#1286

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jprichardson/node-fs-extra/blob/5b29ae3aa5198c33820a07eaa4493a5b6d01fa82/lib/ensure/symlink.js#L60-L63
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.