### PR TITLE
Allow `null` in `CompletionCallback` @types/ace

### DIFF
--- a/types/ace/index.d.ts
+++ b/types/ace/index.d.ts
@@ -3080,7 +3080,7 @@ declare namespace AceAjax {
         docHTML?: string;
       }
       
-      export type CompletionCallback = (error: Error, results: Completion[]) => void;
+      export type CompletionCallback = (error: Error | null, results: Completion[]) => void;
 }
 
 declare var ace: AceAjax.Ace;


### PR DESCRIPTION
The current `CompletionCallback` type doesn't allow you to set `error: null`, which is required if you don't have an actual error. This change allows for that

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
