### PR TITLE
add types for kap plugins

### DIFF
--- a/types/kap-plugin/index.d.ts
+++ b/types/kap-plugin/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for kap-plugin 1.0
+// Project: https://github.com/wulkano/kap/blob/master/docs/plugins.md
+// Definitions by: Connor Peet <https://github.com/connor4312>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.0
+
+import * as got from 'got';
+import { JSONSchema7 } from 'json-schema';
+
+export interface KapContext<T> {
+    format: string;
+    defaultFileName: string;
+    filePath(): Promise<string>;
+    config: { get<K extends keyof T>(key: K): T[K] };
+    request: typeof got;
+    copyToClipboard(text: string): void;
+    notify(text: string): void;
+    setProgress(text: string, percentage: number): void;
+    openConfigFile(): void;
+    cancel(): void;
+}
+
+export type Format = 'gif' | 'mp4' | 'webm' | 'apng';
+
+// TS-3.4 compatible Omit<>:
+export type ConfigSchema<TValue> = Pick<JSONSchema7, Exclude<keyof JSONSchema7, 'required' | 'default'>> & {
+    required?: boolean;
+    default?: TValue;
+};
+
+export interface KapShareService<T = unknown> {
+    action(context: KapContext<T>): Promise<void>;
+    title: string;
+    formats: ReadonlyArray<Format>;
+    config: { [K in keyof T]: ConfigSchema<T[K]> };
+}

--- a/types/kap-plugin/index.d.ts
+++ b/types/kap-plugin/index.d.ts
@@ -79,7 +79,7 @@ export interface KapContext<T> {
      * Returns a Promise that resolves when a deep link for this plugin is
      * opened. The link should be in the format `kap://plugins/{pluginName}/{rest}`,
      * where pluginName is the npm package name and rest is the string the
-     * Promise will resolve with. This is useful for OAuth flows.
+     * Promise will resolve with. This is useful for [OAuth flows](https://github.com/wulkano/kap/blob/master/docs/plugins.md#oauth).
      */
     waitForDeepLink(): Promise<string>;
 }

--- a/types/kap-plugin/index.d.ts
+++ b/types/kap-plugin/index.d.ts
@@ -7,17 +7,26 @@
 import * as got from 'got';
 import { JSONSchema7 } from 'json-schema';
 
+export interface BuiltInConfig {
+    accessToken?: string;
+}
+
+export interface ConfigStore<T> {
+    get<K extends keyof T>(key: K): T[K];
+}
+
 export interface KapContext<T> {
     format: string;
     defaultFileName: string;
     filePath(): Promise<string>;
-    config: { get<K extends keyof T>(key: K): T[K] };
+    config: ConfigStore<T & BuiltInConfig>;
     request: typeof got;
     copyToClipboard(text: string): void;
-    notify(text: string): void;
+    notify(text: string, action?: () => void): void;
     setProgress(text: string, percentage: number): void;
     openConfigFile(): void;
     cancel(): void;
+    waitForDeepLink(): Promise<string>;
 }
 
 export type Format = 'gif' | 'mp4' | 'webm' | 'apng';

--- a/types/kap-plugin/index.d.ts
+++ b/types/kap-plugin/index.d.ts
@@ -8,13 +8,6 @@ import * as got from 'got';
 import * as ElectronStore from 'electron-store';
 import { JSONSchema7 } from 'json-schema';
 
-/**
- * Base options that Kap provides out of the box.
- */
-export interface BuiltInConfig {
-    accessToken?: string;
-}
-
 export interface KapContext<T> {
     /**
      * The file format the user chose in the editor window
@@ -43,7 +36,7 @@ export interface KapContext<T> {
     /**
      * Get and set config for you plugin. It’s an instance of electron-store.
      */
-    config: ElectronStore<T & BuiltInConfig>;
+    config: ElectronStore<T>;
 
     /**
      * Do a network request, like uploading. It’s a wrapper around `got`.
@@ -128,5 +121,5 @@ export interface KapShareService<T = unknown> {
      * Definition of the config the plugins needs. A JSON schema, with the
      * ability to mark properties as `required` individually.
      */
-    config: { [K in keyof T]: ConfigSchema<T[K]> };
+    config: { [K in keyof T]?: ConfigSchema<T[K]> };
 }

--- a/types/kap-plugin/index.d.ts
+++ b/types/kap-plugin/index.d.ts
@@ -2,30 +2,92 @@
 // Project: https://github.com/wulkano/kap/blob/master/docs/plugins.md
 // Definitions by: Connor Peet <https://github.com/connor4312>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import * as got from 'got';
+import * as ElectronStore from 'electron-store';
 import { JSONSchema7 } from 'json-schema';
 
+/**
+ * Base options that Kap provides out of the box.
+ */
 export interface BuiltInConfig {
     accessToken?: string;
 }
 
-export interface ConfigStore<T> {
-    get<K extends keyof T>(key: K): T[K];
-}
-
 export interface KapContext<T> {
-    format: string;
+    /**
+     * The file format the user chose in the editor window
+     */
+    format: Format;
+
+    /**
+     * Prettified version of .format for use in notifications.
+     * For example: GIF, MP4, WebM, APNG.
+     */
+    prettyFormat: string;
+
+    /**
+     * Default file name for the recording. For example: `Kapture 2017-05-30 at 1.03.49.gif`.
+     */
     defaultFileName: string;
-    filePath(): Promise<string>;
-    config: ConfigStore<T & BuiltInConfig>;
+
+    /**
+     * Convert the screen recording to the user chosen format and return a
+     * Promise for the file path. If you want to overwrite the format that the
+     * user selected, you can pass a fileType option. This can be useful if
+     * you, for example, need to handle the GIF conversion yourself.
+     */
+    filePath(options?: { fileType: Format }): Promise<string>;
+
+    /**
+     * Get and set config for you plugin. It’s an instance of electron-store.
+     */
+    config: ElectronStore<T & BuiltInConfig>;
+
+    /**
+     * Do a network request, like uploading. It’s a wrapper around `got`.
+     */
     request: typeof got;
+
+    /**
+     * Copy text to the clipboard. If you for example copy a link to the
+     * uploaded recording to the clipboard, don’t
+     * forget to `.notify()` the user about it.
+     */
     copyToClipboard(text: string): void;
+
+    /**
+     * Show a notification. Optionally pass in a function that is called with
+     * the event when the notification is clicked.
+     */
     notify(text: string, action?: () => void): void;
+
+    /**
+     * Update progress information in the Kap export window. Use this whenever
+     * you have long-running jobs, like uploading. The percentage should
+     * be a number between 0 and 1.
+     */
     setProgress(text: string, percentage: number): void;
+
+    /**
+     * Open the plugin config file in the user’s editor.
+     */
     openConfigFile(): void;
+
+    /**
+     * Indicate that the plugin operation canceled for some reason. This closes
+     * the Kap export window. If the cancelation was not the result of a user
+     * gesture, use .notify() to inform the user why it was canceled.
+     */
     cancel(): void;
+
+    /**
+     * Returns a Promise that resolves when a deep link for this plugin is
+     * opened. The link should be in the format `kap://plugins/{pluginName}/{rest}`,
+     * where pluginName is the npm package name and rest is the string the
+     * Promise will resolve with. This is useful for OAuth flows.
+     */
     waitForDeepLink(): Promise<string>;
 }
 
@@ -38,8 +100,33 @@ export type ConfigSchema<TValue> = Pick<JSONSchema7, Exclude<keyof JSONSchema7, 
 };
 
 export interface KapShareService<T = unknown> {
+    /**
+     * The function that is run when the user clicks the menu item.
+     */
     action(context: KapContext<T>): Promise<void>;
+
+    /**
+     * The title used in the export menu. For example: "Share to GIPHY". The
+     * text should be in title case, for example, "Save to Disk",
+     * not "Save to disk".
+     */
     title: string;
+
+    /**
+     * The file formats you support.
+     */
     formats: ReadonlyArray<Format>;
+
+    /**
+     * A description displayed at the top of the configuration window. You can
+     * use this to explain the config options or link to API docs. Any links in
+     * this description will be parsed into clickable links automatically.
+     */
+    configDescription: string;
+
+    /**
+     * Definition of the config the plugins needs. A JSON schema, with the
+     * ability to mark properties as `required` individually.
+     */
     config: { [K in keyof T]: ConfigSchema<T[K]> };
 }

--- a/types/kap-plugin/kap-plugin-tests.ts
+++ b/types/kap-plugin/kap-plugin-tests.ts
@@ -16,11 +16,8 @@ const service: KapShareService<Config> = {
             required: true,
             default: 'Bilbo',
         },
-        greeting: {
-            type: 'string',
-            // $ExpectError
-            default: true,
-        },
+        // $ExpectError
+        greeting: { type: 'string', default: true },
     },
     action: async context => {
         // $ExpectType string

--- a/types/kap-plugin/kap-plugin-tests.ts
+++ b/types/kap-plugin/kap-plugin-tests.ts
@@ -25,6 +25,8 @@ const service: KapShareService<Config> = {
         // $ExpectType string
         const name = context.config.get('name');
 
+        context.config.get('accessToken');
+
         // $ExpectError
         context.config.get('unknown');
 

--- a/types/kap-plugin/kap-plugin-tests.ts
+++ b/types/kap-plugin/kap-plugin-tests.ts
@@ -3,6 +3,7 @@ import { KapShareService } from 'kap-plugin';
 interface Config {
     name: string;
     greeting: string;
+    accessToken?: string;
 }
 
 const service: KapShareService<Config> = {

--- a/types/kap-plugin/kap-plugin-tests.ts
+++ b/types/kap-plugin/kap-plugin-tests.ts
@@ -1,0 +1,35 @@
+import { KapShareService } from 'kap-plugin';
+
+interface Config {
+    name: string;
+    greeting: string;
+}
+
+const service: KapShareService<Config> = {
+    title: 'My Plugin',
+    formats: ['apng', 'gif'],
+    config: {
+        name: {
+            type: 'string',
+            minLength: 1,
+            required: true,
+            default: 'Bilbo',
+        },
+        greeting: {
+            type: 'string',
+            // $ExpectError
+            default: true,
+        },
+    },
+    action: async context => {
+        // $ExpectType string
+        const name = context.config.get('name');
+
+        // $ExpectError
+        context.config.get('unknown');
+
+        await context.request(`https://example.com/greet/${name}`);
+
+        context.notify('Greeted example.com');
+    },
+};

--- a/types/kap-plugin/package.json
+++ b/types/kap-plugin/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "electron-store": ">=5.1.0"
+    }
+}

--- a/types/kap-plugin/tsconfig.json
+++ b/types/kap-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "kap-plugin-tests.ts"
+    ]
+}

--- a/types/kap-plugin/tslint.json
+++ b/types/kap-plugin/tslint.json
@@ -1,0 +1,8 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        // Disabled since "kap" is its own application, and this only types one
+        // API that it exposes.
+        "npm-naming": false
+    }
+}


### PR DESCRIPTION
This PR adds typings for writing [kap plugins](https://github.com/wulkano/kap/blob/master/docs/plugins.md).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types
- [x] This is not an npm packages and does not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.