### PR TITLE
[babel__core] Fix configFile, babelrcRoots, ignore and only

### DIFF
--- a/types/babel__core/index.d.ts
+++ b/types/babel__core/index.d.ts
@@ -71,7 +71,7 @@ export interface TransformOptions {
      *
      * Default: `undefined`
      */
-    configFile?: string | false | null;
+    configFile?: string | boolean | null;
 
     /**
      * Specify whether or not to use .babelrc and
@@ -87,7 +87,7 @@ export interface TransformOptions {
      *
      * Default: `(root)`
      */
-    babelrcRoots?: true | string | string[] | null;
+    babelrcRoots?: boolean | MatchPattern | MatchPattern[] | null;
 
     /**
      * Defaults to environment variable `BABEL_ENV` if set, or else `NODE_ENV` if set, or else it defaults to `"development"`
@@ -192,7 +192,7 @@ export interface TransformOptions {
      *
      * Default: `null`
      */
-    ignore?: string[] | null;
+    ignore?: MatchPattern[] | null;
 
     /**
      * This option is a synonym for "test"
@@ -240,7 +240,7 @@ export interface TransformOptions {
      *
      * Default: `null`
      */
-    only?: string | RegExp | Array<string | RegExp> | null;
+    only?: MatchPattern[] | null;
 
     /**
      * Allows users to provide an array of options that will be merged into the current configuration one at a time.


### PR DESCRIPTION
Changes:

configFile 
[doc](https://babeljs.io/docs/en/options#configfile) [flow1](
https://github.com/babel/babel/blob/21c91418722e3b0c0e9042427bb1524baebba452/packages/babel-core/src/config/validation/options.js#L182) [flow2](https://github.com/babel/babel/blob/21c91418722e3b0c0e9042427bb1524baebba452/packages/babel-core/src/config/validation/options.js#L263)
`true` is a valid value for `configFile` now.

babelrcRoots
[doc](https://babeljs.io/docs/en/options#babelrcroots) [flow1](https://github.com/babel/babel/blob/21c91418722e3b0c0e9042427bb1524baebba452/packages/babel-core/src/config/validation/options.js#L181) [flow2](https://github.com/babel/babel/blob/21c91418722e3b0c0e9042427bb1524baebba452/packages/babel-core/src/config/validation/options.js#L264)
`false`, regexp(s), function(s) are valid values now.

only 
[doc](https://babeljs.io/docs/en/options#only) [flow1](https://github.com/babel/babel/blob/21c91418722e3b0c0e9042427bb1524baebba452/packages/babel-core/src/config/validation/options.js#L194) [flow2](https://github.com/babel/babel/blob/21c91418722e3b0c0e9042427bb1524baebba452/packages/babel-core/src/config/validation/options.js#L248)
Can't be a single string or regexp anymore, allows functions now.

ignore 
[doc](https://babeljs.io/docs/en/options#ignore) [flow1](https://github.com/babel/babel/blob/21c91418722e3b0c0e9042427bb1524baebba452/packages/babel-core/src/config/validation/options.js#L193) [flow2](https://github.com/babel/babel/blob/21c91418722e3b0c0e9042427bb1524baebba452/packages/babel-core/src/config/validation/options.js#L248)
Now allows regexp and functions in an array too.