### PR TITLE
feat: @rdfjs/fetch

### DIFF
--- a/types/rdfjs__fetch-lite/index.d.ts
+++ b/types/rdfjs__fetch-lite/index.d.ts
@@ -17,11 +17,11 @@ declare namespace rdfFetch {
     }
 
     interface RdfFetchResponse<Q extends BaseQuad = Quad> extends Response {
-        quadStream(): Stream<Q>;
+        quadStream(): Promise<Stream<Q>>;
     }
 
     interface DatasetResponse<D extends DatasetCore<OutQuad, InQuad>, OutQuad extends BaseQuad = Quad, InQuad extends BaseQuad = OutQuad> extends RdfFetchResponse<OutQuad> {
-        dataset(): D;
+        dataset(): Promise<D>;
     }
 }
 

--- a/types/rdfjs__fetch/index.d.ts
+++ b/types/rdfjs__fetch/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for @rdfjs/fetch 2.0
+// Project: https://github.com/rdfjs-base/fetch
+// Definitions by: tpluscode <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { FormatsInit, RdfFetchResponse, FactoryInit, DatasetResponse } from '@rdfjs/fetch-lite'
+import { DatasetCore, Quad, BaseQuad } from 'rdf-js'
+
+declare function rdfFetch(url: string, options: FormatsInit): Promise<RdfFetchResponse>;
+declare function rdfFetch <D extends DatasetCore<OutQuad, InQuad>, OutQuad extends BaseQuad = Quad, InQuad extends BaseQuad = OutQuad>(
+    url: string,
+    options: FactoryInit<D, OutQuad, InQuad>): Promise<DatasetResponse<D, OutQuad, InQuad>>;
+
+export = rdfFetch;

--- a/types/rdfjs__fetch/index.d.ts
+++ b/types/rdfjs__fetch/index.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: tpluscode <https://github.com/tpluscode>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { FormatsInit, RdfFetchResponse, FactoryInit, DatasetResponse } from '@rdfjs/fetch-lite'
-import { DatasetCore, Quad, BaseQuad } from 'rdf-js'
+import { FormatsInit, RdfFetchResponse, FactoryInit, DatasetResponse } from '@rdfjs/fetch-lite';
+import { DatasetCore, Quad, BaseQuad } from 'rdf-js';
 
 declare function rdfFetch(url: string, options: FormatsInit): Promise<RdfFetchResponse>;
 declare function rdfFetch <D extends DatasetCore<OutQuad, InQuad>, OutQuad extends BaseQuad = Quad, InQuad extends BaseQuad = OutQuad>(

--- a/types/rdfjs__fetch/rdfjs__fetch-tests.ts
+++ b/types/rdfjs__fetch/rdfjs__fetch-tests.ts
@@ -1,0 +1,37 @@
+import fetch = require('@rdfjs/fetch');
+import { SinkMap } from '@rdfjs/sink-map';
+import { Stream, Dataset, Quad, DatasetCoreFactory } from 'rdf-js';
+import { EventEmitter } from 'events';
+
+const formats: {
+    parsers: SinkMap<EventEmitter, Stream>;
+} = <any> {};
+
+async function fetchString(): Promise<string> {
+    const response = await fetch('http://example.com', { formats });
+    return response.text();
+}
+
+async function fetchQuadStream(): Promise<Stream> {
+    const response = await fetch('http://example.com', { formats });
+    return response.quadStream();
+}
+
+interface QuadExt extends Quad {
+    toCanonical(): string;
+}
+
+interface DatasetX extends Dataset<QuadExt> {
+    toCanonical(): string;
+}
+const factory: DatasetCoreFactory<QuadExt, QuadExt, DatasetX> = <any> {};
+
+async function fetchDataset(): Promise<DatasetX> {
+    const response = await fetch('http://example.com', { formats, factory });
+    return response.dataset();
+}
+
+async function fetchTypedStream(): Promise<Stream<QuadExt>> {
+    const response = await fetch('http://example.com', { formats, factory });
+    return response.quadStream();
+}

--- a/types/rdfjs__fetch/tsconfig.json
+++ b/types/rdfjs__fetch/tsconfig.json
@@ -23,6 +23,9 @@
             "@rdfjs/fetch-lite": [
                 "rdfjs__fetch-lite"
             ],
+            "@rdfjs/formats-common": [
+                "rdfjs__formats-common"
+            ],
             "@rdfjs/sink-map": [
                 "rdfjs__sink-map"
             ]

--- a/types/rdfjs__fetch/tsconfig.json
+++ b/types/rdfjs__fetch/tsconfig.json
@@ -1,0 +1,35 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@rdfjs/fetch": [
+                "rdfjs__fetch"
+            ],
+            "@rdfjs/fetch-lite": [
+                "rdfjs__fetch-lite"
+            ],
+            "@rdfjs/sink-map": [
+                "rdfjs__sink-map"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "rdfjs__fetch-tests.ts"
+    ]
+}

--- a/types/rdfjs__fetch/tslint.json
+++ b/types/rdfjs__fetch/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
The `@rdfjs/fetch` package is essentially the same code as `@rdfjs/fetch-lite` with additional dependencies. Hence, I duplicated the unit tests and use the base interfaces imported from the latter

Also updated `@rdfjs/fetch-lite` interfaces according to https://github.com/rdfjs-base/fetch-lite#response

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.