### PR TITLE
Add types for miniprogram-sm-crypto

### DIFF
--- a/types/miniprogram-sm-crypto/index.d.ts
+++ b/types/miniprogram-sm-crypto/index.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for miniprogram-sm-crypto 0.1
+// Project: https://github.com/wechat-miniprogram/sm-crypto#readme
+// Definitions by: Thermod <https://github.com/Moonisky>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import BigInteger = require('bigi');
+
+export interface KeyPairHex {
+    privateKey: string;
+    publicKey: string;
+}
+
+export interface KeyPairPoint extends KeyPairHex {
+    k: BigInteger;
+    x1: BigInteger;
+}
+
+/**
+ * Cipher Mode
+ * - `0`：C1C2C3
+ * - `1`：C1C3C2
+ */
+export type CipherMode = 0 | 1;
+
+export namespace sm2 {
+    function generateKeyPairHex(): KeyPairHex;
+    function doEncrypt(msg: string, publicKey: string, cipherMode?: CipherMode): string;
+    function doDecrypt(encryptData: string, privateKey: string, cipherMode?: CipherMode): string;
+    function doSignature(msg: string, privateKey: string, options?: {
+        pointPool?: KeyPairPoint[]
+        der?: boolean
+        hash?: boolean
+        publicKey?: string
+    }): string;
+    function doVerifySignature(msg: string, signHex: string, publicKey: string, options?: {
+        der?: boolean
+        hash?: boolean
+        publicKey?: string
+    }): boolean;
+    function getPoint(): KeyPairPoint;
+}
+
+export function sm3(str: string): string;
+
+export namespace sm4 {
+    function encrypt(inArray: number[], key: number[]): number[];
+    function decrypt(inArray: number[], key: number[]): number[];
+}

--- a/types/miniprogram-sm-crypto/miniprogram-sm-crypto-tests.ts
+++ b/types/miniprogram-sm-crypto/miniprogram-sm-crypto-tests.ts
@@ -1,0 +1,66 @@
+import { sm2, sm3, sm4 } from 'miniprogram-sm-crypto';
+
+const message = "Hello World!";
+
+// get key pair
+const keypair = sm2.generateKeyPairHex();
+
+const publicKey = keypair.publicKey;
+const privateKey = keypair.privateKey;
+
+// encrypt & decrypt
+const encryptData = sm2.doEncrypt(message, publicKey, 1); // encrypt result
+const decryptData = sm2.doDecrypt(encryptData, privateKey, 1); // decrypt result
+
+// signature
+// pure sign + generate elliptic curve points
+const sigValueHex = sm2.doSignature(message, privateKey); // sign
+const verifyResult = sm2.doVerifySignature(message, sigValueHex, publicKey); // verify sign result
+
+// pure sign
+const sigValueHex2 = sm2.doSignature(message, privateKey, {
+    // speed up sign by passing in elliptic curve points that have been generated in advance
+    pointPool: [sm2.getPoint(), sm2.getPoint(), sm2.getPoint(), sm2.getPoint()],
+}); // sign
+const verifyResult2 = sm2.doVerifySignature(message, sigValueHex2, publicKey); // verify sign result
+
+// pure sign + generate elliptic curve points + der encoding
+const sigValueHex3 = sm2.doSignature(message, privateKey, {
+    der: true,
+}); // sign
+const verifyResult3 = sm2.doVerifySignature(message, sigValueHex3, publicKey, {
+    der: true,
+}); // verify sign result
+
+// pure sign + generate elliptic curve points + sm3
+const sigValueHex4 = sm2.doSignature(message, privateKey, {
+    hash: true,
+}); // sign
+const verifyResult4 = sm2.doVerifySignature(message, sigValueHex4, publicKey, {
+    hash: true,
+}); // verify sign result
+
+// pure sign + generate elliptic curve points + sm3 without deriving the public key
+const sigValueHex5 = sm2.doSignature(message, privateKey, {
+    hash: true,
+    publicKey, // if we passing in public key, we can skip deriving the public key in sm3, it will be more faster than previous method
+});
+const verifyResult5 = sm2.doVerifySignature(message, sigValueHex5, publicKey, {
+    hash: true,
+    publicKey,
+});
+
+// obtain a elliptic curve point
+const poin = sm2.getPoint(); // can using in sm2 sign
+
+// sm3
+const hashData = sm3('abc');
+
+// sm4
+const key = [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10];
+
+// encrypt
+const sm4EncryptData = sm4.encrypt([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10], key);
+
+// decrypt
+const sm4DecryptData = sm4.decrypt([0x68, 0x1e, 0xdf, 0x34, 0xd2, 0x06, 0x96, 0x5e, 0x86, 0xb3, 0xe9, 0x4f, 0x53, 0x6e, 0x42, 0x46], key);

--- a/types/miniprogram-sm-crypto/tsconfig.json
+++ b/types/miniprogram-sm-crypto/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "miniprogram-sm-crypto-tests.ts"
+    ]
+}

--- a/types/miniprogram-sm-crypto/tslint.json
+++ b/types/miniprogram-sm-crypto/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/miniprogram-sm-crypto/tslint.json
+++ b/types/miniprogram-sm-crypto/tslint.json
@@ -1,1 +1,29 @@
-{ "extends": "dtslint/dt.json" }
+{
+  "extends": "dtslint/dt.json",
+  "rules": {
+    "callable-types": false,
+    "dt-header": false,
+    "eofline": false,
+    "interface-name": false,
+    "no-angle-bracket-type-assertion": false,
+    "no-padding": false,
+    "no-redundant-jsdoc": false,
+    "no-var-keyword": false,
+    "npm-naming": [
+      true,
+      {
+        "errors": [
+          [
+            "NeedsExportEquals",
+            false
+          ]
+        ],
+        "mode": "code"
+      }
+    ],
+    "prefer-method-signature": false,
+    "strict-export-declare-modifiers": false,
+    "typedef-whitespace": false,
+    "whitespace": false
+  }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.