### PR TITLE
[hosted-git-info] Update types for 3.0

### DIFF
--- a/types/hosted-git-info/index.d.ts
+++ b/types/hosted-git-info/index.d.ts
@@ -1,82 +1,61 @@
-// Type definitions for hosted-git-info 2.7
+// Type definitions for hosted-git-info 3.0
 // Project: https://github.com/npm/hosted-git-info
-// Definitions by: Jason <https://github.com/OiyouYeahYou>
+// Definitions by: Jason <https://github.com/OiyouYeahYou>, Michael <https://github.com/Ovyerus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare class HostedGitInfo {
-    host: HostedGitInfo.hosts;
-    user: string | null;
-    auth: string | null;
-    project: string | null;
-    committish: string | null;
+declare class GitHost {
+    constructor(type: GitHost.Hosts, user: string, auth: string | undefined, project: string, committish: string | undefined, defaultRepresentation: string, opts?: GitHost.FillOptions);
+
+    type: GitHost.Hosts;
+    user: string;
+    auth?: string;
+    project: string;
+    committish?: string;
     default: string;
-    opts: HostedGitInfo.Options;
+    opts: GitHost.Options;
+    protocols: string[];
+    domain: string;
+    treepath?: string;
 
-    constructor(
-        host: HostedGitInfo.hosts,
-        user: string | null,
-        auth: string | null,
-        project: string | null,
-        committish: string | null,
-        defaultRepresentation: string,
-        opts?: HostedGitInfo.Options
-    );
-
-    // From git-host-info
-
-    // defaults
+    // Templates
     sshtemplate: string;
     sshurltemplate: string;
     browsetemplate: string;
+    browsefiletemplate: string;
     docstemplate: string;
+    httpstemplate: string;
     filetemplate: string;
     shortcuttemplate: string;
     pathtemplate: string;
+    bugstemplate: string;
+    gittemplate?: string;
+    tarballtemplate: string;
 
     pathmatch: RegExp;
     protocols_re: RegExp;
     hashformat(fragment: string): string;
 
-    // special
-    protocols: string[];
-    domain: string;
-    bugstemplate: string;
-    gittemplate: string;
-    browsefiletemplate: string;
-    httpstemplate: string;
-    treepath: string;
-    tarballtemplate: string;
-
-    // /From git-host-info
-
     hash(): string;
-    ssh(opts?: HostedGitInfo.FillOptions): string | undefined;
-    sshurl(opts?: HostedGitInfo.FillOptions): string | undefined;
-    browse(
-        path: string,
-        fragment: string,
-        opts?: HostedGitInfo.FillOptions
-    ): string | undefined;
-    browse(path: string, opts?: HostedGitInfo.FillOptions): string | undefined;
-    browse(opts?: HostedGitInfo.FillOptions): string | undefined;
-    docs(opts?: HostedGitInfo.FillOptions): string | undefined;
-    bugs(opts?: HostedGitInfo.FillOptions): string | undefined;
-    https(opts?: HostedGitInfo.FillOptions): string | undefined;
-    git(opts?: HostedGitInfo.FillOptions): string | undefined;
-    shortcut(opts?: HostedGitInfo.FillOptions): string | undefined;
-    path(opts?: HostedGitInfo.FillOptions): string | undefined;
-    tarball(opts?: HostedGitInfo.FillOptions): string | undefined;
-    file(path: string, opts?: HostedGitInfo.FillOptions): string | undefined;
+    ssh(opts?: GitHost.FillOptions): string;
+    sshurl(opts?: GitHost.FillOptions): string;
+    browse(opts?: GitHost.FillOptions): string;
+    browse(path: string, opts?: GitHost.FillOptions): string;
+    browse(path: string, fragment: string, opts?: GitHost.FillOptions): string;
+    docs(opts?: GitHost.FillOptions): string;
+    bugs(opts?: GitHost.FillOptions): string;
+    https(opts?: GitHost.FillOptions): string;
+    git(opts?: GitHost.FillOptions): string;
+    shortcut(opts?: GitHost.FillOptions): string;
+    path(opts?: GitHost.FillOptions): string;
+    tarball(opts?: GitHost.FillOptions): string;
+    file(path: string, opts?: GitHost.FillOptions): string;
     getDefaultRepresentation(): string;
-    toString(opts?: HostedGitInfo.FillOptions): string | undefined;
-
-    static fromUrl(
-        gitUrl: string,
-        options?: HostedGitInfo.Options
-    ): HostedGitInfo;
+    toString(opts?: GitHost.FillOptions): string;
 }
 
-declare namespace HostedGitInfo {
+declare namespace GitHost {
+    function fromUrl(gitUrl: string, opts?: Options): GitHost;
+
     interface Options {
         noCommittish?: boolean;
         noGitPlus?: boolean;
@@ -90,7 +69,7 @@ declare namespace HostedGitInfo {
         treepath?: string;
     }
 
-    type hosts = 'github' | 'bitbucket' | 'gitlab' | 'gist';
+    type Hosts = 'github' | 'bitbucket' | 'gitlab' | 'gist';
 }
 
-export = HostedGitInfo;
+export = GitHost;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/hosted-git-info/blob/4636ac9d66f93965086c93e77150b214c8bce339/git-host.js#L23 (not sure where the original author got `host` from, but this property has always been `type`).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.