### PR TITLE
Increase minimum TS version:

### DIFF
--- a/types/dts-generator/index.d.ts
+++ b/types/dts-generator/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/SitePen/dts-generator#readme
 // Definitions by: Matt Traynham <https://github.com/mtraynham>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.2
+// TypeScript Version: 3.4
 
 import ts = require('typescript');
 import Bluebird = require('bluebird');

--- a/types/mongoose-sequence/index.d.ts
+++ b/types/mongoose-sequence/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ramiel/mongoose-sequence
 // Definitions by: Linus Brolin <https://github.com/linusbrolin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 /// <reference types="mongoose" />
 


### PR DESCRIPTION
1. Dependencies of dts-generator use syntax from TS 3.4 (`as const` perhaps?)
2. Dependencies of mongoose-sequence use `unknown` from TS 3.0.