### PR TITLE
[node-ipc] Export namespace to expose subtypes

### DIFF
--- a/types/node-ipc/index.d.ts
+++ b/types/node-ipc/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 import { Socket } from "net";
-declare namespace NodeIPC {
+export declare namespace NodeIPC {
     class IPC {
         /**
          * Set these variables in the ipc.config scope to overwrite or set default values


### PR DESCRIPTION
This is a trivial change to an existing definition.