### PR TITLE
chrome: Replace chrome accessibility features with ChromeSetting.

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -31,89 +31,14 @@ interface Window {
  * Important: This API works only on Chrome OS.
  */
 declare namespace chrome.accessibilityFeatures {
-    export interface AccessibilityFeaturesGetArg {
-        /** Optional. Whether to return the value that applies to the incognito session (default false).  */
-        incognito?: boolean;
-    }
-
-    export interface AccessibilityFeaturesCallbackArg {
-        /** The value of the setting. */
-        value: any;
-        /**
-         * One of
-         * • not_controllable: cannot be controlled by any extension
-         * • controlled_by_other_extensions: controlled by extensions with higher precedence
-         * • controllable_by_this_extension: can be controlled by this extension
-         * • controlled_by_this_extension: controlled by this extension
-         */
-        levelOfControl: string;
-        /** Optional. Whether the effective value is specific to the incognito session. This property will only be present if the incognito property in the details parameter of get() was true.  */
-        incognitoSpecific?: boolean;
-    }
-
-    export interface AccessibilityFeaturesSetArg {
-        /**
-         * The value of the setting.
-         * Note that every setting has a specific value type, which is described together with the setting. An extension should not set a value of a different type.
-         */
-        value: any;
-        /**
-         * Optional.
-          * The scope of the ChromeSetting. One of
-         * • regular: setting for the regular profile (which is inherited by the incognito profile if not overridden elsewhere),
-         * • regular_only: setting for the regular profile only (not inherited by the incognito profile),
-         * • incognito_persistent: setting for the incognito profile that survives browser restarts (overrides regular preferences),
-         * • incognito_session_only: setting for the incognito profile that can only be set during an incognito session and is deleted when the incognito session ends (overrides regular and incognito_persistent preferences).
-         */
-        scope?: string;
-    }
-
-    export interface AccessibilityFeaturesClearArg {
-        /**
-         * Optional.
-          * The scope of the ChromeSetting. One of
-         * • regular: setting for the regular profile (which is inherited by the incognito profile if not overridden elsewhere),
-         * • regular_only: setting for the regular profile only (not inherited by the incognito profile),
-         * • incognito_persistent: setting for the incognito profile that survives browser restarts (overrides regular preferences),
-         * • incognito_session_only: setting for the incognito profile that can only be set during an incognito session and is deleted when the incognito session ends (overrides regular and incognito_persistent preferences).
-         */
-        scope?: string;
-    }
-
-    export interface AccessibilityFeaturesSetting {
-        /**
-         * Gets the value of a setting.
-         * @param details Which setting to consider.
-         * @param callback The callback parameter should be a function that looks like this:
-         * function(object details) {...};
-         */
-        get(details: AccessibilityFeaturesGetArg, callback: (details: AccessibilityFeaturesCallbackArg) => void): void;
-        /**
-         * Sets the value of a setting.
-         * @param details Which setting to change.
-         * @param callback Called at the completion of the set operation.
-         * If you specify the callback parameter, it should be a function that looks like this:
-         * function() {...};
-         */
-        set(details: AccessibilityFeaturesSetArg, callback?: () => void): void;
-        /**
-         * Clears the setting, restoring any default value.
-         * @param details Which setting to clear.
-         * @param callback Called at the completion of the clear operation.
-         * If you specify the callback parameter, it should be a function that looks like this:
-         * function() {...};
-         */
-        clear(details: AccessibilityFeaturesClearArg, callback?: () => void): void;
-    }
-
-    export var spokenFeedback: AccessibilityFeaturesSetting;
-    export var largeCursor: AccessibilityFeaturesSetting;
-    export var stickyKeys: AccessibilityFeaturesSetting;
-    export var highContrast: AccessibilityFeaturesSetting;
-    export var screenMagnifier: AccessibilityFeaturesSetting;
-    export var autoclick: AccessibilityFeaturesSetting;
-    export var virtualKeyboard: AccessibilityFeaturesSetting;
-    export var animationPolicy: AccessibilityFeaturesSetting;
+    export var spokenFeedback: chrome.types.ChromeSetting;
+    export var largeCursor: chrome.types.ChromeSetting;
+    export var stickyKeys: chrome.types.ChromeSetting;
+    export var highContrast: chrome.types.ChromeSetting;
+    export var screenMagnifier: chrome.types.ChromeSetting;
+    export var autoclick: chrome.types.ChromeSetting;
+    export var virtualKeyboard: chrome.types.ChromeSetting;
+    export var animationPolicy: chrome.types.ChromeSetting;
 }
 
 ////////////////////

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -31,13 +31,53 @@ interface Window {
  * Important: This API works only on Chrome OS.
  */
 declare namespace chrome.accessibilityFeatures {
+    /** **ChromeOS only.** Spoken feedback (text-to-speech). */
     export var spokenFeedback: chrome.types.ChromeSetting;
+    /** **ChromeOS only.** Enlarged cursor. */
     export var largeCursor: chrome.types.ChromeSetting;
+    /** **ChromeOS only.** Sticky modifier keys (like shift or alt). */
     export var stickyKeys: chrome.types.ChromeSetting;
+    /** **ChromeOS only.** High contrast rendering mode. */
     export var highContrast: chrome.types.ChromeSetting;
+    /** **ChromeOS only.** Full screen magnification. */
     export var screenMagnifier: chrome.types.ChromeSetting;
+    /** **ChromeOS only.** Auto mouse click after mouse stops moving. */
     export var autoclick: chrome.types.ChromeSetting;
+    /** **ChromeOS only.** Virtual on-screen keyboard. */
     export var virtualKeyboard: chrome.types.ChromeSetting;
+    /**
+     * **ChromeOS only.**
+     * Caret highlighting.
+     * @since Chrome 51.
+     */
+    export var caretHighlight: chrome.types.ChromeSetting;
+    /**
+     * **ChromeOS only.**
+     * Cursor highlighting.
+     * @since Chrome 51.
+     */
+    export var cursorHighlight: chrome.types.ChromeSetting;
+    /**
+     * **ChromeOS only.**
+     * Focus highlighting.
+     * @since Chrome 51.
+     */
+    export var focusHighlight: chrome.types.ChromeSetting;
+    /**
+     * **ChromeOS only.**
+     * Select-to-speak.
+     * @since Chrome 51.
+     */
+    export var selectToSpeak: chrome.types.ChromeSetting;
+    /**
+     * **ChromeOS only.**
+     * Switch Access.
+     * @since Chrome 51.
+     */
+    export var switchAccess: chrome.types.ChromeSetting;
+    /**
+     * @since Chrome 42.
+     */
     export var animationPolicy: chrome.types.ChromeSetting;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: `accessibilityFeatures` is currently missing the `onChange` event listeners. The [Chrome API docs](https://developer.chrome.com/apps/accessibilityFeatures) says "This API relies on the ChromeSetting prototype of the type API for getting and setting individual accessibility features" and [ChromeSetting](https://developer.chrome.com/apps/types) has `onChange`. It is actually [implemented in Chrome](https://cs.chromium.org/chromium/src/chrome/common/extensions/api/accessibility_features.json) as a ChromeSetting.
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.