### PR TITLE
Update `webpack-dev-middleware` to 3.7

### DIFF
--- a/types/webpack-dev-middleware/index.d.ts
+++ b/types/webpack-dev-middleware/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for webpack-dev-middleware 2.0
+// Type definitions for webpack-dev-middleware 3.7
 // Project: https://github.com/webpack/webpack-dev-middleware
 // Definitions by: Benjamin Lim <https://github.com/bumbleblym>
 //                 reduckted <https://github.com/reduckted>
 //                 Chris Abrams <https://github.com/chrisabrams>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 import * as webpack from 'webpack';
 import * as loglevel from 'loglevel';
@@ -14,42 +14,96 @@ import MemoryFileSystem = require('memory-fs');
 export = WebpackDevMiddleware;
 
 declare function WebpackDevMiddleware(
-	compiler: webpack.ICompiler,
-	options?: WebpackDevMiddleware.Options
+    compiler: webpack.ICompiler,
+    options?: WebpackDevMiddleware.Options,
 ): WebpackDevMiddleware.WebpackDevMiddleware & NextHandleFunction;
 
 declare namespace WebpackDevMiddleware {
-	interface Options {
-		logLevel?: string;
-		lazy?: boolean;
-		watchOptions?: webpack.Options.WatchOptions;
-		publicPath: string;
-		index?: string | boolean;
-		headers?: {
-			[name: string]: string;
-		};
-		stats?: webpack.Options.Stats;
-		reporter?: Reporter | null;
-		serverSideRender?: boolean;
-		logger?: Logger;
-		filename?: string;
-		writeToDisk?: boolean | ((filename: string) => boolean);
-	}
+    interface Options {
+        filename?: string;
+        /**
+         * Set the default file system which will be used by webpack as primary destination of generated files
+         */
+        fs?: MemoryFileSystem;
+        /** This property allows a user to pass custom HTTP headers on each request. eg. { "X-Custom-Header": "yes" } */
+        headers?: {
+            [name: string]: string;
+        };
+        /**
+         * The index path for web server, defaults to "index.html".
+         * If falsy (but not undefined), the server will not respond to requests to the root URL.
+         */
+        index?: string | boolean;
+        /**
+         * This option instructs the module to operate in 'lazy' mode,
+         * meaning that it won't recompile when files change, but rather on each request.
+         */
+        lazy?: boolean;
+        /**
+         * In the rare event that a user would like to provide a custom logging interface,
+         * this property allows the user to assign one
+         */
+        logger?: Logger;
+        /** This property defines the level of messages that the module will log */
+        logLevel?: 'info' | 'warn' | 'error' | 'trace' | 'debug' | 'silent';
+        /**
+         * If true the log output of the module will be prefixed by a timestamp in the HH:mm:ss format.
+         * @default false
+         */
+        logTime?: boolean;
+        /**
+         * This property allows a user to pass the list of HTTP request methods accepted by the server.
+         * @default [ 'GET', 'HEAD' ]
+         */
+        methods?: string[];
+        /**
+         * This property allows a user to register custom mime types or extension mappings
+         * @default null
+         */
+        mimeTypes?: MimeTypeMap | OverrideMimeTypeMap | null;
+        /** The public path that the middleware is bound to */
+        publicPath: string;
+        /** Allows users to provide a custom reporter to handle logging within the module */
+        reporter?: Reporter | null;
+        /** Instructs the module to enable or disable the server-side rendering mode */
+        serverSideRender?: boolean;
+        /** Options for formatting statistics displayed during and after compile */
+        stats?: webpack.Options.Stats;
+        /** The module accepts an Object containing options for file watching, which is passed directly to the compiler provided */
+        watchOptions?: webpack.Options.WatchOptions;
+        /**
+         * If true, the option will instruct the module to write files to the configured location on disk as specified in your webpack config file
+         * This option also accepts a Function value, which can be used to filter which files are written to disk
+         */
+        writeToDisk?: boolean | ((filename: string) => boolean);
+    }
 
-	interface ReporterOptions {
-		state: boolean;
-		stats?: webpack.Stats;
-		log: Logger;
-	}
+    interface MimeTypeMap {
+        [type: string]: string[];
+    }
 
-	type Logger = loglevel.Logger;
-	type Reporter = (middlewareOptions: Options, reporterOptions: ReporterOptions) => void;
+    interface OverrideMimeTypeMap {
+        typeMap: MimeTypeMap;
+        force: boolean;
+    }
 
-	interface WebpackDevMiddleware {
-		close(callback?: () => void): void;
-		invalidate(callback?: (stats: webpack.Stats) => void): void;
-		waitUntilValid(callback?: (stats: webpack.Stats) => void): void;
-		getFilenameFromUrl: (url: string) => string | false;
-		fileSystem: MemoryFileSystem;
-	}
+    interface ReporterOptions {
+        state: boolean;
+        stats?: webpack.Stats;
+        log: Logger;
+    }
+
+    type Logger = loglevel.Logger;
+    type Reporter = (middlewareOptions: Options, reporterOptions: ReporterOptions) => void;
+
+    interface WebpackDevMiddleware {
+        /** A function executed once the middleware has stopped watching. */
+        close(callback?: () => void): void;
+        /** Instructs a webpack-dev-middleware instance to recompile the bundle. e.g. after a change to the configuration. */
+        invalidate(callback?: (stats?: webpack.Stats) => void): void;
+        /** Executes a callback function when the compiler bundle is valid, typically after compilation */
+        waitUntilValid(callback?: (stats?: webpack.Stats) => void): void;
+        getFilenameFromUrl: (url: string) => string | false;
+        fileSystem: MemoryFileSystem;
+    }
 }

--- a/types/webpack-dev-middleware/v2/index.d.ts
+++ b/types/webpack-dev-middleware/v2/index.d.ts
@@ -1,0 +1,55 @@
+// Type definitions for webpack-dev-middleware 2.0
+// Project: https://github.com/webpack/webpack-dev-middleware
+// Definitions by: Benjamin Lim <https://github.com/bumbleblym>
+//                 reduckted <https://github.com/reduckted>
+//                 Chris Abrams <https://github.com/chrisabrams>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import * as webpack from 'webpack';
+import * as loglevel from 'loglevel';
+import { NextHandleFunction } from 'connect';
+import MemoryFileSystem = require('memory-fs');
+
+export = WebpackDevMiddleware;
+
+declare function WebpackDevMiddleware(
+	compiler: webpack.ICompiler,
+	options?: WebpackDevMiddleware.Options
+): WebpackDevMiddleware.WebpackDevMiddleware & NextHandleFunction;
+
+declare namespace WebpackDevMiddleware {
+	interface Options {
+		logLevel?: string;
+		lazy?: boolean;
+		watchOptions?: webpack.Options.WatchOptions;
+		publicPath: string;
+		index?: string | boolean;
+		headers?: {
+			[name: string]: string;
+		};
+		stats?: webpack.Options.Stats;
+		reporter?: Reporter | null;
+		serverSideRender?: boolean;
+		logger?: Logger;
+		filename?: string;
+		writeToDisk?: boolean | ((filename: string) => boolean);
+	}
+
+	interface ReporterOptions {
+		state: boolean;
+		stats?: webpack.Stats;
+		log: Logger;
+	}
+
+	type Logger = loglevel.Logger;
+	type Reporter = (middlewareOptions: Options, reporterOptions: ReporterOptions) => void;
+
+	interface WebpackDevMiddleware {
+		close(callback?: () => void): void;
+		invalidate(callback?: (stats: webpack.Stats) => void): void;
+		waitUntilValid(callback?: (stats: webpack.Stats) => void): void;
+		getFilenameFromUrl: (url: string) => string | false;
+		fileSystem: MemoryFileSystem;
+	}
+}

--- a/types/webpack-dev-middleware/v2/tsconfig.json
+++ b/types/webpack-dev-middleware/v2/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "paths": {
+            "webpack-dev-middleware": [
+                "webpack-dev-middleware/v2"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "webpack-dev-middleware-tests.ts"
+    ]
+}

--- a/types/webpack-dev-middleware/v2/tslint.json
+++ b/types/webpack-dev-middleware/v2/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webpack-dev-middleware/v2/webpack-dev-middleware-tests.ts
+++ b/types/webpack-dev-middleware/v2/webpack-dev-middleware-tests.ts
@@ -1,0 +1,50 @@
+import express = require('express');
+import webpack = require('webpack');
+import webpackDevMiddleware = require('webpack-dev-middleware');
+
+const compiler = webpack({});
+
+let webpackDevMiddlewareInstance = webpackDevMiddleware(compiler);
+
+webpackDevMiddlewareInstance = webpackDevMiddleware(compiler, {
+	logLevel: 'silent',
+	lazy: true,
+	watchOptions: {
+		aggregateTimeout: 300,
+		poll: true,
+	},
+	publicPath: '/assets/',
+	index: 'index.html',
+	headers: {
+		'X-Custom-Header': 'yes'
+	},
+	stats: {
+		colors: true,
+	},
+	reporter: null,
+	serverSideRender: false,
+	writeToDisk: false,
+});
+
+const app = express();
+app.use([webpackDevMiddlewareInstance]);
+
+webpackDevMiddlewareInstance.close(() => {
+	console.log('closed');
+});
+
+webpackDevMiddlewareInstance.invalidate((stats) => {
+	console.log(stats.toJson());
+});
+
+webpackDevMiddlewareInstance.waitUntilValid((stats) => {
+	console.log('Package is in a valid state:' + stats.toJson());
+});
+
+const fs = webpackDevMiddlewareInstance.fileSystem;
+fs.mkdirpSync('foo');
+
+let filename = webpackDevMiddlewareInstance.getFilenameFromUrl('url');
+if (filename !== false) {
+	filename = filename.substr(0);
+}

--- a/types/webpack-dev-middleware/webpack-dev-middleware-tests.ts
+++ b/types/webpack-dev-middleware/webpack-dev-middleware-tests.ts
@@ -7,38 +7,48 @@ const compiler = webpack({});
 let webpackDevMiddlewareInstance = webpackDevMiddleware(compiler);
 
 webpackDevMiddlewareInstance = webpackDevMiddleware(compiler, {
-	logLevel: 'silent',
-	lazy: true,
-	watchOptions: {
-		aggregateTimeout: 300,
-		poll: true,
-	},
-	publicPath: '/assets/',
-	index: 'index.html',
-	headers: {
-		'X-Custom-Header': 'yes'
-	},
-	stats: {
-		colors: true,
-	},
-	reporter: null,
-	serverSideRender: false,
-	writeToDisk: false,
+    logLevel: 'silent',
+    logTime: true,
+    lazy: true,
+    methods: ['GET', 'POST'],
+    mimeTypes: {
+        typeMap: { 'text/html': ['phtml'] },
+        force: true,
+    },
+    watchOptions: {
+        aggregateTimeout: 300,
+        poll: true,
+    },
+    publicPath: '/assets/',
+    index: 'index.html',
+    headers: {
+        'X-Custom-Header': 'yes',
+    },
+    stats: {
+        colors: true,
+    },
+    reporter: null,
+    serverSideRender: false,
+    writeToDisk: false,
 });
 
 const app = express();
 app.use([webpackDevMiddlewareInstance]);
 
 webpackDevMiddlewareInstance.close(() => {
-	console.log('closed');
+    console.log('closed');
 });
 
-webpackDevMiddlewareInstance.invalidate((stats) => {
-	console.log(stats.toJson());
+webpackDevMiddlewareInstance.invalidate(stats => {
+    if (stats) {
+        console.log(stats.toJson());
+    }
 });
 
-webpackDevMiddlewareInstance.waitUntilValid((stats) => {
-	console.log('Package is in a valid state:' + stats.toJson());
+webpackDevMiddlewareInstance.waitUntilValid(stats => {
+    if (stats) {
+        console.log('Package is in a valid state:' + stats.toJson());
+    }
 });
 
 const fs = webpackDevMiddlewareInstance.fileSystem;
@@ -46,5 +56,5 @@ fs.mkdirpSync('foo');
 
 let filename = webpackDevMiddlewareInstance.getFilenameFromUrl('url');
 if (filename !== false) {
-	filename = filename.substr(0);
+    filename = filename.substr(0);
 }

--- a/types/webpack-serve/v1/webpack-serve-tests.ts
+++ b/types/webpack-serve/v1/webpack-serve-tests.ts
@@ -6,7 +6,7 @@ const config: webpack.Configuration = {
   entry: ['index.js'], // when use compiler entry must be array or object
 };
 
-const serveConfig = {
+const serveConfig: serve.Options = {
   http2: true,
   dev: {
     publicPath: '/',


### PR DESCRIPTION
- v2 created
- update configuration options to v3.7

https://github.com/webpack/webpack-dev-middleware/tree/v3.7.2#options

Note that PR contains change for `webpack-serve` v1 tests, otherwise it wont' pass the CI tests (npm test). The change is technical one, without modyfing the `webpack-serve` definition files.

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack-dev-middleware/tree/v3.7.2#options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.