### PR TITLE
react-leaflet: fix GeoJSON data property's type

### DIFF
--- a/types/react-leaflet/index.d.ts
+++ b/types/react-leaflet/index.d.ts
@@ -349,7 +349,7 @@ export class FeatureGroup<P extends FeatureGroupProps = FeatureGroupProps, E ext
 }
 
 export interface GeoJSONProps extends PathProps, FeatureGroupEvents, Leaflet.GeoJSONOptions {
-    data: GeoJSON.GeoJsonObject;
+    data: GeoJSON.GeoJsonObject | GeoJSON.GeoJsonObject[];
 }
 export class GeoJSON<P extends GeoJSONProps = GeoJSONProps, E extends Leaflet.GeoJSON = Leaflet.GeoJSON> extends FeatureGroup<P, E> {
     createLeafletElement(props: P): E;

--- a/types/react-leaflet/react-leaflet-tests.tsx
+++ b/types/react-leaflet/react-leaflet-tests.tsx
@@ -33,6 +33,8 @@ import {
     withLeaflet,
     Viewport,
     useLeaflet,
+    GeoJSON,
+    GeoJSONProps
 } from 'react-leaflet';
 const { BaseLayer, Overlay } = LayersControl;
 
@@ -835,3 +837,53 @@ const leafletComponent = withLeaflet<PolygonProps>(CustomPolygon);
 
 // $ExpectType LeafletContext
 useLeaflet();
+
+const northDakota: GeoJSON.Feature = {
+    type: "Feature",
+    properties: {name: "North Dakota"},
+    geometry: {
+        type: "Polygon",
+        coordinates: [[
+            [-104.05, 48.99],
+            [-97.22,  48.98],
+            [-96.58,  45.94],
+            [-104.03, 45.94],
+            [-104.05, 48.99]
+        ]]
+    }
+};
+
+const colorado: GeoJSON.Feature = {
+    type: "Feature",
+    properties: {name: "Colorado"},
+    geometry: {
+        type: "Polygon",
+        coordinates: [[
+            [-109.05, 41.00],
+            [-102.06, 40.99],
+            [-102.03, 36.99],
+            [-109.04, 36.99],
+            [-109.05, 41.00]
+        ]]
+    }
+};
+
+// GeoJSON
+export class GeoJSONExample extends Component<undefined, undefined> {
+    polygons: GeoJSON.GeoJsonObject[] = [northDakota, colorado];
+
+    vp: Viewport = {
+        center: [-102, 40],
+        zoom: 10
+    };
+
+    render() {
+        return (<Map viewport={this.vp}>
+            <TileLayer
+                url='http://{s}.tile.osm.org/{z}/{x}/{y}.png'
+                attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+            />
+            <GeoJSON data={this.polygons} />
+        </Map>);
+    }
+}


### PR DESCRIPTION
According to the leaflet documentation, the data property can be a GeoJSON object or an array of GeoJSON objects.

https://react-leaflet.js.org/docs/en/components#geojson --> 
https://leafletjs.com/reference-1.6.0.html#geojson

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-leaflet.js.org/docs/en/components#geojson --> 
https://leafletjs.com/reference-1.6.0.html#geojson

