### PR TITLE
feat: Add types for `mocha‑sugar‑free`

### DIFF
--- a/types/mocha-sugar-free/index.d.ts
+++ b/types/mocha-sugar-free/index.d.ts
@@ -1,0 +1,471 @@
+// Type definitions for mocha-sugar-free 1.4
+// Project: https://github.com/Joris-van-der-Wel/mocha-sugar-free#readme
+// Definitions by: ExE Boss <https://github.com/ExE-Boss>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Test, Suite } from 'mocha';
+
+/** Construct a type with the properties of T except for those in type K. */
+type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+
+declare namespace Mocha {
+	export interface Options {
+		/**
+		 * Whether the context should contain a `done` callback.
+		 */
+		async?: boolean;
+
+		/**
+		 * Whether failing to return a PromiseLike should fail the test.
+		 */
+		expectPromise?: boolean;
+
+		/**
+		 * Whether the test should be skipped unconditionally.
+		 */
+		skip?: boolean;
+
+		/**
+		 * Whether the test should be skipped in a browser environment.
+		 */
+		skipIfBrowser?: boolean;
+
+		/**
+		 * Whether the test should be skipped in a WebWorker.
+		 */
+		skipIfWebWorker?: boolean;
+
+		/**
+		 * Whether the test should be skipped outside a browser environment.
+		 */
+		skipUnlessBrowser?: boolean;
+
+		/**
+		 * The test title. Replaced by the title parameter if present.
+		 */
+		title?: string;
+
+		/**
+		 * The test function.
+		 */
+		fn?: TestCase | TestCaseWithDone | SuiteFunc | HookFunc;
+	}
+
+	export type TestCase = (this: void, context: TestContext) => void | PromiseLike<void>;
+	export type TestCaseWithDone = (context: TestContextWithDone) => void;
+	export type HookFunc = (context: HookContext) => void;
+	export type SuiteFunc = (context: SuiteContext) => void;
+
+	interface BaseInterface {
+		/**
+		 * The detected Mocha interface.
+		 *
+		 * @default "bdd"
+		 */
+		detectedInterface: 'bdd' | 'tdd' | 'qunit';
+
+		/**
+		 * Triggers root suite execution.
+		 *
+		 * - _Only available if flag `--delay` is passed to Mocha._
+		 *
+		 * @see https://mochajs.org/api/global.html#runWithSuite
+		 */
+		run(): void;
+	}
+
+	interface BDD extends BaseInterface {
+		detectedInterface: 'bdd';
+
+		/**
+		 * [bdd]
+		 *
+		 * Describe a "suite" with the given `title` and callback `fn` containing nested suites.
+		 */
+		describe: SuiteFunction;
+
+		/**
+		 * [bdd]
+		 *
+		 * Describe a "suite" with the given `title` and callback `fn` containing nested suites.
+		 *
+		 * Indicates this suite should not be executed.
+		 */
+		xdescribe: PendingSuiteFunction;
+
+		/**
+		 * [bdd]
+		 *
+		 * Describe a "suite" with the given `title` and callback `fn` containing nested suites.
+		 */
+		context: SuiteFunction;
+
+		/**
+		 * [bdd]
+		 *
+		 * Describe a "suite" with the given `title` and callback `fn` containing nested suites.
+		 *
+		 * Indicates this suite should not be executed.
+		 */
+		xcontext: PendingSuiteFunction;
+
+		/**
+		 * [bdd]
+		 *
+		 * Describe a specification or test-case with the given `title` and callback `fn` acting as a thunk.
+		 *
+		 * The name of the function is used as the name of the test if `title` is not supplied.
+		 */
+		it: TestFunction;
+
+		/**
+		 * [bdd]
+		 *
+		 * Describe a specification or test-case with the given `title` and callback `fn` acting as a thunk.
+		 *
+		 * The name of the function is used as the name of the test if `title` is not supplied.
+		 *
+		 * Indicates this test should not be executed.
+		 */
+		xit: PendingTestFunction;
+
+		/**
+		 * [bdd]
+		 *
+		 * Describe a specification or test-case with the given `title` and callback `fn` acting as a thunk.
+		 *
+		 * The name of the function is used as the name of the test if `title` is not supplied.
+		 */
+		specify: TestFunction;
+
+		/**
+		 * [bdd]
+		 *
+		 * Describe a specification or test-case with the given `title` and callback `fn` acting as a thunk.
+		 *
+		 * The name of the function is used as the name of the test if `title` is not supplied.
+		 *
+		 * Indicates this test should not be executed.
+		 */
+		xspecify: PendingTestFunction;
+
+		/**
+		 * [bdd]
+		 *
+		 * Execute before running tests.
+		 *
+		 * @see https://mochajs.org/api/global.html#before
+		 */
+		before: HookFunction;
+
+		/**
+		 * [bdd]
+		 *
+		 * Execute after running tests.
+		 *
+		 * @see https://mochajs.org/api/global.html#after
+		 */
+		after: HookFunction;
+
+		/**
+		 * [bdd]
+		 *
+		 * Execute before each test case.
+		 *
+		 * @see https://mochajs.org/api/global.html#beforeEach
+		 */
+		beforeEach: HookFunction;
+
+		/**
+		 * [bdd]
+		 *
+		 * Execute after each test case.
+		 *
+		 * @see https://mochajs.org/api/global.html#afterEach
+		 */
+		afterEach: HookFunction;
+	}
+
+	interface TDD extends BaseInterface {
+		detectedInterface: 'tdd';
+
+		/**
+		 * [tdd, qunit]
+		 *
+		 * Describe a "suite" with the given `title` and callback `fn` containing nested suites.
+		 */
+		suite: SuiteFunction;
+
+		/**
+		 * [tdd, qunit]
+		 *
+		 * Describe a specification or test-case with the given `title` and callback `fn` acting as a thunk.
+		 *
+		 * The name of the function is used as the name of the test if `title` is not supplied.
+		 */
+		test: TestFunction;
+
+		/**
+		 * [tdd]
+		 *
+		 * Execute before running tests.
+		 *
+		 * @see https://mochajs.org/api/global.html#before
+		 */
+		suiteSetup: HookFunction;
+
+		/**
+		 * [tdd]
+		 *
+		 * Execute after running tests.
+		 *
+		 * @see https://mochajs.org/api/global.html#after
+		 */
+		suiteTeardown: HookFunction;
+
+		/**
+		 * [tdd]
+		 *
+		 * Execute before each test case.
+		 *
+		 * @see https://mochajs.org/api/global.html#beforeEach
+		 */
+		setup: HookFunction;
+
+		/**
+		 * [tdd]
+		 *
+		 * Execute after each test case.
+		 *
+		 * @see https://mochajs.org/api/global.html#afterEach
+		 */
+		teardown: HookFunction;
+	}
+
+	interface QUnit extends BaseInterface {
+		detectedInterface: 'qunit';
+
+		suite: SuiteFunction;
+		test: TestFunction;
+	}
+
+	type AnyInterface = Omit<BDD & TDD & QUnit, 'detectedInterface'> & BaseInterface;
+
+	// #region Test functions
+
+	// #endregion
+
+	// #region Test context
+	export interface SuiteContext {
+		isSuite: true;
+		isTest: false;
+		isHook: false;
+	}
+
+	export interface HookContext {
+		isSuite: false;
+		isTest: false;
+		isHook: true;
+		hook: 'before' | 'after' | 'beforeEach' | 'afterEach';
+	}
+
+	export interface TestContextBase {
+		isSuite: false;
+		isTest: true;
+		isHook: false;
+
+		/**
+		 * Mark a test as skipped.
+		 */
+		skip(): never;
+
+		/**
+		 * Get test timeout.
+		 */
+		timeout(): number;
+
+		/**
+		 * Set test timeout.
+		 */
+		timeout(ms: string | number): this;
+
+		/**
+		 * Get test slowness threshold.
+		 */
+		slow(): number;
+
+		/**
+		 * Set test slowness threshold.
+		 */
+		slow(ms: string | number): this;
+
+		/**
+		 * Get whether timeouts are enabled.
+		 */
+		enableTimeouts(): boolean;
+
+		/**
+		 * Set whether timeouts are enabled.
+		 */
+		enableTimeouts(enabled: boolean): this;
+	}
+
+	export interface TestContext extends TestContextBase {
+		/**
+		 * Mark a test as completed.
+		 */
+		done: null;
+	}
+
+	export interface TestContextWithDone extends TestContextBase {
+		/**
+		 * Mark a test as completed.
+		 */
+		done(err: any): void;
+	}
+	// #endregion
+
+	// #region Test function types
+	/**
+	 * [bdd, tdd]
+	 *
+	 * Describe a "hook" to execute the given callback `fn`.
+	 *
+	 * The name of the function is used as the name of the hook.
+	 */
+	export interface HookFunction {
+		(fn?: HookFunc): void;
+		(options: Options & { fn?: HookFunc }, fn?: HookFunc): void;
+	}
+
+	/**
+	 * [bdd, tdd, qunit]
+	 *
+	 * Describe a "suite" with the given `title` and callback `fn` containing nested suites.
+	 */
+	export interface SuiteFunction {
+		(title: string, fn?: SuiteFunc): Suite;
+		(title: string, options?: Options & { fn?: SuiteFunc }, fn?: SuiteFunc): Suite;
+		// tslint:disable-next-line: unified-signatures
+		(options: Options & { title: string; fn?: SuiteFunc }, fn?: SuiteFunc): Suite;
+
+		/**
+		 * [bdd, tdd, qunit]
+		 *
+		 * Indicates this suite should be executed exclusively.
+		 */
+		only: ExclusiveSuiteFunction;
+
+		/**
+		 * [bdd, tdd]
+		 *
+		 * Indicates this suite should not be executed.
+		 */
+		skip: PendingSuiteFunction;
+	}
+
+	/**
+	 * [bdd, tdd, qunit]
+	 *
+	 * Describe a "suite" with the given `title` and callback `fn` containing nested suites.
+	 *
+	 * Indicates this suite should be executed exclusively.
+	 */
+	export interface ExclusiveSuiteFunction {
+		(title: string, fn?: SuiteFunc): Suite;
+		(title: string, options?: Options & { fn?: SuiteFunc }, fn?: SuiteFunc): Suite;
+		// tslint:disable-next-line: unified-signatures
+		(options: Options & { title: string; fn?: SuiteFunc }, fn?: SuiteFunc): Suite;
+	}
+
+	/**
+	 * [bdd, tdd]
+	 *
+	 * Describe a "suite" with the given `title` and callback `fn` containing nested suites.
+	 *
+	 * Indicates this suite should not be executed.
+	 *
+	 * @returns [bdd] `Suite`
+	 * @returns [tdd] `void`
+	 */
+	export interface PendingSuiteFunction {
+		(title: string, fn?: SuiteFunc): Suite | void;
+		(title: string, options?: Options & { fn?: SuiteFunc }, fn?: SuiteFunc): Suite | void;
+		// tslint:disable-next-line: unified-signatures
+		(options: Options & { title: string; fn?: SuiteFunc }, fn?: SuiteFunc): Suite | void;
+	}
+
+	/**
+	 * [bdd, tdd, qunit]
+	 *
+	 * Describe a specification or test-case with the given `title` and callback `fn` acting as a thunk.
+	 *
+	 * The name of the function is used as the name of the test if `title` is not supplied.
+	 */
+	export interface TestFunction {
+		(fn: TestCase): Test;
+		(title: string, fn?: TestCase): Test;
+		(title: string, options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;
+		(title: string, options: Options & { async?: true; fn?: TestCase }, fn?: TestCaseWithDone): Test;
+		// tslint:disable-next-line: unified-signatures
+		(options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;
+		(options: Options & { async?: true; fn?: TestCase }, fn?: TestCaseWithDone): Test;
+
+		/**
+		 * [bdd, tdd, qunit]
+		 *
+		 * Indicates this test should be executed exclusively.
+		 */
+		only: ExclusiveTestFunction;
+
+		/**
+		 * [bdd, tdd, qunit]
+		 *
+		 * Indicates this test should not be executed.
+		 */
+		skip: PendingTestFunction;
+	}
+
+	/**
+	 * [bdd, tdd, qunit]
+	 *
+	 * Describe a specification or test-case with the given `title` and callback `fn` acting as a thunk.
+	 *
+	 * The name of the function is used as the name of the test if `title` is not supplied.
+	 *
+	 * Indicates this test should be executed exclusively.
+	 */
+	export interface ExclusiveTestFunction {
+		(fn: TestCase): Test;
+		(title: string, fn?: TestCase): Test;
+		(title: string, options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;
+		(title: string, options: Options & { async?: true; fn?: TestCase }, fn?: TestCaseWithDone): Test;
+		// tslint:disable-next-line: unified-signatures
+		(options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;
+		(options: Options & { async?: true; fn?: TestCase }, fn?: TestCaseWithDone): Test;
+	}
+
+	/**
+	 * [bdd, tdd, qunit]
+	 *
+	 * Describe a specification or test-case with the given `title` and callback `fn` acting as a thunk.
+	 *
+	 * The name of the function is used as the name of the test if `title` is not supplied.
+	 *
+	 * Indicates this test should not be executed.
+	 */
+	export interface PendingTestFunction {
+		(fn: TestCase): Test;
+		(title: string, fn?: TestCase): Test;
+		(title: string, options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;
+		(title: string, options: Options & { async?: true; fn?: TestCase }, fn?: TestCaseWithDone): Test;
+		// tslint:disable-next-line: unified-signatures
+		(options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;
+		(options: Options & { async?: true; fn?: TestCase }, fn?: TestCaseWithDone): Test;
+	}
+	// #endregion
+}
+
+declare const Mocha: Mocha.AnyInterface;
+
+export = Mocha;

--- a/types/mocha-sugar-free/index.d.ts
+++ b/types/mocha-sugar-free/index.d.ts
@@ -9,10 +9,10 @@ import { Test, Suite } from 'mocha';
 type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
 
 declare namespace Mocha {
-	type TestCase = (this: unknown, context: TestContext) => void | PromiseLike<void>;
-	type TestCaseWithDone = (this: unknown, context: TestContextWithDone) => void;
-	type HookFunc = (this: unknown, context: HookContext) => void;
-	type SuiteFunc = (this: unknown, context: SuiteContext) => void;
+	type TestCase = (this: undefined, context: TestContext) => void | PromiseLike<void>;
+	type TestCaseWithDone = (this: undefined, context: TestContextWithDone) => void;
+	type HookFunc = (this: undefined, context: HookContext) => void;
+	type SuiteFunc = (this: undefined, context: SuiteContext) => void;
 
 	interface Options {
 		/**

--- a/types/mocha-sugar-free/index.d.ts
+++ b/types/mocha-sugar-free/index.d.ts
@@ -9,7 +9,12 @@ import { Test, Suite } from 'mocha';
 type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
 
 declare namespace Mocha {
-	export interface Options {
+	type TestCase = (this: unknown, context: TestContext) => void | PromiseLike<void>;
+	type TestCaseWithDone = (this: unknown, context: TestContextWithDone) => void;
+	type HookFunc = (this: unknown, context: HookContext) => void;
+	type SuiteFunc = (this: unknown, context: SuiteContext) => void;
+
+	interface Options {
 		/**
 		 * Whether the context should contain a `done` callback.
 		 */
@@ -51,11 +56,7 @@ declare namespace Mocha {
 		fn?: TestCase | TestCaseWithDone | SuiteFunc | HookFunc;
 	}
 
-	export type TestCase = (this: void, context: TestContext) => void | PromiseLike<void>;
-	export type TestCaseWithDone = (context: TestContextWithDone) => void;
-	export type HookFunc = (context: HookContext) => void;
-	export type SuiteFunc = (context: SuiteContext) => void;
-
+	// #region Test functions
 	interface BaseInterface {
 		/**
 		 * The detected Mocha interface.
@@ -250,26 +251,23 @@ declare namespace Mocha {
 	}
 
 	type AnyInterface = Omit<BDD & TDD & QUnit, 'detectedInterface'> & BaseInterface;
-
-	// #region Test functions
-
 	// #endregion
 
 	// #region Test context
-	export interface SuiteContext {
+	interface SuiteContext {
 		isSuite: true;
 		isTest: false;
 		isHook: false;
 	}
 
-	export interface HookContext {
+	interface HookContext {
 		isSuite: false;
 		isTest: false;
 		isHook: true;
 		hook: 'before' | 'after' | 'beforeEach' | 'afterEach';
 	}
 
-	export interface TestContextBase {
+	interface TestContextBase {
 		isSuite: false;
 		isTest: true;
 		isHook: false;
@@ -310,14 +308,14 @@ declare namespace Mocha {
 		enableTimeouts(enabled: boolean): this;
 	}
 
-	export interface TestContext extends TestContextBase {
+	interface TestContext extends TestContextBase {
 		/**
 		 * Mark a test as completed.
 		 */
 		done: null;
 	}
 
-	export interface TestContextWithDone extends TestContextBase {
+	interface TestContextWithDone extends TestContextBase {
 		/**
 		 * Mark a test as completed.
 		 */
@@ -333,7 +331,7 @@ declare namespace Mocha {
 	 *
 	 * The name of the function is used as the name of the hook.
 	 */
-	export interface HookFunction {
+	interface HookFunction {
 		(fn?: HookFunc): void;
 		(options: Options & { fn?: HookFunc }, fn?: HookFunc): void;
 	}
@@ -343,7 +341,7 @@ declare namespace Mocha {
 	 *
 	 * Describe a "suite" with the given `title` and callback `fn` containing nested suites.
 	 */
-	export interface SuiteFunction {
+	interface SuiteFunction {
 		(title: string, fn?: SuiteFunc): Suite;
 		(title: string, options?: Options & { fn?: SuiteFunc }, fn?: SuiteFunc): Suite;
 		// tslint:disable-next-line: unified-signatures
@@ -371,7 +369,7 @@ declare namespace Mocha {
 	 *
 	 * Indicates this suite should be executed exclusively.
 	 */
-	export interface ExclusiveSuiteFunction {
+	interface ExclusiveSuiteFunction {
 		(title: string, fn?: SuiteFunc): Suite;
 		(title: string, options?: Options & { fn?: SuiteFunc }, fn?: SuiteFunc): Suite;
 		// tslint:disable-next-line: unified-signatures
@@ -388,7 +386,7 @@ declare namespace Mocha {
 	 * @returns [bdd] `Suite`
 	 * @returns [tdd] `void`
 	 */
-	export interface PendingSuiteFunction {
+	interface PendingSuiteFunction {
 		(title: string, fn?: SuiteFunc): Suite | void;
 		(title: string, options?: Options & { fn?: SuiteFunc }, fn?: SuiteFunc): Suite | void;
 		// tslint:disable-next-line: unified-signatures
@@ -402,7 +400,7 @@ declare namespace Mocha {
 	 *
 	 * The name of the function is used as the name of the test if `title` is not supplied.
 	 */
-	export interface TestFunction {
+	interface TestFunction {
 		(fn: TestCase): Test;
 		(title: string, fn?: TestCase): Test;
 		(title: string, options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;
@@ -435,7 +433,7 @@ declare namespace Mocha {
 	 *
 	 * Indicates this test should be executed exclusively.
 	 */
-	export interface ExclusiveTestFunction {
+	interface ExclusiveTestFunction {
 		(fn: TestCase): Test;
 		(title: string, fn?: TestCase): Test;
 		(title: string, options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;
@@ -454,7 +452,7 @@ declare namespace Mocha {
 	 *
 	 * Indicates this test should not be executed.
 	 */
-	export interface PendingTestFunction {
+	interface PendingTestFunction {
 		(fn: TestCase): Test;
 		(title: string, fn?: TestCase): Test;
 		(title: string, options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;

--- a/types/mocha-sugar-free/mocha-sugar-free-tests.ts
+++ b/types/mocha-sugar-free/mocha-sugar-free-tests.ts
@@ -1,0 +1,35 @@
+import mocha = require('mocha-sugar-free');
+
+// $ExpectType () => void
+mocha.run;
+
+switch (mocha.detectedInterface) {
+	case 'bdd':
+		mocha.describe; // $ExpectType SuiteFunction
+		mocha.xdescribe; // $ExpectType PendingSuiteFunction
+		mocha.context; // $ExpectType SuiteFunction
+		mocha.xcontext; // $ExpectType PendingSuiteFunction
+		mocha.it; // $ExpectType TestFunction
+		mocha.xit; // $ExpectType PendingTestFunction
+		mocha.specify; // $ExpectType TestFunction
+		mocha.xspecify; // $ExpectType PendingTestFunction
+		mocha.before; // $ExpectType HookFunction
+		mocha.after; // $ExpectType HookFunction
+		mocha.beforeEach; // $ExpectType HookFunction
+		mocha.afterEach; // $ExpectType HookFunction
+		break;
+	case 'tdd':
+		mocha.suite; // $ExpectType SuiteFunction
+		mocha.test; // $ExpectType TestFunction
+		mocha.suiteSetup; // $ExpectType HookFunction
+		mocha.suiteTeardown; // $ExpectType HookFunction
+		mocha.setup; // $ExpectType HookFunction
+		mocha.teardown; // $ExpectType HookFunction
+		break;
+	case 'qunit':
+		mocha.suite; // $ExpectType SuiteFunction
+		mocha.test; // $ExpectType TestFunction
+		break;
+	default:
+		mocha.detectedInterface; // $ExpectType never
+}

--- a/types/mocha-sugar-free/tsconfig.json
+++ b/types/mocha-sugar-free/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": ["es2015"],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": ["../"],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"mocha-sugar-free-tests.ts",
+		"index.d.ts"
+	]
+}

--- a/types/mocha-sugar-free/tslint.json
+++ b/types/mocha-sugar-free/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
