### PR TITLE
[serverless] Add getAccountId method on AwsProvider

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -8,6 +8,7 @@ declare class Aws {
     getRegion(): string;
     getServerlessDeploymentBucketName(): string;
     getStage(): string;
+    getAccountId(): Promise<string>;
     request(
         service: string,
         method: string,


### PR DESCRIPTION
Added AwsProvider.getAccountId() for use in plugin code.
Note: I did not add any tests, since there's nothing much to verify than just the method call (the functionality is already tested within the serverless library).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/serverless/serverless/blob/master/lib/plugins/aws/provider/awsProvider.js#L543-L545
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.