### PR TITLE
[rate-limit-redis] should use constructor instead of function

### DIFF
--- a/types/rate-limit-redis/index.d.ts
+++ b/types/rate-limit-redis/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for rate-limit-redis 1.6
 // Project: https://github.com/wyattjoh/rate-limit-redis#readme
 // Definitions by: Chris Suich <https://github.com/csuich2>
+//                 Connor love <https://github.com/dotconnor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
@@ -14,6 +15,8 @@ interface RedisStoreOptions {
     client?: RedisClient;
 }
 
-declare function RedisStore(options?: RedisStoreOptions): Store;
+declare var RedisStore: {
+    new (options?: RedisStoreOptions): Store;
+};
 
 export = RedisStore;

--- a/types/rate-limit-redis/rate-limit-redis-tests.ts
+++ b/types/rate-limit-redis/rate-limit-redis-tests.ts
@@ -5,24 +5,24 @@ import { Store } from 'express-rate-limit';
 let store: Store;
 
 // $ExpectType Store
-store = RedisStore();
+store = new RedisStore();
 
 // $ExpectType Store
-store = RedisStore({
+store = new RedisStore({
     expiry: 1000,
 });
 
 // $ExpectType Store
-store = RedisStore({
+store = new RedisStore({
     prefix: 'types',
 });
 
 // $ExpectType Store
-store = RedisStore({
+store = new RedisStore({
     resetExpiryOnChange: false,
 });
 
 // $ExpectType Store
-store = RedisStore({
+store = new RedisStore({
     client: new RedisClient({}),
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wyattjoh/rate-limit-redis
  - Readme uses `new RedisStore()` instead of `RedisStore`
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
