### PR TITLE
[pdfmake] Include lib dom as a reference

### DIFF
--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -5,7 +5,9 @@
 //                 Enzo Volkmann <https://github.com/evolkmann>
 //                 Andi Pätzold <https://github.com/andipaetzold>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 3.0
+
+/// <reference lib="dom" />
 
 declare module "pdfmake/build/vfs_fonts" {
     let pdfMake: {

--- a/types/pdfmake/tsconfig.json
+++ b/types/pdfmake/tsconfig.json
@@ -2,7 +2,6 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "dom",
             "es6"
         ],
         "noImplicitAny": true,


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---
Hi,

Not having that is an annoyance for people using it on pure node, I don't really want to include lib dom in my tsconfig as it shouldn't be used.

I'm not sure it deserves a breaking release just because of the bump to typescript 3.0, it's imho long overdue.