### PR TITLE
passport prompts - Fix username of contributor

### DIFF
--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -4,7 +4,7 @@
 //                 Eric Naeseth <https://github.com/enaeseth>
 //                 Igor Belagorudsky <https://github.com/theigor>
 //                 Tomek Łaziuk <https://github.com/tlaziuk>
-//                 Daniel Perez Alvarez <https://github.com/danielpa9708>
+//                 Daniel Perez Alvarez <https://github.com/unindented>
 //                 Kevin Stiehl <https://github.com/kstiehl>
 //                 Oleg Vaskevich <https://github.com/vaskevich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/prompts/index.d.ts
+++ b/types/prompts/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for prompts 2.0
 // Project: https://github.com/terkelg/prompts
 // Definitions by: Berkay GURSOY <https://github.com/Berkays>
-//                 Daniel Perez Alvarez <https://github.com/danielpa9708>
+//                 Daniel Perez Alvarez <https://github.com/unindented>
 //                 Kamontat Chantrachirathumrong <https://github.com/kamontat>
 //                 theweirdone <https://github.com/theweirdone>
 //                 whoaa512 <https://github.com/whoaa512>


### PR DESCRIPTION
When creating an issue for @types/passport, I found a user's profile was incorrect. 
[danielpa9708](https://github.com/danielpa9708) is 404.
[unindented](https://github.com/unindented) is what they go by now.

I figured I'd fix it in other definitions too, to help future contributors. 
Please forgive me for not using the PR template.

