### PR TITLE
[@ember/routing] Support more `transitionTo` invocations

### DIFF
--- a/types/ember__routing/route.d.ts
+++ b/types/ember__routing/route.d.ts
@@ -5,6 +5,9 @@ import Evented from '@ember/object/evented';
 import { RenderOptions, RouteQueryParam } from '@ember/routing/types';
 import Controller, { Registry as ControllerRegistry } from '@ember/controller';
 
+// tslint:disable-next-line:strict-export-declare-modifiers
+type RouteModel = object | string | number;
+
 /**
  * The `Ember.Route` class is used to define individual routes. Refer to
  * the [routing guide](http://emberjs.com/guides/routing/) for documentation.
@@ -377,7 +380,24 @@ export default class Route extends EmberObject.extend(ActionHandler, Evented) {
      * @returns       the Transition object associated with this attempted
      *                transition
      */
-    transitionTo(name: string, ...modelsOrOptions: object[]): Transition;
+    transitionTo(name: string, options?: { queryParams: object }): Transition;
+    transitionTo(name: string, modelsA: RouteModel, options?: { queryParams: object }): Transition;
+    transitionTo(name: string, modelsA: RouteModel, modelsB: RouteModel, options?: { queryParams: object }): Transition;
+    transitionTo(
+        name: string,
+        modelsA: RouteModel,
+        modelsB: RouteModel,
+        modelsC: RouteModel,
+        options?: { queryParams: object },
+    ): Transition;
+    transitionTo(
+        name: string,
+        modelsA: RouteModel,
+        modelsB: RouteModel,
+        modelsC: RouteModel,
+        modelsD: RouteModel,
+        options?: { queryParams: object },
+    ): Transition;
     transitionTo(options: { queryParams: object }): Transition;
 
     // https://emberjs.com/api/ember/3.2/classes/Route/methods/intermediateTransitionTo?anchor=intermediateTransitionTo

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -109,11 +109,13 @@ class TransitionToExamples extends Route {
     // because the overload for the version where `models` are passed
     // necessarily includes all objects.
     transitionToModelAndQP() {
+        // $ExpectType Transition
         this.transitionTo('somewhere', { queryParams: { neat: true } });
     }
 
     transitionToJustQP() {
-        this.transitionTo({ queryParams: { neat: 'true' }});
+        // $ExpectType Transition
+        this.transitionTo({ queryParams: { neat: 'true' } });
     }
 
     transitionToNonsense() {
@@ -122,6 +124,26 @@ class TransitionToExamples extends Route {
 
     transitionToBadQP() {
         this.transitionTo({ queryParams: 12 }); // $ExpectError
+    }
+
+    transitionToId() {
+        // $ExpectType Transition
+        this.transitionTo('blog-post', 1);
+    }
+
+    transitionToIdWithQP() {
+        // $ExpectType Transition
+        this.transitionTo('blog-post', 1, { queryParams: { includeComments: true } });
+    }
+
+    transitionToIds() {
+        // $ExpectType Transition
+        this.transitionTo('blog-comment', 1, '13');
+    }
+
+    transitionToIdsWithQP() {
+        // $ExpectType Transition
+        this.transitionTo('blog-comment', 1, '13', { queryParams: { includePost: true } });
     }
 }
 

--- a/types/ember__routing/test/router-service.ts
+++ b/types/ember__routing/test/router-service.ts
@@ -18,3 +18,7 @@ router.transitionTo(
 router.transitionTo('someRoute', { queryParams: { shouldWork: true } });
 router.transitionTo({ queryParams: { areSupported: true } });
 router.transitionTo({ queryParams: 'potato' }); // $ExpectError
+router.transitionTo('someRoute', 1);
+router.transitionTo('someRoute', 1, { queryParams: { areSupported: true } });
+router.transitionTo('someRoute', 1, '13');
+router.transitionTo('someRoute', 1, '13', { queryParams: { areSupported: true } });


### PR DESCRIPTION
The `transitionTo` method on both the router service and routes takes "model" arguments in the form of either an object (which will be resolved as the actual model) or a `string | number` identifier (which will be used to look up the model from the store). Add tests to cover the behavior on both, and add types for `Route.transitionTo` via overrides (replacing the previous spread approach for consistency).


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://api.emberjs.com/ember/3.16/classes/Route/methods/transitionTo?anchor=transitionTo>