### PR TITLE
[@types/sinon] Added signature for assert.calledOnceWithExactly

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1153,6 +1153,12 @@ declare namespace Sinon {
          */
         calledWithExactly(spyOrSpyCall: SinonSpy | SinonSpyCall, ...args: any[]): void;
         /**
+         * Passes if spy was called at exactly once with the provided arguments and no others.
+         * @param spyOrSpyCall
+         * @param args
+         */
+        calledOnceWithExactly(spyOrSpyCall: SinonSpy | SinonSpyCall, ...args: any[]): void;
+        /**
          * Passes if spy was always called with the provided arguments and no others.
          */
         alwaysCalledWithExactly(spy: SinonSpy, ...args: any[]): void;

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -268,6 +268,7 @@ function testAssert() {
     sinon.assert.alwaysCalledWith(spy, 'a', 'b', 'c');
     sinon.assert.neverCalledWith(spy, 'a', 'b', 'c');
     sinon.assert.calledWithExactly(spy, 'a', 'b', 'c');
+    sinon.assert.calledOnceWithExactly(spy, 'a', 'b', 'c');
     sinon.assert.alwaysCalledWithExactly(spy, 'a', 'b', 'c');
     sinon.assert.calledWithMatch(spy, 'a', 'b', 'c');
     sinon.assert.calledWithMatch(spy.firstCall, 'a', 'b', 'c');

--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -1248,6 +1248,15 @@ declare namespace Sinon {
             ...args: MatchArguments<TArgs>
         ): void;
         /**
+         * Passes if spy was called at exactly once with the provided arguments and no others.
+         * @param spyOrSpyCall
+         * @param args
+         */
+        calledOnceWithExactly<TArgs extends any[]>(
+            spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
+            ...args: MatchArguments<TArgs>
+        ): void;
+        /**
          * Passes if spy was always called with the provided arguments and no others.
          */
         alwaysCalledWithExactly<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: MatchArguments<TArgs>): void;

--- a/types/sinon/ts3.1/sinon-tests.ts
+++ b/types/sinon/ts3.1/sinon-tests.ts
@@ -275,6 +275,7 @@ function testAssert() {
     sinon.assert.alwaysCalledWith(spy, 'a', 'b', 'c');
     sinon.assert.neverCalledWith(spy, 'a', 'b', 'c');
     sinon.assert.calledWithExactly(spy, 'a', 'b', 'c');
+    sinon.assert.calledOnceWithExactly(spy, 'a', 'b', 'c');
     sinon.assert.alwaysCalledWithExactly(spy, 'a', 'b', 'c');
     sinon.assert.calledWithMatch(spy, 'a', 'b', 'c');
     sinon.assert.calledWithMatch(spy.firstCall, 'a', 'b', 'c');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sinonjs/sinon/pull/2080#issuecomment-589197118
- ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~ Don't need to do this as it was missed from the current ([7.5](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e32d4f0292c57f63310af65a7fb3708155cf8083/types/sinon/index.d.ts#L1)) version (https://github.com/sinonjs/sinon/blob/master/CHANGELOG.md#750--2019-09-23).
