### PR TITLE
Remove unneeded cast in lyricist tests

### DIFF
--- a/types/lyricist/lyricist-tests.ts
+++ b/types/lyricist/lyricist-tests.ts
@@ -23,7 +23,7 @@ Promise
         const artistByName: Artist = results[2];
         const searchResult: SearchResult[] = results[3];
         const song: Song = results[4];
-        const songsByArtist: SongByArtist[] = results[5] as SongByArtist[];
+        const songsByArtist: SongByArtist[] = results[5];
 
         console.log('album', album.name);
         console.log('artist', artist.name);


### PR DESCRIPTION
Discovered in nightly test run: https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=37418&view=logs&j=b2dd9be2-fb32-52f8-c4c9-7dc0bc384587&t=f2dea62c-b696-5a51-78ad-206032e0a320