### PR TITLE
ws: fix contructor definition

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -43,8 +43,8 @@ declare class WebSocket extends events.EventEmitter {
     onclose: (event: WebSocket.CloseEvent) => void;
     onmessage: (event: WebSocket.MessageEvent) => void;
 
-    constructor(address: string | url.URL, options?: WebSocket.ClientOptions);
-    constructor(address: string | url.URL, protocols?: string | string[], options?: WebSocket.ClientOptions);
+    constructor(address: string | url.URL, options?: WebSocket.ClientOptions | http.ClientRequestArgs);
+    constructor(address: string | url.URL, protocols?: string | string[], options?: WebSocket.ClientOptions | http.ClientRequestArgs);
 
     close(code?: number, data?: string): void;
     ping(data?: any, mask?: boolean, cb?: (err: Error) => void): void;

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -7,6 +7,7 @@
 //                 Orblazer <https://github.com/orblazer>
 //                 reduckted <https://github.com/reduckted>
 //                 teidesu <https://github.com/teidesu>
+//                 Bartosz Wojtkowiak <https://github.com/wojtkowiak>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -115,6 +115,7 @@ import * as url from 'url';
 
 {
     const ws = new WebSocket('ws://www.host.com/path', {
+        timeout: 5000,
         maxPayload: 10 * 1024 * 1024
     });
     ws.on('open', () => ws.send('something assume to be really long'));


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/websockets/ws/blob/HEAD/doc/ws.md#new-websocketaddress-protocols-options>> - there is a paragraph saying `options` can be: `Any other option allowed in http.request() or https.request().`
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
