### PR TITLE
Add types for inline-critical

### DIFF
--- a/types/inline-critical/index.d.ts
+++ b/types/inline-critical/index.d.ts
@@ -1,0 +1,73 @@
+// Type definitions for inline-critical 5.3
+// Project: https://github.com/bezoerb/inline-critical#readme
+// Definitions by: cherryblossom <https://github.com/cherryblossom000>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = inline;
+
+/**
+ * @param html The HTML to use to inline critical styles.
+ * @param styles The styles to inline.
+ * @param options Optional configuration object.
+ * @example
+ * const html = fs.readFileSync('test/fixtures/index.html', 'utf8')
+ * const critical = fs.readFileSync('tests/fixtures/critical.css', 'utf8')
+ * const inlined = inline(html, critical)
+ *
+ * // ignoring stylesheets matching regex
+ * const inlined = inline(html, critical, {ignore: [/bootstrap/]})
+ */
+declare function inline(html: string, styles: string, options?: inline.Options): string;
+
+declare namespace inline {
+    interface Options {
+        /**
+         * Whether to minify the styles before inlining.
+         * @default true
+         */
+        minify?: boolean;
+
+        /**
+         * Whether to remove the inlined styles from any stylesheets referenced in the HTML.
+         * @default false
+         */
+        extract?: boolean;
+
+        /**
+         * The path to be used when extracting styles to find the files references by `href` attributes.
+         * @default process.cwd
+         */
+        basePath?: string;
+
+        /**
+         * Stylesheets to ignore when inlining.
+         * @default []
+         * @example [/bootstrap/]
+         */
+        ignore?: string | RegExp | Array<string | RegExp>;
+
+        /** The selector for the element used by loadCSS as a reference for inlining. */
+        selector?: string;
+
+        /**
+         * The position of the `noscript` fallback.
+         * * `body`: end of body
+         * * `head`: end of head
+         * * `false`: no `noscript`
+         * @default 'body'
+         */
+        noscript?: 'body' | 'head' | false;
+
+        /**
+         * Whether to add loadCSS if it's not already loaded.
+         * @default true
+         */
+        polyfill?: boolean;
+
+        /**
+         * Paths to use in the `href` tag of the `link` elements.
+         * @default false
+         */
+        replaceStylesheets?: string[] | false;
+    }
+}

--- a/types/inline-critical/inline-critical-tests.ts
+++ b/types/inline-critical/inline-critical-tests.ts
@@ -1,0 +1,22 @@
+import inline from 'inline-critical';
+
+// $ExpectType string
+inline('', '');
+
+// $ExpectType string
+inline('', '', {});
+
+// $ExpectType string
+inline('', '', {
+    minify: true,
+    extract: true,
+    basePath: '',
+    ignore: '',
+    selector: '',
+    noscript: false,
+    polyfill: true,
+    replaceStylesheets: false
+});
+
+// $ExpectType string
+inline('', '', {ignore: [/a/]});

--- a/types/inline-critical/tsconfig.json
+++ b/types/inline-critical/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "esModuleInterop": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "inline-critical-tests.ts"
+    ]
+}

--- a/types/inline-critical/tslint.json
+++ b/types/inline-critical/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
