### PR TITLE
feat(@blazor/javascript-interop): type definition for Blazor interop

### DIFF
--- a/types/blazor__javascript-interop/blazor__javascript-interop-tests.ts
+++ b/types/blazor__javascript-interop/blazor__javascript-interop-tests.ts
@@ -1,0 +1,47 @@
+/// <reference lib="DOM" />
+//
+// see {@link https://docs.microsoft.com/en-us/aspnet/core/blazor/javascript-interop?view=aspnetcore-3.1}
+//
+const exampleJsFunctions = {
+    showPrompt(text: string | undefined) {
+        return prompt(text, 'Type your name here');
+    },
+    displayWelcome(welcomeMessage: string) {
+        document.getElementById('welcome')!.innerText = welcomeMessage;
+    },
+    returnArrayAsyncJs() {
+        DotNet.invokeMethodAsync<number[]>('BlazorSample', 'ReturnArrayAsync').then(data => {
+            data.push(4);
+            console.log(data);
+        });
+    },
+    sayHello(dotnetHelper: DotNet.DotNetObject) {
+        return dotnetHelper.invokeMethodAsync<string>('SayHello').then(r => console.log(r));
+    },
+};
+
+interface ColorFlags {
+    red: boolean;
+    green: boolean;
+    blue: boolean;
+}
+
+const testInteropApi = async (dotNetRef: DotNet.DotNetObject) => {
+    // validate api patterns
+    const tokens = [1, 2, 3];
+    DotNet.invokeMethod<string>('MyCoolApp.Core', 'Foo', 'First', 'Second'); // $ExpectType string
+    DotNet.invokeMethod<number>('MyCoolApp.Core', 'Foo', 1, 2); // $ExpectType number
+    const fooResults = await DotNet.invokeMethodAsync<string>('MyCoolApp.Core', 'Foo', 'First', 'Second'); // $ExpectType string
+    DotNet.invokeMethodAsync<string>('MyCoolApp.Core', 'Foo', 'First', 'Second'); // $ExpectType Promise<string>
+    DotNet.invokeMethodAsync<string>('MyCoolApp.Core', 'Foo', 'First', 'Second'); // $ExpectType Promise<string>
+    DotNet.invokeMethodAsync<void>('MyCoolApp.Core', 'Foo', ...tokens); // $ExpectType Promise<void>
+    DotNet.invokeMethodAsync<void>('MyCoolApp.Core', 'Foo', 5, ...tokens, 20, ...[25]); // $ExpectType Promise<void>
+    DotNet.invokeMethodAsync<ColorFlags>('MyCoolApp.Core', 'Foo', 1, 2, 3); // $ExpectType Promise<ColorFlags>
+    dotNetRef.invokeMethod<string>('MyCoolApp.Core', 'Foo', 'First', 'Second'); // $ExpectType string
+    dotNetRef.invokeMethod<number>('MyCoolApp.Core', 'Foo', 1, 2); // $ExpectType number
+    const fooResults2 = await dotNetRef.invokeMethodAsync<string>('MyCoolApp.Core', 'Foo', 'First', 'Second'); // $ExpectType string
+    dotNetRef.invokeMethodAsync<string>('MyCoolApp.Core', 'Foo', 'First', 'Second'); // $ExpectType Promise<string>
+    dotNetRef.invokeMethodAsync<void>('MyCoolApp.Core', 'Foo', ...tokens); // $ExpectType Promise<void>
+    dotNetRef.invokeMethodAsync<void>('MyCoolApp.Core', 'Foo', 5, ...tokens, 20, ...[25]); // $ExpectType Promise<void>
+    dotNetRef.invokeMethodAsync<ColorFlags>('MyCoolApp.Core', 'Foo', 1, 2, 3); // $ExpectType Promise<ColorFlags>
+};

--- a/types/blazor__javascript-interop/index.d.ts
+++ b/types/blazor__javascript-interop/index.d.ts
@@ -1,0 +1,56 @@
+// Type definitions for non-npm package blazor__javascript-interop 3.1
+// Project: https://docs.microsoft.com/en-us/aspnet/core/blazor/javascript-interop?view=aspnetcore-3.1
+// Definitions by: Piotr Błażejewicz (Peter Blazejewicz) <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.0
+
+// Here be dragons!
+// This is community-maintained definition file intended to ease the process of developing
+// high quality JavaScript interop code to be used in Blazor application from your C# .Net code.
+// Could be removed without a notice in case official definition types ships with Blazor itself.
+
+// tslint:disable:no-unnecessary-generics
+
+declare namespace DotNet {
+    /**
+     * Invokes the specified .NET public method synchronously. Not all hosting scenarios support
+     * synchronous invocation, so if possible use invokeMethodAsync instead.
+     *
+     * @param assemblyName The short name (without key/version or .dll extension) of the .NET assembly containing the method.
+     * @param methodIdentifier The identifier of the method to invoke. The method must have a [JSInvokable] attribute specifying this identifier.
+     * @param args Arguments to pass to the method, each of which must be JSON-serializable.
+     * @returns The result of the operation.
+     */
+    function invokeMethod<T>(assemblyName: string, methodIdentifier: string, ...args: any[]): T;
+    /**
+     * Invokes the specified .NET public method asynchronously.
+     *
+     * @param assemblyName The short name (without key/version or .dll extension) of the .NET assembly containing the method.
+     * @param methodIdentifier The identifier of the method to invoke. The method must have a [JSInvokable] attribute specifying this identifier.
+     * @param args Arguments to pass to the method, each of which must be JSON-serializable.
+     * @returns A promise representing the result of the operation.
+     */
+    function invokeMethodAsync<T>(assemblyName: string, methodIdentifier: string, ...args: any[]): Promise<T>;
+    /**
+     * Represents the .NET instance passed by reference to JavaScript.
+     */
+    interface DotNetObject {
+        /**
+         * Invokes the specified .NET instance public method synchronously. Not all hosting scenarios support
+         * synchronous invocation, so if possible use invokeMethodAsync instead.
+         *
+         * @param methodIdentifier The identifier of the method to invoke. The method must have a [JSInvokable] attribute specifying this identifier.
+         * @param args Arguments to pass to the method, each of which must be JSON-serializable.
+         * @returns The result of the operation.
+         */
+        invokeMethod<T>(methodIdentifier: string, ...args: any[]): T;
+        /**
+         * Invokes the specified .NET instance public method asynchronously.
+         *
+         * @param methodIdentifier The identifier of the method to invoke. The method must have a [JSInvokable] attribute specifying this identifier.
+         * @param args Arguments to pass to the method, each of which must be JSON-serializable.
+         * @returns A promise representing the result of the operation.
+         */
+        invokeMethodAsync<T>(methodIdentifier: string, ...args: any[]): Promise<T>;
+    }
+}

--- a/types/blazor__javascript-interop/tsconfig.json
+++ b/types/blazor__javascript-interop/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths":{
+            "@blazor/javascript-interop": ["blazor__javascript-interop"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "blazor__javascript-interop-tests.ts"
+    ]
+}

--- a/types/blazor__javascript-interop/tslint.json
+++ b/types/blazor__javascript-interop/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This is the outcome of the discussion from the AspNetCore project:
dotnet/aspnetcore#18902
The definition covers JavaScript part of the .Net Core Blazor integration with the JavaScript:
https://docs.microsoft.com/en-us/aspnet/core/blazor/javascript-interop?view=aspnetcore-3.1

- type definition based on @microsoft/dotnet-js-interop
- tests

The version number (major.minor) is taken off the .Net Core version (3.1)
The definition has exemption for `no-unnecessary-generics` TSLint rule, to stay synced strictly with the definition it was based on (`@microsoft/dotnet-js-interop` which has no public content available).

/cc @ryanelian @mkArtakMSFT

Thanks!

Please wait with merging until we get sign-off from MS folks

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If not, do not conflict with the name of an NPM package. (the official package is @microsoft/dotnet-js-interop and has no public api to consume)
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.