### PR TITLE
[react-input-autosize] adds copyInputStyles method type

### DIFF
--- a/types/react-input-autosize/index.d.ts
+++ b/types/react-input-autosize/index.d.ts
@@ -17,6 +17,7 @@ export interface AutosizeInputProps extends React.InputHTMLAttributes<HTMLInputE
 }
 
 declare class AutosizeInput extends React.Component<AutosizeInputProps> {
+    copyInputStyles(): void;
     getInput(): HTMLInputElement;
 }
 


### PR DESCRIPTION
https://github.com/JedWatson/react-input-autosize/blob/0aa6225fb4ae4e30d51a23f75b36b15e709efdd0/src/AutosizeInput.js#L89

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:https://github.com/JedWatson/react-input-autosize/blob/0aa6225fb4ae4e30d51a23f75b36b15e709efdd0/src/AutosizeInput.js#L89
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.