### PR TITLE
Add readonly type modifier to compile arguments

### DIFF
--- a/types/moo/index.d.ts
+++ b/types/moo/index.d.ts
@@ -5,6 +5,7 @@
 //                 Martien Oranje <https://github.com/moranje>
 //                 Nick Koester <https://github.com/nickkoester>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.4
 
 export as namespace moo;
 

--- a/types/moo/index.d.ts
+++ b/types/moo/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Nikita Litvin <https://github.com/deltaidea>
 //                 Jörg Vehlow <https://github.com/MofX>
 //                 Martien Oranje <https://github.com/moranje>
+//                 Nick Koester <https://github.com/nickkoester>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace moo;
@@ -70,7 +71,7 @@ export interface Rule {
     type?: TypeMapper;
 }
 export interface Rules {
-    [x: string]: RegExp | string | string[] | Rule | Rule[] | ErrorRule | FallbackRule;
+    [x: string]: RegExp | string | readonly string[] | Rule | Rule[] | ErrorRule | FallbackRule;
 }
 
 export interface Lexer {


### PR DESCRIPTION
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
