### PR TITLE
Fix libxmljs Document.find overloads

### DIFF
--- a/types/libxmljs/index.d.ts
+++ b/types/libxmljs/index.d.ts
@@ -77,7 +77,8 @@ export class Document {
     childNodes(): Element[];
     encoding(): string;
     encoding(enc: string): this;
-    find(xpath: string): Element[];
+    find(xpath: string, ns_uri?: string): Element[];
+    find(xpath: string, namespaces: StringMap): Element[];
     get(xpath: string, namespaces?: StringMap): Element|null;
     node(name: string, content?: string): Element;
     root(): Element|null;

--- a/types/libxmljs/index.d.ts
+++ b/types/libxmljs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Libxmljs 0.18
+// Type definitions for Libxmljs 0.19
 // Project: https://github.com/libxmljs/libxmljs
 // Definitions by: François de Campredon <https://github.com/fdecampredon>
 //                 ComFreek <https://github.com/ComFreek>

--- a/types/libxmljs/index.d.ts
+++ b/types/libxmljs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Libxmljs 0.19
+// Type definitions for Libxmljs 0.18
 // Project: https://github.com/libxmljs/libxmljs
 // Definitions by: François de Campredon <https://github.com/fdecampredon>
 //                 ComFreek <https://github.com/ComFreek>

--- a/types/libxmljs/libxmljs-tests.ts
+++ b/types/libxmljs/libxmljs-tests.ts
@@ -20,6 +20,32 @@ const child = children[0] as libxmljs.Element;
 
 console.log(child.attr('foo')!.value()); // prints "bar"
 
+// find by namespace
+
+const nsXml = `<?xml version="1.0" encoding="UTF-8"?>
+               <office:document-content xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0">
+                 <text:p text:style-name="Heading">Some title</text:p>
+               </office:document-content>`;
+
+const nsXmlDoc = libxmljs.parseXml(nsXml);
+
+const notFound = nsXmlDoc.find('p');
+
+console.log(notFound.length);  // prints 0
+
+const p = nsXmlDoc.find(
+  'xmlns:p',
+  'urn:oasis:names:tc:opendocument:xmlns:text:1.0'
+);
+
+console.log(p[0].text());  // prints "Some title"
+
+const p2 = nsXmlDoc.find('//text:p', {
+  text: 'urn:oasis:names:tc:opendocument:xmlns:text:1.0'
+});
+
+console.log(p2[0].text());  // prints "Some title"
+
 const parser = new libxmljs.SaxParser();
 
 parser.on('startDocument', () => 0);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/libxmljs/libxmljs/blob/6ccce9e37d14e36c00a84238ff1a93200ae09779/lib/document.js#L37
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
