### PR TITLE
[styled-system] Allow null ResponsiveValue

### DIFF
--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -60,7 +60,7 @@ export type RequiredTheme = Required<Theme>;
 export type ResponsiveValue<
     T,
     ThemeType extends Theme = RequiredTheme,
-    > = T | Array<T | null> | { [key in ThemeValue<'breakpoints', ThemeType> & string | number]?: T };
+    > = T | null | Array<T | null> | { [key in ThemeValue<'breakpoints', ThemeType> & string | number]?: T };
 
 export type ThemeValue<K extends keyof ThemeType, ThemeType, TVal = any> =
     ThemeType[K] extends TVal[] ? number :

--- a/types/styled-system/styled-system-tests.tsx
+++ b/types/styled-system/styled-system-tests.tsx
@@ -220,6 +220,7 @@ const test = () => (
         <Box display={{ sm: 'block', md: 'inline-block' }} />
         // maxWidth (responsive)
         <Box maxWidth={1024} />
+        <Box maxWidth={null} />
         <Box maxWidth={[768, null, null, 1024]} />
         <Box maxWidth={{ sm: 768, lg: 1024 }} />
         // minWidth (responsive)


### PR DESCRIPTION
## Motivation
Setting a style prop like...
```
<Select color={null} />
```
or
```
<Select color={error ? 'danger' : null} />
```
... throws `Type 'null' is not assignable to type`.

## Approach
Allow style props to be set to `null`.

## Resources
Styled System test checking expected behavior of `null`:
- https://github.com/styled-system/styled-system/blob/master/packages/core/test/system.js#L154-L160