### PR TITLE
fix [poker-evaluator] Card type too rigid

### DIFF
--- a/types/poker-evaluator/index.d.ts
+++ b/types/poker-evaluator/index.d.ts
@@ -6,11 +6,10 @@
 /// <reference types="node" />
 
 export const HANDTYPES: HandName[];
-export const CARDS: Deck;
 export const ranks: Buffer;
 
-export function evalHand(cards: Card[]): EvaluatedHand;
-export function evalCard(card: Card): number;
+export function evalHand(cards: string[]): EvaluatedHand;
+export function evalCard(card: string): number;
 
 export type HandName =
     'invalid hand' |
@@ -25,61 +24,8 @@ export type HandName =
     'straight flush';
 
 export interface Deck {
-    '2c': 1;
-    '2d': 2;
-    '2h': 3;
-    '2s': 4;
-    '3c': 5;
-    '3d': 6;
-    '3h': 7;
-    '3s': 8;
-    '4c': 9;
-    '4d': 10;
-    '4h': 11;
-    '4s': 12;
-    '5c': 13;
-    '5d': 14;
-    '5h': 15;
-    '5s': 16;
-    '6c': 17;
-    '6d': 18;
-    '6h': 19;
-    '6s': 20;
-    '7c': 21;
-    '7d': 22;
-    '7h': 23;
-    '7s': 24;
-    '8c': 25;
-    '8d': 26;
-    '8h': 27;
-    '8s': 28;
-    '9c': 29;
-    '9d': 30;
-    '9h': 31;
-    '9s': 32;
-    'tc': 33;
-    'td': 34;
-    'th': 35;
-    'ts': 36;
-    'jc': 37;
-    'jd': 38;
-    'jh': 39;
-    'js': 40;
-    'qc': 41;
-    'qd': 42;
-    'qh': 43;
-    'qs': 44;
-    'kc': 45;
-    'kd': 46;
-    'kh': 47;
-    'ks': 48;
-    'ac': 49;
-    'ad': 50;
-    'ah': 51;
-    'as': 52;
+    [key: string]: number;
 }
-
-export type Card = keyof Deck;
 
 export interface EvaluatedHand {
     handType: number; // Index of HANDTYPES array

--- a/types/poker-evaluator/poker-evaluator-tests.ts
+++ b/types/poker-evaluator/poker-evaluator-tests.ts
@@ -1,7 +1,6 @@
-import { HandName, Deck, Card, EvaluatedHand, CARDS, HANDTYPES, evalHand, ranks, evalCard } from 'poker-evaluator';
+import { Deck, evalCard, evalHand, EvaluatedHand, HandName, HANDTYPES, ranks } from 'poker-evaluator';
 
 HANDTYPES; // $ExpectType HandName[]
-CARDS; // $ExpectType Deck
 ranks; // $ExpectType Buffer
 
 evalHand(['as', 'ks', 'qs', 'js', 'ts', '3c', '5h']); // $ExpectType EvaluatedHand
@@ -15,7 +14,6 @@ const result: EvaluatedHand = {
 evalCard('as'); // $ExpectType number
 
 const highCardName: HandName = 'high card';
-const card: Card = '2c';
 const deck: Deck = {
     '2c': 1,
     '2d': 2,


### PR DESCRIPTION
Simplify Deck interface from rigid lowercase '2c', '2d' etc to `key: string`. Remove Card as a type (use `string` instead of `keyof Deck`).  This is because [poker-evaluator's public `evalHand` method](https://github.com/chenosaurus/poker-evaluator/blob/master/lib/PokerEvaluator.js#L74) accepts uppercase/lowercase/mixed-case strings as card inputs (converting to lowercase internally) so the current typing is too strict.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [toLowerCase() call, showing e.g. uppercase "Card" is valid](https://github.com/chenosaurus/poker-evaluator/blob/master/lib/PokerEvaluator.js#L91)
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~ tslint exists already in types/poker-evaluator

