### PR TITLE
Improved meteor/mongo typings.

### DIFF
--- a/types/meteor/globals/mongo.d.ts
+++ b/types/meteor/globals/mongo.d.ts
@@ -1,3 +1,4 @@
+import { Collection as MongoCollection, Db as MongoDb } from 'mongodb';
 // Based on https://github.com/microsoft/TypeScript/issues/28791#issuecomment-443520161
 declare type UnionOmit<T, K extends keyof any> = T extends T ? Pick<T, Exclude<keyof T, K>> : never;
 
@@ -164,8 +165,8 @@ declare module Mongo {
             transform?: Function | null;
         }): T | undefined;
         insert(doc: OptionalId<T>, callback?: Function): string;
-        rawCollection(): any;
-        rawDatabase(): any;
+        rawCollection(): MongoCollection<T>;
+        rawDatabase(): MongoDb;
         remove(selector: Selector<T> | ObjectID | string, callback?: Function): number;
         update(selector: Selector<T> | ObjectID | string, modifier: Modifier<T>, options?: {
             multi?: boolean;

--- a/types/meteor/index.d.ts
+++ b/types/meteor/index.d.ts
@@ -14,6 +14,7 @@
 //                 Per Bergland <https://github.com/perbergland>
 //                 Nicusor Chiciuc <https://github.com/nicu-chiciuc>
 //                 Evan Broder <https://github.com/ebroder>
+//                 Radosław Miernik <https://github.com/radekmie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.7
 

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -1,3 +1,4 @@
+import { Collection as MongoCollection, Db as MongoDb } from 'mongodb';
 import { Meteor } from 'meteor/meteor';
 declare module "meteor/mongo" {
     // Based on https://github.com/microsoft/TypeScript/issues/28791#issuecomment-443520161
@@ -166,8 +167,8 @@ declare module "meteor/mongo" {
                 transform?: Function | null;
             }): T | undefined;
             insert(doc: OptionalId<T>, callback?: Function): string;
-            rawCollection(): any;
-            rawDatabase(): any;
+            rawCollection(): MongoCollection<T>;
+            rawDatabase(): MongoDb;
             remove(selector: Selector<T> | ObjectID | string, callback?: Function): number;
             update(selector: Selector<T> | ObjectID | string, modifier: Modifier<T>, options?: {
                 multi?: boolean;

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -45,13 +45,20 @@ var Monkeys = new Mongo.Collection<MonkeyDAO>('monkeys');
 
 /**
  * From Core, Meteor.startup section
- * Tests Meteor.isServer, Meteor.startup, Collection.insert(), Collection.find()
+ * Tests Meteor.isServer, Meteor.startup, Collection.insert(), Collection.find(), Collection.rawCollection()
  */
 if (Meteor.isServer) {
     Meteor.startup(function () {
         if (Rooms.find().count() === 0) {
             Rooms.insert({ name: "Initial room" });
         }
+
+        Rooms.rawDatabase().stats().then(
+            stats => console.log('stats', stats),
+            error => console.error('stats', error)
+        );
+
+        Rooms.rawCollection().aggregate([{$group: {_id: null, names: {$addToSet: '$name'}}}]).toArray().then();
     });
 }
 

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -59,13 +59,20 @@ var Monkeys = new Mongo.Collection<MonkeyDAO>('monkeys');
 
 /**
  * From Core, Meteor.startup section
- * Tests Meteor.isServer, Meteor.startup, Collection.insert(), Collection.find()
+ * Tests Meteor.isServer, Meteor.startup, Collection.insert(), Collection.find(), Collection.rawCollection()
  */
 if (Meteor.isServer) {
     Meteor.startup(function () {
         if (Rooms.find().count() === 0) {
             Rooms.insert({ name: "Initial room" });
         }
+
+        Rooms.rawDatabase().stats().then(
+            stats => console.log('stats', stats),
+            error => console.error('stats', error)
+        );
+
+        Rooms.rawCollection().aggregate([{$group: {_id: null, names: {$addToSet: '$name'}}}]).toArray().then();
     });
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.meteor.com/api/collections.html#Mongo-Collection-rawCollection
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

I couldn't run the tests because of the `Cannot find module 'csstype'.` error.