### PR TITLE
Add types for postcss-import

### DIFF
--- a/types/postcss-import/index.d.ts
+++ b/types/postcss-import/index.d.ts
@@ -52,12 +52,16 @@ declare namespace atImport {
          * the path(s). If you do not return an absolute path, your path will be resolved to an absolute path using the default resolver. You can use
          * [resolve](https://github.com/substack/node-resolve) for this.
          */
-        resolve?: (id: string, basedir: string, importOptions: AtImportOptions) => string;
+        resolve?: (
+            id: string,
+            basedir: string,
+            importOptions: AtImportOptions,
+        ) => string | string[] | PromiseLike<string | string[]>;
 
         /**
          * You can overwrite the default loading way by setting this option. This function gets `(filename, importOptions)` arguments and returns content or promised content.
          */
-        load?: (filename: string, importOptions: AtImportOptions) => string;
+        load?: (filename: string, importOptions: AtImportOptions) => string | Promise<string>;
 
         /**
          * By default, similar files (based on the same content) are being skipped. It's to optimize output and skip similar files like `normalize.css` for example. If this behavior is not what you

--- a/types/postcss-import/index.d.ts
+++ b/types/postcss-import/index.d.ts
@@ -1,0 +1,77 @@
+// Type definitions for postcss-import 12.0
+// Project: https://github.com/postcss/postcss-import#readme
+// Definitions by: Remco Haszing <https://github.com/remcohaszing>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { AcceptedPlugin, Transformer } from 'postcss';
+
+export = atImport;
+
+/**
+ * This plugin can consume local files, node modules or web_modules. To resolve path of an `@import` rule, it can look into root directory (by default `process.cwd()`), `web_modules`, `node_modules`
+ * or local modules. _When importing a module, it will look for `index.css` or file referenced in `package.json` in the `style` or `main` fields._ You can also provide manually multiples paths where
+ * to look at.
+ *
+ * **Notes:**
+ *
+ * - **This plugin should probably be used as the first plugin of your list. This way, other plugins will work on the AST as if there were only a single file to process, and will probably work as you
+ *   can expect**.
+ * - This plugin works great with [postcss-url](https://github.com/postcss/postcss-url) plugin, which will allow you to adjust assets `url()` (or even inline them) after inlining imported files.
+ * - In order to optimize output, **this plugin will only import a file once** on a given scope (root, media query…). Tests are made from the path & the content of imported files (using a hash table).
+ *   If this behavior is not what you want, look at `skipDuplicates` option
+ * - **If you are looking for glob, or sass like imports (prefixed partials)**, please look at [postcss-easy-import](https://github.com/trysound/postcss-easy-import) (which use this plugin under the
+ *   hood).
+ * - Imports which are not modified (by `options.filter` or because they are remote imports) are moved to the top of the output.
+ * - **This plugin attempts to follow the CSS `@import` spec**; `@import` statements must precede all other statements (besides `@charset`).
+ */
+declare function atImport(options?: atImport.AtImportOptions): Transformer;
+
+declare namespace atImport {
+    interface AtImportOptions {
+        /**
+         * Define the root where to resolve path (eg: place where `node_modules` are). Should not be used that much.
+         *
+         * _Note: nested @import will additionally benefit of the relative dirname of imported files._
+         *
+         * Default: `process.cwd()` or dirname of [the postcss from](https://github.com/postcss/postcss#node-source)
+         */
+        root?: string;
+
+        /**
+         * A string or an array of paths in where to look for files.
+         */
+        path?: string | string[];
+
+        /**
+         * An array of plugins to be applied on each imported files.
+         */
+        plugins?: AcceptedPlugin[];
+
+        /**
+         * You can provide a custom path resolver with this option. This function gets `(id, basedir, importOptions)` arguments and should return a path, an array of paths or a promise resolving to
+         * the path(s). If you do not return an absolute path, your path will be resolved to an absolute path using the default resolver. You can use
+         * [resolve](https://github.com/substack/node-resolve) for this.
+         */
+        resolve?: (id: string, basedir: string, importOptions: AtImportOptions) => string;
+
+        /**
+         * You can overwrite the default loading way by setting this option. This function gets `(filename, importOptions)` arguments and returns content or promised content.
+         */
+        load?: (filename: string, importOptions: AtImportOptions) => string;
+
+        /**
+         * By default, similar files (based on the same content) are being skipped. It's to optimize output and skip similar files like `normalize.css` for example. If this behavior is not what you
+         * want, just set this option to false to disable it.
+         *
+         * @default true
+         */
+        skipDuplicates?: boolean;
+
+        /**
+         * An array of folder names to add to Node's resolver. Values will be appended to the default resolve directories: `["node_modules", "web_modules"]`.
+         *
+         * This option is only for adding additional directories to default resolver. If you provide your own resolver via the `resolve` configuration option above, then this value will be ignored.
+         */
+        addModulesDirectories?: string[];
+    }
+}

--- a/types/postcss-import/package.json
+++ b/types/postcss-import/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^7.0.27"
+    }
+}

--- a/types/postcss-import/postcss-import-tests.ts
+++ b/types/postcss-import/postcss-import-tests.ts
@@ -1,5 +1,5 @@
-import * as postcss from 'postcss';
-import * as atImport from 'postcss-import';
+import postcss = require('postcss');
+import atImport = require('postcss-import');
 
 postcss().use(atImport());
 postcss().use(atImport({ root: '' }));

--- a/types/postcss-import/postcss-import-tests.ts
+++ b/types/postcss-import/postcss-import-tests.ts
@@ -1,0 +1,23 @@
+import * as postcss from 'postcss';
+import * as atImport from 'postcss-import';
+
+postcss().use(atImport());
+postcss().use(atImport({ root: '' }));
+postcss().use(atImport({ path: '' }));
+postcss().use(atImport({ path: [''] }));
+postcss().use(atImport({ plugins: [atImport()] }));
+postcss().use(atImport({ resolve: (id, basedir, importOptions) => id + basedir + importOptions.root }));
+postcss().use(atImport({ load: (filename, importOptions) => filename + importOptions.root }));
+postcss().use(atImport({ skipDuplicates: false }));
+postcss().use(atImport({ addModulesDirectories: [''] }));
+postcss().use(
+    atImport({
+        root: '',
+        path: '',
+        plugins: [atImport()],
+        resolve: (id, basedir, importOptions) => id + basedir + importOptions.root,
+        load: (filename, importOptions) => filename + importOptions.root,
+        skipDuplicates: false,
+        addModulesDirectories: [''],
+    }),
+);

--- a/types/postcss-import/tsconfig.json
+++ b/types/postcss-import/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "postcss-import-tests.ts"
+    ]
+}

--- a/types/postcss-import/tslint.json
+++ b/types/postcss-import/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
postcss/postcss-import#410

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.