### PR TITLE
fix(mocha‑sugar‑free): Correct `Options` type

### DIFF
--- a/types/mocha-sugar-free/index.d.ts
+++ b/types/mocha-sugar-free/index.d.ts
@@ -9,16 +9,23 @@ import { Test, Suite } from 'mocha';
 type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
 
 declare namespace Mocha {
-	type TestCase = (this: undefined, context: TestContext) => void | PromiseLike<void>;
+	type TestCase = (this: undefined, context: TestContext) => void | PromiseLike<any>;
 	type TestCaseWithDone = (this: undefined, context: TestContextWithDone) => void;
 	type HookFunc = (this: undefined, context: HookContext) => void;
 	type SuiteFunc = (this: undefined, context: SuiteContext) => void;
 
 	interface Options {
+		[option: string]: any;
+
 		/**
 		 * Whether the context should contain a `done` callback.
 		 */
 		async?: boolean;
+
+		/**
+		 * Set whether timeouts are enabled.
+		 */
+		enableTimeouts?: boolean;
 
 		/**
 		 * Whether failing to return a PromiseLike should fail the test.
@@ -44,6 +51,16 @@ declare namespace Mocha {
 		 * Whether the test should be skipped outside a browser environment.
 		 */
 		skipUnlessBrowser?: boolean;
+
+		/**
+		 * Set test slowness threshold.
+		 */
+		slow?: string | number;
+
+		/**
+		 * Set test timeout.
+		 */
+		timeout?: string | number;
 
 		/**
 		 * The test title. Replaced by the title parameter if present.
@@ -319,7 +336,7 @@ declare namespace Mocha {
 		/**
 		 * Mark a test as completed.
 		 */
-		done(err: any): void;
+		done(err?: any): void;
 	}
 	// #endregion
 
@@ -404,10 +421,10 @@ declare namespace Mocha {
 		(fn: TestCase): Test;
 		(title: string, fn?: TestCase): Test;
 		(title: string, options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;
-		(title: string, options: Options & { async?: true; fn?: TestCase }, fn?: TestCaseWithDone): Test;
+		(title: string, options: Options & { async: true; fn?: TestCaseWithDone }, fn?: TestCaseWithDone): Test;
 		// tslint:disable-next-line: unified-signatures
 		(options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;
-		(options: Options & { async?: true; fn?: TestCase }, fn?: TestCaseWithDone): Test;
+		(options: Options & { async: true; fn?: TestCaseWithDone }, fn?: TestCaseWithDone): Test;
 
 		/**
 		 * [bdd, tdd, qunit]
@@ -437,10 +454,10 @@ declare namespace Mocha {
 		(fn: TestCase): Test;
 		(title: string, fn?: TestCase): Test;
 		(title: string, options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;
-		(title: string, options: Options & { async?: true; fn?: TestCase }, fn?: TestCaseWithDone): Test;
+		(title: string, options: Options & { async: true; fn?: TestCaseWithDone }, fn?: TestCaseWithDone): Test;
 		// tslint:disable-next-line: unified-signatures
 		(options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;
-		(options: Options & { async?: true; fn?: TestCase }, fn?: TestCaseWithDone): Test;
+		(options: Options & { async: true; fn?: TestCaseWithDone }, fn?: TestCaseWithDone): Test;
 	}
 
 	/**
@@ -456,10 +473,10 @@ declare namespace Mocha {
 		(fn: TestCase): Test;
 		(title: string, fn?: TestCase): Test;
 		(title: string, options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;
-		(title: string, options: Options & { async?: true; fn?: TestCase }, fn?: TestCaseWithDone): Test;
+		(title: string, options: Options & { async: true; fn?: TestCaseWithDone }, fn?: TestCaseWithDone): Test;
 		// tslint:disable-next-line: unified-signatures
 		(options: Options & { async?: false; fn?: TestCase }, fn?: TestCase): Test;
-		(options: Options & { async?: true; fn?: TestCase }, fn?: TestCaseWithDone): Test;
+		(options: Options & { async: true; fn?: TestCaseWithDone }, fn?: TestCaseWithDone): Test;
 	}
 	// #endregion
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/Joris-van-der-Wel/mocha-sugar-free/blob/4dd64403b8ff1e1d071305f14c764dd18551a9b7/lib/mocha-sugar-free.js#L38-L48>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
