### PR TITLE
workbox-sw/v3: increase minimum version of TS to 3.0

### DIFF
--- a/types/workbox-sw/v3/index.d.ts
+++ b/types/workbox-sw/v3/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/GoogleChrome/workbox
 // Definitions by: Frederik Wessberg <https://github.com/wessberg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 3.0
 
 /**
  * ===== BroadcastCacheUpdate =====


### PR DESCRIPTION
Dependencies of workbox-sw v3 use types that are only defined in TS 3.0 and above.