### PR TITLE
[@types/chrome] Added 'silent' option to the chrome package (chrome.notification / NotificationOptions)

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -9,6 +9,7 @@
 //                 ekinsol <https://github.com/ekinsol>
 //                 Thierry Régagnon <https://github.com/tregagnon>
 //                 Brian Wilson <https://github.com/echoabstract>
+//                 Sebastiaan Pasma <https://github.com/spasma>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -4508,6 +4509,12 @@ declare namespace chrome.notifications {
          * @since Chrome 50
          */
         requireInteraction?: boolean;
+        /**
+         * Optional.
+         * Indicates that no sounds or vibrations should be made when the notification is being shown. This defaults to false.
+         * @since Chrome 70
+         */
+        silent?: boolean;
     }
 
     export interface NotificationClosedEvent extends chrome.events.Event<(notificationId: string, byUser: boolean) => void> { }


### PR DESCRIPTION
While working on transferring some old code from plain javascript to TypeScript, I found out that the 'silent' option was missing in the @types/chrome package.

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://developer.chrome.com/apps/notifications
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
