### PR TITLE
hapi-auth-bearer-token: use the newest hapi__hapi typings

### DIFF
--- a/types/hapi-auth-bearer-token/hapi-auth-bearer-token-tests.ts
+++ b/types/hapi-auth-bearer-token/hapi-auth-bearer-token-tests.ts
@@ -1,6 +1,6 @@
 // from https://github.com/johnbrett/hapi-auth-bearer-token
 
-import { Server } from 'hapi';
+import { Server } from '@hapi/hapi';
 import * as AuthBearer from 'hapi-auth-bearer-token';
 
 const server = new Server({ port: 8080 });

--- a/types/hapi-auth-bearer-token/index.d.ts
+++ b/types/hapi-auth-bearer-token/index.d.ts
@@ -9,11 +9,11 @@ import {
     Plugin,
     ResponseToolkit,
     AuthenticationData,
-  } from 'hapi';
+  } from '@hapi/hapi';
 
   type ValidateReturn = AuthenticationData & { isValid: boolean };
 
-  declare module 'hapi' {
+  declare module '@hapi/hapi' {
     interface ServerAuth {
       strategy(name: string, scheme: 'bearer-access-token', options: BearerToken.SchemaOptions): void;
     }

--- a/types/hapi-auth-bearer-token/tsconfig.json
+++ b/types/hapi-auth-bearer-token/tsconfig.json
@@ -12,6 +12,32 @@
         "typeRoots": [
             "../"
         ],
+        "paths": {
+            "@hapi/hapi": [
+                "hapi__hapi"
+            ],
+            "@hapi/boom": [
+                "hapi__boom"
+            ],
+            "@hapi/shot": [
+                "hapi__shot"
+            ],
+            "@hapi/mimos": [
+                "hapi__mimos"
+            ],
+            "@hapi/iron": [
+                "hapi__iron"
+            ],
+            "@hapi/joi": [
+                "hapi__joi"
+            ],
+            "@hapi/podium": [
+                "hapi__podium"
+            ],
+            "@hapi/catbox": [
+                "hapi__catbox"
+            ]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/34479
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


This might need a major bump, since it breaks compatibility with the old module.
