### PR TITLE
Add Slider component to types and test

### DIFF
--- a/types/rebass__forms/index.d.ts
+++ b/types/rebass__forms/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for @rebass/forms 4.0
 // Project: https://github.com/rebassjs/rebass#readme
 // Definitions by: zinozzino <https://github.com/zinozzino>
-// Definitions by: trumanshuck <https://github.com/trumanshuck>
+//                 trumanshuck <https://github.com/trumanshuck>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 

--- a/types/rebass__forms/index.d.ts
+++ b/types/rebass__forms/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for @rebass/forms 4.0
 // Project: https://github.com/rebassjs/rebass#readme
 // Definitions by: zinozzino <https://github.com/zinozzino>
+// Definitions by: trumanshuck <https://github.com/trumanshuck>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
@@ -62,6 +63,12 @@ export interface RadioProps
         Omit<React.InputHTMLAttributes<HTMLInputElement>, keyof BoxKnownProps> {}
 
 export const Radio: React.ComponentType<RadioProps>;
+
+export interface SliderProps
+    extends BoxKnownProps,
+        Omit<React.InputHTMLAttributes<HTMLInputElement>, keyof BoxKnownProps> {}
+
+export const Slider: React.ComponentType<SliderProps>;
 
 export interface CheckboxProps
     extends BoxKnownProps,

--- a/types/rebass__forms/rebass__forms-tests.tsx
+++ b/types/rebass__forms/rebass__forms-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Label, Input, Select, Textarea, Radio, Checkbox } from '@rebass/forms';
+import { Label, Input, Select, Textarea, Radio, Checkbox, Slider } from '@rebass/forms';
 
 export default () => (
     <>
@@ -29,6 +29,9 @@ export default () => (
         </Label>
         <Label width={[1 / 2, 1 / 4]} p={2}>
             <Textarea id="remember" name="remember" />
+        </Label>
+        <Label width={[1 / 2, 1 / 4]} p={2}>
+            <Slider id="remember" name="remember" value={50} />
         </Label>
     </>
 );


### PR DESCRIPTION
Adds missing type for the rebass [slider](https://rebassjs.org/forms/slider/), which exists in rebass 4.0.  Borrows from this [previous pr](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41258).

Linting gives me (and this also seems to break for me on master):
```
$ npm run lint rebass__forms

> definitely-typed@0.0.3 lint /Users/trumanshuck/script/git/DefinitelyTyped
> dtslint types "rebass__forms"

Error: Errors in typescript@next for external dependencies:
../react/index.d.ts(34,22): error TS2307: Cannot find module 'csstype'.
../styled-components/ts3.7/index.d.ts(9,22): error TS2307: Cannot find module 'csstype'.
../styled-components/ts3.7/index.d.ts(17,18): error TS2430: Interface 'CSSObject' incorrectly extends interface 'CSSPseudos'.
  Index signatures are incompatible.
    Type 'string | number | CSSObject' is not assignable to type 'CSSObject'.
      Type 'string' is not assignable to type 'CSSObject'.
../styled-system/index.d.ts(24,22): error TS2307: Cannot find module 'csstype'.
../styled-system__css/index.d.ts(8,22): error TS2307: Cannot find module 'csstype'.

    at /Users/trumanshuck/script/git/DefinitelyTyped/node_modules/dtslint/bin/index.js:193:19
    at Generator.next (<anonymous>)
    at fulfilled (/Users/trumanshuck/script/git/DefinitelyTyped/node_modules/dtslint/bin/index.js:6:58)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! definitely-typed@0.0.3 lint: `dtslint types "rebass__forms"`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the definitely-typed@0.0.3 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/trumanshuck/.npm/_logs/2020-02-16T22_39_27_376Z-debug.log
```


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: [public doc](https://rebassjs.org/forms/slider/), [implementation](https://github.com/rebassjs/rebass/blob/master/packages/forms/src/index.js#L284).

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
