### PR TITLE
feat(gremlin): Add `hasNext` and `[Symbol.asyncIterator]` to `Traversal`

### DIFF
--- a/types/gremlin/gremlin-tests.ts
+++ b/types/gremlin/gremlin-tests.ts
@@ -143,6 +143,7 @@ function processTests() {
   TextP.startingWith();
 
   traversal.getBytecode();
+  traversal.hasNext();
   traversal.iterate();
   traversal.next();
   traversal.toList();

--- a/types/gremlin/gremlin-tests.ts
+++ b/types/gremlin/gremlin-tests.ts
@@ -312,3 +312,12 @@ function dslTests() {
   g.V().where(__.hasNotLabel('test'));
   g.V().aged(33);
 }
+
+async function asyncIteratorTest() {
+  const t = new process.Traversal(null, null, new Bytecode());
+
+  // tslint:disable-next-line: await-promise Bug in tslint: https://github.com/palantir/tslint/issues/3997
+  for await (const v of t) {
+    v;
+  }
+}

--- a/types/gremlin/index.d.ts
+++ b/types/gremlin/index.d.ts
@@ -127,9 +127,10 @@ declare namespace process {
     constructor(graph: Nullable<Graph>, traversalStrategies: Nullable<TraversalStrategies>, bytecode: Bytecode);
     // [asyncIteratorSymbol: symbol | SymbolConstructor](): Traversal; // How can I implement this?
     getBytecode(): Bytecode;
-    toList(): Promise<Traverser[]>;
+    hasNext(): Promise<boolean>;
     iterate(): Promise<void>;
     next(): Promise<{ value: any; done: boolean; }>;
+    toList(): Promise<Traverser[]>;
     toString(): string;
   }
 

--- a/types/gremlin/index.d.ts
+++ b/types/gremlin/index.d.ts
@@ -123,15 +123,15 @@ declare namespace process {
     static startingWith(...args: any[]): TextP;
   }
 
-  class Traversal {
+  class Traversal implements AsyncIterableIterator<any> {
     constructor(graph: Nullable<Graph>, traversalStrategies: Nullable<TraversalStrategies>, bytecode: Bytecode);
-    // [asyncIteratorSymbol: symbol | SymbolConstructor](): Traversal; // How can I implement this?
     getBytecode(): Bytecode;
     hasNext(): Promise<boolean>;
     iterate(): Promise<void>;
-    next(): Promise<{ value: any; done: boolean; }>;
+    next(): Promise<IteratorResult<any>>;
     toList(): Promise<Traverser[]>;
     toString(): string;
+    [Symbol.asyncIterator](): AsyncIterableIterator<any>;
   }
 
   class TraversalSideEffects {}

--- a/types/gremlin/tsconfig.json
+++ b/types/gremlin/tsconfig.json
@@ -3,7 +3,8 @@
         "module": "commonjs",
         "target": "es6",
         "lib": [
-            "es6"
+            "es6",
+            "esnext.asynciterable"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Adds `hasNext` which is a great utility for checking whether an element exists or not.

Also completes the definition started by @matt-sungwook for `[Symoblic.asyncIterator]` support that enables `for-await-of` usage with query results.

Thanks @peterblazejewicz for the pointer toward `consumable-streams` async tests, that showed that the issue I was running into with the linter, while writing tests for the async iterator, was in fact a known bug with TSLint.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [[Symbolic.asyncIterator]](https://github.com/apache/tinkerpop/blob/aab3b4c694196176471b7c8386f262d5502b7447/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js#L44), [hasNext](https://github.com/apache/tinkerpop/blob/aab3b4c694196176471b7c8386f262d5502b7447/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js#L72)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
