### PR TITLE
[recompose] allowing for hoc components wrapped with React.ForwardRef

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -14,7 +14,7 @@
 declare module 'recompose' {
 
     import * as React from 'react';
-    import { ComponentType as Component, ForwardRefExoticComponent, ComponentClass, StatelessComponent, ValidationMap, JSXElementConstructor } from 'react';
+    import { ComponentType as Component, ComponentClass, StatelessComponent, ValidationMap, JSXElementConstructor } from 'react';
 
     type mapper<TInner, TOutter> = (input: TInner) => TOutter;
     type predicate<T> = mapper<T, boolean>;

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -14,7 +14,7 @@
 declare module 'recompose' {
 
     import * as React from 'react';
-    import { ComponentType as Component, ForwardRefExoticComponent, ComponentClass, StatelessComponent, ValidationMap } from 'react';
+    import { ComponentType as Component, ForwardRefExoticComponent, ComponentClass, StatelessComponent, ValidationMap, JSXElementConstructor } from 'react';
 
     type mapper<TInner, TOutter> = (input: TInner) => TOutter;
     type predicate<T> = mapper<T, boolean>;
@@ -37,7 +37,7 @@ declare module 'recompose' {
     }
 
     interface ComponentEnhancer<TInner, TOutter> {
-        (component: Component<TInner>): ComponentClass<TOutter> | ForwardRefExoticComponent<TOutter>;
+        (component: JSXElementConstructor<TInner>): JSXElementConstructor<TOutter>;
     }
 
     // Injects props and removes them from the prop requirements.

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -14,7 +14,7 @@
 declare module 'recompose' {
 
     import * as React from 'react';
-    import { ComponentType as Component, ComponentClass, StatelessComponent, ValidationMap } from 'react';
+    import { ComponentType as Component, ForwardRefExoticComponent, ComponentClass, StatelessComponent, ValidationMap } from 'react';
 
     type mapper<TInner, TOutter> = (input: TInner) => TOutter;
     type predicate<T> = mapper<T, boolean>;
@@ -37,7 +37,7 @@ declare module 'recompose' {
     }
 
     interface ComponentEnhancer<TInner, TOutter> {
-        (component: Component<TInner>): ComponentClass<TOutter>;
+        (component: Component<TInner>): ComponentClass<TOutter> | ForwardRefExoticComponent<TOutter>;
     }
 
     // Injects props and removes them from the prop requirements.


### PR DESCRIPTION
Allowing HoCs which wrap the composed component in `React.ForwardRef`

You can check implementation using this example:
https://gist.github.com/OliverJAsh/d2f462b03b3e6c24f5588ca7915d010e

Keep in mind, they defined `ComponentClass` as type of `composedComponent` (line 5), you'll need to change it to `componentType`, remove line 7 completely and modify a few types accordingly.
