### PR TITLE
Fix typings of express-mysql-session

### DIFF
--- a/types/express-mysql-session/express-mysql-session-tests.ts
+++ b/types/express-mysql-session/express-mysql-session-tests.ts
@@ -1,4 +1,6 @@
-import MySQLStore = require('express-mysql-session');
+import * as mysqlSession from 'express-mysql-session'
+
+const MySQLStore = mysqlSession(session)
 
 const options = {
     host: 'localhost',

--- a/types/express-mysql-session/express-mysql-session-tests.ts
+++ b/types/express-mysql-session/express-mysql-session-tests.ts
@@ -1,13 +1,14 @@
-import * as mysqlSession from 'express-mysql-session'
+import * as mysqlSession from 'express-mysql-session';
+import * as session from 'express-session';
 
-const MySQLStore = mysqlSession(session)
+const MySQLStore = mysqlSession(session);
 
 const options = {
     host: 'localhost',
     port: 3306,
     user: 'root',
     password: '',
-    database: 'session_test'
+    database: 'session_test',
 };
 
 const sessionStore = new MySQLStore(options);

--- a/types/express-mysql-session/index.d.ts
+++ b/types/express-mysql-session/index.d.ts
@@ -8,7 +8,7 @@ import * as expressSession from 'express-session'
 
 export = MySQLStore;
 
-declare function MySQLStore(session: typeof expressSession): typeof MySQLStore
+declare function MySQLStore(session: typeof expressSession): typeof MySQLStoreClass
 
 
 declare namespace MySQLStore {
@@ -35,7 +35,7 @@ declare namespace MySQLStore {
     }
 }
 
-declare class MySQLStore {
+declare class MySQLStoreClass {
     constructor(options: MySQLStore.Options, connection?: any, callback?: (error: any) => void);
 
     setDefaultOptions(): void;

--- a/types/express-mysql-session/index.d.ts
+++ b/types/express-mysql-session/index.d.ts
@@ -1,9 +1,15 @@
-// Type definitions for express-mysql-session 1.2
+// Type definitions for express-mysql-session 2.1
 // Project: https://github.com/chill117/express-mysql-session#readme
-// Definitions by: Akim95 <https://github.com/Akim95>
+// Definitions by: Akim95 <https://github.com/Akim95> Sebastian Krüger <https://github.com/mathe42>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="express-session" />
+
+import * as expressSession from 'express-session'
 
 export = MySQLStore;
+
+declare function MySQLStore(session: typeof expressSession): typeof MySQLStore
+
 
 declare namespace MySQLStore {
     interface Options {

--- a/types/express-mysql-session/index.d.ts
+++ b/types/express-mysql-session/index.d.ts
@@ -1,15 +1,13 @@
 // Type definitions for express-mysql-session 2.1
 // Project: https://github.com/chill117/express-mysql-session#readme
-// Definitions by: Akim95 <https://github.com/Akim95> Sebastian Krüger <https://github.com/mathe42>
+// Definitions by: Akim95 <https://github.com/Akim95>, Sebastian Krüger <https://github.com/mathe42>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-/// <reference types="express-session" />
 
-import * as expressSession from 'express-session'
+import * as expressSession from 'express-session';
 
 export = MySQLStore;
 
-declare function MySQLStore(session: typeof expressSession): typeof MySQLStoreClass
-
+declare function MySQLStore(session: typeof expressSession): typeof MySQLStoreClass;
 
 declare namespace MySQLStore {
     interface Options {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/express-mysql-session
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


If you look at the docs of 1.2 https://www.npmjs.com/package/express-mysql-session/v/1.2.3 it has the same API as now. So this is a fix of the old typings.