### PR TITLE
Update partial typescript support for react-query v1.0.22

### DIFF
--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-query 1.0.22
+// Type definitions for react-query 1.0
 // Project: https://github.com/tannerlinsley/react-query
 // Definitions by: Lukasz Fiszer <https://github.com/lukaszfiszer>
 //                 Jace Hensley <https://github.com/jacehensley>

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -130,12 +130,12 @@ export interface ReactQueryProviderConfig {
 }
 
 export const queryCache: {
-    prefetchQuery: <TResult, TVariables extends object>(
-        queryKey: QueryKey<TVariables>,
-        queryFn: QueryFunction<TResult, TVariables>,
-        options?: PrefetchQueryOptions<TResult>,
-    ) => Promise<TResult>;
-    getQueryData: <TResult, TVariables extends object>(queryKey: QueryKey<TVariables>) => Promise<TResult | null>;
+    prefetchQuery: (
+        queryKey: QueryKey<object>,
+        queryFn: QueryFunction<any, any>,
+        options?: PrefetchQueryOptions<any>,
+    ) => Promise<any>;
+    getQueryData: (queryKey: QueryKey<object>) => Promise<any>;
     setQueryData: (
         queryKey: string | [string, object],
         data: any,
@@ -144,7 +144,7 @@ export const queryCache: {
         },
     ) => void | Promise<void>;
     refetchQueries: (
-        predicate: (<TVariables extends object>(queryKey: QueryKey<TVariables>) => boolean) | QueryKey<object>,
+        predicate: ((queryKey: QueryKey<object>) => boolean) | QueryKey<object>,
         options?: {
             exact?: boolean;
             throwOnError?: boolean;
@@ -152,14 +152,14 @@ export const queryCache: {
         },
     ) => Promise<void>;
     removeQueries: (
-        predicate: (<TVariables extends object>(queryKey: QueryKey<TVariables>) => boolean) | QueryKey<object>,
+        predicate: ((queryKey: QueryKey<object>) => boolean) | QueryKey<object>,
         options?: {
             force?: boolean;
         },
     ) => void;
-    getQuery: <TResult, TVariables extends object>(queryKey: QueryKey<TVariables>) => Promise<TResult | null>;
+    getQuery: (queryKey: QueryKey<object>) => Promise<any>;
     isFetching: number;
-    subscribe: <TResult>(callback: Cache) => Promise<TResult | null>;
+    subscribe: (callback: Cache) => Promise<any>;
     clear: () => string[];
 };
 

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -135,7 +135,7 @@ export const queryCache: {
         queryFn: QueryFunction<TResult, TVariables>,
         options?: PrefetchQueryOptions<TResult>,
     ) => Promise<TResult>;
-    getQueryData: (queryKey: QueryKey<any>) => Promise<any | null>;
+    getQueryData: <TResult, TVariables extends object>(queryKey: QueryKey<TVariables>) => Promise<TResult | null>;
     setQueryData: (
         queryKey: string | [string, object],
         data: any,
@@ -144,7 +144,7 @@ export const queryCache: {
         },
     ) => void | Promise<void>;
     refetchQueries: (
-        predicate: ((queryKey: QueryKey<any>) => boolean) | QueryKey<any>,
+        predicate: (<TVariables extends object>(queryKey: QueryKey<TVariables>) => boolean) | QueryKey<object>,
         options?: {
             exact?: boolean;
             throwOnError?: boolean;
@@ -152,18 +152,18 @@ export const queryCache: {
         },
     ) => Promise<void>;
     removeQueries: (
-        predicate: ((queryKey: QueryKey<any>) => boolean) | QueryKey<any>,
+        predicate: (<TVariables extends object>(queryKey: QueryKey<TVariables>) => boolean) | QueryKey<object>,
         options?: {
             force?: boolean;
         },
     ) => void;
-    getQuery: (queryKey: QueryKey<any>) => Promise<any | null>;
+    getQuery: <TResult, TVariables extends object>(queryKey: QueryKey<TVariables>) => Promise<TResult | null>;
     isFetching: number;
-    subscribe: (callback: Cache) => Promise<any | null>;
-    clear: () => Array<string>;
+    subscribe: <TResult>(callback: Cache) => Promise<TResult | null>;
+    clear: () => string[];
 };
 
-interface Cache {
+export interface Cache {
     queries: object;
     isFetching: number;
 }

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -1,13 +1,12 @@
-import { useMutation, useQuery } from "react-query";
+import { useMutation, useQuery, queryCache } from 'react-query';
 
 const queryFn = () => Promise.resolve();
 
 // Query - simple case
-const querySimple = useQuery('todos',
-    () => Promise.resolve('test'));
+const querySimple = useQuery('todos', () => Promise.resolve('test'));
 querySimple.data; // $ExpectType string | null
 querySimple.error; // $ExpectType Error | null
-querySimple.isLoading; // $ExpectType boolean
+querySimple.isFetching; // $ExpectType boolean
 querySimple.refetch(); // $ExpectType Promise<void>
 queryPaginated.fetchMore; // $ExpectError
 queryPaginated.canFetchMore; // $ExpectError
@@ -15,12 +14,11 @@ queryPaginated.isFetchingMore; // $ExpectError
 
 // Query Variables
 const param = 'test';
-const queryVariables = useQuery(['todos', {param}],
-    (variables) => Promise.resolve(variables.param === 'test'));
+const queryVariables = useQuery(['todos', { param }], variables => Promise.resolve(variables.param === 'test'));
 
 queryVariables.data; // $ExpectType boolean | null
-queryVariables.refetch({variables: {param: 'foo'}}); // $ExpectType Promise<void>
-queryVariables.refetch({variables: {other: 'foo'}}); // $ExpectError
+queryVariables.refetch({ variables: { param: 'foo' } }); // $ExpectType Promise<void>
+queryVariables.refetch({ variables: { other: 'foo' } }); // $ExpectError
 
 // Query with falsey query key
 useQuery(false && ['foo', { bar: 'baz' }], queryFn);
@@ -29,18 +27,24 @@ useQuery(false && ['foo', { bar: 'baz' }], queryFn);
 useQuery(() => ['foo', { bar: 'baz' }], queryFn);
 
 // Query with nested variabes
-const queryNested = useQuery(['key', {
-    nested: {
-        props: [1, 2]
-    }
-}], (variables) => Promise.resolve(variables.nested.props[0]));
+const queryNested = useQuery(
+    [
+        'key',
+        {
+            nested: {
+                props: [1, 2],
+            },
+        },
+    ],
+    variables => Promise.resolve(variables.nested.props[0]),
+);
 queryNested.data; // $ExpectType number | null
 
 // Paginated mode
-const queryPaginated = useQuery('key', () => Promise.resolve({data: [1, 2, 3], next: true}), {
+const queryPaginated = useQuery('key', () => Promise.resolve({ data: [1, 2, 3], next: true }), {
     refetchInterval: 1000,
     paginated: true,
-    getCanFetchMore: (lastPage, allPages) => lastPage.next
+    getCanFetchMore: (lastPage, allPages) => lastPage.next,
 });
 queryPaginated.data; // $ExpectType { data: number[]; next: boolean; }[] | null
 queryPaginated.fetchMore; // $ExpectType (variables?: {} | undefined) => Promise<{ data: number[]; next: boolean; }> || (variables?: object | undefined) => Promise<{ data: number[]; next: boolean; }>
@@ -48,19 +52,22 @@ queryPaginated.canFetchMore; // $ExpectType boolean
 queryPaginated.isFetchingMore; // $ExpectType boolean
 
 // Paginated mode - check if getCanFetchMore is required
-useQuery('key', () => Promise.resolve(), {paginated: true}); // $ExpectError
+useQuery('key', () => Promise.resolve(), { paginated: true }); // $ExpectError
 
 // Simple mutation
 const mutation = () => Promise.resolve(['foo', 1]);
 
 const [mutate] = useMutation(mutation, {
-    refetchQueries: ['todos', ['todo', { id: 5 }], 'reminders'],
-    refetchQueriesOnFailure: false
+    onSuccess: () => {
+        queryCache.refetchQueries('todos');
+        queryCache.refetchQueries(['todo', { id: 5 }]);
+        queryCache.refetchQueries('reminders');
+    },
 });
 mutate();
 mutate(undefined, {
     updateQuery: 'query',
-    waitForRefetchQueries: false
+    waitForRefetchQueries: false,
 });
 
 // Invalid mutatation funciton
@@ -68,16 +75,20 @@ useMutation((arg1: string, arg2: string) => Promise.resolve()); // $ExpectError
 useMutation((arg1: string) => null); // $ExpectError
 
 // Mutation with variables
-const [mutateWithVars] = useMutation(
-    ({param}: {param: number}) => Promise.resolve(Boolean(param)),
+const [mutateWithVars] = useMutation(({ param }: { param: number }) => Promise.resolve(Boolean(param)), {
+    onSuccess: () => {
+        queryCache.refetchQueries('todos');
+        queryCache.refetchQueries(['todo', { id: 5 }]);
+        queryCache.refetchQueries('reminders');
+    },
+});
+
+mutateWithVars(
+    { param: 1 },
     {
-    refetchQueries: ['todos', ['todo', { id: 5 }], 'reminders'],
-    refetchQueriesOnFailure: false
-});
+        updateQuery: 'query',
+        waitForRefetchQueries: false,
+    },
+);
 
-mutateWithVars({param: 1}, {
-  updateQuery: 'query',
-  waitForRefetchQueries: false
-});
-
-mutateWithVars({param: 'test'}); // $ExpectError
+mutateWithVars({ param: 'test' }); // $ExpectError


### PR DESCRIPTION
@lukaszfiszer @JaceHensley @matteofrana 

I've partly updated the definitions to support latest version of react-query. Biggest change is the addition of the `queryCache` object.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/tannerlinsley/react-query](https://github.com/tannerlinsley/react-query)
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
