### PR TITLE
[mongoose] Fix _id type of lean() result

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -79,7 +79,7 @@ declare module "mongoose" {
   type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
   /* Helper type to extract a definition type from a Document type */
-  type DocumentDefinition<T> = Omit<T, keyof Document> & { _id: mongodb.ObjectId };
+  type DocumentDefinition<T> = Omit<T, Exclude<keyof Document, '_id'>>;
 
   /**
    * Gets and optionally overwrites the function used to pluralize collection names

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -1303,14 +1303,14 @@ query.lean(false)
 query.lean({})
 
 interface Location1 extends mongoose.Document {
+    _id: mongoose.Types.ObjectId;
     name: string;
     address: string;
     rating: number;
     reviews: any[];
 };
-var locQuery = <mongoose.DocumentQuery<Location1, Location1>>{};
-async function leanTests() {
-    var location = await locQuery.lean().exec();
+var loc1Query = <mongoose.DocumentQuery<Location1, Location1>>{};
+loc1Query.lean().then(location => {
     if (location) {
         // $ExpectType ObjectId
         location._id;
@@ -1323,7 +1323,28 @@ async function leanTests() {
         // $ExpectError
         location.save();
     }
-}
+});
+
+interface Location2 extends mongoose.Document {
+    _id: string;
+    name: string;
+    rating: number;
+};
+var loc2Query = <mongoose.DocumentQuery<Location2, Location2>>{};
+loc2Query.lean().then(location => {
+    if (location) {
+        // $ExpectType string
+        location._id;
+        // $ExpectType string
+        location.name;
+        // $ExpectType number
+        location.rating;
+        // $ExpectError
+        location.unknown;
+        // $ExpectError
+        location.save();
+    }
+});
 
 /*
  * section schema/array.js
@@ -1965,6 +1986,7 @@ MongoModel.find({
 .exec();
 /* practical example */
 interface Location extends mongoose.Document {
+  _id: mongoose.Types.ObjectId;
   name: string;
   address: string;
   rating: number;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42652#discussion_r390185122
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.