### PR TITLE
[@types/parse] Added AuthProvider and user function definitions

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -21,6 +21,7 @@
 //                  Linus Unnebäck <https://github.com/LinusU>
 //                  Patrick O'Sullivan <https://github.com/REPTILEHAUS>
 //                  Jerome De Leon <https://github.com/JeromeDeLeon>
+//                  Kent Robin Haugen <https://github.com/kentrh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.5
 
@@ -178,6 +179,29 @@ namespace Parse {
 
     interface AuthData {
         [key: string]: any;
+    }
+
+    /**
+     * Interface declaration for Authentication Providers
+     * https://parseplatform.org/Parse-SDK-JS/api/master/AuthProvider.html
+     */
+    interface AuthProvider {
+        /**
+         * Called when _linkWith isn't passed authData. Handle your own authentication here.
+         */
+        authenticate: () => void;
+        /**
+         * (Optional) Called when service is unlinked. Handle any cleanup here.
+         */
+        deauthenticate?: () => void;
+        /**
+         * Unique identifier for this Auth Provider.
+         */
+        getAuthType: () => string;
+        /**
+         * Called when auth data is syncronized. Can be used to determine if authData is still valid
+         */
+        restoreAuthentication: () => boolean;
     }
 
     interface BaseAttributes {
@@ -850,8 +874,10 @@ namespace Parse {
         setPassword(password: string, options?: SuccessFailureOptions): boolean;
         getSessionToken(): string;
 
-        linkWith(user: User, authData: AuthData, options: FullOptions): Promise<User>;
-        _linkWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions): Promise<User>;
+        linkWith: (provider: string | AuthProvider, options: { authData?: AuthData }, saveOpts?: FullOptions) => Promise<User>;
+        _linkWith: (provider: string | AuthProvider, options: { authData?: AuthData }, saveOpts?: FullOptions) => Promise<User>;
+        _isLinked: (provider: string | AuthProvider) => boolean;
+        _unlinkFrom: (provider: string | AuthProvider, options?: FullOptions) => Promise<User>;
     }
     interface UserConstructor extends ObjectStatic {
         new <T extends Attributes>(attributes: T): User<T>;
@@ -868,6 +894,8 @@ namespace Parse {
         extend(protoProps?: any, classProps?: any): any;
         hydrate<T extends User>(userJSON: any): Promise<T>;
         enableUnsafeCurrentUser(): void;
+        logInWith: (provider: string | AuthProvider, options: { authData?: AuthData }, saveOpts?: FullOptions) => Promise<User>;
+        _registerAuthenticationProvider: (provider: AuthProvider) => void;
     }
     const User: UserConstructor;
 

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -874,10 +874,10 @@ namespace Parse {
         setPassword(password: string, options?: SuccessFailureOptions): boolean;
         getSessionToken(): string;
 
-        linkWith: (provider: string | AuthProvider, options: { authData?: AuthData }, saveOpts?: FullOptions) => Promise<User>;
-        _linkWith: (provider: string | AuthProvider, options: { authData?: AuthData }, saveOpts?: FullOptions) => Promise<User>;
+        linkWith: (provider: string | AuthProvider, options: { authData?: AuthData }, saveOpts?: FullOptions) => Promise<this>;
+        _linkWith: (provider: string | AuthProvider, options: { authData?: AuthData }, saveOpts?: FullOptions) => Promise<this>;
         _isLinked: (provider: string | AuthProvider) => boolean;
-        _unlinkFrom: (provider: string | AuthProvider, options?: FullOptions) => Promise<User>;
+        _unlinkFrom: (provider: string | AuthProvider, options?: FullOptions) => Promise<this>;
     }
     interface UserConstructor extends ObjectStatic {
         new <T extends Attributes>(attributes: T): User<T>;

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1669,6 +1669,29 @@ function testUser() {
         // $ExpectError
         new Parse.User<{ example: number }>({ example: 'hello' });
     }
+    async function testAuthenticationProvider() {
+        const authProvider: Parse.AuthProvider = {
+            authenticate: () => { },
+            getAuthType: () => 'customAuthorizationProvider',
+            restoreAuthentication: () => false,
+            deauthenticate: () => { },
+        };
+        const authData: Parse.AuthData = {
+            id: 'some-user-authentication-id',
+            access_token: 'some-access-token',
+            expiration_date: new Date().toISOString(),
+        };
+        Parse.User._registerAuthenticationProvider(authProvider);
+
+        const user = await Parse.User.logInWith(
+            authProvider,
+            { authData },
+            { sessionToken: 'some-session-token', useMasterKey: true },
+        );
+        const isLinked = user._isLinked(authProvider);
+        const unlinkedUser = await user._unlinkFrom(authProvider);
+        const linkedUser = await user.linkWith(authProvider, {authData});
+    }
 }
 
 function testEncryptingUser() {

--- a/types/parse/ts3.7/index.d.ts
+++ b/types/parse/ts3.7/index.d.ts
@@ -848,7 +848,6 @@ namespace Parse {
         getSessionToken(): string;
 
         linkWith: (provider: string | AuthProvider, options: { authData?: AuthData }, saveOpts?: FullOptions) => Promise<this>;
-        _linkWith: (provider: string | AuthProvider, options: { authData?: AuthData }, saveOpts?: FullOptions) => Promise<this>;
         _isLinked: (provider: string | AuthProvider) => boolean;
         _unlinkFrom: (provider: string | AuthProvider, options?: FullOptions) => Promise<this>;
     }

--- a/types/parse/ts3.7/index.d.ts
+++ b/types/parse/ts3.7/index.d.ts
@@ -154,6 +154,29 @@ namespace Parse {
         [key: string]: any;
     }
 
+    /**
+     * Interface declaration for Authentication Providers
+     * https://parseplatform.org/Parse-SDK-JS/api/master/AuthProvider.html
+     */
+    interface AuthProvider {
+        /**
+         * Called when _linkWith isn't passed authData. Handle your own authentication here.
+         */
+        authenticate: () => void;
+        /**
+         * (Optional) Called when service is unlinked. Handle any cleanup here.
+         */
+        deauthenticate?: () => void;
+        /**
+         * Unique identifier for this Auth Provider.
+         */
+        getAuthType: () => string;
+        /**
+         * Called when auth data is syncronized. Can be used to determine if authData is still valid
+         */
+        restoreAuthentication: () => boolean;
+    }
+
     interface BaseAttributes {
         createdAt: Date;
         objectId: string;
@@ -824,8 +847,10 @@ namespace Parse {
         setPassword(password: string, options?: SuccessFailureOptions): boolean;
         getSessionToken(): string;
 
-        linkWith(user: User, authData: AuthData, options: FullOptions): Promise<User>;
-        _linkWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions): Promise<User>;
+        linkWith: (provider: string | AuthProvider, options: { authData?: AuthData }, saveOpts?: FullOptions) => Promise<this>;
+        _linkWith: (provider: string | AuthProvider, options: { authData?: AuthData }, saveOpts?: FullOptions) => Promise<this>;
+        _isLinked: (provider: string | AuthProvider) => boolean;
+        _unlinkFrom: (provider: string | AuthProvider, options?: FullOptions) => Promise<this>;
     }
     interface UserConstructor extends ObjectStatic {
         new <T extends Attributes>(attributes: T): User<T>;
@@ -842,6 +867,8 @@ namespace Parse {
         extend(protoProps?: any, classProps?: any): any;
         hydrate<T extends User>(userJSON: any): Promise<T>;
         enableUnsafeCurrentUser(): void;
+        logInWith: (provider: string | AuthProvider, options: { authData?: AuthData }, saveOpts?: FullOptions) => Promise<User>;
+        _registerAuthenticationProvider: (provider: AuthProvider) => void;
     }
     const User: UserConstructor;
 

--- a/types/parse/ts3.7/parse-tests.ts
+++ b/types/parse/ts3.7/parse-tests.ts
@@ -1669,6 +1669,29 @@ function testUser() {
         // $ExpectError
         new Parse.User<{ example: number }>({ example: 'hello' });
     }
+    async function testAuthenticationProvider() {
+        const authProvider: Parse.AuthProvider = {
+            authenticate: () => { },
+            getAuthType: () => 'customAuthorizationProvider',
+            restoreAuthentication: () => false,
+            deauthenticate: () => { },
+        };
+        const authData: Parse.AuthData = {
+            id: 'some-user-authentication-id',
+            access_token: 'some-access-token',
+            expiration_date: new Date().toISOString(),
+        };
+        Parse.User._registerAuthenticationProvider(authProvider);
+
+        const user = await Parse.User.logInWith(
+            authProvider,
+            { authData },
+            { sessionToken: 'some-session-token', useMasterKey: true },
+        );
+        const isLinked = user._isLinked(authProvider);
+        const unlinkedUser = await user._unlinkFrom(authProvider);
+        const linkedUser = await user.linkWith(authProvider, {authData});
+    }
 }
 
 function testEncryptingUser() {


### PR DESCRIPTION
Added AuthProvider, user._isLinked, user._unlinkFrom, User.logInWith, User._registerAuthenticationProvider. Changed signature of user.linkWith to match the one in the Parse.User documentation

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://parseplatform.org/Parse-SDK-JS/api/master/Parse.User.html>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.