### PR TITLE
[newrelic] adds waitForIdle option to #shutdown

### DIFF
--- a/types/newrelic/index.d.ts
+++ b/types/newrelic/index.d.ts
@@ -6,6 +6,7 @@
 //                 Kyle Scully <https://github.com/zieka>
 //                 Kenneth Aasan <https://github.com/kennethaasan>
 //                 Jon Flaishans <https://github.com/funkswing>
+//                 Dylan Smith <https://github.com/dylansmith>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // https://docs.newrelic.com/docs/agents/nodejs-agent/api-guides/nodejs-agent-api

--- a/types/newrelic/index.d.ts
+++ b/types/newrelic/index.d.ts
@@ -337,7 +337,7 @@ export const instrumentMessages: Instrument;
  */
 export function shutdown(cb?: (error?: Error) => void): void;
 export function shutdown(
-    options?: { collectPendingData?: boolean; timeout?: number },
+    options?: { collectPendingData?: boolean; timeout?: number; waitForIdle?: boolean },
     cb?: (error?: Error) => void,
 ): void;
 

--- a/types/newrelic/newrelic-tests.ts
+++ b/types/newrelic/newrelic-tests.ts
@@ -109,6 +109,10 @@ newrelic.shutdown({ collectPendingData: true, timeout: 3000 });
 newrelic.shutdown({ collectPendingData: true, timeout: 3000 }, err => {
     const error: Error | undefined = err;
 });
+newrelic.shutdown({ collectPendingData: true, timeout: 3000, waitForIdle: true });
+newrelic.shutdown({ collectPendingData: true, timeout: 3000, waitForIdle: true }, err => {
+    const error: Error | undefined = err;
+});
 newrelic.shutdown(err => {
     const error: Error | undefined = err;
 });


### PR DESCRIPTION
The #shutdown method supports an optional `waitForIdle` boolean option which is not currently reflected in the types. This has been in place since v4.110 and the current types are for v6.2.0.

Docs: https://newrelic.github.io/node-newrelic/docs/API.html#shutdown
Changelog: https://github.com/newrelic/node-newrelic/blob/34499217d2f714c3d247c8f2b1c85e9c65fbc5dd/NEWS.md#4110-2018-11-15

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://newrelic.github.io/node-newrelic/docs/API.html#shutdown
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
