### PR TITLE
Yup - preserve null & undefined in Shape & InferType

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -235,10 +235,9 @@ export type ObjectSchemaDefinition<T extends object | null | undefined> = {
  * This is conducive to the functionality of
  * [yup's `object.shape()` method](https://www.npmjs.com/package/yup#objectshapefields-object-nosortedges-arraystring-string-schema).
  */
-export type Shape<T extends object | null | undefined, U extends object> = {
-    [P in keyof T]: P extends keyof U ? U[P] : T[P];
-} &
-    U;
+export type Shape<T extends object | null | undefined, U extends object> =
+  | ({ [P in keyof T]: P extends keyof U ? U[P] : T[P]; } & U)
+  | PreserveOptionals<T>;
 
 export interface ObjectSchemaConstructor {
     <T extends object>(fields?: ObjectSchemaDefinition<T>): ObjectSchema<T>;
@@ -511,8 +510,13 @@ type KeyOfUndefined<T> = {
     [P in keyof T]-?: undefined extends T[P] ? P : never;
 }[keyof T];
 
+type PreserveNull<T> = T extends null ? null : never;
+type PreserveUndefined<T> = T extends undefined ? undefined : never;
+type PreserveOptionals<T> = PreserveNull<T> | PreserveUndefined<T>;
 type Id<T> = { [K in keyof T]: T[K] };
 type RequiredProps<T> = Pick<T, Exclude<keyof T, KeyOfUndefined<T>>>;
 type NotRequiredProps<T> = Partial<Pick<T, KeyOfUndefined<T>>>;
-type InnerInferType<T> = T extends Array<infer T> ? T[] : Id<NotRequiredProps<T> & RequiredProps<T>> ;
+type InnerInferType<T> =
+    | (T extends Array<infer T> ? T[] : Id<NotRequiredProps<T> & RequiredProps<T>>)
+    | PreserveOptionals<T>;
 type InferredArrayType<T> = T extends Array<infer U> ? U : T;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -680,7 +680,7 @@ const definitionBC: yup.ObjectSchemaDefinition<BC> = {
     b: yup.string(),
     c: yup.number(),
 };
-const combinedSchema = yup.object(definitionAB).shape(definitionBC); // $ExpectType ObjectSchema<Shape<AB, BC>>
+const combinedSchema = yup.object(definitionAB).shape(definitionBC); // $ExpectType ObjectSchema<{ a: string; b: string; } & BC>
 
 // $ExpectError
 yup.object<MyInterface>({
@@ -848,5 +848,35 @@ const resultingSchema2 = wrapper<string | number>(true, yup.mixed().oneOf(['1', 
 const arrayOfStringsSchema = yup.array().of(yup.string());
 type ArrayOfStrings = yup.InferType<typeof arrayOfStringsSchema>;
 function returnTheArray(data: ArrayOfStrings): any[] {
-  return data;
+    return data;
 }
+
+const topLevelStringNullable = yup.string().nullable();
+const topLevelStringNullableExample: yup.InferType<typeof topLevelStringNullable> = null;
+
+const topLevelObjectNullable = yup.object().nullable();
+const topLevelObjectNullableExample: yup.InferType<typeof topLevelObjectNullable> = null;
+
+const topLevelArrayNullable = yup.array().nullable();
+const topLevelArrayNullableExample: yup.InferType<typeof topLevelArrayNullable> = null;
+
+const nestedNullableShape = yup.object().shape({
+    foo: yup.object().nullable().shape({})
+});
+const nestedNullableShapeExample: yup.InferType<typeof nestedNullableShape> = {
+    foo: null
+};
+
+const nestedShapeNullable = yup.object().shape({
+    foo: yup.object().shape({}).nullable()
+});
+const nestedShapeNullableExample: yup.InferType<typeof nestedShapeNullable> = {
+    foo: null
+};
+
+const nestedArrayNullable = yup.object().shape({
+    foo: yup.array().nullable()
+});
+const nestedArrayNullableExample: yup.InferType<typeof nestedArrayNullable> = {
+    foo: null
+};


### PR DESCRIPTION
Using `nullable()` / `notRequired()` in certain places caused the `null` or `undefined` type to be forgotten about.  This PR attempts to preserve these.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.