### PR TITLE
Fix types for @tryghost/content-api to match library (@types/tryghost__content-api)

### DIFF
--- a/types/tryghost__content-api/index.d.ts
+++ b/types/tryghost__content-api/index.d.ts
@@ -2,10 +2,10 @@
 // Project: https://github.com/TryGhost/Ghost-SDK/tree/master/packages/content-api
 // Definitions by: Kevin Nguyen <https://github.com/knguyen0125>
 //                 Anton Van Eechaute <https://github.com/antonve>
+//                 Oliver Emery <https://github.com/thrymgjol>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export type ArrayOrValue<T> = T | T[];
-export type Nullable<T> = T | null;
+type Nullable<T> = T | null;
 
 export interface Pagination {
     page: number;
@@ -51,7 +51,7 @@ export interface Twitter {
 
 export interface SocialMedia extends Facebook, Twitter {}
 
-export interface Setting extends Metadata, CodeInjection, SocialMedia {
+export interface Settings extends Metadata, CodeInjection, SocialMedia {
     title?: string;
     description?: string;
     logo?: string;
@@ -105,11 +105,11 @@ export interface PostOrPage extends Identification, Excerpt, CodeInjection, Meta
 
     // Post or Page
     title?: string;
-    html?: string | null;
+    html?: Nullable<string>;
     plaintext?: Nullable<string>;
 
     // Image
-    feature_image?: string | null;
+    feature_image?: Nullable<string>;
     featured?: boolean;
 
     // Dates
@@ -118,7 +118,7 @@ export interface PostOrPage extends Identification, Excerpt, CodeInjection, Meta
     published_at?: Nullable<string>;
 
     // Custom Template for posts and pages
-    custom_template?: string | null;
+    custom_template?: Nullable<string>;
 
     // Post or Page
     page?: boolean;
@@ -135,22 +135,17 @@ export interface PostOrPage extends Identification, Excerpt, CodeInjection, Meta
     canonical_url?: Nullable<string>;
 }
 
-export type GhostData = PostOrPage | Author | Tag | Setting;
+export type GhostData = PostOrPage | Author | Tag | Settings;
 
 export type IncludeParam = 'authors' | 'tags' | 'count.posts';
-
 export type FieldParam = string;
-
 export type FormatParam = 'html' | 'plaintext';
-
 export type FilterParam = string;
-
 export type LimitParam = number | string;
-
 export type PageParam = number;
-
 export type OrderParam = string;
 
+type ArrayOrValue<T> = T | ReadonlyArray<T>;
 export interface Params {
     include?: ArrayOrValue<IncludeParam>;
     fields?: ArrayOrValue<FieldParam>;
@@ -169,30 +164,14 @@ export interface ReadFunction<T> {
     (data: GhostData, options?: Params, memberToken?: Nullable<string>): Promise<T>;
 }
 
-export interface PostObject {
-    posts: PostOrPage[];
+type MetaArray<T> = T[] & {
     meta: { pagination: Pagination };
-}
+};
 
-export interface AuthorsObject {
-    authors: Author[];
-    meta: { pagination: Pagination };
-}
-
-export interface TagsObject {
-    tags: Tag[];
-    meta: { pagination: Pagination };
-}
-
-export interface PagesObject {
-    pages: PostOrPage[];
-    meta: { pagination: Pagination };
-}
-
-export interface SettingsObject {
-    settings: Setting;
-    meta: {};
-}
+export type Posts = MetaArray<PostOrPage>;
+export type Authors = MetaArray<Author>;
+export type Tags = MetaArray<Tag>;
+export type Pages = MetaArray<PostOrPage>;
 
 export interface GhostError {
     errors: Array<{
@@ -218,24 +197,29 @@ export interface GhostContentAPIOptions {
 
 export interface GhostAPI {
     posts: {
-        browse: BrowseFunction<PostObject>;
+        browse: BrowseFunction<Posts>;
         read: ReadFunction<PostOrPage>;
     };
     authors: {
-        browse: BrowseFunction<AuthorsObject>;
+        browse: BrowseFunction<Authors>;
         read: ReadFunction<Author>;
     };
     tags: {
-        browse: BrowseFunction<TagsObject>;
+        browse: BrowseFunction<Tags>;
         read: ReadFunction<Tag>;
     };
     pages: {
-        browse: BrowseFunction<PagesObject>;
+        browse: BrowseFunction<Pages>;
         read: ReadFunction<PostOrPage>;
     };
     settings: {
-        browse: BrowseFunction<SettingsObject>;
+        browse: BrowseFunction<Settings>;
     };
 }
 
-export default function GhostContentAPI(options: GhostContentAPIOptions): GhostAPI;
+declare var GhostContentAPI: {
+    (options: GhostContentAPIOptions): GhostAPI;
+    new (options: GhostContentAPIOptions): GhostAPI;
+};
+
+export default GhostContentAPI;

--- a/types/tryghost__content-api/tryghost__content-api-tests.ts
+++ b/types/tryghost__content-api/tryghost__content-api-tests.ts
@@ -2,11 +2,8 @@ import GhostContentAPI, { PostOrPage } from '@tryghost/content-api';
 
 const api = GhostContentAPI({ url: 'test', version: 'v3', key: '' }); // $ExpectType GhostAPI
 
-let pages: PostOrPage[];
-const pagesBrowsePromise = api.pages.browse(); // $ExpectType Promise<PagesObject>
+const pagesBrowsePromise = api.pages.browse(); // $ExpectType Promise<MetaArray<PostOrPage>>
 
-pagesBrowsePromise.then(pageObject => {
-    pages = pageObject.pages;
-
+pagesBrowsePromise.then(pages => {
     api.pages.read(pages[0], { include: 'authors' }); // $ExpectType Promise<PostOrPage>
 });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [latest](https://github.com/TryGhost/Ghost-SDK/blob/5bfffd3d7d67d1fe908323a88a1ce1bf9788e8c3/packages/content-api/lib/index.js#L91), [version 3](https://github.com/TryGhost/Ghost-SDK/blob/30b6e6e3a11f62526d65ec0e279f9cb4f2a6af64/packages/content-api/lib/index.js#L91), and [version 2](https://github.com/TryGhost/Ghost-SDK/blob/3c167e5917e7a49a0a5fa213a2edd86e084a81a3/packages/content-api/lib/index.js#L91).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

I tried all 3 preceding versions of these type definitions with every version of `@tryghost/content-api` since the definitions were released. Every combination failed with the same errors when I tried to run [the sample code from the Ghost docs](https://ghost.org/docs/api/v2/javascript/content/). I'm a little puzzled because there have been several updates to the type definitions and no one has brought this up. I [put together a quick demo](https://github.com/thrymgjol/ghost-content-api-types-demo/tree/master) just in case there's something I'm completely missing.

The lines I linked to above have remained the same for every version of `@tryghost/content-api` since these type definitions were released:
```js
if (!Array.isArray(res.data[resourceType])) {
    return res.data[resourceType];
}
if (res.data[resourceType].length === 1 && !res.data.meta) {
    return res.data[resourceType][0];
}
return Object.assign(res.data[resourceType], {meta: res.data.meta});
```
In the last statement, the array object is assigned the `meta` property (`SomeObject[] & { meta: { ... } }`), whereas the type definitions give the object the form
```ts
interface PostObject {
    posts: PostOrPage[];
    meta: { pagination: Pagination };
}
```
I received this error no matter which version I tried:
```
error TS2350: Only a void function can be called with the 'new' keyword.
```
or this if I removed `new` ([from the sample code](https://ghost.org/docs/api/v2/javascript/content/))
```
error TS2339: Property 'forEach' does not exist on type 'PostObject'.
```

I resolved both of those errors in these type definitions.
