### PR TITLE
fix: [@types/aws-lambda] add missing prop clientMetadata to CognitoUserPoolTriggerEvent

### DIFF
--- a/types/aws-lambda/test/cognito-tests.ts
+++ b/types/aws-lambda/test/cognito-tests.ts
@@ -55,6 +55,7 @@ const handler: CognitoUserPoolTriggerHandler = async (event, context, callback) 
     str = event.request.privateChallengeParameters!['answer'];
     str = event.request.challengeAnswer!;
     strOrUndefined = event.request.password;
+    str = event.request.clientMetadata!['action'];
     boolOrUndefined = event.response.answerCorrect;
     strOrUndefined = event.response.smsMessage;
     strOrUndefined = event.response.emailMessage;

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger.d.ts
@@ -65,6 +65,7 @@ export interface CognitoUserPoolTriggerEvent {
         privateChallengeParameters?: { [key: string]: string };
         challengeAnswer?: string;
         password?: string;
+        clientMetadata?: { [key: string]: string };
     };
     response: {
         autoConfirmUser?: boolean;


### PR DESCRIPTION
Add missing prop `clientMetadata` to `CognitoUserPoolTriggerEvent`.

See https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html#cognito-user-pools-lambda-trigger-syntax-custom-message

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html#cognito-user-pools-lambda-trigger-syntax-custom-message
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
