### PR TITLE
feat(express-session): correct `unset` option and bump to 1.17

### DIFF
--- a/types/express-session/express-session-tests.ts
+++ b/types/express-session/express-session-tests.ts
@@ -33,7 +33,14 @@ app.use(session({
   resave: true,
   proxy: true,
   saveUninitialized: true,
-  unset: 'keep'
+}));
+app.use(session({
+    secret: 'keyboard cat',
+    unset: 'destroy'
+}));
+app.use(session({
+    secret: 'keyboard cat',
+    unset: 'keep'
 }));
 
 interface MySession extends Express.Session {

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for express-session 1.15
+// Type definitions for express-session 1.17
 // Project: https://github.com/expressjs/session
 // Definitions by: Hiroki Horiuchi <https://github.com/horiuchi>
 //                 Jacob Bogers <https://github.com/jacobbogers>
 //                 Naoto Yokoyama <https://github.com/builtinnya>
 //                 Ryan Cannon <https://github.com/ry7n>
 //                 Tom Spencer <https://github.com/fiznool>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -75,7 +76,13 @@ declare namespace session {
     resave?: boolean;
     proxy?: boolean;
     saveUninitialized?: boolean;
-    unset?: string;
+    /**
+     * Control the result of unsetting req.session (through delete, setting to null, etc.).
+     * - 'destroy' The session will be destroyed (deleted) when the response ends.
+     * - 'keep' The session in the store will be kept, but modifications made during the request are ignored and not saved.
+     * @default 'keep'
+     */
+    unset?: 'destroy' | 'keep';
   }
 
   interface BaseMemoryStore {

--- a/types/express-session/tslint.json
+++ b/types/express-session/tslint.json
@@ -1,6 +1,1 @@
-{
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "prefer-method-signature": false
-    }
-}
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- correct type of `unset` option as per documentation
- test update

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/session#unset
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.