### PR TITLE
Add missing return types for babel__traverse unshiftContainer and replaceWithMultiple

### DIFF
--- a/types/babel-plugin-macros/index.d.ts
+++ b/types/babel-plugin-macros/index.d.ts
@@ -4,6 +4,7 @@
 //                 Jake Runzer <https://github.com/coffee-cup>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.4
+
 import * as Babel from '@babel/core';
 
 export interface References {

--- a/types/babel-plugin-macros/index.d.ts
+++ b/types/babel-plugin-macros/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Billy Kwok <https://github.com/billykwok>
 //                 Jake Runzer <https://github.com/coffee-cup>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// Minimum TypeScript Version: 3.4
 import * as Babel from '@babel/core';
 
 export interface References {

--- a/types/babel__core/index.d.ts
+++ b/types/babel__core/index.d.ts
@@ -5,7 +5,7 @@
 //                 Melvin Groenhoff <https://github.com/mgroenhoff>
 //                 Jessica Franco <https://github.com/Jessidhia>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// Minimum TypeScript Version: 3.4
 
 import { GeneratorOptions } from "@babel/generator";
 import traverse, { Visitor, NodePath } from "@babel/traverse";

--- a/types/babel__standalone/index.d.ts
+++ b/types/babel__standalone/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/babel/babel/tree/master/packages/babel-standalone
 // Definitions by: Matheus Goncalves da Silva <https://github.com/PlayMa256>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.4
+// Minimum TypeScript Version: 3.4
 
 import { TransformOptions, types, FileResultCallback } from '@babel/core';
 

--- a/types/babel__standalone/index.d.ts
+++ b/types/babel__standalone/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/babel/babel/tree/master/packages/babel-standalone
 // Definitions by: Matheus Goncalves da Silva <https://github.com/PlayMa256>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// TypeScript Version: 3.4
 
 import { TransformOptions, types, FileResultCallback } from '@babel/core';
 

--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -101,19 +101,53 @@ const v1: Visitor = {
         path.scope.rename("n");
     },
     ExportDefaultDeclaration(path) {
-        // https://github.com/zeit/next.js/blob/9cfc09e3abd039686803627213188b33fbe13309/packages/next/build/babel/plugins/next-ssg-transform.ts#L44
-        const [pageCompPath] = path.replaceWithMultiple([
-            t.variableDeclaration('const', [
-                t.variableDeclarator(t.identifier('id')),
-            ])
-        ]);
-        path.scope.registerDeclaration(pageCompPath);
+        {
+            const [stringPath, booleanPath] = path.replaceWithMultiple([
+                t.stringLiteral('hello'),
+                t.booleanLiteral(false)
+            ]);
+            // $ExpectType NodePath<t.StringLiteral | t.BooleanLiteral>
+            stringPath
+            // $ExpectType NodePath<t.StringLiteral | t.BooleanLiteral>
+            booleanPath
+        }
+        {
+            const [stringPath, booleanPath] = path.replaceWithMultiple<[t.StringLiteral, t.BooleanLiteral]>([
+                t.stringLiteral('hello'),
+                t.booleanLiteral(false)
+            ]);
+            // $ExpectType NodePath<t.StringLiteral>
+            stringPath
+            // $ExpectType NodePath<t.BooleanLiteral>
+            booleanPath
+        }
     },
     Program(path) {
-        // https://github.com/zeit/next.js/blob/9cfc09e3abd039686803627213188b33fbe13309/packages/next/build/babel/plugins/jsx-pragma.ts#L67
-        const mapping = t.variableDeclaration('var', []);
-        const [newPath] = path.unshiftContainer('body', mapping);
-        const declar = newPath.get('declarations')[0];
+        {
+            const [newPath] = path.unshiftContainer('body', t.stringLiteral('hello'));
+            // $ExpectType NodePath<t.StringLiteral>
+            newPath
+        }
+        {
+            const [stringPath, booleanPath] = path.unshiftContainer('body', [
+                t.stringLiteral('hello'),
+                t.booleanLiteral(false)
+            ]);
+            // $ExpectType NodePath<t.StringLiteral | t.BooleanLiteral>
+            stringPath
+            // $ExpectType NodePath<t.StringLiteral | t.BooleanLiteral>
+            booleanPath
+        }
+        {
+            const [stringPath, booleanPath] = path.unshiftContainer<[t.StringLiteral, t.BooleanLiteral]>('body', [
+                t.stringLiteral('hello'),
+                t.booleanLiteral(false)
+            ]);
+            // $ExpectType NodePath<t.StringLiteral>
+            stringPath
+            // $ExpectType NodePath<t.BooleanLiteral>
+            booleanPath
+        }
     }
 };
 

--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -99,6 +99,21 @@ const v1: Visitor = {
 
         path.scope.rename("n", "x");
         path.scope.rename("n");
+    },
+    ExportDefaultDeclaration(path) {
+        // https://github.com/zeit/next.js/blob/9cfc09e3abd039686803627213188b33fbe13309/packages/next/build/babel/plugins/next-ssg-transform.ts#L44
+        const [pageCompPath] = path.replaceWithMultiple([
+            t.variableDeclaration('const', [
+                t.variableDeclarator(t.identifier('id')),
+            ])
+        ]);
+        path.scope.registerDeclaration(pageCompPath);
+    },
+    Program(path) {
+        // https://github.com/zeit/next.js/blob/9cfc09e3abd039686803627213188b33fbe13309/packages/next/build/babel/plugins/jsx-pragma.ts#L67
+        const mapping = t.variableDeclaration('var', []);
+        const [newPath] = path.unshiftContainer('body', mapping);
+        const declar = newPath.get('declarations')[0];
     }
 };
 

--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -106,47 +106,47 @@ const v1: Visitor = {
                 t.stringLiteral('hello'),
                 t.booleanLiteral(false)
             ]);
-            // $ExpectType NodePath<t.StringLiteral | t.BooleanLiteral>
-            stringPath
-            // $ExpectType NodePath<t.StringLiteral | t.BooleanLiteral>
-            booleanPath
+            // $ExpectType NodePath<BooleanLiteral | StringLiteral>
+            stringPath;
+            // $ExpectType NodePath<BooleanLiteral | StringLiteral>
+            booleanPath;
         }
         {
             const [stringPath, booleanPath] = path.replaceWithMultiple<[t.StringLiteral, t.BooleanLiteral]>([
                 t.stringLiteral('hello'),
                 t.booleanLiteral(false)
             ]);
-            // $ExpectType NodePath<t.StringLiteral>
-            stringPath
-            // $ExpectType NodePath<t.BooleanLiteral>
-            booleanPath
+            // $ExpectType NodePath<StringLiteral>
+            stringPath;
+            // $ExpectType NodePath<BooleanLiteral>
+            booleanPath;
         }
     },
     Program(path) {
         {
             const [newPath] = path.unshiftContainer('body', t.stringLiteral('hello'));
-            // $ExpectType NodePath<t.StringLiteral>
-            newPath
+            // $ExpectType NodePath<StringLiteral>
+            newPath;
         }
         {
             const [stringPath, booleanPath] = path.unshiftContainer('body', [
                 t.stringLiteral('hello'),
                 t.booleanLiteral(false)
             ]);
-            // $ExpectType NodePath<t.StringLiteral | t.BooleanLiteral>
-            stringPath
-            // $ExpectType NodePath<t.StringLiteral | t.BooleanLiteral>
-            booleanPath
+            // $ExpectType NodePath<BooleanLiteral | StringLiteral>
+            stringPath;
+            // $ExpectType NodePath<BooleanLiteral | StringLiteral>
+            booleanPath;
         }
         {
             const [stringPath, booleanPath] = path.unshiftContainer<[t.StringLiteral, t.BooleanLiteral]>('body', [
                 t.stringLiteral('hello'),
                 t.booleanLiteral(false)
             ]);
-            // $ExpectType NodePath<t.StringLiteral>
-            stringPath
-            // $ExpectType NodePath<t.BooleanLiteral>
-            booleanPath
+            // $ExpectType NodePath<StringLiteral>
+            stringPath;
+            // $ExpectType NodePath<BooleanLiteral>
+            booleanPath;
         }
     }
 };

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -6,7 +6,7 @@
 //                 Melvin Groenhoff <https://github.com/mgroenhoff>
 //                 Dean L. <https://github.com/dlgrit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// Minimum TypeScript Version: 3.4
 
 import * as t from "@babel/types";
 
@@ -171,7 +171,7 @@ export interface VisitNodeObject<S, P> {
     exit?: VisitNodeFunction<S, P>;
 }
 
-type NodePaths<T extends Node | Node[]> = T extends Node[] ? { [K in keyof T]: NodePath<T[K]> } : [NodePath<T>]
+export type NodePaths<T extends Node | Node[]> = T extends Node[] ? { [K in keyof T]: NodePath<T[K]> } : [NodePath<T>];
 
 export class NodePath<T = Node> {
     constructor(hub: Hub, parent: Node);

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -171,6 +171,8 @@ export interface VisitNodeObject<S, P> {
     exit?: VisitNodeFunction<S, P>;
 }
 
+type NodePaths<T extends Node | Node[]> = T extends Node[] ? { [K in keyof T]: NodePath<T[K]> } : [NodePath<T>]
+
 export class NodePath<T = Node> {
     constructor(hub: Hub, parent: Node);
     parent: Node;
@@ -272,7 +274,7 @@ export class NodePath<T = Node> {
      *  - Insert the provided nodes after the current node.
      *  - Remove the current node.
      */
-    replaceWithMultiple<NodeType extends Node>(nodes: NodeType[]): Array<NodePath<NodeType>>;
+    replaceWithMultiple<Nodes extends Node[]>(nodes: Nodes): NodePaths<Nodes>;
 
     /**
      * Parse a string as an expression and replace the current node with the result.
@@ -433,7 +435,7 @@ export class NodePath<T = Node> {
      * @param listKey - The key at which the child nodes are stored (usually body).
      * @param nodes - the nodes to insert.
      */
-    unshiftContainer<NodeType extends Node>(listKey: string, nodes: NodeType | NodeType[]): Array<NodePath<NodeType>>;
+    unshiftContainer<Nodes extends Node | Node[]>(listKey: string, nodes: Nodes): NodePaths<Nodes>;
 
     /**
      * Insert child nodes at the end of the current node.

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -272,7 +272,7 @@ export class NodePath<T = Node> {
      *  - Insert the provided nodes after the current node.
      *  - Remove the current node.
      */
-    replaceWithMultiple(nodes: Node[]): void;
+    replaceWithMultiple<NodeType extends Node>(nodes: NodeType[]): Array<NodePath<NodeType>>;
 
     /**
      * Parse a string as an expression and replace the current node with the result.
@@ -433,7 +433,7 @@ export class NodePath<T = Node> {
      * @param listKey - The key at which the child nodes are stored (usually body).
      * @param nodes - the nodes to insert.
      */
-    unshiftContainer(listKey: string, nodes: Node | Node[]): void;
+    unshiftContainer<NodeType extends Node>(listKey: string, nodes: NodeType | NodeType[]): Array<NodePath<NodeType>>;
 
     /**
      * Insert child nodes at the end of the current node.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zeit/next.js/blob/9cfc09e3abd039686803627213188b33fbe13309/packages/next/build/babel/plugins/next-ssg-transform.ts#L44
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Getting rid of some workarounds with `// ts-ignore`

`unshiftContainer` and `replaceWithMultiple` both return an array with paths to the added nodes.