### PR TITLE
Add type definitions for "scrambo"

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
             "_comment": "This will remove husky from when we started migrating to use prettier",
             "pre-commit": "npm uninstall husky"
         }
+    },
+    "dependencies": {
+        "scrambo": "^0.3.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,5 @@
             "_comment": "This will remove husky from when we started migrating to use prettier",
             "pre-commit": "npm uninstall husky"
         }
-    },
-    "dependencies": {
-        "scrambo": "^0.3.0"
     }
 }

--- a/types/scrambo/index.d.ts
+++ b/types/scrambo/index.d.ts
@@ -48,4 +48,4 @@ declare class Scrambo {
     get(number?: number): [string];
 }
 
-export default Scrambo;
+export = Scrambo;

--- a/types/scrambo/index.d.ts
+++ b/types/scrambo/index.d.ts
@@ -1,0 +1,55 @@
+// Type definitions for scrambo 0.3
+// Project: https://github.com/nickcolley/scrambo
+// Definitions by: Christopher Mühl <https://github.com/padarom>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type NNN = '222' | '333' | '444' | '555' | '666' | '777';
+type ScrambleType = NNN | 'clock' | 'minx' | 'pyram' | 'sq1' | 'skewb';
+
+declare class Scrambo {
+    /**
+     * Sets this instance's scrambler type and returns the original instance.
+     * 
+     * @param type
+     */
+    type (type: ScrambleType): Scrambo;
+
+    /**
+     * Returns the currently configured scrambler type.
+     */
+    type (): ScrambleType;
+    
+    /**
+     * Sets this instance's seed and returns the original instance.
+     * 
+     * @param seed
+     */
+    seed (seed: number): Scrambo;
+
+    /**
+     * Returns the current seed type of this scrambler.
+     */
+    seed (): number;
+    
+    /**
+     * Sets this instance's scramble length and returns the original instance.
+     * 
+     * @param length
+     */
+    length (length: number): Scrambo;
+
+    /**
+     * Returns the currently configured scramble length.
+     */
+    length (): number;
+
+    /**
+     * Returns an array of random scrambles with the given length
+     * for the configured scrambler type.
+     * 
+     * @param number defaults to 1
+     */
+    get (number?: number): [string];
+}
+
+export default Scrambo;

--- a/types/scrambo/index.d.ts
+++ b/types/scrambo/index.d.ts
@@ -9,47 +9,43 @@ type ScrambleType = NNN | 'clock' | 'minx' | 'pyram' | 'sq1' | 'skewb';
 declare class Scrambo {
     /**
      * Sets this instance's scrambler type and returns the original instance.
-     * 
      * @param type
      */
-    type (type: ScrambleType): Scrambo;
+    type(type: ScrambleType): Scrambo;
 
     /**
      * Returns the currently configured scrambler type.
      */
-    type (): ScrambleType;
-    
+    type(): ScrambleType;
+
     /**
      * Sets this instance's seed and returns the original instance.
-     * 
      * @param seed
      */
-    seed (seed: number): Scrambo;
+    seed(seed: number): Scrambo;
 
     /**
      * Returns the current seed type of this scrambler.
      */
-    seed (): number;
-    
+    seed(): number;
+
     /**
      * Sets this instance's scramble length and returns the original instance.
-     * 
      * @param length
      */
-    length (length: number): Scrambo;
+    length(length: number): Scrambo;
 
     /**
      * Returns the currently configured scramble length.
      */
-    length (): number;
+    length(): number;
 
     /**
      * Returns an array of random scrambles with the given length
      * for the configured scrambler type.
-     * 
      * @param number defaults to 1
      */
-    get (number?: number): [string];
+    get(number?: number): [string];
 }
 
 export default Scrambo;

--- a/types/scrambo/scrambo-tests.ts
+++ b/types/scrambo/scrambo-tests.ts
@@ -1,4 +1,4 @@
-import Scrambo from 'scrambo';
+import Scrambo = require('scrambo');
 
 (async () => {
     const scrambo = new Scrambo();

--- a/types/scrambo/scrambo-tests.ts
+++ b/types/scrambo/scrambo-tests.ts
@@ -1,0 +1,11 @@
+import Scrambo from 'scrambo';
+
+(async () => {
+    const scrambo = new Scrambo();
+    scrambo.seed(15000);
+
+    const originalType = scrambo.type();
+
+    scrambo.type('minx').length(15).get();
+    scrambo.type(originalType).get(5);
+})();

--- a/types/scrambo/tsconfig.json
+++ b/types/scrambo/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "scrambo-tests.ts"
+    ]
+}

--- a/types/scrambo/tsconfig.json
+++ b/types/scrambo/tsconfig.json
@@ -14,8 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "esModuleInterop": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/scrambo/tsconfig.json
+++ b/types/scrambo/tsconfig.json
@@ -14,7 +14,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",

--- a/types/scrambo/tslint.json
+++ b/types/scrambo/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
