### PR TITLE
fix(react-wait): add missing v0.3 definitions

### DIFF
--- a/types/react-wait/index.d.ts
+++ b/types/react-wait/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-wait 0.3
 // Project: https://github.com/f/react-wait#readme
 // Definitions by: Ifiok Jr. <https://github.com/ifiokjr>
+//                 Paweł Maciejewski <https://github.com/pwlmaciejewski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -8,12 +9,26 @@ import { ComponentType, FunctionComponent } from 'react';
 
 export const Waiter: FunctionComponent;
 
-export interface WaitProps {
+export interface WaitingContextWaitProps {
     fallback: JSX.Element;
+}
+
+export interface WaitProps extends WaitingContextWaitProps {
     on: string;
 }
 
+export interface WaitingContext {
+    isWaiting(): boolean;
+    startWaiting(): void;
+    endWaiting(): void;
+    Wait: ComponentType<WaitingContextWaitProps>;
+}
+
 export interface UseWaitAPI {
+    /**
+     * Returns an array of waiters.
+     */
+    waiters: string[];
     /**
      * Using Wait Component
      *
@@ -79,6 +94,19 @@ export interface UseWaitAPI {
      * ```
      */
     endWaiting(waiter: string): void;
+    /**
+     * Creates a waiting context.
+     *
+     * ```tsx
+     * const { startWaiting, endWaiting, isWaiting, Wait } = createWaitingContext("creating user");
+     *  return (
+     *   <button disabled={isWaiting()}>
+     *     Disabled while creating user
+     *   </button>
+     * );
+     * ```
+     */
+    createWaitingContext(waiter: string): WaitingContext;
 }
 
 export function useWait(): UseWaitAPI;

--- a/types/react-wait/react-wait-tests.tsx
+++ b/types/react-wait/react-wait-tests.tsx
@@ -58,7 +58,7 @@ function testCreateWaitingContext() {
             </Wait>
             <button disabled={isWaiting()} onClick={endWaiting}>Cancel</button>
         </div>
-    )
+    );
 }
 
 function testWaiters() {
@@ -67,5 +67,5 @@ function testWaiters() {
         <ul>
             {waiters.map((waiter, index) => <li key={index}>{waiter}</li>)}
         </ul>
-    )
+    );
 }

--- a/types/react-wait/react-wait-tests.tsx
+++ b/types/react-wait/react-wait-tests.tsx
@@ -47,3 +47,25 @@ const MyComponent = () => (
         <C />
     </Waiter>
 );
+
+function testCreateWaitingContext() {
+    const { createWaitingContext } = useWait();
+    const { startWaiting, endWaiting, isWaiting, Wait } = createWaitingContext('creating user');
+    return (
+        <div>
+            <Wait fallback={<Spinner />}>
+                <button onClick={startWaiting}>Create user</button>
+            </Wait>
+            <button disabled={isWaiting()} onClick={endWaiting}>Cancel</button>
+        </div>
+    )
+}
+
+function testWaiters() {
+    const { waiters } = useWait();
+    return (
+        <ul>
+            {waiters.map((waiter, index) => <li key={index}>{waiter}</li>)}
+        </ul>
+    )
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  * github repo: https://github.com/f/react-wait
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The PR adds some missing type context props definitions:
* [`createWaitingContext()`](https://github.com/f/react-wait#creating-waiting-contexts-using-createwaitingcontextcontext-string)
* [`waiters`](https://github.com/f/react-wait/blob/master/src/index.js#L17)
