### PR TITLE
[terminal-kit]: fix the typings for Callback and inputField

### DIFF
--- a/types/terminal-kit/Terminal.d.ts
+++ b/types/terminal-kit/Terminal.d.ts
@@ -210,13 +210,13 @@ declare namespace Terminal {
       promise?: Promise<boolean>;
     };
 
-    inputField(options: InputFieldOptions, callback: Callback<string>): void;
-    inputField(callback: Callback<string>): void;
+    inputField(options: InputFieldOptions, callback: Callback<string | undefined>): void;
+    inputField(callback: Callback<string | undefined>): void;
     inputField(
       options?: InputFieldOptions
     ): {
       abort: () => void;
-      promise?: Promise<boolean>;
+      promise?: Promise<string | undefined>;
     };
 
     fileInput(options: IFileInputOptions, callback: Callback<string>): void;

--- a/types/terminal-kit/Terminal.d.ts
+++ b/types/terminal-kit/Terminal.d.ts
@@ -210,11 +210,11 @@ declare namespace Terminal {
       promise?: Promise<boolean>;
     };
 
-    inputField(options: InputFieldOptions, callback: Callback<string | undefined>): void;
-    inputField(callback: Callback<string | undefined>): void;
-    inputField(
-      options?: InputFieldOptions
-    ): {
+    inputField(options: InputFieldOptions, callback?: Callback<string | undefined>): {
+      abort: () => void;
+      promise: Promise<string | undefined>;
+    };
+    inputField(callback: Callback<string | undefined>): {
       abort: () => void;
       promise: Promise<string | undefined>;
     };

--- a/types/terminal-kit/Terminal.d.ts
+++ b/types/terminal-kit/Terminal.d.ts
@@ -4,7 +4,7 @@ type Terminal = Terminal.Impl & EventEmitter;
 
 export = Terminal;
 
-type Callback<T> = ((err: any) => void) | ((err: undefined, arg: T) => void);
+type Callback<T> = (err: any, arg: T) => void;
 
 declare namespace Terminal {
   interface Impl {

--- a/types/terminal-kit/Terminal.d.ts
+++ b/types/terminal-kit/Terminal.d.ts
@@ -216,7 +216,7 @@ declare namespace Terminal {
       options?: InputFieldOptions
     ): {
       abort: () => void;
-      promise?: Promise<string | undefined>;
+      promise: Promise<string | undefined>;
     };
 
     fileInput(options: IFileInputOptions, callback: Callback<string>): void;

--- a/types/terminal-kit/terminal-kit-tests.ts
+++ b/types/terminal-kit/terminal-kit-tests.ts
@@ -9,6 +9,7 @@ import t, {
 } from "terminal-kit";
 import "node";
 import * as fs from "fs";
+import assert from "assert";
 
 new t.Rect({width: 4, height: 4});
 // The term() function simply output a string to stdout, using current style
@@ -52,9 +53,9 @@ term.moveTo.cyan(1, 1, "My name is %s, I'm %d.\n", "Jack", 32);
 
 // Get some user input
 term.magenta("Enter your name: ");
-term.inputField((error, input) => {
+assert(term.inputField((error, input) => {
   term.green("\nYour name is '%s'\n", input);
-});
+}).abort);
 
 function terminate() {
   term.grabInput(false);

--- a/types/terminal-kit/terminal-kit-tests.ts
+++ b/types/terminal-kit/terminal-kit-tests.ts
@@ -145,7 +145,7 @@ term("Please enter your name: ");
 
 term.inputField(
   { history, autoComplete, autoCompleteMenu: true },
-  (error: any, input: string) => {
+  (error: any, input: string | undefined) => {
     term.green("\nYour name is '%s'\n", input);
   }
 );

--- a/types/terminal-kit/terminal-kit-tests.ts
+++ b/types/terminal-kit/terminal-kit-tests.ts
@@ -52,7 +52,7 @@ term.moveTo.cyan(1, 1, "My name is %s, I'm %d.\n", "Jack", 32);
 
 // Get some user input
 term.magenta("Enter your name: ");
-term.inputField((error: any, input: any) => {
+term.inputField((error, input) => {
   term.green("\nYour name is '%s'\n", input);
 });
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cronvel/terminal-kit/blob/master/doc/high-level.md#inputfield-options--callback-
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The commit messages contain my rationales for each change.