### PR TITLE
[ramda] rename `then` to `andThen` for 0.27

### DIFF
--- a/types/ramda/OTHER_FILES.txt
+++ b/types/ramda/OTHER_FILES.txt
@@ -5,6 +5,7 @@ es/all.d.ts
 es/allPass.d.ts
 es/always.d.ts
 es/and.d.ts
+es/andThen.d.ts
 es/any.d.ts
 es/anyPass.d.ts
 es/ap.d.ts
@@ -210,7 +211,6 @@ es/takeWhile.d.ts
 es/tap.d.ts
 es/T.d.ts
 es/test.d.ts
-es/then.d.ts
 es/thunkify.d.ts
 es/times.d.ts
 es/toLower.d.ts
@@ -258,6 +258,7 @@ src/all.d.ts
 src/allPass.d.ts
 src/always.d.ts
 src/and.d.ts
+src/andThen.d.ts
 src/any.d.ts
 src/anyPass.d.ts
 src/ap.d.ts
@@ -463,7 +464,6 @@ src/takeWhile.d.ts
 src/tap.d.ts
 src/T.d.ts
 src/test.d.ts
-src/then.d.ts
 src/thunkify.d.ts
 src/times.d.ts
 src/toLower.d.ts

--- a/types/ramda/es/andThen.d.ts
+++ b/types/ramda/es/andThen.d.ts
@@ -1,0 +1,2 @@
+import { andThen } from '../index';
+export default andThen;

--- a/types/ramda/es/then.d.ts
+++ b/types/ramda/es/then.d.ts
@@ -1,2 +1,0 @@
-import { then } from '../index';
-export default then;

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ramda 0.26
+// Type definitions for ramda 0.27
 // Project: https://ramdajs.com
 // Definitions by: Scott O'Malley <https://github.com/TheHandsomeCoder>
 //                 Erwin Poeze <https://github.com/donnut>
@@ -115,6 +115,12 @@ export function always<T>(val: T): () => T;
  */
 export function and<T extends { and?: ((...a: readonly any[]) => any); } | number | boolean | string | null>(fn1: T, val2: any): boolean;
 export function and<T extends { and?: ((...a: readonly any[]) => any); } | number | boolean | string | null>(fn1: T): (val2: any) => boolean;
+
+/**
+ * Returns the result of applying the onSuccess function to the value inside a successfully resolved promise. This is useful for working with promises inside function compositions.
+ */
+export function andThen<A, B>(onSuccess: (a: A) => B | Promise<B>, promise: Promise<A>): Promise<B>;
+export function andThen<A, B>(onSuccess: (a: A) => B | Promise<B>): (promise: Promise<A>) => Promise<B>;
 
 /**
  * Returns true if at least one of elements of the list match the predicate, false otherwise.
@@ -1844,12 +1850,6 @@ export function tap<T>(fn: (a: T) => any): (value: T) => T;
  */
 export function test(regexp: RegExp, str: string): boolean;
 export function test(regexp: RegExp): (str: string) => boolean;
-
-/**
- * Returns the result of applying the onSuccess function to the value inside a successfully resolved promise. This is useful for working with promises inside function compositions.
- */
-export function then<A, B>(onSuccess: (a: A) => B | Promise<B>, promise: Promise<A>): Promise<B>;
-export function then<A, B>(onSuccess: (a: A) => B | Promise<B>): (promise: Promise<A>) => Promise<B>;
 
 /**
  * Creates a thunk out of a function.

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -228,8 +228,8 @@ class F2 {
             return Promise.resolve(user.followers);
         },
     };
-    const followersForUser: (userName: string) => Promise<string[]> = R.pipeWith(R.then, [db.getUserById, db.getFollowers]);
-    const followersForUser2: (userName: string) => Promise<string[]> = R.pipeWith(R.then)([db.getUserById, db.getFollowers]);
+    const followersForUser: (userName: string) => Promise<string[]> = R.pipeWith(R.andThen, [db.getUserById, db.getFollowers]);
+    const followersForUser2: (userName: string) => Promise<string[]> = R.pipeWith(R.andThen)([db.getUserById, db.getFollowers]);
 };
 
 function square(x: number) {
@@ -631,13 +631,13 @@ type Pair = KeyValuePair<string, number>;
     const getMemberName: (email: string) => Promise<{ firstName: string, lastName: string }> = R.pipe(
         makeQuery,
         fetchMember,
-        R.then(R.pick(['firstName', 'lastName'])),
+        R.andThen(R.pick(['firstName', 'lastName'])),
     );
 
     const getMemberTitle: (email: string) => Promise<string> = R.pipe(
         makeQuery,
         fetchMember,
-        R.then(getTitleAsync),
+        R.andThen(getTitleAsync),
     );
 };
 
@@ -771,13 +771,13 @@ type Pair = KeyValuePair<string, number>;
     const recoverFromFailure: (id: string) => Promise<{ firstName: string; lastName: string; }> = R.pipe(
       failedFetch,
       R.otherwise(useDefault),
-      R.then(R.pick(['firstName', 'lastName'])),
+      R.andThen(R.pick(['firstName', 'lastName'])),
     );
 
     const recoverFromFailureByAlternative: (id: string) => Promise<Person> = R.pipe(
       failedFetch,
       R.otherwise(useDefault),
-      R.then(loadAlternative),
+      R.andThen(loadAlternative),
     );
 };
 

--- a/types/ramda/src/andThen.d.ts
+++ b/types/ramda/src/andThen.d.ts
@@ -1,0 +1,2 @@
+import { andThen } from '../index';
+export default andThen;

--- a/types/ramda/src/then.d.ts
+++ b/types/ramda/src/then.d.ts
@@ -1,2 +1,0 @@
-import { then } from '../index';
-export default then;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ramda/ramda/pull/2772
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
