### PR TITLE
Supercluster `getLeaves` should return points only

### DIFF
--- a/types/supercluster/index.d.ts
+++ b/types/supercluster/index.d.ts
@@ -162,7 +162,7 @@ declare class Supercluster<P extends GeoJSON.GeoJsonProperties = Supercluster.An
      * @param limit The number of points to return (set to `Infinity` for all points).
      * @param offset The amount of points to skip (for pagination).
      */
-    getLeaves(clusterId: number, limit?: number, offset?: number): Array<Supercluster.ClusterFeature<C> | Supercluster.PointFeature<P>>; // Cluster[];
+    getLeaves(clusterId: number, limit?: number, offset?: number): Array<Supercluster.PointFeature<P>>;
 
     /**
      * Returns the zoom level on which the cluster expands into several


### PR DESCRIPTION
As per documentation, this method should return points only instead of clusters and points https://github.com/mapbox/supercluster#getleavesclusterid-limit--10-offset--0

-------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mapbox/supercluster#getleavesclusterid-limit--10-offset--0
