### PR TITLE
make @wordpress/block-editor types stricter

### DIFF
--- a/types/wordpress__block-editor/components/color-palette/with-color-context.d.ts
+++ b/types/wordpress__block-editor/components/color-palette/with-color-context.d.ts
@@ -14,8 +14,8 @@ declare namespace withColorContext {
 // prettier-ignore
 declare function withColorContext<
     ProvidedProps extends Partial<withColorContext.Props>,
-    OwnProps extends any,
-    T extends ComponentType<ProvidedProps & OwnProps>
+    OwnProps extends any = any,
+    T extends ComponentType<ProvidedProps & OwnProps> = ComponentType<ProvidedProps & OwnProps>
 >(component: T):
     T extends ComponentType<infer U> ? ComponentType<
         Omit<U, 'colors' | 'disableCustomColors' | 'hasColorsToChoose'> &


### PR DESCRIPTION
Typescript@next is stricter about type parameters constrained to any;
they are default to unknown instead of any during inference for consistency with other
type parameters.

This means that the easiest workaround is to give a type parameter
constrained to `any` a default of `any` so that they once again
default to `any`.

That's what this PR does; it also has to give the subsequent type
parameter a default as well.
