### PR TITLE
[@types/sanitize-html]  Version update 1.20.1 → 1.22.0

### DIFF
--- a/types/sanitize-html/index.d.ts
+++ b/types/sanitize-html/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sanitize-html 1.20.1
+// Type definitions for sanitize-html 1.22.0
 // Project: https://github.com/punkave/sanitize-html
 // Definitions by: Rogier Schouten <https://github.com/rogierschouten>
 //                 Afshin Darian <https://github.com/afshin>
@@ -9,6 +9,7 @@
 //                 Johan Davidsson <https://github.com/johandavidson>
 //                 Jianrong Yu <https://github.com/YuJianrong>
 //                 GP <https://github.com/paambaati>
+//                 tomotetra <https://github.com/tomotetra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -30,6 +31,8 @@ declare namespace sanitize {
   type Transformer = (tagName: string, attribs: Attributes) => Tag;
 
   type AllowedAttribute = string | { name: string; multiple?: boolean; values: string[] };
+
+  type DisallowedTagsModes = 'discard' | 'escape' | 'recursiveEscape';
 
   interface IDefaults {
     allowedAttributes: { [index: string]: AllowedAttribute[] };
@@ -65,6 +68,7 @@ declare namespace sanitize {
     selfClosing?: string[];
     transformTags?: { [tagName: string]: string | Transformer };
     parser?: Options;
+    disallowedTagsMode?: DisallowedTagsModes;
   }
 
 

--- a/types/sanitize-html/sanitize-html-tests.ts
+++ b/types/sanitize-html/sanitize-html-tests.ts
@@ -31,7 +31,8 @@ let options: sanitize.IOptions = {
   allowedSchemesByTag: {
     'a': ['http', 'https']
   },
-  allowProtocolRelative: false
+  allowProtocolRelative: false,
+  disallowedTagsMode: 'escape'
 };
 
 let unsafe = '<div><script>alert("hello");</script></div>';


### PR DESCRIPTION
changes:
- added type definition for `disallowedTagsMode` option, added in [v1.21.0](https://github.com/apostrophecms/sanitize-html/releases/tag/1.21.0)

---
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apostrophecms/sanitize-html/blob/master/CHANGELOG.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
