### PR TITLE
[aws-lambda] Narrow AuthResponseContext type

### DIFF
--- a/types/aws-lambda/common/api-gateway.d.ts
+++ b/types/aws-lambda/common/api-gateway.d.ts
@@ -42,5 +42,5 @@ export interface APIGatewayEventRequestContext {
  * http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-output
  */
 export interface AuthResponseContext {
-    [name: string]: any;
+    [name: string]: string | number | boolean;
 }

--- a/types/aws-lambda/common/api-gateway.d.ts
+++ b/types/aws-lambda/common/api-gateway.d.ts
@@ -42,5 +42,5 @@ export interface APIGatewayEventRequestContext {
  * http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-output
  */
 export interface AuthResponseContext {
-    [name: string]: string | number | boolean;
+    [name: string]: string | number | boolean | undefined;
 }

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -33,6 +33,7 @@
 //                 Alex Bolenok <https://github.com/alex-bolenok-centralreach>
 //                 Marian Zange <https://github.com/marianzange>
 //                 Alexander Pepper <https://github.com/apepper>
+//                 Cassidy Bandy <https://github.com/c-bandy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -158,7 +158,15 @@ const authorizerHandler: CustomAuthorizerHandler = async (event, context, callba
 
     policyDocument = { Version: str, Statement: [statement, statement] };
 
-    const authResponseContext: AuthResponseContext = {
+    // Test bad key types
+    let authResponseContext: AuthResponseContext = {
+        // $ExpectError
+        arrayKey: [],
+        // $ExpectError
+        objectKey: {}
+    };
+
+    authResponseContext = {
         stringKey: str,
         numberKey: num,
         booleanKey: bool,

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -158,13 +158,11 @@ const authorizerHandler: CustomAuthorizerHandler = async (event, context, callba
 
     policyDocument = { Version: str, Statement: [statement, statement] };
 
-    // Test bad key types
-    let authResponseContext: AuthResponseContext = {
-        // $ExpectError
-        arrayKey: [],
-        // $ExpectError
-        objectKey: {}
-    };
+    // $ExpectError
+    let authResponseContext: AuthResponseContext = { arrayKey: ['foo'] };
+
+    // $ExpectError
+    authResponseContext = { objectKey: { bar: 123 } };
 
     authResponseContext = {
         stringKey: strOrUndefined,

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -167,9 +167,9 @@ const authorizerHandler: CustomAuthorizerHandler = async (event, context, callba
     };
 
     authResponseContext = {
-        stringKey: str,
-        numberKey: num,
-        booleanKey: bool,
+        stringKey: strOrUndefined,
+        numberKey: numOrUndefined,
+        booleanKey: boolOrUndefined,
     };
 
     let result: CustomAuthorizerResult = {


### PR DESCRIPTION
Fixes #42418

> You can access the stringKey, numberKey, or booleanKey value (for example, "value", "1", or "true") of the context map in a mapping template by calling $context.authorizer.stringKey, $context.authorizer.numberKey, or $context.authorizer.booleanKey, respectively. The returned values are all stringified. Notice that you cannot set a JSON object or array as a valid value of any key in the context map.

From https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html