### PR TITLE
update(tar-stream): bump to v2

### DIFF
--- a/types/tar-stream/tar-stream-tests.ts
+++ b/types/tar-stream/tar-stream-tests.ts
@@ -1,15 +1,27 @@
 import tar = require('tar-stream');
+import fs = require('fs');
 
 const pack = tar.pack();
+
+// test method overloading
+pack.entry({ name: 'headers.txt' });
+pack.entry({ name: 'headers.txt' }, 'buffer');
+pack.entry({ name: 'headers.txt' }, Buffer.from('buffer'));
+pack.entry({ name: 'headers.txt' }, err => {
+    pack.finalize();
+});
+pack.entry({ name: 'headers.txt' }, Buffer.from('buffer'), err => {
+    pack.finalize();
+});
 
 // add a file called my-test.txt with the content "Hello World!"
 pack.entry({ name: 'my-test1.txt' }, 'Hello World!');
 
 // add a file called my-stream-test.txt from a stream
-const entry = pack.entry({ name: 'my-test2.txt', size: 11 }, (err) => {
-  // the stream was added
-  // no more entries
-  pack.finalize();
+const entry = pack.entry({ name: 'my-test2.txt', size: 11 }, err => {
+    // the stream was added
+    // no more entries
+    pack.finalize();
 });
 
 entry.write('hello');
@@ -22,23 +34,44 @@ const extract = tar.extract();
 const entries: any = {};
 
 extract.on('entry', (header, stream, next) => {
-  // header is the tar header
-  // stream is the content body (might be an empty stream)
-  // call next when you are done with this entry
-  entries[header.name] = true;
-  stream.on('end', () => {
-    next();
-  });
+    // header is the tar header
+    // stream is the content body (might be an empty stream)
+    // call next when you are done with this entry
+    entries[header.name] = true;
+    stream.on('end', () => {
+        next();
+    });
 
-  stream.resume(); // just auto drain the stream
+    stream.resume(); // just auto drain the stream
 });
 
 extract.on('finish', () => {
-  // all entries read
-  console.assert(entries['my-test1.txt'], "missing entry");
-  console.assert(entries['my-test2.txt'], "missing entry");
-  console.log("Found all entries in extract");
+    // all entries read
+    console.assert(entries['my-test1.txt'], 'missing entry');
+    console.assert(entries['my-test2.txt'], 'missing entry');
+    console.log('Found all entries in extract');
 });
 
 // pipe the pack stream
 pack.pipe(extract);
+
+const path = 'YourTarBall.tar';
+const yourTarball = fs.createWriteStream(path);
+
+// add a file called YourFile.txt with the content "Hello World!"
+pack.entry({ name: 'YourFile.txt' }, 'Hello World!', err => {
+    if (err) throw err;
+    pack.finalize();
+});
+
+// pipe the pack stream to your file
+pack.pipe(yourTarball);
+
+yourTarball.on('close', () => {
+    console.log(path + ' has been written');
+    fs.stat(path, (err, stats) => {
+        if (err) throw err;
+        console.log(stats);
+        console.log('Got file info successfully!');
+    });
+});

--- a/types/tar-stream/v1/index.d.ts
+++ b/types/tar-stream/v1/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for tar-stream 2.1
+// Type definitions for tar-stream 1.6
 // Project: https://github.com/mafintosh/tar-stream
 // Definitions by: Guy Lichtman <https://github.com/glicht>
-//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
 
 /// <reference types="node" />
 
@@ -19,20 +19,8 @@ export interface Headers {
     size?: number;
     mtime?: Date;
     linkname?: string | null;
-    type?:
-        | 'file'
-        | 'link'
-        | 'symlink'
-        | 'character-device'
-        | 'block-device'
-        | 'directory'
-        | 'fifo'
-        | 'contiguous-file'
-        | 'pax-header'
-        | 'pax-global-header'
-        | 'gnu-long-link-path'
-        | 'gnu-long-path'
-        | null;
+    type?: 'file' | 'link' | 'symlink' | 'character-device' | 'block-device' | 'directory' | 'fifo' |
+        'contiguous-file' | 'pax-header' | 'pax-global-header' | 'gnu-long-link-path' | 'gnu-long-path' | null;
     uname?: string;
     gname?: string;
     devmajor?: number;
@@ -40,17 +28,14 @@ export interface Headers {
 }
 
 export interface Pack extends stream.Readable {
-    /**
-     * To create a pack stream use tar.pack() and call pack.entry(header, [callback]) to add tar entries.
-     */
-    entry(headers: Headers, callback?: Callback): stream.Writable;
-    entry(headers: Headers, buffer?: string | Buffer, callback?: Callback): stream.Writable;
+    entry(headers: Headers, buffer?: string | Buffer | Callback, callback?: Callback): stream.Writable;
     finalize(): void;
 }
 
 export interface Extract extends stream.Writable {
+    destroy(error?: Error): void;
     on(event: string, listener: (...args: any[]) => void): this;
-    on(event: 'entry', listener: (headers: Headers, stream: stream.PassThrough, next: () => void) => void): this;
+    on(event: "entry", listener: (headers: Headers, stream: stream.PassThrough, next: () => void) => void): this;
 }
 
 export function extract(opts?: stream.WritableOptions): Extract;

--- a/types/tar-stream/v1/tar-stream-tests.ts
+++ b/types/tar-stream/v1/tar-stream-tests.ts
@@ -1,0 +1,44 @@
+import tar = require('tar-stream');
+
+const pack = tar.pack();
+
+// add a file called my-test.txt with the content "Hello World!"
+pack.entry({ name: 'my-test1.txt' }, 'Hello World!');
+
+// add a file called my-stream-test.txt from a stream
+const entry = pack.entry({ name: 'my-test2.txt', size: 11 }, (err) => {
+  // the stream was added
+  // no more entries
+  pack.finalize();
+});
+
+entry.write('hello');
+entry.write(' ');
+entry.write('world');
+entry.end();
+
+const extract = tar.extract();
+
+const entries: any = {};
+
+extract.on('entry', (header, stream, next) => {
+  // header is the tar header
+  // stream is the content body (might be an empty stream)
+  // call next when you are done with this entry
+  entries[header.name] = true;
+  stream.on('end', () => {
+    next();
+  });
+
+  stream.resume(); // just auto drain the stream
+});
+
+extract.on('finish', () => {
+  // all entries read
+  console.assert(entries['my-test1.txt'], "missing entry");
+  console.assert(entries['my-test2.txt'], "missing entry");
+  console.log("Found all entries in extract");
+});
+
+// pipe the pack stream
+pack.pipe(extract);

--- a/types/tar-stream/v1/tsconfig.json
+++ b/types/tar-stream/v1/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "paths": {
+            "tar-stream": [
+                "tar-stream/v1"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "tar-stream-tests.ts"
+    ]
+}

--- a/types/tar-stream/v1/tslint.json
+++ b/types/tar-stream/v1/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- v1 for backward compatibility
- change Pack.entry to be overloaded definition
- amend tests to reflect changes and add new tests

https://github.com/mafintosh/tar-stream/compare/v1.6.2...v2.1.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.