### PR TITLE
fix(react): forwardRef accepts a special rendering function

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -746,6 +746,11 @@ declare namespace React {
         (props: PropsWithChildren<P>, ref: Ref<T>): ReactElement | null;
         displayName?: string;
     }
+    /**
+     * @deprecated Use ForwardRefRenderingFunction. forwardRef doesn't accept a
+     *             "real" component.
+     */
+    interface RefForwardingComponent <T, P = {}> extends ForwardRefRenderingFunction<T, P> {}
 
     function forwardRef<T, P = {}>(render: ForwardRefRenderingFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -522,7 +522,7 @@ declare namespace React {
         displayName?: string;
     }
 
-    interface ForwardRefRenderingFunction<T, P = {}> {
+    interface ForwardRefRenderFunction<T, P = {}> {
         (props: PropsWithChildren<P>, ref: Ref<T>): ReactElement | null;
         displayName?: string;
     }
@@ -531,7 +531,7 @@ declare namespace React {
      * @deprecated Use ForwardRefRenderingFunction. forwardRef doesn't accept a
      *             "real" component.
      */
-    interface RefForwardingComponent <T, P = {}> extends ForwardRefRenderingFunction<T, P> {}
+    interface RefForwardingComponent <T, P = {}> extends ForwardRefRenderFunction<T, P> {}
 
     interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
         new (props: P, context?: any): Component<P, S>;
@@ -753,7 +753,7 @@ declare namespace React {
         propTypes?: WeakValidationMap<P>;
     }
 
-    function forwardRef<T, P = {}>(render: ForwardRefRenderingFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
 
     /** Ensures that the props do not include ref at all */
     type PropsWithoutRef<P> =

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -522,14 +522,6 @@ declare namespace React {
         displayName?: string;
     }
 
-    interface RefForwardingComponent<T, P = {}> {
-        (props: PropsWithChildren<P>, ref: Ref<T>): ReactElement | null;
-        propTypes?: WeakValidationMap<P>;
-        contextTypes?: ValidationMap<any>;
-        defaultProps?: Partial<P>;
-        displayName?: string;
-    }
-
     interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
         new (props: P, context?: any): Component<P, S>;
         propTypes?: WeakValidationMap<P>;
@@ -750,7 +742,12 @@ declare namespace React {
         propTypes?: WeakValidationMap<P>;
     }
 
-    function forwardRef<T, P = {}>(Component: RefForwardingComponent<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+    interface ForwardRefRenderingFunction<T, P = {}> {
+        (props: PropsWithChildren<P>, ref: Ref<T>): ReactElement | null;
+        displayName?: string;
+    }
+
+    function forwardRef<T, P = {}>(render: ForwardRefRenderingFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
 
     /** Ensures that the props do not include ref at all */
     type PropsWithoutRef<P> =

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -525,6 +525,14 @@ declare namespace React {
     interface ForwardRefRenderFunction<T, P = {}> {
         (props: PropsWithChildren<P>, ref: Ref<T>): ReactElement | null;
         displayName?: string;
+        /**
+         * defaultProps are not supported on render functions
+         */
+        defaultProps?: never;
+        /**
+         * propTypes are not supported on render functions
+         */
+        propTypes?: never;
     }
 
     /**

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -525,6 +525,8 @@ declare namespace React {
     interface ForwardRefRenderFunction<T, P = {}> {
         (props: PropsWithChildren<P>, ref: Ref<T>): ReactElement | null;
         displayName?: string;
+        // explicit rejected with `never` required due to
+        // https://github.com/microsoft/TypeScript/issues/36826
         /**
          * defaultProps are not supported on render functions
          */

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -522,6 +522,17 @@ declare namespace React {
         displayName?: string;
     }
 
+    interface ForwardRefRenderingFunction<T, P = {}> {
+        (props: PropsWithChildren<P>, ref: Ref<T>): ReactElement | null;
+        displayName?: string;
+    }
+
+    /**
+     * @deprecated Use ForwardRefRenderingFunction. forwardRef doesn't accept a
+     *             "real" component.
+     */
+    interface RefForwardingComponent <T, P = {}> extends ForwardRefRenderingFunction<T, P> {}
+
     interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
         new (props: P, context?: any): Component<P, S>;
         propTypes?: WeakValidationMap<P>;
@@ -741,16 +752,6 @@ declare namespace React {
         defaultProps?: Partial<P>;
         propTypes?: WeakValidationMap<P>;
     }
-
-    interface ForwardRefRenderingFunction<T, P = {}> {
-        (props: PropsWithChildren<P>, ref: Ref<T>): ReactElement | null;
-        displayName?: string;
-    }
-    /**
-     * @deprecated Use ForwardRefRenderingFunction. forwardRef doesn't accept a
-     *             "real" component.
-     */
-    interface RefForwardingComponent <T, P = {}> extends ForwardRefRenderingFunction<T, P> {}
 
     function forwardRef<T, P = {}>(render: ForwardRefRenderingFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
 

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -412,18 +412,13 @@ const ForwardingRefComponentPropTypes: React.WeakValidationMap<ForwardingRefComp
 ForwardingRefComponent.propTypes = ForwardingRefComponentPropTypes;
 
 // render function tests
-function ForwardRefRenderFunctionWithPropTypes() {
-    return null;
-}
-ForwardRefRenderFunctionWithPropTypes.propTypes = {};
+// need the explicit type declaration for typescript < 3.1
+const ForwardRefRenderFunctionWithPropTypes: { (): null, propTypes?: {} } = () => null;
 // Warning: forwardRef render functions do not support propTypes or defaultProps
 // $ExpectError
 React.forwardRef(ForwardRefRenderFunctionWithPropTypes);
 
-function ForwardRefRenderFunctionWithDefaultProps() {
-    return null;
-}
-ForwardRefRenderFunctionWithDefaultProps.defaultProps = {};
+const ForwardRefRenderFunctionWithDefaultProps: { (): null, defaultProps?: {} } = () => null;
 // Warning: forwardRef render functions do not support propTypes or defaultProps
 // $ExpectError
 React.forwardRef(ForwardRefRenderFunctionWithDefaultProps);

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -411,6 +411,23 @@ const ForwardingRefComponent = React.forwardRef((props: ForwardingRefComponentPr
 const ForwardingRefComponentPropTypes: React.WeakValidationMap<ForwardingRefComponentProps> = {};
 ForwardingRefComponent.propTypes = ForwardingRefComponentPropTypes;
 
+// render function tests
+function ForwardRefRenderFunctionWithPropTypes() {
+    return null;
+}
+ForwardRefRenderFunctionWithPropTypes.propTypes = {};
+// Warning: forwardRef render functions do not support propTypes or defaultProps
+// $ExpectError
+React.forwardRef(ForwardRefRenderFunctionWithPropTypes);
+
+function ForwardRefRenderFunctionWithDefaultProps() {
+    return null;
+}
+ForwardRefRenderFunctionWithDefaultProps.defaultProps = {};
+// Warning: forwardRef render functions do not support propTypes or defaultProps
+// $ExpectError
+React.forwardRef(ForwardRefRenderFunctionWithDefaultProps);
+
 function RefCarryingComponent() {
     const ref = React.createRef<RefComponent>();
     // Without the explicit type argument, TypeScript infers `{ref: React.RefObject<RefComponent>}`


### PR DESCRIPTION
Closes #37660 

The returned component already allows `propTypes` (was probably fixed without referencing the issue). However, `forwardRef` still allowed a proper component (which causes a warning when using `defaultProps` and `propTypes`). This PR fixes this by narrowing the type to a special "render function".

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/react-api.html#reactforwardref
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- ~[ ]~ If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
