### PR TITLE
[react-table]Added disableGlobalFilter in prep for 7.0.0 stable

### DIFF
--- a/types/react-table/Readme.md
+++ b/types/react-table/Readme.md
@@ -56,6 +56,7 @@ import {
   UseFiltersInstanceProps,
   UseFiltersOptions,
   UseFiltersState,
+  UseGlobalFiltersColumnOptions,
   UseGlobalFiltersInstanceProps,
   UseGlobalFiltersOptions,
   UseGlobalFiltersState,
@@ -141,6 +142,7 @@ declare module 'react-table' {
 
   export interface Column<D extends object = {}>
     extends UseFiltersColumnOptions<D>,
+      UseGlobalFiltersColumnOptions<D>,
       UseGroupByColumnOptions<D>,
       UseResizeColumnsColumnOptions<D>,
       UseSortByColumnOptions<D> {}

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -6,7 +6,7 @@
 //                 Jason Clark <https://github.com/riceboyler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.5
-// reflects react-table@7.0.0-rc.16
+// reflects react-table@7.0.0 - (prepping for stable 7.0.0 release https://github.com/tannerlinsley/react-table/issues/1964)
 
 // tslint:disable:no-empty-interface
 // no-empty-interface is disabled to allow easy extension with declaration merging
@@ -15,7 +15,17 @@
 // no-unnecessary-generics is disabled because many of these definitions are either used in a generic
 // context or the signatures are required to match for declaration merging
 
-import { ComponentType, DependencyList, EffectCallback, MouseEvent, ReactElement, ReactNode, ReactText, ReactFragment, CSSProperties } from 'react';
+import {
+    ComponentType,
+    DependencyList,
+    EffectCallback,
+    MouseEvent,
+    ReactElement,
+    ReactNode,
+    ReactText,
+    ReactFragment,
+    CSSProperties,
+} from 'react';
 
 export {};
 
@@ -237,7 +247,7 @@ export interface UseTableColumnProps<D extends object> {
     depth: number; // not documented
     index: number; // not documented
     placeholderOf?: ColumnInstance;
- }
+}
 
 export interface UseTableRowProps<D extends object> {
     cells: Array<Cell<D>>;
@@ -457,11 +467,16 @@ export type UseGlobalFiltersOptions<D extends object> = Partial<{
     manualGlobalFilter: boolean;
     filterTypes: FilterTypes<D>;
     autoResetGlobalFilter?: boolean;
+    disableGlobalFilter?: boolean;
 }>;
 
 export interface UseGlobalFiltersState<D extends object> {
     globalFilter: any;
 }
+
+export type UseGlobalFiltersColumnOptions<D extends object> = Partial<{
+    disableGlobalFilter?: boolean;
+}>;
 
 export interface UseGlobalFiltersInstanceProps<D extends object> {
     preGlobalFilteredRows: Array<Row<D>>;
@@ -820,7 +835,7 @@ export function loopHooks(hooks: Hooks, ...args: any[]): void;
 export function ensurePluginOrder<D extends object = {}>(
     plugins: Array<PluginHook<D>>,
     befores: string[],
-    pluginName: string
+    pluginName: string,
 ): void;
 
 export function functionalUpdate<D extends object = {}>(

--- a/types/react-table/react-table-tests.tsx
+++ b/types/react-table/react-table-tests.tsx
@@ -445,7 +445,8 @@ function Table({ columns, data, updateMyData, skipPageReset }: Table<Data>) {
                                                 // If the cell is aggregated, use the Aggregated
                                                 // renderer for cell
                                                 cell.render('Aggregated')
-                                            ) : cell.isPlaceholder ? null : ( // For cells with repeated values, render null
+                                            ) : cell.isPlaceholder ? null : (
+                                                // For cells with repeated values, render null
                                                 // Otherwise, just render the regular cell
                                                 cell.render('Cell', { editable: true })
                                             )}

--- a/types/react-table/react-table-tests.tsx
+++ b/types/react-table/react-table-tests.tsx
@@ -25,6 +25,8 @@ import {
     UseFiltersInstanceProps,
     UseFiltersOptions,
     UseFiltersState,
+    UseGlobalFiltersOptions,
+    UseGlobalFiltersColumnOptions,
     useGroupBy,
     UseGroupByCellProps,
     UseGroupByColumnOptions,
@@ -49,6 +51,7 @@ import {
     UseSortByOptions,
     UseSortByState,
     useTable,
+    useGlobalFilter,
 } from 'react-table';
 
 declare module 'react-table' {
@@ -57,6 +60,7 @@ declare module 'react-table' {
     interface TableOptions<D extends object>
         extends UseExpandedOptions<D>,
             UseFiltersOptions<D>,
+            UseGlobalFiltersOptions<D>,
             UseGroupByOptions<D>,
             UsePaginationOptions<D>,
             UseRowSelectOptions<D>,
@@ -84,6 +88,7 @@ declare module 'react-table' {
 
     interface Column<D extends object = {}>
         extends UseFiltersColumnOptions<D>,
+            UseGlobalFiltersColumnOptions<D>,
             UseGroupByColumnOptions<D>,
             UseSortByColumnOptions<D> {}
 
@@ -360,6 +365,7 @@ function Table({ columns, data, updateMyData, skipPageReset }: Table<Data>) {
         },
         useGroupBy,
         useFilters,
+        useGlobalFilter,
         useSortBy,
         useExpanded,
         usePagination,
@@ -439,7 +445,7 @@ function Table({ columns, data, updateMyData, skipPageReset }: Table<Data>) {
                                                 // If the cell is aggregated, use the Aggregated
                                                 // renderer for cell
                                                 cell.render('Aggregated')
-                                            ) : cell.isPlaceholder ? null : (// For cells with repeated values, render null
+                                            ) : cell.isPlaceholder ? null : ( // For cells with repeated values, render null
                                                 // Otherwise, just render the regular cell
                                                 cell.render('Cell', { editable: true })
                                             )}
@@ -625,6 +631,7 @@ const Component = (props: {}) => {
                         // Aggregate the average age of visitors
                         aggregate: 'average',
                         Aggregated: ({ cell: { value } }: CellProps<Data>) => `${value} (avg)`,
+                        disableGlobalFilter: true,
                     },
                     {
                         Header: 'Visits',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tannerlinsley/react-table/pull/1963

Added support for `disableGlobalFilter` that was added to both instance and column options in the above referenced PR.