### PR TITLE
[@hapi/catbox-memcached] add types for @hapi/catbox-memcached

### DIFF
--- a/types/hapi__catbox-memcached/hapi__catbox-memcached-tests.ts
+++ b/types/hapi__catbox-memcached/hapi__catbox-memcached-tests.ts
@@ -1,0 +1,21 @@
+import CatboxMemcached = require('@hapi/catbox-memcached');
+import { Server } from '@hapi/hapi';
+
+new CatboxMemcached<string>();
+
+const options: CatboxMemcached.Options = {
+    host: 'test',
+    port: 0,
+    timeout: 0,
+    idle: 0,
+    partition: 'test',
+};
+
+new Server({
+    cache: {
+        provider: {
+            constructor: CatboxMemcached,
+            options,
+        },
+    },
+});

--- a/types/hapi__catbox-memcached/index.d.ts
+++ b/types/hapi__catbox-memcached/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for @hapi/catbox-memcached 3.0
+// Project: https://github.com/hapijs/catbox-memcached#readme
+// Definitions by: Avery Fay <https://github.com/btmorex>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { CacheKey, ClientApi, ClientOptions } from '@hapi/catbox';
+
+declare namespace CatboxMemcached {
+    interface Options extends ClientOptions {
+        host?: string;
+        port?: number;
+        location?: string;
+        timeout?: number;
+        idle?: number;
+    }
+}
+
+interface CatboxMemcached<T> extends ClientApi<T> {}
+
+declare class CatboxMemcached<T> implements ClientApi<T> {
+    constructor(options?: CatboxMemcached.Options);
+    generateKey(key: CacheKey): string;
+}
+
+export = CatboxMemcached;

--- a/types/hapi__catbox-memcached/tsconfig.json
+++ b/types/hapi__catbox-memcached/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "paths": {
+            "@hapi/catbox": ["hapi__catbox"],
+            "@hapi/catbox-memcached": ["hapi__catbox-memcached"],
+            "@hapi/hapi": ["hapi__hapi"],
+            "@hapi/joi": ["hapi__joi"],
+            "@hapi/mimos": ["hapi__mimos"],
+            "@hapi/podium": ["hapi__podium"],
+            "@hapi/shot": ["hapi__shot"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "hapi__catbox-memcached-tests.ts"]
+}

--- a/types/hapi__catbox-memcached/tslint.json
+++ b/types/hapi__catbox-memcached/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.