### PR TITLE
[@types/frida-gum]: update: make `Java.Wrapper` more generic

### DIFF
--- a/types/frida-gum/frida-gum-tests.ts
+++ b/types/frida-gum/frida-gum-tests.ts
@@ -57,17 +57,37 @@ Java.enumerateClassLoadersSync()
     .forEach(classLoader => {
         // $ExpectType ClassFactory
         const factory = Java.ClassFactory.get(classLoader);
-        interface StringProps {
-            substring: Java.MethodDispatcher;
+        interface Props {
+            myMethod: Java.MethodDispatcher;
+            myField: Java.Field<number>;
         }
-        // $ExpectType Wrapper<StringProps>
-        const JavaLangString = factory.use<StringProps>("java.lang.String");
+        // $ExpectType Wrapper<Props>
+        const MyJavaClass = factory.use<Props>("my.java.class");
+        // $ExpectError
+        factory.use<{ illegal: string }>("");
         // $ExpectType string
-        JavaLangString.$className;
-        // $ExpectType MethodDispatcher
-        JavaLangString.substring;
-        JavaLangString.substring.implementation = function(...args) {
-            // $ExpectType MethodDispatcher
-            this.substring;
-        } as Java.MethodImplementation<StringProps>;
+        MyJavaClass.$className;
+        // $ExpectType MethodDispatcher<Props>
+        MyJavaClass.myMethod;
+        // $ExpectType Wrapper<Props>
+        MyJavaClass.myMethod.holder;
+        // $ExpectType Wrapper<Props>
+        MyJavaClass.myMethod.holder.myField.holder.myMethod.holder;
+        MyJavaClass.myMethod.implementation = function(...args) {
+            // $ExpectType MethodDispatcher<Props>
+            this.myMethod;
+            // $ExpectType Field<number, Props>
+            this.myField;
+            // $ExpectType number
+            this.myField.value;
+        };
+        // $ExpectType Wrapper<Props>
+        Java.retain(MyJavaClass);
+        interface AnotherProps {
+            anotherMethod: Java.MethodDispatcher;
+            anotherField: Java.Field<string>;
+        }
+        const MyAnotherJavaClass = factory.use<AnotherProps>("my.another.java.class");
+        // $ExpectType Wrapper<AnotherProps>
+        Java.cast(MyJavaClass, MyAnotherJavaClass);
     });

--- a/types/frida-gum/frida-gum-tests.ts
+++ b/types/frida-gum/frida-gum-tests.ts
@@ -57,6 +57,17 @@ Java.enumerateClassLoadersSync()
     .forEach(classLoader => {
         // $ExpectType ClassFactory
         const factory = Java.ClassFactory.get(classLoader);
-        // $ExpectType Wrapper
-        factory.use("java.lang.String");
+        interface StringProps {
+            substring: Java.MethodDispatcher;
+        }
+        // $ExpectType Wrapper<StringProps>
+        const JavaLangString = factory.use<StringProps>("java.lang.String");
+        // $ExpectType string
+        JavaLangString.$className;
+        // $ExpectType MethodDispatcher
+        JavaLangString.substring;
+        JavaLangString.substring.implementation = function(...args) {
+            // $ExpectType MethodDispatcher
+            this.substring;
+        } as Java.MethodImplementation<StringProps>;
     });

--- a/types/frida-gum/index.d.ts
+++ b/types/frida-gum/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/frida/frida
 // Definitions by: Ole André Vadla Ravnås <https://github.com/oleavr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// Minimum TypeScript Version: 3.5
 
 /**
  * Returns a hexdump of the provided ArrayBuffer or NativePointerValue target.
@@ -4096,7 +4096,7 @@ declare namespace Java {
      *
      * @param className Canonical class name to get a wrapper for.
      */
-    function use(className: string): Wrapper;
+    function use<T extends Properties<T> = {}>(className: string): Wrapper<T>;
 
     /**
      * Opens the .dex file at `filePath`.
@@ -4214,10 +4214,12 @@ declare namespace Java {
         onComplete: () => void;
     }
 
+    type Properties<T> = Record<keyof T, MethodDispatcher | Field>;
+
     /**
      * Dynamically generated wrapper for any Java class, instance, or interface.
      */
-    interface Wrapper {
+    type Wrapper<T extends Properties<T> = {}> = T & {
         /**
          * Allocates and initializes a new instance of the given class.
          *
@@ -4259,7 +4261,7 @@ declare namespace Java {
          * Methods and fields.
          */
         [name: string]: any;
-    }
+    };
 
     interface MethodDispatcher extends Method {
         /**
@@ -4304,7 +4306,7 @@ declare namespace Java {
          * replace the original implementation. Assign `null` at a future point
          * to revert back to the original implementation.
          */
-        implementation: MethodImplementation | null;
+        implementation: MethodImplementation<any> | null;
 
         /**
          * Method return type.
@@ -4330,7 +4332,7 @@ declare namespace Java {
         clone: (options: NativeFunctionOptions) => Method;
     }
 
-    type MethodImplementation = (this: Wrapper, ...params: any[]) => any;
+    type MethodImplementation<T extends Properties<T> = {}> = (this: Wrapper<T>, ...params: any[]) => any;
 
     interface Field {
         /**
@@ -4545,7 +4547,7 @@ declare namespace Java {
          *
          * @param className Canonical class name to get a wrapper for.
          */
-        use(className: string): Wrapper;
+        use<T extends Properties<T> = {}>(className: string): Wrapper<T>;
 
         /**
          * Opens the .dex file at `filePath`.

--- a/types/frida-gum/index.d.ts
+++ b/types/frida-gum/index.d.ts
@@ -4096,7 +4096,7 @@ declare namespace Java {
      *
      * @param className Canonical class name to get a wrapper for.
      */
-    function use<T extends Properties<T> = {}>(className: string): Wrapper<T>;
+    function use<T extends Members<T> = {}>(className: string): Wrapper<T>;
 
     /**
      * Opens the .dex file at `filePath`.
@@ -4117,9 +4117,9 @@ declare namespace Java {
     /**
      * Duplicates a JavaScript wrapper for later use outside replacement method.
      *
-     * @param handle An existing wrapper retrieved from `this` in replacement method.
+     * @param obj An existing wrapper retrieved from `this` in replacement method.
      */
-    function retain(obj: Wrapper): Wrapper;
+    function retain<T extends Members<T> = {}>(obj: Wrapper<T>): Wrapper<T>;
 
     /**
      * Creates a JavaScript wrapper given the existing instance at `handle` of
@@ -4128,7 +4128,10 @@ declare namespace Java {
      * @param handle An existing wrapper or a JNI handle.
      * @param klass Class wrapper for type to cast to.
      */
-    function cast(handle: Wrapper | NativePointerValue, klass: Wrapper): Wrapper;
+    function cast<From extends Members<From> = {}, To extends Members<To> = {}>(
+        handle: Wrapper<From> | NativePointerValue,
+        klass: Wrapper<To>
+    ): Wrapper<To>;
 
     /**
      * Creates a Java array with elements of the specified `type`, from a
@@ -4214,25 +4217,30 @@ declare namespace Java {
         onComplete: () => void;
     }
 
-    type Properties<T> = Record<keyof T, MethodDispatcher | Field>;
+    type Members<T> = Record<keyof T, MethodDispatcher | Field>;
 
     /**
      * Dynamically generated wrapper for any Java class, instance, or interface.
      */
-    type Wrapper<T extends Properties<T> = {}> = T & {
+    type Wrapper<T extends Members<T> = {}> = {
+        /**
+         * Automatically inject holder's type to all fields and methods
+         */
+        [K in keyof T]: T[K] extends Field<infer Value> ? Field<Value, T> : MethodDispatcher<T>
+    } & {
         /**
          * Allocates and initializes a new instance of the given class.
          *
          * Use this to create a new instance.
          */
-        $new: MethodDispatcher;
+        $new: MethodDispatcher<T>;
 
         /**
          * Allocates a new instance without initializing it.
          *
          * Call `$init()` to initialize it.
          */
-        $alloc: MethodDispatcher;
+        $alloc: MethodDispatcher<T>;
 
         /**
          * Initializes an instance that was allocated but not yet initialized.
@@ -4240,7 +4248,7 @@ declare namespace Java {
          *
          * Replace the `implementation` property to hook a given constructor.
          */
-        $init: MethodDispatcher;
+        $init: MethodDispatcher<T>;
 
         /**
          * Retrieves a `java.lang.Class` wrapper for the current class.
@@ -4263,11 +4271,11 @@ declare namespace Java {
         [name: string]: any;
     };
 
-    interface MethodDispatcher extends Method {
+    interface MethodDispatcher<Holder extends Members<Holder> = {}> extends Method<Holder> {
         /**
          * Available overloads.
          */
-        overloads: Method[];
+        overloads: Array<Method<Holder>>;
 
         /**
          * Obtains a specific overload.
@@ -4275,10 +4283,10 @@ declare namespace Java {
          * @param args Signature of the overload to obtain.
          *             For example: `"java.lang.String", "int"`.
          */
-        overload(...args: string[]): Method;
+        overload(...args: string[]): Method<Holder>;
     }
 
-    interface Method {
+    interface Method<Holder extends Members<Holder> = {}> {
         (...params: any[]): any;
 
         /**
@@ -4289,7 +4297,7 @@ declare namespace Java {
         /**
          * Class that this method belongs to.
          */
-        holder: Wrapper;
+        holder: Wrapper<Holder>;
 
         /**
          * What kind of method this is, i.e. constructor vs static vs instance.
@@ -4306,7 +4314,7 @@ declare namespace Java {
          * replace the original implementation. Assign `null` at a future point
          * to revert back to the original implementation.
          */
-        implementation: MethodImplementation<any> | null;
+        implementation: MethodImplementation<Holder> | null;
 
         /**
          * Method return type.
@@ -4329,21 +4337,21 @@ declare namespace Java {
          * Useful for e.g. setting `traps: "all"` to perform execution tracing
          * in conjunction with Stalker.
          */
-        clone: (options: NativeFunctionOptions) => Method;
+        clone: (options: NativeFunctionOptions) => Method<Holder>;
     }
 
-    type MethodImplementation<T extends Properties<T> = {}> = (this: Wrapper<T>, ...params: any[]) => any;
+    type MethodImplementation<This extends Members<This> = {}> = (this: Wrapper<This>, ...params: any[]) => any;
 
-    interface Field {
+    interface Field<Value = any, Holder extends Members<Holder> = {}> {
         /**
          * Current value of this field. Assign to update the field's value.
          */
-        value: any;
+        value: Value;
 
         /**
          * Class that this field belongs to.
          */
-        holder: Wrapper;
+        holder: Wrapper<Holder>;
 
         /**
          * What kind of field this is, i.e. static vs instance.
@@ -4547,7 +4555,7 @@ declare namespace Java {
          *
          * @param className Canonical class name to get a wrapper for.
          */
-        use<T extends Properties<T> = {}>(className: string): Wrapper<T>;
+        use<T extends Members<T> = {}>(className: string): Wrapper<T>;
 
         /**
          * Opens the .dex file at `filePath`.
@@ -4568,9 +4576,9 @@ declare namespace Java {
         /**
          * Duplicates a JavaScript wrapper for later use outside replacement method.
          *
-         * @param handle An existing wrapper retrieved from `this` in replacement method.
+         * @param obj An existing wrapper retrieved from `this` in replacement method.
          */
-        retain(obj: Wrapper): Wrapper;
+        retain<T extends Members<T> = {}>(obj: Wrapper<T>): Wrapper<T>;
 
         /**
          * Creates a JavaScript wrapper given the existing instance at `handle` of
@@ -4579,7 +4587,10 @@ declare namespace Java {
          * @param handle An existing wrapper or a JNI handle.
          * @param klass Class wrapper for type to cast to.
          */
-        cast(handle: Wrapper | NativePointerValue, klass: Wrapper): Wrapper;
+        cast<From extends Members<From> = {}, To extends Members<To> = {}>(
+            handle: Wrapper<From> | NativePointerValue,
+            klass: Wrapper<To>
+        ): Wrapper<To>;
 
         /**
          * Creates a Java array with elements of the specified `type`, from a

--- a/types/frida-gum/index.d.ts
+++ b/types/frida-gum/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package frida-gum 15.0
+// Type definitions for non-npm package frida-gum 15.1
 // Project: https://github.com/frida/frida
 // Definitions by: Ole André Vadla Ravnås <https://github.com/oleavr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
Dynamic key `name` with value type `any` is used in `Java.Wrapper` to give access to methods and fields of Java class/instance. I improved it in a more generic way, and now we can write code as follows:

```ts
interface Props {
    method: Java.MethodDispatcher;
    field: Java.Field;
}
const cls = Java.use<Props>("my.app");
cls.method.implementation = function (...args) { // `method` can be inferred from `cls`
    console.log(this.field); // `field` can be inferred from `this`
    return this.method(...args); // `method` can also be inferred from `this`
} as Java.MethodImplementation<Props>;
```

(For backward compatibility, dynamic key `name` is not removed.)

Btw, I'm not very familiar with frida, so many occurrences of `Java.Wrapper` is still not typed, but I'm willing to improve it if necessary.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/frida-gum/index.d.ts#L4220>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
