### PR TITLE
Preparation for React-Native 0.62: Add type for fadingEdgeLength prop

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-native 0.61
+// Type definitions for react-native 0.62
 // Project: https://github.com/facebook/react-native
 // Definitions by: Eloy Durán <https://github.com/alloy>
 //                 HuHuanming <https://github.com/huhuanming>
@@ -34,6 +34,7 @@
 //                 Abe Dolinger <https://github.com/256hz>
 //                 Dominique Richard <https://github.com/doumart>
 //                 Mohamed Shaban <https://github.com/drmas>
+//                 André Krüger <https://github.com/akrger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -4020,6 +4021,18 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
      * This may improve scroll performance for large lists.
      */
     removeClippedSubviews?: boolean;
+
+    /**
+     * Fades out the edges of the the scroll content.
+     *
+     * If the value is greater than 0, the fading edges will be set accordingly
+     * to the current scroll direction and position,
+     * indicating if there is more content to show.
+     *
+     * The default value is 0.
+     * @platform android
+     */
+    fadingEdgeLength?: number;
 }
 
 export class FlatList<ItemT = any> extends React.Component<FlatListProps<ItemT>> {
@@ -6239,6 +6252,18 @@ export interface ScrollViewPropsAndroid {
      * Enables nested scrolling for Android API level 21+. Nested scrolling is supported by default on iOS.
      */
     nestedScrollEnabled?: boolean;
+
+    /**
+     * Fades out the edges of the the scroll content.
+     *
+     * If the value is greater than 0, the fading edges will be set accordingly
+     * to the current scroll direction and position,
+     * indicating if there is more content to show.
+     *
+     * The default value is 0.
+     * @platform android
+     */
+    fadingEdgeLength?: number
 }
 
 export interface ScrollViewProps extends ViewProps, ScrollViewPropsIOS, ScrollViewPropsAndroid, Touchable {

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -437,6 +437,7 @@ export class FlatListTest extends React.Component<FlatListProps<number>, {}> {
                 ListFooterComponentStyle={{ padding: 8 }}
                 ListHeaderComponent={null}
                 ListHeaderComponentStyle={{ padding: 8 }}
+                fadingEdgeLength={200}
             />
         );
     }
@@ -543,6 +544,7 @@ class ScrollerListComponentTest extends React.Component<{}, { dataSource: ListVi
                             style={[scrollViewStyle1.scrollView, scrollViewStyle2]}
                             onScrollToTop={() => {}}
                             scrollToOverflowEnabled={true}
+                            fadingEdgeLength={200}
                         />
                     );
                 }}


### PR DESCRIPTION
This adds the types for FlatList and ScrollView on Android

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/facebook/react-native/pull/26163>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
