### PR TITLE
[bson] Add 'value' property to Double class

### DIFF
--- a/types/bson/index.d.ts
+++ b/types/bson/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Hiroki Horiuchi <https://github.com/horiuchi>
 //                 Federico Caselli <https://github.com/CaselIT>
 //                 Justin Grant <https://github.com/justingrant>
+//                 Mikael Lirbank <https://github.com/lirbank>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node"/>
@@ -181,6 +182,12 @@ export class Double {
      * @param value The number we want to represent as a double.
      */
     constructor(value: number);
+
+    /**
+     * https://github.com/mongodb/js-bson/blob/master/lib/double.js#L17
+     */
+    value: number;
+
 
     valueOf(): number;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

@horiuchi @CaselIT @justingrant

### Reasoning

This change is correct (see link in the source code), but the main reason I added the property is to prevent `Double` from being compatible with `number`. Let me explain.

With the current typings for Double, consider the following.

```ts
const n1: Double = 123 // pass
const n2: Double = new Double(123) // pass
const n3: number = new Double(123) // Type 'Double' is not assignable to type 'number'
```

When using JSON-schema validators and setting a field to be a `double`, you can store JS number directly IF it has a decimal point. Ex:

```ts
col.insertOne({myDoubleField: 123.456}); // works
col.insertOne({myDoubleField: 123}); // Document failed validation
```

This is silly, but that's how it is. So to solve this you can do:
```ts
col.insertOne({myDoubleField: new Double(123.456)}); // works
col.insertOne({myDoubleField: new Double(123)}); // works too
```

Now, say you don't know ahead of time if the input `number` is a decimal style or integer style number it'd be nice to protect against using regular JS `numbers` (as they only work in some cases). 

```ts
function writeToDb(num: Double) {
  col.insertOne({myDoubleField: num}); // works
}

writeToDb(new Double(1)); // works
writeToDb(new Double(1.1)); // works
writeToDb(1); // fails document validation, and is not caught by the type system
writeToDb(1.1); // works, since it is a `number` with decimal point, but the type system should not had allowed this coz `number` is not `Double`.
```

With this PR the third `writeToDb(1)` and fourth `writeToDb(1.1)` examples will not pass the type check.

You could argue that this can be solved in other ways, but these are just contrived examples, and in my case I use TS typings generated from the JSON schema and generics, and then it would be really nice if the types can be statically checked. Eg in short, I don't think you should be able to assign a `number` to a `Double` type.