### PR TITLE
Updated @types/datadog-winston module import methodology to fix consuming side

### DIFF
--- a/types/datadog-winston/index.d.ts
+++ b/types/datadog-winston/index.d.ts
@@ -4,10 +4,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-import * as Transport from "winston-transport";
+import TransportStream = require("winston-transport");
 
 declare namespace DatadogWinston {
-    interface DatadogTransportOptions extends Transport.TransportStreamOptions {
+    interface DatadogTransportOptions extends TransportStream.TransportStreamOptions {
         apiKey: string;
         hostname?: string;
         service?: string;
@@ -16,7 +16,7 @@ declare namespace DatadogWinston {
     }
 }
 
-declare class DatadogWinston extends Transport {
+declare class DatadogWinston extends TransportStream {
     constructor(options: DatadogWinston.DatadogTransportOptions);
 
     log?(info: any, next: () => void): void;


### PR DESCRIPTION
I recently tried to use this library (I am the original contributor) within my project running the latest TypeScript version and am getting an error when I try to import the `DatadogWinston` class.  The usage and error looks like this:

**Usage**
```
import DatadogWinston = require("datadog-winston");

const transport: TransportStream = new DatadogWinston({
    apiKey: "123",
    ddsource: "node.js",
    ddtags: "tag",
    hostname: os.hostname(),
    level: "debug",
    service: "foo"
});
```

**Error**
```
const transport: TransportStream
Type 'DatadogWinston' is missing the following properties from type 'TransportStream': writable, writableHighWaterMark, writableLength, _write, and 24 more.
```

As you can see, my TS Compiler doesn't think that `DatadogWinston` properly implements `TransportStream`.  In my local `index.d.ts`, I was able to simply change from

```
import * as Transport from "winston-transport";
```
to either
```
import TransportStream from "winston-transport";
```
**OR**
```
import TransportStream = require("winston-transport");
```
And both appear to work fine and the tsc build as well as the VS Code TS Language Server seem to agree.  I'm still a little unsure why this is happening and if there is a way for me to fix this on the consumer side rather than on the typings declaration side, so if there is and this change is unneeded please let me know!

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [N/A] Provide a URL to documentation or source code which provides context for the suggested changes: not a URL, but an example above
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.