### PR TITLE
Synced up prop types with latest version of 'react-mic'

### DIFF
--- a/types/react-mic/index.d.ts
+++ b/types/react-mic/index.d.ts
@@ -46,4 +46,19 @@ export interface ReactMicProps {
 
     /** Background color */
     backgroundColor?: string;
+    
+    /** Audio Bits Per Second */
+    audioBitsPerSecond?: number;
+    
+    /** Media output type */
+    mimeType?: string;
+    
+    /** Sample Rate */
+    sampleRate: number;
+    
+    /** Buffer Size */
+    bufferSize: number;
+    
+    /** Recorder Params */
+    recorderParams: any;
 }


### PR DESCRIPTION
This pull adds the missing prop types that are available in the latest version of the 'react-mic' package.