### PR TITLE
fix(lodash): No `strict` override

### DIFF
--- a/types/lodash/scripts/tsconfig.json
+++ b/types/lodash/scripts/tsconfig.json
@@ -5,7 +5,6 @@
         "baseUrl": "../..",
         "esModuleInterop": true,
         "noEmit": true,
-        "noImplicitAny": true,
         "pretty": true,
         "strict": true,
         "typeRoots": [

--- a/types/lodash/ts3.1/scripts/tsconfig.json
+++ b/types/lodash/ts3.1/scripts/tsconfig.json
@@ -4,8 +4,7 @@
         "module": "commonjs",
         "baseUrl": "../..",
         "esModuleInterop": true,
-        "noEmit": false,
-        "noImplicitAny": true,
+        "noEmit": true,
         "pretty": true,
         "strict": true,
         "typeRoots": [


### PR DESCRIPTION
There’s no reason to set `"noImplicitAny": true` when `"strict": true` is already set.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/microsoft/dtslint/pull/277>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
