### PR TITLE
[aws-lambda] Add protocol to APIGatewayRequestContext.

### DIFF
--- a/types/aws-lambda/common/api-gateway.d.ts
+++ b/types/aws-lambda/common/api-gateway.d.ts
@@ -9,6 +9,7 @@ export interface APIGatewayEventRequestContext {
     domainPrefix?: string;
     eventType?: string;
     extendedRequestId?: string;
+    protocol: string;
     httpMethod: string;
     identity: {
         accessKey: string | null;

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -28,6 +28,7 @@ let proxyHandler: APIGatewayProxyHandler = async (event, context, callback) => {
     requestContext = event.requestContext;
     str = event.resource;
 
+    str = requestContext.protocol;
     str = requestContext.accountId;
     str = requestContext.apiId;
     const authContext: AuthResponseContext | null | undefined = requestContext.authorizer;


### PR DESCRIPTION
Fixes #42049.

No decent docs from AWS for the actual proxy integration, on the
Lambda side or the API Gateway side, but there's an approximation on
the API Gateway docs for the VTL $context variable:

https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#context-variable-reference

From experimentation, not all of the variables referenced above exist,
at least most of the time, but everything except the `protocol` that
was present in what I received already existed. If that makes any sense.