### PR TITLE
[@types/jsonapi-serializer] Use dictionary for links fields on SerializerOptions

### DIFF
--- a/types/jsonapi-serializer/index.d.ts
+++ b/types/jsonapi-serializer/index.d.ts
@@ -18,10 +18,10 @@ export interface SerializerOptions {
     included?: boolean;
     id?: string;
     attributes?: string[];
-    topLevelLinks?: { [key: string]: string | ((...args: any[]) => any) };
-    dataLinks?: { [key: string]: string | ((...args: any[]) => any) };
+    topLevelLinks?: { [key: string]: string | ((...args: unknown[]) => unknown) };
+    dataLinks?: { [key: string]: string | ((...args: unknown[]) => unknown) };
     dataMeta?: (() => void) | object;
-    relationshipLinks?: { [key: string]: string | ((...args: any[]) => any) };
+    relationshipLinks?: { [key: string]: string | ((...args: unknown[]) => unknown) };
     relationshipMeta?: object;
     ignoreRelationshipData?: boolean;
     keyForAttribute?: string | KeyForAttribute;

--- a/types/jsonapi-serializer/index.d.ts
+++ b/types/jsonapi-serializer/index.d.ts
@@ -18,10 +18,10 @@ export interface SerializerOptions {
     included?: boolean;
     id?: string;
     attributes?: string[];
-    topLevelLinks?: string[] | Array<() => void>;
-    dataLinks?: string[] | Array<() => void>;
+    topLevelLinks?: { [key: string]: string | (() => string) };
+    dataLinks?: { [key: string]: string | (() => string) };
     dataMeta?: (() => void) | object;
-    relationshipLinks?: object;
+    relationshipLinks?: { [key: string]: string | (() => string) };
     relationshipMeta?: object;
     ignoreRelationshipData?: boolean;
     keyForAttribute?: string | KeyForAttribute;

--- a/types/jsonapi-serializer/index.d.ts
+++ b/types/jsonapi-serializer/index.d.ts
@@ -13,15 +13,17 @@ export interface Relation {
     included?: boolean;
 }
 
+export type LinkFunction = (...records: any[]) => any
+
 export interface SerializerOptions {
     ref?: (() => void) | boolean | string;
     included?: boolean;
     id?: string;
     attributes?: string[];
-    topLevelLinks?: { [key: string]: string | ((...args: any[]) => any) };
-    dataLinks?: { [key: string]: string | ((...args: any[]) => any) };
+    topLevelLinks?: { [key: string]: string | LinkFunction };
+    dataLinks?: { [key: string]: string | LinkFunction };
     dataMeta?: (() => void) | object;
-    relationshipLinks?: { [key: string]: string | ((...args: any[]) => any) };
+    relationshipLinks?: { [key: string]: string | LinkFunction };
     relationshipMeta?: object;
     ignoreRelationshipData?: boolean;
     keyForAttribute?: string | KeyForAttribute;

--- a/types/jsonapi-serializer/index.d.ts
+++ b/types/jsonapi-serializer/index.d.ts
@@ -18,10 +18,10 @@ export interface SerializerOptions {
     included?: boolean;
     id?: string;
     attributes?: string[];
-    topLevelLinks?: { [key: string]: string | (() => string) };
-    dataLinks?: { [key: string]: string | (() => string) };
+    topLevelLinks?: { [key: string]: string | ((...args: any[]) => any) };
+    dataLinks?: { [key: string]: string | ((...args: any[]) => any) };
     dataMeta?: (() => void) | object;
-    relationshipLinks?: { [key: string]: string | (() => string) };
+    relationshipLinks?: { [key: string]: string | ((...args: any[]) => any) };
     relationshipMeta?: object;
     ignoreRelationshipData?: boolean;
     keyForAttribute?: string | KeyForAttribute;

--- a/types/jsonapi-serializer/index.d.ts
+++ b/types/jsonapi-serializer/index.d.ts
@@ -18,10 +18,10 @@ export interface SerializerOptions {
     included?: boolean;
     id?: string;
     attributes?: string[];
-    topLevelLinks?: { [key: string]: string | ((...args: unknown[]) => unknown) };
-    dataLinks?: { [key: string]: string | ((...args: unknown[]) => unknown) };
+    topLevelLinks?: { [key: string]: string | ((...args: any[]) => any) };
+    dataLinks?: { [key: string]: string | ((...args: any[]) => any) };
     dataMeta?: (() => void) | object;
-    relationshipLinks?: { [key: string]: string | ((...args: unknown[]) => unknown) };
+    relationshipLinks?: { [key: string]: string | ((...args: any[]) => any) };
     relationshipMeta?: object;
     ignoreRelationshipData?: boolean;
     keyForAttribute?: string | KeyForAttribute;

--- a/types/jsonapi-serializer/index.d.ts
+++ b/types/jsonapi-serializer/index.d.ts
@@ -13,7 +13,7 @@ export interface Relation {
     included?: boolean;
 }
 
-export type LinkFunction = (...records: any[]) => any
+export type LinkFunction = (...records: any[]) => any;
 
 export interface SerializerOptions {
     ref?: (() => void) | boolean | string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/SeyZ/jsonapi-serializer/blob/master/README.md#available-serialization-option-opts-argument
  - https://github.com/SeyZ/jsonapi-serializer/blob/master/lib/serializer.js#L11
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
