### PR TITLE
[sanitize-html] Add disallowedTagMode option

### DIFF
--- a/types/sanitize-html/index.d.ts
+++ b/types/sanitize-html/index.d.ts
@@ -9,6 +9,7 @@
 //                 Johan Davidsson <https://github.com/johandavidson>
 //                 Jianrong Yu <https://github.com/YuJianrong>
 //                 GP <https://github.com/paambaati>
+//                 Marcell Toth <https://github.com/marcelltoth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -37,6 +38,7 @@ declare namespace sanitize {
     allowedSchemesByTag: { [index: string]: string[] };
     allowedTags: string[];
     selfClosing: string[];
+    disallowedTagsMode: 'discard';
   }
 
 
@@ -65,6 +67,7 @@ declare namespace sanitize {
     selfClosing?: string[];
     transformTags?: { [tagName: string]: string | Transformer };
     parser?: Options;
+    disallowedTagsMode?: 'escape' | 'recursiveEscape' | 'discard';
   }
 
 

--- a/types/sanitize-html/sanitize-html-tests.ts
+++ b/types/sanitize-html/sanitize-html-tests.ts
@@ -31,7 +31,8 @@ let options: sanitize.IOptions = {
   allowedSchemesByTag: {
     'a': ['http', 'https']
   },
-  allowProtocolRelative: false
+  allowProtocolRelative: false,
+  disallowedTagsMode: 'escape'
 };
 
 let unsafe = '<div><script>alert("hello");</script></div>';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apostrophecms/sanitize-html#what-if-i-want-disallowed-tags-to-be-escaped-rather-than-discarded
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **N/A**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. **N/A**
