### PR TITLE
[ember-data] Fix Model.belongsTo and Model.hasMany

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -28,15 +28,15 @@ type MaybeModel<T> = T extends DS.Model ? T : never;
 
 type UnboxBelongsTo<T> =
     T extends DS.PromiseObject<infer C> ? MaybeModel<C>
-      : T extends Ember.ComputedProperty<infer C & DS.PromiseObject<infer C>, infer C> ? MaybeModel<C>
-      : T extends Ember.ComputedProperty<infer C> ? MaybeModel<C>
+    //   : T extends Ember.ComputedProperty<infer C & DS.PromiseObject<infer C>, infer C> ? MaybeModel<C>
+    //   : T extends Ember.ComputedProperty<infer C> ? MaybeModel<C>
       : MaybeModel<T>;
 
 type UnboxHasMany<T> =
     T extends DS.PromiseManyArray<infer C> ? MaybeModel<C>
       : T extends Ember.Array<infer C> ? MaybeModel<C>
-      : T extends Ember.ComputedProperty<DS.PromiseManyArray<infer C>, Ember.Array<infer C>> ? MaybeModel<C>
-      : T extends Ember.ComputedProperty<DS.ManyArray<infer C>> ? MaybeModel<C>
+    //   : T extends Ember.ComputedProperty<DS.PromiseManyArray<infer C>, Ember.Array<infer C>> ? MaybeModel<C>
+    //   : T extends Ember.ComputedProperty<DS.ManyArray<infer C>> ? MaybeModel<C>
       : never;
 
 type BelongsToModels<Model extends DS.Model> = {

--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -23,7 +23,31 @@ import AdapterRegistry from 'ember-data/types/registries/adapter';
 type ModelKeys<Model extends DS.Model> = Exclude<keyof Model, keyof DS.Model>;
 
 type AttributesFor<Model extends DS.Model> = ModelKeys<Model>; // TODO: filter to attr properties only (TS 2.8)
-type RelationshipsFor<Model extends DS.Model> = ModelKeys<Model>; // TODO: filter to hasMany/belongsTo properties only (TS 2.8)
+
+type MaybeModel<T> = T extends DS.Model ? T : never;
+
+type UnboxBelongsTo<T> =
+    T extends DS.PromiseObject<infer C> ? MaybeModel<C>
+      : T extends Ember.ComputedProperty<infer C & DS.PromiseObject<infer C>, infer C> ? MaybeModel<C>
+      : T extends Ember.ComputedProperty<infer C> ? MaybeModel<C>
+      : MaybeModel<T>;
+
+type UnboxHasMany<T> =
+    T extends DS.PromiseManyArray<infer C> ? MaybeModel<C>
+      : T extends Ember.Array<infer C> ? MaybeModel<C>
+      : T extends Ember.ComputedProperty<DS.PromiseManyArray<infer C>, Ember.Array<infer C>> ? MaybeModel<C>
+      : T extends Ember.ComputedProperty<DS.ManyArray<infer C>> ? MaybeModel<C>
+      : never;
+
+type BelongsToModels<Model extends DS.Model> = {
+    [k in keyof Model]: UnboxBelongsTo<Model[k]>
+};
+
+type HasManyModels<Model extends DS.Model> = {
+    [k in keyof Model]: UnboxHasMany<Model[k]>
+};
+
+type KeysForRelationships<Model extends DS.Model> = keyof BelongsToModels<Model> & keyof HasManyModels<Model>;
 
 export interface ChangedAttributes {
     [key: string]: [any, any] | undefined;
@@ -43,7 +67,7 @@ interface RelationshipMetaOptions {
     [k: string]: any;
 }
 interface RelationshipMeta<Model extends DS.Model> {
-    key: RelationshipsFor<Model>;
+    key: KeysForRelationships<Model>;
     kind: 'belongsTo' | 'hasMany';
     type: keyof ModelRegistry;
     options: RelationshipMetaOptions;
@@ -64,7 +88,7 @@ export namespace DS {
 
     interface RelationshipOptions<M extends Model> {
         async?: boolean;
-        inverse?: RelationshipsFor<M> | null;
+        inverse?: KeysForRelationships<M> | null;
         polymorphic?: boolean;
     }
 
@@ -546,11 +570,11 @@ export namespace DS {
         /**
          * Get the reference for the specified belongsTo relationship.
          */
-        belongsTo(name: RelationshipsFor<this>): BelongsToReference;
+        belongsTo<T extends Model, K extends keyof BelongsToModels<T>>(this: T, name: K): BelongsToReference<BelongsToModels<T>[K]>;
         /**
          * Get the reference for the specified hasMany relationship.
          */
-        hasMany(name: RelationshipsFor<this>): HasManyReference<any>;
+        hasMany<T extends Model, K extends keyof HasManyModels<T>>(this: T, name: K): HasManyReference<HasManyModels<T>[K]>;
         /**
          * Given a callback, iterates over each of the relationships in the model,
          * invoking the callback with the name of each relationship and its relationship
@@ -725,7 +749,7 @@ export namespace DS {
      * addon author to perform meta-operations on a belongs-to
      * relationship.
      */
-    class BelongsToReference {
+    class BelongsToReference<T extends Model> {
         /**
          * This returns a string that represents how the reference will be
          * looked up when it is loaded. If the relationship has a link it will
@@ -762,7 +786,7 @@ export namespace DS {
          * relationship is not yet loaded. If the relationship is not loaded
          * it will always return `null`.
          */
-        value(): Model | null;
+        value(): T | null;
         /**
          * Loads a record in a belongs to relationship if it is not already
          * loaded. If the relationship is already loaded this method does not
@@ -1005,11 +1029,11 @@ export namespace DS {
         /**
          * Returns the current value of a belongsTo relationship.
          */
-        belongsTo<L extends RelationshipsFor<ModelRegistry[K]>>(
+        belongsTo<L extends keyof BelongsToModels<ModelRegistry[K]>>(
             keyName: L,
             options?: {}
         ): Snapshot | null | undefined;
-        belongsTo<L extends RelationshipsFor<ModelRegistry[K]>>(
+        belongsTo<L extends keyof BelongsToModels<ModelRegistry[K]>>(
             keyName: L,
             options: { id: true }
         ): string | null | undefined;
@@ -1017,11 +1041,11 @@ export namespace DS {
         /**
          * Returns the current value of a hasMany relationship.
          */
-        hasMany<L extends RelationshipsFor<ModelRegistry[K]>>(
+        hasMany<L extends keyof HasManyModels<ModelRegistry[K]>>(
             keyName: L,
             options?: { ids: false }
         ): Snapshot[] | undefined;
-        hasMany<L extends RelationshipsFor<ModelRegistry[K]>>(
+        hasMany<L extends keyof HasManyModels<ModelRegistry[K]>>(
             keyName: L,
             options: { ids: true }
         ): string[] | undefined;

--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -28,15 +28,15 @@ type MaybeModel<T> = T extends DS.Model ? T : never;
 
 type UnboxBelongsTo<T> =
     T extends DS.PromiseObject<infer C> ? MaybeModel<C>
-    //   : T extends Ember.ComputedProperty<infer C & DS.PromiseObject<infer C>, infer C> ? MaybeModel<C>
-    //   : T extends Ember.ComputedProperty<infer C> ? MaybeModel<C>
+      : T extends Ember.ComputedProperty<infer C & DS.PromiseObject<infer C>, infer C> ? MaybeModel<C>
+      : T extends Ember.ComputedProperty<infer C> ? MaybeModel<C>
       : MaybeModel<T>;
 
 type UnboxHasMany<T> =
     T extends DS.PromiseManyArray<infer C> ? MaybeModel<C>
       : T extends Ember.Array<infer C> ? MaybeModel<C>
-    //   : T extends Ember.ComputedProperty<DS.PromiseManyArray<infer C>, Ember.Array<infer C>> ? MaybeModel<C>
-    //   : T extends Ember.ComputedProperty<DS.ManyArray<infer C>> ? MaybeModel<C>
+      : T extends Ember.ComputedProperty<DS.PromiseManyArray<infer C>, Ember.Array<infer C>> ? MaybeModel<C>
+      : T extends Ember.ComputedProperty<DS.ManyArray<infer C>> ? MaybeModel<C>
       : never;
 
 type BelongsToModels<Model extends DS.Model> = {

--- a/types/ember-data/test/belongs-to.ts
+++ b/types/ember-data/test/belongs-to.ts
@@ -7,6 +7,7 @@ class Folder extends DS.Model {
     name = DS.attr('string');
     children = DS.hasMany('folder', { inverse: 'parent' });
     parent = DS.belongsTo('folder', { inverse: 'children' });
+    parentSync = DS.belongsTo('folder', { inverse: 'children', async: false });
 }
 
 declare module 'ember-data/types/registries/model' {
@@ -28,5 +29,10 @@ folder.set('parent', folder);
 folder.set('parent', folder.get('parent'));
 folder.set('parent', store.findRecord('folder', 3));
 
-// $ExpectType Model | null
-folder.belongsTo('parent').value();
+assertType<Folder|null>(
+    folder.belongsTo('parent').value()
+);
+assertType<Folder|null>(
+    folder.belongsTo('parentSync').value()
+);
+folder.belongsTo('non-existing').value(); // $ExpectError

--- a/types/ember-data/test/belongs-to.ts
+++ b/types/ember-data/test/belongs-to.ts
@@ -29,10 +29,6 @@ folder.set('parent', folder);
 folder.set('parent', folder.get('parent'));
 folder.set('parent', store.findRecord('folder', 3));
 
-assertType<Folder|null>(
-    folder.belongsTo('parent').value()
-);
-assertType<Folder|null>(
-    folder.belongsTo('parentSync').value()
-);
+folder.belongsTo('parent').value()!; // $ExpectType Folder
+folder.belongsTo('parentSync').value()!; // $ExpectType Folder
 folder.belongsTo('non-existing').value(); // $ExpectError

--- a/types/ember-data/test/has-many.ts
+++ b/types/ember-data/test/has-many.ts
@@ -60,5 +60,13 @@ class Polymorphic extends DS.Model {
     paymentMethods = DS.hasMany('payment-method', { polymorphic: true });
 }
 
-// $ExpectType ManyArray<any> | null
-blogPost.hasMany('commentsAsync').value();
+assertType<BlogComment>(
+    blogPost.hasMany('commentsAsync').value()!.get('firstObject')!
+);
+
+assertType<BlogComment>(
+    blogPost.hasMany('commentsSync').value()!.get('firstObject')!
+);
+
+// $ExpectError
+blogPost.hasMany('non-existing');

--- a/types/ember-data/test/has-many.ts
+++ b/types/ember-data/test/has-many.ts
@@ -60,13 +60,11 @@ class Polymorphic extends DS.Model {
     paymentMethods = DS.hasMany('payment-method', { polymorphic: true });
 }
 
-assertType<BlogComment>(
-    blogPost.hasMany('commentsAsync').value()!.get('firstObject')!
-);
+ // $ExpectType BlogComment
+blogPost.hasMany('commentsAsync').value()!.get('firstObject')!;
 
-assertType<BlogComment>(
-    blogPost.hasMany('commentsSync').value()!.get('firstObject')!
-);
+ // $ExpectType BlogComment
+blogPost.hasMany('commentsSync').value()!.get('firstObject')!;
 
 // $ExpectError
 blogPost.hasMany('non-existing');

--- a/types/ember-data/test/relationships.ts
+++ b/types/ember-data/test/relationships.ts
@@ -77,12 +77,18 @@ class Series extends DS.Model {
     title = DS.attr('string');
 }
 
+class Post extends DS.Model {
+    title = DS.attr('string');
+    comments = DS.hasMany('comment');
+}
+
 class RelationalPost extends DS.Model {
     title = DS.attr('string');
     tag = DS.attr('string');
     comments = DS.hasMany('comment', { async: true });
     relatedPosts = DS.hasMany('post');
-    series = DS.belongsTo('series');
+    series = DS.belongsTo('series', { async: true});
+    seriesSync = DS.belongsTo('series', { async: false});
 }
 
 declare module 'ember-data/types/registries/model' {
@@ -90,14 +96,26 @@ declare module 'ember-data/types/registries/model' {
         'relational-post': RelationalPost;
         comment: Comment;
         series: Series;
+        post: Post;
     }
 }
 
-let blogPost = store.peekRecord('relational-post', 1);
-blogPost!.get('comments').then((comments) => {
+let blogPost = store.peekRecord('relational-post', 1)!;
+blogPost.get('comments').then((comments) => {
     // now we can work with the comments
     let author: string = comments.get('firstObject')!.get('author');
 });
 
-blogPost!.hasMany('relatedPosts');
-blogPost!.belongsTo('series');
+assertType<DS.ManyArray<Post> | null>(
+    blogPost.hasMany('relatedPosts').value()
+);
+assertType<DS.BelongsToReference<Series> | null>(
+    blogPost.belongsTo('series')
+);
+
+assertType<DS.BelongsToReference<Series> | null>(
+    blogPost.belongsTo('seriesSync')
+);
+
+// $ExpectError
+blogPost.belongsTo('non-existing');

--- a/types/ember-data__model/test/model.ts
+++ b/types/ember-data__model/test/model.ts
@@ -106,34 +106,23 @@ reloaded = user.reload({ adapterOptions: { fastAsCanBe: 'yessirree' } });
 const human = Human.create();
 
 function testBelongsTo() {
-    assertType<DS.BelongsToReference<Human>>(
-        human.belongsTo('mother')
-    );
+    human.belongsTo('mother').value()!; // $ExpectType Human
 
-    assertType<DS.BelongsToReference<Human>>(
-        human.belongsTo('motherSync')
-    );
+    human.belongsTo('motherSync').value()!; // $ExpectType Human
 
-    assertType<DS.BelongsToReference<never>>(
-        human.belongsTo('children') // wrong relationship kind
-    );
+    // wrong relationship kind
+    human.belongsTo('children').value()!; // $ExpectType never
 
     human.belongsTo('undefined').value()!; // $ExpectError
 }
 
 function testHasMany() {
-    assertType<DS.HasManyReference<Human>>(
-        human.hasMany('children')
-    );
+    human.hasMany('children').value()!; // $ExpectType ManyArray<Human>
 
-    assertType<DS.HasManyReference<Human>>(
-        human.hasMany('childrenSync')
-    );
+    human.hasMany('childrenSync').value()!; // $ExpectType ManyArray<Human>
 
-    // errors
-    assertType<DS.HasManyReference<never>>(
-        human.hasMany('mother') // wrong relationship kind
-    );
+    // wrong relationship kind
+    human.hasMany('mother').value()!; // $ExpectType ManyArray<never>
 
     human.hasMany('undefined').value()!; // $ExpectError
 }


### PR DESCRIPTION
This enables relationships aware `model.belongsTo(` and `model.hasMany(`:
 - Specifying correct relationship name correctly infers related model type via `reference.value()`
 - fixed `this.belongsTo` and `this.hasMany`, which have been broken previously
 - Specifying wrong key for relationship now have one of the following behaviors:
    - passing a key which doesn't exist on a model, would lead to TS error
    - passing a key which is defined, but doesn't match relationship kind(for instance `this.belongsTo` for `hasMany` field), would result to `DS.BelongsToReference<never>` or `DS.HasManyReference<never>`, which is not a hard error, but prevents you to use any of reference apis. I've tried to achieve a hard error here, but it doesn't seem super easy to do, so I left it in a state described above.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - [WIP docs for native classes](https://github.com/typed-ember/ember-cli-typescript/blob/657f25cad01e1f725152257cd625d20e0606c175/tests/dummy/app/templates/docs/ember-data/models.md), PR - https://github.com/typed-ember/ember-cli-typescript/pull/935
   - https://api.emberjs.com/ember-data/3.16/functions/@ember-data%2Fmodel/belongsTo
   - https://api.emberjs.com/ember-data/release/classes/BelongsToReference
   - https://api.emberjs.com/ember-data/3.16/functions/@ember-data%2Fmodel/hasMany
   - https://api.emberjs.com/ember-data/release/classes/HasManyReference