### PR TITLE
[jasmine] Support custom async matchers

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -14,6 +14,7 @@
 //                 Stephen Farrar <https://github.com/stephenfarrar>
 //                 Alex Povar <https://github.com/zvirja>
 //                 Dominik Ehrenberg <https://github.com/djungowski>
+//                 Chives <https://github.com/chivesrs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -140,7 +140,7 @@ declare function expect(): jasmine.NothingMatcher;
  * @checkReturnValue see https://tsetse.info/check-return-value
  * @param actual - Actual computed value to test expectations against.
  */
-declare function expectAsync<T, U>(actual: PromiseLike<T>): jasmine.AsyncMatchers<T, U>;
+declare function expectAsync<T, U>(actual: T|PromiseLike<T>): jasmine.AsyncMatchers<T, U>;
 
 /**
  * Explicitly mark a spec as failed.
@@ -278,7 +278,7 @@ declare namespace jasmine {
     function addCustomEqualityTester(equalityTester: CustomEqualityTester): void;
 
     function addMatchers(matchers: CustomMatcherFactories): void;
-    function addAsyncMatchers(matchers: CustomMatcherFactories): void;
+    function addAsyncMatchers(matchers: CustomAsyncMatcherFactories): void;
 
     function stringMatching(str: string | RegExp): AsymmetricMatcher<string>;
 
@@ -346,10 +346,23 @@ declare namespace jasmine {
         negativeCompare?(actual: any, ...expected: any[]): CustomMatcherResult;
     }
 
+    interface CustomAsyncMatcher {
+        compare<T>(actual: T, expected: T, ...args: any[]): Promise<CustomMatcherResult>;
+        compare(actual: any, ...expected: any[]): Promise<CustomMatcherResult>;
+        negativeCompare?<T>(actual: T, expected: T, ...args: any[]): Promise<CustomMatcherResult>;
+        negativeCompare?(actual: any, ...expected: any[]): Promise<CustomMatcherResult>;
+    }
+
     type CustomMatcherFactory = (util: MatchersUtil, customEqualityTesters: ReadonlyArray<CustomEqualityTester>) => CustomMatcher;
 
+    type CustomAsyncMatcherFactory = (util: MatchersUtil, customEqualityTesters: ReadonlyArray<CustomEqualityTester>) => CustomAsyncMatcher;
+
     interface CustomMatcherFactories {
-        [index: string]: CustomMatcherFactory;
+        [name: string]: CustomMatcherFactory;
+    }
+
+    interface CustomAsyncMatcherFactories {
+        [name: string]: CustomAsyncMatcherFactory;
     }
 
     interface CustomMatcherResult {

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1357,6 +1357,10 @@ declare namespace jasmine {
         toBeGoofy(expected?: Expected<T>): boolean;
         toBeWithinRange(expected?: Expected<T>, floor?: number, ceiling?: number): boolean;
     }
+
+    interface AsyncMatchers<T, U> {
+        toBeEight(): Promise<void>;
+    }
 }
 
 describe("Custom matcher: 'toBeGoofy'", () => {
@@ -1402,6 +1406,51 @@ describe("Custom matcher: 'toBeGoofy'", () => {
 
         expect(result.pass).toBe(false);
         expect(result.message).toBe(`Expected ${actual} to be goofy, but it was not very goofy`);
+    });
+});
+
+describe("Custom async matcher: 'toBeEight'", () => {
+    beforeEach(() => {
+        jasmine.addAsyncMatchers({
+            toBeEight: () => {
+                return {
+                    // tslint:disable-next-line:no-any
+                    compare: async (input: any) => {
+                        return {
+                            pass: input === 8,
+                            message: `${JSON.stringify(input)} is not 8`,
+                        };
+                    },
+                };
+            },
+        });
+
+        // $ExpectError
+        jasmine.addAsyncMatchers({
+            toBeBadlyTyped: () => {
+                return {
+                    compare: () => {
+                        return {
+                            pass: true,
+                            message: 'I am not an async function / not returning promise!',
+                        };
+                    },
+                };
+            },
+        });
+    });
+
+    it("works in positive case", async () => {
+        await expectAsync(8).toBeEight();
+    });
+
+    it("works in negative case", async () => {
+        await expectAsync("seven").not.toBeEight();
+    });
+
+    it("fails correctly", async () => {
+        // This compiles, but the test fails at runtime (as {} isn't 8).
+        await expectAsync({}).toBeEight();
     });
 });
 

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -137,7 +137,7 @@ declare function expect(): jasmine.NothingMatcher;
  * @checkReturnValue see https://tsetse.info/check-return-value
  * @param actual - Actual computed value to test expectations against.
  */
-declare function expectAsync<T, U>(actual: Promise<T>): jasmine.AsyncMatchers<T, U>;
+declare function expectAsync<T, U>(actual: T|Promise<T>): jasmine.AsyncMatchers<T, U>;
 
 /**
  * Explicitly mark a spec as failed.
@@ -281,7 +281,7 @@ declare namespace jasmine {
     function addCustomEqualityTester(equalityTester: CustomEqualityTester): void;
 
     function addMatchers(matchers: CustomMatcherFactories): void;
-    function addAsyncMatchers(matchers: CustomMatcherFactories): void;
+    function addAsyncMatchers(matchers: CustomAsyncMatcherFactories): void;
 
     function stringMatching(str: string | RegExp): AsymmetricMatcher<string>;
 
@@ -349,10 +349,23 @@ declare namespace jasmine {
         negativeCompare?(actual: any, ...expected: any[]): CustomMatcherResult;
     }
 
+    interface CustomAsyncMatcher {
+        compare<T>(actual: T, expected: T, ...args: any[]): Promise<CustomMatcherResult>;
+        compare(actual: any, ...expected: any[]): Promise<CustomMatcherResult>;
+        negativeCompare?<T>(actual: T, expected: T, ...args: any[]): Promise<CustomMatcherResult>;
+        negativeCompare?(actual: any, ...expected: any[]): Promise<CustomMatcherResult>;
+    }
+
     type CustomMatcherFactory = (util: MatchersUtil, customEqualityTesters: ReadonlyArray<CustomEqualityTester>) => CustomMatcher;
 
+    type CustomAsyncMatcherFactory = (util: MatchersUtil, customEqualityTesters: ReadonlyArray<CustomEqualityTester>) => CustomAsyncMatcher;
+
     interface CustomMatcherFactories {
-        [index: string]: CustomMatcherFactory;
+        [name: string]: CustomMatcherFactory;
+    }
+
+    interface CustomAsyncMatcherFactories {
+        [name: string]: CustomAsyncMatcherFactory;
     }
 
     interface CustomMatcherResult {

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -13,6 +13,7 @@
 //                 Stephen Farrar <https://github.com/stephenfarrar>
 //                 Alex Povar <https://github.com/zvirja>
 //                 Dominik Ehrenberg <https://github.com/djungowski>
+//                 Chives <https://github.com/chivesrs>
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts
 
 /**

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -1326,6 +1326,10 @@ declare namespace jasmine {
         toBeGoofy(expected?: Expected<T>): boolean;
         toBeWithinRange(expected?: Expected<T>, floor?: number, ceiling?: number): boolean;
     }
+
+    interface AsyncMatchers<T, U> {
+        toBeEight(): Promise<void>;
+    }
 }
 
 describe("Custom matcher: 'toBeGoofy'", () => {
@@ -1371,6 +1375,51 @@ describe("Custom matcher: 'toBeGoofy'", () => {
 
         expect(result.pass).toBe(false);
         expect(result.message).toBe(`Expected ${actual} to be goofy, but it was not very goofy`);
+    });
+});
+
+describe("Custom async matcher: 'toBeEight'", () => {
+    beforeEach(() => {
+        jasmine.addAsyncMatchers({
+            toBeEight: () => {
+                return {
+                    // tslint:disable-next-line:no-any
+                    compare: async (input: any) => {
+                        return {
+                            pass: input === 8,
+                            message: `${JSON.stringify(input)} is not 8`,
+                        };
+                    },
+                };
+            },
+        });
+
+        jasmine.addAsyncMatchers({
+            // $ExpectError
+            toBeBadlyTyped: () => {
+                return {
+                    compare: () => {
+                        return {
+                            pass: true,
+                            message: 'I am not an async function / not returning promise!',
+                        };
+                    },
+                };
+            },
+        });
+    });
+
+    it("works in positive case", async () => {
+        await expectAsync(8).toBeEight();
+    });
+
+    it("works in negative case", async () => {
+        await expectAsync("seven").not.toBeEight();
+    });
+
+    it("fails correctly", async () => {
+        // This compiles, but the test fails at runtime (as {} isn't 8).
+        await expectAsync({}).toBeEight();
     });
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See below.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

See codepen https://codepen.io/chivesrs/pen/zYGEZvP and the Jasmine PR to introduce this feature https://github.com/jasmine/jasmine/pull/1732, Be sure to click on "Spec List" to see the passing tests (the first 2 are intended to pass, the 3rd is intended to fail, it should be obvious why based on reading the test source code). The test source code is available in the JS pane on the far right. You may need to scroll and/or maximize the panel.

![image](https://user-images.githubusercontent.com/7110657/75955255-797a3400-5e83-11ea-8d49-29db2b968fe2.png)
