### PR TITLE
Improved meteor/universe:i18n typings.

### DIFF
--- a/types/meteor-universe-i18n/index.d.ts
+++ b/types/meteor-universe-i18n/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for non-npm package https://github.com/vazco/meteor-universe-i18n 1.14
 // Project: meteor-universe-i18n
 // Definitions by: Mathias Scherer <https://github.com/mathewmeconry>
+//                 Radosław Miernik <https://github.com/radekmie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.7
 

--- a/types/meteor-universe-i18n/index.d.ts
+++ b/types/meteor-universe-i18n/index.d.ts
@@ -9,12 +9,17 @@
 /// <reference types="node" />
 
 // tslint:disable-next-line no-single-declare-module
-declare module "meteor/universe:i18n" {
-    import { OutgoingHttpHeaders } from "http";
+declare module 'meteor/universe:i18n' {
+    import { OutgoingHttpHeaders } from 'http';
 
     namespace i18n {
         // component functions
-        function createComponent(translator?: Translator, locale?: string, reactjs?: React.ReactInstance, type?: any): new () => React.Component<ReactComponentProps>;
+        function createComponent(
+            translator?: Translator,
+            locale?: string,
+            reactjs?: React.ReactInstance,
+            type?: any,
+        ): new () => React.Component<ReactComponentProps>;
 
         // translator functions
         function createTranslator(namespace: string, options?: TranslaterOptions): Translator;
@@ -89,7 +94,7 @@ declare module "meteor/universe:i18n" {
         string, // numberTypographic
         number, // decimal
         string, // currency
-        [number] | [number, number] // groupNumberBY
+        [number] | [number, number], // groupNumberBY
     ];
 
     interface i18nOptions {

--- a/types/meteor-universe-i18n/index.d.ts
+++ b/types/meteor-universe-i18n/index.d.ts
@@ -40,7 +40,7 @@ declare module 'meteor/universe:i18n' {
         function getTranslations(namespace: string, locale?: string): string[];
 
         // options
-        var options: Readonly<i18nOptions>;
+        let options: Readonly<i18nOptions>;
         function setOptions(options: Partial<i18nOptions>): void;
 
         // number operations
@@ -58,7 +58,7 @@ declare module 'meteor/universe:i18n' {
         function runWithLocale(locale: string, func: (...keys: any[]) => void): void;
 
         // language getters
-        var _locales: Readonly<{ [locale: string]: Readonly<i18nLocaleEntry> }>;
+        let _locales: Readonly<{ [locale: string]: Readonly<i18nLocaleEntry> }>;
         function getLanguages(type?: 'code' | 'name' | 'nativeNames'): string[];
         function getLanguageName(locale?: string): string;
         function getLanguageNativeName(locale?: string): string;

--- a/types/meteor-universe-i18n/index.d.ts
+++ b/types/meteor-universe-i18n/index.d.ts
@@ -33,8 +33,9 @@ declare module "meteor/universe:i18n" {
         function __(...key: string[]): string;
         function getTranslations(namespace: string, locale?: string): string[];
 
-        // options setter
-        function setOptions(options: i18nOptions): void;
+        // options
+        var options: Readonly<i18nOptions>;
+        function setOptions(options: Partial<i18nOptions>): void;
 
         // number operations
         function parseNumber(number: string, locale?: string): string;
@@ -51,6 +52,7 @@ declare module "meteor/universe:i18n" {
         function runWithLocale(locale: string, func: (...keys: any[]) => void): void;
 
         // language getters
+        var _locales: Readonly<{ [locale: string]: Readonly<i18nLocaleEntry> }>;
         function getLanguages(type?: 'code' | 'name' | 'nativeNames'): string[];
         function getLanguageName(locale?: string): string;
         function getLanguageNativeName(locale?: string): string;
@@ -62,6 +64,7 @@ declare module "meteor/universe:i18n" {
         // others
         function isRTL(locale?: string): boolean;
         function getAllKeysForLocale(locale?: string, excactlyThis?: boolean): string[];
+        function normalize(locale: string): string | undefined;
 
         // events
         function onChangeLocale(callback: (locale: string) => void): void;
@@ -77,15 +80,26 @@ declare module "meteor/universe:i18n" {
         _containerType?: string;
     }
 
+    type i18nLocaleEntry = [
+        string, // code
+        string, // name
+        string, // localName
+        boolean, // isRTL
+        string, // numberTypographic
+        number, // decimal
+        string, // currency
+        [number] | [number, number] // groupNumberBY
+    ];
+
     interface i18nOptions {
-        defaultLocale?: string;
-        open?: string;
-        close?: string;
+        defaultLocale: string;
+        open: string;
+        close: string;
         purify?: () => void;
-        hideMissing?: boolean;
-        hostUrl?: string;
+        hideMissing: boolean;
+        hostUrl: string;
         translationsHeaders?: OutgoingHttpHeaders;
-        sameLocaleOnServerConnection?: boolean;
+        sameLocaleOnServerConnection: boolean;
     }
 
     interface GetTranslationParams {

--- a/types/meteor-universe-i18n/meteor-universe-i18n-tests.ts
+++ b/types/meteor-universe-i18n/meteor-universe-i18n-tests.ts
@@ -102,6 +102,8 @@ i18n.getAllKeysForLocale();
 i18n.getAllKeysForLocale('de-CH');
 i18n.getAllKeysForLocale('de-CH', true);
 
+i18n.normalize('en');
+
 i18n.onChangeLocale((newLocale: string) => {
     console.log(newLocale);
 });

--- a/types/meteor-universe-i18n/meteor-universe-i18n-tests.ts
+++ b/types/meteor-universe-i18n/meteor-universe-i18n-tests.ts
@@ -24,12 +24,12 @@ i18n.addTranslation('en-US', 'Common.ok', 'Ok');
 
 i18n.addTranslations('en-US', {
     Common: {
-        hello: 'Hello {$name} {$0}!'
-    }
+        hello: 'Hello {$name} {$0}!',
+    },
 });
 
 i18n.addTranslations('en-US', 'Common', {
-    hello: 'Hello {$name} {$0}!'
+    hello: 'Hello {$name} {$0}!',
 });
 i18n.__('foo');
 i18n.__('foo', { _locale: 'de-CH', _namespace: 'test' });
@@ -51,7 +51,7 @@ i18n.setOptions({
 
     // cleanups untrust/unknown tags, to secure your application against XSS attacks.
     // at browser side, default policy is to sanitize strings as a PCDATA
-    purify: () => { }, // On server side as a default option is that nothing is purifying (but you can provide function for that);
+    purify: () => {}, // On server side as a default option is that nothing is purifying (but you can provide function for that);
 
     // decides whether to show when there's no translation in the current and default language
     hideMissing: false,
@@ -64,7 +64,7 @@ i18n.setOptions({
     translationsHeaders: { 'Cache-Control': 'max-age=2628000' },
 
     // synchronizes server connection with locale on client. (method invoked by client will be with client side locale);
-    sameLocaleOnServerConnection: true
+    sameLocaleOnServerConnection: true,
 });
 
 i18n.parseNumber('7013217.715'); // 7,013,217.715


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/vazco/meteor-universe-i18n/blob/77899915ddbbaec96d8d7358b92c7d1a39acfb6e/lib/i18n.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

I just added a few missing properties. I couldn't run the tests because of the `Cannot find module 'csstype'.` error. Also, these typings were kind of old and using prettier on it changed quite a few lines as well.