### PR TITLE
update(browser-resolve): align with v1.11

### DIFF
--- a/types/browser-resolve/browser-resolve-tests.ts
+++ b/types/browser-resolve/browser-resolve-tests.ts
@@ -1,37 +1,46 @@
-import browserResolve = require('browser-resolve');
+import resolve = require('browser-resolve');
 
-function basic_test_async(callback: (err?: Error, resolved?: string) => void) {
-  browserResolve('typescript', function(error, resolved) {
-    if (error) {
-      return callback(error);
-    }
-    callback(null, resolved);
-  });
-}
+const basic_test_async = (callback: (err?: Error | null, resolved?: string) => void) => {
+    // $ExpectType void
+    resolve('typescript', (error, resolved) => {
+        if (error) {
+            callback(error);
+            return;
+        }
+        callback(null, resolved);
+    });
+};
 
-function basic_test_sync() {
-  var resolved = browserResolve.sync('typescript');
-}
+// $ExpectType string
+resolve.sync('typescript');
 
-function options_test_async() {
-  browserResolve('typescript', {
-    browser: 'jsnext:main',
+resolve(
+    'typescript',
+    {
+        browser: 'jsnext:main',
+        filename: './browser-resolve/browser-resolve.js',
+        modules: {
+            fs: './fs-shim.js',
+        },
+    },
+    (error, resolved) => {
+        if (error) {
+            console.error(error);
+            return;
+        }
+        console.log(resolved);
+    },
+);
+
+resolve.sync('typescript', {
     filename: './browser-resolve/browser-resolve.js',
-    modules: {
-      fs: './fs-shim.js'
-    }
-  }, function(error, resolved) {
-    if (error) {
-      console.error(error);
-      return;
-    }
-    console.log(resolved);
-  });
-}
+    modules: {},
+});
 
-function options_test_sync() {
-  var resolved = browserResolve.sync('typescript', {
-    filename: './browser-resolve/browser-resolve.js',
-    modules: {}
-  });
-}
+resolve.sync('@scope/my-module', {
+    browser: 'module',
+    packageFilter: pkg => {
+        pkg.module = pkg.module || pkg.browser;
+        return pkg;
+    },
+});

--- a/types/browser-resolve/index.d.ts
+++ b/types/browser-resolve/index.d.ts
@@ -1,59 +1,62 @@
-// Type definitions for browser-resolve
+// Type definitions for browser-resolve 1.11
 // Project: https://github.com/defunctzombie/node-browser-resolve
 // Definitions by: Mario Nebl <https://github.com/marionebl>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="resolve" />
-
-import * as resolve from 'resolve';
+import * as resv from 'resolve';
 
 /**
- * Callback invoked when resolving asynchronously
- *
- * @param error
- * @param resolved Absolute path to resolved identifier
- */
-type resolveCallback = (err?: Error, resolved?: string) => void;
-
-/**
- * Resolve a module path and call cb(err, path [, pkg])
+ * Resolve a module path and call cb(err, path)
  *
  * @param id Identifier to resolve
  * @param callback
  */
-declare function browserResolve(id: string, cb: resolveCallback): void;
+declare function resolve(id: string, cb: resolve.Callback): void;
 
 /**
- * Resolve a module path and call cb(err, path [, pkg])
+ * Resolve a module path and call cb(err, path)
  *
  * @param id Identifier to resolve
  * @param options Options to use for resolving, optional.
  * @param callback
  */
-declare function browserResolve(id: string, opts: browserResolve.AsyncOpts, cb: resolveCallback): void;
+declare function resolve(id: string, opts: resolve.AsyncOpts, cb: resolve.Callback): void;
 
-/**
- * Returns a module path
- *
- * @param id Identifier to resolve
- * @param options Options to use for resolving, optional.
- */
-declare function browserResolveSync(id: string, opts?: browserResolve.SyncOpts): string;
+declare namespace resolve {
+    interface Opts {
+        /**
+         * the 'browser' property to use from package.json
+         * @default 'browser'
+         */
+        browser?: string;
+        /**
+         * the calling filename where the require() call originated (in the source)
+         */
+        filename?: string;
+        /**
+         * modules object with id to path mappings to consult before doing manual resolution
+         * (use to provide core modules)
+         */
+        modules?: any;
+    }
 
-declare namespace browserResolve {
-  interface Opts {
-    // the 'browser' property to use from package.json (defaults to 'browser')
-    browser?: string;
-    // the calling filename where the require() call originated (in the source)
-    filename?: string;
-    // modules object with id to path mappings to consult before doing manual resolution (use to provide core modules)
-    modules?: any;
-  }
+    type AsyncOpts = resv.AsyncOpts & Opts;
+    type SyncOpts = resv.SyncOpts & Opts;
 
-  export interface AsyncOpts extends resolve.AsyncOpts, Opts { }
-  export interface SyncOpts extends resolve.SyncOpts, Opts { }
+    /**
+     * Callback invoked when resolving asynchronously
+     * @param error
+     * @param resolved Absolute path to resolved identifier
+     */
+    type Callback = (err: Error | null, resolved?: string) => void;
 
-  export var sync: typeof browserResolveSync;
+    /**
+     * Returns a module path
+     * @param id Identifier to resolve
+     * @param options Options to use for resolving.
+     */
+    function sync(id: string, opts?: SyncOpts): string;
 }
 
-export = browserResolve;
+export = resolve;

--- a/types/browser-resolve/tsconfig.json
+++ b/types/browser-resolve/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/browser-resolve/tslint.json
+++ b/types/browser-resolve/tslint.json
@@ -1,15 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "callable-types": false,
-        "dt-header": false,
-        "no-redundant-jsdoc": false,
-        "no-reference-import": false,
-        "no-var-keyword": false,
-        "no-void-expression": false,
-        "only-arrow-functions": false,
-        "prefer-const": false,
-        "prefer-method-signature": false,
-        "strict-export-declare-modifiers": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
- add version to TS Header
- align package configuration
- align package definition with the orignal package details:
https://github.com/defunctzombie/node-browser-resolve/blob/master/index.js
- remove 3-slashes reference as duplicate
- minor refine of the `callback` `error` parameter (can be null as per
usage)
- minor JSDOC corrections
- update authors
- update tests

https://github.com/defunctzombie/node-browser-resolve#api

Thanks!

/cc @marionebl

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/defunctzombie/node-browser-resolve#api
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.