### PR TITLE
[express-serve-static-core] Distinct handler type by http methods

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -8,6 +8,7 @@
 //                 aereal <https://github.com/aereal>
 //                 Jose Luis Leon <https://github.com/JoseLion>
 //                 David Stephens <https://github.com/dwrss>
+//                 Shin Ando <https://github.com/andoshin11>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -54,7 +55,7 @@ export type RequestHandlerParams<P extends Params = ParamsDictionary, ResBody = 
     | Array<RequestHandler<P>
     | ErrorRequestHandler<P>>;
 
-export interface IRouterMatcher<T> {
+export interface IRouterMatcher<T, Method extends 'all' | 'get' | 'post' | 'put' | 'delete' | 'patch' | 'options' | 'head' = any> {
     // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
     <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any>(path: PathParams, ...handlers: Array<RequestHandler<P, ResBody, ReqBody>>): T;
     // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
@@ -107,14 +108,14 @@ export interface IRouter extends RequestHandler {
      * Special-cased "all" method, applying the given route `path`,
      * middleware, and callback to _every_ HTTP method.
      */
-    all: IRouterMatcher<this>;
-    get: IRouterMatcher<this>;
-    post: IRouterMatcher<this>;
-    put: IRouterMatcher<this>;
-    delete: IRouterMatcher<this>;
-    patch: IRouterMatcher<this>;
-    options: IRouterMatcher<this>;
-    head: IRouterMatcher<this>;
+    all: IRouterMatcher<this, 'all'>;
+    get: IRouterMatcher<this, 'get'>;
+    post: IRouterMatcher<this, 'post'>;
+    put: IRouterMatcher<this, 'put'>;
+    delete: IRouterMatcher<this, 'delete'>;
+    patch: IRouterMatcher<this, 'patch'>;
+    options: IRouterMatcher<this, 'options'>;
+    head: IRouterMatcher<this, 'head'>;
 
     checkout: IRouterMatcher<this>;
     connect: IRouterMatcher<this>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

## Why the change?
I'm currently writing & generating type definitions for Express handlers, using path literal type to distinguish each endpoints. [Here](https://github.com/andoshin11/typed-oax) is the library I'm working on.

- [typed-oax](https://github.com/andoshin11/typed-oax)

Here's the example of the declaration file.

```ts
// express.d.ts

import { RequestHandler } from "express";
declare module "express-serve-static-core" {
  type Pet = {
    id: number;
    name: string;
    sex?: "male" | "female";
  };
  export interface IRouterMatcher<T> {
    <
      P extends Params = ParamsDictionary,
      ResBody = { pets: Pet[]; } | { pet: Pet; },
      ReqBody = null | { name: string; sex: "male" | 'female' }
    >(
      path: "/pets",
      ...handlers: Array<RequestHandler<P, ResBody, ReqBody>>
    ): T;
    <
      P extends Params = { petId: string; },
      ResBody = { pet: Pet; },
      ReqBody = null | { name?: string; sex?: "male" | "female"; }
    >(
      path: "/pets/:petId",
      ...handlers: Array<RequestHandler<P, ResBody, ReqBody>>
    ): T;
  }
}
```

The above type definition allows us to use such type inference 👇 . Entire section is statically typed.

<img width="738" alt="Screen Shot 2020-03-08 at 22 02 24" src="https://user-images.githubusercontent.com/8381075/76163342-9155fe80-6188-11ea-9ffe-7b95994bb933.png">


However, due to the limitation by current method agnostic type definitions, I am not able to define handler types for the different HTTP method.
See the `ResBody` section of the path `/pets`. (I was forced to provide union types for both `GET /pets` and `POST /pets` response 😞 )

## After the change...
After this PR gets merged, we are able to change req/res types depending on HTTP methods.

```ts
  export interface IRouterMatcher<T, Method> {
    <
      P extends Params = ParamsDictionary,
      ResBody = Method extends 'get' ?
        { pets: Pet[]; } : Method extends 'post' ?
        { pet: Pet; } : any,
      ReqBody = Method extends 'get' ?
        never : Method extends 'post' ?
        { name: string; sex: "male" | 'female' } : any
    >(
      path: "/pets",
      ...handlers: Array<RequestHandler<P, ResBody, ReqBody>>
    ): T;
  }
```

<img width="882" alt="Screen Shot 2020-03-08 at 22 14 31" src="https://user-images.githubusercontent.com/8381075/76163524-3cb38300-618a-11ea-8914-5b611bbc2232.png">

Hope everyone likes this minor yet powerful change to the core. Thank you.


P.S. sorry for my poor English.