### PR TITLE
[@ember/component] make `helper` type-safe

### DIFF
--- a/types/ember__component/helper.d.ts
+++ b/types/ember__component/helper.d.ts
@@ -1,31 +1,42 @@
-import EmberObject from "@ember/object";
+import EmberObject from '@ember/object';
 
 /**
  * Ember Helpers are functions that can compute values, and are used in templates.
  * For example, this code calls a helper named `format-currency`:
  */
-export default class Helper extends EmberObject {
+export default class Helper<T = unknown> extends EmberObject {
     /**
      * In many cases, the ceremony of a full `Ember.Helper` class is not required.
      * The `helper` method create pure-function helpers without instances. For
-     * example:
+     * example: *
+     * ```app/helpers/format-currency.js
+     * import { helper } from '@ember/component/helper';
+     * export default helper(function(params, hash) {
+     *   let cents = params[0];
+     *   let currency = hash.currency;
+     *   return `${currency}${cents * 0.01}`;
+     * });
+     * ```
      */
-    static helper(helper: (params: any[], hash?: object) => any): Helper;
+    helper<Fn extends (params: any[]) => T>(helperFn: Fn): Fn;
+    helper<Fn extends (params: any[], hash: { [key: string]: any }) => T>(helperFn: Fn): Fn;
     /**
      * Override this function when writing a class-based helper.
      */
-    compute(params: any[], hash: object): any;
+    compute<Fn extends (params: any[]) => T>(helperFn: Fn): Fn;
+    compute<Fn extends (params: any[], hash: { [key: string]: any }) => T>(helperFn: Fn): Fn;
     /**
      * On a class-based helper, it may be useful to force a recomputation of that
      * helpers value. This is akin to `rerender` on a component.
      */
-    recompute(): any;
+    recompute(): T;
 }
 
 /**
  * In many cases, the ceremony of a full `Helper` class is not required.
  * The `helper` method create pure-function helpers without instances. For
  * example:
+ *
  * ```app/helpers/format-currency.js
  * import { helper } from '@ember/component/helper';
  * export default helper(function(params, hash) {
@@ -35,4 +46,5 @@ export default class Helper extends EmberObject {
  * });
  * ```
  */
-export function helper(helperFn: (params: any[], hash?: any) => any): any;
+export function helper<Fn extends (params: any[]) => any>(helperFn: Fn): Fn;
+export function helper<Fn extends (params: any[], hash: { [key: string]: any }) => any>(helperFn: Fn): Fn;

--- a/types/ember__component/index.d.ts
+++ b/types/ember__component/index.d.ts
@@ -1,8 +1,11 @@
 // Type definitions for non-npm package @ember/component 3.0
 // Project: https://emberjs.com/api/ember/3.4/modules/@ember%2Fcomponent
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 /// <reference types="jquery" />
 

--- a/types/ember__component/test/helper.ts
+++ b/types/ember__component/test/helper.ts
@@ -1,4 +1,3 @@
-import { assertType } from './lib/assert';
 import Helper, { helper } from '@ember/component/helper';
 
 class Timestamp extends Helper {
@@ -16,10 +15,17 @@ class Timestamp extends Helper {
     }
 }
 
+// $ExpectType<([a, b]: number[]) => number>
 const addHelper = helper(function add([a, b]: number[]) {
     return a + b;
 });
 
-const dasherizeHelper = helper(function dasherize([str]: string[], { delim = '-'}) {
+// $ExpectType<([str]: string[], { delim }: { delim: string | undefined }) => string>
+const dasherizeHelper = helper(function dasherize([str]: string[], { delim = '-' }) {
     return str.split(/[\s\n\_\.]+/g).join(delim);
 });
+
+type Resolved<T> = T extends Promise<infer U> ? U : T;
+declare const resolve: <T>([promise]: Array<Promise<T>>) => Resolved<T>;
+
+helper(resolve); // $ExpectType<<T>([promise]: Array<Promise<T>>) => Resolved<T>>


### PR DESCRIPTION
This doesn't have a large impact *today*, since most uses of helpers are in templates which are not type-checked, but it *will* be useful in the future and is useful for tests.

This bumps minimum TS version to 3.0 to support `unknown`; this is *well* within Typed Ember's standard support policy of latest-two-TS-versions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - <https://api.emberjs.com/ember/3.16/functions/@ember%2Fcomponent%2Fhelper/helper>
    - <https://api.emberjs.com/ember/3.16/classes/Helper>