### PR TITLE
Add types for serverless-jest-plugin.

### DIFF
--- a/types/lambda-wrapper/index.d.ts
+++ b/types/lambda-wrapper/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for lambda-wrapper 0.3
+// Project: https://github.com/nordcloud/lambda-wrapper
+// Definitions by: Gaelan Steele <https://github.com/Gaelan>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.3
+
+import { Handler, Context, Callback } from 'aws-lambda';
+
+export interface Wrapped<TEvent, TResult> {
+    // None of these functions resolve the promise if a callback is present, so prohibit using both.
+    run(event: TEvent, context: Partial<Context>, callback: Callback<TResult>): void;
+    run(event: TEvent, callback: Callback<TResult>): void;
+    run(event: TEvent, context?: Partial<Context>): Promise<TResult>;
+
+    runHandler(event: TEvent, context: Partial<Context>, callback?: Callback<TResult>): void;
+    runHandler(event: TEvent, context: Partial<Context>): Promise<TResult>;
+}
+
+export function wrap<TEvent, TResult, THandlerName extends string = 'handler'>(
+    mod: { [name in THandlerName]: Handler<TEvent, TResult> },
+    options?: { handler?: THandlerName },
+): Wrapped<TEvent, TResult>;
+export function wrap(mod: { lambdaFunction: string; region: string }, options?: {}): Wrapped<any, any>;
+
+// Legacy (pre-v0.1) API for backwards compatibility
+export function init(mod: any, options: any): void;
+export function run(event: any, context: Partial<Context>, callback: Callback): Promise<any>;
+export function run(event: any, callback: Callback): Promise<any>;

--- a/types/lambda-wrapper/lambda-wrapper-tests.ts
+++ b/types/lambda-wrapper/lambda-wrapper-tests.ts
@@ -1,0 +1,32 @@
+// Official exampeles, lightly adapted
+import lambdaWrapper = require('lambda-wrapper');
+import { Handler } from 'aws-lambda';
+
+declare const handler: Handler<{ key1: string; key2: string }, { resultProp: any }>;
+let lambda = lambdaWrapper.wrap({ handler });
+
+lambda = lambdaWrapper.wrap({
+    region: 'eu-west-1',
+    lambdaFunction: 'myFunctionName',
+});
+
+const event = { key1: 'val1', key2: 'val2' };
+lambda.run(event, (err, data) => {
+    if (err) {
+        // ... handle error
+    }
+    data && data.resultProp;
+});
+
+lambda.runHandler(event, { memoryLimitInMB: '1000' }, (err, data) => {
+    if (err) {
+        // ... handle error
+    }
+    // ... process data returned by the Lambda function
+    data && data.resultProp;
+});
+
+// Other tests
+
+lambda = lambdaWrapper.wrap({ fooHandler: handler }, { handler: 'fooHandler' });
+lambda.run(event).then(data => data.resultProp);

--- a/types/lambda-wrapper/tsconfig.json
+++ b/types/lambda-wrapper/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "lambda-wrapper-tests.ts"
+    ]
+}

--- a/types/lambda-wrapper/tslint.json
+++ b/types/lambda-wrapper/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/serverless-jest-plugin/index.d.ts
+++ b/types/serverless-jest-plugin/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for serverless-jest-plugin 0.3
+// Project: https://github.com/nordcloud/serverless-jest-plugin#readme
+// Definitions by: Gaelan Steele <https://github.com/Gaelan>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.3
+
+import Serverless = require('serverless');
+import Plugin = require('serverless/classes/Plugin');
+import lw = require('lambda-wrapper');
+export = ServerlessJestPlugin;
+
+declare class ServerlessJestPlugin implements Plugin {
+    constructor(serverless: Serverless, options: Serverless.Options);
+
+    hooks: Plugin.Hooks;
+    commands: Plugin.Commands;
+}
+
+declare namespace ServerlessJestPlugin {
+    function getWrapper(modName: string, modPath: string, handler: string): lw.Wrapped<any, any>;
+
+    const lambdaWrapper: typeof lw;
+}

--- a/types/serverless-jest-plugin/serverless-jest-plugin-tests.ts
+++ b/types/serverless-jest-plugin/serverless-jest-plugin-tests.ts
@@ -1,0 +1,8 @@
+import { lambdaWrapper, getWrapper } from 'serverless-jest-plugin';
+
+let lambda = lambdaWrapper.wrap({
+    region: 'eu-west-1',
+    lambdaFunction: 'myFunctionName',
+});
+
+lambda = getWrapper('foo', 'foo/bar.js', 'fooHandler');

--- a/types/serverless-jest-plugin/tsconfig.json
+++ b/types/serverless-jest-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "serverless-jest-plugin-tests.ts"
+    ]
+}

--- a/types/serverless-jest-plugin/tslint.json
+++ b/types/serverless-jest-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
*Note:* This PR depends on #42408.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.) **The code I want this for isn't ported to TS yet, but some of the tests are based on our JS code.**
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
