### PR TITLE
[amqp-connection-manager] Improve SetupFunc

### DIFF
--- a/types/amqp-connection-manager/index.d.ts
+++ b/types/amqp-connection-manager/index.d.ts
@@ -59,7 +59,7 @@ export interface AmqpConnectionManagerOptions {
  */
 export function connect(urls: string[], options?: AmqpConnectionManagerOptions): AmqpConnectionManager;
 
-export type SetupFunc = ((channel: ConfirmChannel, callback: (error?: Error) => void) => void) | ((channel: ConfirmChannel) => Promise<void>);
+export type SetupFunc = (channel: ConfirmChannel, callback?: (error?: Error) => void) => Promise<any> | void;
 
 export interface CreateChannelOpts {
 	/**


### PR DESCRIPTION
This PR simplifies and somewhat improves `SetupFunc` type although this still does not fully exclude a possibility of a programmer error.

- Previously, compiler would accept, e.g. following code:

```typescript
const channelWrapper = connection.createChannel({
    setup: (channel: ConfirmChannel) => 1
});
```

and after this PR: `Type 'number' is not assignable to type 'void | Promise<any>'`

- Previously compiler required explicitly specifying `(channel: ConfirmChannel)`, but now user can omit `ConfirmChannel`, e.g.:

```typescript
const channelWrapper = connection.createChannel({
    setup: channel =>
        Promise.all([
            channel.assertQueue(queueName),
            channel.prefetch(1)
        ])
});
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/benbria/node-amqp-connection-manager/blob/6b512e8a84453ea8ff860bc0f3ce8615000f005a/src/ChannelWrapper.js#L20
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.