### PR TITLE
[wordpress__blocks]: Add Children attributes

### DIFF
--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -272,6 +272,12 @@ export namespace AttributeSource {
               default?: string;
           });
 
+    interface Children {
+        source: 'children';
+        type: 'array';
+        selector?: string;
+    }
+
     interface HTML {
         source: 'html';
         type: 'string';
@@ -327,6 +333,7 @@ export namespace AttributeSource {
 
 export type BlockAttribute<T> =
     | AttributeSource.Attribute
+    | AttributeSource.Children
     | AttributeSource.HTML
     | AttributeSource.Meta
     | AttributeSource.Query<T>

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for @wordpress/blocks 6.4
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/blocks/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
+//                 Jon Surrell <https://github.com/sirreal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 


### PR DESCRIPTION
Add `children` block attribute source.

  - https://github.com/WordPress/gutenberg/blob/cfc9cd4135da010319471c2c071690ca4051c4bb/packages/blocks/src/api/parser.js#L189-L190
  - https://github.com/WordPress/gutenberg/blob/cfc9cd4135da010319471c2c071690ca4051c4bb/packages/blocks/src/api/children.js#L124-L138

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/WordPress/gutenberg/blob/cfc9cd4135da010319471c2c071690ca4051c4bb/packages/blocks/src/api/parser.js#L189-L190
  - https://github.com/WordPress/gutenberg/blob/cfc9cd4135da010319471c2c071690ca4051c4bb/packages/blocks/src/api/children.js#L124-L138
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
