### PR TITLE
add missing option `transformKey` in `flat`

### DIFF
--- a/types/flat/flat-tests.ts
+++ b/types/flat/flat-tests.ts
@@ -1,14 +1,6 @@
-
-
 import { flatten, unflatten } from "flat";
 
 namespace TestFlatten {
-	let options: {
-		delimiter?: string;
-		safe?: boolean;
-		maxDepth?: number;
-	};
-
 	type Target = {
 		a: {
 			b: number;
@@ -26,16 +18,22 @@ namespace TestFlatten {
 	let result: Result;
 
 	result = flatten<Target, Result>(target);
-	result = flatten<Target, Result>(target, options);
+	result = flatten<Target, Result>(target, {});
+	result = flatten<Target, Result>(target, {
+	    delimiter: '_',
+    });
+    result = flatten<Target, Result>(target, {
+        maxDepth: 3,
+    });
+    result = flatten<Target, Result>(target, {
+        safe: true,
+    });
+    result = flatten<Target, Result>(target, {
+        transformKey: (key: string) => key,
+    });
 }
 
 namespace TestUnflatten {
-	let options: {
-		delimiter?: string;
-		object?: boolean;
-		overwrite?: boolean;
-	};
-
 	type Target = {
 		'a.b': number;
 		'c.0.0': boolean;
@@ -53,5 +51,17 @@ namespace TestUnflatten {
 	let result: Result;
 
 	result = unflatten<Target, Result>(target);
-	result = unflatten<Target, Result>(target, options);
+    result = unflatten<Target, Result>(target, {});
+    result = unflatten<Target, Result>(target, {
+        delimiter: '_',
+    });
+    result = unflatten<Target, Result>(target, {
+        object: true,
+    });
+    result = unflatten<Target, Result>(target, {
+        overwrite: true,
+    });
+    result = unflatten<Target, Result>(target, {
+        transformKey: (key: string) => key,
+    });
 }

--- a/types/flat/index.d.ts
+++ b/types/flat/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for flat
+// Type definitions for flat 5.0.0
 // Project: https://github.com/hughsk/flat
 // Definitions by:  Ilya Mochalov <https://github.com/chrootsu>
 //                  Oz Weiss <https://github.com/thewizarodofoz>

--- a/types/flat/index.d.ts
+++ b/types/flat/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for flat
 // Project: https://github.com/hughsk/flat
-// Definitions by: Ilya Mochalov <https://github.com/chrootsu>
+// Definitions by:  Ilya Mochalov <https://github.com/chrootsu>
+//                  Oz Weiss <https://github.com/thewizarodofoz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var flatten: FlatTypes.Flatten;
@@ -12,6 +13,7 @@ declare namespace FlatTypes {
 		delimiter?: string;
 		safe?: boolean;
 		maxDepth?: number;
+        transformKey?: (key: string) => string;
 	}
 
 	interface Flatten {
@@ -28,6 +30,7 @@ declare namespace FlatTypes {
 		delimiter?: string;
 		object?: boolean;
 		overwrite?: boolean;
+        transformKey?: (key: string) => string;
 	}
 
 	interface Unflatten {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hughsk/flat/blob/master/index.js#L16
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


**NOTE**: I have changed the tests because the `options` part was not meaningful (= was not really testing the types) because of how [typescript checks object literals](https://www.typescriptlang.org/docs/handbook/interfaces.html#excess-property-checks).