### PR TITLE
feat(node): add `entryType` to all types and interfaces that use it

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -41,6 +41,7 @@
 //                 Minh Son Nguyen <https://github.com/nguymin4>
 //                 Junxiao Shi <https://github.com/yoursunny>
 //                 Ilia Baryshnikov <https://github.com/qwelias>
+//                 Surasak Chaisurin <https://github.com/Ryan-Willpower>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // NOTE: These definitions support NodeJS and TypeScript 3.5.

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -1,6 +1,8 @@
 declare module 'perf_hooks' {
     import { AsyncResource } from 'async_hooks';
 
+    type EntryType = 'node' | 'mark' | 'measure' | 'gc' | 'function' | 'http2' | 'http';
+
     interface PerformanceEntry {
         /**
          * The total number of milliseconds elapsed for this entry.
@@ -22,7 +24,7 @@ declare module 'perf_hooks' {
          * The type of the performance entry.
          * Currently it may be one of: 'node', 'mark', 'measure', 'gc', or 'function'.
          */
-        readonly entryType: string;
+        readonly entryType: EntryType;
 
         /**
          * When performanceEntry.entryType is equal to 'gc', the performance.kind property identifies
@@ -98,8 +100,6 @@ declare module 'perf_hooks' {
          */
         readonly v8Start: number;
     }
-
-    type EntryType = 'node' | 'mark' | 'measure' | 'gc' | 'function' | 'http2' | 'http';
 
     interface Performance {
         /**

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -1,5 +1,5 @@
-declare module "perf_hooks" {
-    import { AsyncResource } from "async_hooks";
+declare module 'perf_hooks' {
+    import { AsyncResource } from 'async_hooks';
 
     interface PerformanceEntry {
         /**
@@ -99,6 +99,8 @@ declare module "perf_hooks" {
         readonly v8Start: number;
     }
 
+    type EntryType = 'node' | 'mark' | 'measure' | 'gc' | 'function' | 'http2' | 'http';
+
     interface Performance {
         /**
          * If name is not provided, removes all PerformanceFunction objects from the Performance Timeline.
@@ -133,7 +135,7 @@ declare module "perf_hooks" {
          * @param type
          * @return list of all PerformanceEntry objects
          */
-        getEntriesByName(name: string, type?: string): PerformanceEntry[];
+        getEntriesByName(name: string, type?: EntryType): PerformanceEntry[];
 
         /**
          * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
@@ -141,7 +143,7 @@ declare module "perf_hooks" {
          * @param type
          * @return list of all PerformanceEntry objects
          */
-        getEntriesByType(type: string): PerformanceEntry[];
+        getEntriesByType(type: EntryType): PerformanceEntry[];
 
         /**
          * Creates a new PerformanceMark entry in the Performance Timeline.
@@ -202,13 +204,13 @@ declare module "perf_hooks" {
          * @return a list of PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
          * whose performanceEntry.name is equal to name, and optionally, whose performanceEntry.entryType is equal to type.
          */
-        getEntriesByName(name: string, type?: string): PerformanceEntry[];
+        getEntriesByName(name: string, type?: EntryType): PerformanceEntry[];
 
         /**
          * @return Returns a list of PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
          * whose performanceEntry.entryType is equal to type.
          */
-        getEntriesByType(type: string): PerformanceEntry[];
+        getEntriesByType(type: EntryType): PerformanceEntry[];
     }
 
     type PerformanceObserverCallback = (list: PerformanceObserverEntryList, observer: PerformanceObserver) => void;
@@ -227,7 +229,7 @@ declare module "perf_hooks" {
          * Property buffered defaults to false.
          * @param options
          */
-        observe(options: { entryTypes: string[], buffered?: boolean }): void;
+        observe(options: { entryTypes: EntryType[]; buffered?: boolean }): void;
     }
 
     namespace constants {


### PR DESCRIPTION
Add `entryType` to all types and interfaces that use it. Because I think this is better than using `string` or `string[]` type, which could easily cause an error.

PS. I run the `npm test` twice and it passed on my machine.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [performanceEntry.entryType](https://nodejs.org/api/perf_hooks.html#perf_hooks_performanceentry_entrytype)
