### PR TITLE
feat(mini-css-extract-plugin): missing `moduleFilename` option

### DIFF
--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -3,10 +3,10 @@
 // Definitions by: JounQin <https://github.com/JounQin>
 //                 Katsuya Hino <https://github.com/dobogo>
 //                 Spencer Miskoviak <https://github.com/skovy>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
-import { Plugin } from 'webpack';
+import { compilation, Plugin } from 'webpack';
 
 /**
  * Lightweight CSS extraction webpack plugin
@@ -40,6 +40,12 @@ declare namespace MiniCssExtractPlugin {
          * like in the case of module concatenation and tree shaking.
          */
         esModule?: boolean;
+        /**
+         * With the `moduleFilename` option you can use chunk data to customize the filename.
+         * This is particularly useful when dealing with multiple entry points
+         * and wanting to get more control out of the filename for a given entry point/chunk
+         */
+        moduleFilename?: (chunk: compilation.Chunk) => string;
     }
 }
 

--- a/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
+++ b/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
@@ -34,11 +34,7 @@ configuration = {
             // or any other compile-to-css language
             {
                 test: /\.less$/,
-                use: [
-                    MiniCssExtractPlugin.loader,
-                    'css-loader',
-                    'style-loader',
-                ],
+                use: [MiniCssExtractPlugin.loader, 'css-loader', 'style-loader'],
             },
             // You could also use other loaders the same way. I. e. the autoprefixer-loader
         ],
@@ -73,6 +69,24 @@ configuration = {
             filename: 'styles.css',
             chunkFilename: 'style.css',
             ignoreOrder: true,
+        }),
+    ],
+};
+
+configuration = {
+    // ...
+    plugins: [
+        new MiniCssExtractPlugin({
+            esModule: true,
+        }),
+    ],
+};
+
+configuration = {
+    // ...
+    plugins: [
+        new MiniCssExtractPlugin({
+            moduleFilename: ({ name }) => `${name.replace('/js/', '/css/')}.css`,
         }),
     ],
 };


### PR DESCRIPTION
- update type definition with missig `moduleFilename` option
- update tests
- minor code cleanup via Prettier

https://github.com/webpack-contrib/mini-css-extract-plugin#module-filename-option

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack-contrib/mini-css-extract-plugin#module-filename-option