### PR TITLE
chai: Tighten argument types of assert.throw methods.

### DIFF
--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -130,7 +130,7 @@ declare namespace Chai {
     export interface AssertionStatic extends AssertionPrototype {
         prototype: AssertionPrototype;
 
-        new (target: any, message?: string, ssfi?: Function, lockSsfi?: boolean): Assertion;
+        new(target: any, message?: string, ssfi?: Function, lockSsfi?: boolean): Assertion;
 
         // Deprecated properties:
         includeStack: boolean;
@@ -170,8 +170,8 @@ declare namespace Chai {
     }
 
     interface ShouldThrow {
-        (actual: Function, expected?: string|RegExp, message?: string): void;
-        (actual: Function, constructor: Error|Function, expected?: string|RegExp, message?: string): void;
+        (actual: Function, expected?: string | RegExp, message?: string): void;
+        (actual: Function, constructor: Error | Function, expected?: string | RegExp, message?: string): void;
     }
 
     interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
@@ -364,12 +364,12 @@ declare namespace Chai {
 
     interface Keys {
         (...keys: string[]): Assertion;
-        (keys: ReadonlyArray<any>|Object): Assertion;
+        (keys: ReadonlyArray<any> | Object): Assertion;
     }
 
     interface Throw {
-        (expected?: string|RegExp, message?: string): Assertion;
-        (constructor: Error|Function, expected?: string|RegExp, message?: string): Assertion;
+        (expected?: string | RegExp, message?: string): Assertion;
+        (constructor: Error | Function, expected?: string | RegExp, message?: string): Assertion;
     }
 
     interface RespondTo {
@@ -1170,7 +1170,7 @@ declare namespace Chai {
          * @param fn   Function that may throw.
          * @param message   Message to display on error.
          */
-        throw(fn: Function, message?: string): void;
+        throw(fn: () => void, message?: string): void;
 
         /**
          * Asserts that function will throw an error with message matching regexp.
@@ -1179,7 +1179,7 @@ declare namespace Chai {
          * @param regExp   Potential expected message match.
          * @param message   Message to display on error.
          */
-        throw(fn: Function, regExp: RegExp): void;
+        throw(fn: () => void, regExp: RegExp): void;
 
         /**
          * Asserts that function will throw an error that is an instance of constructor.
@@ -1188,7 +1188,7 @@ declare namespace Chai {
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
          */
-        throw(fn: Function, constructor: Function, message?: string): void;
+        throw(fn: () => void, constructor: ErrorConstructor, message?: string): void;
 
         /**
          * Asserts that function will throw an error that is an instance of constructor
@@ -1198,7 +1198,7 @@ declare namespace Chai {
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
          */
-        throw(fn: Function, constructor: Function, regExp: RegExp): void;
+        throw(fn: () => void, constructor: ErrorConstructor, regExp: RegExp): void;
 
         /**
          * Asserts that fn will throw an error.
@@ -1206,7 +1206,7 @@ declare namespace Chai {
          * @param fn   Function that may throw.
          * @param message   Message to display on error.
          */
-        throws(fn: Function, message?: string): void;
+        throws(fn: () => void, message?: string): void;
 
         /**
          * Asserts that function will throw an error with message matching regexp.
@@ -1215,7 +1215,7 @@ declare namespace Chai {
          * @param errType  Potential expected message match or error constructor.
          * @param message   Message to display on error.
          */
-        throws(fn: Function, errType: RegExp|Function, message?: string): void;
+        throws(fn: () => void, errType: RegExp | ErrorConstructor, message?: string): void;
 
         /**
          * Asserts that function will throw an error that is an instance of constructor
@@ -1225,7 +1225,7 @@ declare namespace Chai {
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
          */
-        throws(fn: Function, errType: Function, regExp: RegExp): void;
+        throws(fn: () => void, constructor: ErrorConstructor, regExp: RegExp): void;
 
         /**
          * Asserts that fn will throw an error.
@@ -1233,7 +1233,7 @@ declare namespace Chai {
          * @param fn   Function that may throw.
          * @param message   Message to display on error.
          */
-        Throw(fn: Function, message?: string): void;
+        Throw(fn: () => void, message?: string): void;
 
         /**
          * Asserts that function will throw an error with message matching regexp.
@@ -1242,7 +1242,7 @@ declare namespace Chai {
          * @param regExp   Potential expected message match.
          * @param message   Message to display on error.
          */
-        Throw(fn: Function, regExp: RegExp): void;
+        Throw(fn: () => void, regExp: RegExp): void;
 
         /**
          * Asserts that function will throw an error that is an instance of constructor.
@@ -1251,7 +1251,7 @@ declare namespace Chai {
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
          */
-        Throw(fn: Function, errType: Function, message?: string): void;
+        Throw(fn: () => void, constructor: ErrorConstructor, message?: string): void;
 
         /**
          * Asserts that function will throw an error that is an instance of constructor
@@ -1261,7 +1261,7 @@ declare namespace Chai {
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
          */
-        Throw(fn: Function, errType: Function, regExp: RegExp): void;
+        Throw(fn: () => void, constructor: ErrorConstructor, regExp: RegExp): void;
 
         /**
          * Asserts that fn will not throw an error.
@@ -1269,7 +1269,7 @@ declare namespace Chai {
          * @param fn   Function that may throw.
          * @param message   Message to display on error.
          */
-        doesNotThrow(fn: Function, message?: string): void;
+        doesNotThrow(fn: () => void, message?: string): void;
 
         /**
          * Asserts that function will throw an error with message matching regexp.
@@ -1278,7 +1278,7 @@ declare namespace Chai {
          * @param regExp   Potential expected message match.
          * @param message   Message to display on error.
          */
-        doesNotThrow(fn: Function, regExp: RegExp): void;
+        doesNotThrow(fn: () => void, regExp: RegExp): void;
 
         /**
          * Asserts that function will throw an error that is an instance of constructor.
@@ -1287,7 +1287,7 @@ declare namespace Chai {
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
          */
-        doesNotThrow(fn: Function, errType: Function, message?: string): void;
+        doesNotThrow(fn: () => void, constructor: ErrorConstructor, message?: string): void;
 
         /**
          * Asserts that function will throw an error that is an instance of constructor
@@ -1297,7 +1297,7 @@ declare namespace Chai {
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
          */
-        doesNotThrow(fn: Function, errType: Function, regExp: RegExp): void;
+        doesNotThrow(fn: () => void, constructor: ErrorConstructor, regExp: RegExp): void;
 
         /**
          * Compares two values using operator.

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -5,12 +5,13 @@
 //                 Andrew Brown <https://github.com/AGBrown>,
 //                 Olivier Chevet <https://github.com/olivr70>,
 //                 Matt Wistrand <https://github.com/mwistrand>,
-//                 Josh Goldberg <https://github.com/joshuakgoldberg>
-//                 Shaun Luttin <https://github.com/shaunluttin>
-//                 Gintautas Miselis <https://github.com/Naktibalda>
-//                 Satana Charuwichitratana <https://github.com/micksatana>
-//                 Erik Schierboom <https://github.com/ErikSchierboom>
-//                 Bogdan Paranytsia <https://github.com/bparan>
+//                 Josh Goldberg <https://github.com/joshuakgoldberg>,
+//                 Shaun Luttin <https://github.com/shaunluttin>,
+//                 Gintautas Miselis <https://github.com/Naktibalda>,
+//                 Satana Charuwichitratana <https://github.com/micksatana>,
+//                 Erik Schierboom <https://github.com/ErikSchierboom>,
+//                 Bogdan Paranytsia <https://github.com/bparan>,
+//                 CXuesong <https://github.com/CXuesong>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chaijs/chai/blob/8c2b25ca1b722339112522a24a79e530b883d4b2/lib/chai/core/assertions.js#L2635
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
