### PR TITLE
[@types/tryghost__content-api] Fix filter parameter for browsing

### DIFF
--- a/types/tryghost__content-api/index.d.ts
+++ b/types/tryghost__content-api/index.d.ts
@@ -155,7 +155,7 @@ export interface Params {
     include?: ArrayOrValue<IncludeParam>;
     fields?: ArrayOrValue<FieldParam>;
     formats?: ArrayOrValue<FormatParam>;
-    filters?: ArrayOrValue<FilterParam>;
+    filter?: ArrayOrValue<FilterParam>;
     limit?: ArrayOrValue<LimitParam>;
     page?: ArrayOrValue<PageParam>;
     order?: ArrayOrValue<OrderParam>;


### PR DESCRIPTION
As mentionned in the Ghost content API documentation https://ghost.org/docs/api/v3/javascript/filtering/ , the parameter is "filter" and not "filters"
