### PR TITLE
postman-collection: fixed types to reflect current SDK

### DIFF
--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -479,11 +479,21 @@ export class Request extends Property<RequestDefinition> implements RequestDefin
 }
 
 export interface RequestAuthDefinition extends PropertyDefinition {
-    type?: string;
+    type?: 'oauth2' | 'hawk' | 'noauth' | 'basic' | 'oauth1' | 'apikey' | 'digest' | 'bearer' | 'awsv4' | 'edgegrid' | 'ntlm';
+    oauth2?: VariableDefinition[];
+    hawk?: VariableDefinition[];
+    basic?: VariableDefinition[];
+    oauth1?: VariableDefinition[];
+    apikey?: VariableDefinition[];
+    digest?: VariableDefinition[];
+    bearer?: VariableDefinition[];
+    awsv4?: VariableDefinition[];
+    edgegrid?: VariableDefinition[];
+    ntlm?: VariableDefinition[];
 }
 
 export class RequestAuth extends Property<RequestAuthDefinition> implements RequestAuthDefinition {
-    type: string;
+    type: Required<RequestAuthDefinition['type']>;
 
     constructor(options: RequestAuthDefinition, parent?: Property<PropertyDefinition> | PropertyList<RequestAuth>);
 

--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -176,7 +176,7 @@ export interface CollectionDefinition extends ItemGroupDefinition {
         name?: string;
         version?: string;
     };
-    variable?: VariableDefinition;
+    variable?: VariableDefinition[];
 }
 
 export class Collection extends ItemGroup<Request> {

--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -434,8 +434,8 @@ export class QueryParam extends Property<QueryParamDefinition> implements QueryP
 export interface RequestDefinition extends PropertyDefinition {
     url: string | Url;
     method?: string;
-    header?: HeaderDefinition;
-    body?: RequestBody;
+    header?: HeaderDefinition[];
+    body?: RequestBodyDefinition;
     auth?: RequestAuthDefinition;
     proxy?: ProxyConfigDefinition;
     certificate?: CertificateDefinition;

--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-collection 3.5.5
+// Type definitions for postman-collection 3.5
 // Project: https://github.com/postmanlabs/postman-collection
 // Definitions by: Kyle Buzby <https://github.com/kbuzby>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-collection 3.0
+// Type definitions for postman-collection 3.1
 // Project: https://github.com/postmanlabs/postman-collection
 // Definitions by: Kyle Buzby <https://github.com/kbuzby>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-collection 3.1
+// Type definitions for postman-collection 3.5.5
 // Project: https://github.com/postmanlabs/postman-collection
 // Definitions by: Kyle Buzby <https://github.com/kbuzby>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -209,7 +209,8 @@ export interface CookieDefinition {
     extensions?: Array<{key: string; value: string}>;
 }
 
-export class Cookie extends PropertyBase<CookieDefinition> implements CookieDefinition {
+export class Cookie extends PropertyBase<CookieDefinition> implements Exclude<CookieDefinition, 'key'> {
+    name?: string;
     domain: string;
     expires: Date;
     extensions?: Array<{key: string; value: string}>;

--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -179,7 +179,7 @@ export interface CollectionDefinition extends ItemGroupDefinition {
     variable?: VariableDefinition[];
 }
 
-export class Collection extends ItemGroup<Request> {
+export class Collection extends ItemGroup<Item> {
     events: EventList;
     variables: VariableList;
     version?: Version;

--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -12,14 +12,20 @@ export interface PropertyBaseDefinition {
 export class PropertyBase<TDefinition extends {}> implements PropertyBaseDefinition {
     description?: string | DescriptionDefinition;
 
-    constructor(definition?: PropertyBaseDefinition | {info: PropertyBaseDefinition} | string);
+    constructor(definition?: PropertyBaseDefinition | { info: PropertyBaseDefinition } | string);
 
-    findInParents(property: string, customizer?: (item: PropertyBase<PropertyBaseDefinition>) => boolean): PropertyBase<PropertyBaseDefinition> ;
+    findInParents(
+        property: string,
+        customizer?: (item: PropertyBase<PropertyBaseDefinition>) => boolean,
+    ): PropertyBase<PropertyBaseDefinition>;
 
-    findParentContaining(property: any, customizer: (item: PropertyBase<PropertyBaseDefinition>) => boolean): PropertyBase<PropertyBaseDefinition>;
+    findParentContaining(
+        property: any,
+        customizer: (item: PropertyBase<PropertyBaseDefinition>) => boolean,
+    ): PropertyBase<PropertyBaseDefinition>;
 
     forEachParent(iterator: (item: any) => void): void;
-    forEachParent(options: {withRoot: boolean}, iterator: (item: any) => void): void;
+    forEachParent(options: { withRoot: boolean }, iterator: (item: any) => void): void;
 
     meta(): any;
 
@@ -47,11 +53,15 @@ export class Property<TDefinition extends {}> extends PropertyBase<TDefinition> 
     id: string;
     name: string;
 
-    constructor(definition?: TDefinition | {info: TDefinition, disabled: boolean});
+    constructor(definition?: TDefinition | { info: TDefinition; disabled: boolean });
 
     describe(content: string, type?: string): void;
 
-    toObjectResolved(scope: {variables: VariableList} | null, overrides: any[], options?: {ignoreOwnVariables: boolean}): TDefinition;
+    toObjectResolved(
+        scope: { variables: VariableList } | null,
+        overrides: any[],
+        options?: { ignoreOwnVariables: boolean },
+    ): TDefinition;
 
     static replaceSubstitutions(str: string, variables: VariableList | VariableList[]): string;
 
@@ -60,14 +70,14 @@ export class Property<TDefinition extends {}> extends PropertyBase<TDefinition> 
 
 export interface CertificateDefinition extends PropertyDefinition {
     matches?: string[] | UrlMatchPatternList;
-    key?: {src?: string} | string;
-    cert?: {src?: string} | string;
+    key?: { src?: string } | string;
+    cert?: { src?: string } | string;
     passphrase?: string;
 }
 
 export class Certificate extends Property<CertificateDefinition> implements CertificateDefinition {
-    cert: {src?: string};
-    key: {src?: string};
+    cert: { src?: string };
+    key: { src?: string };
     matches: UrlMatchPatternList;
     passphrase: string;
 
@@ -186,9 +196,13 @@ export class Collection extends ItemGroup<Item> {
 
     constructor(definition?: CollectionDefinition, environments?: any[]);
 
-    syncVariablesFrom(obj: {[key: string]: VariableDefinition}, track?: boolean, prune?: boolean): {created: string[], updated: string[], deleted: string[]} | undefined;
+    syncVariablesFrom(
+        obj: { [key: string]: VariableDefinition },
+        track?: boolean,
+        prune?: boolean,
+    ): { created: string[]; updated: string[]; deleted: string[] } | undefined;
 
-    syncVariablesTo(obj?: {[key: string]: VariableDefinition}): {[key: string]: VariableDefinition};
+    syncVariablesTo(obj?: { [key: string]: VariableDefinition }): { [key: string]: VariableDefinition };
 
     toJSON(): CollectionDefinition;
 
@@ -206,14 +220,14 @@ export interface CookieDefinition {
     httpOnly?: boolean;
     hostOnly?: boolean;
     session?: boolean;
-    extensions?: Array<{key: string; value: string}>;
+    extensions?: Array<{ key: string; value: string }>;
 }
 
 export class Cookie extends PropertyBase<CookieDefinition> implements Exclude<CookieDefinition, 'key'> {
     name?: string;
     domain: string;
     expires: Date;
-    extensions?: Array<{key: string; value: string}>;
+    extensions?: Array<{ key: string; value: string }>;
     hostOnly?: boolean;
     httpOnly?: boolean;
     maxAge?: number;
@@ -232,7 +246,7 @@ export class Cookie extends PropertyBase<CookieDefinition> implements Exclude<Co
 
     static parse(str: string): CookieDefinition;
 
-    static splitParam(param: string): {key: string, value: string | boolean };
+    static splitParam(param: string): { key: string; value: string | boolean };
 }
 
 export class CookieList extends PropertyList<Cookie> {
@@ -314,7 +328,7 @@ export class Header extends Property<HeaderDefinition> implements HeaderDefiniti
     key: string;
     value: string;
 
-    constructor(options: string | HeaderDefinition, name?: string)
+    constructor(options: string | HeaderDefinition, name?: string);
 
     toString(): string;
 
@@ -366,7 +380,7 @@ export class Item extends Property<ItemDefinition> {
 }
 
 export interface ProxyConfigDefinition extends PropertyDefinition {
-    match?: string | {pattern: string} | UrlMatchPattern;
+    match?: string | { pattern: string } | UrlMatchPattern;
     host?: string;
     port?: number;
     tunnel?: boolean;
@@ -419,7 +433,7 @@ export class QueryParam extends Property<QueryParamDefinition> implements QueryP
 
     toString(): string;
 
-    update(param: string | {key: string, value?: string}): void;
+    update(param: string | { key: string; value?: string }): void;
 
     valueOf(): string;
 
@@ -427,7 +441,7 @@ export class QueryParam extends Property<QueryParamDefinition> implements QueryP
 
     static parseSingle(param: string, idx: number, all: string[]): QueryParamDefinition;
 
-    static unparse(params: QueryParamDefinition[], options?: {encode?: boolean, ignoreDisabled?: boolean}): string;
+    static unparse(params: QueryParamDefinition[], options?: { encode?: boolean; ignoreDisabled?: boolean }): string;
 
     static unparseSingle(obj: QueryParamDefinition, encode: boolean): string;
 }
@@ -463,9 +477,9 @@ export class Request extends Property<RequestDefinition> implements RequestDefin
 
     forEachHeader(callback: (header: Header, context: Request) => void): void;
 
-    getHeaders(options?: {ignoreCase?: boolean, enabled?: boolean}): any;
+    getHeaders(options?: { ignoreCase?: boolean; enabled?: boolean }): any;
 
-    removeHeader(toRemove: string | Header, options?: {ignoreCase: boolean}): void;
+    removeHeader(toRemove: string | Header, options?: { ignoreCase: boolean }): void;
 
     removeQueryParams(params: string | string[] | QueryParamDefinition[] | QueryParamDefinition): void;
 
@@ -479,7 +493,18 @@ export class Request extends Property<RequestDefinition> implements RequestDefin
 }
 
 export interface RequestAuthDefinition extends PropertyDefinition {
-    type?: 'oauth2' | 'hawk' | 'noauth' | 'basic' | 'oauth1' | 'apikey' | 'digest' | 'bearer' | 'awsv4' | 'edgegrid' | 'ntlm';
+    type?:
+        | 'oauth2'
+        | 'hawk'
+        | 'noauth'
+        | 'basic'
+        | 'oauth1'
+        | 'apikey'
+        | 'digest'
+        | 'bearer'
+        | 'awsv4'
+        | 'edgegrid'
+        | 'ntlm';
     oauth2?: VariableDefinition[];
     hawk?: VariableDefinition[];
     basic?: VariableDefinition[];
@@ -503,9 +528,15 @@ export class RequestAuth extends Property<RequestAuthDefinition> implements Requ
 
     parameters(): VariableList;
 
-    update(options: VariableList | Array<{key: string, value: string}> | {key: string, value: string}, type?: string): void;
+    update(
+        options: VariableList | Array<{ key: string; value: string }> | { key: string; value: string },
+        type?: string,
+    ): void;
 
-    use(type: string, options: VariableList | Array<{key: string, value: string}> | {key: string, value: string}): void;
+    use(
+        type: string,
+        options: VariableList | Array<{ key: string; value: string }> | { key: string; value: string },
+    ): void;
 
     static isValidType(type: any): boolean;
 }
@@ -514,7 +545,7 @@ export interface RequestBodyDefinition extends PropertyBaseDefinition {
     mode: string;
     raw?: string;
     urlencoded?: QueryParamDefinition[] | PropertyList<QueryParam> | string;
-    file?: string | {src: string};
+    file?: string | { src: string };
     formdata?: FormParamDefinition[] | PropertyList<FormParam>;
 }
 
@@ -526,7 +557,7 @@ export class RequestBody extends PropertyBase<RequestBodyDefinition> implements 
         file: string;
     };
 
-    file?: {src: string};
+    file?: { src: string };
     formdata?: PropertyList<FormParam>;
     mode: string;
     raw?: string;
@@ -566,9 +597,9 @@ export class Response extends Property<ResponseDefinition> implements ResponseDe
 
     dataURI(): string;
 
-    details(): {name: string, detail: string, code: number, standardName: string} | undefined;
+    details(): { name: string; detail: string; code: number; standardName: string } | undefined;
 
-    encoding(): {format: string, source: string};
+    encoding(): { format: string; source: string };
 
     json(reviver?: any, strict?: boolean): any;
 
@@ -582,13 +613,16 @@ export class Response extends Property<ResponseDefinition> implements ResponseDe
 
     update(options: ResponseDefinition): void;
 
-    static createFromNode(response: {
-        body: string | Buffer | Uint8Array,
-        headers?: HeaderDefinition[],
-        statusCode: number,
-        statusMessage?: string,
-        elapsedTime: number
-    }, cookies: CookieDefinition[]): Response;
+    static createFromNode(
+        response: {
+            body: string | Buffer | Uint8Array;
+            headers?: HeaderDefinition[];
+            statusCode: number;
+            statusMessage?: string;
+            elapsedTime: number;
+        },
+        cookies: CookieDefinition[],
+    ): Response;
 
     static isResponse(obj: any): boolean;
 }
@@ -614,7 +648,7 @@ export class Script extends Property<ScriptDefinition> implements ScriptDefiniti
 }
 
 export interface UrlDefinition extends PropertyBaseDefinition {
-    auth?: {user: string, password: string};
+    auth?: { user: string; password: string };
     hash?: string;
     host?: string[] | string;
     path: string[] | string;
@@ -625,7 +659,7 @@ export interface UrlDefinition extends PropertyBaseDefinition {
 }
 
 export class Url extends PropertyBase<UrlDefinition> implements UrlDefinition {
-    auth?: {user: string, password: string};
+    auth?: { user: string; password: string };
     hash?: string;
     host?: string[];
     path: string[];
@@ -642,15 +676,15 @@ export class Url extends PropertyBase<UrlDefinition> implements UrlDefinition {
 
     getOAuth1BaseUrl(): string;
 
-    getPath(options?: {unresolved: boolean}): string;
+    getPath(options?: { unresolved: boolean }): string;
 
     getPathWithQuery(): string;
 
-    getQueryString(options?: {encode?: boolean, ignoredDisabled?: boolean}): string;
+    getQueryString(options?: { encode?: boolean; ignoredDisabled?: boolean }): string;
 
     getRaw(): string;
 
-    getRemote(options?: {forcePort: boolean}): string;
+    getRemote(options?: { forcePort: boolean }): string;
 
     removeQueryParams(params: QueryParamDefinition[] | QueryParamDefinition | string[] | string): void;
 
@@ -666,19 +700,25 @@ export class Url extends PropertyBase<UrlDefinition> implements UrlDefinition {
 export class UrlMatchPattern {
     pattern?: string;
 
-    constructor(options: string | {pattern: string});
+    constructor(options: string | { pattern: string });
 
-    createMatchPattern(): {protocols: string[], host: string, path: RegExp} | undefined;
+    createMatchPattern(): { protocols: string[]; host: string; path: RegExp } | undefined;
 
     getProtocols(): string[];
 
     globPatternToRegexp(pattern: string): RegExp;
 
-    matchAbsoluteHostPattern(matchRegexObject: {protocols: string[], host: string, path: RegExp}, remote: string): boolean;
+    matchAbsoluteHostPattern(
+        matchRegexObject: { protocols: string[]; host: string; path: RegExp },
+        remote: string,
+    ): boolean;
 
-    matchAnyHost(matchRegexObject: {protocols: string[], host: string, path: RegExp}): boolean;
+    matchAnyHost(matchRegexObject: { protocols: string[]; host: string; path: RegExp }): boolean;
 
-    matchSuffixHostPattern(matchRegexObject: {protocols: string[], host: string, path: RegExp}, remote: string): boolean;
+    matchSuffixHostPattern(
+        matchRegexObject: { protocols: string[]; host: string; path: RegExp },
+        remote: string,
+    ): boolean;
 
     test(urlStr: string): boolean;
 
@@ -688,11 +728,11 @@ export class UrlMatchPattern {
 
     testProtocol(protocol: string): boolean;
 
-    toJSON(): {pattern: string};
+    toJSON(): { pattern: string };
 
     toString(): string;
 
-    update(options: {pattern: string}): void;
+    update(options: { pattern: string }): void;
 
     static MATCH_ALL_URLS: string;
 
@@ -716,7 +756,7 @@ export class Variable extends Property<VariableDefinition> implements VariableDe
     type: string;
     value: any;
 
-    constructor(definition?: VariableDefinition | {[index: string]: VariableDefinition});
+    constructor(definition?: VariableDefinition | { [index: string]: VariableDefinition });
 
     cast(value: any): any;
 
@@ -742,8 +782,8 @@ export class Variable extends Property<VariableDefinition> implements VariableDe
         string: StringConstructor;
         boolean: BooleanConstructor;
         number: NumberConstructor;
-        json: {in: (val: any) => string, out: (val: string) => any};
-        any: {in: <T>(val: T) => T, out: <T>(val: T) => T};
+        json: { in: (val: any) => string; out: (val: string) => any };
+        any: { in: <T>(val: T) => T; out: <T>(val: T) => T };
     };
 }
 
@@ -754,9 +794,13 @@ export class VariableList extends PropertyList<Variable> {
 
     substitute<T>(obj: T, overrides?: VariableList, mutate?: boolean): T;
 
-    syncFromObject(obj: {[key: string]: VariableDefinition}, track?: boolean, prune?: boolean): {created: string[], updated: string[], deleted: string[]} | undefined;
+    syncFromObject(
+        obj: { [key: string]: VariableDefinition },
+        track?: boolean,
+        prune?: boolean,
+    ): { created: string[]; updated: string[]; deleted: string[] } | undefined;
 
-    syncToObject(obj?: {[key: string]: VariableDefinition}): {[key: string]: VariableDefinition};
+    syncToObject(obj?: { [key: string]: VariableDefinition }): { [key: string]: VariableDefinition };
 
     static isVariableList(obj: any): boolean;
 }
@@ -768,7 +812,10 @@ export interface VariableScopeDefinition extends PropertyDefinition {
 export class VariableScope extends Property<VariableScopeDefinition> implements VariableScopeDefinition {
     values?: VariableDefinition[];
 
-    constructor(definition: VariableScopeDefinition | VariableList | VariableDefinition[], layers?: VariableList[] | VariableList);
+    constructor(
+        definition: VariableScopeDefinition | VariableList | VariableDefinition[],
+        layers?: VariableList[] | VariableList,
+    );
 
     addLayer(list: VariableList): void;
 
@@ -780,9 +827,13 @@ export class VariableScope extends Property<VariableScopeDefinition> implements 
 
     set(key: string, value: any, type: string): void;
 
-    syncVariablesFrom(obj: {[key: string]: VariableDefinition}, track?: boolean, prune?: boolean): {created: string[], updated: string[], deleted: string[]} | undefined;
+    syncVariablesFrom(
+        obj: { [key: string]: VariableDefinition },
+        track?: boolean,
+        prune?: boolean,
+    ): { created: string[]; updated: string[]; deleted: string[] } | undefined;
 
-    syncVariablesTo(obj?: {[key: string]: VariableDefinition}): {[key: string]: VariableDefinition};
+    syncVariablesTo(obj?: { [key: string]: VariableDefinition }): { [key: string]: VariableDefinition };
 
     toJSON(): any;
 
@@ -790,7 +841,7 @@ export class VariableScope extends Property<VariableScopeDefinition> implements 
 
     unset(key: string): void;
 
-    variables(): {[key: string]: VariableDefinition};
+    variables(): { [key: string]: VariableDefinition };
 
     static isVariableScope(obj: any): boolean;
 }

--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -493,7 +493,7 @@ export interface RequestAuthDefinition extends PropertyDefinition {
 }
 
 export class RequestAuth extends Property<RequestAuthDefinition> implements RequestAuthDefinition {
-    type: Required<RequestAuthDefinition['type']>;
+    type: NonNullable<RequestAuthDefinition['type']>;
 
     constructor(options: RequestAuthDefinition, parent?: Property<PropertyDefinition> | PropertyList<RequestAuth>);
 

--- a/types/postman-collection/postman-collection-tests.ts
+++ b/types/postman-collection/postman-collection-tests.ts
@@ -8,19 +8,19 @@ pbDef.description; // $ExpectType string | DescriptionDefinition | undefined
 const PropertyBase = pmCollection.PropertyBase;
 
 let pb = new PropertyBase();
-pb = new PropertyBase("string definition");
-pb = new PropertyBase({description: "string description"});
-pb = new PropertyBase({info: {}});
-pb = new PropertyBase({info: {description: "string description"}});
+pb = new PropertyBase('string definition');
+pb = new PropertyBase({ description: 'string description' });
+pb = new PropertyBase({ info: {} });
+pb = new PropertyBase({ info: { description: 'string description' } });
 
 pb.description; // $ExpectType string | DescriptionDefinition | undefined
-pb.findInParents("string"); // $ExpectType PropertyBase<PropertyBaseDefinition>
-pb.findInParents("string", (el) => true); // $ExpectType PropertyBase<PropertyBaseDefinition>
+pb.findInParents('string'); // $ExpectType PropertyBase<PropertyBaseDefinition>
+pb.findInParents('string', el => true); // $ExpectType PropertyBase<PropertyBaseDefinition>
 
-pb.findParentContaining("string", (el) => true); // $ExpectType PropertyBase<PropertyBaseDefinition>
+pb.findParentContaining('string', el => true); // $ExpectType PropertyBase<PropertyBaseDefinition>
 
-pb.forEachParent((el) => {}); // $ExpectType void
-pb.forEachParent({withRoot: true}, (el) => {}); // $ExpectType void
+pb.forEachParent(el => {}); // $ExpectType void
+pb.forEachParent({ withRoot: true }, el => {}); // $ExpectType void
 
 pb.meta(); // $ExpectType any
 
@@ -30,9 +30,9 @@ pb.setParent(pb); // $ExpectType void
 
 pb.toJSON(); // $ExpectType {}
 
-PropertyBase.propertyIsMeta(null, "string"); // $ExpectType boolean
+PropertyBase.propertyIsMeta(null, 'string'); // $ExpectType boolean
 
-PropertyBase.propertyUnprefixMeta(null, "_String"); // $ExpectType string
+PropertyBase.propertyUnprefixMeta(null, '_String'); // $ExpectType string
 
 PropertyBase.toJSON({}); // $ExpectType any
 
@@ -47,20 +47,20 @@ propDef.description; // $$ExpectType string | DescriptionDefinition | undefined
 const Property = pmCollection.Property;
 let p = new Property();
 p = new Property(propDef);
-p = new Property({info: propDef, disabled: true});
+p = new Property({ info: propDef, disabled: true });
 
 p.id; // $ExpectType string
 p.name; // $ExpectType string
 p.disabled; // $ExpectType boolean
 
-p.describe("string"); // $ExpectType void
-p.describe("String", "string"); // $ExpectType void
+p.describe('string'); // $ExpectType void
+p.describe('String', 'string'); // $ExpectType void
 
 p.toObjectResolved(null, []); // $ExpectType {}
-p.toObjectResolved({variables: new pmCollection.VariableList(p, [])}, []); // $ExpectType {}
-p.toObjectResolved(null, [], {ignoreOwnVariables: true}); // $ExpectType {}
+p.toObjectResolved({ variables: new pmCollection.VariableList(p, []) }, []); // $ExpectType {}
+p.toObjectResolved(null, [], { ignoreOwnVariables: true }); // $ExpectType {}
 
-Property.replaceSubstitutions("string", new pmCollection.VariableList(p, [])); // $ExpectType string
+Property.replaceSubstitutions('string', new pmCollection.VariableList(p, [])); // $ExpectType string
 Property.replaceSubstitutionsIn({}, [new pmCollection.VariableList(p, [])], false); // $ExpectType {}
 
 // CertificateDefinition Tests
@@ -77,15 +77,15 @@ certificate.key; // $ExpectType { src?: string | undefined; }
 certificate.matches; // $ExpectType UrlMatchPatternList
 certificate.passphrase; // $ExpectType string
 
-certificate.canApplyTo("string"); // $ExpectType boolean
-certificate.canApplyTo(new pmCollection.Url({host: "string", path: "string"})); // $ExpectType boolean
+certificate.canApplyTo('string'); // $ExpectType boolean
+certificate.canApplyTo(new pmCollection.Url({ host: 'string', path: 'string' })); // $ExpectType boolean
 
 certificate.update({}); // $ExpectType void
 
 pmCollection.Certificate.isCertificate(certificate); // $ExpectType boolean
 
 // PropertyList Tests
-const pList = new pmCollection.PropertyList<pmCollection.Certificate>("Certificate", null, []);
+const pList = new pmCollection.PropertyList<pmCollection.Certificate>('Certificate', null, []);
 pList.add(certificate); // $ExpectType void
 pList.all(); // $ExpectType Certificate[]
 pList.append(certificate); // $ExpectType void
@@ -97,24 +97,24 @@ pList.each((el: pmCollection.Certificate) => {}); // $ExpectType void
 pList.each((el: pmCollection.Certificate) => {}, pList); // $ExpectType void
 pList.eachParent((el: any) => {}); // $ExpectType void
 pList.eachParent((el: any) => {}, pList); // $ExpectType void
-pList.filter((el) => true, pList); // $ExpectType Certificate[]
-pList.find((el) => true, pList); // $ExpectType Certificate
-pList.get("string"); // $ExpectType any
-pList.has("string"); // $ExpectType boolean
-pList.has("string", null); // $ExpectType boolean
+pList.filter(el => true, pList); // $ExpectType Certificate[]
+pList.find(el => true, pList); // $ExpectType Certificate
+pList.get('string'); // $ExpectType any
+pList.has('string'); // $ExpectType boolean
+pList.has('string', null); // $ExpectType boolean
 pList.has(certificate); // $ExpectType boolean
 pList.idx(1); // ExpectType Certificate
-pList.indexOf("string"); // ExpectType number
-pList.insert(certificate, "string"); // ExpectType void
+pList.indexOf('string'); // ExpectType number
+pList.insert(certificate, 'string'); // ExpectType void
 pList.insert(certificate, certificate); // ExpectType void
-pList.insertAfter(certificate, "string"); // ExpectType void
+pList.insertAfter(certificate, 'string'); // ExpectType void
 pList.insertAfter(certificate, certificate); // ExpectType void
-pList.map((el) => el); // ExpectType any
-pList.map((el) => el, pList); // ExpectType any
-pList.one("string"); // ExpectType Certificate
+pList.map(el => el); // ExpectType any
+pList.map(el => el, pList); // ExpectType any
+pList.one('string'); // ExpectType Certificate
 pList.populate([]); // ExpectType void
-pList.remove((el) => true, pList); // ExpectType void
-pList.remove("string", pList); // ExpectType void
+pList.remove(el => true, pList); // ExpectType void
+pList.remove('string', pList); // ExpectType void
 pList.remove(certificate, pList); // $ExpectType void
 pList.repopulate(null); // $ExpectType void
 pList.toJSON(); // $ExpectType any
@@ -125,7 +125,7 @@ pmCollection.PropertyList.isPropertyList(pList); // $ExpectType boolean
 
 // CertificateList Tests
 const certList = new pmCollection.CertificateList(null, [pList]);
-certList.resolveOne("string"); // $ExpectType CertificateDefinition
+certList.resolveOne('string'); // $ExpectType CertificateDefinition
 pmCollection.CertificateList.isCertificateList(certList); // $ExpectType boolean
 
 // ItemGroupDefinition Tests
@@ -140,14 +140,14 @@ ig.auth; // $ExpectType RequestAuth | undefined
 ig.items; // $ExpectType PropertyList<Certificate | ItemGroup<Certificate>>
 ig.events; // $ExpectType EventList
 
-ig.authorizeRequestsUsing("string"); // $ExpectType void
+ig.authorizeRequestsUsing('string'); // $ExpectType void
 ig.authorizeRequestsUsing({}); // $ExpectType void
-ig.authorizeRequestsUsing("string", new pmCollection.VariableList(ig, [])); // $ExpectType void
+ig.authorizeRequestsUsing('string', new pmCollection.VariableList(ig, [])); // $ExpectType void
 
-ig.forEachItem((el) => {}); // $ExpectType void
-ig.forEachItemGroup((el) => {}); // $ExpectType void
+ig.forEachItem(el => {}); // $ExpectType void
+ig.forEachItemGroup(el => {}); // $ExpectType void
 
-ig.oneDeep("string"); // $ExpectType Certificate
+ig.oneDeep('string'); // $ExpectType Certificate
 
 pmCollection.ItemGroup.isItemGroup(ig); // $ExpectType boolean
 
@@ -176,8 +176,8 @@ pmCollection.Collection.isCollection(collection); // $ExpectType boolean
 
 // CookieDefinition Tests
 const cookieDef: pmCollection.CookieDefinition = {
-    domain: "string",
-    path: "string"
+    domain: 'string',
+    path: 'string',
 };
 cookieDef.key; // $ExpectType string | undefined
 cookieDef.value; // ExpectType string | undefined
@@ -212,8 +212,8 @@ cookie.update(cookieDef); // $ExpectType void
 cookie.valueOf(); // $ExpectType string
 
 pmCollection.Cookie.isCookie({}); // $ExpectType boolean
-pmCollection.Cookie.parse("string"); // $ExpectType CookieDefinition
-pmCollection.Cookie.splitParam("string"); // $ExpectType { key: string; value: string | boolean; }
+pmCollection.Cookie.parse('string'); // $ExpectType CookieDefinition
+pmCollection.Cookie.splitParam('string'); // $ExpectType { key: string; value: string | boolean; }
 
 // CookieList Tests
 
@@ -224,8 +224,8 @@ pmCollection.CookieList.isCookieList(cookieList); // $ExpectType boolean
 // DescriptionDefinition Tests
 
 const descDef: pmCollection.DescriptionDefinition = {
-    content: "string",
-    type: "string"
+    content: 'string',
+    type: 'string',
 };
 descDef.content; // $ExpectType string
 descDef.type; // $ExpectType string | undefined
@@ -233,7 +233,7 @@ descDef.type; // $ExpectType string | undefined
 // Description Tests
 
 let desc = new pmCollection.Description();
-desc = new pmCollection.Description("string");
+desc = new pmCollection.Description('string');
 desc = new pmCollection.Description(descDef);
 
 desc.content; // $ExpectType string
@@ -241,8 +241,8 @@ desc.type; // $ExpectType string
 
 desc.toJSON(); // $ExpectType DescriptionDefinition
 desc.toString(); // $ExpectType string
-desc.update("string"); // $ExpectType void
-desc.update("string", "string"); // $ExpectType void
+desc.update('string'); // $ExpectType void
+desc.update('string', 'string'); // $ExpectType void
 desc.update(descDef); // $ExpectType void
 
 pmCollection.Description.isDescription(desc); // $ExpectType boolean
@@ -250,7 +250,7 @@ pmCollection.Description.isDescription(desc); // $ExpectType boolean
 // EventDefinition Tests
 
 const eventDesc: pmCollection.EventDefinition = {
-    script: "string"
+    script: 'string',
 };
 eventDesc.listen; // $ExpectType string | undefined
 eventDesc.script; // $ExpectType string | string[] | ScriptDefinition | Script
@@ -266,8 +266,8 @@ event.update(eventDesc); // $ExpectType void
 // EventList Tests
 
 const eventList = new pmCollection.EventList(null, [event]);
-eventList.listeners("string"); // $ExpectType Event[]
-eventList.listenersOwn("string"); // $ExpectType Event[]
+eventList.listeners('string'); // $ExpectType Event[]
+eventList.listenersOwn('string'); // $ExpectType Event[]
 
 pmCollection.EventList.isEventList(eventList); // $ExpectType boolean
 
@@ -289,8 +289,8 @@ fp.valueOf(); // $ExpectType any
 // HeaderDefinition Tests
 
 const headerDef: pmCollection.HeaderDefinition = {
-    key: "string",
-    value: "string"
+    key: 'string',
+    value: 'string',
 };
 headerDef.key; // $ExpectType string | undefined
 headerDef.value; // $ExpectType string | undefined
@@ -298,8 +298,8 @@ headerDef.system; // $ExpectType boolean | undefined
 
 // Header Tests
 
-let header = new pmCollection.Header("string");
-header = new pmCollection.Header("string", "string");
+let header = new pmCollection.Header('string');
+header = new pmCollection.Header('string', 'string');
 header = new pmCollection.Header(headerDef);
 
 header.key; // $ExpectType string
@@ -311,19 +311,19 @@ header.update(headerDef); // $ExpectType void
 
 header.valueOf(); // $ExpectType string
 
-pmCollection.Header.create("string"); // $ExpectType Header
-pmCollection.Header.create("string", "string"); // $ExpectType Header
-pmCollection.Header.create(headerDef, "string"); // $ExpectType Header
+pmCollection.Header.create('string'); // $ExpectType Header
+pmCollection.Header.create('string', 'string'); // $ExpectType Header
+pmCollection.Header.create(headerDef, 'string'); // $ExpectType Header
 
 pmCollection.Header.isHeader(header); // $ExpectType boolean
 
-pmCollection.Header.parse("string"); // $ExpectType HeaderDefinition[]
+pmCollection.Header.parse('string'); // $ExpectType HeaderDefinition[]
 
-pmCollection.Header.parseSingle("string"); // $ExpectType HeaderDefinition
+pmCollection.Header.parseSingle('string'); // $ExpectType HeaderDefinition
 
 pmCollection.Header.unparse(new pmCollection.HeaderList(null, [header])); // $ExpectType string
 pmCollection.Header.unparse([headerDef]); // $ExpectType string
-pmCollection.Header.unparse([headerDef], "\n"); // $ExpectType string
+pmCollection.Header.unparse([headerDef], '\n'); // $ExpectType string
 
 pmCollection.Header.unparseSingle(headerDef); // $ExpectType string
 
@@ -350,14 +350,14 @@ item.events; // $ExpectType EventList
 item.request; // $ExpectType Request
 item.responses; // $ExpectType PropertyList<Response>
 
-item.authorizeRequestUsing("string"); // $ExpectType void
+item.authorizeRequestUsing('string'); // $ExpectType void
 item.authorizeRequestUsing({}); // $ExpectType void
-item.authorizeRequestUsing("string", new pmCollection.VariableList(item, [])); // $ExpectType void
+item.authorizeRequestUsing('string', new pmCollection.VariableList(item, [])); // $ExpectType void
 
 item.getAuth(); // $ExpectType RequestAuth
 
 item.getEvents(); // $ExpectType Event[]
-item.getEvents("string"); // $ExpectType Event[]
+item.getEvents('string'); // $ExpectType Event[]
 
 pmCollection.Item.isItem(item); // $ExpectType boolean
 
@@ -383,11 +383,11 @@ proxyConf.getProtocols(); // $ExpectType string[]
 
 proxyConf.getProxyUrl(); // $ExpectType string
 
-proxyConf.test("string"); // $ExpectType boolean
+proxyConf.test('string'); // $ExpectType boolean
 
 proxyConf.update(proxyConfDef); // $ExpectType void
 
-proxyConf.updateProtocols(["string"]); // $ExpectType void
+proxyConf.updateProtocols(['string']); // $ExpectType void
 
 pmCollection.ProxyConfig.isProxyConfig(proxyConf); // $ExpectType boolean
 
@@ -395,8 +395,8 @@ pmCollection.ProxyConfig.isProxyConfig(proxyConf); // $ExpectType boolean
 
 const proxyConfigList = new pmCollection.ProxyConfigList(null, [proxyConf]);
 
-proxyConfigList.resolve("string"); // $ExpectType ProxyConfig
-proxyConfigList.resolve(new pmCollection.Url({host: "string", path: "string"})); // $ExpectType ProxyConfig
+proxyConfigList.resolve('string'); // $ExpectType ProxyConfig
+proxyConfigList.resolve(new pmCollection.Url({ host: 'string', path: 'string' })); // $ExpectType ProxyConfig
 
 pmCollection.ProxyConfigList.isProxyConfigList(proxyConfigList); // $ExpectType boolean
 
@@ -404,7 +404,7 @@ pmCollection.ProxyConfigList.isProxyConfigList(proxyConfigList); // $ExpectType 
 
 const qpDef: pmCollection.QueryParamDefinition = {
     key: null,
-    value: null
+    value: null,
 };
 qpDef.key; // $ExpectType string | null
 qpDef.value; // $ExpectType string | null
@@ -412,7 +412,7 @@ qpDef.system; // $ExpectType boolean | undefined
 
 // QueryParam Tests
 
-let qp = new pmCollection.QueryParam("string");
+let qp = new pmCollection.QueryParam('string');
 qp = new pmCollection.QueryParam(qpDef);
 
 qp.key; // $ExpectType string | null
@@ -421,29 +421,29 @@ qp.system; // $ExpectType boolean | undefined
 
 qp.toString(); // $ExpectType string
 
-qp.update("string"); // $ExpectType void
-qp.update({key: "string"}); // $ExpectType void
-qp.update({key: "string", value: "string"}); // $ExpectType void
+qp.update('string'); // $ExpectType void
+qp.update({ key: 'string' }); // $ExpectType void
+qp.update({ key: 'string', value: 'string' }); // $ExpectType void
 
 qp.valueOf(); // $ExpectType string
 
 pmCollection.QueryParam._postman_propertyAllowsMultipleValues; // $ExpectType boolean
 pmCollection.QueryParam._postman_propertyIndexKey; // $ExpectType string
 
-pmCollection.QueryParam.parse("string"); // $ExpectType QueryParamDefinition[]
+pmCollection.QueryParam.parse('string'); // $ExpectType QueryParamDefinition[]
 
-pmCollection.QueryParam.parseSingle("string", 1, ["string"]); // $ExpectType QueryParamDefinition
+pmCollection.QueryParam.parseSingle('string', 1, ['string']); // $ExpectType QueryParamDefinition
 
 pmCollection.QueryParam.unparse([qpDef]); // $ExpectType string
-pmCollection.QueryParam.unparse([qpDef], {encode: true}); // $ExpectType string
-pmCollection.QueryParam.unparse([qpDef], {encode: true, ignoreDisabled: true}); // $ExpectType string
+pmCollection.QueryParam.unparse([qpDef], { encode: true }); // $ExpectType string
+pmCollection.QueryParam.unparse([qpDef], { encode: true, ignoreDisabled: true }); // $ExpectType string
 
 pmCollection.QueryParam.unparseSingle(qpDef, true); // $ExpectType string
 
 // RequestDefinition Tests
 
 const reqDef: pmCollection.RequestDefinition = {
-    url: "string"
+    url: 'string',
 };
 reqDef.url; // $ExpectType string | Url
 reqDef.method; // $ExpectType string | undefined
@@ -454,7 +454,7 @@ reqDef.proxy; // $ExpectType ProxyConfigDefinition | undefined
 reqDef.certificate; // $ExpectType CertificateDefinition | undefined
 
 // Request Tests
-let req = new pmCollection.Request("string");
+let req = new pmCollection.Request('string');
 req = new pmCollection.Request(reqDef);
 
 req.auth; // $ExpectType RequestAuth | undefined
@@ -467,32 +467,32 @@ req.url; // $ExpectType Url
 
 req.update(reqDef); // $ExpectType void
 
-req.authorizeUsing("string"); // $ExpectType void
+req.authorizeUsing('string'); // $ExpectType void
 req.authorizeUsing({}); // $ExpectType void
 req.authorizeUsing(null); // $ExpectType void
-req.authorizeUsing("string", new pmCollection.VariableList(p, []));
+req.authorizeUsing('string', new pmCollection.VariableList(p, []));
 
 req.getHeaders(); // $ExpectType any
-req.getHeaders({ignoreCase: true}); // $ExpectType any
-req.getHeaders({enabled: true}); // $ExpectType any
-req.getHeaders({ignoreCase: true, enabled: true}); // $ExpectType any
+req.getHeaders({ ignoreCase: true }); // $ExpectType any
+req.getHeaders({ enabled: true }); // $ExpectType any
+req.getHeaders({ ignoreCase: true, enabled: true }); // $ExpectType any
 
 req.forEachHeader((header: pmCollection.Header, context: pmCollection.Request) => {}); // $ExpectType void
 
 req.addHeader(header); // $ExpectType void
 req.addHeader(headerDef); // $ExpectType void
 
-req.removeHeader("string"); // $ExpectType void
+req.removeHeader('string'); // $ExpectType void
 req.removeHeader(header); // $ExpectType void
-req.removeHeader(header, {ignoreCase: true}); // $ExpectType void
+req.removeHeader(header, { ignoreCase: true }); // $ExpectType void
 
 req.upsertHeader(headerDef); // $ExpectType void
 
-req.addQueryParams("string"); // $ExpectType void
+req.addQueryParams('string'); // $ExpectType void
 req.addQueryParams([qpDef]); // $ExpectType void
 
-req.removeQueryParams("string"); // $ExpectType void
-req.removeQueryParams(["string"]); // $ExpectType void
+req.removeQueryParams('string'); // $ExpectType void
+req.removeQueryParams(['string']); // $ExpectType void
 req.removeQueryParams([qpDef]); // $ExpectType void
 req.removeQueryParams(qpDef); // $ExpectType void
 
@@ -515,25 +515,25 @@ reqAuth = new pmCollection.RequestAuth(reqAuthDef, collection);
 reqAuth.type; // $ExpectType "oauth2" | "hawk" | "noauth" | "basic" | "oauth1" | "apikey" | "digest" | "bearer" | "awsv4" | "edgegrid" | "ntlm"
 
 reqAuth.update(new pmCollection.VariableList(collection, [])); // $ExpectType void
-reqAuth.update({key: "string", value: "string"}); // $ExpectType void
-reqAuth.update([{key: "string", value: "string"}]); // $ExpectType void
-reqAuth.update([{key: "string", value: "string"}], "string"); // $ExpectType void
+reqAuth.update({ key: 'string', value: 'string' }); // $ExpectType void
+reqAuth.update([{ key: 'string', value: 'string' }]); // $ExpectType void
+reqAuth.update([{ key: 'string', value: 'string' }], 'string'); // $ExpectType void
 
-reqAuth.use("string", new pmCollection.VariableList(collection, [])); // $ExpectType void
-reqAuth.use("string", {key: "string", value: "string"}); // $ExpectType void
-reqAuth.use("string", [{key: "string", value: "string"}]); // $ExpectType void
+reqAuth.use('string', new pmCollection.VariableList(collection, [])); // $ExpectType void
+reqAuth.use('string', { key: 'string', value: 'string' }); // $ExpectType void
+reqAuth.use('string', [{ key: 'string', value: 'string' }]); // $ExpectType void
 
 reqAuth.current(); // $ExpectType any
 
 reqAuth.parameters(); // $ExpectType VariableList
 
-reqAuth.clear("string"); // $ExpectType void
+reqAuth.clear('string'); // $ExpectType void
 
 pmCollection.RequestAuth.isValidType(reqAuth); // $ExpectType boolean
 
 // RequestBodyDefinition Tests
 
-const reqBodyDef: pmCollection.RequestBodyDefinition = {mode: 'raw'};
+const reqBodyDef: pmCollection.RequestBodyDefinition = { mode: 'raw' };
 reqBodyDef.mode; // $ExpectType string
 reqBodyDef.raw; // $ExpectType string | undefined
 reqBodyDef.urlencoded; // $ExpectType string | QueryParamDefinition[] | PropertyList<QueryParam> | undefined
@@ -562,7 +562,7 @@ pmCollection.RequestBody.MODES.urlencoded; // $ExpectType string
 pmCollection.RequestBody.MODES.file; // $ExpectType string
 
 // ResponseDefinition Tests
-const respDef: pmCollection.ResponseDefinition = {code: 200, responseTime: 1};
+const respDef: pmCollection.ResponseDefinition = { code: 200, responseTime: 1 };
 respDef.code; // $ExpectType number
 respDef.header; // $ExpectType HeaderDefinition[] | undefined
 respDef.cookie; // $ExpectType CookieDefinition[] | undefined
@@ -601,7 +601,7 @@ response.size(); // $ExpectType number
 
 response.encoding(); // $ExpectType { format: string; source: string; }
 
-pmCollection.Response.createFromNode({body: "string", statusCode: 200, elapsedTime: 1}, []); // $ExpectType Response
+pmCollection.Response.createFromNode({ body: 'string', statusCode: 200, elapsedTime: 1 }, []); // $ExpectType Response
 
 pmCollection.Response.isResponse(response); // $ExpectType boolean
 
@@ -616,16 +616,16 @@ scriptDef.exec; // $ExpectType string | string[] | undefined
 
 let script = new pmCollection.Script();
 script = new pmCollection.Script(scriptDef);
-script = new pmCollection.Script("string");
-script = new pmCollection.Script(["string"]);
+script = new pmCollection.Script('string');
+script = new pmCollection.Script(['string']);
 
 script.exec; // $ExpectType string[] | undefined
 script.src; // $ExpectType Url | undefined
 script.type; // $ExpectType string
 
 script.update(scriptDef); // $ExpectType void
-script.update("string"); // $ExpectType void
-script.update(["string"]); // $ExpectType void
+script.update('string'); // $ExpectType void
+script.update(['string']); // $ExpectType void
 
 script.toSource(); // $ExpectType string | undefined
 
@@ -634,12 +634,12 @@ pmCollection.Script.isScript(script); // $ExpectType boolean
 // UrlDefinition Tests
 
 let urlDef: pmCollection.UrlDefinition = {
-    host: "string",
-    path: "string"
+    host: 'string',
+    path: 'string',
 };
 urlDef = {
-    host: ["string"],
-    path: ["string"]
+    host: ['string'],
+    path: ['string'],
 };
 
 urlDef.auth; // $ExpectType { user: string; password: string; } | undefined
@@ -654,7 +654,7 @@ urlDef.protocol; // $ExpectType string | undefined
 // Url Tests
 
 let url = new pmCollection.Url(urlDef);
-url = new pmCollection.Url("string");
+url = new pmCollection.Url('string');
 
 url.auth; // $ExpectType { user: string; password: string; } | undefined
 url.hash; // $ExpectType string | undefined
@@ -665,11 +665,11 @@ url.protocol; // $ExpectType string | undefined
 url.query; // $ExpectType PropertyList<QueryParam>
 url.variables; // $ExpectType VariableList
 
-url.addQueryParams("string"); // $ExpectType void
+url.addQueryParams('string'); // $ExpectType void
 url.addQueryParams([qp, qpDef]); // $ExpectType void
 
-url.removeQueryParams("string"); // $ExpectType void
-url.removeQueryParams(["string"]); // $ExpectType void
+url.removeQueryParams('string'); // $ExpectType void
+url.removeQueryParams(['string']); // $ExpectType void
 url.removeQueryParams(qp); // $ExpectType void
 url.removeQueryParams([qp]); // $ExpectType void
 
@@ -679,53 +679,53 @@ url.toString(); // $ExpectType string
 url.toString(false); // $ExpectType string
 
 url.getPath(); // $ExpectType string
-url.getPath({unresolved: true}); // $ExpectType string
+url.getPath({ unresolved: true }); // $ExpectType string
 
 url.getQueryString(); // $ExpectType string
-url.getQueryString({encode: true}); // $ExpectType string
-url.getQueryString({ignoredDisabled: true}); // $ExpectType string
-url.getQueryString({encode: true, ignoredDisabled: true}); // $ExpectType string
+url.getQueryString({ encode: true }); // $ExpectType string
+url.getQueryString({ ignoredDisabled: true }); // $ExpectType string
+url.getQueryString({ encode: true, ignoredDisabled: true }); // $ExpectType string
 
 url.getPathWithQuery(); // $ExpectType string
 
 url.getHost(); // $ExpectType string
 
 url.getRemote(); // $ExpectType string
-url.getRemote({forcePort: true}); // $ExpectType string
+url.getRemote({ forcePort: true }); // $ExpectType string
 
 url.getOAuth1BaseUrl(); // $ExpectType string
 
-pmCollection.Url.parse("string"); // $ExpectType UrlDefinition
+pmCollection.Url.parse('string'); // $ExpectType UrlDefinition
 
 pmCollection.Url.isUrl(url); // $ExpectType boolean
 
 // UrlMatchPattern Tests
-let urlMatch = new pmCollection.UrlMatchPattern("string");
-urlMatch = new pmCollection.UrlMatchPattern({pattern: "string"});
+let urlMatch = new pmCollection.UrlMatchPattern('string');
+urlMatch = new pmCollection.UrlMatchPattern({ pattern: 'string' });
 
 urlMatch.pattern; // $ExpectType string | undefined
 
-urlMatch.update({pattern: "string"}); // $ExpectType void
+urlMatch.update({ pattern: 'string' }); // $ExpectType void
 
 urlMatch.createMatchPattern(); // $ExpectType { protocols: string[]; host: string; path: RegExp; } | undefined
 
-urlMatch.globPatternToRegexp("string"); // $ExpectType RegExp
+urlMatch.globPatternToRegexp('string'); // $ExpectType RegExp
 
-urlMatch.testProtocol("string"); // $ExpectType boolean
+urlMatch.testProtocol('string'); // $ExpectType boolean
 
 urlMatch.getProtocols(); // $ExpectType string[]
 
-urlMatch.testHost("string"); // $ExpectType boolean
+urlMatch.testHost('string'); // $ExpectType boolean
 
-urlMatch.matchAnyHost({protocols: [], host: "string", path: new RegExp('')}); // $ExpectType boolean
+urlMatch.matchAnyHost({ protocols: [], host: 'string', path: new RegExp('') }); // $ExpectType boolean
 
-urlMatch.matchSuffixHostPattern({protocols: [], host: "string", path: new RegExp('')}, "string"); // $ExpectType boolean
+urlMatch.matchSuffixHostPattern({ protocols: [], host: 'string', path: new RegExp('') }, 'string'); // $ExpectType boolean
 
-urlMatch.matchAbsoluteHostPattern({protocols: [], host: "string", path: new RegExp('')}, "string"); // $ExpectType boolean
+urlMatch.matchAbsoluteHostPattern({ protocols: [], host: 'string', path: new RegExp('') }, 'string'); // $ExpectType boolean
 
-urlMatch.testPath("string"); // $ExpectType boolean
+urlMatch.testPath('string'); // $ExpectType boolean
 
-urlMatch.test("string"); // $ExpectType boolean
+urlMatch.test('string'); // $ExpectType boolean
 
 urlMatch.toString(); // $ExpectType string
 
@@ -738,7 +738,7 @@ pmCollection.UrlMatchPattern.PROTOCOL_DELIMITER; // $ExpectType string
 // UrlMatchPatternList Tests
 const urlMatchList = new pmCollection.UrlMatchPatternList(collection, []);
 
-urlMatchList.test("string"); // $ExpectType boolean
+urlMatchList.test('string'); // $ExpectType boolean
 
 // VariableDefinition Tests
 const varDef: pmCollection.VariableDefinition = {};
@@ -748,7 +748,7 @@ varDef.key; // $ExpectType string | undefined
 
 // Variable Tests
 let variable = new pmCollection.Variable(varDef);
-variable = new pmCollection.Variable({key: varDef});
+variable = new pmCollection.Variable({ key: varDef });
 
 variable.key; // $ExpectType string | undefined
 variable.type; // $ExpectType string
@@ -768,7 +768,7 @@ variable.castIn({}); // $ExpectType any
 
 variable.castOut({}); // $ExpectType any
 
-variable.valueType("string", true); // $ExpectType string
+variable.valueType('string', true); // $ExpectType string
 
 variable.update(varDef); // $ExpectType void
 
@@ -784,10 +784,10 @@ pmCollection.Variable.types.any; // $ExpectType { in: <T>(val: T) => T; out: <T>
 
 const vList = new pmCollection.VariableList(collection, [variable]);
 
-vList.replace("string"); // $ExpectType string
-vList.replace("string", vList); // $ExpectType string
+vList.replace('string'); // $ExpectType string
+vList.replace('string', vList); // $ExpectType string
 
-vList.substitute("string"); // $ExpectType "string"
+vList.substitute('string'); // $ExpectType "string"
 vList.substitute({}, vList); // $ExpectType {}
 vList.substitute(null, vList, false); // $ExpectType null
 
@@ -796,7 +796,7 @@ vList.syncFromObject({}, false); // $ExpectType { created: string[]; updated: st
 vList.syncFromObject({}, false, false); // $ExpectType { created: string[]; updated: string[]; deleted: string[]; } | undefined
 
 vList.syncToObject(); // $ExpectType { [key: string]: VariableDefinition; }
-vList.syncToObject({key: varDef}); // $ExpectType { [key: string]: VariableDefinition; }
+vList.syncToObject({ key: varDef }); // $ExpectType { [key: string]: VariableDefinition; }
 
 pmCollection.VariableList.isVariableList(vList); // $ExpectType boolean
 
@@ -816,13 +816,13 @@ varScope.variables(); // ExpectType { [key: string]: VariableDefinition; }
 
 varScope.toObject(false, false); // $ExpectType any
 
-varScope.has("string"); // $ExpectType boolean
+varScope.has('string'); // $ExpectType boolean
 
-varScope.get("string"); // $ExpectType any
+varScope.get('string'); // $ExpectType any
 
-varScope.set("string", {}, "any"); // $ExpectType void
+varScope.set('string', {}, 'any'); // $ExpectType void
 
-varScope.unset("string"); // $ExpectType void
+varScope.unset('string'); // $ExpectType void
 
 varScope.clear(); // $ExpectType void
 
@@ -831,7 +831,7 @@ varScope.syncVariablesFrom({}, false); // $ExpectType { created: string[]; updat
 varScope.syncVariablesFrom({}, false, false); // $ExpectType { created: string[]; updated: string[]; deleted: string[]; } | undefined
 
 varScope.syncVariablesTo(); // $ExpectType { [key: string]: VariableDefinition; }
-varScope.syncVariablesTo({key: varDef}); // $ExpectType { [key: string]: VariableDefinition; }
+varScope.syncVariablesTo({ key: varDef }); // $ExpectType { [key: string]: VariableDefinition; }
 
 varScope.toJSON(); // $ExpectType any
 
@@ -852,7 +852,7 @@ verDef.version; // $ExpectType string | undefined
 // Version Tests
 let version = new pmCollection.Version();
 version = new pmCollection.Version(verDef);
-version = new pmCollection.Version("string");
+version = new pmCollection.Version('string');
 
 version.build; // $ExpectType string | undefined
 version.major; // $ExpectType string | undefined
@@ -864,6 +864,6 @@ version.string; // $ExpectType string | undefined
 
 version.set(); // ExpectType void
 version.set(verDef); // $ExpectType void
-version.set("string"); // $ExpectType void
+version.set('string'); // $ExpectType void
 
 version.toString(); // $ExpectType string

--- a/types/postman-collection/postman-collection-tests.ts
+++ b/types/postman-collection/postman-collection-tests.ts
@@ -154,7 +154,7 @@ pmCollection.ItemGroup.isItemGroup(ig); // $ExpectType boolean
 // CollectionDefinition Tests
 const colDef: pmCollection.CollectionDefinition = {};
 colDef.info; // $ExpectType { id?: string | undefined; name?: string | undefined; version?: string | undefined; } | undefined
-colDef.variable; // $ExpectType VariableDefinition | undefined
+colDef.variable; // $ExpectType VariableDefinition[] | undefined
 
 let collection: pmCollection.Collection;
 collection = new pmCollection.Collection();
@@ -447,8 +447,8 @@ const reqDef: pmCollection.RequestDefinition = {
 };
 reqDef.url; // $ExpectType string | Url
 reqDef.method; // $ExpectType string | undefined
-reqDef.header; // $ExpectType HeaderDefinition | undefined
-reqDef.body; // $ExpectType RequestBody | undefined
+reqDef.header; // $ExpectType HeaderDefinition[] | undefined
+reqDef.body; // $ExpectType RequestBodyDefinition | undefined
 reqDef.auth; // $ExpectType RequestAuthDefinition | undefined
 reqDef.proxy; // $ExpectType ProxyConfigDefinition | undefined
 reqDef.certificate; // $ExpectType CertificateDefinition | undefined
@@ -505,14 +505,14 @@ pmCollection.Request.isRequest(req); // $ExpectType boolean
 // RequestAuthDefinition Tests
 
 const reqAuthDef: pmCollection.RequestAuthDefinition = {};
-reqAuthDef.type; // $ExpectType string | undefined
+reqAuthDef.type; // $ExpectType "oauth2" | "hawk" | "noauth" | "basic" | "oauth1" | "apikey" | "digest" | "bearer" | "awsv4" | "edgegrid" | "ntlm" | undefined
 
 // RequestAuth Tests
 
 let reqAuth = new pmCollection.RequestAuth(reqAuthDef);
 reqAuth = new pmCollection.RequestAuth(reqAuthDef, collection);
 
-reqAuth.type; // $ExpectType string
+reqAuth.type; // $ExpectType "oauth2" | "hawk" | "noauth" | "basic" | "oauth1" | "apikey" | "digest" | "bearer" | "awsv4" | "edgegrid" | "ntlm"
 
 reqAuth.update(new pmCollection.VariableList(collection, [])); // $ExpectType void
 reqAuth.update({key: "string", value: "string"}); // $ExpectType void


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
* SDK source code: https://github.com/postmanlabs/postman-collection
* SDK docs: http://www.postmanlabs.com/postman-collection/

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This PR introduces fixes to the definitions (to reflect SDK) and updates them to the latest version.
