### PR TITLE
Update styled-components to 5.0

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -468,15 +468,23 @@ export class ServerStyleSheet {
     seal(): void;
 }
 
-type StyleSheetManagerProps =
-    | {
-          sheet: ServerStyleSheet;
-          target?: never;
-      }
-    | {
-          sheet?: never;
-          target: HTMLElement;
-      };
+export type StylisPlugin = (
+    context: number,
+    selector: string[],
+    parent: string[],
+    content: string,
+    line: number,
+    column: number,
+    length: number,
+) => string | void;
+
+export interface StyleSheetManagerProps {
+    disableCSSOMInjection?: boolean;
+    disableVendorPrefixes?: boolean;
+    stylisPlugins?: StylisPlugin[];
+    sheet?: ServerStyleSheet;
+    target?: HTMLElement;
+}
 
 export class StyleSheetManager extends React.Component<
     StyleSheetManagerProps

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -367,6 +367,7 @@ export interface ThemedStyledComponentsModule<
     ThemeProvider: ThemeProviderComponent<T, U>;
     ThemeConsumer: React.Consumer<T>;
     ThemeContext: React.Context<T>;
+    useTheme(): T;
 
     // This could be made to assert `target is StyledComponent<any, T>` instead, but that feels not type safe
     isStyledComponent: typeof isStyledComponent;
@@ -392,6 +393,8 @@ export type WithThemeFnInterface<T extends object> = BaseWithThemeFnInterface<
     AnyIfEmpty<T>
 >;
 export const withTheme: WithThemeFnInterface<DefaultTheme>;
+
+export function useTheme(): DefaultTheme;
 
 /**
  * This interface can be augmented by users to add types to `styled-components`' default theme

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for styled-components 4.4
+// Type definitions for styled-components 5.0
 // Project: https://github.com/styled-components/styled-components, https://styled-components.com
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 //                 Ihor Chulinda <https://github.com/Igmat>
@@ -9,6 +9,7 @@
 //                 David Ruisinger <https://github.com/flavordaaave>
 //                 Matthew Wagerfield <https://github.com/wagerfield>
 //                 Yuki Ito <https://github.com/Lazyuki>
+//                 Maciej Goszczycki <https://github.com/mgoszcz2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -118,9 +119,6 @@ export type InterpolationFunction<P> = (props: P) => Interpolation<P>;
 type Attrs<P, A extends Partial<P>, T> =
     | ((props: ThemedStyledProps<P, T>) => A)
     | A;
-type DeprecatedAttrs<P, A extends Partial<P>, T> = {
-    [K in keyof A]: ((props: ThemedStyledProps<P, T>) => A[K]) | A[K]
-};
 
 export type ThemedGlobalStyledClassProps<P, T> = WithOptionalTheme<P, T> & {
     suppressMultiMountWarning?: boolean;
@@ -260,18 +258,6 @@ export interface ThemedStyledFunction<
     >(
         attrs: Attrs<StyledComponentPropsWithRef<C> & U, NewA, T>
     ): ThemedStyledFunction<C, T, O & NewA, A | keyof NewA>;
-    // Only this overload is deprecated
-    // tslint:disable:unified-signatures
-    /** @deprecated Prefer using the new single function style, to be removed in v5 */
-    attrs<
-        U,
-        NewA extends Partial<StyledComponentPropsWithRef<C> & U> & {
-            [others: string]: any;
-        } = {}
-    >(
-        attrs: DeprecatedAttrs<StyledComponentPropsWithRef<C> & U, NewA, T>
-    ): ThemedStyledFunction<C, T, O & NewA, A | keyof NewA>;
-    // tslint:enable:unified-signatures
 }
 
 export type StyledFunction<

--- a/types/styled-components/native.d.ts
+++ b/types/styled-components/native.d.ts
@@ -10,6 +10,7 @@ export {
   ThemeProps,
   ThemeProvider,
   withTheme,
+  useTheme,
 } from './index';
 
 import {
@@ -227,6 +228,7 @@ export interface ReactNativeThemedStyledComponentsModule<
   ThemeProvider: ThemeProviderComponent<T, U>;
   ThemeConsumer: React.Consumer<T>;
   ThemeContext: React.Context<T>;
+  useTheme(): T;
 
   // This could be made to assert `target is StyledComponent<any, T>` instead, but that feels not type safe
   isStyledComponent: typeof isStyledComponent;

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -476,7 +476,7 @@ sheet.seal();
 
 const sheet2 = new ServerStyleSheet();
 const element = (
-    <StyleSheetManager sheet={sheet2.instance}>
+    <StyleSheetManager sheet={sheet2.instance} disableCSSOMInjection>
         <SSRTitle>Hello world</SSRTitle>
     </StyleSheetManager>
 );

--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -333,6 +333,7 @@ export interface ThemedStyledComponentsModule<
     ThemeProvider: ThemeProviderComponent<T, U>;
     ThemeConsumer: React.Consumer<T>;
     ThemeContext: React.Context<T>;
+    useTheme(): T;
 
     // This could be made to assert `target is StyledComponent<any, T>` instead, but that feels not type safe
     isStyledComponent: typeof isStyledComponent;
@@ -358,6 +359,8 @@ export type WithThemeFnInterface<T extends object> = BaseWithThemeFnInterface<
     AnyIfEmpty<T>
 >;
 export const withTheme: WithThemeFnInterface<DefaultTheme>;
+
+export function useTheme(): DefaultTheme;
 
 /**
  * This interface can be augmented by users to add types to `styled-components`' default theme

--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -102,9 +102,6 @@ export type InterpolationFunction<P> = (props: P) => Interpolation<P>;
 type Attrs<P, A extends Partial<P>, T> =
     | ((props: ThemedStyledProps<P, T>) => A)
     | A;
-type DeprecatedAttrs<P, A extends Partial<P>, T> = {
-    [K in keyof A]: ((props: ThemedStyledProps<P, T>) => A[K]) | A[K]
-};
 
 export type ThemedGlobalStyledClassProps<P, T> = WithOptionalTheme<P, T> & {
     suppressMultiMountWarning?: boolean;
@@ -227,18 +224,6 @@ export interface ThemedStyledFunction<
     >(
         attrs: Attrs<StyledComponentPropsWithRef<C> & U, NewA, T>
     ): ThemedStyledFunction<C, T, O & NewA, A | keyof NewA>;
-    // Only this overload is deprecated
-    // tslint:disable:unified-signatures
-    /** @deprecated Prefer using the new single function style, to be removed in v5 */
-    attrs<
-        U,
-        NewA extends Partial<StyledComponentPropsWithRef<C> & U> & {
-            [others: string]: any;
-        } = {}
-    >(
-        attrs: DeprecatedAttrs<StyledComponentPropsWithRef<C> & U, NewA, T>
-    ): ThemedStyledFunction<C, T, O & NewA, A | keyof NewA>;
-    // tslint:enable:unified-signatures
 }
 
 export type StyledFunction<

--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -435,15 +435,23 @@ export class ServerStyleSheet {
     seal(): void;
 }
 
-type StyleSheetManagerProps =
-    | {
-          sheet: ServerStyleSheet;
-          target?: never;
-      }
-    | {
-          sheet?: never;
-          target: HTMLElement;
-      };
+export type StylisPlugin = (
+    context: number,
+    selector: string[],
+    parent: string[],
+    content: string,
+    line: number,
+    column: number,
+    length: number,
+) => string | void;
+
+export interface StyleSheetManagerProps {
+    disableCSSOMInjection?: boolean;
+    disableVendorPrefixes?: boolean;
+    stylisPlugins?: StylisPlugin[];
+    sheet?: ServerStyleSheet;
+    target?: HTMLElement;
+}
 
 export class StyleSheetManager extends React.Component<
     StyleSheetManagerProps

--- a/types/styled-components/ts3.7/native.d.ts
+++ b/types/styled-components/ts3.7/native.d.ts
@@ -10,6 +10,7 @@ export {
   ThemeProps,
   ThemeProvider,
   withTheme,
+  useTheme,
 } from './index';
 
 import {
@@ -219,6 +220,7 @@ export interface ReactNativeThemedStyledComponentsModule<
   ThemeProvider: ThemeProviderComponent<T, U>;
   ThemeConsumer: React.Consumer<T>;
   ThemeContext: React.Context<T>;
+  useTheme(): T;
 
   // This could be made to assert `target is StyledComponent<any, T>` instead, but that feels not type safe
   isStyledComponent: typeof isStyledComponent;

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -475,7 +475,7 @@ sheet.seal();
 
 const sheet2 = new ServerStyleSheet();
 const element = (
-    <StyleSheetManager sheet={sheet2.instance}>
+    <StyleSheetManager sheet={sheet2.instance} disableCSSOMInjection>
         <SSRTitle>Hello world</SSRTitle>
     </StyleSheetManager>
 );


### PR DESCRIPTION
1. Add new StyleSheetManager props
2. Remove deprecated ThemedStyledFunction attrs overload
3. Add the useTheme hook (sadly the best type for it is DefaultTheme)

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://styled-components.com/releases#v5.0.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.