### PR TITLE
[he] export encode instead of declare

### DIFF
--- a/types/he/index.d.ts
+++ b/types/he/index.d.ts
@@ -77,7 +77,7 @@ export interface Encode {
 
     options: EncodeOptions;
 }
-declare var encode: Encode;
+export var encode: Encode;
 
 export interface DecodeOptions {
     /**


### PR DESCRIPTION
All other functions the library provides are exported, encode was declared which does not seem to make sense, considering the documentation shows it to be used the same as the others.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/he#heencodetext-options