### PR TITLE
react-select: Add missing headingProps to ComponentProps

### DIFF
--- a/types/react-select/src/components/Group.d.ts
+++ b/types/react-select/src/components/Group.d.ts
@@ -8,6 +8,8 @@ interface ComponentProps {
   children: ReactNode;
   /** Component to wrap the label, recieves headingProps. */
   Heading: ComponentType<any>;
+  /** Props to pass to Heading. */
+  headingProps: any;
   /** Label to be displayed in the heading component. */
   label: ReactNode;
 }


### PR DESCRIPTION
https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/components/Group.js

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/components/Group.js>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
