### PR TITLE
fixed domain/range mixup

### DIFF
--- a/types/d3-scale/d3-scale-tests.ts
+++ b/types/d3-scale/d3-scale-tests.ts
@@ -108,8 +108,11 @@ rangeNumbers = linearScaleNumber.range();
 linearScaleString = linearScaleString.range(['steelblue', 'brown']);
 rangeStrings = linearScaleString.range();
 
+// $ExpectError
 linearScaleNumString = linearScaleNumString.range(rangeNumbers);
-rangeNumbers = linearScaleNumString.range();
+
+linearScaleNumString = linearScaleNumString.range(['steelblue', 'brown']);
+domainStrings = linearScaleNumString.range();
 
 // invert(...) -----------------------------------------------------------------
 
@@ -224,8 +227,10 @@ rangeNumbers = powerScaleNumber.range();
 powerScaleString = powerScaleString.range(['steelblue', 'brown']);
 rangeStrings = powerScaleString.range();
 
+// $ExpectError
 powerScaleNumString = powerScaleNumString.range(rangeNumbers);
-rangeNumbers = powerScaleNumString.range();
+powerScaleNumString = powerScaleNumString.range(['steelblue', 'brown']);
+domainStrings = powerScaleNumString.range();
 
 // invert(...) -----------------------------------------------------------------
 
@@ -326,8 +331,10 @@ rangeNumbers = logScaleNumber.range();
 logScaleString = logScaleString.range(['steelblue', 'brown']);
 rangeStrings = logScaleString.range();
 
+// $ExpectError
 logScaleNumString = logScaleNumString.range(rangeNumbers);
-rangeNumbers = logScaleNumString.range();
+logScaleNumString = logScaleNumString.range(['steelblue', 'brown']);
+domainStrings = logScaleNumString.range();
 
 // invert(...) -----------------------------------------------------------------
 
@@ -480,8 +487,11 @@ rangeNumbers = localTimeScaleNumber.range();
 localTimeScaleString = localTimeScaleString.range(['steelblue', 'brown']);
 rangeStrings = localTimeScaleString.range();
 
+// $ExpectError
 localTimeScaleNumString = localTimeScaleNumString.range(rangeNumbers);
-rangeNumbers = localTimeScaleNumString.range();
+
+localTimeScaleNumString = localTimeScaleNumString.range(['steelblue', 'brown']);
+domainStrings = localTimeScaleNumString.range();
 
 // invert(...) -----------------------------------------------------------------
 

--- a/types/d3-scale/index.d.ts
+++ b/types/d3-scale/index.d.ts
@@ -34,7 +34,7 @@ export interface InterpolatorFactory<T, U> {
 /**
  * A helper interface for a continuous scale defined over a numeric domain.
  */
-export interface ScaleContinuousNumeric<Range, Output> {
+export interface ScaleContinuousNumeric<Domain, Range> {
     /**
      * Given a value from the domain, returns the corresponding value from the range, subject to interpolation, if any.
      *
@@ -44,7 +44,7 @@ export interface ScaleContinuousNumeric<Range, Output> {
      *
      * @param value A numeric value from the domain.
      */
-    (value: number | { valueOf(): number }): Output;
+    (value: number | { valueOf(): number }): Range;
 
     /**
      * Given a value from the range, returns the corresponding value from the domain. Inversion is useful for interaction,
@@ -703,7 +703,7 @@ export function scaleIdentity(): ScaleIdentity;
  * If range element and output element type differ, the interpolator factory used with the scale must match this behavior and
  * convert the interpolated range element to a corresponding output element.
  */
-export interface ScaleTime<Range, Output> {
+export interface ScaleTime<Domain, Range> {
     /**
      * Given a value from the domain, returns the corresponding value from the range, subject to interpolation, if any.
      *
@@ -713,7 +713,7 @@ export interface ScaleTime<Range, Output> {
      *
      * @param value A temporal value from the domain. If the value is not a Date, it will be coerced to Date.
      */
-    (value: Date | number | { valueOf(): number }): Output;
+    (value: Date | number | { valueOf(): number }): Range;
 
     /**
      * Given a value from the range, returns the corresponding value from the domain. Inversion is useful for interaction,
@@ -806,7 +806,7 @@ export interface ScaleTime<Range, Output> {
      *
      * @param interpolate An interpolation factory. The generics for Range and Output of the scale must correspond to the interpolation factory applied to the scale.
      */
-    interpolate(interpolate: InterpolatorFactory<Range, Output>): this;
+    interpolate(interpolate: InterpolatorFactory<Domain, Range>): this;
     /**
      * Sets the scale’s range interpolator factory. This interpolator factory is used to create interpolators for each adjacent pair of values from the range;
      * these interpolators then map a normalized domain parameter t in [0, 1] to the corresponding value in the range.
@@ -821,7 +821,7 @@ export interface ScaleTime<Range, Output> {
      *
      * @param interpolate An interpolation factory. The generics for Range and Output of the scale must correspond to the interpolation factory applied to the scale.
      */
-    interpolate<NewOutput>(interpolate: InterpolatorFactory<Range, NewOutput>): ScaleTime<Range, NewOutput>;
+    interpolate<NewOutput>(interpolate: InterpolatorFactory<Domain, NewOutput>): ScaleTime<Domain, NewOutput>;
 
     /**
      * Returns representative dates from the scale’s domain. The returned tick values are uniformly-spaced (mostly),
@@ -968,7 +968,7 @@ export function scaleTime<Output>(): ScaleTime<Output, Output>;
  *
  * The interpolator factory may be set using the interpolate(...) method of the scale.
  */
-export function scaleTime<Range, Output>(): ScaleTime<Range, Output>;
+export function scaleTime<Domain, Range>(): ScaleTime<Domain, Range>;
 
 /**
  * Constructs a new time scale using Coordinated Universal Time (UTC) with the domain [2000-01-01, 2000-01-02], the unit range [0, 1], the default interpolator and clamping disabled.
@@ -1001,7 +1001,7 @@ export function scaleUtc<Output>(): ScaleTime<Output, Output>;
  *
  * The interpolator factory may be set using the interpolate(...) method of the scale.
  */
-export function scaleUtc<Range, Output>(): ScaleTime<Range, Output>;
+export function scaleUtc<Domain, Range>(): ScaleTime<Domain, Range>;
 
 // -------------------------------------------------------------------------------
 // Sequential Scale Factory
@@ -1312,7 +1312,7 @@ export interface ScaleQuantile<Range> {
      *
      * @param domain Array of domain values.
      */
-    domain(domain: Array<number | { valueOf(): number } | null | undefined >): this;
+    domain(domain: Array<number | { valueOf(): number } | null | undefined>): this;
 
     /**
      * Returns the current range.


### PR DESCRIPTION
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://observablehq.com/@d3/d3-scaletime
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

@tomwanzek , @gustavderdrache , @borisyankov , @denisname 

I found this mistake while trying to reproduce the example given at https://observablehq.com/@d3/line-chart

I copied the code and it didn't accept the range:

![image](https://user-images.githubusercontent.com/18500203/75696093-4f6e1980-5cab-11ea-8988-4121a7a8e2a7.png)

The mistake happened because of a copy paste error i suppose:

https://github.com/RSWilli/DefinitelyTyped/blob/e94bac7afa23b5bcc5bfe355111c39c5f97e3f33/types/d3-scale/index.d.ts#L706

https://github.com/DefinitelyTyped/DefinitelyTyped/compare/master...RSWilli:master#diff-96f5ea7516d7157f8457259d7b7a7ac6R37

The generic arguments of the interface were called `<Range, Output>` instead of `<Domain, Range>` like elsewhere in the file

this resulted in a misuse of the Type `Range`, because it referred to the first parameter