### PR TITLE
Added type definitions for react-mapbox-gl-geocoder

### DIFF
--- a/types/react-mapbox-gl-geocoder/index.d.ts
+++ b/types/react-mapbox-gl-geocoder/index.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for react-mapbox-gl-geocoder1.1
+// Project: https://github.com/groinder/react-mapbox-gl-geocoder/
+// Definitions by: Addis Rengel Sempertegui <https://github.com/LuaXD>
+// Definitions:    Definitely Typed <https://github.com/DefinitelyTyped>
+// TypeScript Version: 3.0
+
+import * as React from 'react';
+
+export default class Geocoder extends React.Component<GeocoderProps> {
+  debounceTimeout: any;
+  state: any;
+  getDerivedStateFromProps(nextProps: any, state: any) : any;
+  onChange(event: any) : void;
+  onSelected(item: any) : void;
+  showResults() : void;
+  hideResults() : void;
+}
+export interface GeocoderProps  {
+    timeout: number,
+    queryParams: object,
+    viewport: object,
+    onSelected: Function,
+    transitionDuration: number,
+    hideOnSelect: boolean,
+    pointZoom: number,
+    mapboxApiAccessToken: string,
+    formatItem: Function,
+    className: string,
+    inputComponent: Function,
+    itemComponent: Function,
+    limit: number,
+    localGeocoder: Function,
+    localOnly: boolean,
+    updateInputOnSelect: boolean,
+    initialInputValue: string
+}
+
+

--- a/types/react-mapbox-gl-geocoder/test/react-map-gl-geocoder-tests.tsx
+++ b/types/react-mapbox-gl-geocoder/test/react-map-gl-geocoder-tests.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import Geocoder from 'react-mapbox-gl-geocoder';
+import ReactMapGL from 'react-map-gl';
+
+const mapAccess: any = {
+    mapboxApiAccessToken: "pk.test"
+};
+
+const mapStyle: any = {
+    width: '100%',
+    height: 600
+};
+
+const queryParams: any = {
+    country: 'us'
+};
+
+class App extends React.Component {
+    state = {
+        viewport: {}
+    };
+
+    onSelected = (viewport: any, item: any) => {
+        this.setState({viewport});
+        console.log('Selected: ', item);
+    }
+
+    render() {
+        const {viewport} = this.state;
+
+        return (
+            <div>
+                <Geocoder
+                    {...mapAccess} onSelected={this.onSelected} viewport={viewport} hideOnSelect={true}
+                    queryParams={queryParams}
+                />
+                <ReactMapGL
+                    {...mapAccess} {...viewport} {...mapStyle}
+                    onViewportChange={(newViewport) => this.setState({viewport: newViewport})}
+                />
+            </div>
+        );
+    }
+}

--- a/types/react-mapbox-gl-geocoder/tsconfig.json
+++ b/types/react-mapbox-gl-geocoder/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+          "es6",
+          "dom"
+      ],
+      "jsx": "react",
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": [
+          "../"
+      ],
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+      "index.d.ts",
+      "test/react-map-gl-geocoder-tests.tsx"
+  ]
+}

--- a/types/react-mapbox-gl-geocoder/tslint.json
+++ b/types/react-mapbox-gl-geocoder/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
