### PR TITLE
ssh2: Fix callback types

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -45,9 +45,9 @@ export interface Channel extends stream.Duplex {
     /** Indicates whether this is a server or client channel. */
     server: boolean;
     /** The channel type, usually "session". */
-    type: string | undefined;
+    type?: string;
     /** The channel subtype, usually "exec", "shell", or undefined. */
-    subtype: string | undefined;
+    subtype?: string;
 
     /**
      * Sends EOF to the remote side.
@@ -249,7 +249,7 @@ export class Client extends events.EventEmitter {
      * @param options Options for the command.
      * @param callback The callback to execute when the command has completed.
      */
-    exec(command: string, options: ExecOptions, callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
+    exec(command: string, options: ExecOptions, callback: (err: Error | undefined, channel: ClientChannel | undefined) => void): boolean;
 
     /**
      * Executes a command on the server.
@@ -259,7 +259,7 @@ export class Client extends events.EventEmitter {
      * @param command The command to execute.
      * @param callback The callback to execute when the command has completed.
      */
-    exec(command: string, callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
+    exec(command: string, callback: (err: Error | undefined, channel: ClientChannel | undefined) => void): boolean;
 
     /**
      * Starts an interactive shell session on the server.
@@ -270,7 +270,7 @@ export class Client extends events.EventEmitter {
      * @param options Options for the command.
      * @param callback The callback to execute when the channel has been created.
      */
-    shell(window: PseudoTtyOptions | false, options: ShellOptions, callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
+    shell(window: PseudoTtyOptions | false, options: ShellOptions, callback: (err: Error | undefined, channel: ClientChannel | undefined) => void): boolean;
 
     /**
      * Starts an interactive shell session on the server.
@@ -280,7 +280,7 @@ export class Client extends events.EventEmitter {
      * @param window Either an object containing containing pseudo-tty settings, `false` to suppress creation of a pseudo-tty.
      * @param callback The callback to execute when the channel has been created.
      */
-    shell(window: PseudoTtyOptions | false, callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
+    shell(window: PseudoTtyOptions | false, callback: (err: Error | undefined, channel: ClientChannel | undefined) => void): boolean;
 
     /**
      * Starts an interactive shell session on the server.
@@ -290,7 +290,7 @@ export class Client extends events.EventEmitter {
      * @param options Options for the command.
      * @param callback The callback to execute when the channel has been created.
      */
-    shell(options: ShellOptions, callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
+    shell(options: ShellOptions, callback: (err: Error | undefined, channel: ClientChannel | undefined) => void): boolean;
 
     /**
      * Starts an interactive shell session on the server.
@@ -299,7 +299,7 @@ export class Client extends events.EventEmitter {
      *
      * @param callback The callback to execute when the channel has been created.
      */
-    shell(callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
+    shell(callback: (err: Error | undefined, channel: ClientChannel | undefined) => void): boolean;
 
     /**
      * Bind to `remoteAddr` on `remotePort` on the server and forward incoming TCP connections.
@@ -320,7 +320,7 @@ export class Client extends events.EventEmitter {
      * @param remotePort The remote port to bind on the server. If this value is `0`, the actual bound port is provided to `callback`.
      * @param callback An optional callback that is invoked when the remote address is bound.
      */
-    forwardIn(remoteAddr: string, remotePort: number, callback?: (err: Error | undefined, bindPort: number) => void): boolean;
+    forwardIn(remoteAddr: string, remotePort: number, callback?: (err: Error | undefined, bindPort: number | undefined) => void): boolean;
 
     /**
      * Unbind from `remoteAddr` on `remotePort` on the server and stop forwarding incoming TCP
@@ -346,7 +346,7 @@ export class Client extends events.EventEmitter {
      * @param dstPort The destination port.
      * @param callback The callback that is invoked when the address is bound.
      */
-    forwardOut(srcIP: string, srcPort: number, dstIP: string, dstPort: number, callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
+    forwardOut(srcIP: string, srcPort: number, dstIP: string, dstPort: number, callback: (err: Error | undefined, channel: ClientChannel | undefined) => void): boolean;
 
     /**
      * Starts an SFTP session.
@@ -355,7 +355,7 @@ export class Client extends events.EventEmitter {
      *
      * @param callback The callback that is invoked when the SFTP session has started.
      */
-    sftp(callback: (err: Error | undefined, sftp: SFTPWrapper) => void): boolean;
+    sftp(callback: (err: Error | undefined, sftp: SFTPWrapper | undefined) => void): boolean;
 
     /**
      * Invokes `subsystem` on the server.
@@ -365,7 +365,7 @@ export class Client extends events.EventEmitter {
      * @param subsystem The subsystem to start on the server.
      * @param callback The callback that is invoked when the subsystem has started.
      */
-    subsys(subsystem: string, callback: (err: Error | undefined, channel: ClientChannel) => void): boolean;
+    subsys(subsystem: string, callback: (err: Error | undefined, channel: ClientChannel | undefined) => void): boolean;
 
     /**
      * Disconnects the socket.
@@ -407,7 +407,7 @@ export class Client extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    openssh_forwardOutStreamLocal(socketPath: string, callback?: (err: Error | undefined, channel: ClientChannel) => void): boolean;
+    openssh_forwardOutStreamLocal(socketPath: string, callback?: (err: Error | undefined, channel: ClientChannel | undefined) => void): boolean;
 }
 
 export interface ConnectConfig {
@@ -697,7 +697,7 @@ export class Server extends events.EventEmitter {
     /**
      * Asynchronously get the number of concurrent connections on the server.
      */
-    getConnections(callback: (err: Error | undefined, count: number) => void): void;
+    getConnections(callback: (err: Error | null, count: number) => void): void;
 
     /**
      * Stops the server from accepting new connections and keeps existing connections. This
@@ -848,7 +848,7 @@ export interface Connection extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    x11(originAddr: string, originPort: number, callback: (err: Error | undefined, channel: ServerChannel) => void): boolean;
+    x11(originAddr: string, originPort: number, callback: (err: Error | undefined, channel: ServerChannel | undefined) => void): boolean;
 
     /**
      * Alert the client of an incoming TCP connection on `boundAddr` on port `boundPort` from
@@ -856,7 +856,7 @@ export interface Connection extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    forwardOut(boundAddr: string, boundPort: number, remoteAddr: string, remotePort: number, callback: (err: Error | undefined, channel: ServerChannel) => void): boolean;
+    forwardOut(boundAddr: string, boundPort: number, remoteAddr: string, remotePort: number, callback: (err: Error | undefined, channel: ServerChannel | undefined) => void): boolean;
 
     /**
      * Initiates a rekeying with the client.
@@ -949,7 +949,7 @@ export interface PublicKeyAuthContext extends AuthContextBase {
     /** The public key sent by the client. */
     key: PublicKey;
     /** The signature to verify, or `undefined` if the client is only checking the validity of the key. */
-    signature: Buffer | undefined;
+    signature?: Buffer;
     /** The signature algorithm, or `undefined` if the client is only checking the validity of the key. */
     sigAlgo: string;
     /** The data used to verify the key, or `undefined` if the client is only checking the validity of the key. */
@@ -969,7 +969,7 @@ export interface HostbasedAuthContext extends AuthContextBase {
     /** The public key sent by the client. */
     key: PublicKey;
     /** The signature to verify, or `undefined` if the client is only checking the validity of the key. */
-    signature: Buffer | undefined;
+    signature?: Buffer;
     /** The signature algorithm, or `undefined` if the client is only checking the validity of the key. */
     sigAlgo: string;
     /** The data used to verify the key, or `undefined` if the client is only checking the validity of the key. */
@@ -1261,43 +1261,43 @@ export interface SFTPWrapper extends events.EventEmitter {
      * (Client-only)
      * Downloads a file at `remotePath` to `localPath` using parallel reads for faster throughput.
      */
-    fastGet(remotePath: string, localPath: string, options: TransferOptions, callback: (err: any) => void): void;
+    fastGet(remotePath: string, localPath: string, options: TransferOptions, callback: (err: Error | undefined) => void): void;
 
     /**
      * (Client-only)
      * Downloads a file at `remotePath` to `localPath` using parallel reads for faster throughput.
      */
-    fastGet(remotePath: string, localPath: string, callback: (err: any) => void): void;
+    fastGet(remotePath: string, localPath: string, callback: (err: Error | undefined) => void): void;
 
     /**
      * (Client-only)
      * Uploads a file from `localPath` to `remotePath` using parallel reads for faster throughput.
      */
-    fastPut(localPath: string, remotePath: string, options: TransferOptions, callback: (err: any) => void): void;
+    fastPut(localPath: string, remotePath: string, options: TransferOptions, callback: (err: Error | undefined) => void): void;
 
     /**
      * (Client-only)
      * Uploads a file from `localPath` to `remotePath` using parallel reads for faster throughput.
      */
-    fastPut(localPath: string, remotePath: string, callback: (err: any) => void): void;
+    fastPut(localPath: string, remotePath: string, callback: (err: Error | undefined) => void): void;
 
     /**
      * (Client-only)
      * Reads a file in memory and returns its contents
      */
-    readFile(remotePath: string, options: ReadFileOptions, callback: (err: any, handle: Buffer) => void): void;
+    readFile(remotePath: string, options: ReadFileOptions, callback: (err: Error | undefined, handle: Buffer | undefined) => void): void;
 
     /**
      * (Client-only)
      * Reads a file in memory and returns its contents
      */
-    readFile(remotePath: string, encoding: string, callback: (err: any, handle: Buffer) => void): void;
+    readFile(remotePath: string, encoding: string, callback: (err: Error | undefined, handle: Buffer | undefined) => void): void;
 
     /**
      * (Client-only)
      * Reads a file in memory and returns its contents
      */
-    readFile(remotePath: string, callback: (err: any, handle: Buffer) => void): void;
+    readFile(remotePath: string, callback: (err: Error | undefined, handle: Buffer | undefined) => void): void;
 
     /**
      * (Client-only)
@@ -1317,7 +1317,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    open(filename: string, mode: string, attributes: InputAttributes, callback: (err: any, handle: Buffer) => void): boolean;
+    open(filename: string, mode: string, attributes: InputAttributes, callback: (err: Error | undefined, handle: Buffer | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1325,7 +1325,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    open(filename: string, mode: string, callback: (err: any, handle: Buffer) => void): boolean;
+    open(filename: string, mode: string, callback: (err: Error | undefined, handle: Buffer | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1333,7 +1333,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    close(handle: Buffer, callback: (err: any) => void): boolean;
+    close(handle: Buffer, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1342,13 +1342,13 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    read(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number, callback: (err: any, bytesRead: number, buffer: Buffer, position: number) => void): boolean;
+    read(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number, callback: (err: Error | undefined, bytesRead: number, buffer: Buffer, position: number) => void): boolean;
 
     /**
      * (Client-only)
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    write(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number, callback: (err: any) => void): boolean;
+    write(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1356,7 +1356,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    fstat(handle: Buffer, callback: (err: any, stats: Stats) => void): boolean;
+    fstat(handle: Buffer, callback: (err: Error | undefined, stats: Stats | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1364,7 +1364,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    fsetstat(handle: Buffer, attributes: InputAttributes, callback: (err: any) => void): boolean;
+    fsetstat(handle: Buffer, attributes: InputAttributes, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1372,7 +1372,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    futimes(handle: Buffer, atime: number | Date, mtime: number | Date, callback: (err: any) => void): boolean;
+    futimes(handle: Buffer, atime: number | Date, mtime: number | Date, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1380,7 +1380,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    fchown(handle: Buffer, uid: number, gid: number, callback: (err: any) => void): boolean;
+    fchown(handle: Buffer, uid: number, gid: number, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1388,7 +1388,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    fchmod(handle: Buffer, mode: number | string, callback: (err: any) => void): boolean;
+    fchmod(handle: Buffer, mode: number | string, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1396,7 +1396,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    opendir(path: string, callback: (err: any, handle: Buffer) => void): boolean;
+    opendir(path: string, callback: (err: Error | undefined, handle: Buffer | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1404,7 +1404,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    readdir(location: string | Buffer, callback: (err: any, list: FileEntry[]) => void): boolean;
+    readdir(location: string | Buffer, callback: (err: Error | undefined, list: FileEntry[] | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1412,7 +1412,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    unlink(path: string, callback: (err: any) => void): boolean;
+    unlink(path: string, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1420,7 +1420,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    rename(srcPath: string, destPath: string, callback: (err: any) => void): boolean;
+    rename(srcPath: string, destPath: string, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1428,7 +1428,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    mkdir(path: string, attributes: InputAttributes, callback: (err: any) => void): boolean;
+    mkdir(path: string, attributes: InputAttributes, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1436,7 +1436,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    mkdir(path: string, callback: (err: any) => void): boolean;
+    mkdir(path: string, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1444,7 +1444,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    rmdir(path: string, callback: (err: any) => void): boolean;
+    rmdir(path: string, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1452,7 +1452,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    stat(path: string, callback: (err: any, stats: Stats) => void): boolean;
+    stat(path: string, callback: (err: Error | undefined, stats: Stats | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1461,7 +1461,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    lstat(path: string, callback: (err: any, stats: Stats) => void): boolean;
+    lstat(path: string, callback: (err: Error | undefined, stats: Stats | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1469,7 +1469,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    setstat(path: string, attributes: InputAttributes, callback: (err: any) => void): boolean;
+    setstat(path: string, attributes: InputAttributes, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1477,7 +1477,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    utimes(path: string, atime: number | Date, mtime: number | Date, callback: (err: any) => void): boolean;
+    utimes(path: string, atime: number | Date, mtime: number | Date, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1485,7 +1485,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    chown(path: string, uid: number, gid: number, callback: (err: any) => void): boolean;
+    chown(path: string, uid: number, gid: number, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1493,7 +1493,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    chmod(path: string, mode: number | string, callback: (err: any) => void): boolean;
+    chmod(path: string, mode: number | string, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1501,7 +1501,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    readlink(path: string, callback: (err: any, target: string) => void): boolean;
+    readlink(path: string, callback: (err: Error | undefined, target: string | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1509,7 +1509,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    symlink(targetPath: string, linkPath: string, callback: (err: any) => void): boolean;
+    symlink(targetPath: string, linkPath: string, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only)
@@ -1517,7 +1517,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    realpath(path: string, callback: (err: any, absPath: string) => void): boolean;
+    realpath(path: string, callback: (err: Error | undefined, absPath: string) => void): boolean;
 
     /**
      * (Client-only, OpenSSH extension)
@@ -1525,7 +1525,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    ext_openssh_rename(srcPath: string, destPath: string, callback: (err: any) => void): boolean;
+    ext_openssh_rename(srcPath: string, destPath: string, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only, OpenSSH extension)
@@ -1533,7 +1533,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    ext_openssh_statvfs(path: string, callback: (err: any, fsInfo: any) => void): boolean;
+    ext_openssh_statvfs(path: string, callback: (err: Error | undefined, fsInfo: any) => void): boolean;
 
     /**
      * (Client-only, OpenSSH extension)
@@ -1541,7 +1541,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    ext_openssh_fstatvfs(handle: Buffer, callback: (err: any, fsInfo: any) => void): boolean;
+    ext_openssh_fstatvfs(handle: Buffer, callback: (err: Error | undefined, fsInfo: any) => void): boolean;
 
     /**
      * (Client-only, OpenSSH extension)
@@ -1549,7 +1549,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    ext_openssh_hardlink(targetPath: string, linkPath: string, callback: (err: any) => void): boolean;
+    ext_openssh_hardlink(targetPath: string, linkPath: string, callback: (err: Error | undefined) => void): boolean;
 
     /**
      * (Client-only, OpenSSH extension)
@@ -1557,7 +1557,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    ext_openssh_fsync(handle: Buffer, callback: (err: any, fsInfo: any) => void): boolean;
+    ext_openssh_fsync(handle: Buffer, callback: (err: Error | undefined, fsInfo: any) => void): boolean;
 
     /**
      * Ends the stream.
@@ -1567,7 +1567,7 @@ export interface SFTPWrapper extends events.EventEmitter {
     /**
      * Emitted when an error occurred.
      */
-    on(event: "error", listener: (err: any) => void): this;
+    on(event: "error", listener: (err: Error | undefined) => void): this;
 
     /**
      * Emitted when the session has ended.

--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -1517,7 +1517,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    realpath(path: string, callback: (err: Error | undefined, absPath: string) => void): boolean;
+    realpath(path: string, callback: (err: Error | undefined, absPath: string | undefined) => void): boolean;
 
     /**
      * (Client-only, OpenSSH extension)

--- a/types/ssh2/ssh2-tests.ts
+++ b/types/ssh2/ssh2-tests.ts
@@ -16,8 +16,8 @@ var Client = require('ssh2').Client;
 var conn = new Client();
 conn.on('ready', () => {
     console.log('Client :: ready');
-    conn.exec('uptime', (err: Error, stream: ssh2.ClientChannel) => {
-        if (err) throw err;
+    conn.exec('uptime', (err?: Error, stream?: ssh2.ClientChannel) => {
+        if (err || !stream) throw err;
         stream
             .on('close', (code: any, signal: any) => {
                 console.log('Stream :: close :: code: ' + code + ', signal: ' + signal);
@@ -42,8 +42,8 @@ var Client = require('ssh2').Client;
 var conn = new Client();
 conn.on('ready', () => {
     console.log('Client :: ready');
-    conn.shell( (err: Error, stream: ssh2.ClientChannel) => {
-        if (err) throw err;
+    conn.shell( (err?: Error, stream?: ssh2.ClientChannel) => {
+        if (err || !stream) throw err;
         stream.on('close', () => {
             console.log('Stream :: close');
             conn.end();
@@ -68,8 +68,8 @@ var Client = require('ssh2').Client;
 var conn = new Client();
 conn.on('ready', () => {
     console.log('Client :: ready');
-    conn.forwardOut('192.168.100.102', 8000, '127.0.0.1', 80, (err: Error, stream: ssh2.ClientChannel) => {
-        if (err) throw err;
+    conn.forwardOut('192.168.100.102', 8000, '127.0.0.1', 80, (err?: Error, stream?: ssh2.ClientChannel) => {
+        if (err || !stream) throw err;
         stream.on('close', () => {
             console.log('TCP :: CLOSED');
             conn.end();
@@ -99,7 +99,7 @@ var Client = require('ssh2').Client;
 var conn = new Client();
 conn.on('ready', () => {
     console.log('Client :: ready');
-    conn.forwardIn('127.0.0.1', 8000, (err: Error) => {
+    conn.forwardIn('127.0.0.1', 8000, (err?: Error) => {
         if (err) throw err;
         console.log('Listening for connections on server on port 8000!');
     });
@@ -133,10 +133,10 @@ var Client = require('ssh2').Client;
 var conn = new Client();
 conn.on('ready', () => {
     console.log('Client :: ready');
-    conn.sftp( (err: Error, sftp: ssh2.SFTPWrapper) => {
-        if (err) throw err;
-        sftp.readdir('foo', (err: Error, list: ssh2_streams.FileEntry[]) => {
-            if (err) throw err;
+    conn.sftp( (err?: Error, sftp?: ssh2.SFTPWrapper) => {
+        if (err || !sftp) throw err;
+        sftp.readdir('foo', (err?: Error, list?: ssh2_streams.FileEntry[]) => {
+            if (err || list === undefined) throw err;
             console.dir(list);
             conn.end();
         });
@@ -157,8 +157,8 @@ var conn1 = new Client(),
 
 conn1.on('ready', () => {
     console.log('FIRST :: connection ready');
-    conn1.exec('nc 192.168.1.2 22', (err: Error, stream: ssh2.ClientChannel) => {
-        if (err) {
+    conn1.exec('nc 192.168.1.2 22', (err?: Error, stream?: ssh2.ClientChannel) => {
+        if (err || !stream) {
             console.log('FIRST :: exec error: ' + err);
             return conn1.end();
         }
@@ -176,8 +176,8 @@ conn1.on('ready', () => {
 
 conn2.on('ready', () => {
     console.log('SECOND :: connection ready');
-    conn2.exec('uptime', (err: Error, stream: ssh2.ClientChannel) => {
-        if (err) {
+    conn2.exec('uptime', (err?: Error, stream?: ssh2.ClientChannel) => {
+        if (err || !stream) {
             console.log('SECOND :: exec error: ' + err);
             return conn1.end();
         }
@@ -207,8 +207,8 @@ conn.on('x11', (info: any, accept: any, reject: any) => {
 });
 
 conn.on('ready', () => {
-    conn.exec('xeyes', { x11: true }, (err: Error, stream: ssh2.ClientChannel) => {
-        if (err) throw err;
+    conn.exec('xeyes', { x11: true }, (err?: Error, stream?: ssh2.ClientChannel) => {
+        if (err || !stream) throw err;
         var code = 0;
         stream.on('end', () => {
             if (code !== 0)
@@ -246,8 +246,8 @@ socks.createServer( (info: any, accept: any, deny: any) => {
             info.srcPort,
             info.dstAddr,
             info.dstPort,
-             (err: Error, stream: ssh2.ClientChannel) => {
-                if (err) {
+             (err?: Error, stream?: ssh2.ClientChannel) => {
+                if (err || !stream) {
                     conn.end();
                     return deny();
                 }
@@ -281,8 +281,8 @@ var conn = new Client();
 
 conn.on('ready', () => {
     console.log('Client :: ready');
-    conn.subsys('netconf', (err: Error, stream: ssh2.ClientChannel) => {
-        if (err) throw err;
+    conn.subsys('netconf', (err?: Error, stream?: ssh2.ClientChannel) => {
+        if (err || !stream) throw err;
         stream.on('data', (data: any) => {
             console.log(data);
         }).write(xmlhello);
@@ -428,8 +428,3 @@ new ssh2.Server({
 }).listen(0, '127.0.0.1', function () {
         console.log('Listening on port ' + this.address().port);
     });
-
-
-
-
-


### PR DESCRIPTION
These were half-fixed recently (in my local version `err` cannot be `undefined`). But if you check the code the second parameter to all the callbacks should be `| undefined` too. I haven't checked all these callbacks exhaustively.

I also changed the SFTP callbacks from `any` to `Error | undefined`. Again I haven't fully analysed the entire code but it seems likely that this is the correc type.

Also changed some fields to use `?` which is a bit more idiomatic, and fixed the type of the `getConnections` callback (according to the Node typings - who knows if those are correct?).

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.) 
- [x] Add or edit tests to reflect the change. (Run with `npm test`.) **Note: `npm test` did not work because `stdout maxBuffer length exceeded`, and neither did any of the suggestions for how to run a single test directly. However I'm not sure of the value of `ssh2-tests.ts` anyway because the previous commit should have broken it and apparently nothing noticed this.**
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mscdex/ssh2/blob/master/lib/client.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

