### PR TITLE
[classnames] accept the "default" export in the argument for classnames/bind

### DIFF
--- a/types/classnames/bind.d.ts
+++ b/types/classnames/bind.d.ts
@@ -1,7 +1,15 @@
 import { ClassNamesFn } from './types';
 
+type CssModule = Record<
+        string,
+        | string
+        // To accept be the "default" export while using the
+        // `import * as styles from '[...].postcss';` way to import the CSS module.
+        | Record<string, string>
+    >;
+
 interface ClassNamesBind extends ClassNamesFn {
-    bind(styles: Record<string, string>): ClassNamesFn;
+    bind(styles: CssModule): ClassNamesFn;
 }
 type ClassNamesBindExport = ClassNamesBind & {
     default: ClassNamesBind;


### PR DESCRIPTION
While using [the `import * as styles from '[...].postcss';` way](https://github.com/facebook/react/pull/18102) to import the CSS module, an additional `.default` property will be attached to the imported styles, which value will be an object, causing a type error if it's passed to classnames/bind.

When using `import * as styles from '[...].postcss';`, the structure of `styles` will be:

```js
{
  'some-class': 'actual_some-class',
  'another-class': 'actual_another-class',
  'default': {
    'some-class': 'actual_some-class',
    'another-class': 'actual_another-class',
  }
}
```

And the `default` part is causing the error.

<img width="534" alt="screen_shot_2020-03-05_at_4 01 28_pm" src="https://user-images.githubusercontent.com/3784687/76074938-17324800-5fd7-11ea-88a9-048f046a88e5.png">

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

