### PR TITLE
yup SchemaDescription test params

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -246,6 +246,9 @@ export interface ObjectSchemaConstructor {
 }
 
 export interface ObjectSchema<T extends object | null | undefined = object> extends Schema<T> {
+    fields: {
+      [k in keyof T]: Schema<T[k]>
+    };
     shape<U extends object>(
         fields: ObjectSchemaDefinition<U>,
         noSortEdges?: Array<[string, string]>,

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -371,7 +371,7 @@ export interface SchemaDescription {
     type: string;
     label: string;
     meta: object;
-    tests: Array<{ name: string; params: object }>;
+    tests: Array<{ name: string; params: { [k: string]: any } }>;
     fields: Record<string, SchemaFieldDescription>;
 }
 

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -446,7 +446,7 @@ const description: SchemaDescription = {
     label: 'label',
     meta: { key: 'value' },
     tests: [
-        { name: 'test1', params: {} },
+        { name: 'test1', params: {param1: 'param1'} },
         { name: 'test2', params: {} },
     ],
     fields: {
@@ -476,6 +476,8 @@ const description: SchemaDescription = {
         },
      },
 };
+
+description.tests[0].params.param1
 
 const testOptions: TestOptions = {
     name: 'name',

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -63,6 +63,35 @@ const node: ObjectSchema<any> = yup.object().shape({
     id: yup.number(),
     child: yup.lazy(() => node.default(undefined)),
 });
+
+const numberfield: Schema<number> = yup.object().shape({
+  id: yup.number()
+}).fields.id;
+
+const stringfield: Schema<string> = yup.object().shape({
+  name: yup.string()
+}).fields.name;
+
+const mixedfield: Schema<any> = yup.object().shape({
+  m: yup.mixed()
+}).fields.m;
+
+const booleanfield: Schema<boolean> = yup.object().shape({
+  b: yup.boolean()
+}).fields.b;
+
+const datefield: Schema<Date> = yup.object().shape({
+  d: yup.date()
+}).fields.d;
+
+const arrayfield: Schema<any[]> = yup.object().shape({
+  a: yup.array()
+}).fields.a;
+
+const objectfield: Schema<object> = yup.object().shape({
+  o: yup.object()
+}).fields.o;
+
 const renderable = yup.lazy(value => {
     switch (typeof value) {
         case 'number':

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -477,7 +477,7 @@ const description: SchemaDescription = {
      },
 };
 
-description.tests[0].params.param1
+const param1: any = description.tests[0].params.param1;
 
 const testOptions: TestOptions = {
     name: 'name',

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -64,33 +64,23 @@ const node: ObjectSchema<any> = yup.object().shape({
     child: yup.lazy(() => node.default(undefined)),
 });
 
-const numberfield: Schema<number> = yup.object().shape({
-  id: yup.number()
-}).fields.id;
-
-const stringfield: Schema<string> = yup.object().shape({
-  name: yup.string()
-}).fields.name;
-
-const mixedfield: Schema<any> = yup.object().shape({
-  m: yup.mixed()
-}).fields.m;
-
-const booleanfield: Schema<boolean> = yup.object().shape({
-  b: yup.boolean()
-}).fields.b;
-
-const datefield: Schema<Date> = yup.object().shape({
-  d: yup.date()
-}).fields.d;
-
-const arrayfield: Schema<any[]> = yup.object().shape({
-  a: yup.array()
-}).fields.a;
-
-const objectfield: Schema<object> = yup.object().shape({
+// ObjectSchema.fields
+const fieldsTestSchema = yup.object().shape({
+  s: yup.string(),
+  n: yup.number(),
+  m: yup.mixed(),
+  b: yup.boolean(),
+  d: yup.date(),
+  a: yup.array(),
   o: yup.object()
-}).fields.o;
+})
+const stringField: Schema<string> = fieldsTestSchema.fields.s
+const numberField: Schema<number> = fieldsTestSchema.fields.n
+const mixedField: Schema<any> = fieldsTestSchema.fields.m
+const booleanField: Schema<boolean> = fieldsTestSchema.fields.b
+const dateField: Schema<Date> = fieldsTestSchema.fields.d
+const arrayField: Schema<any[]> = fieldsTestSchema.fields.a
+const objectField: Schema<object> = fieldsTestSchema.fields.o
 
 const renderable = yup.lazy(value => {
     switch (typeof value) {

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -73,14 +73,14 @@ const fieldsTestSchema = yup.object().shape({
   d: yup.date(),
   a: yup.array(),
   o: yup.object()
-})
-const stringField: Schema<string> = fieldsTestSchema.fields.s
-const numberField: Schema<number> = fieldsTestSchema.fields.n
-const mixedField: Schema<any> = fieldsTestSchema.fields.m
-const booleanField: Schema<boolean> = fieldsTestSchema.fields.b
-const dateField: Schema<Date> = fieldsTestSchema.fields.d
-const arrayField: Schema<any[]> = fieldsTestSchema.fields.a
-const objectField: Schema<object> = fieldsTestSchema.fields.o
+});
+const stringField: Schema<string> = fieldsTestSchema.fields.s;
+const numberField: Schema<number> = fieldsTestSchema.fields.n;
+const mixedField: Schema<any> = fieldsTestSchema.fields.m;
+const booleanField: Schema<boolean> = fieldsTestSchema.fields.b;
+const dateField: Schema<Date> = fieldsTestSchema.fields.d;
+const arrayField: Schema<any[]> = fieldsTestSchema.fields.a;
+const objectField: Schema<object> = fieldsTestSchema.fields.o;
 
 const renderable = yup.lazy(value => {
     switch (typeof value) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This PR is trying to solve a trivial problem of yup types. An example of the problem is shown in https://codesandbox.io/s/jovial-frog-7pqym.
As shown in the example, TS complains that the 'min' property does not exist. But if you look at the console output, this property does exist. Hence a false alert.

The solution is simply redefining the type of test params.

As I know little of the codebase of yup, any suggestion that better addresses the issue is welcome.
