### PR TITLE
feat(standard-engine): new type definition v12

### DIFF
--- a/types/standard-engine/index.d.ts
+++ b/types/standard-engine/index.d.ts
@@ -1,0 +1,153 @@
+// Type definitions for standard-engine 12.0
+// Project: https://github.com/flet/standard-engine
+// Definitions by: Piotr Błażejewicz (Peter Blazejewicz) <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import eslint = require('eslint');
+import { type } from 'os';
+
+export class Linter {
+    constructor(opts?: LinterOptions);
+    /**
+     * Lint the provided source text to enforce your defined style.
+     * An opts object may be provided
+     */
+    lintTextSync(text: string, opts?: LintTextOptions): eslint.CLIEngine.LintReport;
+    lintText(text: string, opts: LintTextOptions, callback: LintCallback): void;
+    lintText(text: string, callback: LintCallback): void;
+
+    /**
+     * Lint the provided files globs.
+     * An opts object may be provided
+     */
+    lintFiles(files: string | string[], callback: LintCallback): void;
+    lintFiles(files: string | string[], opts: LintFilesOptions | undefined, callback: LintCallback): void;
+}
+
+/**
+ * Construct a type with the properties of T except for those in type K.
+ */
+export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+
+export type PickWithSomeRequired<T, TRequired extends keyof T> = Omit<T, TRequired> & Pick<Required<T>, TRequired>;
+
+export type ParseOptions = PickWithSomeRequired<
+    Options & { eslintConfig: ESLintConfig },
+    'ignore' | 'cwd' | 'fix' | 'eslintConfig'
+>;
+
+export interface LinterOptions {
+    bugs?: string;
+    cmd: string;
+    /** @default process.cwd() */
+    cwd?: string;
+    eslint: typeof eslint;
+    eslintConfig?: ESLintConfig;
+    homepage?: string;
+    /**
+     * This function is called with the current options object (opts),
+     * any options extracted from the project's package.json (packageOpts),
+     * and the directory that contained that package.json file
+     * (rootDir, equivalent to opts.cwd if no file was found).
+     * Modify and return opts, or return a new object with the options that are to be used.
+     */
+    parseOpts?: (opts: ParseOptions, packageOpts: any, rootDir: string) => ParseOptions;
+    tagline?: string;
+    version?: string;
+}
+
+export interface ESLintConfig {
+    /** @default true */
+    cache?: boolean;
+    /** @default  path.join(HOME_OR_TMP, `.${this.cmd}-v${majorVersion}-cache/` */
+    cacheLocation?: string;
+    configFile?: string;
+    /** @default [] */
+    envs?: string[];
+    /** @default false */
+    fix?: boolean;
+    /** @default [] */
+    globals?: string[];
+    /** @default false */
+    ignore?: boolean;
+    /** @default [] */
+    plugins?: string[];
+    /** @default false */
+    useEslintrc?: boolean;
+}
+
+/**
+ * This is the full set of options accepted by the above APIs.
+ * Not all options make sense for each API
+ */
+export interface Options {
+    /**
+     * file globs to ignore
+     * @default []
+     */
+    ignore?: string[];
+    /**
+     * current working directory
+     * @default process.cwd()
+     */
+    cwd?: string;
+    /** path of the file containing the text being linted */
+    filename?: string;
+    /**
+     * automatically fix problems
+     * @default false
+     */
+    fix?: boolean;
+    /**
+     * custom global variables to declare
+     * @default [];
+     */
+    global?: string | string[];
+    /**
+     * custom global variables to declare
+     * @default [];
+     */
+    globals?: string | string[];
+    /**
+     * custom eslint plugins
+     * @default []
+     */
+    plugin?: string | string[];
+    /**
+     * custom eslint plugins
+     * @default []
+     */
+    plugins?: string | string[];
+    /**
+     * custom eslint environment
+     * @default []
+     */
+    env?: string | string[];
+    /**
+     * custom eslint environment
+     * @default []
+     */
+    envs?: string | string[];
+    /** custom js parser (e.g. babel-eslint) */
+    parser?: string;
+}
+
+export interface LintDefaultOptions {
+    /**
+     * use options from nearest package.json?
+     * @default true
+     */
+    usePackageJson?: boolean;
+}
+
+export type LintTextOptions = Exclude<Options, 'ignore' | 'cwd'> & LintDefaultOptions;
+
+export type LintFilesOptions = Exclude<Options, 'cwd' | 'filename'> & LintDefaultOptions;
+
+export type LintCallback = (error: Error | null, results: eslint.CLIEngine.LintReport) => void;
+
+// exported from `standard-engine`
+
+export function cli(opts: LinterOptions): void;
+
+export const linter: typeof Linter;

--- a/types/standard-engine/index.d.ts
+++ b/types/standard-engine/index.d.ts
@@ -6,22 +6,24 @@
 import eslint = require('eslint');
 import { type } from 'os';
 
-export class Linter {
-    constructor(opts?: LinterOptions);
-    /**
-     * Lint the provided source text to enforce your defined style.
-     * An opts object may be provided
-     */
-    lintTextSync(text: string, opts?: LintTextOptions): eslint.CLIEngine.LintReport;
-    lintText(text: string, opts: LintTextOptions, callback: LintCallback): void;
-    lintText(text: string, callback: LintCallback): void;
+declare namespace standardEngine {
+    class Linter {
+        constructor(opts?: LinterOptions);
+        /**
+         * Lint the provided source text to enforce your defined style.
+         * An opts object may be provided
+         */
+        lintTextSync(text: string, opts?: LintTextOptions): eslint.CLIEngine.LintReport;
+        lintText(text: string, opts: LintTextOptions, callback: LintCallback): void;
+        lintText(text: string, callback: LintCallback): void;
 
-    /**
-     * Lint the provided files globs.
-     * An opts object may be provided
-     */
-    lintFiles(files: string | string[], callback: LintCallback): void;
-    lintFiles(files: string | string[], opts: LintFilesOptions | undefined, callback: LintCallback): void;
+        /**
+         * Lint the provided files globs.
+         * An opts object may be provided
+         */
+        lintFiles(files: string | string[], callback: LintCallback): void;
+        lintFiles(files: string | string[], opts: LintFilesOptions | undefined, callback: LintCallback): void;
+    }
 }
 
 /**
@@ -150,4 +152,7 @@ export type LintCallback = (error: Error | null, results: eslint.CLIEngine.LintR
 
 export function cli(opts: LinterOptions): void;
 
-export const linter: typeof Linter;
+export const linter: typeof standardEngine.Linter;
+
+// added to prevent automatic export of standardEngine namespace
+export {};

--- a/types/standard-engine/standard-engine-tests.ts
+++ b/types/standard-engine/standard-engine-tests.ts
@@ -106,4 +106,4 @@ const standardConfig: standardEngine.LinterOptions = {
     tagline: 'Use JavaScript Standard Style',
     version: pkg.version,
 };
-new Linter(standardConfig);
+new Linter(standardConfig); // $ExpectType Linter

--- a/types/standard-engine/standard-engine-tests.ts
+++ b/types/standard-engine/standard-engine-tests.ts
@@ -1,0 +1,109 @@
+/// <reference types="node" />
+import standardEngine = require('standard-engine');
+import { cli, linter as Linter, LinterOptions } from 'standard-engine';
+import path = require('path');
+import eslint = require('eslint');
+
+const pkg = {
+    version: '',
+    homepage: '',
+    bugs: {
+        url: '',
+    },
+};
+
+const defaultOptions: standardEngine.Options = {
+    cwd: process.cwd(),
+    env: 'browser',
+    envs: ['browser', 'mocha'],
+    filename: __filename,
+    fix: true,
+    global: 'myVar0',
+    globals: ['myVar1', 'myVar2'],
+    ignore: ['**/out/', '/lib/select2/', '/lib/ckeditor/', 'tmp.js'],
+    parser: 'babel-eslint',
+    plugin: 'flowtype',
+    plugins: ['flowtype'],
+};
+
+const opts: LinterOptions = {
+    version: pkg.version,
+    homepage: pkg.homepage,
+    bugs: pkg.bugs.url,
+    eslint, // pass any version of eslint >= 1.0.0
+    cmd: 'pocketlint', // should match the "bin" key in your package.json
+    tagline: 'Live by your own standards!', // displayed in output --help
+    eslintConfig: {
+        configFile: path.join(__dirname, 'eslintrc.json'),
+    },
+    parseOpts: (opts, packageOpts, rootDir) => {
+        // provide implementation here, then return the opts object (or a new one)
+        // The following options are provided in the opts object, and must be on the returned object:
+        // ignore: array of file globs to ignore
+        // cwd: string, the current working directory
+        // fix: boolean, whether to automatically fix problems
+        // eslintConfig: object, the options passed to ESLint's CLIEngine
+        opts['ignore']; // $ExpectType string[]
+        opts['cwd']; // $ExpectType string
+        opts['fix']; // $ExpectType boolean
+        opts['eslintConfig']; // $ExpectType ESLintConfig
+        return opts;
+    },
+};
+
+standardEngine.cli(opts);
+cli(opts);
+
+const linter = new Linter(opts);
+linter.lintFiles('main.js', (error, results) => {
+    if (error) {
+        error; // $ExpectType Error
+        return;
+    }
+    error; // $ExpectType null
+    results; // $ExpectType LintReport
+});
+// $ExpectType void
+linter.lintFiles(
+    ['main.js'],
+    {
+        filename: 'main.js',
+        fix: true,
+    },
+    (error, results) => {
+        if (error) {
+            error; // $ExpectType Error
+            return;
+        }
+        error; // $ExpectType null
+        results; // $ExpectType LintReport
+    },
+);
+// $ExpectType void
+linter.lintText('const a = {};', (error, results) => {
+    if (error) {
+        error; // $ExpectType Error
+        return;
+    }
+    error; // $ExpectType null
+    results; // $ExpectType LintReport
+});
+// $ExpectType LintReport
+linter.lintTextSync('const a = {};', {
+    fix: true,
+});
+// $ExpectType LintReport
+linter.lintTextSync('const a = {};');
+
+const standardConfig: standardEngine.LinterOptions = {
+    bugs: pkg.bugs.url,
+    cmd: 'standard',
+    eslint,
+    eslintConfig: {
+        configFile: path.join(__dirname, 'eslintrc.json'),
+    },
+    homepage: pkg.homepage,
+    tagline: 'Use JavaScript Standard Style',
+    version: pkg.version,
+};
+new Linter(standardConfig);

--- a/types/standard-engine/tsconfig.json
+++ b/types/standard-engine/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "standard-engine-tests.ts"
+    ]
+}

--- a/types/standard-engine/tslint.json
+++ b/types/standard-engine/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- type definitions
- tests coverage for day-to-day usage scenarios

https://github.com/standard/standard-engine#readme
https://github.com/standard/standard-engine#usage

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.