### PR TITLE
[@types/crypto-js] Fixed CryptoJS.lib.WordArray.random return type.

### DIFF
--- a/types/crypto-js/crypto-js-tests.ts
+++ b/types/crypto-js/crypto-js-tests.ts
@@ -18,6 +18,8 @@ FR.onloadend = () => {
 	var hash = CryptoJS.SHA1(CryptoJS.lib.WordArray.create(FR.result)).toString()
 }
 
+var randomWordArrayEncoded = CryptoJS.lib.WordArray.random(16).toString(CryptoJS.enc.Hex);
+
 // Ciphers
 var encrypted: CryptoJS.WordArray;
 var decrypted: CryptoJS.DecryptedMessage;

--- a/types/crypto-js/index.d.ts
+++ b/types/crypto-js/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for crypto-js v3.1.8
 // Project: https://github.com/evanvosberg/crypto-js
 // Definitions by: Michael Zabka <https://github.com/misak113>
+//                 Max Lysenko <https://github.com/maximlysenko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = CryptoJS;
@@ -43,6 +44,7 @@ declare namespace CryptoJS {
 	interface LibWordArray {
 		sigBytes: number,
 		words: number[],
+		toString(encoder?: Encoder): string;
 	}
 	export interface WordArray {
 		iv: string;
@@ -145,7 +147,7 @@ declare namespace CryptoJS {
 		lib: {
 			WordArray: {
 				create: (v: any) => LibWordArray;
-				random: (v: number) => string;
+				random: (v: number) => LibWordArray;
 			};
 		};
 		mode: {


### PR DESCRIPTION
Currently the return type of `CryptoJS.lib.WordArray.random` method is set to `string`, however actual return value is of type `LibWordArray`. Furthermore, `toString(encoder?: Encoder)` can be called on `LibWordArray`, which is missing. Fixed that as well.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
