### PR TITLE
Add new types for mitranim/posterus

### DIFF
--- a/types/posterus/fiber.d.ts
+++ b/types/posterus/fiber.d.ts
@@ -1,0 +1,3 @@
+import { Future } from './index';
+
+export function fiber(iterator: IterableIterator<any>): Future;

--- a/types/posterus/index.d.ts
+++ b/types/posterus/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for posterus 0.4
+// Project: https://github.com/Mitranim/posterus#readme
+// Definitions by: David Govea <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+export class Future<T = any, E extends Error = Error> {
+    static from: <T = any, E extends Error = Error>(result?: T, error?: E) => Future<T, E>;
+    static fromResult: <T = any>(...args: T extends undefined ? [] | [undefined] : [T]) => Future<T>;
+    static fromError: <E extends Error = Error>(error: E) => Future<undefined, E>;
+    static fromPromise: <T>(promise: Promise<T>) => Future<T>;
+    static all: (values: any[]) => Future;
+    static race: (values: any[]) => Future;
+    static onUnhandledRejection: (future: Future) => void;
+    static scheduler: Scheduler;
+
+    map: <U = any, V extends Error = Error>(
+        mapper: (error?: E, result?: T) => U | Promise<U> | Future<U, V>,
+    ) => Future<U, V>;
+    mapResult: <U = any, V extends Error = Error>(mapper: (result: T) => U | Promise<U> | Future<U, V>) => Future<U, V>;
+    mapError: <U = any, V extends Error = Error>(mapper: (error: E) => U | Promise<U> | Future<U, V>) => Future<U, V>;
+    finally: (mapper: (error?: E, result?: T) => any) => Future<T, E>;
+    deinit: () => void;
+    weak: () => Future<T, E>;
+    settle: (error?: E, result?: T) => void;
+    toPromise: () => Promise<T>;
+    then: Promise<T>['then'];
+    catch: Promise<T>['catch'];
+    finishPending: () => void;
+    deref: () => T | undefined;
+}
+
+export class Scheduler {
+    tick(): void;
+    deinit(): void;
+    asap(callback: () => void): void;
+}
+
+export function isFuture(value: any): boolean;
+export function isDeinitError(error: any): boolean;

--- a/types/posterus/posterus-tests.ts
+++ b/types/posterus/posterus-tests.ts
@@ -1,0 +1,30 @@
+import { Future, Scheduler } from 'posterus';
+import { fiber } from 'posterus/fiber';
+
+const anyFuture = new Future();
+anyFuture.settle(undefined, 10);
+anyFuture.settle(undefined, 'foo');
+anyFuture.settle('not an Error'); // $ExpectError
+
+const future = new Future<string>();
+future.settle(undefined, 'result');
+future.settle(undefined, 10); // $ExpectError
+
+const undefinedResult = Future.fromResult();
+
+const futureString = future.mapResult<string>(() => 'result');
+
+const futureWrongType = future.mapResult<string>(() => 9000); // $ExpectError
+
+function* generatorTask() {
+    yield Promise.resolve();
+    return Promise.resolve(10);
+}
+const task = fiber(generatorTask())
+    .mapResult(res => 11)
+    .finally(() => ({}));
+
+Future.scheduler.asap(() => {});
+const scheduler = new Scheduler();
+scheduler.tick();
+scheduler.deinit();

--- a/types/posterus/tsconfig.json
+++ b/types/posterus/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "posterus-tests.ts"
+    ]
+}

--- a/types/posterus/tslint.json
+++ b/types/posterus/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Package: https://github.com/mitranim/posterus

had to disable no-unnecesary-generics to allow optional type specification on the constructor's return value -- could not figure out a way to achieve a type api similar to `Promise` without disabling this rule.

Desired api:
```
const futureAny = new Future();
const futureString = new Future<string>();
```

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
