### PR TITLE
[mongoose] fix MongooseDocument inheritance, discriminator Models

### DIFF
--- a/types/mongoose-simple-random/index.d.ts
+++ b/types/mongoose-simple-random/index.d.ts
@@ -10,7 +10,7 @@ declare namespace pluginFunc { }
 export = pluginFunc;
 
 declare module "mongoose" {
-    interface Model<T extends Document> extends NodeJS.EventEmitter, ModelProperties {
+    interface Model<T extends MongooseDocument> extends NodeJS.EventEmitter, ModelProperties {
         findRandom(conditions: Object, projection?: Object | null, options?: Object | null, callback?: (err: any, res?: T[]) => void)
             : void;
     }


### PR DESCRIPTION
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
(https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-----

Actually this is quite a big change and I think is not backwards compatible.

However, the existing types does not reflect the actual code, (especially discriminator models), and I wish in the future it can be fixed so I don't have to write many `@ts-ignore` in my projects.

Feel free to discuss and/or modify the PR, as I'm not sure how to do this in a good way.