### PR TITLE
feat(parameterize): add parameterize typings

### DIFF
--- a/types/parameterize/index.d.ts
+++ b/types/parameterize/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for parameterize 1.0
+// Project: https://github.com/fyalavuz/node-parameterize#readme
+// Definitions by: Eduardo Turiño <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = parameterize;
+
+declare function parameterize(s: string, num_chars?: number, delimiter?: string): string;

--- a/types/parameterize/index.d.ts
+++ b/types/parameterize/index.d.ts
@@ -3,4 +3,4 @@
 // Definitions by: Eduardo Turiño <https://github.com/me>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export = function parameterize(s: string, num_chars?: number, delimiter?: string): string;
+export default function parameterize(s: string, num_chars?: number, delimiter?: string): string;

--- a/types/parameterize/index.d.ts
+++ b/types/parameterize/index.d.ts
@@ -3,6 +3,6 @@
 // Definitions by: Eduardo Turiño <https://github.com/me>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export = parameterize;
-
-declare function parameterize(s: string, num_chars?: number, delimiter?: string): string;
+declare module 'parameterize' {
+    export default function parameterize(s: string, num_chars?: number, delimiter?: string): string;
+}

--- a/types/parameterize/index.d.ts
+++ b/types/parameterize/index.d.ts
@@ -3,4 +3,5 @@
 // Definitions by: Eduardo Turiño <https://github.com/me>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export default function parameterize(s: string, num_chars?: number, delimiter?: string): string;
+declare function parameterize(s: string, num_chars?: number, delimiter?: string): string;
+export = parameterize;

--- a/types/parameterize/index.d.ts
+++ b/types/parameterize/index.d.ts
@@ -3,6 +3,4 @@
 // Definitions by: Eduardo Turiño <https://github.com/me>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'parameterize' {
-    export default function parameterize(s: string, num_chars?: number, delimiter?: string): string;
-}
+export = function parameterize(s: string, num_chars?: number, delimiter?: string): string;

--- a/types/parameterize/parameterize-tests.ts
+++ b/types/parameterize/parameterize-tests.ts
@@ -1,4 +1,4 @@
-import parameterize from 'parameterize';
+import parameterize = require('parameterize');
 
 parameterize('asa'); // $ExpectType string
 parameterize('aeda', 12); // $ExpectType string

--- a/types/parameterize/parameterize-tests.ts
+++ b/types/parameterize/parameterize-tests.ts
@@ -1,4 +1,4 @@
-const parameterize = require('parameterize');
+import parameterize = require('parameterize');
 
 parameterize('asa'); // $ExpectType string
 parameterize('aeda', 12); // $ExpectType string

--- a/types/parameterize/parameterize-tests.ts
+++ b/types/parameterize/parameterize-tests.ts
@@ -1,0 +1,5 @@
+import parameterize from 'parameterize';
+
+parameterize('asa'); // $ExpectType string
+parameterize('aeda', 12); // $ExpectType string
+parameterize('aeda', 12, '_'); // $ExpectType string

--- a/types/parameterize/parameterize-tests.ts
+++ b/types/parameterize/parameterize-tests.ts
@@ -1,4 +1,4 @@
-import parameterize = require('parameterize');
+const parameterize = require('parameterize');
 
 parameterize('asa'); // $ExpectType string
 parameterize('aeda', 12); // $ExpectType string

--- a/types/parameterize/tsconfig.json
+++ b/types/parameterize/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parameterize-tests.ts"
+    ]
+}

--- a/types/parameterize/tslint.json
+++ b/types/parameterize/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
