### PR TITLE
yargs: fix and use type of `builder` in `command`

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -29,7 +29,7 @@
 import { DetailedArguments, Configuration } from 'yargs-parser';
 
 declare namespace yargs {
-    type BuilderCallback<T, R> = ((args: Argv<T>) => Argv<R>) | ((args: Argv<T>) => void);
+    type BuilderCallback<T, R> = ((args: Argv<T>) => PromiseLike<Argv<R>>) | ((args: Argv<T>) => Argv<R>) | ((args: Argv<T>) => void);
 
     type ParserConfigurationOptions = Configuration & {
         /** Sort commands alphabetically. Default is `false` */
@@ -771,7 +771,7 @@ declare namespace yargs {
     }
 
     type ParseCallback<T = {}> = (err: Error | undefined, argv: Arguments<T>, output: string) => void;
-    type CommandBuilder<T = {}, U = {}> = { [key: string]: Options } | ((args: Argv<T>) => Argv<U>);
+    type CommandBuilder<T = {}, U = {}> = { [key: string]: Options } | ((args: Argv<T>) => Argv<U>) | ((args: Argv<T>) => PromiseLike<Argv<U>>);
     type SyncCompletionFunction = (current: string, argv: any) => string[];
     type AsyncCompletionFunction = (current: string, argv: any, done: (completion: ReadonlyArray<string>) => void) => void;
     type PromiseCompletionFunction = (current: string, argv: any) => Promise<string[]>;

--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -8,6 +8,7 @@
 //                 Steffen Viken Valvåg <https://github.com/steffenvv>
 //                 Emily Marigold Klassen <https://github.com/forivall>
 //                 ExE Boss <https://github.com/ExE-Boss>
+//                 Aankhen <https://github.com/Aankhen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -144,7 +145,7 @@ declare namespace yargs {
          * Note that when `void` is returned, the handler `argv` object type will not include command-specific arguments.
          * @param [handler] Function, which will be executed with the parsed `argv` object.
          */
-        command<U = T>(command: string | ReadonlyArray<string>, description: string, builder?: BuilderCallback<T, U>, handler?: (args: Arguments<U>) => void): Argv<T>;
+        command<U = T>(command: string | ReadonlyArray<string>, description: string, builder?: BuilderCallback<T, U>, handler?: (args: Arguments<U>) => void): Argv<U>;
         command<O extends { [key: string]: Options }>(command: string | ReadonlyArray<string>, description: string, builder?: O, handler?: (args: Arguments<InferredOptionTypes<O>>) => void): Argv<T>;
         command<U>(command: string | ReadonlyArray<string>, description: string, module: CommandModule<T, U>): Argv<U>;
         command<U = T>(command: string | ReadonlyArray<string>, showInHelp: false, builder?: BuilderCallback<T, U>, handler?: (args: Arguments<U>) => void): Argv<T>;

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -1193,6 +1193,37 @@ function Argv$defaultCommandWithPositional(): string {
     return argv.arg;
 }
 
+function Argv$commandsWithAsynchronousBuilders() {
+    const argv1 = yargs.command(
+        "command <arg>",
+        "some command",
+        (yargs) =>
+            Promise.resolve(
+                yargs.positional("arg", {
+                    demandOption: true,
+                    describe: "argument",
+                    type: "string",
+                })),
+        () => { }).argv;
+
+    const arg1: string = argv1.arg;
+
+    const argv2 = yargs.command({
+        command: "command <arg>",
+        describe: "some command",
+        builder: (yargs) =>
+            Promise.resolve(
+                yargs.positional("arg", {
+                    demandOption: true,
+                    describe: "argument",
+                    type: "string",
+                })),
+        handler: () => {}
+    }).argv;
+
+    const arg2: string = argv2.arg;
+}
+
 function makeSingleton() {
     yargsSingleton(process.argv.slice(2));
 }

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -1178,6 +1178,21 @@ function Argv$parsed() {
     const parsedArgs = yargs.parsed;
 }
 
+function Argv$defaultCommandWithPositional(): string {
+    const argv = yargs.command(
+        "$0 <arg>",
+        "default command",
+        (yargs) =>
+            yargs.positional("arg", {
+                demandOption: true,
+                describe: "argument",
+                type: "string",
+            }),
+        () => { }).argv;
+
+    return argv.arg;
+}
+
 function makeSingleton() {
     yargsSingleton(process.argv.slice(2));
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/yargs/yargs/blob/cc8af7698b7c8daa55b215a780403f625d579f57/lib/command.js#L238-L246>> (for asynchronous builder)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This fixes #34592 by implementing @adamdoyle’s suggestion therein and also addresses @joelverhagen’s [comment](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34592#issuecomment-536226788).