### PR TITLE
Add deprecated deep imports for consistency with uuid@7.x

### DIFF
--- a/types/uuid/uuid-tests.ts
+++ b/types/uuid/uuid-tests.ts
@@ -2,6 +2,11 @@
 
 import { v1 as uuidv1, v4 as uuidv4, v3 as uuidv3, v5 as uuidv5 } from 'uuid';
 
+import v1 = require('uuid/v1');
+import v3 = require('uuid/v3');
+import v4 = require('uuid/v4');
+import v5 = require('uuid/v5');
+
 const randoms = [
     0x10, 0x91, 0x56, 0xbe, 0xc4, 0xfb, 0xc1, 0xea,
     0x71, 0xb4, 0xef, 0xe1, 0x67, 0x1c, 0x58, 0x36
@@ -61,3 +66,9 @@ uuidv4(null, g); // $ExpectType Buffer
 class CustomBuffer extends Uint8Array {}
 const h = new CustomBuffer(10);
 uuidv4(null, h); // $ExpectType CustomBuffer
+
+// Legacy deep import
+stringv1 = v1();
+stringv4 = v4();
+const l3: string = v3('hello', MY_NAMESPACE);
+const l5: string = v5('hello', MY_NAMESPACE);

--- a/types/uuid/v1.d.ts
+++ b/types/uuid/v1.d.ts
@@ -1,0 +1,8 @@
+import { v1 } from './interfaces';
+
+/*
+ * @deprecated Deep requiring like `require('uuid/v1')` is deprecated. See https://github.com/uuidjs/uuid#deep-requires-now-deprecated
+ */
+declare const v1: v1;
+
+export = v1;

--- a/types/uuid/v3.d.ts
+++ b/types/uuid/v3.d.ts
@@ -1,0 +1,8 @@
+import { v3 } from './interfaces';
+
+/*
+ * @deprecated Deep requiring like `require('uuid/v3')` is deprecated. See https://github.com/uuidjs/uuid#deep-requires-now-deprecated
+ */
+declare const v3: v3;
+
+export = v3;

--- a/types/uuid/v4.d.ts
+++ b/types/uuid/v4.d.ts
@@ -1,0 +1,8 @@
+import { v4 } from './interfaces';
+
+/*
+ * @deprecated Deep requiring like `require('uuid/v4')` is deprecated. See https://github.com/uuidjs/uuid#deep-requires-now-deprecated
+ */
+declare const v4: v4;
+
+export = v4;

--- a/types/uuid/v5.d.ts
+++ b/types/uuid/v5.d.ts
@@ -1,0 +1,8 @@
+import { v5 } from './interfaces';
+
+/*
+ * @deprecated Deep requiring like `require('uuid/v5')` is deprecated. See https://github.com/uuidjs/uuid#deep-requires-now-deprecated
+ */
+declare const v5: v5;
+
+export = v5;


### PR DESCRIPTION
Fixes #42634

Added again for consistency with uuid@7.x

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/uuidjs/uuid#deep-requires-now-deprecated