### PR TITLE
Remove unsupported tab control and visibility flag

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -590,10 +590,6 @@ declare namespace Office {
          */
         id: string;
         /**
-         * Specifies whether the tab is visible. The default is true.
-         */
-        visible?: boolean;
-        /**
          * Specifies the controls in the tab, such as menu items, buttons, etc.
          */
         controls?: Control[];
@@ -614,16 +610,7 @@ declare namespace Office {
          * Indicates whether the control should be enabled or disabled. The default is true.
          */
         enabled?: boolean;
-    }
-    /**
-     * Represents a gallery that displays a collection of related items or controls in the ribbon.
-     */
-    interface Gallery extends Control {
-        /**
-         * Used to refresh the gallery control including optional data to be passed to the gallery control at the time of refresh action.
-         */
-        refreshData?: { [key: string]: string | null };
-    }    
+    }   
     /**
      * Represents the runtime environment of the add-in and provides access to key objects of the API. 
      * The current context exists as a property of Office. It is accessed using `Office.context`.

--- a/types/office-js-preview/office-js-preview-tests.ts
+++ b/types/office-js-preview/office-js-preview-tests.ts
@@ -328,6 +328,11 @@ async function testOfficeDirectApis() {
         tabs: [
             {
                 id: 'test-id',
+                controls: [
+                {
+                    id: 'button-1',
+                    visible: true,
+                }]
             },
         ],
     });


### PR DESCRIPTION
The earlier update mistakenly added unsupported APIs. This PR is to remove them from the d.ts.

Please fill in this template.
- [ X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ X] Test the change in your own code. (Compile and run.)
- [ X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.microsoft.com/en-us/office/dev/add-ins/design/ux-design-pattern-templates