### PR TITLE
[mongoose] Use mongodb.FilterQuery type

### DIFF
--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -1,3 +1,4 @@
+import * as mongodb from 'mongodb';
 import * as mongoose from 'mongoose';
 
 // dummy variables
@@ -1302,14 +1303,66 @@ query.lean() // true
 query.lean(false)
 query.lean({})
 
+interface OtherLocation extends mongoose.Document {
+    type: string;
+}
 interface Location1 extends mongoose.Document {
-    _id: mongoose.Types.ObjectId;
+    _id: mongodb.ObjectId;
     name: string;
     address: string;
     rating: number;
     reviews: any[];
+    ref1: mongodb.ObjectId;
+    // This type is useful for using with `populate()`
+    ref2: mongodb.ObjectId | OtherLocation;
 };
+var loc1Document = <Location1>{};
 var loc1Query = <mongoose.DocumentQuery<Location1, Location1>>{};
+loc1Query.count({ name: 'foo' });
+// $ExpectError
+loc1Query.count({ name: 123 });
+loc1Query.countDocuments({ name: 'foo' });
+loc1Query.find({ _id: new mongodb.ObjectId() });
+loc1Query.find({ _id: 'string-allowed' });
+loc1Query.find({ _id: loc1Document });
+// $ExpectError
+loc1Query.find({ _id: 123 });
+// $ExpectError
+loc1Query.find({ _id: { foo: 'bar' } });
+loc1Query.find({ ref1: new mongodb.ObjectId() });
+loc1Query.find({ ref1: 'string-allowed' });
+// $ExpectError
+loc1Query.find({ ref1: 123 });
+loc1Query.find({ ref2: new mongodb.ObjectId() });
+loc1Query.find({ ref2: 'string-allowed' });
+// $ExpectError
+loc1Query.find({ ref2: 123 });
+loc1Query.find({
+    name: 'foo',
+    address: /bar/, // strings are allowed as RegExp
+    rating: 10,
+    facilities: { $exists: true },
+    'reviews.0': { $exists: true } // additional queries are allowed
+});
+// $ExpectError
+loc1Query.find({ name: 123 });
+// $ExpectError
+loc1Query.find({ rating: 'foo' });
+loc1Query.findOne({ name: 'foo', rating: 10 });
+// $ExpectError
+loc1Query.findOne({ rating: 'foo' });
+loc1Query.findOneAndRemove({ name: 'foo', rating: 10 });
+// $ExpectError
+loc1Query.findOneAndRemove({ rating: 'foo' });
+loc1Query.findOneAndUpdate({ name: 'foo', rating: 10 }, { rating: 20 });
+// $ExpectError
+loc1Query.findOneAndUpdate({ rating: 'foo' }, { rating: 20 });
+loc1Query.remove({ name: 'foo', rating: 10 });
+// $ExpectError
+loc1Query.remove({ rating: 'foo' });
+loc1Query.update({ name: 'foo', rating: 10 }, { rating: 20 });
+// $ExpectError
+loc1Query.update({ rating: 'foo' }, { rating: 20 });
 loc1Query.lean().then(location => {
     if (location) {
         // $ExpectType ObjectId
@@ -1921,6 +1974,7 @@ MongoModel.findById(999, function (err, user) {
     console.log(user);
   });
 });
+// $ExpectError
 MongoModel.find(999, function (err, users) {
   var opts = [{ path: 'company', match: { x: 1 }, select: 'name' }]
   var promise = MongoModel.populate(users, opts);
@@ -1986,7 +2040,7 @@ MongoModel.find({
 .exec();
 /* practical example */
 interface Location extends mongoose.Document {
-  _id: mongoose.Types.ObjectId;
+  _id: mongodb.ObjectId;
   name: string;
   address: string;
   rating: number;
@@ -2004,6 +2058,7 @@ const locationSchema = new mongoose.Schema({
   openingTimes: [mongoose.Schema.Types.Mixed],
   reviews: [mongoose.SchemaTypes.Mixed]
 });
+var locDocument = <Location>{};
 var LocModel = mongoose.model<Location>("Location", locationSchema);
 LocModel.findById(999)
   .select("-reviews -rating")
@@ -2035,16 +2090,42 @@ LocModel.find({}).$where('')
     locations[0].name;
     locations[1].openingTimes;
   });
-LocModel.count({})
+LocModel.find({
+    name: 'foo',
+    address: /bar/, // strings are allowed as RegExp
+    rating: 10,
+    facilities: { $exists: true },
+    'reviews.0': { $exists: true } // additional queries are allowed
+});
+LocModel.find({ _id: new mongodb.ObjectId() });
+LocModel.find({ _id: 'string-allowed' });
+LocModel.find({ _id: locDocument });
+// $ExpectError
+LocModel.find({ _id: 123 });
+// $ExpectError
+LocModel.find({ _id: { foo: 'bar' } });
+// $ExpectError
+LocModel.find({ name: 123 });
+// $ExpectError
+LocModel.find({ rating: 'foo' });
+LocModel.count({ name: 'foo'})
   .exec(function (err, count) {
     count.toFixed();
   });
+// $ExpectError
+LocModel.count({ name: 123 });
+LocModel.countDocuments({ name: 'foo' });
+// $ExpectError
+LocModel.countDocuments({ name: 123 });
 LocModel.distinct('')
   .select('-review')
   .exec(function (err, distinct) {
     distinct.concat;
   })
   .then(cb).catch(cb);
+LocModel.exists({ name: 'foo' });
+// $ExpectError
+LocModel.exists({ name: 123 });
 LocModel.findByIdAndRemove()
   .exec(function (err, doc) {
     if (!doc) {
@@ -2066,7 +2147,7 @@ LocModel.findOne({}, function (err, doc) {
   }
 });
 LocModel
-    .findOne({ name: 'foo' })
+    .findOne({ name: 'foo', rating: 10 })
     .lean()
     .exec()
     .then(function(doc) {
@@ -2085,6 +2166,8 @@ LocModel.findOneAndRemove()
       location.name;
     }
   });
+LocModel.findOneAndRemove({ name: 'foo', rating: 10 });
+LocModel.findOneAndDelete({ name: 'foo', rating: 10 });
 LocModel.findOneAndUpdate().exec().then(function (arg) {
   if (arg) {
     arg.openingTimes;
@@ -2102,6 +2185,14 @@ LocModel.geoSearch({}, {
   near: [1, 2],
   maxDistance: 22
 }, function (err, res) { res[0].openingTimes; });
+LocModel.remove({ name: 'foo' });
+LocModel.deleteOne({ name: 'foo' });
+LocModel.deleteMany({ name: 'foo' });
+LocModel.replaceOne({ name: 'foo' }, { name: 'bar' });
+LocModel.update({ name: 'foo' }, { name: 'bar' });
+LocModel.updateOne({ name: 'foo' }, { name: 'bar' });
+LocModel.updateMany({ name: 'foo' }, { name: 'bar' });
+
 interface IStatics {
   staticMethod2: (a: number) => string;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint mongoose` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The mongodb types already use this filter type: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mongodb/index.d.ts#L974
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.