### PR TITLE
Add missing definition for moment-timezone

### DIFF
--- a/types/moment-timezone/index.d.ts
+++ b/types/moment-timezone/index.d.ts
@@ -4,6 +4,7 @@
 //                 Alan Brazil Lins <https://github.com/alanblins>
 //                 Agustin Carrasco <https://github.com/asermax>
 //                 Borys Kupar <https://github.com/borys-kupar>
+//                 Justin Rahardjo <https://github.com/justindra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import moment = require('./moment-timezone');

--- a/types/moment-timezone/moment-timezone-tests.ts
+++ b/types/moment-timezone/moment-timezone-tests.ts
@@ -52,6 +52,9 @@ moment.tz(obj, "America/Los_Angeles");
 moment.tz.zone('America/Los_Angeles').abbr(1403465838805);
 moment.tz.zone('America/Los_Angeles').utcOffset(1403465838805);
 
+moment.tz.zonesForCountry('US');
+moment.tz.zonesForCountry('US', { offset: true });
+
 const zone = moment.tz.zone('America/New_York');
 zone.parse(Date.UTC(2012, 2, 19, 8, 30)); // 240
 

--- a/types/moment-timezone/moment-timezone.d.ts
+++ b/types/moment-timezone/moment-timezone.d.ts
@@ -32,6 +32,12 @@ declare module 'moment' {
     (date: any, timezone: string): moment.Moment;
 
     zone(timezone: string): MomentZone | null;
+    /**
+     * Get a list of timezones for some country
+     * @param country The country code
+     * @param options Set offset to true to also get offsets
+     */
+    zonesForCountry(country: string, options?: { offset: boolean }): string[];
 
     add(packedZoneString: string): void;
     add(packedZoneString: string[]): void;


### PR DESCRIPTION
The `zonesForCountry` method definition was missing.

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://momentjs.com/timezone/docs/#/using-timezones/getting-country-zones/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
