### PR TITLE
Fix @theme-ui/color types

### DIFF
--- a/types/theme-ui__color/index.d.ts
+++ b/types/theme-ui__color/index.d.ts
@@ -4,14 +4,26 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.5
 
-export * from 'polished';
-// A few polished functions have been renamed in theme-ui
-// If these are updated in polished, then the code below can be deleted
-import {
-    adjustHue as rotate,
-    rgba as alpha,
-    setHue as hue,
-    setLightness as lightness,
-    setSaturation as saturation,
-} from 'polished';
-export { alpha, hue, lightness, rotate, saturation };
+export function darken(color: string, number: number | string): string;
+export function lighten(color: string, number: number | string): string;
+export function rotate(color: string, degree: number | string): string;
+
+export function hue(color: string, hue: number | string): string;
+export function saturation(color: string, saturation: number | string): string;
+export function lightness(color: string, lightness: number | string): string;
+
+export function desaturate(color: string, number: number | string): string;
+export function saturate(color: string, number: number | string): string;
+
+export function shade(color: string, number: number | string): string;
+export function tint(color: string, number: number | string): string;
+
+export function transparentize(color: string, number: number | string): string;
+export function alpha(color: string, number: number | string): string;
+
+export function mix(color: string, otherColor: string, number?: number | string): string;
+
+export function complement(color: string): string;
+export function invert(color: string): string;
+
+export function grayscale(color: string): string;

--- a/types/theme-ui__color/index.d.ts
+++ b/types/theme-ui__color/index.d.ts
@@ -26,4 +26,4 @@ export function mix(color: string, otherColor: string, number?: number | string)
 export function complement(color: string): string;
 export function invert(color: string): string;
 
-export function grayscale(color: string): string;
+export function grayscale(color: string, number: number | string): string;

--- a/types/theme-ui__color/package.json
+++ b/types/theme-ui__color/package.json
@@ -1,6 +1,0 @@
-{
-  "private": true,
-  "dependencies": {
-    "polished": "^3.4.1"
-  }
-}

--- a/types/theme-ui__color/theme-ui__color-tests.ts
+++ b/types/theme-ui__color/theme-ui__color-tests.ts
@@ -17,20 +17,42 @@ import {
     grayscale,
 } from '@theme-ui/color';
 
-darken(0.2, '#000');
-lighten(0.2, '#000');
-rotate(0.2, '#000');
-hue(0.2, '#000');
-saturation(0.2, '#000');
-lightness(0.2, '#000');
-desaturate(0.1, '#000');
-saturate(0.1, '#000');
-shade('20%', '#000');
-tint('20%', '#000');
-transparentize(0.2, '#000');
+darken('#000', 0.2);
+darken('#000', '0.2');
+lighten('#000', 0.2);
+lighten('#000', '0.2');
+rotate('#000', 0.2);
+rotate('#000', '0.2');
+
+hue('#000', 2);
+hue('#000', '2');
+
+saturation('#000', 0.2);
+saturation('#000', '0.2');
+lightness('#000', 0.2);
+lightness('#000', '0.2');
+
+desaturate('#000', 0.1);
+desaturate('#000', '0.1');
+saturate('#000', 0.1);
+saturate('#000', '0.1');
+
+shade('#000', 0.25);
+shade('#000', '0.25');
+tint('#000', 0.25);
+tint('#000', '0.25');
+
+transparentize('#000', 0.2);
+transparentize('#000', '0.2');
 alpha('#000', 0.2);
-mix(0.25, '#000', '#FFF');
-complement('#000');
+alpha('#000', '0.2');
+
+mix('#000', '#FFF');
+mix('#000', '#FFF', 0.25);
+mix('#000', '#FFF', '0.25');
+
 complement('#000');
 invert('#000');
-grayscale('#000');
+
+grayscale('#000', 0.25);
+grayscale('#000', '0.25');


### PR DESCRIPTION
@hasparus Thanks for picking up that the parameter order was wrong, totally missed that 🤦‍♂.
Have fixed up the parameter order, added more tests and marked number in the `mix` function as optional, as [the source](https://github.com/system-ui/theme-ui/blob/master/packages/color/src/index.js#L26) has a default param.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42358#issuecomment-586747791