### PR TITLE
[webpack-dev-server] Add sockWrite method and sockets property

### DIFF
--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -10,6 +10,7 @@
 //                 Billy Le <https://github.com/billy-le>
 //                 Chris Paterson <https://github.com/chrispaterson>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 William Artero <https://github.com/wwmoraes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -354,6 +355,8 @@ declare module 'webpack' {
 }
 
 declare class WebpackDevServer {
+    sockets: NodeJS.EventEmitter[];
+
     constructor(webpack: webpack.Compiler | webpack.MultiCompiler, config?: WebpackDevServer.Configuration);
 
     static addDevServerEntrypoints(
@@ -367,6 +370,8 @@ declare class WebpackDevServer {
     listen(port: number, callback?: (error?: Error) => void): http.Server;
 
     close(callback?: () => void): void;
+
+    sockWrite(sockets: NodeJS.EventEmitter[], type: string, data?: any): void;
 }
 
 export = WebpackDevServer;

--- a/types/webpack-dev-server/webpack-dev-server-tests.ts
+++ b/types/webpack-dev-server/webpack-dev-server-tests.ts
@@ -115,6 +115,12 @@ const c6: WebpackDevServer.Configuration = {
 server = new WebpackDevServer(compiler, config);
 server.listen(8080, "localhost", () => { });
 
+// test the socket writer
+server.sockWrite(server.sockets, "type1");
+server.sockWrite(server.sockets, "type2", {message: "OK"});
+
+server.close();
+
 // HTTPS example
 server = new WebpackDevServer(compiler, {
     publicPath: "/assets/",


### PR DESCRIPTION
Existing method and object as seen on code:

https://github.com/webpack/webpack-dev-server/blob/master/lib/Server.js#L925
https://github.com/webpack/webpack-dev-server/blob/master/lib/Server.js#L85

Though this mechanism is [undocumented](https://webpack.js.org/configuration/dev-server/), it is vastly used by plugins to hook up on HMR, [for instance](https://github.com/webpack/webpack-dev-server/issues/1271). Facebook's create-react-app [uses it as well](https://github.com/facebook/create-react-app/blob/7e6d6cd05f3054723c8b015c813e13761659759e/packages/react-scripts/scripts/start.js#L106-L111), and ejected applications running on typescript are unable to build if using strict settings.

Augmenting doesn't seem possible as [it is exported using `export = `](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/webpack-dev-server/index.d.ts#L372). 
