### PR TITLE
Fix js-cookie types

### DIFF
--- a/types/js-cookie/index.d.ts
+++ b/types/js-cookie/index.d.ts
@@ -57,7 +57,7 @@ declare namespace Cookies {
         /**
          * Create a cookie
          */
-        set(name: string, value: string | T, options?: CookieAttributes): void;
+        set(name: string, value: string | T, options?: CookieAttributes): string | undefined;
 
         /**
          * Read cookie

--- a/types/js-cookie/js-cookie-tests.ts
+++ b/types/js-cookie/js-cookie-tests.ts
@@ -1,5 +1,6 @@
 import Cookies = require("js-cookie");
 
+// $ExpectType string | undefined
 Cookies.set('name', 'value');
 Cookies.set('name', 'value', { expires: 7 });
 Cookies.set('name', 'value', { expires: new Date() });


### PR DESCRIPTION
Calls to `set()` return a string or undefined, not void.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/js-cookie/js-cookie/blob/v2.2.1/src/js.cookie.js#L48
  - https://github.com/js-cookie/js-cookie/blob/v2.2.1/src/js.cookie.js#L98