### PR TITLE
[@testing-library/jest-dom] Adding enhanced descriptions and examples

### DIFF
--- a/types/testing-library__jest-dom/index.d.ts
+++ b/types/testing-library__jest-dom/index.d.ts
@@ -12,25 +12,373 @@ declare namespace jest {
     interface Matchers<R, T> {
         /**
          * @deprecated
+         * since v1.9.0
+         * @description
+         * Assert whether a value is a DOM element, or not. Contrary to what its name implies, this matcher only checks
+         * that you passed to it a valid DOM element.
+         *
+         * It does not have a clear definition of what "the DOM" is. Therefore, it does not check whether that element
+         * is contained anywhere.
+         * @see
+         * [testing-library/jest-dom#toBeInTheDom](https:github.com/testing-library/jest-dom#toBeInTheDom)
          */
         toBeInTheDOM(container?: HTMLElement | SVGElement): R;
+        /**
+         * @description
+         * Assert whether an element is present in the document or not.
+         * @example
+         * <svg data-testid="svg-element"></svg>
+         *
+         * expect(queryByTestId('svg-element')).toBeInTheDocument()
+         * expect(queryByTestId('does-not-exist')).not.toBeInTheDocument()
+         * @see
+         * [testing-library/jest-dom#tobeinthedocument](https:github.com/testing-library/jest-dom#tobeinthedocument)
+         */
         toBeInTheDocument(): R;
+        /**
+         * @description
+         * This allows you to check if an element is currently visible to the user.
+         *
+         * An element is visible if **all** the following conditions are met:
+         * * it does not have its css property display set to none
+         * * it does not have its css property visibility set to either hidden or collapse
+         * * it does not have its css property opacity set to 0
+         * * its parent element is also visible (and so on up to the top of the DOM tree)
+         * * it does not have the hidden attribute
+         * * if `<details />` it has the open attribute
+         * @example
+         * <div
+         *   data-testid="zero-opacity"
+         *   style="opacity: 0"
+         * >
+         *   Zero Opacity
+         * </div>
+         *
+         * <div data-testid="visible">Visible Example</div>
+         *
+         * expect(getByTestId('zero-opacity')).not.toBeVisible()
+         * expect(getByTestId('visible')).toBeVisible()
+         * @see
+         * [testing-library/jest-dom#tobevisible](https:github.com/testing-library/jest-dom#tobevisible)
+         */
         toBeVisible(): R;
+        /**
+         * @description
+         * Assert whether an element has content or not.
+         * @example
+         * <span data-testid="not-empty">
+         *   <span data-testid="empty"></span>
+         * </span>
+         *
+         * expect(getByTestId('empty')).toBeEmpty()
+         * expect(getByTestId('not-empty')).not.toBeEmpty()
+         * @see
+         * [testing-library/jest-dom#tobeempty](https:github.com/testing-library/jest-dom#tobeempty)
+         */
         toBeEmpty(): R;
+        /**
+         * @description
+         * Allows you to check whether an element is disabled from the user's perspective.
+         *
+         * Matches if the element is a form control and the `disabled` attribute is specified on this element or the
+         * element is a descendant of a form element with a `disabled` attribute.
+         * @example
+         * <button
+         *   data-testid="button"
+         *   type="submit"
+         *   disabled
+         * >
+         *   submit
+         * </button>
+         *
+         * expect(getByTestId('button')).toBeDisabled()
+         * @see
+         * [testing-library/jest-dom#tobedisabled](https:github.com/testing-library/jest-dom#tobedisabled)
+         */
         toBeDisabled(): R;
+        /**
+         * @description
+         * Allows you to check whether an element is not disabled from the user's perspective.
+         *
+         * Works like `not.toBeDisabled()`.
+         *
+         * Use this matcher to avoid double negation in your tests.
+         * @example
+         * <button
+         *   data-testid="button"
+         *   type="submit"
+         * >
+         *   submit
+         * </button>
+         *
+         * expect(getByTestId('button')).toBeEnabled()
+         * @see
+         * [testing-library/jest-dom#tobeenabled](https:github.com/testing-library/jest-dom#tobeenabled)
+         */
         toBeEnabled(): R;
+        /**
+         * @description
+         * Check if a form element, or the entire `form`, is currently invalid.
+         *
+         * An `input`, `select`, `textarea`, or `form` element is invalid if it has an `aria-invalid` attribute with no
+         * value or a value of "true", or if the result of `checkValidity()` is false.
+         * @example
+         * <input data-testid="no-aria-invalid" />
+         *
+         * <form data-testid="invalid-form">
+         *   <input required />
+         * </form>
+         *
+         * expect(getByTestId('no-aria-invalid')).not.toBeInvalid()
+         * expect(getByTestId('invalid-form')).toBeInvalid()
+         * @see
+         * [testing-library/jest-dom#tobeinvalid](https:github.com/testing-library/jest-dom#tobeinvalid)
+         */
         toBeInvalid(): R;
+        /**
+         * @description
+         * This allows you to check if a form element is currently required.
+         *
+         * An element is required if it is having a `required` or `aria-required="true"` attribute.
+         * @example
+         * <input data-testid="required-input" required />
+         * <div
+         *   data-testid="supported-role"
+         *   role="tree"
+         *   required />
+         *
+         * expect(getByTestId('required-input')).toBeRequired()
+         * expect(getByTestId('supported-role')).not.toBeRequired()
+         * @see
+         * [testing-library/jest-dom#toberequired](https:github.com/testing-library/jest-dom#toberequired)
+         */
         toBeRequired(): R;
+        /**
+         * @description
+         * Allows you to check if a form element is currently required.
+         *
+         * An `input`, `select`, `textarea`, or `form` element is invalid if it has an `aria-invalid` attribute with no
+         * value or a value of "false", or if the result of `checkValidity()` is true.
+         * @example
+         * <input data-testid="aria-invalid" aria-invalid />
+         *
+         * <form data-testid="valid-form">
+         *   <input />
+         * </form>
+         *
+         * expect(getByTestId('no-aria-invalid')).not.toBeValid()
+         * expect(getByTestId('invalid-form')).toBeInvalid()
+         * @see
+         * [testing-library/jest-dom#tobevalid](https:github.com/testing-library/jest-dom#tobevalid)
+         */
         toBeValid(): R;
+        /**
+         * @description
+         * Allows you to assert whether an element contains another element as a descendant or not.
+         * @example
+         * <span data-testid="ancestor">
+         *   <span data-testid="descendant"></span>
+         * </span>
+         *
+         * const ancestor = getByTestId('ancestor')
+         * const descendant = getByTestId('descendant')
+         * const nonExistantElement = getByTestId('does-not-exist')
+         * expect(ancestor).toContainElement(descendant)
+         * expect(descendant).not.toContainElement(ancestor)
+         * expect(ancestor).not.toContainElement(nonExistantElement)
+         * @see
+         * [testing-library/jest-dom#tocontainelement](https:github.com/testing-library/jest-dom#tocontainelement)
+         */
         toContainElement(element: HTMLElement | SVGElement | null): R;
+        /**
+         * @description
+         * Assert whether a string representing a HTML element is contained in another element.
+         * @example
+         * <span data-testid="parent">
+         *   <span data-testid="child"></span>
+         * </span>
+         *
+         * const parent = getByTestId('parent')
+         * expect(parent).toContainerHTML(<span data-testid="child"></span>)
+         * @see
+         * [testing-library/jest-dom#tocontainhtml](https:github.com/testing-library/jest-dom#tocontainhtml)
+         */
         toContainHTML(htmlText: string): R;
+        /**
+         * @description
+         * Allows you to check if a given element has an attribute or not.
+         *
+         * You can also optionally check that the attribute has a specific expected value or partial match using
+         * [expect.stringContaining](https://jestjs.io/docs/en/expect.html#expectnotstringcontainingstring) or
+         * [expect.stringMatching](https://jestjs.io/docs/en/expect.html#expectstringmatchingstring-regexp).
+         * @example
+         * <button
+         *   data-testid="ok-button"
+         *   type="submit"
+         *   disabled
+         * >
+         *   ok
+         * </button>
+         *
+         * expect(button).toHaveAttribute('disabled')
+         * expect(button).toHaveAttribute('type', 'submit')
+         * expect(button).not.toHaveAttribute('type', 'button')
+         * @see
+         * [testing-library/jest-dom#tohaveattribute](https:github.com/testing-library/jest-dom#tohaveattribute)
+         */
         toHaveAttribute(attr: string, value?: unknown): R;
+        /**
+         * @description
+         * Check whether the given element has certain classes within its `class` attribute.
+         *
+         * You must provide at least one class, unless you are asserting that an element does not have any classes.
+         * @example
+         * <button
+         *   data-testid="delete-button"
+         *   class="btn xs btn-danger"
+         * >
+         *   delete item
+         * </button>
+         *
+         * <div data-testid="no-classes">no classes</div>
+         *
+         * const deleteButton = getByTestId('delete-button')
+         * const noClasses = getByTestId('no-classes')
+         * expect(deleteButton).toHaveClass('btn')
+         * expect(deleteButton).toHaveClass('btn-danger xs')
+         * expect(noClasses).not.toHaveClass()
+         * @see
+         * [testing-library/jest-dom#tohaveclass](https:github.com/testing-library/jest-dom#tohaveclass)
+         */
         toHaveClass(...classNames: string[]): R;
+        /**
+         * @description
+         * Assert whether an element has focus or not.
+         * @example
+         * <div>
+         *   <input type="text" data-testid="element-to-focus" />
+         * </div>
+         *
+         * const input = getByTestId('element-to-focus')
+         * input.focus()
+         * expect(input).toHaveFocus()
+         * input.blur()
+         * expect(input).not.toHaveFocus()
+         * @see
+         * [testing-library/jest-dom#tohavefocus](https:github.com/testing-library/jest-dom#tohavefocus)
+         */
         toHaveFocus(): R;
+        /**
+         * @description
+         * Check if a form or fieldset contains form controls for each given name, and having the specified value.
+         *
+         * Can only be invoked on a form or fieldset element.
+         * @example
+         * <form data-testid="login-form">
+         *   <input type="text" name="username" value="jane.doe" />
+         *   <input type="password" name="password" value="123" />
+         *   <input type="checkbox" name="rememberMe" checked />
+         *   <button type="submit">Sign in</button>
+         * </form>
+         *
+         * expect(getByTestId('login-form')).toHaveFormValues({
+         *   username: 'jane.doe',
+         *   rememberMe: true,
+         * })
+         * @see
+         * [testing-library/jest-dom#tohaveformvalues](https:github.com/testing-library/jest-dom#tohaveformvalues)
+         */
         toHaveFormValues(expectedValues: Record<string, unknown>): R;
+        /**
+         * @description
+         * Check if an element has specific css properties with specific values applied.
+         *
+         * Only matches if the element has *all* the expected properties applied, not just some of them.
+         * @example
+         * <button
+         *   data-test-id="submit-button"
+         *   style="background-color: green; display: none"
+         * >
+         *   submit
+         * </button>
+         *
+         * const button = getByTestId('submit-button')
+         * expect(button).toHaveStyle('background-color: green')
+         * expect(button).toHaveStyle({
+         *   background-color: 'green',
+         *   display: none
+         * })
+         * @see
+         * [testing-library/jest-dom#tohavestyle](https:github.com/testing-library/jest-dom#tohavestyle)
+         */
         toHaveStyle(css: string | Record<string, unknown>): R;
+        /**
+         * @description
+         * Check whether the given element has a text content or not.
+         *
+         * When a string argument is passed through, it will perform a partial case-sensitive match to the element
+         * content.
+         *
+         * To perform a case-insensitive match, you can use a RegExp with the `/i` modifier.
+         *
+         * If you want to match the whole content, you can use a RegExp to do it.
+         * @example
+         * <span data-testid="text-content">Text Content</span>
+         *
+         * const element = getByTestId('text-content')
+         * expect(element).toHaveTextContent('Content')
+         * // to match the whole content
+         * expect(element).toHaveTextContent(/^Text Content$/)
+         * // to use case-insentive match
+         * expect(element).toHaveTextContent(/content$/i)
+         * expect(element).not.toHaveTextContent('content')
+         * @see
+         * [testing-library/jest-dom#tohavetextcontent](https:github.com/testing-library/jest-dom#tohavetextcontent)
+         */
         toHaveTextContent(text: string | RegExp, options?: { normalizeWhitespace: boolean }): R;
+        /**
+         * @description
+         * Check whether the given form element has the specified value.
+         *
+         * Accepts `<input>`, `<select>`, and `<textarea>` elements with the exception of `<input type="checkbox">` and
+         * `<input type="radiobox">`, which can be matched only using
+         * [toBeChecked](https:github.com/testing-library/jest-dom#tobechecked) or
+         * [toHaveFormValues](https:github.com/testing-library/jest-dom#tohaveformvalues).
+         * @example
+         * <input
+         *   type="number"
+         *   value="5"
+         *   data-testid="input-number" />
+         *
+         * const numberInput = getByTestId('input-number')
+         * expect(numberInput).toHaveValue(5)
+         * @see
+         * [testing-library/jest-dom#tohavevalue](https:github.com/testing-library/jest-dom#tohavevalue)
+         */
         toHaveValue(value?: string | string[] | number): R;
+        /**
+         * @description
+         * Assert whether the given element is checked.
+         *
+         * It accepts an `input` of type `checkbox` or `radio` and elements with a `role` of `radio` with a valid
+         * `aria-checked` attribute of "true" or "false".
+         * @example
+         * <input
+         *   type="checkbox"
+         *   checked
+         *   data-testid="input-checkbox" />
+         * <input
+         *   type="radio"
+         *   value="foo"
+         *   data-testid="input-radio" />
+         *
+         * const inputCheckbox = getByTestId('input-checkbox')
+         * const inputRadio = getByTestId('input-radio')
+         * expect(inputCheckbox).toBeChecked()
+         * expect(inputRadio).not.toBeChecked()
+         * @see
+         * [testing-library/jest-dom#tobechecked](https:github.com/testing-library/jest-dom#tobechecked)
+         */
         toBeChecked(): R;
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

---

**Why the change?**
Previous type defs did not include descriptions or relevant links to the github documentation.

This PR adds JSDoc support to allow editors/IDEs a better intellisense experience.

With JSDoc-like syntax we can add `@describe `, `@example`, and `@see` to show proper usage in-line while coding.

Here's how it looks when working:

![jsdoc-examples](https://user-images.githubusercontent.com/3946895/76176741-40dea100-6188-11ea-8368-b43908b89cb3.gif)

All of the examples and describe statements were taken from the original `jest-dom` docs here:
https://github.com/testing-library/jest-dom