### PR TITLE
[callback-to-async-iterator]: Add Types

### DIFF
--- a/types/callback-to-async-iterator/callback-to-async-iterator-tests.ts
+++ b/types/callback-to-async-iterator/callback-to-async-iterator-tests.ts
@@ -1,3 +1,5 @@
 import { callbackToAsyncIterator } from "callback-to-async-iterator";
 
 callbackToAsyncIterator(() => {}); // $ExpectType AsyncIterator<unknown, any, undefined>
+
+callbackToAsyncIterator<string>(() => {}); // $ExpectType AsyncIterator<string, any, undefined>

--- a/types/callback-to-async-iterator/callback-to-async-iterator-tests.ts
+++ b/types/callback-to-async-iterator/callback-to-async-iterator-tests.ts
@@ -1,0 +1,3 @@
+import { callbackToAsyncIterator } from "callback-to-async-iterator";
+
+callbackToAsyncIterator(() => {}); // $ExpectType AsyncIterator<unknown, any, undefined>

--- a/types/callback-to-async-iterator/index.d.ts
+++ b/types/callback-to-async-iterator/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/withspectrum/callback-to-async-iterator#readme
 // Definitions by: Zachary Svoboda <https://github.com/me>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.6
 
 export interface AsyncifyOptions<T> {
     onClose: () => void | T;
@@ -9,4 +10,4 @@ export interface AsyncifyOptions<T> {
     buffering: boolean;
 }
 
-export function callbackToAsyncIterator<T>(listener: (callback: () => T) => void, options?: AsyncifyOptions<T>): AsyncIterator<T>;
+export function callbackToAsyncIterator<T>(listener: (callback: (message: T) => void) => void, options?: AsyncifyOptions<T>): AsyncIterator<T>;

--- a/types/callback-to-async-iterator/index.d.ts
+++ b/types/callback-to-async-iterator/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for callback-to-async-iterator 1.1
+// Project: https://github.com/withspectrum/callback-to-async-iterator#readme
+// Definitions by: Zachary Svoboda <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface AsyncifyOptions<T> {
+    onClose: () => void | T;
+    onError: () => Error;
+    buffering: boolean;
+}
+
+export function callbackToAsyncIterator<T>(listener: (callback: () => T) => void, options?: AsyncifyOptions<T>): AsyncIterator<T>;

--- a/types/callback-to-async-iterator/index.d.ts
+++ b/types/callback-to-async-iterator/index.d.ts
@@ -10,4 +10,7 @@ export interface AsyncifyOptions<T> {
     buffering: boolean;
 }
 
-export function callbackToAsyncIterator<T>(listener: (callback: (message: T) => void) => void, options?: AsyncifyOptions<T>): AsyncIterator<T>;
+export function callbackToAsyncIterator<T>(
+    listener: (callback: (message: T) => void) => void,
+    options?: AsyncifyOptions<T>,
+): AsyncIterator<T>;

--- a/types/callback-to-async-iterator/tsconfig.json
+++ b/types/callback-to-async-iterator/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "esnext.asynciterable"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "callback-to-async-iterator-tests.ts"
+    ]
+}

--- a/types/callback-to-async-iterator/tslint.json
+++ b/types/callback-to-async-iterator/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Fixes #36354

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
