### PR TITLE
Set minimum TS version of googlemaps dependents to 3.0

### DIFF
--- a/types/google-maps/index.d.ts
+++ b/types/google-maps/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>, Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// TypeScript Version: 2.7
+// TypeScript Version: 3.0
 
 /// <reference types="googlemaps" />
 

--- a/types/googlemaps.infobubble/index.d.ts
+++ b/types/googlemaps.infobubble/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://google-maps-utility-library-v3.googlecode.com/svn/trunk/infobubble/src/
 // Definitions by: Johan Nilsson <https://github.com/Dashue>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.0
 
 /// <reference types="google-maps" />
 

--- a/types/marker-animate-unobtrusive/index.d.ts
+++ b/types/marker-animate-unobtrusive/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/terikon/marker-animate-unobtrusive
 // Definitions by: Roman Viskin <https://github.com/viskin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.0
 
 /// <reference types="googlemaps" />
 

--- a/types/ngmap/index.d.ts
+++ b/types/ngmap/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/allenhwkim/angularjs-google-maps
 // Definitions by: Niko Kovačič <https://github.com/nkovacic>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 /// <reference types="angular" />
 /// <reference types="googlemaps" />

--- a/types/viewporter/index.d.ts
+++ b/types/viewporter/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/zynga/viewporter
 // Definitions by: Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 interface Viewporter {
     preventPageScroll: boolean;


### PR DESCRIPTION
Types-publisher's dependency tracking code missed this when googlemaps started requiring 3.0 about 6 months ago.