### PR TITLE
feat(cometd): Add Status type used by CometD.prototype.getStatus()

### DIFF
--- a/types/cometd/index.d.ts
+++ b/types/cometd/index.d.ts
@@ -84,6 +84,7 @@ export interface Configuration {
 
 export type ConnectionType = 'long-polling' | 'callback-polling' | 'iframe' | 'flash';
 export type ReconnectAdvice = 'retry' | 'handshake' | 'none';
+export type Status = 'disconnected' | 'disconnecting' | 'handshaking' | 'connected' | 'connecting';
 
 export interface BaseMessage {
     successful: boolean;
@@ -412,12 +413,12 @@ export class CometD {
      *
      * @return the status of the Bayeux communication
      */
-    getStatus(): string;
+    getStatus(): Status;
 
     /**
-     * Returns whether this instance has been disconnected.
+     * Returns true if this instance is disconnected or disconnecting.
      *
-     * @return whether this instance has been disconnected.
+     * @return whether this instance disconnected or disconnecting.
      */
     isDisconnected(): boolean;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cometd/cometd-javascript/blob/master/cometd.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
