### PR TITLE
iab-vpaid: Correct AdVideoMidPoint to AdVideoMidpoint (lowercase 'p').

### DIFF
--- a/types/iab-vpaid/iab-vpaid-tests.ts
+++ b/types/iab-vpaid/iab-vpaid-tests.ts
@@ -6,5 +6,8 @@ if (window.getVPAIDAd) {
     ad.subscribe((url, id, playerHandles) => {
         /* Handle click */
     }, 'AdClickThru');
+    ad.subscribe(() => {
+        /* Handle video midpoint */
+    }, 'AdVideoMidpoint');
     ad.startAd();
 }

--- a/types/iab-vpaid/index.d.ts
+++ b/types/iab-vpaid/index.d.ts
@@ -39,7 +39,7 @@ declare namespace iab.vpaid {
         | 'AdVolumeChange'
         | 'AdVideoStart'
         | 'AdVideoFirstQuartile'
-        | 'AdVideoMidPoint'
+        | 'AdVideoMidpoint'
         | 'AdVideoThirdQuartile'
         | 'AdVideoComplete'
         | 'AdUserAcceptInvitation'


### PR DESCRIPTION
Per spec this event is called `AdVideoMidpoint` (lowercase 'p').

See: https://www.iab.com/wp-content/uploads/2015/06/VPAID_2_0_Final_04-10-2012.pdf

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.iab.com/wp-content/uploads/2015/06/VPAID_2_0_Final_04-10-2012.pdf
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **N/A**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.