### PR TITLE
fix(koa): return type of callback method

### DIFF
--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -513,7 +513,7 @@ declare class Application<
      * Return a request handler callback
      * for node's native http/http2 server.
      */
-    callback(): (req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse) => void;
+    callback(): (req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse) => Promise<void>;
 
     /**
      * Initialize a new context.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~

---

The `callback` method returns the function `handleRequest` ([lib/application.js#L146-L151](https://github.com/koajs/koa/blob/eda27608f7d39ede86d7b402aae64b1867ce31c6/lib/application.js#L146-L151)) which itself returns the result of `this.handleRequest` ([lib/application.js#L160-L167](https://github.com/koajs/koa/blob/eda27608f7d39ede86d7b402aae64b1867ce31c6/lib/application.js#L160-L167)) which is a promise (see [lib/application.js#L166](https://github.com/koajs/koa/blob/eda27608f7d39ede86d7b402aae64b1867ce31c6/lib/application.js#L166)).

The resolved return type of this promise can either be that of `this.onerror` ([lib/application.js#L197-L207](https://github.com/koajs/koa/blob/eda27608f7d39ede86d7b402aae64b1867ce31c6/lib/application.js#L197-L207)) or `respond` ([lib/application.js#L214-L264](https://github.com/koajs/koa/blob/eda27608f7d39ede86d7b402aae64b1867ce31c6/lib/application.js#L214-L264)) which is `void` in both cases.

Therefore the proper return type of the `callback` method's returned function is `Promise<void>`. Invoking the function in a node repl is also proof that a promise is returned:

<img src="https://user-images.githubusercontent.com/3410759/75070110-dd4f4500-54f2-11ea-9a74-aee15693b82d.png" width="235">