### PR TITLE
Make cache-manager tests strictNullChecks safe

### DIFF
--- a/types/cache-manager/cache-manager-tests.ts
+++ b/types/cache-manager/cache-manager-tests.ts
@@ -49,10 +49,11 @@ memoryCache.wrap<{ id: number, name: string }>(key, (cb: any) => {
     });
 });
 
-memoryCache.store.keys().then((result) => {
-
-    //console.log(result);
-});
+if (memoryCache.store.keys) {
+    memoryCache.store.keys().then((result) => {
+        //console.log(result);
+    });
+}
 
 const multiCache = cacheManager.multiCaching([memoryCache]);
 


### PR DESCRIPTION
The new Store code in cache-manager wasn't strictNullChecks safe, which caused problems because a community member enabled strictNullChecks in most packages during the review period for #42554.

This change just fixes the tests, although the optional methods on Store are a bit suspicious. From skimming cache-manager's documentation, I couldn't figure out if having the methods be optional was accurate.