### PR TITLE
fix(archive): types for ZipEntryData and TarEntryData

### DIFF
--- a/types/archiver/archiver-tests.ts
+++ b/types/archiver/archiver-tests.ts
@@ -30,28 +30,27 @@ archiver.abort();
 
 archiver.pipe(writeStream);
 archiver.append(readStream, { name: 'archiver.d.ts' });
-archiver.append(readStream, { date: '05/05/1991' });
-archiver.append(readStream, { date: new Date() });
-archiver.append(readStream, { mode: 1 });
-archiver.append(readStream, { mode: 1, stats: new fs.Stats() });
-
-archiver.append(readStream, {name: 'archiver.d.ts'})
-.append(readStream, {name: 'archiver.d.ts'});
+archiver.append(readStream, { name: 'buffer.txt', date: '05/05/1991' });
+archiver.append(readStream, { name: 'buffer.txt', date: new Date() });
+archiver.append(readStream, { name: 'buffer.txt', mode: 1 });
+archiver.append(readStream, { name: 'buffer.txt', mode: 1, stats: new fs.Stats() });
+archiver.append('Some content', { name: 'filename', store: true });
+archiver.append(readStream, { name: 'archiver.d.ts' }).append(readStream, { name: 'archiver.d.ts' });
 
 archiver.directory('./path', './someOtherPath');
 archiver.directory('./', '', {});
 archiver.directory('./', false, { name: 'test' });
 archiver.directory('./', false, (entry: Archiver.EntryData) => {
-    entry.name = "foobar";
+    entry.name = 'foobar';
     return entry;
 });
 archiver.directory('./', false, (entry: Archiver.EntryData) => false);
 
 archiver.append(readStream, {
-    name: "sub/folder.xml"
+    name: 'sub/folder.xml',
 });
 
-archiver.glob("**", {
+archiver.glob('**', {
     cwd: 'path/to/files',
 });
 archiver.glob('./path', {}, {});

--- a/types/archiver/index.d.ts
+++ b/types/archiver/index.d.ts
@@ -1,12 +1,19 @@
-// Type definitions for archiver 3.0.0
+// Type definitions for archiver 3.1
 // Project: https://github.com/archiverjs/node-archiver
-// Definitions by: Esri <https://github.com/archiverjs/node-archiver>, Dolan Miu <https://github.com/dolanmiu>, Crevil <https://github.com/crevil>
+// Definitions by:  Esri <https://github.com/archiverjs/node-archiver>
+//                  Dolan Miu <https://github.com/dolanmiu>
+//                  Crevil <https://github.com/crevil>
+//                  Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as fs from 'fs';
 import * as stream from 'stream';
 import * as glob from 'glob';
 import { ZlibOptions } from 'zlib';
+
+type Partial<T> = {
+    [P in keyof T]?: T[P];
+};
 
 declare function archiver(format: archiver.Format, options?: archiver.ArchiverOptions): archiver.Archiver;
 
@@ -17,12 +24,30 @@ declare namespace archiver {
     function registerFormat(format: string, module: Function): void;
 
     interface EntryData {
-        name?: string;
-        prefix?: string;
-        stats?: fs.Stats;
+        /** Sets the entry name including internal path */
+        name: string;
+        /** Sets the entry date */
         date?: Date | string;
+        /** Sets the entry permissions */
         mode?: number;
+        /**
+         * Sets a path prefix for the entry name.
+         * Useful when working with methods like `directory` or `glob`
+         */
+        prefix?: string;
+        /**
+         * Sets the fs stat data for this entry allowing
+         * for reduction of fs stat calls when stat data is already known
+         */
+        stats?: fs.Stats;
     }
+
+    interface ZipEntryData extends EntryData {
+        /** Sets the compression method to STORE */
+        store?: boolean;
+    }
+
+    type TarEntryData = EntryData;
 
     interface ProgressData {
         entries: {
@@ -39,7 +64,7 @@ declare namespace archiver {
     type EntryDataFunction = (entry: EntryData) => false | EntryData;
 
     class ArchiverError extends Error {
-        code: string;       // Since archiver format support is modular, we cannot enumerate all possible error codes, as the modules can throw arbitrary ones.
+        code: string; // Since archiver format support is modular, we cannot enumerate all possible error codes, as the modules can throw arbitrary ones.
         data: any;
         path?: any;
 
@@ -48,12 +73,12 @@ declare namespace archiver {
 
     interface Archiver extends stream.Transform {
         abort(): this;
-        append(source: stream.Readable | Buffer | string, name?: EntryData): this;
+        append(source: stream.Readable | Buffer | string, data?: EntryData | ZipEntryData | TarEntryData): this;
 
         /** if false is passed for destpath, the path of a chunk of data in the archive is set to the root */
-        directory(dirpath: string, destpath: false | string, data?: EntryData | EntryDataFunction): this;
+        directory(dirpath: string, destpath: false | string, data?: Partial<EntryData> | EntryDataFunction): this;
         file(filename: string, data: EntryData): this;
-        glob(pattern: string, options?: glob.IOptions, data?: EntryData): this;
+        glob(pattern: string, options?: glob.IOptions, data?: Partial<EntryData>): this;
         finalize(): Promise<void>;
 
         setFormat(format: string): this;


### PR DESCRIPTION
- correct EntryData `name` property (always required)
- add Zip*/Tar* entry data subtypes
- provide a way to use EntryData `name` as optional - as required by the
Archiver.directory(...) definition and usage in package
- update version
- minor code clenaup via Prettier

Fixes: #42572

/cc @iherman

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.archiverjs.com/archiver#append
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.