### PR TITLE
[Simplebar] Add typing for v5

### DIFF
--- a/types/simplebar/index.d.ts
+++ b/types/simplebar/index.d.ts
@@ -31,9 +31,21 @@ declare namespace SimpleBar {
     }
 
     interface ClassNamesOptions {
-        content?: string;
-        scrollContent?: string;
+        contentEl?: string;
+        contentWrapper?: string;
+        offset?: string;
+        mask?: string;
+        wrapper?: string;
+        placeholder?: string;
         scrollbar?: string;
         track?: string;
+        heightAutoObserverWrapperEl?: string;
+        heightAutoObserverEl?: string;
+        visible?: string;
+        horizontal?: string;
+        vertical?: string;
+        hover?: string;
+        dragging?: string;
+        [className: string]: string;
     }
 }

--- a/types/simplebar/index.d.ts
+++ b/types/simplebar/index.d.ts
@@ -1,28 +1,35 @@
-// Type definitions for simplebar.js 2.4
+// Type definitions for simplebar.js 5.1
 // Project: https://github.com/Grsmto/simplebar, https://grsmto.github.io/simplebar
-// Definitions by: Gregor Woiwode <https://github.com/gregonnet>, Leonard Thieu <https://github.com/leonard-thieu>
+// Definitions by: Valikhan Akhmedov <https://github.com/val-o>, Gregor Woiwode <https://github.com/gregonnet>, Leonard Thieu <https://github.com/leonard-thieu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 3.1
 
 export as namespace SimpleBar;
 export = SimpleBar;
 
 declare class SimpleBar {
     static removeObserver(): void;
+    static initHtmlApi(): void;
 
     constructor(element: HTMLElement, options?: SimpleBar.Options);
 
-    recalculate(): void;
-    getScrollElement(): Element;
-    getContentElement(): Element;
+    public recalculate(): void;
+    public getScrollElement(): Element;
+    public getContentElement(): Element;
+
+    public instances: Pick<WeakMap<HTMLElement, SimpleBar>, 'get' | 'has'>;
 }
 
 declare namespace SimpleBar {
     interface Options {
-        wrapContent?: boolean;
         autoHide?: boolean;
-        scrollbarMinSize?: number;
         classNames?: ClassNamesOptions;
+        forceVisible?: boolean | 'x' | 'y';
+        direction?: 'rtl' | 'ltr';
+        timeout?: number;
+        clickOnTrack?: boolean;
+        scrollbarMinSize?: number;
+        scrollbarMaxSize?: number;
     }
 
     interface ClassNamesOptions {

--- a/types/simplebar/index.d.ts
+++ b/types/simplebar/index.d.ts
@@ -2,22 +2,20 @@
 // Project: https://github.com/Grsmto/simplebar, https://grsmto.github.io/simplebar
 // Definitions by: Valikhan Akhmedov <https://github.com/val-o>, Gregor Woiwode <https://github.com/gregonnet>, Leonard Thieu <https://github.com/leonard-thieu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 2.8
 
 export as namespace SimpleBar;
 export = SimpleBar;
 
 declare class SimpleBar {
     static removeObserver(): void;
-    static initHtmlApi(): void;
+    static instances: Pick<WeakMap<HTMLElement, SimpleBar>, 'get' | 'has'>;
 
     constructor(element: HTMLElement, options?: SimpleBar.Options);
 
-    public recalculate(): void;
-    public getScrollElement(): Element;
-    public getContentElement(): Element;
-
-    public instances: Pick<WeakMap<HTMLElement, SimpleBar>, 'get' | 'has'>;
+    recalculate(): void;
+    getScrollElement(): Element;
+    getContentElement(): Element;
 }
 
 declare namespace SimpleBar {

--- a/types/simplebar/simplebar-tests.ts
+++ b/types/simplebar/simplebar-tests.ts
@@ -1,17 +1,17 @@
-function test_start() {
+function test_constructorWithoutOpts() {
     new SimpleBar(document.getElementById('myElement'));
 }
 
-function test_options_wrapContent() {
-    new SimpleBar(document.getElementById('myElement'), { wrapContent: false });
-}
-
-function test_options_autoHide() {
-    new SimpleBar(document.getElementById('myElement'), { autoHide: false });
-}
-
-function test_options_scrollbarMinSize() {
-    new SimpleBar(document.getElementById('myElement'), { scrollbarMinSize: 10 });
+function test_constructor() {
+    new SimpleBar(document.getElementById('myElement'), {
+        autoHide: true,
+        clickOnTrack: true,
+        direction: 'ltr',
+        forceVisible: 'x',
+        scrollbarMaxSize: 20,
+        scrollbarMinSize: 10,
+        timeout: 300,
+    });
 }
 
 function test_options_classNames() {
@@ -21,31 +21,19 @@ function test_options_classNames() {
             content: 'simplebar-content',
             scrollContent: 'simplebar-scroll-content',
             scrollbar: 'simplebar-scrollbar',
-            track: 'simplebar-track'
-        }
+            track: 'simplebar-track',
+        },
     });
 }
 
-function test_recalculate() {
+function test_instanceFunctions() {
     const el = new SimpleBar(document.getElementById('myElement'));
     el.recalculate();
+    const contentEl: Element = el.getContentElement();
+    const scrollEl: Element = el.getScrollElement();
 }
 
-function test_getScrollElement() {
-    const el = new SimpleBar(document.getElementById('myElement'));
-    el.getScrollElement();
-}
-
-function test_scrollEvent() {
-    const el = new SimpleBar(document.getElementById('myElement'));
-    el.getScrollElement().addEventListener('scroll', () => { });
-}
-
-function test_getContentElement() {
-    const el = new SimpleBar(document.getElementById('myElement'));
-    el.getContentElement();
-}
-
-function test_removeObserver() {
+function test_staticFunctions() {
     SimpleBar.removeObserver();
+    SimpleBar.instances.get(new HTMLDivElement());
 }

--- a/types/simplebar/v2/index.d.ts
+++ b/types/simplebar/v2/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for simplebar.js 2.4
+// Project: https://github.com/Grsmto/simplebar, https://grsmto.github.io/simplebar
+// Definitions by: Valikhan Akhmedov <https://github.com/val-o>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+export as namespace SimpleBar;
+export = SimpleBar;
+
+declare class SimpleBar {
+    static removeObserver(): void;
+
+    constructor(element: HTMLElement, options?: SimpleBar.Options);
+
+    recalculate(): void;
+    getScrollElement(): Element;
+    getContentElement(): Element;
+}
+
+declare namespace SimpleBar {
+    interface Options {
+        wrapContent?: boolean;
+        autoHide?: boolean;
+        scrollbarMinSize?: number;
+        classNames?: ClassNamesOptions;
+    }
+
+    interface ClassNamesOptions {
+        content?: string;
+        scrollContent?: string;
+        scrollbar?: string;
+        track?: string;
+    }
+}

--- a/types/simplebar/v2/index.d.ts
+++ b/types/simplebar/v2/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for simplebar.js 2.4
 // Project: https://github.com/Grsmto/simplebar, https://grsmto.github.io/simplebar
-// Definitions by: Valikhan Akhmedov <https://github.com/val-o>
+// Definitions by: Gregor Woiwode <https://github.com/gregonnet>, Leonard Thieu <https://github.com/leonard-thieu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/types/simplebar/v2/simplebar-tests.ts
+++ b/types/simplebar/v2/simplebar-tests.ts
@@ -1,0 +1,51 @@
+function test_start() {
+    new SimpleBar(document.getElementById('myElement'));
+}
+
+function test_options_wrapContent() {
+    new SimpleBar(document.getElementById('myElement'), { wrapContent: false });
+}
+
+function test_options_autoHide() {
+    new SimpleBar(document.getElementById('myElement'), { autoHide: false });
+}
+
+function test_options_scrollbarMinSize() {
+    new SimpleBar(document.getElementById('myElement'), { scrollbarMinSize: 10 });
+}
+
+function test_options_classNames() {
+    new SimpleBar(document.getElementById('myElement'), {
+        classNames: {
+            // defaults
+            content: 'simplebar-content',
+            scrollContent: 'simplebar-scroll-content',
+            scrollbar: 'simplebar-scrollbar',
+            track: 'simplebar-track'
+        }
+    });
+}
+
+function test_recalculate() {
+    const el = new SimpleBar(document.getElementById('myElement'));
+    el.recalculate();
+}
+
+function test_getScrollElement() {
+    const el = new SimpleBar(document.getElementById('myElement'));
+    el.getScrollElement();
+}
+
+function test_scrollEvent() {
+    const el = new SimpleBar(document.getElementById('myElement'));
+    el.getScrollElement().addEventListener('scroll', () => { });
+}
+
+function test_getContentElement() {
+    const el = new SimpleBar(document.getElementById('myElement'));
+    el.getContentElement();
+}
+
+function test_removeObserver() {
+    SimpleBar.removeObserver();
+}

--- a/types/simplebar/v2/test/module-tests.ts
+++ b/types/simplebar/v2/test/module-tests.ts
@@ -1,0 +1,4 @@
+import SimpleBar = require('simplebar');
+
+// $ExpectType typeof SimpleBar
+SimpleBar;

--- a/types/simplebar/v2/tsconfig.json
+++ b/types/simplebar/v2/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "simplebar-tests.ts",
+        "test/module-tests.ts"
+    ]
+}

--- a/types/simplebar/v2/tsconfig.json
+++ b/types/simplebar/v2/tsconfig.json
@@ -9,10 +9,15 @@
         "noImplicitThis": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
-        "baseUrl": "../",
+        "baseUrl": "../../",
         "typeRoots": [
-            "../"
+            "../../"
         ],
+        "paths": {
+            "simplebar": [
+                "simplebar/v2"
+            ]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
@@ -20,6 +25,6 @@
     "files": [
         "index.d.ts",
         "simplebar-tests.ts",
-        "test/module-tests.ts"
+        "../test/module-tests.ts"
     ]
 }

--- a/types/simplebar/v2/tsconfig.json
+++ b/types/simplebar/v2/tsconfig.json
@@ -25,6 +25,6 @@
     "files": [
         "index.d.ts",
         "simplebar-tests.ts",
-        "../test/module-tests.ts"
+        "test/module-tests.ts"
     ]
 }

--- a/types/simplebar/v2/tslint.json
+++ b/types/simplebar/v2/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Hi people, although 'wrapContent' option was removed from v5, I am not sure if creating of v2 folder was necessary, because it wouldn't break existing codebases.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
