### PR TITLE
[@types/React] Add path to SVGAttributes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2431,6 +2431,7 @@ declare namespace React {
         overlineThickness?: number | string;
         paintOrder?: number | string;
         panose1?: number | string;
+        path?: string;
         pathLength?: number | string;
         patternContentUnits?: string;
         patternTransform?: number | string;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -27,6 +27,11 @@ FunctionComponent2.defaultProps = {
     <g>
         <text x="200" y="300" strokeWidth="5" stroke="black" alignmentBaseline="middle">
             Hello, world!
+            <animateMotion
+                path="M20,50 C20,-50 180,150 180,50 C180-50 20,150 20,50 z"
+                dur="5s"
+                repeatCount="indefinite"
+            />
         </text>
         <div slot="Some Div"> Hello again! </div>
     </g>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/issues/8154

I recently used the path attribute in an `animateMotion` tag and got a typescript error that the attribute doesn't exist on type `SVGProps<SVGElement>` even though it rendered and worked correctly. Even though the attribute isn't reflected on the react website of the list of supported SVG attributes, according to the issue I linked it looks like it actually is supported in >= React 16.
