### PR TITLE
fix(autoprefixer): correct deprecated properties

### DIFF
--- a/types/autoprefixer/autoprefixer-tests.ts
+++ b/types/autoprefixer/autoprefixer-tests.ts
@@ -18,6 +18,12 @@ const ap2: Transformer = autoprefixer({
     ignoreUnknownVersions: false,
 });
 
+const deprecationTest = autoprefixer({
+    browser: 'defaults',
+    browsers: 'defaults',
+    browserslist: 'defaults',
+});
+
 autoprefixer.info(); // $ExpectedType () => void
 autoprefixer.data; // $ExpectType { browsers: any; prefixes: any; }
 autoprefixer.defaults; // $ExpectedType string

--- a/types/autoprefixer/index.d.ts
+++ b/types/autoprefixer/index.d.ts
@@ -30,9 +30,21 @@ declare namespace autoprefixer {
         grid?: false | 'autoplace' | 'no-autoplace';
         /** custom usage statistics for > 10% in my stats browsers query */
         stats?: Stats;
-        /** @deprecated Replace Autoprefixer `browsers` option to `Browserslist` config */
+        /** @deprecated 'Change `browser` option to `overrideBrowserslist` in Autoprefixer */
+        browser?: string;
+        /**
+         * @deprecated Replace Autoprefixer `browsers` option to Browserslist config.
+         * Use `browserslist` key in `package.json` or `.browserslistrc` file.
+         */
         browsers?: string[] | string;
-        /** list of queries for target browsers */
+        /** @deprecated Change `browserslist` option to `overrideBrowserslist` in Autoprefixer */
+        browserslist?: string[] | string;
+        /**
+         * list of queries for target browsers.
+         * Try to not use it.
+         * The best practice is to use `.browserslistrc` config or `browserslist` key in `package.json`
+         * to share target browsers with Babel, ESLint and Stylelint
+         */
         overrideBrowserslist?: BrowserslistTarget;
         /** do not raise error on unknown browser version in `Browserslist` config. */
         ignoreUnknownVersions?: boolean;


### PR DESCRIPTION
- added deprecated options that are still in the api, but not documented
as public option anymore
- documentation for `overrideBrowserslist` updated

https://github.com/postcss/autoprefixer/blob/master/lib/autoprefixer.js#L68-L93

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/postcss/autoprefixer/blob/master/lib/autoprefixer.js#L68-L93