### PR TITLE
update customKeys and extraKeys attribute for showHintOptions

### DIFF
--- a/types/codemirror/addon/hint/show-hint.d.ts
+++ b/types/codemirror/addon/hint/show-hint.d.ts
@@ -61,8 +61,8 @@ declare module "codemirror" {
         closeOnUnfocus?: boolean;
         completeOnSingleClick?: boolean;
         container?: HTMLElement | null;
-        customKeys?: {[x: string]: () => void} | null;
-        extraKeys?: {[x: string]: () => void} | null;
+        customKeys?: {[key: string]: (editor: Editor, handle: Handle) => void} | null;
+        extraKeys?: {[key: string]: (editor: Editor, handle: Handle) => void} | null;
     }
 
     /** The Handle used to interact with the autocomplete dialog box.*/

--- a/types/codemirror/addon/hint/show-hint.d.ts
+++ b/types/codemirror/addon/hint/show-hint.d.ts
@@ -61,8 +61,8 @@ declare module "codemirror" {
         closeOnUnfocus?: boolean;
         completeOnSingleClick?: boolean;
         container?: HTMLElement | null;
-        customKeys?: {[key: string]: (editor: Editor, handle: Handle) => void} | null;
-        extraKeys?: {[key: string]: (editor: Editor, handle: Handle) => void} | null;
+        customKeys?: {[key: string]: (editor: Editor, handle: Handle) => void | string} | null;
+        extraKeys?: {[key: string]: (editor: Editor, handle: Handle) => void | string} | null;
     }
 
     /** The Handle used to interact with the autocomplete dialog box.*/

--- a/types/codemirror/addon/hint/show-hint.d.ts
+++ b/types/codemirror/addon/hint/show-hint.d.ts
@@ -62,7 +62,7 @@ declare module "codemirror" {
         completeOnSingleClick?: boolean;
         container?: HTMLElement | null;
         customKeys?: {[key: string]: (editor: Editor, handle: Handle) => void | string} | null;
-        extraKeys?: {[key: string]: (editor: Editor, handle: Handle) => void | string} | null;
+        extraKeys?: {[key: string]: ((editor: Editor, handle: Handle) => void) | string} | null;
     }
 
     /** The Handle used to interact with the autocomplete dialog box.*/

--- a/types/codemirror/addon/hint/show-hint.d.ts
+++ b/types/codemirror/addon/hint/show-hint.d.ts
@@ -61,7 +61,7 @@ declare module "codemirror" {
         closeOnUnfocus?: boolean;
         completeOnSingleClick?: boolean;
         container?: HTMLElement | null;
-        customKeys?: {[key: string]: (editor: Editor, handle: Handle) => void | string} | null;
+        customKeys?: {[key: string]: ((editor: Editor, handle: Handle) => void) | string} | null;
         extraKeys?: {[key: string]: ((editor: Editor, handle: Handle) => void) | string} | null;
     }
 


### PR DESCRIPTION
@rohit-gohri , this [commit](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/d66b9a5834cef7f5d2b9e98208d03bf71fb0fc1e) is really exciting and very helpful to use codemirror `hint` addon within typescript projects.
However, I get into some trouble using `customKeys` and `extraKeys` attributes because we can't pass any arguments for the handler function as it's declared as `() => void`.
Please refer to `customKeys` and `extraKeys` implementation on codemirror [here](https://github.com/codemirror/CodeMirror/blob/5f722737883bbeadb2a629857d3961490e4134ca/addon/hint/show-hint.js#L183).
Actually, when we are defining `customKeys` and `extraKeys`, its purpose is to write custom handlers for specific keys, so the arguments `editor: Editor` and `handler: Handler` is mandatory.
It'd be helpful if we update these two attributes `customKeys` and `extraKeys` with
```
customKeys?: {[x: string]: (editor: cm.Editor, handle: cm.Handle) => void} | null;
extraKeys?: {[x: string]: (editor: cm.Editor, handle: cm.Handle) => void} | null;
```
instead of 
```
customKeys?: {[x: string]: () => void} | null;
extraKeys?: {[x: string]: () => void} | null;
```
Thank you for your attention.