### PR TITLE
twig: Added overload to Template.render when allow_async=false

### DIFF
--- a/types/twig/index.d.ts
+++ b/types/twig/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>
 //                 Tim Schumacher <https://github.com/enko>
 //                 Maik Tizziani <https://github.com/mtizziani>
+//                 Daniel Melcer <https://github.com/dmelcer9>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Imported from: https://github.com/soywiz/typescript-node-definitions/twig.d.ts
@@ -24,6 +25,7 @@ export interface Parameters {
 
 export interface Template {
     reset(blocks: any): void;
+    render(context?: any, params?: any, allow_async?: false): string;
     render(context?: any, params?: any, allow_async?: boolean): string | Promise<string>;
     renderAsync(context?: any, params?: any): Promise<string>;
     importFile(file: string): Template;

--- a/types/twig/twig-tests.ts
+++ b/types/twig/twig-tests.ts
@@ -24,6 +24,13 @@ const result: string = temp.render();
 
 const async_result: string | Promise<string> = temp.render(undefined, undefined, true);
 
+function twig_async_param(b: boolean){
+    const maybe_async_result: string | Promise<string> = temp.render(undefined, undefined, b);
+}
+
+twig_async_param(true);
+twig_async_param(false);
+
 const compOpts: twig.CompileOptions = {
 	filename: str,
 	settings: value

--- a/types/twig/twig-tests.ts
+++ b/types/twig/twig-tests.ts
@@ -24,7 +24,7 @@ const result: string = temp.render();
 
 const async_result: string | Promise<string> = temp.render(undefined, undefined, true);
 
-function twig_async_param(b: boolean){
+function twig_async_param(b: boolean) {
     const maybe_async_result: string | Promise<string> = temp.render(undefined, undefined, b);
 }
 

--- a/types/twig/twig-tests.ts
+++ b/types/twig/twig-tests.ts
@@ -20,6 +20,10 @@ const params: twig.Parameters = {
 
 const temp: twig.Template = twig.twig(params);
 
+const result: string = temp.render();
+
+const async_result: string | Promise<string> = temp.render(undefined, undefined, true);
+
 const compOpts: twig.CompileOptions = {
 	filename: str,
 	settings: value


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/twigjs/twig.js/blob/51544ce66e355cf7b142d7f58d52f71088548bad/ASYNC.md#switching-render-mode

Typescript-bot was a bit overzealous in closing https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42249 so submitting a new PR.