### PR TITLE
feat(file-entry-cache): type definition v5.0

### DIFF
--- a/types/file-entry-cache/file-entry-cache-tests.ts
+++ b/types/file-entry-cache/file-entry-cache-tests.ts
@@ -1,0 +1,23 @@
+import fileEntryCache = require('file-entry-cache');
+
+const cache = fileEntryCache.create('testCache');
+fileEntryCache.create('myCaceh', './fixtures', false); // $ExpectType FileEntryCache
+fileEntryCache.createFromFile('./fixtures/data.txt', true); // $ExpectType FileEntryCache
+const files = ['./fixtures/*.txt'];
+let oFiles = cache.getUpdatedFiles(files);
+cache.reconcile();
+const cache2 = fileEntryCache.create('testCache');
+oFiles = cache.getUpdatedFiles(files);
+cache.removeEntry('path/to/file');
+const entries = cache.normalizeEntries(files);
+cache.deleteCacheFile();
+cache.destroy();
+// entry = {
+//   key: 'some/name/file', the path to the file
+//   changed: true, // if the file was changed since previous run
+//   meta: {
+//     size: 3242, // the size of the file
+//     mtime: 231231231, // the modification time of the file
+//     data: {} // some extra field stored for this file (useful to save the result of a transformation on the file
+//   }
+// };

--- a/types/file-entry-cache/index.d.ts
+++ b/types/file-entry-cache/index.d.ts
@@ -1,0 +1,83 @@
+// Type definitions for file-entry-cache 5.0
+// Project: https://github.com/royriojas/file-entry-cache#readme
+// Definitions by: Piotr Błażejewicz (Peter Blazejewicz) <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+/**
+ * @param pathToCache - the path to the cache file (this combines the cache name and directory
+ * @param useCheckSum - Whether to use md5 checksum to verify if file changed.
+ * If false the default will be to use the mtime and size of the file
+ */
+export function createFromFile(pathToCache: string, useCheckSum?: boolean): FileEntryCache;
+
+/**
+ * @param cacheName - the name of the cache to be created
+ * @param directory - the directory to load the cache from
+ * @param usecheckSum - Whether to use md5 checksum to verify if file changed.
+ * If false the default will be to use the mtime and size of the file
+ */
+export function create(cacheName: string, directory?: string, usecheckSum?: boolean): FileEntryCache;
+
+export interface FileEntryCache {
+    /** the flat cache storage used to persist the metadata of the `files */
+    cache: object;
+    /** Given a buffer, calculate md5 hash of its content. */
+    getHash(buffer: Buffer): string;
+    /**  Return whether or not a file has changed since last time reconcile was called */
+    hasFileChanged(file: string): boolean;
+    /**
+     * given an array of file paths it return and object with three arrays:
+     *  - changedFiles: Files that changed since previous run
+     *  - notChangedFiles: Files that haven't change
+     *  - notFoundFiles: Files that were not found, probably deleted
+     */
+    analyzeFiles(files?: string[]): AnalyzedFilesInfo;
+    getFileDescriptor(file: string): FileDescriptor;
+    /**
+     * Return the list o the files that changed compared
+     * against the ones stored in the cache
+     */
+    getUpdatedFiles(files?: string[]): string[];
+    /**
+     * return the list of file
+     */
+    normalizeEntries(files?: string[]): FileDescriptor[];
+    /**
+     * Remove an entry from the file-entry-cache.
+     * Useful to force the file to still be considered
+     * modified the next time the process is run
+     */
+    removeEntry(entryName: string): void;
+    /**
+     * Delete the cache file from the disk
+     */
+    deleteCacheFile(): void;
+    /**
+     * remove the cache from the file and clear the memory cache
+     */
+    destroy(): void;
+    /**
+     * Sync the files and persist them to the cache
+     */
+    reconcile(noPrune?: boolean): void;
+}
+
+export interface AnalyzedFilesInfo {
+    readonly changedFiles: string[];
+    readonly notFoundFiles: string[];
+    readonly notChangedFiles: string[];
+}
+
+export interface FileDescriptor {
+    readonly key: string;
+    readonly notFound: boolean;
+    readonly err?: Error;
+    readonly changed?: boolean;
+    readonly meta?: {
+        readonly size?: number;
+        readonly mtime?: number;
+        readonly hash?: string;
+    };
+}

--- a/types/file-entry-cache/tsconfig.json
+++ b/types/file-entry-cache/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "file-entry-cache-tests.ts"
+    ]
+}

--- a/types/file-entry-cache/tslint.json
+++ b/types/file-entry-cache/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- new type definitions
- tests coverage

https://github.com/royriojas/file-entry-cache#usage

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.