### PR TITLE
Fix return type of serviceworker-webpack-plugin register()

### DIFF
--- a/types/serviceworker-webpack-plugin/lib/runtime.d.ts
+++ b/types/serviceworker-webpack-plugin/lib/runtime.d.ts
@@ -1,5 +1,11 @@
 export interface ServiceWorkerWebpackPluginRuntime {
-    register(options?: RegistrationOptions): Promise<ServiceWorkerRegistration>;
+    /**
+     * Register the service worker registered using serviceworker-webpack-plugin.
+     *
+     * @param options Forwarded to `navigator.serviceWorker.register()`
+     * @returns A promise if the runtime supports service workers, otherwise false.
+     */
+    register(options?: RegistrationOptions): false | Promise<ServiceWorkerRegistration>;
 }
 
 declare const runtime: ServiceWorkerWebpackPluginRuntime;

--- a/types/serviceworker-webpack-plugin/serviceworker-webpack-plugin-tests.ts
+++ b/types/serviceworker-webpack-plugin/serviceworker-webpack-plugin-tests.ts
@@ -43,10 +43,15 @@ new ServiceWorkerWebpackPlugin<number>({
     },
 });
 
-runtime.register().then(registration => {
-    registration.pushManager;
-});
+const serviceworkerPromise = runtime.register();
+if (serviceworkerPromise) {
+    serviceworkerPromise.then(registration => {
+        registration.pushManager;
+    });
 
-runtime.register({ scope: '' }).then(registration => {
-    registration.pushManager;
-});
+    serviceworkerPromise.then(registration => {
+        registration.pushManager;
+    });
+} else {
+    console.log(serviceworkerPromise === false);
+}


### PR DESCRIPTION
It has an inconsistent API. It returns false if `navigator.serviceWorker` is undefined.

TSdoc was added to clarify this quirk.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/oliviertassinari/serviceworker-webpack-plugin/blob/master/src/runtimeTemplate.js
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~