### PR TITLE
Add type declaration for gl-fbo

### DIFF
--- a/types/gl-fbo/gl-fbo-tests.ts
+++ b/types/gl-fbo/gl-fbo-tests.ts
@@ -1,0 +1,32 @@
+import texture2D = require('gl-texture2d');
+import glFBO from 'gl-fbo';
+
+type Texture = ReturnType<typeof texture2D>;
+
+const gl = new WebGLRenderingContext();
+
+glFBO(gl, [12, 34]);
+glFBO(gl, [12, 34], {preferFloat: true});
+glFBO(gl, [12, 34], {float: false});
+glFBO(gl, [12, 34], {color: 2});
+glFBO(gl, [12, 34], {depth: false});
+glFBO(gl, [12, 34], {stencil: false});
+
+const fbo = glFBO(gl, [12, 34]);
+fbo.bind();
+fbo.dispose();
+
+// $ExpectType [number, number]
+fbo.shape;
+
+// $ExpectType WebGLRenderingContext
+fbo.gl;
+
+// $ExpectType WebGLFramebuffer
+fbo.handle;
+
+// $ExpectType Texture[]
+fbo.color;
+
+// $ExpectType Texture | null
+fbo.depth;

--- a/types/gl-fbo/index.d.ts
+++ b/types/gl-fbo/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for gl-fbo 2.0
+// Project: https://github.com/stackgl/gl-fbo
+// Definitions by: Nick Krichevsky <https://github.com/ollien>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import texture2D = require('gl-texture2d');
+
+type Texture = ReturnType<typeof texture2D>;
+
+declare class FrameBuffer {
+    shape: [number, number];
+    gl: WebGLRenderingContext;
+    handle: WebGLFramebuffer;
+    color: Texture[];
+    depth: Texture|null;
+
+    bind(): void;
+    dispose(): void;
+}
+
+interface FrameBufferOptions {
+    preferFloat?: boolean;
+    float?: boolean;
+    color?: number;
+    depth?: boolean;
+    stencil?: boolean;
+}
+
+ declare function glFBO(
+     gl: WebGLRenderingContext,
+     shape: [number, number],
+     options?: FrameBufferOptions
+ ): FrameBuffer;
+
+ export = glFBO;

--- a/types/gl-fbo/tsconfig.json
+++ b/types/gl-fbo/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "gl-fbo-tests.ts"
+    ]
+}

--- a/types/gl-fbo/tslint.json
+++ b/types/gl-fbo/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR adds type declarations for [gl-fbo](https://www.npmjs.com/package/gl-fbo).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.