### PR TITLE
@testing-library__react: add debug options

### DIFF
--- a/types/testing-library__react/index.d.ts
+++ b/types/testing-library__react/index.d.ts
@@ -9,6 +9,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
+import { OptionsReceived as PrettyFormatOptions } from 'pretty-format';
 import { queries, Queries, BoundFunction } from '@testing-library/dom';
 import { act as reactAct } from 'react-dom/test-utils';
 
@@ -17,7 +18,11 @@ export * from '@testing-library/dom';
 export type RenderResult<Q extends Queries = typeof queries> = {
     container: HTMLElement;
     baseElement: HTMLElement;
-    debug: (baseElement?: HTMLElement | DocumentFragment | Array<HTMLElement | DocumentFragment>) => void;
+    debug: (
+      baseElement?: HTMLElement | DocumentFragment | Array<HTMLElement | DocumentFragment>,
+      maxLength?: number,
+      options?: PrettyFormatOptions
+    ) => void;
     rerender: (ui: React.ReactElement) => void;
     unmount: () => boolean;
     asFragment: () => DocumentFragment;

--- a/types/testing-library__react/package.json
+++ b/types/testing-library__react/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "pretty-format": "^25.1.0"
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/testing-library/react-testing-library/pull/596
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
