### PR TITLE
[@types/ramda] narrow add function type to match implementation

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -69,12 +69,10 @@ export * from './tools';
 export const __: Placeholder; /* This is used in examples throughout the docs, but I it only seems to be directly explained here: https://ramdajs.com/0.9/docs/#op */
 
 /**
- * Adds two numbers (or strings). Equivalent to a + b but curried.
+ * Adds two numbers. Equivalent to a + b but curried.
  */
 export function add(a: number, b: number): number;
-export function add(a: string, b: string): string;
 export function add(a: number): (b: number) => number;
-export function add(a: string): (b: string) => string;
 
 /**
  * Creates a new list iteration function from an existing one by adding two new parameters to its callback

--- a/types/ramda/test/add-tests.ts
+++ b/types/ramda/test/add-tests.ts
@@ -5,21 +5,13 @@ import * as R from 'ramda';
   R.add(2, 3); // =>  5
   // $ExpectType number
   R.add(7)(10); // => 17
-  // $ExpectType string
-  R.add('Hello', ' World'); // =>  "Hello World"
-  // $ExpectType string
-  R.add('Hello')(' World'); // =>  "Hello World"
 };
 
 () => {
-  // cannot add a number to a string or vice-versa
+  // cannot add anything other than two numbers
 
   // $ExpectError
-  R.add('2', 3);
+  R.add('foo', 'bar');
   // $ExpectError
-  R.add(2, '3');
-  // $ExpectError
-  R.add('2')(3);
-  // $ExpectError
-  R.add(2)('3');
+  R.add('foo')('bar');
 };


### PR DESCRIPTION
add only operates on numbers, not strings

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ramda/ramda/blob/v0.26.0/source/add.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

^^ Unsure if I should increment the version number given the existing definition is incorrect!
