### PR TITLE
[react-transition-group] Make timeout optional if addEndListener is specified

### DIFF
--- a/types/react-transition-group/CSSTransition.d.ts
+++ b/types/react-transition-group/CSSTransition.d.ts
@@ -13,7 +13,7 @@ export interface CSSTransitionClassNames {
     exitDone?: string;
 }
 
-export interface CSSTransitionProps extends TransitionProps {
+export type CSSTransitionProps = TransitionProps & {
     /**
      * The animation `classNames` applied to the component as it enters or exits.
      * A single name can be provided and it will be suffixed for each stage: e.g.
@@ -38,7 +38,7 @@ export interface CSSTransitionProps extends TransitionProps {
      * ```
      */
     classNames?: string | CSSTransitionClassNames;
-}
+};
 
 declare class CSSTransition extends Component<CSSTransitionProps> {}
 

--- a/types/react-transition-group/Transition.d.ts
+++ b/types/react-transition-group/Transition.d.ts
@@ -31,14 +31,7 @@ export interface TransitionActions {
     exit?: boolean;
 }
 
-export type TransitionStatus =
-    typeof ENTERING |
-    typeof ENTERED |
-    typeof EXITING |
-    typeof EXITED |
-    typeof UNMOUNTED;
-export type TransitionChildren = ReactNode | ((status: TransitionStatus) => ReactNode);
-export interface TransitionProps extends TransitionActions {
+interface BaseTransitionProps {
     /**
      * Show the component; triggers the enter or exit states
      */
@@ -59,34 +52,6 @@ export interface TransitionProps extends TransitionActions {
      * component after it finishes exiting.
      */
     unmountOnExit?: boolean;
-
-    /**
-     * The duration of the transition, in milliseconds. Required unless addEndListener is provided.
-     *
-     * You may specify a single timeout for all transitions:
-     * ```js
-     *   timeout={500}
-     * ```
-     * or individually:
-     * ```js
-     * timeout={{
-     *  appear: 500,
-     *  enter: 300,
-     *  exit: 500,
-     * }}
-     * ```
-     * - appear defaults to the value of `enter`
-     * - enter defaults to `0`
-     * - exit defaults to `0`
-     */
-    timeout: number | { appear?: number, enter?: number, exit?: number };
-
-    /**
-     * Add a custom transition end trigger. Called with the transitioning DOM
-     * node and a done callback. Allows for more fine grained transition end
-     * logic. Note: Timeouts are still used as a fallback if provided.
-     */
-    addEndListener?: EndHandler;
 
     /**
      * Callback fired before the "entering" status is applied. An extra
@@ -140,6 +105,75 @@ export interface TransitionProps extends TransitionActions {
     children?: TransitionChildren;
     [ prop: string ]: any;
 }
+
+export type TransitionStatus =
+    typeof ENTERING |
+    typeof ENTERED |
+    typeof EXITING |
+    typeof EXITED |
+    typeof UNMOUNTED;
+export type TransitionChildren = ReactNode | ((status: TransitionStatus) => ReactNode);
+
+interface TimeoutProps extends BaseTransitionProps {
+    /**
+     * The duration of the transition, in milliseconds. Required unless addEndListener is provided.
+     *
+     * You may specify a single timeout for all transitions:
+     * ```js
+     *   timeout={500}
+     * ```
+     * or individually:
+     * ```js
+     * timeout={{
+     *  appear: 500,
+     *  enter: 300,
+     *  exit: 500,
+     * }}
+     * ```
+     * - appear defaults to the value of `enter`
+     * - enter defaults to `0`
+     * - exit defaults to `0`
+     */
+    timeout: number | { appear?: number, enter?: number, exit?: number };
+
+    /**
+     * Add a custom transition end trigger. Called with the transitioning DOM
+     * node and a done callback. Allows for more fine grained transition end
+     * logic. Note: Timeouts are still used as a fallback if provided.
+     */
+    addEndListener?: EndHandler;
+}
+
+interface EndListenerProps extends BaseTransitionProps {
+    /**
+     * The duration of the transition, in milliseconds. Required unless addEndListener is provided.
+     *
+     * You may specify a single timeout for all transitions:
+     * ```js
+     *   timeout={500}
+     * ```
+     * or individually:
+     * ```js
+     * timeout={{
+     *  appear: 500,
+     *  enter: 300,
+     *  exit: 500,
+     * }}
+     * ```
+     * - appear defaults to the value of `enter`
+     * - enter defaults to `0`
+     * - exit defaults to `0`
+     */
+    timeout?: number | { appear?: number, enter?: number, exit?: number };
+    /**
+     * Add a custom transition end trigger. Called with the transitioning DOM
+     * node and a done callback. Allows for more fine grained transition end
+     * logic. Note: Timeouts are still used as a fallback if provided.
+     */
+    addEndListener: EndHandler;
+}
+
+export type TransitionProps = TimeoutProps | EndListenerProps;
 
 /**
  * The Transition component lets you describe a transition from one component

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -169,6 +169,8 @@ const Test: React.StatelessComponent = () => {
                     <div>{ "test" }</div>
                 </Transition>
 
+                <Transition addEndListener={() => {}}/>
+
                 <CSSTransition
                     in
                     mountOnEnter


### PR DESCRIPTION
The `Transition` component only requires timeout to be specified of `addEndListener` is not, but it is unconditionally required with the current type definitions. This PR fixes that by making `TransitionProps` a union of a type that has an optional `timeout` and required addEventListener or the inverse.

Previously this library exported `TransitionProps` as an interface, but now it's exported as a type that is a union of two different interfaces, which means it can no longer be inherited from. To me that means it's a breaking change, and we should bump the major version number, but I'd like input if I go down that route.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactcommunity.org/react-transition-group/transition#Transition-prop-timeout
