### PR TITLE
Allow null to be passed to Meteor.publish. Add is_auto to options.

### DIFF
--- a/types/meteor/globals/meteor.d.ts
+++ b/types/meteor/globals/meteor.d.ts
@@ -221,7 +221,7 @@ declare module Meteor {
     function onConnection(callback: Function): void;
     /** Connection **/
 
-    function publish(name: string, func: (this: Subscription, ...args: any[]) => void): void;
+    function publish(name: string | null, func: (this: Subscription, ...args: any[]) => void, options?: {is_auto: boolean}): void;
 
     function _debug(...args: any[]): void;
 }

--- a/types/meteor/meteor.d.ts
+++ b/types/meteor/meteor.d.ts
@@ -226,7 +226,7 @@ declare module "meteor/meteor" {
         function onConnection(callback: Function): void;
         /** Connection **/
 
-        function publish(name: string, func: (this: Subscription, ...args: any[]) => void): void;
+        function publish(name: string | null, func: (this: Subscription, ...args: any[]) => void, options?: {is_auto: boolean}): void;
 
         function _debug(...args: any[]): void;
     }

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -494,6 +494,14 @@ Meteor.publish("userData", function () {
         { fields: { 'other': 1, 'things': 1 } });
 });
 
+/**
+ * `null` can be passed as the first argument
+ * `is_auto` can be passed as an option
+ */
+Meteor.publish(null, function () {
+    return 3;
+}, { is_auto : true });
+
 Meteor.users.deny({ update: function () { return true; } });
 
 /**

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -508,6 +508,14 @@ Meteor.publish("userData", function () {
         { fields: { 'other': 1, 'things': 1 } });
 });
 
+/**
+ * `null` can be passed as the first argument
+ * `is_auto` can be passed as an option
+ */
+Meteor.publish(null, function () {
+    return 3;
+}, { is_auto : true });
+
 Meteor.users.deny({ update: function () { return true; } });
 
 /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/meteor/meteor/blob/devel/packages/ddp-server/livedata_server.js#L1492

`Meteor.publish` can be passed `null` as the first argument. Also there is a less documented option `is_auto` that can be passed as the 3rd argument.

I could not run `npm test`, getting the following error:
```
Error: cloudevents-sdk/v03: do not directly import specific versions of another types package.
You should work with the latest version of cloudevents-sdk instead.
```
even though I've already added the changes in our project using `patch-package`. 

Also there's a problem with `scripts/generate-globals` https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42666#issuecomment-595092523
