### PR TITLE
Pg: Adds a boolean value for the parseInputDatesAsUTC ClientConfig option

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -22,6 +22,7 @@ export interface ClientConfig {
     keepAlive?: boolean;
     stream?: stream.Duplex;
     statement_timeout?: false | number;
+    parseInputDatesAsUTC?: boolean;
     ssl?: boolean | ConnectionOptions;
     query_timeout?: number;
     keepAliveInitialDelayMillis?: number;


### PR DESCRIPTION
If changing an existing definition:
[x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/blob/master/packages/pg/lib/defaults.js#L56