### PR TITLE
atom: improve support for v1.40

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -72,6 +72,7 @@ declare let workspaceCenter: Atom.WorkspaceCenter;
 declare let pixelPos: Atom.PixelPosition;
 declare let textEditorElement: Atom.TextEditorElement;
 declare let textEditorComponent: Atom.TextEditorComponent;
+declare let timingMarkers: Atom.TimingMarker[];
 
 // AtomEnvironment ============================================================
 function testAtomEnvironment() {
@@ -161,6 +162,7 @@ function testAtomEnvironment() {
     str = atom.getVersion();
     bool = atom.isReleasedVersion();
     num = atom.getWindowLoadTime();
+    timingMarkers = atom.getStartupMarkers();
     obj = atom.getLoadSettings();
 
     // Managing The Atom Window
@@ -1905,6 +1907,7 @@ function testSelection() {
     selection.setBufferRange([[0, 0], [0, 0]], {});
     selection.setBufferRange(range, { autoscroll: true, preserveFolds: false });
     selection.setBufferRange([pos, pos], { autoscroll: true });
+    selection.setBufferRange(range, { reversed: true });
 
     const [startingRow, endingRow ]: [number, number] = selection.getBufferRowRange();
 
@@ -3343,6 +3346,8 @@ function testWorkspace() {
 
     panel = atom.workspace.addModalPanel({ item: element });
     panel = atom.workspace.addModalPanel({ item: element, priority: 100, visible: true });
+    panel = atom.workspace.addModalPanel({ item: element, autoFocus: element });
+    panel = atom.workspace.addModalPanel({ item: element, autoFocus: () => element });
 
     const potentialPanel = atom.workspace.panelForItem(element);
     if (potentialPanel) {

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -139,6 +139,9 @@ export interface AtomEnvironment {
     /** Get the time taken to completely load the current window. */
     getWindowLoadTime(): number;
 
+    /** Get the all the markers with the information about startup time. */
+    getStartupMarkers(): TimingMarker[];
+
     /** Get the load settings for the current window. */
     getLoadSettings(): WindowLoadSettings;
 
@@ -2972,7 +2975,7 @@ export interface Workspace {
         item: T,
         visible?: boolean,
         priority?: number,
-        autoFocus?: boolean,
+        autoFocus?: boolean | FocusableHTMLElement,
     }): Panel<T>;
 
     /**
@@ -4670,6 +4673,7 @@ export interface Selection {
 
     /** Modifies the buffer Range for the selection. */
     setBufferRange(bufferRange: RangeCompatible, options?: {
+        reversed?: boolean,
         preserveFolds?: boolean,
         autoscroll?: boolean,
     }): void;
@@ -5243,7 +5247,10 @@ export class TextBuffer {
     /** Determine whether the buffer is empty. */
     isEmpty(): boolean;
 
-    /** Get the entire text of the buffer. */
+    /**
+     *  Get the entire text of the buffer. Avoid using this unless you know that
+     *  the buffer's text is reasonably short.
+     */
     getText(): string;
 
     /** Get the text in a range. */
@@ -6103,7 +6110,7 @@ export interface ConfigValues {
      */
     "core.fileSystemWatcher": "native"|"experimental"|"poll"|"atom";
 
-    /** Experimental: Use the new Tree-sitter parsing system for supported languages. */
+    /** Use the new Tree-sitter parsing system for supported languages. */
     "core.useTreeSitterParsers": boolean;
 
     /**
@@ -6407,7 +6414,7 @@ export interface CopyMarkerOptions {
      */
     exclusive?: boolean;
 
-    /** -DEPRECATED- Custom properties to be associated with the marker. */
+    /** Custom properties to be associated with the marker. */
     properties?: object;
 }
 
@@ -6861,6 +6868,14 @@ export interface JQueryCompatible<Element extends Node = HTMLElement> extends It
     jquery: string;
 }
 
+/**
+ *  The type used by the `focus-trap` library to target a specific DOM node.
+ *
+ *  A DOM node, a selector string (which will be passed to `document.querySelector()`
+ *  to find the DOM node), or a function that returns a DOM node.
+ */
+export type FocusableHTMLElement = HTMLElement | string | { (): HTMLElement };
+
 /** The types usable when constructing a point via the Point::fromObject method. */
 export type PointCompatible = PointLike|[number, number];
 
@@ -7079,6 +7094,11 @@ export interface TextChange {
     newText: string;
     oldText: string;
     start: Point;
+}
+
+export interface TimingMarker {
+    label: string;
+    time: number;
 }
 
 /** Result returned by `Grammar.tokenizeLine`. */


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [Documentation](https://flight-manual.atom.io/api/v1.40.0/AtomEnvironment/)
  - [Release Page](https://github.com/atom/atom/releases/tag/v1.40.0)
  - [AtomEnvironment.getStartupMarkers](https://flight-manual.atom.io/api/v1.40.0/AtomEnvironment/#instance-getStartupMarkers)
  - [Selection.setBufferRange](https://flight-manual.atom.io/api/v1.40.0/Selection/#instance-setBufferRange)
  - [focus-trap Parameter Types](https://github.com/davidtheclark/focus-trap#Usage)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This is a brief followup to pull request #42549, which bumped the definition version to v1.40. This includes all public API changes not included by that pull request.