### PR TITLE
feat(gremlin): Add type support for v3.4.4

### DIFF
--- a/types/gremlin/index.d.ts
+++ b/types/gremlin/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for gremlin 3.4
 // Project: https://tinkerpop.apache.org/
-// Definitions by: matt-sungwook <https://github.com/matt-sungwook>
+// Definitions by: matt-sungwook <https://github.com/matt-sungwook>, keith1024 <https://github.com/keith1024>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export {
@@ -9,34 +9,48 @@ export {
   structure,
 };
 
+import RemoteConnection = driver.RemoteConnection;
+
+import Bytecode = process.Bytecode;
+import GraphTraversalSource = process.GraphTraversalSource;
+import Traversal = process.Traversal;
+import TraversalSideEffects = process.TraversalSideEffects;
+import TraversalStrategy = process.TraversalStrategy;
+import Traverser = process.Traverser;
+
+import Graph = structure.Graph;
+
+type Nullable<T> = T | null;
+interface Newable<T> { new (...args: any[]): T; }
+
 declare namespace driver {
   class RemoteConnection {
     constructor(url: string);
     open(): Promise<void>;
-    submit(bytecode: process.Bytecode): Promise<any>;
+    submit(bytecode: Bytecode): Promise<any>;
     close(): Promise<void>;
   }
 
-  class RemoteStrategy extends process.TraversalStrategy {
+  class RemoteStrategy extends TraversalStrategy {
     constructor(connection: RemoteConnection);
     apply(traversal: RemoteTraversal): Promise<any>;
   }
 
-  class RemoteTraversal extends process.Traversal {
-    constructor(traversers?: process.Traverser[], sideEffects?: process.TraversalSideEffects);
+  class RemoteTraversal extends Traversal {
+    constructor(traversers?: Traverser[], sideEffects?: TraversalSideEffects);
   }
 
   class DriverRemoteConnection extends RemoteConnection {
     constructor(url: string, options?: any);
     open(): Promise<void>;
-    submit(bytecode: process.Bytecode): Promise<any>;
+    submit(bytecode: Bytecode): Promise<any>;
     close(): Promise<void>;
   }
 
   class Client {
     constructor(url: string, options?: any);
     open(): Promise<void>;
-    submit(message: process.Bytecode | string, bindings?: any): Promise<any>;
+    submit(message: Bytecode | string, bindings?: any): Promise<any>;
     close(): Promise<void>;
   }
 
@@ -106,7 +120,7 @@ declare namespace process {
   }
 
   class Traversal {
-    constructor(graph: structure.Graph | null, traversalStrategies: TraversalStrategies | null, bytecode: Bytecode);
+    constructor(graph: Nullable<Graph>, traversalStrategies: Nullable<TraversalStrategies>, bytecode: Bytecode);
     // [asyncIteratorSymbol: symbol | SymbolConstructor](): Traversal; // How can I implement this?
     getBytecode(): Bytecode;
     toList(): Promise<Traverser[]>;
@@ -212,219 +226,227 @@ declare namespace process {
   };
 
   class GraphTraversal extends Traversal {
-    constructor(graph: structure.Graph | null, traversalStrategies: TraversalStrategies | null, bytecode: Bytecode);
-    V(...args: any[]): GraphTraversal;
-    addE(...args: any[]): GraphTraversal;
-    addV(...args: any[]): GraphTraversal;
-    aggregate(...args: any[]): GraphTraversal;
-    and(...args: any[]): GraphTraversal;
-    as(...args: any[]): GraphTraversal;
-    barrier(...args: any[]): GraphTraversal;
-    both(...args: any[]): GraphTraversal;
-    bothE(...args: any[]): GraphTraversal;
-    bothV(...args: any[]): GraphTraversal;
-    branch(...args: any[]): GraphTraversal;
-    by(...args: any[]): GraphTraversal;
-    cap(...args: any[]): GraphTraversal;
-    choose(...args: any[]): GraphTraversal;
-    coalesce(...args: any[]): GraphTraversal;
-    coin(...args: any[]): GraphTraversal;
-    connectedComponent(...args: any[]): GraphTraversal;
-    constant(...args: any[]): GraphTraversal;
-    count(...args: any[]): GraphTraversal;
-    cyclicPath(...args: any[]): GraphTraversal;
-    dedup(...args: any[]): GraphTraversal;
-    drop(...args: any[]): GraphTraversal;
-    emit(...args: any[]): GraphTraversal;
-    filter(...args: any[]): GraphTraversal;
-    flatMap(...args: any[]): GraphTraversal;
-    fold(...args: any[]): GraphTraversal;
-    from_(...args: any[]): GraphTraversal;
-    group(...args: any[]): GraphTraversal;
-    groupCount(...args: any[]): GraphTraversal;
-    has(...args: any[]): GraphTraversal;
-    hasId(...args: any[]): GraphTraversal;
-    hasKey(...args: any[]): GraphTraversal;
-    hasLabel(...args: any[]): GraphTraversal;
-    hasNot(...args: any[]): GraphTraversal;
-    hasValue(...args: any[]): GraphTraversal;
-    id(...args: any[]): GraphTraversal;
-    identity(...args: any[]): GraphTraversal;
-    in_(...args: any[]): GraphTraversal;
-    inE(...args: any[]): GraphTraversal;
-    inV(...args: any[]): GraphTraversal;
-    index(...args: any[]): GraphTraversal;
-    inject(...args: any[]): GraphTraversal;
-    is(...args: any[]): GraphTraversal;
-    key(...args: any[]): GraphTraversal;
-    label(...args: any[]): GraphTraversal;
-    limit(...args: any[]): GraphTraversal;
-    local(...args: any[]): GraphTraversal;
-    loops(...args: any[]): GraphTraversal;
-    map(...args: any[]): GraphTraversal;
-    match(...args: any[]): GraphTraversal;
-    math(...args: any[]): GraphTraversal;
-    max(...args: any[]): GraphTraversal;
-    mean(...args: any[]): GraphTraversal;
-    min(...args: any[]): GraphTraversal;
-    not(...args: any[]): GraphTraversal;
-    option(...args: any[]): GraphTraversal;
-    optional(...args: any[]): GraphTraversal;
-    or(...args: any[]): GraphTraversal;
-    order(...args: any[]): GraphTraversal;
-    otherV(...args: any[]): GraphTraversal;
-    out(...args: any[]): GraphTraversal;
-    outE(...args: any[]): GraphTraversal;
-    outV(...args: any[]): GraphTraversal;
-    pageRank(...args: any[]): GraphTraversal;
-    path(...args: any[]): GraphTraversal;
-    peerPressure(...args: any[]): GraphTraversal;
-    profile(...args: any[]): GraphTraversal;
-    program(...args: any[]): GraphTraversal;
-    project(...args: any[]): GraphTraversal;
-    properties(...args: any[]): GraphTraversal;
-    property(...args: any[]): GraphTraversal;
-    propertyMap(...args: any[]): GraphTraversal;
-    range(...args: any[]): GraphTraversal;
-    read(...args: any[]): GraphTraversal;
-    repeat(...args: any[]): GraphTraversal;
-    sack(...args: any[]): GraphTraversal;
-    sample(...args: any[]): GraphTraversal;
-    select(...args: any[]): GraphTraversal;
-    shortestPath(...args: any[]): GraphTraversal;
-    sideEffect(...args: any[]): GraphTraversal;
-    simplePath(...args: any[]): GraphTraversal;
-    skip(...args: any[]): GraphTraversal;
-    store(...args: any[]): GraphTraversal;
-    subgraph(...args: any[]): GraphTraversal;
-    sum(...args: any[]): GraphTraversal;
-    tail(...args: any[]): GraphTraversal;
-    timeLimit(...args: any[]): GraphTraversal;
-    times(...args: any[]): GraphTraversal;
-    to(...args: any[]): GraphTraversal;
-    toE(...args: any[]): GraphTraversal;
-    toV(...args: any[]): GraphTraversal;
-    tree(...args: any[]): GraphTraversal;
-    unfold(...args: any[]): GraphTraversal;
-    union(...args: any[]): GraphTraversal;
-    until(...args: any[]): GraphTraversal;
-    value(...args: any[]): GraphTraversal;
-    valueMap(...args: any[]): GraphTraversal;
-    values(...args: any[]): GraphTraversal;
-    where(...args: any[]): GraphTraversal;
-    with_(...args: any[]): GraphTraversal;
-    write(...args: any[]): GraphTraversal;
+    constructor(graph: Nullable<Graph>, traversalStrategies: Nullable<TraversalStrategies>, bytecode: Bytecode);
+    V(...args: any[]): this;
+    addE(...args: any[]): this;
+    addV(...args: any[]): this;
+    aggregate(...args: any[]): this;
+    and(...args: any[]): this;
+    as(...args: any[]): this;
+    barrier(...args: any[]): this;
+    both(...args: any[]): this;
+    bothE(...args: any[]): this;
+    bothV(...args: any[]): this;
+    branch(...args: any[]): this;
+    by(...args: any[]): this;
+    cap(...args: any[]): this;
+    choose(...args: any[]): this;
+    coalesce(...args: any[]): this;
+    coin(...args: any[]): this;
+    connectedComponent(...args: any[]): this;
+    constant(...args: any[]): this;
+    count(...args: any[]): this;
+    cyclicPath(...args: any[]): this;
+    dedup(...args: any[]): this;
+    drop(...args: any[]): this;
+    elementMap(...args: any[]): this;
+    emit(...args: any[]): this;
+    filter(...args: any[]): this;
+    flatMap(...args: any[]): this;
+    fold(...args: any[]): this;
+    from_(...args: any[]): this;
+    group(...args: any[]): this;
+    groupCount(...args: any[]): this;
+    has(...args: any[]): this;
+    hasId(...args: any[]): this;
+    hasKey(...args: any[]): this;
+    hasLabel(...args: any[]): this;
+    hasNot(...args: any[]): this;
+    hasValue(...args: any[]): this;
+    id(...args: any[]): this;
+    identity(...args: any[]): this;
+    in_(...args: any[]): this;
+    inE(...args: any[]): this;
+    inV(...args: any[]): this;
+    index(...args: any[]): this;
+    inject(...args: any[]): this;
+    is(...args: any[]): this;
+    key(...args: any[]): this;
+    label(...args: any[]): this;
+    limit(...args: any[]): this;
+    local(...args: any[]): this;
+    loops(...args: any[]): this;
+    map(...args: any[]): this;
+    match(...args: any[]): this;
+    math(...args: any[]): this;
+    max(...args: any[]): this;
+    mean(...args: any[]): this;
+    min(...args: any[]): this;
+    not(...args: any[]): this;
+    option(...args: any[]): this;
+    optional(...args: any[]): this;
+    or(...args: any[]): this;
+    order(...args: any[]): this;
+    otherV(...args: any[]): this;
+    out(...args: any[]): this;
+    outE(...args: any[]): this;
+    outV(...args: any[]): this;
+    pageRank(...args: any[]): this;
+    path(...args: any[]): this;
+    peerPressure(...args: any[]): this;
+    profile(...args: any[]): this;
+    program(...args: any[]): this;
+    project(...args: any[]): this;
+    properties(...args: any[]): this;
+    property(...args: any[]): this;
+    propertyMap(...args: any[]): this;
+    range(...args: any[]): this;
+    read(...args: any[]): this;
+    repeat(...args: any[]): this;
+    sack(...args: any[]): this;
+    sample(...args: any[]): this;
+    select(...args: any[]): this;
+    shortestPath(...args: any[]): this;
+    sideEffect(...args: any[]): this;
+    simplePath(...args: any[]): this;
+    skip(...args: any[]): this;
+    store(...args: any[]): this;
+    subgraph(...args: any[]): this;
+    sum(...args: any[]): this;
+    tail(...args: any[]): this;
+    timeLimit(...args: any[]): this;
+    times(...args: any[]): this;
+    to(...args: any[]): this;
+    toE(...args: any[]): this;
+    toV(...args: any[]): this;
+    tree(...args: any[]): this;
+    unfold(...args: any[]): this;
+    union(...args: any[]): this;
+    until(...args: any[]): this;
+    value(...args: any[]): this;
+    valueMap(...args: any[]): this;
+    values(...args: any[]): this;
+    where(...args: any[]): this;
+    with_(...args: any[]): this;
+    write(...args: any[]): this;
   }
 
-  class GraphTraversalSource {
-    constructor(graph: structure.Graph | null, traversalStrategies: TraversalStrategies | null, bytecode: Bytecode);
-    withRemote(remoteConnection: driver.RemoteConnection): GraphTraversalSource;
+  class GraphTraversalSource<T extends GraphTraversal = GraphTraversal> {
+    constructor(
+      graph: Nullable<Graph>,
+      traversalStrategies: Nullable<TraversalStrategies>,
+      bytecode?: Bytecode,
+      graphTraversalSourceClass?: Newable<GraphTraversalSource>,
+      graphTraversalClass?: Newable<T>,
+    );
+    withRemote(remoteConnection: RemoteConnection): this;
     toString(): string;
-    with_(...args: any[]): GraphTraversalSource;
-    withBulk(...args: any[]): GraphTraversalSource;
-    withPath(...args: any[]): GraphTraversalSource;
-    withSack(...args: any[]): GraphTraversalSource;
-    withSideEffect(...args: any[]): GraphTraversalSource;
-    withStrategies(...args: any[]): GraphTraversalSource;
-    withoutStrategies(...args: any[]): GraphTraversalSource;
-    E(...args: any[]): GraphTraversal;
-    V(...args: any[]): GraphTraversal;
-    addE(...args: any[]): GraphTraversal;
-    addV(...args: any[]): GraphTraversal;
-    inject(...args: any[]): GraphTraversal;
-    io(...args: any[]): GraphTraversal;
+    with_(...args: any[]): this;
+    withBulk(...args: any[]): this;
+    withPath(...args: any[]): this;
+    withSack(...args: any[]): this;
+    withSideEffect(...args: any[]): this;
+    withStrategies(...args: any[]): this;
+    withoutStrategies(...args: any[]): this;
+    E(...args: any[]): T;
+    V(...args: any[]): T;
+    addE(...args: any[]): T;
+    addV(...args: any[]): T;
+    inject(...args: any[]): T;
+    io(...args: any[]): T;
   }
 
-  interface Statics {
-    V: (...args: any[]) => GraphTraversal;
-    addE: (...args: any[]) => GraphTraversal;
-    addV: (...args: any[]) => GraphTraversal;
-    aggregate: (...args: any[]) => GraphTraversal;
-    and: (...args: any[]) => GraphTraversal;
-    as: (...args: any[]) => GraphTraversal;
-    barrier: (...args: any[]) => GraphTraversal;
-    both: (...args: any[]) => GraphTraversal;
-    bothE: (...args: any[]) => GraphTraversal;
-    bothV: (...args: any[]) => GraphTraversal;
-    branch: (...args: any[]) => GraphTraversal;
-    cap: (...args: any[]) => GraphTraversal;
-    choose: (...args: any[]) => GraphTraversal;
-    coalesce: (...args: any[]) => GraphTraversal;
-    coin: (...args: any[]) => GraphTraversal;
-    constant: (...args: any[]) => GraphTraversal;
-    count: (...args: any[]) => GraphTraversal;
-    cyclicPath: (...args: any[]) => GraphTraversal;
-    dedup: (...args: any[]) => GraphTraversal;
-    drop: (...args: any[]) => GraphTraversal;
-    emit: (...args: any[]) => GraphTraversal;
-    filter: (...args: any[]) => GraphTraversal;
-    flatMap: (...args: any[]) => GraphTraversal;
-    fold: (...args: any[]) => GraphTraversal;
-    group: (...args: any[]) => GraphTraversal;
-    groupCount: (...args: any[]) => GraphTraversal;
-    has: (...args: any[]) => GraphTraversal;
-    hasId: (...args: any[]) => GraphTraversal;
-    hasKey: (...args: any[]) => GraphTraversal;
-    hasLabel: (...args: any[]) => GraphTraversal;
-    hasNot: (...args: any[]) => GraphTraversal;
-    hasValue: (...args: any[]) => GraphTraversal;
-    id: (...args: any[]) => GraphTraversal;
-    identity: (...args: any[]) => GraphTraversal;
-    in_: (...args: any[]) => GraphTraversal;
-    inE: (...args: any[]) => GraphTraversal;
-    inV: (...args: any[]) => GraphTraversal;
-    index: (...args: any[]) => GraphTraversal;
-    inject: (...args: any[]) => GraphTraversal;
-    is: (...args: any[]) => GraphTraversal;
-    key: (...args: any[]) => GraphTraversal;
-    label: (...args: any[]) => GraphTraversal;
-    limit: (...args: any[]) => GraphTraversal;
-    local: (...args: any[]) => GraphTraversal;
-    loops: (...args: any[]) => GraphTraversal;
-    map: (...args: any[]) => GraphTraversal;
-    match: (...args: any[]) => GraphTraversal;
-    math: (...args: any[]) => GraphTraversal;
-    max: (...args: any[]) => GraphTraversal;
-    mean: (...args: any[]) => GraphTraversal;
-    min: (...args: any[]) => GraphTraversal;
-    not: (...args: any[]) => GraphTraversal;
-    optional: (...args: any[]) => GraphTraversal;
-    or: (...args: any[]) => GraphTraversal;
-    order: (...args: any[]) => GraphTraversal;
-    otherV: (...args: any[]) => GraphTraversal;
-    out: (...args: any[]) => GraphTraversal;
-    outE: (...args: any[]) => GraphTraversal;
-    outV: (...args: any[]) => GraphTraversal;
-    path: (...args: any[]) => GraphTraversal;
-    project: (...args: any[]) => GraphTraversal;
-    properties: (...args: any[]) => GraphTraversal;
-    property: (...args: any[]) => GraphTraversal;
-    propertyMap: (...args: any[]) => GraphTraversal;
-    range: (...args: any[]) => GraphTraversal;
-    repeat: (...args: any[]) => GraphTraversal;
-    sack: (...args: any[]) => GraphTraversal;
-    sample: (...args: any[]) => GraphTraversal;
-    select: (...args: any[]) => GraphTraversal;
-    sideEffect: (...args: any[]) => GraphTraversal;
-    simplePath: (...args: any[]) => GraphTraversal;
-    skip: (...args: any[]) => GraphTraversal;
-    store: (...args: any[]) => GraphTraversal;
-    subgraph: (...args: any[]) => GraphTraversal;
-    sum: (...args: any[]) => GraphTraversal;
-    tail: (...args: any[]) => GraphTraversal;
-    timeLimit: (...args: any[]) => GraphTraversal;
-    times: (...args: any[]) => GraphTraversal;
-    to: (...args: any[]) => GraphTraversal;
-    toE: (...args: any[]) => GraphTraversal;
-    toV: (...args: any[]) => GraphTraversal;
-    tree: (...args: any[]) => GraphTraversal;
-    unfold: (...args: any[]) => GraphTraversal;
-    union: (...args: any[]) => GraphTraversal;
-    until: (...args: any[]) => GraphTraversal;
-    value: (...args: any[]) => GraphTraversal;
-    valueMap: (...args: any[]) => GraphTraversal;
-    values: (...args: any[]) => GraphTraversal;
-    where: (...args: any[]) => GraphTraversal;
+  interface Statics<T extends GraphTraversal = GraphTraversal> {
+    V: (...args: any[]) => T;
+    addE: (...args: any[]) => T;
+    addV: (...args: any[]) => T;
+    aggregate: (...args: any[]) => T;
+    and: (...args: any[]) => T;
+    as: (...args: any[]) => T;
+    barrier: (...args: any[]) => T;
+    both: (...args: any[]) => T;
+    bothE: (...args: any[]) => T;
+    bothV: (...args: any[]) => T;
+    branch: (...args: any[]) => T;
+    cap: (...args: any[]) => T;
+    choose: (...args: any[]) => T;
+    coalesce: (...args: any[]) => T;
+    coin: (...args: any[]) => T;
+    constant: (...args: any[]) => T;
+    count: (...args: any[]) => T;
+    cyclicPath: (...args: any[]) => T;
+    dedup: (...args: any[]) => T;
+    drop: (...args: any[]) => T;
+    elementMap: (...args: any[]) => T;
+    emit: (...args: any[]) => T;
+    filter: (...args: any[]) => T;
+    flatMap: (...args: any[]) => T;
+    fold: (...args: any[]) => T;
+    group: (...args: any[]) => T;
+    groupCount: (...args: any[]) => T;
+    has: (...args: any[]) => T;
+    hasId: (...args: any[]) => T;
+    hasKey: (...args: any[]) => T;
+    hasLabel: (...args: any[]) => T;
+    hasNot: (...args: any[]) => T;
+    hasValue: (...args: any[]) => T;
+    id: (...args: any[]) => T;
+    identity: (...args: any[]) => T;
+    in_: (...args: any[]) => T;
+    inE: (...args: any[]) => T;
+    inV: (...args: any[]) => T;
+    index: (...args: any[]) => T;
+    inject: (...args: any[]) => T;
+    is: (...args: any[]) => T;
+    key: (...args: any[]) => T;
+    label: (...args: any[]) => T;
+    limit: (...args: any[]) => T;
+    local: (...args: any[]) => T;
+    loops: (...args: any[]) => T;
+    map: (...args: any[]) => T;
+    match: (...args: any[]) => T;
+    math: (...args: any[]) => T;
+    max: (...args: any[]) => T;
+    mean: (...args: any[]) => T;
+    min: (...args: any[]) => T;
+    not: (...args: any[]) => T;
+    optional: (...args: any[]) => T;
+    or: (...args: any[]) => T;
+    order: (...args: any[]) => T;
+    otherV: (...args: any[]) => T;
+    out: (...args: any[]) => T;
+    outE: (...args: any[]) => T;
+    outV: (...args: any[]) => T;
+    path: (...args: any[]) => T;
+    project: (...args: any[]) => T;
+    properties: (...args: any[]) => T;
+    property: (...args: any[]) => T;
+    propertyMap: (...args: any[]) => T;
+    range: (...args: any[]) => T;
+    repeat: (...args: any[]) => T;
+    sack: (...args: any[]) => T;
+    sample: (...args: any[]) => T;
+    select: (...args: any[]) => T;
+    sideEffect: (...args: any[]) => T;
+    simplePath: (...args: any[]) => T;
+    skip: (...args: any[]) => T;
+    store: (...args: any[]) => T;
+    subgraph: (...args: any[]) => T;
+    sum: (...args: any[]) => T;
+    tail: (...args: any[]) => T;
+    timeLimit: (...args: any[]) => T;
+    times: (...args: any[]) => T;
+    to: (...args: any[]) => T;
+    toE: (...args: any[]) => T;
+    toV: (...args: any[]) => T;
+    tree: (...args: any[]) => T;
+    unfold: (...args: any[]) => T;
+    union: (...args: any[]) => T;
+    until: (...args: any[]) => T;
+    value: (...args: any[]) => T;
+    valueMap: (...args: any[]) => T;
+    values: (...args: any[]) => T;
+    where: (...args: any[]) => T;
   }
 
   const statics: Statics;
@@ -436,12 +458,12 @@ declare namespace process {
     translate(bytecode: Bytecode): string;
   }
 
-  function traversal(): AnonymousTraversalSource;
+  function traversal<S extends GraphTraversalSource = GraphTraversalSource>(traversalSourceClass?: Newable<S>): AnonymousTraversalSource<S>;
 
-  class AnonymousTraversalSource {
-    static traversal(): AnonymousTraversalSource;
-    withRemote(remoteConnection: driver.RemoteConnection): GraphTraversalSource;
-    withGraph(graph: structure.Graph): GraphTraversalSource;
+  class AnonymousTraversalSource<S extends GraphTraversalSource = GraphTraversalSource> {
+    static traversal<S extends GraphTraversalSource>(traversalSourceClass?: Newable<S>): AnonymousTraversalSource<S>;
+    withRemote(remoteConnection: RemoteConnection): S;
+    withGraph(graph: Graph): S;
   }
 
   interface WithOptions {
@@ -483,7 +505,7 @@ declare namespace structure {
   }
 
   class Graph {
-    traversal(): process.GraphTraversalSource;
+    traversal(): GraphTraversalSource;
     toString(): string;
   }
 


### PR DESCRIPTION
Add DSL type support

- Base classes `GraphTraversalSource` and `GraphTraversal`steps return `this`
in order to not lose the extensions added by derived DSL classes.
- Generic type `T` is used by `GraphTraversalSource`, and `Statics`
to specificy their steps `GraphTraversal` return type. Defaults to `GraphTraversal`.
- Generic type `S` is used by `AnonymousTraversalSource`, to specify the
underlying `GraphTraversalSource` type. Defaults to `GraphTraversalSource`.

Add DSL tests

Add definitions for `elementMap`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/apache/tinkerpop/blob/master/CHANGELOG.asciidoc#tinkerpop-344-release-date-october-14-2019>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.