### PR TITLE
Added missing methods zonesForCountry() and countries from v0.5.28 of moment-timezone

### DIFF
--- a/types/moment-timezone/index.d.ts
+++ b/types/moment-timezone/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for moment-timezone.js 0.5
+// Type definitions for moment-timezone.js 0.5.28
 // Project: http://momentjs.com/timezone/
 // Definitions by: Michel Salib <https://github.com/michelsalib>
 //                 Alan Brazil Lins <https://github.com/alanblins>
 //                 Agustin Carrasco <https://github.com/asermax>
 //                 Borys Kupar <https://github.com/borys-kupar>
+//                 Anthony Rainer <https://github.com/pristinesource>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import moment = require('./moment-timezone');

--- a/types/moment-timezone/index.d.ts
+++ b/types/moment-timezone/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for moment-timezone.js 0.5.28
+// Type definitions for moment-timezone.js 0.5
 // Project: http://momentjs.com/timezone/
 // Definitions by: Michel Salib <https://github.com/michelsalib>
 //                 Alan Brazil Lins <https://github.com/alanblins>

--- a/types/moment-timezone/moment-timezone-tests.ts
+++ b/types/moment-timezone/moment-timezone-tests.ts
@@ -88,3 +88,11 @@ const zoneAbbr: string = moment.tz('America/Los_Angeles').zoneAbbr();
 const zoneName: string = moment.tz('America/Los_Angeles').zoneName();
 
 const zoneType: string | undefined = moment.tz('2013-11-18 11:55').tz();
+
+const zones1: string[] = moment.tz.zonesForCountry("US");
+
+const zones2: moment.tz.MomentZoneOffset[] = moment.tz.zonesForCountry("CN", true);
+
+const zones3: string[] = moment.tz.zonesForCountry("GB", false);
+
+const countries: string[] = moment.countries();

--- a/types/moment-timezone/moment-timezone-tests.ts
+++ b/types/moment-timezone/moment-timezone-tests.ts
@@ -1,59 +1,64 @@
 import moment = require('moment-timezone');
 
-const june = moment("2014-06-01T12:00:00Z");
+const june = moment('2014-06-01T12:00:00Z');
 june.tz('America/Los_Angeles').format('ha z');
 
-const a = moment.tz("2013-11-18 11:55", "America/Toronto");
-const b = moment.tz("May 12th 2014 8PM", "MMM Do YYYY hA", "America/Toronto");
-const c = moment.tz(1403454068850, "America/Toronto");
-const d = moment.tz("May 12th 2014 8PM", "MMM Do YYYY hA", true, "America/Toronto");
+const a = moment.tz('2013-11-18 11:55', 'America/Toronto');
+const b = moment.tz('May 12th 2014 8PM', 'MMM Do YYYY hA', 'America/Toronto');
+const c = moment.tz(1403454068850, 'America/Toronto');
+const d = moment.tz('May 12th 2014 8PM', 'MMM Do YYYY hA', true, 'America/Toronto');
 
 a.tz();
 
 const num = 1367337600000;
 const arr = [2013, 5, 1];
-const str = "2013-12-01";
+const str = '2013-12-01';
 const date = new Date(2013, 4, 1);
 const mo = moment([2013, 4, 1]);
 const obj = { year : 2013, month : 5, day : 1 };
-const format = "YYYY-MM-DD";
-const formats = ["YYYY-MM-DD", "YYYY/MM/DD"];
-const formatsIncludingSpecial = ["YYYY-MM-DD", moment.ISO_8601];
-const language = "en";
+const format = 'YYYY-MM-DD';
+const formats = ['YYYY-MM-DD', 'YYYY/MM/DD'];
+const formatsIncludingSpecial = ['YYYY-MM-DD', moment.ISO_8601];
+const language = 'en';
 
 moment.tz();
-moment.tz("America/Los_Angeles");
-moment.tz("America/Los_Angeles").tz("Asia/Tomsk", true);
+moment.tz('America/Los_Angeles');
+moment.tz('America/Los_Angeles').tz('Asia/Tomsk', true);
 
-moment.tz(num, "America/Los_Angeles");
-moment.tz(arr, "America/Los_Angeles");
-moment.tz(str, "America/Los_Angeles");
-moment.tz(str, format, "America/Los_Angeles");
-moment.tz(str, format, true, "America/Los_Angeles");
-moment.tz(str, format, language, "America/Los_Angeles");
-moment.tz(str, format, language, true, "America/Los_Angeles");
-moment.tz(str, formats, "America/Los_Angeles");
-moment.tz(str, formats, true, "America/Los_Angeles");
-moment.tz(str, formats, language, "America/Los_Angeles");
-moment.tz(str, formats, language, true, "America/Los_Angeles");
-moment.tz(str, moment.ISO_8601, "America/Los_Angeles");
-moment.tz(str, moment.ISO_8601, true, "America/Los_Angeles");
-moment.tz(str, moment.ISO_8601, language, "America/Los_Angeles");
-moment.tz(str, moment.ISO_8601, language, true, "America/Los_Angeles");
-moment.tz(str, formatsIncludingSpecial, "America/Los_Angeles");
-moment.tz(str, formatsIncludingSpecial, true, "America/Los_Angeles");
-moment.tz(str, formatsIncludingSpecial, language, "America/Los_Angeles");
-moment.tz(str, formatsIncludingSpecial, language, true, "America/Los_Angeles");
+moment.tz(num, 'America/Los_Angeles');
+moment.tz(arr, 'America/Los_Angeles');
+moment.tz(str, 'America/Los_Angeles');
+moment.tz(str, format, 'America/Los_Angeles');
+moment.tz(str, format, true, 'America/Los_Angeles');
+moment.tz(str, format, language, 'America/Los_Angeles');
+moment.tz(str, format, language, true, 'America/Los_Angeles');
+moment.tz(str, formats, 'America/Los_Angeles');
+moment.tz(str, formats, true, 'America/Los_Angeles');
+moment.tz(str, formats, language, 'America/Los_Angeles');
+moment.tz(str, formats, language, true, 'America/Los_Angeles');
+moment.tz(str, moment.ISO_8601, 'America/Los_Angeles');
+moment.tz(str, moment.ISO_8601, true, 'America/Los_Angeles');
+moment.tz(str, moment.ISO_8601, language, 'America/Los_Angeles');
+moment.tz(str, moment.ISO_8601, language, true, 'America/Los_Angeles');
+moment.tz(str, formatsIncludingSpecial, 'America/Los_Angeles');
+moment.tz(str, formatsIncludingSpecial, true, 'America/Los_Angeles');
+moment.tz(str, formatsIncludingSpecial, language, 'America/Los_Angeles');
+moment.tz(str, formatsIncludingSpecial, language, true, 'America/Los_Angeles');
 
-moment.tz(date, "America/Los_Angeles");
-moment.tz(mo, "America/Los_Angeles");
-moment.tz(obj, "America/Los_Angeles");
+moment.tz(date, 'America/Los_Angeles');
+moment.tz(mo, 'America/Los_Angeles');
+moment.tz(obj, 'America/Los_Angeles');
 
-moment.tz.zone('America/Los_Angeles').abbr(1403465838805);
-moment.tz.zone('America/Los_Angeles').utcOffset(1403465838805);
+const zone1: moment.MomentZone | null = moment.tz.zone('America/Los_Angeles');
+if (zone1 != null) {
+  zone1.abbr(1403465838805);
+  zone1.utcOffset(1403465838805);
+}
 
-const zone = moment.tz.zone('America/New_York');
-zone.parse(Date.UTC(2012, 2, 19, 8, 30)); // 240
+const zone2: moment.MomentZone | null = moment.tz.zone('America/New_York');
+if (zone2 != null) {
+  zone2.parse(Date.UTC(2012, 2, 19, 8, 30)); // 240
+}
 
 moment.tz.add('America/Los_Angeles|PST PDT|80 70|0101|1Lzm0 1zb0 Op0');
 moment.tz.add([
@@ -89,10 +94,10 @@ const zoneName: string = moment.tz('America/Los_Angeles').zoneName();
 
 const zoneType: string | undefined = moment.tz('2013-11-18 11:55').tz();
 
-const zones1: string[] = moment.tz.zonesForCountry("US");
+const zones1: string[] = moment.tz.zonesForCountry('US');
 
-const zones2: moment.MomentZoneOffset[] = moment.tz.zonesForCountry("CN", true);
+const zones2: moment.MomentZoneOffset[] = moment.tz.zonesForCountry('CN', true);
 
-const zones3: string[] = moment.tz.zonesForCountry("GB", false);
+const zones3: string[] = moment.tz.zonesForCountry('GB', false);
 
 const countries: string[] = moment.tz.countries();

--- a/types/moment-timezone/moment-timezone-tests.ts
+++ b/types/moment-timezone/moment-timezone-tests.ts
@@ -91,7 +91,7 @@ const zoneType: string | undefined = moment.tz('2013-11-18 11:55').tz();
 
 const zones1: string[] = moment.tz.zonesForCountry("US");
 
-const zones2: moment.tz.MomentZoneOffset[] = moment.tz.zonesForCountry("CN", true);
+const zones2: moment.MomentZoneOffset[] = moment.tz.zonesForCountry("CN", true);
 
 const zones3: string[] = moment.tz.zonesForCountry("GB", false);
 

--- a/types/moment-timezone/moment-timezone-tests.ts
+++ b/types/moment-timezone/moment-timezone-tests.ts
@@ -95,4 +95,4 @@ const zones2: moment.MomentZoneOffset[] = moment.tz.zonesForCountry("CN", true);
 
 const zones3: string[] = moment.tz.zonesForCountry("GB", false);
 
-const countries: string[] = moment.countries();
+const countries: string[] = moment.tz.countries();

--- a/types/moment-timezone/moment-timezone.d.ts
+++ b/types/moment-timezone/moment-timezone.d.ts
@@ -16,6 +16,11 @@ declare module 'moment' {
     utcOffset(timestamp: number): number;
     parse(timestamp: number): number;
   }
+    
+  interface MomentZoneOffset {
+      name: string;
+      offset: number;
+  }
 
   interface MomentTimezone {
     (): moment.Moment;
@@ -42,9 +47,13 @@ declare module 'moment' {
     load(data: { version: string; links: string[]; zones: string[] }): void;
 
     names(): string[];
+    zonesForCountry<T extends true>(country: string, with_offset: T ): T extends true ? MomentZoneOffset[] : never;
+    zonesForCountry<T extends false>(country: string, with_offset?: T ): T extends false ? string[] : never;
+    zonesForCountry(country: string, with_offset?: boolean ): MomentZoneOffset[] | string[];
+    countries(): string[];
     guess(ignoreCache?: boolean): string;
 
-    setDefault(timezone?: string): MomentTimezone;
+    setDefault(timezone?: string): Moment;
   }
 
   interface Moment {

--- a/types/moment-timezone/moment-timezone.d.ts
+++ b/types/moment-timezone/moment-timezone.d.ts
@@ -16,7 +16,7 @@ declare module 'moment' {
     utcOffset(timestamp: number): number;
     parse(timestamp: number): number;
   }
-    
+
   interface MomentZoneOffset {
       name: string;
       offset: number;
@@ -47,9 +47,9 @@ declare module 'moment' {
     load(data: { version: string; links: string[]; zones: string[] }): void;
 
     names(): string[];
-    zonesForCountry<T extends true>(country: string, with_offset: T ): T extends true ? MomentZoneOffset[] : never;
-    zonesForCountry<T extends false>(country: string, with_offset?: T ): T extends false ? string[] : never;
-    zonesForCountry(country: string, with_offset?: boolean ): MomentZoneOffset[] | string[];
+    zonesForCountry<T extends true>(country: string, with_offset: T): T extends true ? MomentZoneOffset[] : never;
+    zonesForCountry<T extends false>(country: string, with_offset?: T): T extends false ? string[] : never;
+    zonesForCountry(country: string, with_offset?: boolean): MomentZoneOffset[] | string[];
     countries(): string[];
     guess(ignoreCache?: boolean): string;
 


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://momentjs.com/timezone/docs/#/using-timezones/getting-country-zones/
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.