### PR TITLE
[mongoose] Add AsyncIterator on Query and Aggregate

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -35,6 +35,7 @@
 //                 Thomas Pischulski <https://github.com/nephix>
 //                 Sam Kim <https://github.com/rlaace423>
 //                 Dongjun Lee <https://github.com/ChazEpps>
+//                 Clement Debiaune <https://github.com/Unibozu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -2296,8 +2297,11 @@ declare module "mongoose" {
 
     /** Flag to opt out of using $geoWithin. */
     static use$geoWithin: boolean;
-  }
 
+    /** AsyncIterator - https://mongoosejs.com/docs/api/query.html#query_Query-Symbol.asyncIterator */
+    [Symbol.asyncIterator](): AsyncIterator<DocType>;
+  }
+  
   // https://github.com/aheckmann/mquery
   // mquery currently does not have a type definition please
   //   replace it if one is ever created
@@ -2703,10 +2707,10 @@ declare module "mongoose" {
 
     // If cursor option is on, could return an object
     /** Executes the aggregate pipeline on the currently bound Model. */
-    exec(callback?: (err: any, result: T) => void): Promise<T> | any;
+    exec(callback?: (err: any, result: T[]) => void): Promise<T[]> | any;
 
     /** Execute the aggregation with explain */
-    explain(callback?: (err: any, result: T) => void): Promise<T>;
+    explain(callback?: (err: any, result: T[]) => void): Promise<T[]>;
 
     /**
      * Appends a new custom $group operator to this aggregate pipeline.
@@ -2804,7 +2808,7 @@ declare module "mongoose" {
     sort(arg: string | any): this;
 
     /** Provides promise for aggregate. */
-    then: Promise<T>["then"];
+    then: Promise<T[]>["then"];
 
     /**
      * Appends new custom $unwind operator(s) to this aggregate pipeline.
@@ -2818,6 +2822,9 @@ declare module "mongoose" {
      * new in mongodb 3.2
      */
     unwind(...opts: { path: string, includeArrayIndex?: string, preserveNullAndEmptyArrays?: boolean }[]): this;
+
+    /** AsyncIterator - https://mongoosejs.com/docs/api/aggregate.html#aggregate_Aggregate-Symbol.asyncIterator */
+    [Symbol.asyncIterator](): AsyncIterator<T>;
   }
 
   /*
@@ -2994,8 +3001,8 @@ declare module "mongoose" {
      * If a callback is not passed, the aggregate itself is returned.
      * @param aggregations pipeline operator(s) or operator array
      */
-    aggregate<U = any>(aggregations?: any[]): Aggregate<U[]>;
-    aggregate<U = any>(aggregations: any[], cb: Function): Promise<U[]>;
+    aggregate<U = any>(aggregations?: any[]): Aggregate<U>;
+    aggregate<U = any>(aggregations: any[], cb: Function): Promise<U>;
 
     /** Counts number of matching documents in a database collection. */
     count(conditions: any, callback?: (err: any, count: number) => void): Query<number> & QueryHelpers;

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -2280,3 +2280,26 @@ Animal2.find().byName('fido').exec(function(err, animals) {
 Animal2.findOne().byName('fido').exec(function(err, animal) {
   console.log(animal);
 });
+
+/* AsyncIterator: https://mongoosejs.com/docs/api/query.html#query_Query-Symbol.asyncIterator */
+
+interface asyncIteratorDocument extends mongoose.Document {
+  foo: string
+}
+
+const asyncIteratorModel = mongoose.model<asyncIteratorDocument, mongoose.Model<asyncIteratorDocument>>('AsyncIterator', new mongoose.Schema({}));
+
+async function queryAsyncIteratorTest() {
+  // tslint has invalid assumption on checking for AsyncIterator - see https://github.com/microsoft/TypeScript/issues/21115
+  // This is not going to be fixed on tslint so the ignore needs to remain until DefinitelyTyped moves to eslint
+  // tslint:disable-next-line await-promise
+  for await (const d of asyncIteratorModel.find({})) {
+    d.foo;
+  }
+
+  // tslint:disable-next-line await-promise
+  for await (const agg of asyncIteratorModel.aggregate<{group: string}>()) {
+    agg.group;
+  }
+}
+

--- a/types/mongoose/tsconfig.json
+++ b/types/mongoose/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "ESNext.AsyncIterable"
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,


### PR DESCRIPTION
This PR adds support for AsyncIterator on mongoose `DocumentQuery` and `Aggregate`.

I had to add `ESNext.AsyncIterator` to `lib` which means upstream projects will need to add this lib themselves to update. There was no mention of how to deal with that in the Readme so let me know the best way. A few alternative can be to bring the types for `AsyncIterator` in the file or type the iterator with an `AsyncIterator`-like typing...

Tested on a fairly big API project using `for await`

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://mongoosejs.com/docs/api/query.html#query_Query-Symbol.asyncIterator and https://mongoosejs.com/docs/api/aggregate.html#aggregate_Aggregate-Symbol.asyncIterator
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
