### PR TITLE
pdfmake - update v0.1.65

### DIFF
--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pdfmake 0.1.65
+// Type definitions for pdfmake 0.1
 // Project: http://pdfmake.org
 // Definitions by: Milen Stefanov <https://github.com/m1llen1um>
 //                 Rajab Shakirov <https://github.com/radziksh>

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -142,7 +142,7 @@ declare module "pdfmake/build/pdfmake" {
         Double = "double",
         Wavy = "wavy"
     }
-    
+
     enum PageBreak {
         Before = "before",
         After = "after"
@@ -153,7 +153,6 @@ declare module "pdfmake/build/pdfmake" {
 		font?: any;
 		/** size of the font in pt */
 		fontSize?: number;
-		/**  */
 		fontFeatures?: any;
 		/** whether to use bold text (default: false) */
 		bold?: boolean;
@@ -180,7 +179,7 @@ declare module "pdfmake/build/pdfmake" {
 		/** the line height (default: 1) */
 		lineHeight?: number;
 		characterSpacing?: number;
-		noWrap?: boolean;	
+		noWrap?: boolean;
 		/** the color of the bullets in a buletted list */
 		markerColor?: string;
 		leadingIndent?: any;
@@ -218,7 +217,7 @@ declare module "pdfmake/build/pdfmake" {
         widths?: Array<string | number>;
     }
 
-    export interface Content {
+    interface Content {
 		layout?: Layout;
         style?: string | string[];
         margin?: Margins;
@@ -248,7 +247,7 @@ declare module "pdfmake/build/pdfmake" {
         title: Content;
     }
 
-    export interface TDocumentDefinitions {
+    interface TDocumentDefinitions {
         background?: string | ((currentPage: number, pageSize: PageSize) => string | Content | null);
         compress?: boolean;
         content: string | Content | Array<string | Content>;
@@ -343,21 +342,21 @@ declare module "pdfmake/build/pdfmake" {
         fonts: { [name: string]: TFontFamilyTypes };
         createPdf(documentDefinitions: TDocumentDefinitions): TCreatedPdf;
 	}
-	
+
 	interface Watermark {
 		/** watermark text */
-		text?: string,
+		text?: string;
 		/** color of text */
-		color?: string,
+		color?: string;
 		/** opacity of text */
-		opacity?: number,
+		opacity?: number;
 		/** bold style of text */
-		bold?: boolean,
+		bold?: boolean;
 		/** italics style of text */
-		italics?: true,
+		italics?: true;
 		/** own font size of text (ideal size is calculated automatically) (minimal version: 0.1.60) */
-		fontSize?: number,
+		fontSize?: number;
 		/** angle of text rotation (minimal version: 0.1.60) */
-		angle?: number
+		angle?: number;
 	}
 }

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -27,70 +27,25 @@ declare module "pdfmake/build/pdfmake" {
         vfs?: any
     ): TCreatedPdf;
 
-    enum PageSize {
-        A0_x_4 = "4A0",
-        A0_x_2 = "2A0",
-        AO = "A0",
-        A1 = "A1",
-        A2 = "A2",
-        A3 = "A3",
-        A4 = "A4",
-        A5 = "A5",
-        A6 = "A6",
-        A7 = "A7",
-        A8 = "A8",
-        A9 = "A9",
-        A1O = "A10",
-        BO = "B0",
-        B1 = "B1",
-        B2 = "B2",
-        B3 = "B3",
-        B4 = "B4",
-        B5 = "B5",
-        B6 = "B6",
-        B7 = "B7",
-        B8 = "B8",
-        B9 = "B9",
-        B1O = "B10",
-        CO = "C0",
-        C1 = "C1",
-        C2 = "C2",
-        C3 = "C3",
-        C4 = "C4",
-        C5 = "C5",
-        C6 = "C6",
-        C7 = "C7",
-        C8 = "C8",
-        C9 = "C9",
-        C1O = "C10",
-        RA1 = "RA1",
-        RA2 = "RA2",
-        RA3 = "RA3",
-        RA4 = "RA4",
-        SRA1 = "SRA1",
-        SRA2 = "SRA2",
-        SRA3 = "SRA3",
-        SRA4 = "SRA4",
-        EXECUTIVE = "EXECUTIVE",
-        FOLIO = "FOLIO",
-        LEGAL = "LEGAL",
-        LETTER = "LETTER",
-        TABLOID = "TABLOID"
-    }
+    type PageSize =
+        "4A0"|"2A0"|"A0"|"A1"|"A2"|"A3"|"A4"|"A5"|"A6"|"A7"|"A8"|"A9"|"A10"|
+        "B0"|"B1"|"B2"|"B3"|"B4"|"B5"|"B6"|"B7"|"B8"|"B9"|"B10"|
+        "C0"|"C1"|"C2"|"C3"|"C4"|"C5"|"C6"|"C7"|"C8"|"C9"|"C10"|
+        "RA1"|"RA2"|"RA3"|"RA4"|
+        "SRA1"|"SRA2"|"SRA3"|"SRA4"|
+        "EXECUTIVE"|"FOLIO"|"LEGAL"|"LETTER"|"TABLOID";
 
-    enum PageOrientation {
-        PORTRAIT = "PORTRAIT",
-        LANDSCAPE = "LANDSCAPE"
-	}
+    type PageOrientation = "portrait" | "landscape";
 
-	enum Layout {
-		/** no borders */
-		NoBorders = "noBorders",
-		/** header line only */
-		HeaderLineOnly = "headerLineOnly",
-		/** light horizontal lines */
-		LightHorizontalLines = "lightHorizontalLines"
-	}
+    type Layout = "noBorders" | "headerLineOnly" | "lightHorizontalLines";
+
+    type Alignment = "left" | "center" | "right";
+
+	type Decoration = "underline" | "lineThrough" | "overline";
+
+    type DecorationStyle = "dashed" | "dotted" | "double" | "wavy";
+
+    type PageBreak = "before" | "after";
 
     let pdfMake: pdfMakeStatic;
 
@@ -123,30 +78,6 @@ declare module "pdfmake/build/pdfmake" {
     ) => any;
 
     type Margins = number | [number, number] | [number, number, number, number];
-
-	enum Alignment {
-        Left = "left",
-        Center = "center",
-        Right = "right"
-    }
-
-	enum Decoration {
-        Underline = "underline",
-        LineThrough = "lineThrough",
-        OverLine = "overline"
-    }
-
-    enum DecorationStyle {
-        Dashed = "dashed",
-        Dotted = "dotted",
-        Double = "double",
-        Wavy = "wavy"
-    }
-
-    enum PageBreak {
-        Before = "before",
-        After = "after"
-    }
 
     interface Style {
 		/** name of the font */

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -4,6 +4,7 @@
 //                 Rajab Shakirov <https://github.com/radziksh>
 //                 Enzo Volkmann <https://github.com/evolkmann>
 //                 Andi Pätzold <https://github.com/andipaetzold>
+//                 Neal Mummau <https://github.com/nmummau>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -80,7 +81,16 @@ declare module "pdfmake/build/pdfmake" {
     enum PageOrientation {
         PORTRAIT = "PORTRAIT",
         LANDSCAPE = "LANDSCAPE"
-    }
+	}
+
+	enum Layout {
+		/** no borders */
+		NoBorders = "noBorders",
+		/** header line only */
+		HeaderLineOnly = "headerLineOnly",
+		/** light horizontal lines */
+		LightHorizontalLines = "lightHorizontalLines"
+	}
 
     let pdfMake: pdfMakeStatic;
 
@@ -96,9 +106,13 @@ declare module "pdfmake/build/pdfmake" {
     }
 
     interface TDocumentInformation {
-        title?: string;
-        author?: string;
-        subject?: string;
+		/** the title of the document */
+		title?: string;
+		/** the name of the author */
+		author?: string;
+		/** the subject of the document */
+		subject?: string;
+		/** keywords associated with the document */
         keywords?: string;
     }
 
@@ -110,27 +124,66 @@ declare module "pdfmake/build/pdfmake" {
 
     type Margins = number | [number, number] | [number, number, number, number];
 
-    type Alignment = "left" | "right" | "justify" | "center" | string;
+	enum Alignment {
+        Left = "left",
+        Center = "center",
+        Right = "right"
+    }
+
+	enum Decoration {
+        Underline = "underline",
+        LineThrough = "lineThrough",
+        OverLine = "overline"
+    }
+
+    enum DecorationStyle {
+        Dashed = "dashed",
+        Dotted = "dotted",
+        Double = "double",
+        Wavy = "wavy"
+    }
+    
+    enum PageBreak {
+        Before = "before",
+        After = "after"
+    }
 
     interface Style {
-        font?: any;
-        fontSize?: number;
-        fontFeatures?: any;
-        bold?: boolean;
-        italics?: boolean;
-        alignment?: Alignment;
+		/** name of the font */
+		font?: any;
+		/** size of the font in pt */
+		fontSize?: number;
+		/**  */
+		fontFeatures?: any;
+		/** whether to use bold text (default: false) */
+		bold?: boolean;
+		/** whether to use italic text (default: false) */
+		italics?: boolean;
+		/** the alignment of the text */
+		alignment?: Alignment;
+		/** the color of the text (color name e.g., ‘blue’ or hexadecimal color e.g., ‘#ff5500’) */
         color?: string;
-        columnGap?: any;
-        fillColor?: string;
-        decoration?: any;
-        decorationany?: any;
-        decorationColor?: string;
-        background?: any;
-        lineHeight?: number;
-        characterSpacing?: number;
-        noWrap?: boolean;
-        markerColor?: string;
-        leadingIndent?: any;
+        /** optional space between columns */
+		columnGap?: any;
+		/** the background color of a table cell */
+		fillColor?: string;
+		/** the background opacity of a table cell */
+		fillOpacity?: string;
+		/** the text decoration to applu (‘underline’ or ‘lineThrough’ or ‘overline’) */
+		decoration?: Decoration;
+		/** (‘dashed’ or ‘dotted’ or ‘double’ or ‘wavy’) */
+		decorationStyle?: DecorationStyle;
+		/** the color of the text decoration, see color */
+		decorationColor?: string;
+		/** the background color of the text */
+		background?: any;
+		/** the line height (default: 1) */
+		lineHeight?: number;
+		characterSpacing?: number;
+		noWrap?: boolean;	
+		/** the color of the bullets in a buletted list */
+		markerColor?: string;
+		leadingIndent?: any;
         [additionalProperty: string]: any;
     }
 
@@ -165,25 +218,37 @@ declare module "pdfmake/build/pdfmake" {
         widths?: Array<string | number>;
     }
 
-    interface Content {
+    export interface Content {
+		layout?: Layout;
         style?: string | string[];
         margin?: Margins;
         text?: string | string[] | Content[];
         columns?: Content[];
         stack?: Content[];
         image?: string;
+        svg?: string;
         width?: string | number;
         height?: string | number;
         fit?: [number, number];
-        pageBreak?: "before" | "after";
+        pageBreak?: PageBreak;
         alignment?: Alignment;
         table?: Table;
+        /** to treat a paragraph as a bulleted list, set an array of items under the ul key */
         ul?: Content[];
+        /** for numbered lists set the ol key */
         ol?: Content[];
+        qr?: string;
+        toc?: TableOfContent;
+        tocItem?: boolean | string | string[];
         [additionalProperty: string]: any;
     }
 
-    interface TDocumentDefinitions {
+    interface TableOfContent {
+        id?: string;
+        title: Content;
+    }
+
+    export interface TDocumentDefinitions {
         background?: string | ((currentPage: number, pageSize: PageSize) => string | Content | null);
         compress?: boolean;
         content: string | Content | Array<string | Content>;
@@ -202,6 +267,7 @@ declare module "pdfmake/build/pdfmake" {
         pageOrientation?: PageOrientation;
         pageSize?: PageSize | { width: number; height: number };
         styles?: Style;
+        watermark?: Watermark;
     }
 
     interface CurrentNode {
@@ -276,5 +342,22 @@ declare module "pdfmake/build/pdfmake" {
         vfs: TFontFamily;
         fonts: { [name: string]: TFontFamilyTypes };
         createPdf(documentDefinitions: TDocumentDefinitions): TCreatedPdf;
-    }
+	}
+	
+	interface Watermark {
+		/** watermark text */
+		text?: string,
+		/** color of text */
+		color?: string,
+		/** opacity of text */
+		opacity?: number,
+		/** bold style of text */
+		bold?: boolean,
+		/** italics style of text */
+		italics?: true,
+		/** own font size of text (ideal size is calculated automatically) (minimal version: 0.1.60) */
+		fontSize?: number,
+		/** angle of text rotation (minimal version: 0.1.60) */
+		angle?: number
+	}
 }

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -61,13 +61,13 @@ declare module "pdfmake/build/pdfmake" {
     }
 
     interface TDocumentInformation {
-		/** the title of the document */
-		title?: string;
-		/** the name of the author */
-		author?: string;
-		/** the subject of the document */
-		subject?: string;
-		/** keywords associated with the document */
+        /** the title of the document */
+        title?: string;
+        /** the name of the author */
+        author?: string;
+        /** the subject of the document */
+        subject?: string;
+        /** keywords associated with the document */
         keywords?: string;
     }
 
@@ -80,40 +80,40 @@ declare module "pdfmake/build/pdfmake" {
     type Margins = number | [number, number] | [number, number, number, number];
 
     interface Style {
-		/** name of the font */
-		font?: any;
-		/** size of the font in pt */
-		fontSize?: number;
-		fontFeatures?: any;
-		/** whether to use bold text (default: false) */
-		bold?: boolean;
-		/** whether to use italic text (default: false) */
-		italics?: boolean;
-		/** the alignment of the text */
-		alignment?: Alignment;
-		/** the color of the text (color name e.g., ‘blue’ or hexadecimal color e.g., ‘#ff5500’) */
+        /** name of the font */
+        font?: any;
+        /** size of the font in pt */
+        fontSize?: number;
+        fontFeatures?: any;
+        /** whether to use bold text (default: false) */
+        bold?: boolean;
+        /** whether to use italic text (default: false) */
+        italics?: boolean;
+        /** the alignment of the text */
+        alignment?: Alignment;
+        /** the color of the text (color name e.g., ‘blue’ or hexadecimal color e.g., ‘#ff5500’) */
         color?: string;
         /** optional space between columns */
-		columnGap?: any;
-		/** the background color of a table cell */
-		fillColor?: string;
-		/** the background opacity of a table cell */
-		fillOpacity?: string;
-		/** the text decoration to applu (‘underline’ or ‘lineThrough’ or ‘overline’) */
-		decoration?: Decoration;
-		/** (‘dashed’ or ‘dotted’ or ‘double’ or ‘wavy’) */
-		decorationStyle?: DecorationStyle;
-		/** the color of the text decoration, see color */
-		decorationColor?: string;
-		/** the background color of the text */
-		background?: any;
-		/** the line height (default: 1) */
-		lineHeight?: number;
-		characterSpacing?: number;
-		noWrap?: boolean;
-		/** the color of the bullets in a buletted list */
-		markerColor?: string;
-		leadingIndent?: any;
+        columnGap?: any;
+        /** the background color of a table cell */
+        fillColor?: string;
+        /** the background opacity of a table cell */
+        fillOpacity?: string;
+        /** the text decoration to applu (‘underline’ or ‘lineThrough’ or ‘overline’) */
+        decoration?: Decoration;
+        /** (‘dashed’ or ‘dotted’ or ‘double’ or ‘wavy’) */
+        decorationStyle?: DecorationStyle;
+        /** the color of the text decoration, see color */
+        decorationColor?: string;
+        /** the background color of the text */
+        background?: any;
+        /** the line height (default: 1) */
+        lineHeight?: number;
+        characterSpacing?: number;
+        noWrap?: boolean;
+        /** the color of the bullets in a buletted list */
+        markerColor?: string;
+        leadingIndent?: any;
         [additionalProperty: string]: any;
     }
 
@@ -149,7 +149,7 @@ declare module "pdfmake/build/pdfmake" {
     }
 
     interface Content {
-		layout?: Layout;
+        layout?: Layout;
         style?: string | string[];
         margin?: Margins;
         text?: string | string[] | Content[];
@@ -272,22 +272,22 @@ declare module "pdfmake/build/pdfmake" {
         vfs: TFontFamily;
         fonts: { [name: string]: TFontFamilyTypes };
         createPdf(documentDefinitions: TDocumentDefinitions): TCreatedPdf;
-	}
+    }
 
-	interface Watermark {
-		/** watermark text */
-		text?: string;
-		/** color of text */
-		color?: string;
-		/** opacity of text */
-		opacity?: number;
-		/** bold style of text */
-		bold?: boolean;
-		/** italics style of text */
-		italics?: true;
-		/** own font size of text (ideal size is calculated automatically) (minimal version: 0.1.60) */
-		fontSize?: number;
-		/** angle of text rotation (minimal version: 0.1.60) */
-		angle?: number;
-	}
+    interface Watermark {
+        /** watermark text */
+        text?: string;
+        /** color of text */
+        color?: string;
+        /** opacity of text */
+        opacity?: number;
+        /** bold style of text */
+        bold?: boolean;
+        /** italics style of text */
+        italics?: true;
+        /** own font size of text (ideal size is calculated automatically) (minimal version: 0.1.60) */
+        fontSize?: number;
+        /** angle of text rotation (minimal version: 0.1.60) */
+        angle?: number;
+    }
 }

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -41,7 +41,7 @@ declare module "pdfmake/build/pdfmake" {
 
     type Alignment = "left" | "center" | "right";
 
-	type Decoration = "underline" | "lineThrough" | "overline";
+    type Decoration = "underline" | "lineThrough" | "overline";
 
     type DecorationStyle = "dashed" | "dotted" | "double" | "wavy";
 

--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pdfmake 0.1
+// Type definitions for pdfmake 0.1.65
 // Project: http://pdfmake.org
 // Definitions by: Milen Stefanov <https://github.com/m1llen1um>
 //                 Rajab Shakirov <https://github.com/radziksh>

--- a/types/pdfmake/pdfmake-tests.ts
+++ b/types/pdfmake/pdfmake-tests.ts
@@ -1321,7 +1321,7 @@ const definitions: pdfMake.TDocumentDefinitions[] = [
         compress: false,
         content: ['This document does not use compression']
     },
-    //Table of Contents tests
+    // Table of Contents tests
     {
         content: [
             {
@@ -1347,16 +1347,16 @@ const definitions: pdfMake.TDocumentDefinitions[] = [
             {
                 text: 'This is a header',
                 style: 'header',
-                tocItem: 'mainToc' //if is used id in toc
+                tocItem: 'mainToc' // if is used id in toc
             },
             {
                 text: 'This is a header',
                 style: 'header',
                 tocItem: ['mainToc', 'subToc'] // for multiple tocs
-            },
+            }
         ]
     },
-    //Watermark tests
+    // Watermark tests
     {
         content: "Watermark content",
         watermark: {
@@ -1369,12 +1369,12 @@ const definitions: pdfMake.TDocumentDefinitions[] = [
             angle: 70
         }
     }
-]
+];
 
 const downloadPdf = () => {
     const pdf = pdfMake;
     pdf.vfs = pdfFonts.pdfMake.vfs;
-    
+
     for (const def of definitions) {
         pdfMake.createPdf(def).download();
     }
@@ -1383,7 +1383,7 @@ const downloadPdf = () => {
 const openPdf = () => {
     const pdf = pdfMake;
     pdf.vfs = pdfFonts.pdfMake.vfs;
-    
+
     for (const def of definitions) {
         pdfMake.createPdf(def).open();
     }
@@ -1392,7 +1392,7 @@ const openPdf = () => {
 const openPdfInSameWindow = () => {
     const pdf = pdfMake;
     pdf.vfs = pdfFonts.pdfMake.vfs;
-    
+
     for (const def of definitions) {
         pdfMake.createPdf(def).open({}, window);
     }
@@ -1401,7 +1401,7 @@ const openPdfInSameWindow = () => {
 const printPdf = () => {
     const pdf = pdfMake;
     pdf.vfs = pdfFonts.pdfMake.vfs;
-    
+
     for (const def of definitions) {
         pdfMake.createPdf(def).print();
     }
@@ -1410,7 +1410,7 @@ const printPdf = () => {
 const printPdfInSameWindow = () => {
     const pdf = pdfMake;
     pdf.vfs = pdfFonts.pdfMake.vfs;
-    
+
     for (const def of definitions) {
         pdfMake.createPdf(def).print({}, window);
     }
@@ -1424,9 +1424,9 @@ const pdfAsBaseSixtyFourData = () => {
         const pdfDocGenerator = pdfMake.createPdf(def);
         pdfDocGenerator.getBase64((data) => {
             alert(data);
-        });   
+        });
     }
-}
+};
 
 const pdfAsBuffer = () => {
     const pdf = pdfMake;
@@ -1436,9 +1436,9 @@ const pdfAsBuffer = () => {
         const pdfDocGenerator = pdfMake.createPdf(def);
         pdfDocGenerator.getBuffer((buffer) => {
             // ...
-        }); 
+        });
     }
-}
+};
 
 const pdfAsBlob = () => {
     const pdf = pdfMake;
@@ -1448,9 +1448,9 @@ const pdfAsBlob = () => {
         const pdfDocGenerator = pdfMake.createPdf(def);
         pdfDocGenerator.getBlob((blob) => {
             // ...
-        }); 
+        });
     }
-}
+};
 
 const getPdfKitDocumentObject = () => {
     const pdf = pdfMake;
@@ -1462,4 +1462,4 @@ const getPdfKitDocumentObject = () => {
             // ...
         });
     }
-}
+};

--- a/types/pdfmake/pdfmake-tests.ts
+++ b/types/pdfmake/pdfmake-tests.ts
@@ -424,7 +424,7 @@ const definitions: pdfMake.TDocumentDefinitions[] = [
                     ]
                 }
             },
-            { text: 'Column/row spans', pageBreak: pdfMake.PageBreak.Before, style: 'subheader' },
+            { text: 'Column/row spans', pageBreak: 'before', style: 'subheader' },
             'Each cell-element can set a rowSpan or colSpan',
             {
                 style: 'tableExample',
@@ -449,7 +449,7 @@ const definitions: pdfMake.TDocumentDefinitions[] = [
                     ]
                 }
             },
-            { text: 'Headers', pageBreak: pdfMake.PageBreak.Before, style: 'subheader' },
+            { text: 'Headers', pageBreak: 'before', style: 'subheader' },
             'You can declare how many rows should be treated as a header. Headers are',
             ' automatically repeated on the following pages',
             { text: ['It is also possible to set keepWithHeaderRows to make sure there will be no page-break'
@@ -483,7 +483,7 @@ const definitions: pdfMake.TDocumentDefinitions[] = [
                 ]
             },
             'with more options coming soon...\n\npdfmake currently has a few predefined styles (see them on the next page)',
-            { text: 'noBorders:', fontSize: 14, bold: true, pageBreak: pdfMake.PageBreak.Before, margin: [0, 0, 0, 8] },
+            { text: 'noBorders:', fontSize: 14, bold: true, pageBreak: 'before', margin: [0, 0, 0, 8] },
             {
                 style: 'tableExample',
                 table: {
@@ -498,7 +498,7 @@ const definitions: pdfMake.TDocumentDefinitions[] = [
                         ['Sample value 1', 'Sample value 2', 'Sample value 3'],
                     ]
                 },
-                layout: pdfMake.Layout.NoBorders
+                layout: 'noBorders'
             },
             { text: 'headerLineOnly:', fontSize: 14, bold: true, margin: [0, 20, 0, 8] },
             {
@@ -515,7 +515,7 @@ const definitions: pdfMake.TDocumentDefinitions[] = [
                         ['Sample value 1', 'Sample value 2', 'Sample value 3'],
                     ]
                 },
-                layout: pdfMake.Layout.HeaderLineOnly
+                layout: 'headerLineOnly'
             },
             { text: 'lightHorizontalLines:', fontSize: 14, bold: true, margin: [0, 20, 0, 8] },
             {
@@ -531,7 +531,7 @@ const definitions: pdfMake.TDocumentDefinitions[] = [
                         ['Sample value 1', 'Sample value 2', 'Sample value 3'],
                     ]
                 },
-                layout: pdfMake.Layout.LightHorizontalLines
+                layout: 'lightHorizontalLines'
             },
             { text: 'but you can provide a custom styler as well', margin: [0, 20, 0, 8] },
             {
@@ -585,7 +585,7 @@ const definitions: pdfMake.TDocumentDefinitions[] = [
                     }
                 }
             },
-            { text: 'Optional border', fontSize: 14, bold: true, pageBreak: pdfMake.PageBreak.Before, margin: [0, 0, 0, 8] },
+            { text: 'Optional border', fontSize: 14, bold: true, pageBreak: 'before', margin: [0, 0, 0, 8] },
             'Each cell contains an optional border property: an array of 4 booleans for left border, top border, right border, bottom border.',
             {
                 style: 'tableExample',
@@ -1296,7 +1296,7 @@ const definitions: pdfMake.TDocumentDefinitions[] = [
             {
                 image: 'sampleImage.jpg',
                 fit: [100, 100],
-                pageBreak: pdfMake.PageBreak.After
+                pageBreak: 'after'
             },
             // Warning! Make sure to copy this definition and paste it to an
             // external text editor, as the online AceEditor has some troubles

--- a/types/pdfmake/pdfmake-tests.ts
+++ b/types/pdfmake/pdfmake-tests.ts
@@ -1,7 +1,7 @@
 import * as pdfMake from 'pdfmake/build/pdfmake';
 import * as pdfFonts from 'pdfmake/build/vfs_fonts';
 
-const definitions = [
+const definitions: pdfMake.TDocumentDefinitions[] = [
     {
         content: [
             'First paragraph',
@@ -424,7 +424,7 @@ const definitions = [
                     ]
                 }
             },
-            { text: 'Column/row spans', pageBreak: 'before', style: 'subheader' },
+            { text: 'Column/row spans', pageBreak: pdfMake.PageBreak.Before, style: 'subheader' },
             'Each cell-element can set a rowSpan or colSpan',
             {
                 style: 'tableExample',
@@ -449,7 +449,7 @@ const definitions = [
                     ]
                 }
             },
-            { text: 'Headers', pageBreak: 'before', style: 'subheader' },
+            { text: 'Headers', pageBreak: pdfMake.PageBreak.Before, style: 'subheader' },
             'You can declare how many rows should be treated as a header. Headers are',
             ' automatically repeated on the following pages',
             { text: ['It is also possible to set keepWithHeaderRows to make sure there will be no page-break'
@@ -483,7 +483,7 @@ const definitions = [
                 ]
             },
             'with more options coming soon...\n\npdfmake currently has a few predefined styles (see them on the next page)',
-            { text: 'noBorders:', fontSize: 14, bold: true, pageBreak: 'before', margin: [0, 0, 0, 8] },
+            { text: 'noBorders:', fontSize: 14, bold: true, pageBreak: pdfMake.PageBreak.Before, margin: [0, 0, 0, 8] },
             {
                 style: 'tableExample',
                 table: {
@@ -498,7 +498,7 @@ const definitions = [
                         ['Sample value 1', 'Sample value 2', 'Sample value 3'],
                     ]
                 },
-                layout: 'noBorders'
+                layout: pdfMake.Layout.NoBorders
             },
             { text: 'headerLineOnly:', fontSize: 14, bold: true, margin: [0, 20, 0, 8] },
             {
@@ -515,7 +515,7 @@ const definitions = [
                         ['Sample value 1', 'Sample value 2', 'Sample value 3'],
                     ]
                 },
-                layout: 'headerLineOnly'
+                layout: pdfMake.Layout.HeaderLineOnly
             },
             { text: 'lightHorizontalLines:', fontSize: 14, bold: true, margin: [0, 20, 0, 8] },
             {
@@ -531,7 +531,7 @@ const definitions = [
                         ['Sample value 1', 'Sample value 2', 'Sample value 3'],
                     ]
                 },
-                layout: 'lightHorizontalLines'
+                layout: pdfMake.Layout.LightHorizontalLines
             },
             { text: 'but you can provide a custom styler as well', margin: [0, 20, 0, 8] },
             {
@@ -585,7 +585,7 @@ const definitions = [
                     }
                 }
             },
-            { text: 'Optional border', fontSize: 14, bold: true, pageBreak: 'before', margin: [0, 0, 0, 8] },
+            { text: 'Optional border', fontSize: 14, bold: true, pageBreak: pdfMake.PageBreak.Before, margin: [0, 0, 0, 8] },
             'Each cell contains an optional border property: an array of 4 booleans for left border, top border, right border, bottom border.',
             {
                 style: 'tableExample',
@@ -1296,7 +1296,7 @@ const definitions = [
             {
                 image: 'sampleImage.jpg',
                 fit: [100, 100],
-                pageBreak: 'after'
+                pageBreak: pdfMake.PageBreak.After
             },
             // Warning! Make sure to copy this definition and paste it to an
             // external text editor, as the online AceEditor has some troubles
@@ -1320,15 +1320,146 @@ const definitions = [
     {
         compress: false,
         content: ['This document does not use compression']
+    },
+    //Table of Contents tests
+    {
+        content: [
+            {
+                toc: {
+                    title: {text: 'INDEX', style: 'header'}
+                }
+            }
+        ]
+    },
+    {
+        content: [
+            {
+                toc: {
+                    id: 'mainToc',
+                    title: {text: 'INDEX', style: 'header'}
+                }
+            },
+            {
+                text: 'This is a header',
+                style: 'header',
+                tocItem: true,
+            },
+            {
+                text: 'This is a header',
+                style: 'header',
+                tocItem: 'mainToc' //if is used id in toc
+            },
+            {
+                text: 'This is a header',
+                style: 'header',
+                tocItem: ['mainToc', 'subToc'] // for multiple tocs
+            },
+        ]
+    },
+    //Watermark tests
+    {
+        content: "Watermark content",
+        watermark: {
+            text: "Test Environment",
+            color: "red",
+            opacity: 0.3,
+            bold: true,
+            italics: true,
+            fontSize: 20,
+            angle: 70
+        }
     }
-];
+]
 
-const createPdf = () => {
-  const pdf = pdfMake;
-  pdf.vfs = pdfFonts.pdfMake.vfs;
-
-  for (const definition of definitions) {
-      const typedDefinition: pdfMake.TDocumentDefinitions = definition;
-      pdfMake.createPdf(typedDefinition).download();
-  }
+const downloadPdf = () => {
+    const pdf = pdfMake;
+    pdf.vfs = pdfFonts.pdfMake.vfs;
+    
+    for (const def of definitions) {
+        pdfMake.createPdf(def).download();
+    }
 };
+
+const openPdf = () => {
+    const pdf = pdfMake;
+    pdf.vfs = pdfFonts.pdfMake.vfs;
+    
+    for (const def of definitions) {
+        pdfMake.createPdf(def).open();
+    }
+};
+
+const openPdfInSameWindow = () => {
+    const pdf = pdfMake;
+    pdf.vfs = pdfFonts.pdfMake.vfs;
+    
+    for (const def of definitions) {
+        pdfMake.createPdf(def).open({}, window);
+    }
+};
+
+const printPdf = () => {
+    const pdf = pdfMake;
+    pdf.vfs = pdfFonts.pdfMake.vfs;
+    
+    for (const def of definitions) {
+        pdfMake.createPdf(def).print();
+    }
+};
+
+const printPdfInSameWindow = () => {
+    const pdf = pdfMake;
+    pdf.vfs = pdfFonts.pdfMake.vfs;
+    
+    for (const def of definitions) {
+        pdfMake.createPdf(def).print({}, window);
+    }
+};
+
+const pdfAsBaseSixtyFourData = () => {
+    const pdf = pdfMake;
+    pdf.vfs = pdfFonts.pdfMake.vfs;
+
+    for (const def of definitions) {
+        const pdfDocGenerator = pdfMake.createPdf(def);
+        pdfDocGenerator.getBase64((data) => {
+            alert(data);
+        });   
+    }
+}
+
+const pdfAsBuffer = () => {
+    const pdf = pdfMake;
+    pdf.vfs = pdfFonts.pdfMake.vfs;
+
+    for (const def of definitions) {
+        const pdfDocGenerator = pdfMake.createPdf(def);
+        pdfDocGenerator.getBuffer((buffer) => {
+            // ...
+        }); 
+    }
+}
+
+const pdfAsBlob = () => {
+    const pdf = pdfMake;
+    pdf.vfs = pdfFonts.pdfMake.vfs;
+
+    for (const def of definitions) {
+        const pdfDocGenerator = pdfMake.createPdf(def);
+        pdfDocGenerator.getBlob((blob) => {
+            // ...
+        }); 
+    }
+}
+
+const getPdfKitDocumentObject = () => {
+    const pdf = pdfMake;
+    pdf.vfs = pdfFonts.pdfMake.vfs;
+
+    for (const def of definitions) {
+        const pdfDocGenerator = pdfMake.createPdf(def);
+        pdfDocGenerator.getStream((gs) => {
+            // ...
+        });
+    }
+}

--- a/types/pdfmake/tslint.json
+++ b/types/pdfmake/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "indent": [true, "spaces", 4],
         "no-declare-current-package": false
     }
 }


### PR DESCRIPTION
Removed enums - converted to types.
Added missing parts from documentation and source code
Added tests
Added tslint rule for indentation

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint pdfmake`

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [PdfMake Docs](https://pdfmake.github.io/docs) and [PdfMake repository](https://github.com/bpampuch/pdfmake)
- [x] This PR brings the type definitions up to date with [pdfmake v0.1.65](https://github.com/bpampuch/pdfmake/releases/tag/0.1.65)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

close [issue 35081](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/35081)
close [issue 31011](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31011)