### PR TITLE
fix(poker-evaluator) Type CARDS as Deck

### DIFF
--- a/types/poker-evaluator/index.d.ts
+++ b/types/poker-evaluator/index.d.ts
@@ -6,6 +6,7 @@
 /// <reference types="node" />
 
 export const HANDTYPES: HandName[];
+export const CARDS: Deck;
 export const ranks: Buffer;
 
 export function evalHand(cards: string[]): EvaluatedHand;


### PR DESCRIPTION
Replace the typing of CARDS as `Deck`, removed in error when [simplifying the Deck interface and removing Card type](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42386).

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Exported CARDS from lib](https://github.com/chenosaurus/poker-evaluator/blob/master/lib/PokerEvaluator.js#L19)
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
