### PR TITLE
[d3-brush] Added keymodifiers definition

### DIFF
--- a/types/d3-brush/d3-brush-tests.ts
+++ b/types/d3-brush/d3-brush-tests.ts
@@ -57,6 +57,12 @@ brush = brush.filter(function(d, i, group) {
 let filterFn: (this: SVGGElement, d: BrushDatum, index: number, group: SVGGElement[]) => boolean;
 filterFn = brush.filter();
 
+// keyModifiers() ----------------------------------------------------------------
+
+// chainable
+brush = brush.keyModifiers(true);
+const keyModifiers: boolean = brush.keyModifiers();
+
 // handleSize() ----------------------------------------------------------------
 
 // chainable

--- a/types/d3-brush/index.d.ts
+++ b/types/d3-brush/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for D3JS d3-brush module 1.0
+// Type definitions for D3JS d3-brush module 1.1
 // Project: https://github.com/d3/d3-brush/, https://d3js.org/d3-brush
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-// Last module patch version validated against: 1.0.3
+// Last module patch version validated against: 1.1.5
 
 import { ArrayLike, Selection, TransitionLike, ValueFn } from 'd3-selection';
 
@@ -137,6 +137,20 @@ export interface BrushBehavior<Datum> {
      * with this as the current DOM element. The function returns a boolean value.
      */
     filter(filterFn: ValueFn<SVGGElement, Datum, boolean>): this;
+
+    /**
+     * Returns the current key modifiers flag.
+     */
+    keyModifiers(): boolean;
+    /**
+     * Sets the key modifiers flag and returns the brush.
+     *
+     * The key modifiers flag determines whether the brush listens to key events during brushing.
+     * The default value is true.
+     *
+     * @param keyModifiers New value for key modifiers flag.
+     */
+    keyModifiers(modifiers: boolean): this;
 
     /**
      * Returns the current handle size, which defaults to six.


### PR DESCRIPTION
I have added definitions for `brush.keyModifiers` which were added in `v1.1.0` of `d3-brush`.
https://github.com/d3/d3-brush/releases/tag/v1.1.0
https://github.com/d3/d3-brush/blob/master/README.md#brush_keyModifiers

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-brush/releases/tag/v1.1.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
