### PR TITLE
feat(filing-cabinet): type definitions for v2.5

### DIFF
--- a/types/filing-cabinet/filing-cabinet-tests.ts
+++ b/types/filing-cabinet/filing-cabinet-tests.ts
@@ -1,0 +1,19 @@
+import cabinet = require('filing-cabinet');
+
+const result = cabinet({
+    partial: 'somePartialPath',
+    directory: 'path/to/all/files',
+    filename: 'path/to/parent/file',
+    ast: {},
+    config: 'path/to/requirejs/config',
+    webpackConfig: 'path/to/webpack/config',
+    nodeModulesConfig: {
+        entry: 'module',
+    },
+    tsConfig: 'path/to/typescript/config',
+});
+result; // $ExpectType string
+
+cabinet.register('.scss', (partial, filename, directory, config) => {
+    return `file.scss`;
+});

--- a/types/filing-cabinet/index.d.ts
+++ b/types/filing-cabinet/index.d.ts
@@ -1,0 +1,59 @@
+// Type definitions for filing-cabinet 2.5
+// Project: https://github.com/mrjoelkemp/node-filing-cabinet
+// Definitions by: Piotr Błażejewicz (Peter Blazejewicz) <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace cabinet {
+    interface Options {
+        /** the dependency path */
+        partial: string;
+        /** the path to all files */
+        directory: string;
+        /** the path to the file containing the partial */
+        filename: string;
+        /**
+         * the parsed AST for filename
+         * Useful optimization for avoiding a parse of filename
+         */
+        ast?: any;
+        /**
+         * `requirejs` config for resolving aliased JavaScript modules
+         */
+        config?: any;
+        /**
+         * `webpack` config for resolving aliased JavaScript modules
+         */
+        webpackConfig?: any;
+        /**
+         * config for resolving entry file for `node_modules`.
+         * This value overrides the main attribute in the `package.json` file;
+         * used in conjunction with the `packageFilter` of the resolve package
+         */
+        nodeModulesConfig?: any;
+        /**
+         * Path to a typescript configuration.
+         * Could also be an object representing a pre-parsed typescript config
+         */
+        tsConfig?: string | object;
+        /**
+         * For typescript files, whether to prefer *.js over *.d.ts
+         */
+        noTypeDefinitions?: boolean;
+    }
+
+    type Resolver = (partial: string, filename: string, directory: string, config?: any) => void;
+
+    /**
+     * Register a custom lookup resolver for a file extension
+     * If a given extension does not have a registered resolver,
+     * cabinet will use a generic file resolver which is basically `require('path').join`
+     * with a bit of extension defaulting logic
+     * @param extension the extension of the file that should use the custom resolver (ex: '.py', '.php')
+     * @param resolver  A resolver of partial paths
+     */
+    function register(extension: string, resolver: Resolver): void;
+}
+
+declare function cabinet(options: cabinet.Options): string;
+
+export = cabinet;

--- a/types/filing-cabinet/tsconfig.json
+++ b/types/filing-cabinet/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "filing-cabinet-tests.ts"
+    ]
+}

--- a/types/filing-cabinet/tslint.json
+++ b/types/filing-cabinet/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- type definitions
- tests

https://github.com/dependents/node-filing-cabinet#usage

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.