### PR TITLE
fix(googlemaps): add missing OverlayView static methods. Closes #42515

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -546,6 +546,8 @@ class Overlay extends google.maps.OverlayView {
 }
 let overlay = new Overlay();
 overlay.setMap(map);
+google.maps.OverlayView.preventMapHitsAndGesturesFrom(div); // $ExpectType void
+google.maps.OverlayView.preventMapHitsFrom(div); // $ExpectType void
 
 /***** Rectangles *****/
 // https://developers.google.com/maps/documentation/javascript/examples/rectangle-simple

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -1987,7 +1987,21 @@ declare namespace google.maps {
         opacity?: number;
     }
 
+    /**
+     * see {@link https://developers.google.com/maps/documentation/javascript/reference/overlay-view#OverlayView}
+     */
     class OverlayView extends MVCObject {
+        /**
+         * Stops click, tap, drag, and wheel events on the element from bubbling up to the map.
+         * Use this to prevent map dragging and zooming, as well as map "click" events
+         */
+        static preventMapHitsAndGesturesFrom(element: Element): void;
+        /**
+         * Stops click or tap on the element from bubbling up to the map.
+         * Use this to prevent the map from triggering "click" events
+         */
+        static preventMapHitsFrom(element: Element): void;
+
         draw(): void;
         getMap(): Map | StreetViewPanorama;
         getPanes(): MapPanes;


### PR DESCRIPTION
- `preventMapHitsAndGesturesFrom`
- `preventMapHitsFrom`

/cc @Bat-Orshikh

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://developers.google.com/maps/documentation/javascript/reference/overlay-view#OverlayView.preventMapHitsAndGesturesFrom
https://developers.google.com/maps/documentation/javascript/reference/overlay-view#OverlayView.preventMapHitsFrom