### PR TITLE
feat: types for @rdfjs/dataset

### DIFF
--- a/types/rdfjs__dataset/DatasetCore.d.ts
+++ b/types/rdfjs__dataset/DatasetCore.d.ts
@@ -1,0 +1,13 @@
+import * as RDF from 'rdf-js';
+
+declare class DatasetCore implements RDF.DatasetCore {
+    constructor(quads: RDF.Quad[]);
+    size: number;
+    add(quad: RDF.Quad): this;
+    delete(quad: RDF.Quad): this;
+    has(quad: RDF.Quad): boolean;
+    match(subject?: RDF.Term | null, predicate?: RDF.Term | null, object?: RDF.Term | null, graph?: RDF.Term | null): this;
+    [Symbol.iterator](): Iterator<RDF.Quad>;
+}
+
+export = DatasetCore;

--- a/types/rdfjs__dataset/index.d.ts
+++ b/types/rdfjs__dataset/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for @rdfjs/dataset 1.0
+// Project: https://github.com/rdfjs-base/dataset
+// Definitions by: tpluscode <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { DataFactory, DefaultGraph } from 'rdf-js';
+import DatasetCore = require('./DatasetCore');
+
+declare function dataset(): DatasetCore;
+
+declare const Dataset: {
+    dataset(): DatasetCore;
+    defaultGraphInstance: DefaultGraph;
+} & Required<DataFactory>;
+
+export = Dataset;

--- a/types/rdfjs__dataset/rdfjs__dataset-tests.ts
+++ b/types/rdfjs__dataset/rdfjs__dataset-tests.ts
@@ -1,0 +1,12 @@
+import * as RDF from 'rdf-js';
+import rdf = require('@rdfjs/dataset');
+
+const dataset: RDF.DatasetCore = rdf.dataset();
+const literal: RDF.Literal = rdf.literal('foo');
+const blankNode: RDF.BlankNode = rdf.blankNode('foo');
+const variable: RDF.Variable = rdf.variable('foo');
+const graph: RDF.DefaultGraph = rdf.defaultGraph();
+const defaultGraph: RDF.DefaultGraph = rdf.defaultGraphInstance;
+const namedNode: RDF.NamedNode = rdf.namedNode('foo');
+const triple: RDF.Triple = rdf.triple(namedNode, variable, literal);
+const quad: RDF.Quad = rdf.quad(namedNode, variable, literal, graph);

--- a/types/rdfjs__dataset/tsconfig.json
+++ b/types/rdfjs__dataset/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@rdfjs/dataset": [
+                "rdfjs__dataset"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "rdfjs__dataset-tests.ts"
+    ]
+}

--- a/types/rdfjs__dataset/tslint.json
+++ b/types/rdfjs__dataset/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.