### PR TITLE
yup SchemaDescription test params

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -371,7 +371,7 @@ export interface SchemaDescription {
     type: string;
     label: string;
     meta: object;
-    tests: Array<{ name: string; params: object }>;
+    tests: Array<{ name: string; params: { [k: string]: any } }>;
     fields: Record<string, SchemaFieldDescription>;
 }
 

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -446,7 +446,7 @@ const description: SchemaDescription = {
     label: 'label',
     meta: { key: 'value' },
     tests: [
-        { name: 'test1', params: {} },
+        { name: 'test1', params: {param1: 'param1'} },
         { name: 'test2', params: {} },
     ],
     fields: {
@@ -476,6 +476,8 @@ const description: SchemaDescription = {
         },
      },
 };
+
+description.tests[0].params.param1
 
 const testOptions: TestOptions = {
     name: 'name',

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -477,7 +477,7 @@ const description: SchemaDescription = {
      },
 };
 
-description.tests[0].params.param1
+const param1: any = description.tests[0].params.param1;
 
 const testOptions: TestOptions = {
     name: 'name',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This PR solves a trivial problem: SchemaDescription in yup package didn't allow test params to be accessed without complaining. an example of the problem is shown in https://codesandbox.io/s/jovial-frog-7pqym. 
As shown in the example, TS complains that the property 'min' does not exist. However, if you look at the console output, this property does exist. Hence a false alert.

The solution simply allows the value of any type with the key of the string type to be directly accessed.

As I know very little of yup's codebase, anyone is welcome to submit a PR that better addresses the issue.