### PR TITLE
[ioredis] Add lpop for Cluster

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1326,6 +1326,9 @@ declare namespace IORedis {
 
         rpushBuffer(key: string, ...values: Buffer[]): Promise<number>;
 
+        lpop(key: KeyType, callback: (err: Error, res: string) => void): void;
+        lpop(key: KeyType): Promise<string>;
+
         lpopBuffer(key: KeyType, callback: (err: Error, res: Buffer) => void): void;
         lpopBuffer(key: KeyType): Promise<Buffer>;
 

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -279,6 +279,18 @@ cluster.decr('key', (err, data) => {
 });
 
 listData.forEach(value => {
+    cluster.rpush('bufferlist', Buffer.from(value));
+});
+
+listData.forEach(value => {
+    cluster.lpop('bufferlist', (err, data) => {
+        if (data !== value) {
+            console.log(data);
+        }
+    });
+});
+
+listData.forEach(value => {
     cluster.rpushBuffer('bufferlist', Buffer.from(value));
 });
 


### PR DESCRIPTION
Add lpop() method for Cluster.
lpop() defined only in Redis interface and Pipeline interface, but actually exists in Cluster interface.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<<https://npmdoc.github.io/node-npmdoc-ioredis/build/apidoc.html#apidoc.element.ioredis.Cluster.prototype.lpop>>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.