### PR TITLE
feat(simpl-schema): Export additional interfaces

### DIFF
--- a/types/simpl-schema/index.d.ts
+++ b/types/simpl-schema/index.d.ts
@@ -107,15 +107,17 @@ interface SimpleSchemaValidationError {
   [key: string]: number | string;
 }
 
+export type SimpleSchemaDefinition = {
+    [key: string]: SchemaDefinition
+      | BooleanConstructor | StringConstructor | NumberConstructor | DateConstructor
+      | ArrayConstructor
+      | string | RegExp
+      | SimpleSchema
+  } | any[];
+
 interface SimpleSchemaStatic {
   new(
-    schema: {
-      [key: string]: SchemaDefinition
-        | BooleanConstructor | StringConstructor | NumberConstructor | DateConstructor
-        | ArrayConstructor
-        | string | RegExp
-        | SimpleSchema
-    } | any[],
+    schema: SimpleSchemaDefinition,
     options?: SimpleSchemaOptions
   ): SimpleSchema;
   namedContext(name?: string): SimpleSchemaValidationContextStatic;

--- a/types/simpl-schema/simpl-schema-tests.ts
+++ b/types/simpl-schema/simpl-schema-tests.ts
@@ -1,6 +1,6 @@
-import SimpleSchema from 'simpl-schema';
+import SimpleSchema, { SimpleSchemaDefinition } from 'simpl-schema';
 
-const StringSchema = new SimpleSchema({
+const schema: SimpleSchemaDefinition = {
     basicString: {
         type: String
     },
@@ -27,7 +27,9 @@ const StringSchema = new SimpleSchema({
           else if (text.length < 10) return SimpleSchema.ErrorTypes.MIN_STRING;
         }
     }
-});
+};
+
+const StringSchema = new SimpleSchema(schema);
 
 StringSchema.validate({
     basicString: "Test",


### PR DESCRIPTION
So that we can reuse them when declaring SimpleSchema arguments...

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
> - [x] Provide a URL to documentation or source code which provides context for the suggested changes:

I doubt there is some URL talking about my problem. I mean, I just want to move the schema definition out of the constructor call when declaring a new schema (as I did in the modified test file)...  
**EDIT:** [Here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3e6006ccb4d3d4a0dcacbbf6fac2344f32cb9f6d/types/simpl-schema/simpl-schema-tests.ts#L3) is the link of the modified test file.