### PR TITLE
[react] Mirror React Hooks Flow and exhaustive deps behaviour

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -22,6 +22,7 @@
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 Kyle Scully <https://github.com/zieka>
 //                 Cong Zhang <https://github.com/dancerphil>
+//                 Jannes Drijkoningen <https://github.com/jannes-io>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -1052,8 +1053,6 @@ declare namespace React {
      * @see https://reactjs.org/docs/hooks-reference.html#useimperativehandle
      */
     function useImperativeHandle<T, R extends T>(ref: Ref<T>|undefined, init: () => R, deps?: DependencyList): void;
-    // I made 'inputs' required here and in useMemo as there's no point to memoizing without the memoization key
-    // useCallback(X) is identical to just using X, useMemo(() => Y) is identical to just using Y.
     /**
      * `useCallback` will return a memoized version of the callback that only changes if one of the `inputs`
      * has changed.
@@ -1062,7 +1061,7 @@ declare namespace React {
      * @see https://reactjs.org/docs/hooks-reference.html#usecallback
      */
     // TODO (TypeScript 3.0): <T extends (...args: never[]) => unknown>
-    function useCallback<T extends (...args: any[]) => any>(callback: T, deps: DependencyList): T;
+    function useCallback<T extends (...args: any[]) => any>(callback: T, deps?: DependencyList): T;
     /**
      * `useMemo` will only recompute the memoized value when one of the `deps` has changed.
      *
@@ -1081,8 +1080,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#usememo
      */
-    // allow undefined, but don't make it optional as that is very likely a mistake
-    function useMemo<T>(factory: () => T, deps: DependencyList | undefined): T;
+    function useMemo<T>(factory: () => T, deps?: DependencyList): T;
     /**
      * `useDebugValue` can be used to display a label for custom hooks in React DevTools.
      *

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -187,10 +187,11 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     React.useDebugValue(id, value => value.toFixed());
     React.useDebugValue(id);
 
+    // allow passing an empty dependency array
+    React.useMemo(() => {}, []);
     // allow passing an explicit undefined
     React.useMemo(() => {}, undefined);
-    // but don't allow it to be missing
-    // $ExpectError
+    // allow passing no deps
     React.useMemo(() => {});
 
     // useState convenience overload


### PR DESCRIPTION
react-hooks/exhaustive-deps is set up to correctly follow React's Flow definition of useCallback and useMemo. However the suggested solutions do not work in TypeScript since @types/react "interpreted" the definitions of Facebook.

When not passing any deps:
```
Failed to compile.
Expected 2 arguments, but got 1.  TS2554
```
When passing undefined as deps:
```
React Hook useMemo was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies react-hooks/exhaustive-deps
React Hook useMemo has a missing dependency: 'someDep'. Either include it or remove the dependency array react-hooks/exhaustive-deps
```
As you can tell, this behavior is very confusing so I propose we simply mirror react and let react-hooks/exhaustive-deps do the dependency checking as it also does for useEffect.

This PR aims to mirror the React Flow definitions and have the dep arrays as optional parameters. It should be 100% backwards compatible since the constraints have been loosened.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/blob/master/packages/react/src/ReactHooks.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.