### PR TITLE
Remove thislooksfun from list of selenium-webdriver maintainers

### DIFF
--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -8,7 +8,6 @@
 //   Ziyu <https://github.com/oddui>
 //   Johann Wolf <https://github.com/beta-vulgaris>
 //   Aleksey Chemakin <https://github.com/Dzenly>
-//   thislooksfun <https://github.com/thislooksfun>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 


### PR DESCRIPTION
I no longer want to be a maintainer for selenium-webdriver, so I am removing myself from the list.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
