### PR TITLE
added missing static methods type for OverlayView class in @types/googlemaps

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -14,6 +14,7 @@
 //                 Vladimir Dashukevich <https://github.com/life777>
 //                 Simon Haenisch <https://github.com/simonhaenisch>
 //                 Gavin Nitta <https://github.com/gshigeto>
+//                 Bat-Orshikh Baavgaikhuu <https://github.com/Bat-Orshikh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // TypeScript Version: 3.0
@@ -1995,6 +1996,10 @@ declare namespace google.maps {
         onAdd(): void;
         onRemove(): void;
         setMap(map: Map | StreetViewPanorama | null): void;
+        /** @see {@link https://developers.google.com/maps/documentation/javascript/reference/overlay-view#OverlayView.preventMapHitsAndGesturesFrom Maps JavaScript API} */
+        static preventMapHitsAndGesturesFrom(element: Element): void;
+        /** @see {@link https://developers.google.com/maps/documentation/javascript/reference/overlay-view#OverlayView.preventMapHitsFrom Maps JavaScript API} */
+        static preventMapHitsFrom(element: Element): void;
     }
 
     /** @see {@link https://developers.google.com/maps/documentation/javascript/reference/overlay-view#MapPanes Maps JavaScript API} */

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -2001,7 +2001,10 @@ declare namespace google.maps {
          * @see {@link https://developers.google.com/maps/documentation/javascript/reference/overlay-view#OverlayView.preventMapHitsAndGesturesFrom Maps JavaScript API}
          */
         static preventMapHitsAndGesturesFrom(element: Element): void;
-        /** @see {@link https://developers.google.com/maps/documentation/javascript/reference/overlay-view#OverlayView.preventMapHitsFrom Maps JavaScript API} */
+        /**
+         * Stops click or tap on the element from bubbling up to the map. Use this to prevent the map from triggering "click" events.
+         * @see {@link https://developers.google.com/maps/documentation/javascript/reference/overlay-view#OverlayView.preventMapHitsFrom Maps JavaScript API}
+         */
         static preventMapHitsFrom(element: Element): void;
     }
 

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -1996,7 +1996,10 @@ declare namespace google.maps {
         onAdd(): void;
         onRemove(): void;
         setMap(map: Map | StreetViewPanorama | null): void;
-        /** @see {@link https://developers.google.com/maps/documentation/javascript/reference/overlay-view#OverlayView.preventMapHitsAndGesturesFrom Maps JavaScript API} */
+        /**
+         * Stops click, tap, drag, and wheel events on the element from bubbling up to the map. Use this to prevent map dragging and zooming, as well as map "click" events.
+         * @see {@link https://developers.google.com/maps/documentation/javascript/reference/overlay-view#OverlayView.preventMapHitsAndGesturesFrom Maps JavaScript API}
+         */
         static preventMapHitsAndGesturesFrom(element: Element): void;
         /** @see {@link https://developers.google.com/maps/documentation/javascript/reference/overlay-view#OverlayView.preventMapHitsFrom Maps JavaScript API} */
         static preventMapHitsFrom(element: Element): void;


### PR DESCRIPTION
Added `preventMapHitsAndGesturesFrom` and `preventMapHitsFrom` static method declaration on OverlayView class in @types/googlemaps.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- N/A If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- N/A If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
