### PR TITLE
feat(karma): update constants export details

### DIFF
--- a/types/karma/index.d.ts
+++ b/types/karma/index.d.ts
@@ -14,10 +14,10 @@ import Promise = require('bluebird');
 import https = require('https');
 import { Appender } from 'log4js';
 import { EventEmitter } from 'events';
-import constants = require('./lib/constants');
+import * as karmaConstants from './lib/constants';
+import { VERSION } from './lib/constants';
 
-export { constants };
-export const VERSION: typeof constants.VERSION;
+export { karmaConstants as constants, VERSION };
 /**
  * `start` method is deprecated since 0.13. It will be removed in 0.14.
  * Please use

--- a/types/karma/index.d.ts
+++ b/types/karma/index.d.ts
@@ -14,7 +14,10 @@ import Promise = require('bluebird');
 import https = require('https');
 import { Appender } from 'log4js';
 import { EventEmitter } from 'events';
+import constants = require('./lib/constants');
 
+export { constants };
+export const VERSION: typeof constants.VERSION;
 /**
  * `start` method is deprecated since 0.13. It will be removed in 0.14.
  * Please use
@@ -27,36 +30,8 @@ import { EventEmitter } from 'events';
  * @deprecated
  */
 export const server: DeprecatedServer;
-
 export const runner: Runner;
 export const stopper: Stopper;
-
-export const VERSION: string;
-export const constants: Constants;
-
-export interface Constants {
-    VERSION: string;
-    DEFAULT_PORT: number;
-    DEFAULT_HOSTNAME: string;
-    DEFAULT_LISTEN_ADDR: string;
-    LOG_DISABLE: string;
-    LOG_ERROR: string;
-    LOG_WARN: string;
-    LOG_INFO: string;
-    LOG_DEBUG: string;
-    LOG_LOG: string;
-    LOG_PRIORITIES: string[];
-    COLOR_PATTERN: string;
-    NO_COLOR_PATTERN: string;
-    CONSOLE_APPENDER: {
-        type: string;
-        layout: {
-            type: string;
-            pattern: string;
-        };
-    };
-    EXIT_CODE: string;
-}
 
 export namespace launcher {
     class Launcher {

--- a/types/karma/index.d.ts
+++ b/types/karma/index.d.ts
@@ -14,10 +14,10 @@ import Promise = require('bluebird');
 import https = require('https');
 import { Appender } from 'log4js';
 import { EventEmitter } from 'events';
-import * as karmaConstants from './lib/constants';
+import * as constants from './lib/constants';
 import { VERSION } from './lib/constants';
 
-export { karmaConstants as constants, VERSION };
+export { constants, VERSION };
 /**
  * `start` method is deprecated since 0.13. It will be removed in 0.14.
  * Please use

--- a/types/karma/karma-tests.ts
+++ b/types/karma/karma-tests.ts
@@ -196,3 +196,22 @@ karma.config.parseConfig('karma.conf.js', {
     singleRun: true,
     restartOnFileChange: true,
 });
+
+// constants
+karma.VERSION; // $ExpectType string
+karma.constants.VERSION; // $ExpectType string
+karma.constants.DEFAULT_PORT; // $ExpectType string | number
+karma.constants.DEFAULT_HOSTNAME; // $ExpectType string
+karma.constants.DEFAULT_LISTEN_ADDR; // $ExpectType string
+karma.constants.LOG_DISABLE; // $ExpectType "OFF"
+karma.constants.LOG_ERROR; // $ExpectType "ERROR"
+karma.constants.LOG_WARN; // $ExpectType "WARN"
+karma.constants.LOG_INFO; // $ExpectType "INFO"
+karma.constants.LOG_DEBUG; // $ExpectType "DEBUG"
+karma.constants.LOG_LOG; // $ExpectType "LOG"
+karma.constants.LOG_PRIORITIES; // $ExpectType ["OFF", "ERROR", "WARN", "LOG", "INFO", "DEBUG"]
+karma.constants.COLOR_PATTERN; // $ExpectType string
+karma.constants.NO_COLOR_PATTERN; // $ExpectType string
+karma.constants.CONSOLE_APPENDER; // $ExpectType { type: string; layout: { type: string; pattern: string; }; }
+karma.constants.EXIT_CODE; // $ExpectType string
+karma.constants.LOG_PRIORITIES[5] === 'DEBUG';

--- a/types/karma/lib/constants.d.ts
+++ b/types/karma/lib/constants.d.ts
@@ -1,42 +1,36 @@
-declare const constants: Constants;
+/** The current version of karma */
+export const VERSION: string;
+/** The default port used for the karma server */
+export const DEFAULT_PORT: string | number;
+/** The default hostname used for the karma server */
+export const DEFAULT_HOSTNAME: string;
+/** The default listen address used for the karma server */
+export const DEFAULT_LISTEN_ADDR: string;
+/** The value for disabling logs */
+export const LOG_DISABLE: 'OFF';
+/** The value for the log `error` level */
+export const LOG_ERROR: 'ERROR';
+/** The value for the log `warn` level */
+export const LOG_WARN: 'WARN';
+/** The value for the log `info` level */
+export const LOG_INFO: 'INFO';
+/** The value for the log `debug` level */
+export const LOG_DEBUG: 'DEBUG';
+export const LOG_LOG: 'LOG';
+/** An array of log levels in descending order, i.e. LOG_DISABLE, LOG_ERROR, LOG_WARN, LOG_LOG, LOG_INFO, and LOG_DEBUG */
+export const LOG_PRIORITIES: ['OFF', 'ERROR', 'WARN', 'LOG', 'INFO', 'DEBUG'];
 
-interface Constants {
-    /** The current version of karma */
-    VERSION: string;
-    /** The default port used for the karma server */
-    DEFAULT_PORT: string | number;
-    /** The default hostname used for the karma server */
-    DEFAULT_HOSTNAME: string;
-    /** The default listen address used for the karma server */
-    DEFAULT_LISTEN_ADDR: string;
-    /** The value for disabling logs */
-    LOG_DISABLE: 'OFF';
-    /** The value for the log `error` level */
-    LOG_ERROR: 'ERROR';
-    /** The value for the log `warn` level */
-    LOG_WARN: 'WARN';
-    /** The value for the log `info` level */
-    LOG_INFO: 'INFO';
-    /** The value for the log `debug` level */
-    LOG_DEBUG: 'DEBUG';
-    LOG_LOG: 'LOG';
-    /** An array of log levels in descending order, i.e. LOG_DISABLE, LOG_ERROR, LOG_WARN, LOG_LOG, LOG_INFO, and LOG_DEBUG */
-    LOG_PRIORITIES: ['OFF', 'ERROR', 'WARN', 'LOG', 'INFO', 'DEBUG'];
-
-    /** The default color pattern for log output */
-    COLOR_PATTERN: string;
-    /** The default pattern for log output without color */
-    NO_COLOR_PATTERN: string;
-    /** The default console appender */
-    CONSOLE_APPENDER: {
+/** The default color pattern for log output */
+export const COLOR_PATTERN: string;
+/** The default pattern for log output without color */
+export const NO_COLOR_PATTERN: string;
+/** The default console appender */
+export const CONSOLE_APPENDER: {
+    type: string;
+    layout: {
         type: string;
-        layout: {
-            type: string;
-            pattern: string;
-        };
+        pattern: string;
     };
-    /** The exit code */
-    EXIT_CODE: string;
-}
-
-export = constants;
+};
+/** The exit code */
+export const EXIT_CODE: string;

--- a/types/karma/lib/constants.d.ts
+++ b/types/karma/lib/constants.d.ts
@@ -1,0 +1,42 @@
+declare const constants: Constants;
+
+interface Constants {
+    /** The current version of karma */
+    VERSION: string;
+    /** The default port used for the karma server */
+    DEFAULT_PORT: string | number;
+    /** The default hostname used for the karma server */
+    DEFAULT_HOSTNAME: string;
+    /** The default listen address used for the karma server */
+    DEFAULT_LISTEN_ADDR: string;
+    /** The value for disabling logs */
+    LOG_DISABLE: 'OFF';
+    /** The value for the log `error` level */
+    LOG_ERROR: 'ERROR';
+    /** The value for the log `warn` level */
+    LOG_WARN: 'WARN';
+    /** The value for the log `info` level */
+    LOG_INFO: 'INFO';
+    /** The value for the log `debug` level */
+    LOG_DEBUG: 'DEBUG';
+    LOG_LOG: 'LOG';
+    /** An array of log levels in descending order, i.e. LOG_DISABLE, LOG_ERROR, LOG_WARN, LOG_LOG, LOG_INFO, and LOG_DEBUG */
+    LOG_PRIORITIES: ['OFF', 'ERROR', 'WARN', 'LOG', 'INFO', 'DEBUG'];
+
+    /** The default color pattern for log output */
+    COLOR_PATTERN: string;
+    /** The default pattern for log output without color */
+    NO_COLOR_PATTERN: string;
+    /** The default console appender */
+    CONSOLE_APPENDER: {
+        type: string;
+        layout: {
+            type: string;
+            pattern: string;
+        };
+    };
+    /** The exit code */
+    EXIT_CODE: string;
+}
+
+export = constants;

--- a/types/karma/tslint.json
+++ b/types/karma/tslint.json
@@ -1,1 +1,11 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-duplicate-imports": [
+            true,
+            {
+                "allow-namespace-imports": true
+            }
+        ]
+    }
+}


### PR DESCRIPTION
- move Constatns to separate file
- export as named re-export from main module
- add missing type for 'PORT' - should be `number` OR `string` depending
on the source of this contant. If read from ENV it will be a string
always.
- add missing documentation
- move LOG types to use string literal types to use in the values in
typechecks and intelllisense
- tests updated

https://github.com/karma-runner/karma/blob/master/lib/constants.js

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/karma-runner/karma/blob/master/lib/constants.js
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.