### PR TITLE
ArangoDB: Remove import of graphql

### DIFF
--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -1531,9 +1531,17 @@ declare module "@arangodb/foxx/queues" {
 }
 
 declare module "@arangodb/foxx/graphql" {
-    import { formatError, GraphQLSchema } from "graphql";
-    type GraphQLModule = object;
-    type GraphQLFormatErrorFunction = typeof formatError;
+    type GraphQLSchema = object;
+    type GraphQLFormatErrorFunction = (error: any) => any;
+    type GraphQLModule = {
+      formatError: GraphQLFormatErrorFunction;
+      Source: any;
+      parse: any;
+      validate: any;
+      specifiedRules: any;
+      getOperationAST: any;
+      execute: any;
+    };
     interface GraphQLOptions {
         schema: GraphQLSchema;
         context?: any;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -1541,7 +1541,7 @@ declare module "@arangodb/foxx/graphql" {
       specifiedRules: any;
       getOperationAST: any;
       execute: any;
-    };
+    }
     interface GraphQLOptions {
         schema: GraphQLSchema;
         context?: any;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -1533,7 +1533,7 @@ declare module "@arangodb/foxx/queues" {
 declare module "@arangodb/foxx/graphql" {
     type GraphQLSchema = object;
     type GraphQLFormatErrorFunction = (error: any) => any;
-    type GraphQLModule = {
+    interface GraphQLModule {
       formatError: GraphQLFormatErrorFunction;
       Source: any;
       parse: any;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

These typings are typically used for Foxx services. There's no reason to introduce a hard dependency on installing the graphql module just to be able to validate that the graphql module or schema users are passing into the (entirely optional) graphql integration is fully well-formed.

Rough type checking is entirely sufficient and avoid accidentally bloating the bundle size for services that don't use graphql (which is most of them).

This change reduces the type checking for one function but removes the dependency on graphql (and iterall as a transient dependency).