### PR TITLE
Correct argument order for secp256k1 API v4.0

### DIFF
--- a/types/secp256k1/index.d.ts
+++ b/types/secp256k1/index.d.ts
@@ -128,12 +128,12 @@ export function ecdsaSign(message: Uint8Array, privateKey: Uint8Array, options?:
  * - Compute point `R = (s^-1 * m * G + s^-1 * r * Q)`. Reject if `R` is infinity.
  * - Signature is valid if R's `x` coordinate equals to `r`.
  */
-export function ecdsaVerify(message: Uint8Array, signature: Uint8Array, publicKey: Uint8Array): boolean;
+export function ecdsaVerify(signature: Uint8Array, message: Uint8Array, publicKey: Uint8Array): boolean;
 
 /**
  * Recover an ECDSA public key from a signature.
  */
-export function ecdsaRecover(message: Uint8Array, signature: Uint8Array, recovery: number, compressed?: boolean): Uint8Array;
+export function ecdsaRecover(signature: Uint8Array, recovery: number, message: Uint8Array, compressed?: boolean): Uint8Array;
 
 /**
  * Compute an EC Diffie-Hellman secret and applied sha256 to compressed public key.


### PR DESCRIPTION
Change argument order for `verify` and `recover` to meet API v4.0

See https://github.com/cryptocoinjs/secp256k1-node/blob/master/API.md for more details

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [API v4.0](https://github.com/cryptocoinjs/secp256k1-node/blob/master/API.md)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.