### PR TITLE
Add es-module-lexer

### DIFF
--- a/types/es-module-lexer/es-module-lexer-tests.ts
+++ b/types/es-module-lexer/es-module-lexer-tests.ts
@@ -1,0 +1,21 @@
+import { init, parse } from 'es-module-lexer';
+
+init.then(() => {
+    // Parse is ready
+});
+
+parse(`'asdf'`);
+parse(`/asdf/`, 'other-sourcename');
+
+const source = `
+    import test from "test";
+    console.log(test);
+    export { x }
+`;
+
+const [imported, exported] = parse(source, '@');
+const { s, e, ss, se, d } = imported[0];
+d === -1;
+source.slice(s, e) === 'test';
+source.slice(ss, se) === 'import test from "test"';
+exported[0] === 'x';

--- a/types/es-module-lexer/index.d.ts
+++ b/types/es-module-lexer/index.d.ts
@@ -1,0 +1,54 @@
+// Type definitions for es-module-lexer 0.3
+// Project: https://github.com/guybedford/es-module-lexer
+// Definitions by: Tiger Oakes <https://github.com/NotWoods>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface ImportSpecifier {
+    /**
+     * Start of module specifier
+     * @example
+     * const source = `import { a } from 'asdf'`;
+     * const [imports, exports] = parse(source);
+     * source.substring(imports[0].s, imports[0].e);
+     * // Returns "asdf"
+     */
+    s: number;
+    /**
+     * End of module specifier
+     */
+    e: number;
+
+    /**
+     * Start of import statement
+     * @example
+     * const source = `import { a } from 'asdf'`;
+     * const [imports, exports] = parse(source);
+     * source.substring(imports[0].s, imports[0].e);
+     * // Returns "import { a } from 'asdf';"
+     */
+    ss: number;
+    /**
+     * End of import statement
+     */
+    se: number;
+
+    /**
+     * If this import statement is a dynamic import, this is the start value.
+     * Otherwise this is `-1`.
+     */
+    d: number;
+}
+
+/**
+ * Wait for init to resolve before calling `parse`.
+ */
+export const init: Promise<void>;
+
+/**
+ * Outputs the list of exports and locations of import specifiers,
+ * including dynamic import and import meta handling.
+ * @param source Source code to parser
+ * @param name Optional sourcename
+ * @returns Tuple contaning imports list and exports list.
+ */
+export function parse(source: string, name?: string): [ImportSpecifier[], string[]];

--- a/types/es-module-lexer/tsconfig.json
+++ b/types/es-module-lexer/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "es-module-lexer-tests.ts"
+    ]
+}

--- a/types/es-module-lexer/tslint.json
+++ b/types/es-module-lexer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.


https://github.com/guybedford/es-module-lexer