### PR TITLE
[auth0] Add missing users_json to ImportUsersOptions

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -375,6 +375,12 @@ management.importUsers({
     upsert: true
 }, (err, data) => console.log(data));
 
+management.importUsers({
+    users_json: "some json data",
+    connection_id: 'con_id',
+    send_completion_email: false
+}, (err, data) => console.log(data));
+
 management.exportUsers({
     connection_id: 'con_id',
     fields: [

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -669,13 +669,22 @@ export interface VerificationEmailJob {
     created_at?: string;
 }
 
-export interface ImportUsersOptions {
-    users: string;
+export interface BaseImportUsersOptions {
     connection_id: string;
     upsert?: boolean;
     external_id?: string;
     send_completion_email?: boolean;
 }
+
+export interface ImportUsersFromFileOptions extends BaseImportUsersOptions {
+    users: string;
+}
+
+export interface ImportUsersFromJsonOptions extends BaseImportUsersOptions {
+    users_json: string;
+}
+
+export type ImportUsersOptions = ImportUsersFromFileOptions | ImportUsersFromJsonOptions;
 
 export interface ExportUsersOptions {
     connection_id?: string;


### PR DESCRIPTION
Additionally, make `users` optional because either `users` or `users_json` is mandatory.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://auth0.github.io/node-auth0/module-management.JobsManager.html#importUsers
  - https://github.com/auth0/node-auth0/blob/423590665c59d0832a31bfbd8474db2ef8d6ac45/src/management/JobsManager.js#L150
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
