### PR TITLE
parse-prefer-header: More specific typings

### DIFF
--- a/types/parse-prefer-header/index.d.ts
+++ b/types/parse-prefer-header/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for parse-prefer-header 1.0
 // Project: https://github.com/ppaskaris/node-parse-prefer-header
-// Definitions by: Vincenzo Chianese <https://github.com/XVincentX>
+// Definitions by: Vincenzo Chianese <https://github.com/XVincentX>, Marcell Toth <https://github.com/marcelltoth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare function parsePreferHeader(preferHeader: string | string[] | null | undefined): { [key: string]: string | true };

--- a/types/parse-prefer-header/index.d.ts
+++ b/types/parse-prefer-header/index.d.ts
@@ -3,6 +3,6 @@
 // Definitions by: Vincenzo Chianese <https://github.com/XVincentX>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function parsePreferHeader(preferHeader: string | string[]): { [key: string]: string | boolean };
+declare function parsePreferHeader(preferHeader: string | string[] | null | undefined): { [key: string]: string | boolean };
 
 export = parsePreferHeader;

--- a/types/parse-prefer-header/index.d.ts
+++ b/types/parse-prefer-header/index.d.ts
@@ -3,6 +3,6 @@
 // Definitions by: Vincenzo Chianese <https://github.com/XVincentX>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function parsePreferHeader(preferHeader: string | string[] | null | undefined): { [key: string]: string | boolean };
+declare function parsePreferHeader(preferHeader: string | string[] | null | undefined): { [key: string]: string | true };
 
 export = parsePreferHeader;

--- a/types/parse-prefer-header/index.d.ts
+++ b/types/parse-prefer-header/index.d.ts
@@ -3,6 +3,6 @@
 // Definitions by: Vincenzo Chianese <https://github.com/XVincentX>, Marcell Toth <https://github.com/marcelltoth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function parsePreferHeader(preferHeader: string | string[] | null | undefined): { [key: string]: string | true };
+declare function parsePreferHeader(preferHeader: string | ReadonlyArray<string> | null | undefined): { [key: string]: string | true };
 
 export = parsePreferHeader;

--- a/types/parse-prefer-header/parse-prefer-header-tests.ts
+++ b/types/parse-prefer-header/parse-prefer-header-tests.ts
@@ -1,6 +1,11 @@
 import parsePreferHeader = require('parse-prefer-header');
 
-parsePreferHeader(['respond-async, wait=100', 'handling=lenient'] as ReadonlyArray<string>);
+const testArray = ['respond-async, wait=100', 'handling=lenient'];
+
+const readonlyTestArray: ReadonlyArray<string> = testArray;
+
+parsePreferHeader(testArray);
+parsePreferHeader(readonlyTestArray);
 parsePreferHeader('');
 parsePreferHeader(null);
 parsePreferHeader(undefined);

--- a/types/parse-prefer-header/parse-prefer-header-tests.ts
+++ b/types/parse-prefer-header/parse-prefer-header-tests.ts
@@ -2,3 +2,6 @@ import parsePreferHeader = require('parse-prefer-header');
 
 parsePreferHeader(['respond-async, wait=100', 'handling=lenient']);
 parsePreferHeader('');
+
+parsePreferHeader(null);
+parsePreferHeader(undefined);

--- a/types/parse-prefer-header/parse-prefer-header-tests.ts
+++ b/types/parse-prefer-header/parse-prefer-header-tests.ts
@@ -1,7 +1,6 @@
 import parsePreferHeader = require('parse-prefer-header');
 
-parsePreferHeader(['respond-async, wait=100', 'handling=lenient']);
+parsePreferHeader(['respond-async, wait=100', 'handling=lenient'] as ReadonlyArray<string>);
 parsePreferHeader('');
-
 parsePreferHeader(null);
 parsePreferHeader(undefined);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Short [README](https://github.com/ppaskaris/node-parse-prefer-header), and [source code](https://github.com/ppaskaris/node-parse-prefer-header/blob/master/index.js) (67 lines)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **N/A**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

## Rationale:

1. The function accepts null/undefined inputs ([lines 47-49](https://github.com/ppaskaris/node-parse-prefer-header/blob/master/index.js#L47-L49)), and utilizing this can be useful as the caller can spare a null check or `|| ''` when calling the method.
2. The method does not modify its argument (even) if it is an array ([code](https://github.com/ppaskaris/node-parse-prefer-header/blob/master/index.js#L44)), so `ReadonlyArray` is more appropriate.
3. The values in the returned object are either strings (if the preference has a value), or `true`. `false` is not possible. See [code](https://github.com/ppaskaris/node-parse-prefer-header/blob/master/index.js#L33).