### PR TITLE
@types/react-burger-menu: make react-burger-menu styles prop use Partial

### DIFF
--- a/types/react-burger-menu/index.d.ts
+++ b/types/react-burger-menu/index.d.ts
@@ -6,7 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from "react";
+import * as React from 'react';
 
 export interface State {
     isOpen: boolean;
@@ -55,19 +55,19 @@ export interface Props {
     // styles && styles.pageWrap ? PropTypes.string.isRequired : PropTypes.string,
     pageWrapId?: string;
     right?: boolean;
-    styles?: Styles;
+    styles?: Partial<Styles>;
     width?: number | string;
 }
 
-export class ReactBurgerMenu extends React.Component<Props> { }
+export class ReactBurgerMenu extends React.Component<Props> {}
 
-export class slide extends ReactBurgerMenu { }
-export class stack extends ReactBurgerMenu { }
-export class elastic extends ReactBurgerMenu { }
-export class bubble extends ReactBurgerMenu { }
-export class push extends ReactBurgerMenu { }
-export class pushRotate extends ReactBurgerMenu { }
-export class scaleDown extends ReactBurgerMenu { }
-export class scaleRotate extends ReactBurgerMenu { }
-export class fallDown extends ReactBurgerMenu { }
-export class reveal extends ReactBurgerMenu { }
+export class slide extends ReactBurgerMenu {}
+export class stack extends ReactBurgerMenu {}
+export class elastic extends ReactBurgerMenu {}
+export class bubble extends ReactBurgerMenu {}
+export class push extends ReactBurgerMenu {}
+export class pushRotate extends ReactBurgerMenu {}
+export class scaleDown extends ReactBurgerMenu {}
+export class scaleRotate extends ReactBurgerMenu {}
+export class fallDown extends ReactBurgerMenu {}
+export class reveal extends ReactBurgerMenu {}

--- a/types/react-burger-menu/react-burger-menu-tests.tsx
+++ b/types/react-burger-menu/react-burger-menu-tests.tsx
@@ -2,28 +2,27 @@ import * as React from 'react';
 import { slide as Menu, State } from 'react-burger-menu';
 
 class Example extends React.Component {
-  showSettings(event: {
-    preventDefault(): void;
-  }) {
-    event.preventDefault();
-  }
+    showSettings(event: { preventDefault(): void }) {
+        event.preventDefault();
+    }
 
-  render() {
-    return (
-      <Menu
-        customBurgerIcon={<img src="img/icon.svg" />}
-        customCrossIcon={<img src="img/icon.svg" />}
-        onStateChange={this.onStateChange}
-      >
-        <a id="home" className="menu-item" href="/">Home</a>
-        <a id="about" className="menu-item" href="/about">About</a>
-        <a id="contact" className="menu-item" href="/contact">Contact</a>
-        <a onClick={this.showSettings} className="menu-item--small" href="">Settings</a>
-      </Menu>
-    );
-  }
+    render() {
+        return (
+            <Menu
+                customBurgerIcon={<img src="img/icon.svg" />}
+                customCrossIcon={<img src="img/icon.svg" />}
+                onStateChange={this.onStateChange}
+                styles={{}}
+            >
+                <a id="home" className="menu-item" href="/">Home</a>
+                <a id="about" className="menu-item" href="/about">About</a>
+                <a id="contact" className="menu-item" href="/contact">Contact</a>
+                <a onClick={this.showSettings} className="menu-item--small" href="">Settings</a>
+            </Menu>
+        );
+    }
 
-  onStateChange = (state: State): void => {
-    console.log(state.isOpen);
-  }
+    onStateChange = (state: State): void => {
+        console.log(state.isOpen);
+    }
 }


### PR DESCRIPTION
Note for reviewers:
Most of the diff in this PR is from prettier, so you'll probably want to hide whitespace changes.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


Updating a new definition: 

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
* The PropTypes show pretty clearly that `styles` is not expected to be a fully populated `Styles` object, since it defaults to `{}`:
 https://github.com/negomi/react-burger-menu/blob/a12c9cdc709aa26471895d183dae4d2e0a06270a/src/menuFactory.js#L392
* Here's an example of null-checks against `prop.styles` properties as well.
  https://github.com/negomi/react-burger-menu/blob/master/src/menuFactory.js#L139
* For reference, the `Styles` type definition:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e30c6374d1dae0294a5e8abfa081085a0c5356c7/types/react-burger-menu/index.d.ts#L15-L25
~~-  If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
~~-  If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~