### PR TITLE
[hapi-server-session] add types for hapi-server-session

### DIFF
--- a/types/hapi-server-session/hapi-server-session-tests.ts
+++ b/types/hapi-server-session/hapi-server-session-tests.ts
@@ -1,0 +1,20 @@
+import hapiServerSessionPlugin from 'hapi-server-session';
+import { Server } from '@hapi/hapi';
+
+const server = new Server();
+
+server.register({
+    plugin: hapiServerSessionPlugin,
+    options: {
+        algorithm: 'md5',
+        cache: { segment: 'test' },
+        cookie: { ttl: null },
+        expiresIn: 86400,
+        key: 'test',
+        name: 'test',
+        size: 32,
+        vhost: ['test'],
+    },
+});
+
+server.route({ path: '/', method: 'GET', handler: (request, _h) => request.session });

--- a/types/hapi-server-session/index.d.ts
+++ b/types/hapi-server-session/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for hapi-server-session 5.1
+// Project: https://github.com/btmorex/hapi-server-session
+// Definitions by: Avery Fay <https://github.com/btmorex>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { BinaryLike } from 'crypto';
+import { CachePolicyOptions, Plugin, ServerStateCookieOptions } from '@hapi/hapi';
+
+declare module '@hapi/hapi' {
+    interface Request {
+        session: any;
+    }
+}
+
+export interface Options {
+    algorithm?: string;
+    cache?: CachePolicyOptions<any>;
+    cookie?: ServerStateCookieOptions;
+    expiresIn?: number;
+    key?: BinaryLike;
+    name?: string;
+    size?: number;
+    vhost?: string | string[];
+}
+
+export const plugin: Plugin<Options>;
+
+export default plugin;

--- a/types/hapi-server-session/tsconfig.json
+++ b/types/hapi-server-session/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "paths": {
+            "@hapi/catbox": ["hapi__catbox"],
+            "@hapi/hapi": ["hapi__hapi"],
+            "@hapi/joi": ["hapi__joi"],
+            "@hapi/mimos": ["hapi__mimos"],
+            "@hapi/podium": ["hapi__podium"],
+            "@hapi/shot": ["hapi__shot"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "hapi-server-session-tests.ts"]
+}

--- a/types/hapi-server-session/tslint.json
+++ b/types/hapi-server-session/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.