### PR TITLE
Add just-map-values and just-safe-set types

### DIFF
--- a/types/just-map-values/index.d.ts
+++ b/types/just-map-values/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for just-map-values 1.1
+// Project: https://github.com/angus-c/just#readme
+// Definitions by: Roman Lerchster <https://github.com/wa4-fearless-otter>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function map<O extends {}>(item: O, callback: (value: any, key: string, object: O) => any): {};
+
+export = map;

--- a/types/just-map-values/index.d.ts
+++ b/types/just-map-values/index.d.ts
@@ -3,6 +3,6 @@
 // Definitions by: Roman Lerchster <https://github.com/wa4-fearless-otter>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function map<O extends {}>(item: O, callback: (value: any, key: string, object: O) => any): {};
+declare function map<T extends {}>(item: T, callback: (value: any, key: string, object: T) => any): {};
 
 export = map;

--- a/types/just-map-values/just-map-values-tests.ts
+++ b/types/just-map-values/just-map-values-tests.ts
@@ -1,0 +1,11 @@
+import map = require("just-map-values");
+
+const obj = {foo: {bar: []}};
+
+map(obj, (value) => value); // $ExpectType {}
+map(obj, (value, key, object) => ''); // $ExpectType {}
+
+// Incorrect argument
+map(); // $ExpectError
+map(obj); // $ExpectError
+map(obj, ''); // $ExpectError

--- a/types/just-map-values/tsconfig.json
+++ b/types/just-map-values/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "just-map-values-tests.ts"
+    ]
+}

--- a/types/just-map-values/tslint.json
+++ b/types/just-map-values/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/just-safe-set/index.d.ts
+++ b/types/just-safe-set/index.d.ts
@@ -3,6 +3,6 @@
 // Definitions by: Roman Lerchster <https://github.com/wa4-fearless-otter>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function set(item: any[] | {}, target: string | Symbol | (string | Symbol)[], value: any): boolean;
+declare function set(item: any[] | {}, target: string | symbol | Array<string | symbol>, value: any): boolean;
 
 export = set;

--- a/types/just-safe-set/index.d.ts
+++ b/types/just-safe-set/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for just-safe-set 2.1
+// Project: https://github.com/angus-c/just#readme
+// Definitions by: Roman Lerchster <https://github.com/wa4-fearless-otter>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function set(item: any[] | {}, target: string | string[], value: any): boolean;
+
+export = set;

--- a/types/just-safe-set/index.d.ts
+++ b/types/just-safe-set/index.d.ts
@@ -3,6 +3,6 @@
 // Definitions by: Roman Lerchster <https://github.com/wa4-fearless-otter>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function set(item: any[] | {}, target: string | string[], value: any): boolean;
+declare function set(item: any[] | {}, target: string | Symbol | (string | Symbol)[], value: any): boolean;
 
 export = set;

--- a/types/just-safe-set/just-safe-set-tests.ts
+++ b/types/just-safe-set/just-safe-set-tests.ts
@@ -4,10 +4,10 @@ const arr = ['one', 'two'];
 const obj = {foo: {bar: arr}};
 
 // Pass single `object`.
-set(arr, '0', {}); // $ExpectType any
-set(arr, ['0'], ''); // $ExpectType any
-set(obj, 'foo.bar', 0); // $ExpectType any
-set(obj, 'foo.bar.0', 1); // $ExpectType any
+set(arr, '0', {}); // $ExpectType boolean
+set(arr, ['0'], ''); // $ExpectType boolean
+set(obj, 'foo.bar', 0); // $ExpectType boolean
+set(obj, 'foo.bar.0', 1); // $ExpectType boolean
 
 // Incorrect argument
 set(); // $ExpectError

--- a/types/just-safe-set/just-safe-set-tests.ts
+++ b/types/just-safe-set/just-safe-set-tests.ts
@@ -1,0 +1,22 @@
+import set = require("just-safe-set");
+
+const arr = ['one', 'two'];
+const obj = {foo: {bar: arr}};
+
+// Pass single `object`.
+set(arr, '0', {}); // $ExpectType any
+set(arr, ['0'], ''); // $ExpectType any
+set(obj, 'foo.bar', 0); // $ExpectType any
+set(obj, 'foo.bar.0', 1); // $ExpectType any
+
+// Incorrect argument
+set(); // $ExpectError
+set(obj); // $ExpectError
+set([]); // $ExpectError
+set({}); // $ExpectError
+set(obj, 3); // $ExpectError
+set(obj, [3]); // $ExpectError
+set(false); // $ExpectError
+set(null); // $ExpectError
+set(undefined); // $ExpectError
+set(obj, 'foo.bar'); // $ExpectError

--- a/types/just-safe-set/tsconfig.json
+++ b/types/just-safe-set/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "just-safe-set-tests.ts"
+    ]
+}

--- a/types/just-safe-set/tslint.json
+++ b/types/just-safe-set/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
