### PR TITLE
feat(obsolete-web): new package definition

### DIFF
--- a/types/obsolete-web/index.d.ts
+++ b/types/obsolete-web/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for obsolete-web 0.5
+// Project: https://github.elenet.me/fe/obsolete-webpack-plugin
+// Definitions by: Piotr Błażejewicz (Peter Blazejewicz) <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare class Obsolete {
+    constructor(options?: Options);
+    static defaultOptions: Readonly<Required<Options>>;
+    /**
+     * Test browser compatibility.
+     */
+    test(browsers: string[], done?: () => void): boolean;
+}
+
+interface Options {
+    /**
+     * The prompt html template injected to the bottom of body. The default value is:
+     * ```html
+     * <div>Your browser is not supported. <button id="obsoleteClose">&times;</button></div>
+     * ```
+     */
+    template?: string;
+    /**
+     * If set 'afterbegin', the template will be injected into the start of body.
+     * If set 'beforeend', the template will be injected into the end of body
+     * @default 'afterbegin'
+     */
+    position?: 'afterbeing' | 'beforened';
+    /**
+     * If the current browser useragent doesn't match one of the target browsers, it's considered as unsupported.
+     * Thus, the prompt will be shown.
+     * @default false
+     */
+    promptOnNonTargetBrowser?: boolean;
+    /**
+     * If the current browser useragent is unknown, the prompt will be shown
+     * @default true
+     */
+    promptOnUnknownBrowser?: boolean;
+}
+
+export as namespace Obsolete;
+
+export = Obsolete;

--- a/types/obsolete-web/test/obsolete-web-commonjs.tests.ts
+++ b/types/obsolete-web/test/obsolete-web-commonjs.tests.ts
@@ -1,0 +1,16 @@
+/// <reference types="node" />
+import Obsolete = require('obsolete-web');
+
+const {
+    template, // $ExpectType string
+    position, // $ExpedtType string
+    promptOnNonTargetBrowser, // $ExpectType boolean
+    promptOnUnknownBrowser, // $ExpectType boolean
+} = Obsolete.defaultOptions;
+
+new Obsolete();
+new Obsolete(Obsolete.defaultOptions);
+new Obsolete().test(['ie 10', 'chrome 23']);
+new Obsolete().test(['ie 10', 'chrome 23'], () => {
+    console.log('done');
+});

--- a/types/obsolete-web/test/obsolete-web-global.tests.ts
+++ b/types/obsolete-web/test/obsolete-web-global.tests.ts
@@ -1,0 +1,13 @@
+const {
+    template, // $ExpectType string
+    position, // $ExpedtType string
+    promptOnNonTargetBrowser, // $ExpectType boolean
+    promptOnUnknownBrowser, // $ExpectType boolean
+} = Obsolete.defaultOptions;
+
+new Obsolete();
+new Obsolete(Obsolete.defaultOptions);
+new Obsolete().test(['ie 10', 'chrome 23']);
+new Obsolete().test(['ie 10', 'chrome 23'], () => {
+    console.log('done');
+});

--- a/types/obsolete-web/tsconfig.json
+++ b/types/obsolete-web/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "test/obsolete-web-commonjs.tests.ts",
+        "test/obsolete-web-global.tests.ts"
+    ]
+}

--- a/types/obsolete-web/tslint.json
+++ b/types/obsolete-web/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition files
- tests for global/CommonJS usage

https://github.com/ElemeFE/obsolete-webpack-plugin/tree/master/packages/obsolete-web

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.