### PR TITLE
[codemirror] Add addon display/autorefresh

### DIFF
--- a/types/codemirror/addon/comment/comment.d.ts
+++ b/types/codemirror/addon/comment/comment.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for CodeMirror
+// Type definitions for codemirror
 // Project: https://github.com/marijnh/CodeMirror
 // Definitions by: Nikolaj Kappler <https://github.com/nkappler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/codemirror/addon/display/autorefresh.d.ts
+++ b/types/codemirror/addon/display/autorefresh.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for CodeMirror
+// Project: https://github.com/marijnh/CodeMirror
+// Definitions by: mtgto <https://github.com/mtgto>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// See docs https://codemirror.net/doc/manual.html#addon_autorefresh
+
+import * as CodeMirror from "codemirror";
+
+declare module "codemirror" {
+    interface EditorConfiguration {
+        // if true, it will be refreshed the first time the editor becomes visible.
+        // you can pass delay (msec) time as polling duration
+        autoRefresh?: boolean | { delay: number };
+    }
+}

--- a/types/codemirror/addon/display/panel.d.ts
+++ b/types/codemirror/addon/display/panel.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for CodeMirror
+// Type definitions for codemirror
 // Project: https://github.com/marijnh/CodeMirror
 // Definitions by: Nikolaj Kappler <https://github.com/nkappler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/codemirror/addon/edit/closebrackets.d.ts
+++ b/types/codemirror/addon/edit/closebrackets.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for CodeMirror
+// Type definitions for codemirror
 // Project: https://github.com/codemirror/CodeMirror
 // Definitions by: ficristo <https://github.com/ficristo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/codemirror/addon/edit/closetag.d.ts
+++ b/types/codemirror/addon/edit/closetag.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for CodeMirror
+// Type definitions for codemirror
 // Project: https://github.com/codemirror/CodeMirror
 // Definitions by: ficristo <https://github.com/ficristo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/codemirror/addon/edit/matchbrackets.d.ts
+++ b/types/codemirror/addon/edit/matchbrackets.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for CodeMirror
+// Type definitions for codemirror
 // Project: https://github.com/marijnh/CodeMirror
 // Definitions by: Sixin Li <https://github.com/sixinli>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/codemirror/addon/edit/matchtags.d.ts
+++ b/types/codemirror/addon/edit/matchtags.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for CodeMirror
+// Type definitions for codemirror
 // Project: https://github.com/codemirror/CodeMirror
 // Definitions by: ficristo <https://github.com/ficristo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/codemirror/addon/hint/show-hint.d.ts
+++ b/types/codemirror/addon/hint/show-hint.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for CodeMirror
+// Type definitions for codemirror
 // Project: https://github.com/marijnh/CodeMirror
 // Definitions by: jacqt <https://github.com/jacqt>
 //                 basarat <https://github.com/basarat>

--- a/types/codemirror/addon/runmode/runmode.d.ts
+++ b/types/codemirror/addon/runmode/runmode.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for CodeMirror
+// Type definitions for codemirror
 // Project: https://github.com/marijnh/CodeMirror
 // Definitions by: Joseph Vaughan <https://github.com/Joev->
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/codemirror/addon/scroll/scrollpastend.d.ts
+++ b/types/codemirror/addon/scroll/scrollpastend.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for CodeMirror
+// Type definitions for codemirror
 // Project: https://github.com/codemirror/CodeMirror
 // Definitions by: ficristo <https://github.com/ficristo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/codemirror/addon/search/match-highlighter.d.ts
+++ b/types/codemirror/addon/search/match-highlighter.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for CodeMirror
+// Type definitions for codemirror
 // Project: https://github.com/codemirror/CodeMirror
 // Definitions by: ficristo <https://github.com/ficristo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/codemirror/addon/search/searchcursor.d.ts
+++ b/types/codemirror/addon/search/searchcursor.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for CodeMirror
+// Type definitions for codemirror
 // Project: https://github.com/marijnh/CodeMirror
 // Definitions by: jacqt <https://github.com/jacqt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/codemirror/addon/selection/active-line.d.ts
+++ b/types/codemirror/addon/selection/active-line.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for CodeMirror
+// Type definitions for codemirror
 // Project: https://github.com/codemirror/CodeMirror
 // Definitions by: ficristo <https://github.com/ficristo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/codemirror/addon/tern/tern.d.ts
+++ b/types/codemirror/addon/tern/tern.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for CodeMirror
+// Type definitions for codemirror
 // Project: https://github.com/marijnh/CodeMirror
 // Definitions by: Nikolaj Kappler <https://github.com/nkappler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for CodeMirror
+// Type definitions for codemirror
 // Project: https://github.com/marijnh/CodeMirror
 // Definitions by: mihailik <https://github.com/mihailik>
 //                 nrbernard <https://github.com/nrbernard>

--- a/types/codemirror/test/addon/display/autorefresh.ts
+++ b/types/codemirror/test/addon/display/autorefresh.ts
@@ -1,0 +1,6 @@
+import * as CodeMirror from "codemirror";
+import "codemirror/addon/display/autorefresh";
+
+const myCodeMirror: CodeMirror.Editor = CodeMirror(document.body, {
+    autoRefresh: true
+});

--- a/types/codemirror/tsconfig.json
+++ b/types/codemirror/tsconfig.json
@@ -22,6 +22,7 @@
         "test/index.ts",
         "test/addon/comment/comment.ts",
         "test/addon/display/panel.ts",
+        "test/addon/display/autorefresh.ts",
         "test/addon/edit/closebrackets.ts",
         "test/addon/edit/closetag.ts",
         "test/addon/edit/matchbrackets.ts",


### PR DESCRIPTION
Reopen #42457

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://codemirror.net/doc/manual.html#addon_autorefresh
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

----

```
@azoson
Can we make this property nullable? 🤔
This source assigns null to the cm.state.autoRefresh like following:

    if (cm.state.autoRefresh) {
      stopListening(cm, cm.state.autoRefresh)
      cm.state.autoRefresh = null
    } 

Do you know whether is this assignment allowed to addon users?

@mtgto
Document says autoRefresh is optional param either true or { delay: xxx (msec) } object.
Implementation of autorefresh addons, you notice, is nullable.
But, IMO, we should not be nullable because doc does not mention it can be null.
```
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42457#discussion_r381398509