### PR TITLE
feat(find-cache-dir): update to v3.2

### DIFF
--- a/types/find-cache-dir/find-cache-dir-tests.ts
+++ b/types/find-cache-dir/find-cache-dir-tests.ts
@@ -1,16 +1,16 @@
 import findCacheDir = require('find-cache-dir');
 
-findCacheDir({ name: 'unicorns' }); // $ExpectType string | null
-findCacheDir({ name: 'unicorns', files: 'foo' }); // $ExpectType string | null
-findCacheDir({ name: 'unicorns', files: ['foo', 'bar'] }); // $ExpectType string | null
-findCacheDir({ name: 'unicorns', cwd: 'foo' }); // $ExpectType string | null
-findCacheDir({ name: 'unicorns', create: true }); // $ExpectType string | null
-findCacheDir({ name: 'unicorns', thunk: false }); // $ExpectType string | null
+findCacheDir({ name: 'unicorns' }); // $ExpectType string | undefined
+findCacheDir({ name: 'unicorns', files: 'foo' }); // $ExpectType string | undefined
+findCacheDir({ name: 'unicorns', files: ['foo', 'bar'] }); // $ExpectType string | undefined
+findCacheDir({ name: 'unicorns', cwd: 'foo' }); // $ExpectType string | undefined
+findCacheDir({ name: 'unicorns', create: true }); // $ExpectType string | undefined
+findCacheDir({ name: 'unicorns', thunk: false }); // $ExpectType string | undefined
 findCacheDir({}); // $ExpectError
 findCacheDir(); // $ExpectError
 
 const thunk = findCacheDir({ name: 'unicorns', thunk: true });
-thunk; // $ExpectType ((...pathParts: string[]) => string) | null
+thunk; // $ExpectType ((...pathParts: string[]) => string) | undefined
 
 if (thunk) {
     thunk(); // $ExpectType string

--- a/types/find-cache-dir/v2/find-cache-dir-tests.ts
+++ b/types/find-cache-dir/v2/find-cache-dir-tests.ts
@@ -1,0 +1,19 @@
+import findCacheDir = require('find-cache-dir');
+
+findCacheDir({ name: 'unicorns' }); // $ExpectType string | null
+findCacheDir({ name: 'unicorns', files: 'foo' }); // $ExpectType string | null
+findCacheDir({ name: 'unicorns', files: ['foo', 'bar'] }); // $ExpectType string | null
+findCacheDir({ name: 'unicorns', cwd: 'foo' }); // $ExpectType string | null
+findCacheDir({ name: 'unicorns', create: true }); // $ExpectType string | null
+findCacheDir({ name: 'unicorns', thunk: false }); // $ExpectType string | null
+findCacheDir({}); // $ExpectError
+findCacheDir(); // $ExpectError
+
+const thunk = findCacheDir({ name: 'unicorns', thunk: true });
+thunk; // $ExpectType ((...pathParts: string[]) => string) | null
+
+if (thunk) {
+    thunk(); // $ExpectType string
+    thunk('bar.js'); // $ExpectType string
+    thunk('baz', 'quz.js'); // $ExpectType string
+}

--- a/types/find-cache-dir/v2/index.d.ts
+++ b/types/find-cache-dir/v2/index.d.ts
@@ -1,19 +1,20 @@
-// Type definitions for find-cache-dir 3.2
+// Type definitions for find-cache-dir 2.0
 // Project: https://github.com/avajs/find-cache-dir#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
-//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = findCacheDir;
 
 /**
- * Finds the cache directory using the supplied options.
- * The algorithm tries to find a `package.json` file, searching every parent directory of the `cwd` specified
- * (or implied from other options). It returns a `string` containing the absolute path to the cache directory,
- * or `undefined` if `package.json` was never found or if the `node_modules` directory is unwritable.
+ * Finds the cache directory using the supplied options. The algorithm tries to find a `package.json` file,
+ * searching every parent directory of the `cwd` specified (or implied from other options).
+ * @param options
+ * @returns A string containing the absolute path to the cache directory, or null if package.json was never found.
  */
-declare function findCacheDir(options: findCacheDir.OptionsWithThunk): ((...pathParts: string[]) => string) | undefined;
-declare function findCacheDir(options: findCacheDir.Options): string | undefined;
+declare function findCacheDir(
+    options: findCacheDir.OptionsWithThunk
+): ((...pathParts: string[]) => string) | null;
+declare function findCacheDir(options: findCacheDir.Options): string | null;
 
 declare namespace findCacheDir {
     interface Options {

--- a/types/find-cache-dir/v2/tsconfig.json
+++ b/types/find-cache-dir/v2/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "paths": {
+            "find-cache-dir": [
+                "find-cache-dir/v2"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "find-cache-dir-tests.ts"
+    ]
+}

--- a/types/find-cache-dir/v2/tslint.json
+++ b/types/find-cache-dir/v2/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- v2 for backward compatibility
- migrate return type from `null` to `undefined`

https://github.com/avajs/find-cache-dir#readme

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/avajs/find-cache-dir#readme
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.