### PR TITLE
[stripe-v3] fix: add missing subtype 'validation_error' to ErrorType

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -14,6 +14,7 @@
 //                 Hiroshi Ioka <https://github.com/hirochachacha>
 //                 Austin Turner <https://github.com/paustint>
 //                 Kevin Soltysiak <https://github.com/ksol>
+//                 Kohei Matsubara <https://github.com/matsuby>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var Stripe: stripe.StripeStatic;
@@ -296,7 +297,8 @@ declare namespace stripe {
         | 'card_error'
         | 'idempotency_error'
         | 'invalid_request_error'
-        | 'rate_limit_error';
+        | 'rate_limit_error'
+        | 'validation_error';
 
     interface Error {
         /**


### PR DESCRIPTION
https://stripe.com/docs/api/errors

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://stripe.com/docs/api/errors>>