### PR TITLE
[@types/leaflet.gridlayer.googlemutant] add GoogleLayer methods to GoogleMutant interface

### DIFF
--- a/types/leaflet.gridlayer.googlemutant/index.d.ts
+++ b/types/leaflet.gridlayer.googlemutant/index.d.ts
@@ -10,6 +10,26 @@ declare module 'leaflet' {
     namespace gridLayer {
         interface GoogleMutant extends GridLayer {
             setElementSize(e: HTMLElement, size: Point): void ;
+
+            /**
+             * Add additional Google Maps layer.
+             *
+             * https://developers.google.com/maps/documentation/javascript/trafficlayer
+             *
+             * @param googleLayerName such as BicyclingLayer, TrafficLayer, or TransitLayer.
+             * @param options? constructor arguments to pass through to the google layer.
+             * @returns Promise for the native Google Maps Layer instance.
+             */
+            addGoogleLayer(googleLayerName: string, options?: object): Promise<object>;
+
+            /**
+             * Removes Google Maps layer.
+             *
+             *  https://developers.google.com/maps/documentation/javascript/trafficlayer
+             *
+             * @param googleLayerName such as BicyclingLayer, TrafficLayer, or TransitLayer.
+             */
+            removeGoogleLayer(googleLayerName: string): void;
         }
 
         type GoogleMutantType = 'roadmap' | 'satellite' | 'terrain' | 'hybrid';

--- a/types/leaflet.gridlayer.googlemutant/index.d.ts
+++ b/types/leaflet.gridlayer.googlemutant/index.d.ts
@@ -9,7 +9,7 @@ import * as L from 'leaflet';
 declare module 'leaflet' {
     namespace gridLayer {
         interface GoogleMutant extends GridLayer {
-            setElementSize(e: HTMLElement, size: Point): void ;
+            setElementSize(e: HTMLElement, size: Point): void;
 
             /**
              * Add additional Google Maps layer.

--- a/types/leaflet.gridlayer.googlemutant/leaflet.gridlayer.googlemutant-tests.ts
+++ b/types/leaflet.gridlayer.googlemutant/leaflet.gridlayer.googlemutant-tests.ts
@@ -3,19 +3,22 @@ import 'leaflet.gridlayer.googlemutant';
 
 const map = L.map('foo');
 
-const roads = L.gridLayer.googleMutant({
-    type: 'roadmap'
-}).addTo(map);
+const roads = L.gridLayer
+    .googleMutant({
+        type: 'roadmap',
+    })
+    .addTo(map);
 
-const styled = L.gridLayer.googleMutant({
-    type: 'satellite',
-    styles: [
-        { elementType: 'labels', stylers: [ { visibility: 'off' } ] },
-        { featureType: 'water' , stylers: [ { color: '#444444'  } ] }
-    ]
-}).addTo(map);
+const styled = L.gridLayer
+    .googleMutant({
+        type: 'satellite',
+        styles: [
+            { elementType: 'labels', stylers: [{ visibility: 'off' }] },
+            { featureType: 'water', stylers: [{ color: '#444444' }] },
+        ],
+    })
+    .addTo(map);
 
-styled.addGoogleLayer('TrafficLayer')
-    .then(nativeTrafficLayer => {
-        styled.removeGoogleLayer('TrafficLayer');
-    });
+styled.addGoogleLayer('TrafficLayer').then(nativeTrafficLayer => {
+    styled.removeGoogleLayer('TrafficLayer');
+});

--- a/types/leaflet.gridlayer.googlemutant/leaflet.gridlayer.googlemutant-tests.ts
+++ b/types/leaflet.gridlayer.googlemutant/leaflet.gridlayer.googlemutant-tests.ts
@@ -14,3 +14,8 @@ const styled = L.gridLayer.googleMutant({
         { featureType: 'water' , stylers: [ { color: '#444444'  } ] }
     ]
 }).addTo(map);
+
+styled.addGoogleLayer('TrafficLayer')
+    .then(nativeTrafficLayer => {
+        styled.removeGoogleLayer('TrafficLayer');
+    });


### PR DESCRIPTION
Please fill in this template.

- [ X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [X ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: https://gitlab.com/IvanSanchez/Leaflet.GridLayer.GoogleMutant/-/blob/master/Leaflet.GoogleMutant.js#L124
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

This adds definitions to add additional layers such as traffic through GoogleMutant. The arguments passed through to Google Maps vary but seem to either be an object or none.