### PR TITLE
[@types/marked] fixed type of `marked.MarkedOptions.highlight` in case of async highlighting

### DIFF
--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -5,6 +5,7 @@
 //                 CrossR <https://github.com/CrossR>
 //                 Mike Wickett <https://github.com/mwickett>
 //                 Hitomi Hatsukaze <https://github.com/htkzhtm>
+//                 Ezra Celli <https://github.com/ezracelli>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace marked;
@@ -17,7 +18,7 @@ export = marked;
  * @param callback Function called when the markdownString has been fully parsed when using async highlighting
  * @return String of compiled HTML
  */
-declare function marked(src: string, callback: (error: any | undefined, parseResult: string) => void): string;
+declare function marked(src: string, callback?: (error: any | undefined, parseResult: string) => void): string | void;
 
 /**
  * Compiles markdown to HTML.
@@ -27,7 +28,7 @@ declare function marked(src: string, callback: (error: any | undefined, parseRes
  * @param callback Function called when the markdownString has been fully parsed when using async highlighting
  * @return String of compiled HTML
  */
-declare function marked(src: string, options?: marked.MarkedOptions, callback?: (error: any | undefined, parseResult: string) => void): string;
+declare function marked(src: string, options?: marked.MarkedOptions, callback?: (error: any | undefined, parseResult: string) => void): string | void;
 
 declare namespace marked {
     const defaults: MarkedOptions;

--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -16,6 +16,7 @@ export = marked;
  *
  * @param src String of markdown source to be compiled
  * @param options Optional hash of options
+ * @return String of compiled HTML
  */
 declare function marked(src: string, options?: marked.MarkedOptions): string;
 
@@ -23,11 +24,17 @@ declare function marked(src: string, options?: marked.MarkedOptions): string;
  * Compiles markdown to HTML asynchronously.
  *
  * @param src String of markdown source to be compiled
- * @param options Optional hash of options
  * @param callback Function called when the markdownString has been fully parsed when using async highlighting
- * @return String of compiled HTML
  */
 declare function marked(src: string, callback: (error: any | undefined, parseResult: string) => void): void;
+
+/**
+ * Compiles markdown to HTML asynchronously.
+ *
+ * @param src String of markdown source to be compiled
+ * @param options Hash of options
+ * @param callback Function called when the markdownString has been fully parsed when using async highlighting
+ */
 declare function marked(src: string, options: marked.MarkedOptions, callback: (error: any | undefined, parseResult: string) => void): void;
 
 declare namespace marked {

--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -309,7 +309,7 @@ declare namespace marked {
         /**
          * A function to highlight code blocks. The function takes three arguments: code, lang, and callback.
          */
-        highlight?(code: string, lang: string, callback?: (error: any | undefined, code: string) => void): string;
+        highlight?(code: string, lang: string, callback?: (error: any | undefined, code: string) => void): string | void;
 
         /**
          * Set the prefix for code block classes.

--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -18,7 +18,8 @@ export = marked;
  * @param callback Function called when the markdownString has been fully parsed when using async highlighting
  * @return String of compiled HTML
  */
-declare function marked(src: string, callback?: (error: any | undefined, parseResult: string) => void): string | void;
+declare function marked(src: string): string;
+declare function marked(src: string, callback: (error: any | undefined, parseResult: string) => void): void;
 
 /**
  * Compiles markdown to HTML.
@@ -28,7 +29,8 @@ declare function marked(src: string, callback?: (error: any | undefined, parseRe
  * @param callback Function called when the markdownString has been fully parsed when using async highlighting
  * @return String of compiled HTML
  */
-declare function marked(src: string, options?: marked.MarkedOptions, callback?: (error: any | undefined, parseResult: string) => void): string | void;
+declare function marked(src: string, options: marked.MarkedOptions): string;
+declare function marked(src: string, options: marked.MarkedOptions, callback: (error: any | undefined, parseResult: string) => void): void;
 
 declare namespace marked {
     const defaults: MarkedOptions;

--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -309,9 +309,12 @@ declare namespace marked {
         headerPrefix?: string;
 
         /**
-         * A function to highlight code blocks. The function takes three arguments: code, lang, and callback.
+         * A function to highlight code blocks. The function can either be
+         * synchronous (returning a string) or asynchronous (callback invoked
+         * with an error if any occurred during highlighting and a string
+         * if highlighting was successful)
          */
-        highlight?(code: string, lang: string, callback?: (error: any | undefined, code: string) => void): string | void;
+        highlight?(code: string, lang: string, callback?: (error: any | undefined, code?: string) => void): string | void;
 
         /**
          * Set the prefix for code block classes.

--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -12,24 +12,22 @@ export as namespace marked;
 
 export = marked;
 /**
- * Compiles markdown to HTML.
+ * Compiles markdown to HTML synchronously.
  *
  * @param src String of markdown source to be compiled
- * @param callback Function called when the markdownString has been fully parsed when using async highlighting
- * @return String of compiled HTML
+ * @param options Optional hash of options
  */
-declare function marked(src: string): string;
-declare function marked(src: string, callback: (error: any | undefined, parseResult: string) => void): void;
+declare function marked(src: string, options?: marked.MarkedOptions): string;
 
 /**
- * Compiles markdown to HTML.
+ * Compiles markdown to HTML asynchronously.
  *
  * @param src String of markdown source to be compiled
- * @param options Hash of options
+ * @param options Optional hash of options
  * @param callback Function called when the markdownString has been fully parsed when using async highlighting
  * @return String of compiled HTML
  */
-declare function marked(src: string, options: marked.MarkedOptions): string;
+declare function marked(src: string, callback: (error: any | undefined, parseResult: string) => void): void;
 declare function marked(src: string, options: marked.MarkedOptions, callback: (error: any | undefined, parseResult: string) => void): void;
 
 declare namespace marked {

--- a/types/marked/marked-tests.ts
+++ b/types/marked/marked-tests.ts
@@ -26,7 +26,7 @@ options = marked.defaults;
 
 function callback(err: string, markdown: string) {
     console.log('Callback called!');
-    return markdown;
+    console.log(markdown);
 }
 
 let myOldMarked: typeof marked = marked.options(options);
@@ -34,13 +34,13 @@ myOldMarked = marked.setOptions(options);
 
 console.log(marked('1) I am using __markdown__.'));
 console.log(marked('2) I am using __markdown__.', options));
-console.log(marked('3) I am using __markdown__.', callback));
-console.log(marked('4) I am using __markdown__.', options, callback));
+marked('3) I am using __markdown__.', callback);
+marked('4) I am using __markdown__.', options, callback);
 
 console.log(marked.parse('5) I am using __markdown__.'));
 console.log(marked.parse('6) I am using __markdown__.', options));
-console.log(marked.parse('7) I am using __markdown__.', callback));
-console.log(marked.parse('8) I am using __markdown__.', options, callback));
+marked.parse('7) I am using __markdown__.', callback);
+marked.parse('8) I am using __markdown__.', options, callback);
 
 const text = 'Something';
 const tokens: marked.TokensList = marked.lexer(text, options);

--- a/types/marked/marked-tests.ts
+++ b/types/marked/marked-tests.ts
@@ -16,9 +16,9 @@ let options: marked.MarkedOptions = {
     renderer: new marked.Renderer(),
 };
 
-options.highlight = (code: string, lang: string, callback) => {
+options.highlight = (code: string, lang: string, callback: (error: any | undefined, code?: string) => void) => {
+    callback(new Error());
     callback(null, '');
-    callback(new Error(), '');
 };
 
 options = marked.getDefaults();

--- a/types/marked/marked-tests.ts
+++ b/types/marked/marked-tests.ts
@@ -16,6 +16,11 @@ let options: marked.MarkedOptions = {
     renderer: new marked.Renderer(),
 };
 
+options.highlight = (code: string, lang: string, callback) => {
+    callback(null, '');
+    callback(new Error(), '');
+};
+
 options = marked.getDefaults();
 options = marked.defaults;
 


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `marked` could have no return value &mdash; https://github.com/markedjs/marked/blob/6ae3651627c46bb03c54e2d71a5d73f4750ee47a/src/marked.js#L113
  - `marked` is not async if `marked.MarkedOptions.highlight` does not specify a callback &mdash; https://github.com/markedjs/marked/blob/6ae3651627c46bb03c54e2d71a5d73f4750ee47a/src/marked.js#L73
  - `marked.MarkedOptions.highlight` does not have to return a string if specified with a callback &mdash; https://marked.js.org/#/USING_ADVANCED.md#highlight
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **N/A**
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. **N/A**
