### PR TITLE
feat(jest): add `SpiedFunction` type

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1051,6 +1051,11 @@ declare namespace jest {
     interface SpyInstance<T = any, Y extends any[] = any> extends MockInstance<T, Y> {}
 
     /**
+     * Represents a function that has been spied on.
+     */
+    type SpiedFunction<T extends (...args: any[]) => any> = SpyInstance<ReturnType<T>, ArgsType<T>>;
+
+    /**
      * Wrap a function with mock definitions
      *
      * @example

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -437,10 +437,17 @@ spy4 = jest.spyOn(spiedTarget, 'returnsString');
 spy4.mockImplementation(() => 1);
 spy4.mockRestore();
 
-// $ExpectType SpyInstance<number, []>
-const spy5 = jest.spyOn(spiedTarget2, 'value', 'get');
+let spy5: jest.SpiedFunction<typeof spiedTarget.setValue>;
+
+// $ExpectType SpyInstance<void, [string]>
+spy5 = jest.spyOn(spiedTarget, 'setValue');
 // $ExpectError
-spy5.mockReturnValue('5');
+spy5 = jest.spyOn(spiedTarget, 'returnsString');
+
+// $ExpectType SpyInstance<number, []>
+const spy6 = jest.spyOn(spiedTarget2, 'value', 'get');
+// $ExpectError
+spy6.mockReturnValue('5');
 
 // $ExpectType SpyInstance<void, [number]>
 jest.spyOn(spiedTarget2, 'value', 'set');


### PR DESCRIPTION
This adds a utility type in the vain of `MockedFunction`, to make it easier to type spied functions:

```
const mockPrintContents = 'hello world';
let printTFFileContentsSpy: jest.SpiedFunction<typeof printers.printTFFileContents>;

beforeEach(
  () =>
    (printTFFileContentsSpy = jest
      .spyOn(printers, 'printTFFileContents')
      .mockReturnValue(mockPrintContents))
);
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.