### PR TITLE
[math-expression-evaluator] Add typing for math-expression-evaluator

### DIFF
--- a/types/math-expression-evaluator/index.d.ts
+++ b/types/math-expression-evaluator/index.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for math-expression-evaluator 1.2
+// Project: https://github.com/bugwheels94/math-expression-evaluator
+// Definitions by:  Adam Zerella <https://github.com/adamzerella>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface Token {
+    token: string;
+    type: number;
+    value?: string|((a: number, b?: number) => number);
+    show: string;
+    preced?: number;
+}
+
+declare class Mexp {
+    static lex(inp: string, tokens?: Token[]): Mexp;
+    formulaEval(): Mexp;
+    toPostfix(): Mexp;
+    postfixEval(pair?: object): number|string;
+    static eval(exp: string, tokens?: Token[], pair?: object): string;
+    static eval(exp: string, mexp?: object): string;
+    static addToken(tokens: Token[]): void;
+}
+
+export = Mexp;

--- a/types/math-expression-evaluator/math-expression-evaluator-tests.ts
+++ b/types/math-expression-evaluator/math-expression-evaluator-tests.ts
@@ -1,0 +1,36 @@
+import Mexp = require("math-expression-evaluator");
+
+Mexp.eval("5*.8");
+Mexp.eval("5*.8", { mexp: 5 });
+Mexp.eval("mexp(3)", [{
+    type: 0,
+    show: "mexp(\",value:function(a){return 5*a;}",
+    preced: 11,
+    token: "mexp"
+}]);
+Mexp.eval("mexp(3)", [{
+    type: 0,
+    token: "inverse",
+    show: "inverse",
+    value: (a => 1 / a)
+}]);
+
+Mexp.addToken([{
+    type: 3,
+    token: "git",
+    show: "git",
+    value: "git"
+}]);
+Mexp.eval("mexp*3", { mexp: 5 });
+
+Mexp.addToken([{
+    type: 0,
+    show: "mexp",
+    value: (a => 5 * a),
+    preced: 11,
+    token: "mexp"
+}]);
+Mexp.lex("mexp3").toPostfix().postfixEval();
+
+Mexp.lex('mexp3').toPostfix();
+Mexp.lex('mexp3').toPostfix().formulaEval();

--- a/types/math-expression-evaluator/tsconfig.json
+++ b/types/math-expression-evaluator/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+        "es6"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": [
+        "../"
+      ],
+      "types": [
+
+      ],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+      "index.d.ts",
+      "math-expression-evaluator-tests.ts"
+    ]
+}

--- a/types/math-expression-evaluator/tslint.json
+++ b/types/math-expression-evaluator/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Done what I could following the documentation at http://bugwheels94.github.io/math-expression-evaluator/#how-to-define-a-token and source code, some doc links are broken but the core API seems to make sense...