### PR TITLE
Add definitions for apple-signin-api

### DIFF
--- a/types/apple-signin-api/apple-signin-api-tests.ts
+++ b/types/apple-signin-api/apple-signin-api-tests.ts
@@ -6,7 +6,7 @@ const ClientConfig: AppleSignInAPI.ClientConfigI = {
     usePopup: false,
 };
 
-const signinResponse: AppleSignInAPI.signInResponse = {
+const signInResponse: AppleSignInAPI.SignInResponseI = {
     authorization: {
         state: '[STATE]',
         code: '[CODE]',
@@ -21,10 +21,22 @@ const signinResponse: AppleSignInAPI.signInResponse = {
     },
 };
 
-const AuthI: AppleSignInAPI.AuthI = {
+const signInError: AppleSignInAPI.SignInErrorI = {
+    error: '[ERROR]',
+};
+
+const AuthGood: AppleSignInAPI.AppleID = {
     auth: {
         init: () => new Promise(() => {}),
-        signIn: () => new Promise(() => signinResponse),
+        signIn: () => new Promise(() => signInResponse),
+        renderButton: () => {},
+    },
+};
+
+const AuthBad: AppleSignInAPI.AppleID = {
+    auth: {
+        init: () => new Promise(() => {}),
+        signIn: () => new Promise(() => signInError),
         renderButton: () => {},
     },
 };

--- a/types/apple-signin-api/apple-signin-api-tests.ts
+++ b/types/apple-signin-api/apple-signin-api-tests.ts
@@ -1,0 +1,30 @@
+const ClientConfig: AppleSignInAPI.ClientConfigI = {
+    clientId: '',
+    redirectURI: '',
+    scope: '',
+    state: '',
+    usePopup: false,
+};
+
+const signinResponse: AppleSignInAPI.signInResponse = {
+    authorization: {
+        state: '[STATE]',
+        code: '[CODE]',
+        id_token: '[ID_TOKEN]',
+    },
+    user: {
+        email: '[EMAIL]',
+        name: {
+            firstName: '[FIRST_NAME]',
+            lastName: '[LAST_NAME]',
+        },
+    },
+};
+
+const AuthI: AppleSignInAPI.AuthI = {
+    auth: {
+        init: () => new Promise(() => {}),
+        signIn: () => new Promise(() => signinResponse),
+        renderButton: () => {},
+    },
+};

--- a/types/apple-signin-api/index.d.ts
+++ b/types/apple-signin-api/index.d.ts
@@ -1,16 +1,39 @@
-// Type definitions for non-npm package Apple Sign in API 0.1
+// Type definitions for non-npm package Apple Sign in API 1.4
 // Project: https://developer.apple.com/documentation/signinwithapplejs
 // Definitions by: Julius Lungys <https://github.com/voidpumpkin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace AppleSignInAPI {
+    // https://developer.apple.com/documentation/signinwithapplejs/authorizationi
+    interface AuthorizationI {
+        code: string;
+        id_token: string;
+        state: string;
+    }
+    // https://developer.apple.com/documentation/signinwithapplejs/namei
+    interface NameI {
+        firstName: string;
+        lastName: string;
+    }
+    // https://developer.apple.com/documentation/signinwithapplejs/signinerrori
+    interface SignInErrorI {
+        error: string;
+    }
+    // https://developer.apple.com/documentation/signinwithapplejs/signinresponsei
+    interface SignInResponseI {
+        authorization: AuthorizationI;
+        user?: UserI;
+    }
+    // https://developer.apple.com/documentation/signinwithapplejs/useri
+    interface UserI {
+        email: string;
+        name: NameI;
+    }
     // https://developer.apple.com/documentation/signinwithapplejs/authi
     interface AuthI {
-        auth: {
-            init: (config?: ClientConfigI) => Promise<void>;
-            signIn: (config?: ClientConfigI) => Promise<signInResponse>;
-            renderButton: () => void;
-        };
+        init: (config: ClientConfigI) => Promise<void>;
+        signIn: (signInConfig?: ClientConfigI) => Promise<SignInResponseI | SignInErrorI>;
+        renderButton: () => void;
     }
     // https://developer.apple.com/documentation/signinwithapplejs/clientconfigi
     interface ClientConfigI {
@@ -18,15 +41,9 @@ declare namespace AppleSignInAPI {
         redirectURI: string;
         scope: string;
         state: string;
-        usePopup: boolean; // Mentioned in https://developer.apple.com/documentation/signinwithapplejs/configuring_your_webpage_for_sign_in_with_apple
+        usePopup: boolean;
     }
-    // https://developer.apple.com/documentation/signinwithapplejs/configuring_your_webpage_for_sign_in_with_apple
-    interface signInResponse {
-        authorization: {
-            code: string;
-            id_token: string;
-            state: string;
-        };
-        user?: { name: { firstName: string; lastName: string }; email: string };
+    interface AppleID {
+        auth: AuthI;
     }
 }

--- a/types/apple-signin-api/index.d.ts
+++ b/types/apple-signin-api/index.d.ts
@@ -27,6 +27,6 @@ declare namespace AppleSignInAPI {
             id_token: string;
             state: string;
         };
-        user: { name: { firstName: string; lastName: string }; email: string };
+        user?: { name: { firstName: string; lastName: string }; email: string };
     }
 }

--- a/types/apple-signin-api/index.d.ts
+++ b/types/apple-signin-api/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for non-npm package Apple Sign in API 0.1
+// Project: https://developer.apple.com/documentation/signinwithapplejs
+// Definitions by: Julius Lungys <https://github.com/voidpumpkin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace AppleSignInAPI {
+    // https://developer.apple.com/documentation/signinwithapplejs/authi
+    interface AuthI {
+        auth: {
+            init: (config?: ClientConfigI) => Promise<void>;
+            signIn: (config?: ClientConfigI) => Promise<signInResponse>;
+            renderButton: () => void;
+        };
+    }
+    // https://developer.apple.com/documentation/signinwithapplejs/clientconfigi
+    interface ClientConfigI {
+        clientId: string;
+        redirectURI: string;
+        scope: string;
+        state: string;
+        usePopup: boolean; // Mentioned in https://developer.apple.com/documentation/signinwithapplejs/configuring_your_webpage_for_sign_in_with_apple
+    }
+    // https://developer.apple.com/documentation/signinwithapplejs/configuring_your_webpage_for_sign_in_with_apple
+    interface signInResponse {
+        authorization: {
+            code: string;
+            id_token: string;
+            state: string;
+        };
+        user: { name: { firstName: string; lastName: string }; email: string };
+    }
+}

--- a/types/apple-signin-api/tsconfig.json
+++ b/types/apple-signin-api/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "apple-signin-api-tests.ts"
+    ]
+}

--- a/types/apple-signin-api/tslint.json
+++ b/types/apple-signin-api/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adding definitions for [apple-signin-api](https://developer.apple.com/documentation/signinwithapplejs)

Apple documentation is actually not completely in sync with all the data we have, so here are some pictures objects in use:
![image](https://user-images.githubusercontent.com/32368314/74753094-49724480-5278-11ea-9621-6f586d943304.png)
![image](https://user-images.githubusercontent.com/32368314/74753522-ea60ff80-5278-11ea-9c46-bdc0c53f0b6e.png)
![image](https://user-images.githubusercontent.com/32368314/74753546-f2b93a80-5278-11ea-839e-389277ac91e3.png)



Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
