### PR TITLE
[jasmine] Fix buggy typings with overload resolution

### DIFF
--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1781,6 +1781,34 @@ describe("User scenarios", () => {
     });
 });
 
+describe("handles overloaded functions in spies", () => {
+    class MyClass {
+        myFunc(x: number): number;
+        myFunc(x: string, y: string): string;
+        myFunc(...p: any[]): number|string {
+            return 4;
+        }
+    }
+
+    it("works for one parameter overload", () => {
+        const s = new MyClass();
+        spyOn(s, "myFunc").and.returnValue(5);
+        const r = s.myFunc(4);
+        expect(s.myFunc).toHaveBeenCalledWith(4);
+        expect(r).toBe(5);
+        spyOn(s, "myFunc").and.returnValues(5, 6, 7, 8);
+    });
+
+    it("works for two parameter overload", () => {
+        const s = new MyClass();
+        spyOn(s, "myFunc").and.returnValue("s");
+        const r = s.myFunc("a", "b");
+        expect(s.myFunc).toHaveBeenCalledWith("a", "b");
+        expect(r).toBe("s");
+        spyOn(s, "myFunc").and.returnValues("s", "r", "t");
+    });
+});
+
 (() => {
     // from boot.js
     const env = jasmine.getEnv();

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -1750,6 +1750,34 @@ describe("User scenarios", () => {
     });
 });
 
+describe("handles overloaded functions in spies", () => {
+    class MyClass {
+        myFunc(x: number): number;
+        myFunc(x: string, y: string): string;
+        myFunc(...p: any[]): number|string {
+            return 4;
+        }
+    }
+
+    it("works for one parameter overload", () => {
+        const s = new MyClass();
+        spyOn(s, "myFunc").and.returnValue(5);
+        const r = s.myFunc(4);
+        expect(s.myFunc).toHaveBeenCalledWith(4);
+        expect(r).toBe(5);
+        spyOn(s, "myFunc").and.returnValues(5, 6, 7, 8);
+    });
+
+    it("works for two parameter overload", () => {
+        const s = new MyClass();
+        spyOn(s, "myFunc").and.returnValue("s");
+        const r = s.myFunc("a", "b");
+        expect(s.myFunc).toHaveBeenCalledWith("a", "b");
+        expect(r).toBe("s");
+        spyOn(s, "myFunc").and.returnValues("s", "r", "t");
+    });
+});
+
 (() => {
     // from boot.js
     const env = jasmine.getEnv();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See below.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Fixes #42455 and #39162. Apparently parameter inference with overloads does not work very well per https://github.com/microsoft/TypeScript/issues/32418.

I've added typings tests in both the outer and inner `ts3.1` directories to make sure. Here's a Codepen to prove everything works at runtime (it's slightly different than the typings tests but it proves the same point): https://codepen.io/chivesrs/pen/dyoJywz.