### PR TITLE
Add return type to webpack-hot-client default function

### DIFF
--- a/types/webpack-hot-client/index.d.ts
+++ b/types/webpack-hot-client/index.d.ts
@@ -1,54 +1,72 @@
-// Type definitions for webpack-hot-client 4.0
+// Type definitions for webpack-hot-client 4.1
 // Project: https://github.com/webpack-contrib/webpack-hot-client
 // Definitions by: Ryan Clark <https://github.com/rynclark>
 //                 ZSkycat <https://github.com/ZSkycat>
+//                 Brian Armstrong <https://github.com/barm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
 /// <reference types="node" />
 
-import * as webpack from 'webpack';
 import * as net from 'net';
+import * as webpack from 'webpack';
+import { Server } from 'ws';
 
 export = WebpackHotClient;
 
 declare function WebpackHotClient(
-  compiler: webpack.Compiler | webpack.MultiCompiler,
-  options: WebpackHotClient.Options
-): void;
+    compiler: webpack.Compiler | webpack.MultiCompiler,
+    options: WebpackHotClient.Options,
+): WebpackHotClient.Client;
 
 declare namespace WebpackHotClient {
-  interface WebpackHotHost {
-    /** Client hostname that is used in the browser by WebSockets */
-    client: string;
-    /** Server hostname */
-    server: string;
-  }
+    interface WebSocketServer extends Server {
+        /** Forwards a message to each open client on the WebSocketServer */
+        broadcast(data: any): void;
+        /** Processes stats and sends messages through broadcast() */
+        send(stats: webpack.Stats): void;
+    }
 
-  interface Options {
-    /** Automatically configure every entry */
-    allEntries?: boolean;
-    /** Auto configure the given webpack config with the hot configuration */
-    autoConfigure?: boolean;
-    /** Level of information for webpack-hot-client to output */
-    host?: WebpackHotHost | string;
-    /** Enable hot module reloading */
-    hmr?: boolean;
-    /** Enable HTTPS */
-    https?: boolean;
-    /** Level of information for webpack-hot-client to output */
-    logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent';
-    /** Prepend timestamp to each log line */
-    logTime?: boolean;
-    /** Port that the WebSocket listens on */
-    port?: number;
-    /** Reload the page if a patch cannot be applied by webpack */
-    reload?: boolean;
-    /** Server instance for webpack-hot-client to connect to */
-    server?: net.Server;
-    /** Webpack stats configuration */
-    stats?: webpack.Options.Stats;
-    /** Webpack compile target */
-    validTargets?: string[];
-  }
+    interface Client {
+        /** Function that closes the WebSocketServer opened by the module. */
+        close(callback?: () => void): void;
+        /** WebSocketServer instance with some hot-client specific method overrides */
+        server: WebSocketServer;
+        /** Readonly version of the options after applying defaults */
+        options: Readonly<Options>;
+    }
+
+    interface WebpackHotHost {
+        /** Client hostname that is used in the browser by WebSockets */
+        client: string;
+        /** Server hostname */
+        server: string;
+    }
+
+    interface Options {
+        /** Automatically configure every entry */
+        allEntries?: boolean;
+        /** Auto configure the given webpack config with the hot configuration */
+        autoConfigure?: boolean;
+        /** Host that the WebSocket listens on */
+        host?: WebpackHotHost | string;
+        /** Enable hot module reloading */
+        hmr?: boolean;
+        /** Enable HTTPS */
+        https?: boolean;
+        /** Level of information for webpack-hot-client to output */
+        logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent';
+        /** Prepend timestamp to each log line */
+        logTime?: boolean;
+        /** Port that the WebSocket listens on */
+        port?: number;
+        /** Reload the page if a patch cannot be applied by webpack */
+        reload?: boolean;
+        /** Server instance for webpack-hot-client to connect to */
+        server?: net.Server;
+        /** Webpack stats configuration */
+        stats?: webpack.Options.Stats;
+        /** Webpack compile target */
+        validTargets?: string[];
+    }
 }

--- a/types/webpack-hot-client/webpack-hot-client-tests.ts
+++ b/types/webpack-hot-client/webpack-hot-client-tests.ts
@@ -5,4 +5,11 @@ const compiler = webpack();
 
 hot(compiler, { logLevel: 'info', reload: false });
 
-hot(compiler, { logLevel: 'info', reload: false, validTargets: ['web', 'node'] });
+const client = hot(compiler, { logLevel: 'info', reload: false, validTargets: ['web', 'node'] });
+
+const { close, server, options} = client;
+
+close(() => {});
+server.on('listening', () => {});
+server.broadcast({type: 'message'});
+const entries = options.allEntries;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

~If adding a new definition:~
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/shellscape/webpack-hot-client/blob/master/lib/index.js#L68
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

~If removing a declaration:~
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.