### PR TITLE
[react-phone-number-input] Add back in removed optional props: international & country

### DIFF
--- a/types/react-phone-number-input/index.d.ts
+++ b/types/react-phone-number-input/index.d.ts
@@ -81,8 +81,8 @@ export interface PhoneInputProps extends Omit<React.InputHTMLAttributes<string>,
     countries?: string[];
 
     /**
-     * If country is specified then the phone number can only be input in "national" 
-     * (not "international") format, and will be parsed as a phone number belonging 
+     * If country is specified then the phone number can only be input in "national"
+     * (not "international") format, and will be parsed as a phone number belonging
      * to the country. Example: country="US"
      */
     country?: string;
@@ -147,13 +147,13 @@ export interface PhoneInputProps extends Omit<React.InputHTMLAttributes<string>,
     >;
 
     /**
-     * If country is specified and international property is true then the phone number can only be input 
-     * in "international" format for that country, but without "country calling code" part. 
-     * For example, if country is "US" and international property is not passed then the phone number can 
-     * only be input in the "national" format for US ((213) 373-4253). But if country is "US" and 
-     * international property is true then the phone number will be input in the "international" format 
-     * for US (213 373 4253) without "country calling code" part (+1). This could be used for implementing 
-     * phone number input components that show "country calling code" part before the input field and then 
+     * If country is specified and international property is true then the phone number can only be input
+     * in "international" format for that country, but without "country calling code" part.
+     * For example, if country is "US" and international property is not passed then the phone number can
+     * only be input in the "national" format for US ((213) 373-4253). But if country is "US" and
+     * international property is true then the phone number will be input in the "international" format
+     * for US (213 373 4253) without "country calling code" part (+1). This could be used for implementing
+     * phone number input components that show "country calling code" part before the input field and then
      * the user can fill in the rest of their phone number in the input field.
      */
     international?: boolean;

--- a/types/react-phone-number-input/index.d.ts
+++ b/types/react-phone-number-input/index.d.ts
@@ -79,6 +79,14 @@ export interface PhoneInputProps extends Omit<React.InputHTMLAttributes<string>,
      * @example ["RU", "UA", "KZ"]
      */
     countries?: string[];
+
+    /**
+     * If country is specified then the phone number can only be input in "national" 
+     * (not "international") format, and will be parsed as a phone number belonging 
+     * to the country. Example: country="US"
+     */
+    country?: string;
+
     /**
      * Can be used to place some countries on top of the list of country <select/> options.
      *  - "|" — inserts a separator.
@@ -137,6 +145,19 @@ export interface PhoneInputProps extends Omit<React.InputHTMLAttributes<string>,
     inputComponent?: React.ForwardRefExoticComponent<
         React.InputHTMLAttributes<HTMLInputElement> & React.RefAttributes<any>
     >;
+
+    /**
+     * If country is specified and international property is true then the phone number can only be input 
+     * in "international" format for that country, but without "country calling code" part. 
+     * For example, if country is "US" and international property is not passed then the phone number can 
+     * only be input in the "national" format for US ((213) 373-4253). But if country is "US" and 
+     * international property is true then the phone number will be input in the "international" format 
+     * for US (213 373 4253) without "country calling code" part (+1). This could be used for implementing 
+     * phone number input components that show "country calling code" part before the input field and then 
+     * the user can fill in the rest of their phone number in the input field.
+     */
+    international?: boolean;
+
     /**
      * If `country` property is passed along with `international={true}` property
      * then the phone number will be input in "international" format for that `country`

--- a/types/react-phone-number-input/react-phone-number-input-tests.tsx
+++ b/types/react-phone-number-input/react-phone-number-input-tests.tsx
@@ -13,6 +13,7 @@ const test1 = (
         defaultCountry="NZ"
         countries={['NZ', 'US', 'FR']}
         placeholder="Place holder"
+        international={true}
     >
         <div>panel 1</div>
         <div>panel 2</div>

--- a/types/react-phone-number-input/react-phone-number-input-tests.tsx
+++ b/types/react-phone-number-input/react-phone-number-input-tests.tsx
@@ -14,6 +14,7 @@ const test1 = (
         countries={['NZ', 'US', 'FR']}
         placeholder="Place holder"
         international={true}
+        country={'US'}
     >
         <div>panel 1</div>
         <div>panel 2</div>


### PR DESCRIPTION
Some of the props were taken out as part of #41957 but `international` and `country` should be included.
- International is optional. It allows prefixing the input value with the country code.
- Country is optional.  It allows setting the value without the dropdown/select.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/catamphetamine/react-phone-number-input](https://github.com/catamphetamine/react-phone-number-input)
