### PR TITLE
[@types/leaflet] Exposed protected _shadow property in Leaflet.Marker class

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1905,6 +1905,8 @@ export class Marker<P = any> extends Layer {
     options: MarkerOptions;
     dragging?: Handler;
     feature?: geojson.Feature<geojson.Point, P>;
+
+    protected _shadow: HTMLElement | undefined;
 }
 
 export function marker(latlng: LatLngExpression, options?: MarkerOptions): Marker;

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -502,6 +502,16 @@ class MyMarker extends L.Marker {
 	constructor() {
 		super([12, 13]);
 	}
+
+	// adapted from Leaflet.AnimatedMarker
+	animate() {
+		const speed = 1000;
+
+		if (L.DomUtil.TRANSITION) {
+			if (this.getElement()) { this.getElement().style.setProperty(L.DomUtil.TRANSITION, `all ${speed}ms linear`); }
+			if (this._shadow) { this._shadow.style.setProperty(L.DomUtil.TRANSITION, `all ${speed}ms linear`); }
+		}
+	}
 }
 
 class MyLayer extends L.Layer {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Leaflet/Leaflet/blob/0d06c4256f4312a7122c23626c8bd36e14269d01/src/layer/marker/Marker.js#L251

In order to rewrite the Leaflet.Animated plugin as typescript, _shadow property in Leaflet Marker class must be exposed:
https://github.com/openplans/Leaflet.AnimatedMarker/blob/3cbfe2bcab3503badacbd22fed0e7c659c2bf320/src/AnimatedMarker.js#L71