### PR TITLE
update(mongodb): MongoError `hasErrorLabel` missing from 3.5

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -225,10 +225,20 @@ export interface MongoCallback<T> {
 
 export type WithTransactionCallback<T> = (session: ClientSession) => Promise<T>;
 
-/** http://mongodb.github.io/node-mongodb-native/3.1/api/MongoError.html */
+/**
+ * Creates a new MongoError
+ * see {@link http://mongodb.github.io/node-mongodb-native/3.5/api/MongoError.html}
+ */
 export class MongoError extends Error {
     constructor(message: string);
-    static create(options: object): MongoError;
+    /**
+     * @deprecated
+     */
+    static create(options: string): MongoError;
+    /**
+     * Checks the error to see if it has an error label
+     */
+    hasErrorLabel(label: string): boolean;
     code?: number;
     /**
      * While not documented, the 'errmsg' prop is AFAIK the only way to find out
@@ -252,14 +262,20 @@ export class MongoError extends Error {
 }
 
 
-/** http://mongodb.github.io/node-mongodb-native/3.1/api/MongoNetworkError.html */
+/**
+ * An error indicating an issue with the network, including TCP errors and timeouts
+ * see {@link https://mongodb.github.io/node-mongodb-native/3.5/api/MongoNetworkError.html}
+ */
 export class MongoNetworkError extends MongoError {
     constructor(message: string);
     errorLabels: string[];
 }
 
 
-/** http://mongodb.github.io/node-mongodb-native/3.1/api/MongoParseError.html */
+/**
+ * An error used when attempting to parse a value (like a connection string)
+ * see {@link https://mongodb.github.io/node-mongodb-native/3.5/api/MongoParseError.html}
+ */
 export class MongoParseError extends MongoError {
     constructor(message: string);
 }

--- a/types/mongodb/test/index.ts
+++ b/types/mongodb/test/index.ts
@@ -58,7 +58,9 @@ async function testFunc(): Promise<mongodb.MongoClient> {
 
 mongodb.connect(
   connectionString,
-  (err: mongodb.MongoError, client: mongodb.MongoClient) => {},
+  (err: mongodb.MongoError, client: mongodb.MongoClient) => {
+      err.hasErrorLabel('label'); // $ExpectType boolean
+  },
 );
 mongodb.connect(
   connectionString,


### PR DESCRIPTION
This is minor change:
- add missing `hasErrroLabel` method to the MongoError
- mark `create` static method as deprecated
- updates JSDoc for error classes to use 3.5 version

Thanks!

https://mongodb.github.io/node-mongodb-native/3.5/api/MongoError.html

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
