### PR TITLE
feat(morgan): update morgan to v 1.9

### DIFF
--- a/types/morgan/index.d.ts
+++ b/types/morgan/index.d.ts
@@ -1,16 +1,20 @@
-// Type definitions for morgan 1.7
+// Type definitions for morgan 1.9
 // Project: https://github.com/expressjs/morgan
 // Definitions by: James Roland Cabresos <https://github.com/staticfunction>
 //                 Paolo Scanferla <https://github.com/pscanf>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 import express = require('express');
 
 declare namespace morgan {
     type FormatFn = (tokens: TokenIndexer, req: express.Request, res: express.Response) => string | undefined | null;
 
-    type TokenCallbackFn = (req: express.Request, res: express.Response, arg?: string | number | boolean) => string;
+    type TokenCallbackFn = (
+        req: express.Request,
+        res: express.Response,
+        arg?: string | number | boolean,
+    ) => string | undefined;
 
     interface TokenIndexer {
         [tokenName: string]: TokenCallbackFn;
@@ -134,6 +138,7 @@ declare namespace morgan {
         /***
          * Buffer duration before writing logs to the stream, defaults to false.
          * When set to true, defaults to 1000 ms.
+         * @deprecated
          */
         buffer?: boolean;
 

--- a/types/morgan/morgan-tests.ts
+++ b/types/morgan/morgan-tests.ts
@@ -15,36 +15,38 @@ morgan('tiny');
 morgan(':remote-addr :method :url');
 
 morgan('combined', {
-  buffer: true,
-  immediate: true,
-  skip: (req, res) => res.statusCode < 400,
-  stream: {
-    write: (str: string) => {
-      console.log(str);
-    }
-  }
+    buffer: true,
+    immediate: true,
+    skip: (req, res) => res.statusCode < 400,
+    stream: {
+        write: (str: string) => {
+            console.log(str);
+        },
+    },
 });
 
 // a custom format function
 morgan((tokens, req, res) => {
-  return [
-    tokens.method(req, res),
-    tokens.url(req, res),
-    tokens.status(req, res),
-    tokens.res(req, res, 'content-length'), '-',
-    tokens['response-time'](req, res), 'ms'
-  ].join(' ');
+    return [
+        tokens.method(req, res),
+        tokens.url(req, res),
+        tokens.status(req, res),
+        tokens.res(req, res, 'content-length'),
+        '-',
+        tokens['response-time'](req, res),
+        'ms',
+    ].join(' ');
 });
 // a custom format function with options
-morgan((_tokens, _req, _res) => "", {
-  buffer: true,
-  immediate: true,
-  skip: (req, res) => res.statusCode < 400,
-  stream: {
-    write: (str: string) => {
-      console.log(str);
-    }
-  }
+morgan((_tokens, _req, _res) => '', {
+    buffer: true,
+    immediate: true,
+    skip: (req, res) => res.statusCode < 400,
+    stream: {
+        write: (str: string) => {
+            console.log(str);
+        },
+    },
 });
 
 // test interface definition for morgan
@@ -57,35 +59,46 @@ morgan.format('tiny-extended', ':method :url :status :res[content-length] - :res
 // extend morgan.FormatFn interface with memoizer property to avoid unnecessary re-compiling
 // of status-code range driven colorized format functions
 interface FormatFnIndexer {
-  [memoizerName: string]: morgan.FormatFn;
+    [memoizerName: string]: morgan.FormatFn;
 }
 
 interface ExtendedFormatFn extends morgan.FormatFn {
-  memoizer: FormatFnIndexer;
+    memoizer: FormatFnIndexer;
 }
 
 const developmentExtendedFormatLine = ((tokens, req, res): string | undefined | null => {
-  // get the status code if response written
-  const status = res.statusCode;
+    // get the status code if response written
+    const status = res.statusCode;
 
-  // get status color
-  const color = status >= 500 ? 31 // red
-    : status >= 400 ? 33 // yellow
-    : status >= 300 ? 36 // cyan
-    : status >= 200 ? 32 // green
-    : 0; // no color
+    // get status color
+    const color =
+        status >= 500
+            ? 31 // red
+            : status >= 400
+            ? 33 // yellow
+            : status >= 300
+            ? 36 // cyan
+            : status >= 200
+            ? 32 // green
+            : 0; // no color
 
-  // get colored format function, if previously memoized, otherwise undefined
-  let fn: morgan.FormatFn | undefined = developmentExtendedFormatLine.memoizer[color];
+    // get colored format function, if previously memoized, otherwise undefined
+    let fn: morgan.FormatFn | undefined = developmentExtendedFormatLine.memoizer[color];
 
-  if (!fn) {
-    // compile
-    fn = developmentExtendedFormatLine.memoizer[color] = morgan.compile(`\x1b[0m:method :url \x1b[${color}m:status \x1b[0m:response-time ms - :res[content-length]\x1b[0m :user-agent`);
-  }
+    if (!fn) {
+        // compile
+        fn = developmentExtendedFormatLine.memoizer[color] = morgan.compile(
+            `\x1b[0m:method :url \x1b[${color}m:status \x1b[0m:response-time ms - :res[content-length]\x1b[0m :user-agent`,
+        );
+    }
 
-  return fn(tokens, req, res);
+    return fn(tokens, req, res);
 }) as ExtendedFormatFn;
 
 developmentExtendedFormatLine.memoizer = {};
 
 morgan.format('dev-extended', developmentExtendedFormatLine);
+
+morgan.token('status', (req, res) => {
+    return res.headersSent ? String(res.statusCode) : undefined;
+});


### PR DESCRIPTION
This is minor update:
- version bump
- `TokenCallbackFn` return type redefinition to allow returning
`undefined`:
https://github.com/expressjs/morgan/commit/03765069ec594f60cdaadac0fafb3473fe72074e
- deprecate `buffer` option:
https://github.com/expressjs/morgan/commit/dafb4cd0682f95ab069c7a266303709054a1f40d
- reformat code

Thanks!