### PR TITLE
Improve type definitions for package shuffle-array

### DIFF
--- a/types/shuffle-array/index.d.ts
+++ b/types/shuffle-array/index.d.ts
@@ -36,7 +36,7 @@ interface ShuffleArray {
      * arr - The given array.
      * options - Optional configuration options.
      */
-    pick<T>(arr: ReadonlyArray<T>, options?: PickOptions): T | T[];
+    pick<T>(arr: ReadonlyArray<T>, options?: PickOptions): T | T[];
 }
 declare var shuffle: ShuffleArray;
 export = shuffle;

--- a/types/shuffle-array/index.d.ts
+++ b/types/shuffle-array/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for shuffle-array
+// Type definitions for shuffle-array 1.0.1
 // Project: https://github.com/pazguille/shuffle-array
 // Definitions by: rhysd <https://rhysd.github.io>
 //                 jwulf0 <https://github.com/jwulf0>

--- a/types/shuffle-array/index.d.ts
+++ b/types/shuffle-array/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for shuffle-array 1.0.1
+// Type definitions for shuffle-array 1.0
 // Project: https://github.com/pazguille/shuffle-array
-// Definitions by: rhysd <https://rhysd.github.io>
+// Definitions by: rhysd <https://github.com/rhysd>
 //                 jwulf0 <https://github.com/jwulf0>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/shuffle-array/index.d.ts
+++ b/types/shuffle-array/index.d.ts
@@ -9,7 +9,7 @@
  * copy - Sets if should return a shuffled copy of the given array. By default it's a falsy value.
  * rng - Specifies a custom random number generator.
  */
-interface ShuffleOption {
+interface ShuffleOptions {
     copy?: boolean;
     rng?: () => number;
 }
@@ -17,7 +17,7 @@ interface ShuffleOption {
  * picks - Specifies how many random elements you want to pick. By default it picks 1.
  * rng - Specifies a custom random number generator.
  */
-interface PickOption {
+interface PickOptions {
     picks?: number;
     rng?: () => number;
 }
@@ -28,7 +28,7 @@ interface ShuffleArray {
      * arr - The given array.
      * options - Optional configuration options.
      */
-    <T>(arr: T[], options?: ShuffleOption): T[];
+    <T>(arr: T[], options?: ShuffleOptions): T[];
     /**
      * Pick one or more random elements from the given array. If options.picks is
      * omitted or === 1, a single element will be returned; otherwise an array.
@@ -36,7 +36,7 @@ interface ShuffleArray {
      * arr - The given array.
      * options - Optional configuration options.
      */
-    pick<T>(arr: ReadonlyArray<T>, options?: PickOption): T | T[];
+    pick<T>(arr: ReadonlyArray<T>, options?: PickOptions): T | T[];
 }
 declare var shuffle: ShuffleArray;
 export = shuffle;

--- a/types/shuffle-array/index.d.ts
+++ b/types/shuffle-array/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for shuffle-array
 // Project: https://github.com/pazguille/shuffle-array
 // Definitions by: rhysd <https://rhysd.github.io>
+//                 jwulf0 <https://github.com/jwulf0>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
@@ -29,12 +30,13 @@ interface ShuffleArray {
      */
     <T>(arr: T[], options?: ShuffleOption): T[];
     /**
-     * Pick one or more random elements from the given array.
+     * Pick one or more random elements from the given array. If options.picks is
+     * omitted or === 1, a single element will be returned; otherwise an array.
      *
      * arr - The given array.
      * options - Optional configuration options.
      */
-    pick<T>(arr: T[], options?: Object): T[];
+    pick<T>(arr: ReadonlyArray<T>, options?: PickOption): T | T[];
 }
 declare var shuffle: ShuffleArray;
 export = shuffle;

--- a/types/shuffle-array/shuffle-array-tests.ts
+++ b/types/shuffle-array/shuffle-array-tests.ts
@@ -11,7 +11,7 @@ result = shuffle(a, {rng: () => 0});
 result = shuffle(a, {copy: true, rng: () => 0});
 
 var b = ['aaa', 'bbb', 'ccc']
-var result2: string[];
+var result2: string | string[];
 result2 = shuffle.pick(b);
 result2 = shuffle.pick(b, {});
 result2 = shuffle.pick(b, {picks: 3});

--- a/types/shuffle-array/tslint.json
+++ b/types/shuffle-array/tslint.json
@@ -3,7 +3,6 @@
     "rules": {
         "ban-types": false,
         "callable-types": false,
-        "dt-header": false,
         "no-consecutive-blank-lines": false,
         "no-redundant-jsdoc": false,
         "no-var-keyword": false,


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pazguille/shuffle-array/blob/master/index.js you can see that the `pick` function returns a single element or an array
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. Set to 1.0.1; did not have any version number previously.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

=====

It's 3 changes, the most importent is the return type of the `pick`-method (which is wrong in the previous version; might be due to a change in `shuffle-array`, idk). Also, I updated the parameter type to `ReadonlyArray<T>` as is encouraged in the readme. Last, I simply changed names of option-interfaces from having the suffix `Option` to `Options` as that seems to be a better fit intuitively; but I can revert that if such changes are discouraged.

This is my first contribution to `DefinetelyTyped`, please let me know if I missed something in the contribution guidelines.
