### PR TITLE
[pino] add `levelKey` option, deprecate `changeLevelName` option

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pino 5.15
+// Type definitions for pino 5.17
 // Project: https://github.com/pinojs/pino.git, http://getpino.io
 // Definitions by: Peter Snider <https://github.com/psnider>
 //                 BendingBender <https://github.com/BendingBender>
@@ -226,6 +226,10 @@ declare namespace P {
         useLevelLabels?: boolean;
         /**
          * Changes the property `level` to any string value you pass in. Default: 'level'
+         */
+        levelKey?: string;
+        /**
+         * (DEPRECATED, use `levelKey`) Changes the property `level` to any string value you pass in. Default: 'level'
          */
         changeLevelName?: string;
         /**

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -77,6 +77,7 @@ pino({
 
 pino({ base: null });
 pino({ base: { foo: 'bar' }, changeLevelName: 'severity' });
+pino({ base: { foo: 'bar' }, levelKey: 'severity' });
 if ('pino' in log) console.log(`pino version: ${log.pino}`);
 
 log.child({ a: 'property' }).info('hello child!');


### PR DESCRIPTION
This mirrors the changes from [this](https://github.com/pinojs/pino/commit/72eb875edc09057e853a09c19712a0a9ca713ae0) commit which is included from version [v5.17.0](https://github.com/pinojs/pino/commit/c4fbfdb45a52082bae2e37e801a19e710c58338c).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/pino/commit/72eb875edc09057e853a09c19712a0a9ca713ae0
- x ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.