### PR TITLE
feat(alex): type definitions for `alex` v8.1

### DIFF
--- a/types/alex/alex-tests.ts
+++ b/types/alex/alex-tests.ts
@@ -1,0 +1,22 @@
+// configs
+const exemption = ['word', 'noun'];
+const config: alex.AlexOptions = {
+    allow: exemption,
+    noBinary: true,
+    profanitySureness: 1,
+};
+
+// api
+
+alex('We’ve confirmed his identity.'); // $ExpectType VFile
+alex('We’ve confirmed his identity.', exemption); // $ExpectType VFile
+alex('We’ve confirmed his identity.', config); // $ExpectType VFile
+alex.markdown('### We’ve confirmed his **identity**.'); // $ExpectType VFile
+alex.markdown('### We’ve confirmed his **identity**.', exemption); // $ExpectType VFile
+alex.markdown('### We’ve confirmed his **identity**.', config); // $ExpectType VFile
+alex.html('<p class="black">He walked to class.</p>'); // $ExpectType VFile
+alex.html('<p class="black">He walked to class.</p>', exemption); // $ExpectType VFile
+alex.html('<p class="black">He walked to class.</p>', config); // $ExpectType VFile
+alex.text('The `boogeyman`.'); // $ExpectType VFile
+alex.text('The `boogeyman`.', exemption); // $ExpectType VFile
+alex.text('The `boogeyman`.', config); // $ExpectType VFile

--- a/types/alex/index.d.ts
+++ b/types/alex/index.d.ts
@@ -1,0 +1,49 @@
+// Type definitions for alex 8.1
+// Project: https://alexjs.com
+// Definitions by: Piotr Błażejewicz (Peter Blazejewicz) <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+/// <reference types="node" />
+
+import * as vfile from 'vfile';
+
+/**
+ * finds gender favoring, polarizing, race related, religion inconsiderate, or other unequal phrasing in text.
+ */
+declare function alex(value: vfile.VFile | string, config?: alex.Config): vfile.VFile;
+
+declare namespace alex {
+    /**
+     * This is either an array of words to ignore or custom Alex' config
+     */
+    type Config = AlexOptions | string[];
+
+    interface AlexOptions {
+        /** an array of rules (the default is []) */
+        allow?: string[];
+        /**
+         * When turned on (`true`), pairs such as `he` and `she` and `garbageman` or `garbagewoman` are seen as errors.
+         * When turned off (`false`, the default), such pairs are okay
+         */
+        noBinary?: boolean;
+        /**
+         * the minimum rating (including) that you want to check for.
+         * If you set it to 1 (maybe) then it will warn for level 1 and 2 (likely) profanities,
+         * but not for level 0 (unlikely).
+         */
+        profanitySureness?: 0 | 1 | 2;
+    }
+
+    /** Check Markdown (ignoring syntax). */
+    function markdown(value: vfile.VFile | string, config?: Config): vfile.VFile;
+
+    /** Check HTML (ignoring syntax). */
+    function html(value: vfile.VFile | string, config?: Config): vfile.VFile;
+
+    /** Check plain text (as in, syntax is checked). */
+    function text(value: vfile.VFile | string, config?: Config): vfile.VFile;
+}
+
+export as namespace alex;
+export = alex;

--- a/types/alex/package.json
+++ b/types/alex/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "vfile": "^4.0.2"
+    }
+}

--- a/types/alex/tsconfig.json
+++ b/types/alex/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "alex-tests.ts"
+    ]
+}

--- a/types/alex/tslint.json
+++ b/types/alex/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- type definitions
- tests

https://alexjs.com/
https://github.com/get-alex/alex#readme

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. 
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.