### PR TITLE
fix(rsocket-flowable): makes Single.error() generic

### DIFF
--- a/types/rsocket-flowable/Single.d.ts
+++ b/types/rsocket-flowable/Single.d.ts
@@ -46,7 +46,7 @@ export interface IFutureSubject<T> {
  */
 export default class Single<T> {
     static of<U>(value: U): Single<U>;
-    static error<U = any>(error: Error): Single<U>;
+    static error(error: Error): Single<never>;
     constructor(source: Source<T>);
     subscribe(partialSubscriber?: Partial<IFutureSubscriber<T>>): void;
     flatMap<R>(fn: (data: T) => Single<R>): Single<R>;

--- a/types/rsocket-flowable/Single.d.ts
+++ b/types/rsocket-flowable/Single.d.ts
@@ -46,7 +46,7 @@ export interface IFutureSubject<T> {
  */
 export default class Single<T> {
     static of<U>(value: U): Single<U>;
-    static error(error: Error): Single<never>;
+    static error<U = never>(error: Error): Single<U>;
     constructor(source: Source<T>);
     subscribe(partialSubscriber?: Partial<IFutureSubscriber<T>>): void;
     flatMap<R>(fn: (data: T) => Single<R>): Single<R>;

--- a/types/rsocket-flowable/Single.d.ts
+++ b/types/rsocket-flowable/Single.d.ts
@@ -46,7 +46,7 @@ export interface IFutureSubject<T> {
  */
 export default class Single<T> {
     static of<U>(value: U): Single<U>;
-    static error(error: Error): Single<{}>;
+    static error<U = any>(error: Error): Single<U>;
     constructor(source: Source<T>);
     subscribe(partialSubscriber?: Partial<IFutureSubscriber<T>>): void;
     flatMap<R>(fn: (data: T) => Single<R>): Single<R>;

--- a/types/rsocket-flowable/Single.d.ts
+++ b/types/rsocket-flowable/Single.d.ts
@@ -46,7 +46,7 @@ export interface IFutureSubject<T> {
  */
 export default class Single<T> {
     static of<U>(value: U): Single<U>;
-    static error<U = never>(error: Error): Single<U>;
+    static error(error: Error): Single<never>;
     constructor(source: Source<T>);
     subscribe(partialSubscriber?: Partial<IFutureSubscriber<T>>): void;
     flatMap<R>(fn: (data: T) => Single<R>): Single<R>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rsocket/rsocket-js/pull/76
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
