### PR TITLE
[contract-proxy-kit] Widen operations field type for execTransactions spec

### DIFF
--- a/types/contract-proxy-kit/contract-proxy-kit-tests.ts
+++ b/types/contract-proxy-kit/contract-proxy-kit-tests.ts
@@ -73,7 +73,7 @@ CPK.create({ web3 }).then(async cpk => {
             data: '0x',
         },
         {
-            operation: CPK.CALL,
+            operation: CPK.CALL.toString(),
             to: '0xffcf8fdee72ac11b5c542428b35eef5769c409f0',
             value: `${1e18}`,
             data: '0x',
@@ -93,7 +93,7 @@ CPK.create({ web3 }).then(async cpk => {
     await cpk.execTransactions(
         [
             {
-                operation: CPK.CALL,
+                operation: CPK.CALL.toString(),
                 to: '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1',
                 value: `${1e18}`,
                 data: '0x',

--- a/types/contract-proxy-kit/index.d.ts
+++ b/types/contract-proxy-kit/index.d.ts
@@ -35,7 +35,7 @@ declare namespace CPK {
     type CPKConfig = Web3SpecificConfig | EthersSpecificConfig;
 
     interface Transaction {
-        operation: 0 | 1;
+        operation: number | string | object;
         to: string;
         value: number | string | object;
         data: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gnosis/contract-proxy-kit/issues/8
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
