### PR TITLE
dockerode: Improve GetEventsOptions to allow passing a filter object

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -72,6 +72,16 @@ docker.getEvents(
     },
 );
 
+docker.getEvents(
+    {
+        since: new Date().getTime() / 1000,
+        filters: { event: ['pull'] },
+    },
+    (err, stream) => {
+        // NOOP
+    },
+);
+
 docker.getEvents((err, stream) => {
     // NOOP
 });

--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -9,213 +9,211 @@ const docker3 = new Docker({ protocol: 'http', host: '127.0.0.1', port: 3000 });
 const docker4 = new Docker({ host: '127.0.0.1', port: 3000 });
 
 const docker5 = new Docker({
-  host: '192.168.1.10',
-  port: process.env.DOCKER_PORT || 2375,
-  ca: 'ca',
-  cert: 'cert',
-  key: 'key'
+    host: '192.168.1.10',
+    port: process.env.DOCKER_PORT || 2375,
+    ca: 'ca',
+    cert: 'cert',
+    key: 'key',
 });
 
 const docker6 = new Docker({
-  protocol: 'https', // you can enforce a protocol
-  host: '192.168.1.10',
-  port: process.env.DOCKER_PORT || 2375,
-  ca: 'ca',
-  cert: 'cert',
-  key: 'key'
+    protocol: 'https', // you can enforce a protocol
+    host: '192.168.1.10',
+    port: process.env.DOCKER_PORT || 2375,
+    ca: 'ca',
+    cert: 'cert',
+    key: 'key',
 });
 
 const docker7 = new Docker({
-  host: '192.168.1.10',
-  port: process.env.DOCKER_PORT || 2375,
-  ca: fs.readFileSync('ca.pem'),
-  cert: fs.readFileSync('cert.pem'),
-  key: fs.readFileSync('key.pem'),
-  version: 'v1.25' // required when Docker >= v1.13, https://docs.docker.com/engine/api/version-history/
+    host: '192.168.1.10',
+    port: process.env.DOCKER_PORT || 2375,
+    ca: fs.readFileSync('ca.pem'),
+    cert: fs.readFileSync('cert.pem'),
+    key: fs.readFileSync('key.pem'),
+    version: 'v1.25', // required when Docker >= v1.13, https://docs.docker.com/engine/api/version-history/
 });
 
 const docker8 = new Docker({
-  protocol: 'https', // you can enforce a protocol
-  host: '192.168.1.10',
-  port: process.env.DOCKER_PORT || 2375,
-  ca: fs.readFileSync('ca.pem'),
-  cert: fs.readFileSync('cert.pem'),
-  key: fs.readFileSync('key.pem')
+    protocol: 'https', // you can enforce a protocol
+    host: '192.168.1.10',
+    port: process.env.DOCKER_PORT || 2375,
+    ca: fs.readFileSync('ca.pem'),
+    cert: fs.readFileSync('cert.pem'),
+    key: fs.readFileSync('key.pem'),
 });
 
 const docker9 = new Docker({
-  Promise
+    Promise,
 });
 
 async function foo() {
-  const containers = await docker7.listContainers();
-  for (const container of containers) {
-    const foo = await docker7.getContainer(container.Id);
-    const inspect = await foo.inspect();
-  }
+    const containers = await docker7.listContainers();
+    for (const container of containers) {
+        const foo = await docker7.getContainer(container.Id);
+        const inspect = await foo.inspect();
+    }
 
-  const images = await docker5.listImages();
-  for (const image of images) {
-    const foo = await docker5.getImage(image.Id);
-    const inspect = await foo.inspect();
-    await foo.remove();
-  }
+    const images = await docker5.listImages();
+    for (const image of images) {
+        const foo = await docker5.getImage(image.Id);
+        const inspect = await foo.inspect();
+        await foo.remove();
+    }
 }
 
 docker.getEvents(
-  {
-    since: new Date().getTime() / 1000,
-    filters: `{ "event": ["pull"] }`,
-  },
-  (err, stream) => {
-    // NOOP
-  },
+    {
+        since: new Date().getTime() / 1000,
+        filters: `{ "event": ["pull"] }`,
+    },
+    (err, stream) => {
+        // NOOP
+    },
 );
 
 docker.getEvents((err, stream) => {
-  // NOOP
+    // NOOP
 });
 
 docker.getEvents().then(stream => {
-  // NOOP
+    // NOOP
 });
 
 const container = docker.getContainer('container-id');
 container.inspect((err, data) => {
-  // NOOP
+    // NOOP
 });
 
 container.start((err, data) => {
-  // NOOP
+    // NOOP
 });
 
 container.remove((err, data) => {
-  // NOOP
+    // NOOP
 });
 
 docker.listContainers((err, containers) => {
-  containers.forEach(container => {
-    docker
-      .getContainer(container.Id)
-      .stop((err, data) => {
-        // NOOP
-      });
-  });
+    containers.forEach(container => {
+        docker.getContainer(container.Id).stop((err, data) => {
+            // NOOP
+        });
+    });
 });
 
 docker.listContainers().then(containers => {
-  return containers.map(container => docker.getContainer(container.Id));
+    return containers.map(container => docker.getContainer(container.Id));
 });
 
 docker.buildImage('archive.tar', { t: 'imageName' }, (err, response) => {
-  // NOOP
+    // NOOP
 });
 
-docker.buildImage({context: '.', src: ['Dockerfile', 'test.sh']}, { t: 'imageName' }, (err, response) => {
-	// NOOP
+docker.buildImage({ context: '.', src: ['Dockerfile', 'test.sh'] }, { t: 'imageName' }, (err, response) => {
+    // NOOP
 });
 
 docker.createContainer({ Tty: true }, (err, container) => {
-  container.start((err, data) => {
-    // NOOP
-  });
+    container.start((err, data) => {
+        // NOOP
+    });
 });
 
 docker.pruneContainers((err, response) => {
-  	// NOOP
+    // NOOP
 });
 
 docker.pruneImages((err, response) => {
-  // NOOP
+    // NOOP
 });
 
 docker.pruneNetworks((err, response) => {
-  // NOOP
+    // NOOP
 });
 
 docker.pruneVolumes((err, response) => {
-  // NOOP
+    // NOOP
 });
 
 const plugin = docker.getPlugin('pluginName', 'remoteName');
 plugin.configure((err, response) => {
-  // NOOP;
+    // NOOP;
 });
 
 plugin.disable((err, response) => {
- // NOOP
+    // NOOP
 });
 
 plugin.enable((err, response) => {
-  // NOOP
+    // NOOP
 });
 
 plugin.inspect((err, response) => {
-  // NOOP
+    // NOOP
 });
 
 plugin.privileges((err, response) => {
-  // NOOP
+    // NOOP
 });
 
 plugin.pull({}, (err, response) => {
-  // NOOP
+    // NOOP
 });
 
 plugin.push((err, response) => {
-  // NOOP
+    // NOOP
 });
 
 plugin.remove((err, response) => {
-  // NOOP
+    // NOOP
 });
 
 plugin.upgrade({}, (err, response) => {
-  // NOOP
+    // NOOP
 });
 
 const secret = docker.getSecret('secretName');
 secret.inspect((err, response) => {
-  // NOOP
+    // NOOP
 });
 
 secret.remove((err, response) => {
-  // NOOP
+    // NOOP
 });
 
 secret.update((err, response) => {
-  // NOOP
+    // NOOP
 });
 
 const node = docker.getNode('nodeName');
 node.inspect((err, reponse) => {
-  // NOOP
+    // NOOP
 });
 
 node.inspect().then(response => {
-  // NOOP
+    // NOOP
 });
 
 node.update({}, (err, response) => {
-  // NOOP
+    // NOOP
 });
 
 node.update((err, response) => {
-  // NOOP
+    // NOOP
 });
 
 node.update({}).then(response => {
-  // NOOP;
+    // NOOP;
 });
 
 node.remove({}, (err, response) => {
-  // NOOP
+    // NOOP
 });
 
 node.remove((err, response) => {
-  // NOOP
+    // NOOP
 });
 
 node.remove({}).then(response => {
-  // NOOP;
+    // NOOP;
 });

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -21,1316 +21,1348 @@ import * as events from 'events';
 // https://github.com/apocas/docker-modem
 
 declare namespace Dockerode {
-  class Container {
-    constructor(modem: any, id: string);
+    class Container {
+        constructor(modem: any, id: string);
 
-    modem: any;
-    id: string;
+        modem: any;
+        id: string;
 
-    inspect(options: {}, callback: Callback<ContainerInspectInfo>): void;
-    inspect(callback: Callback<ContainerInspectInfo>): void;
-    inspect(options?: {}): Promise<ContainerInspectInfo>;
+        inspect(options: {}, callback: Callback<ContainerInspectInfo>): void;
+        inspect(callback: Callback<ContainerInspectInfo>): void;
+        inspect(options?: {}): Promise<ContainerInspectInfo>;
 
-    rename(options: {}, callback: Callback<any>): void;
-    rename(options: {}): Promise<any>;
+        rename(options: {}, callback: Callback<any>): void;
+        rename(options: {}): Promise<any>;
 
-    update(options: {}, callback: Callback<any>): void;
-    update(options: {}): Promise<any>;
+        update(options: {}, callback: Callback<any>): void;
+        update(options: {}): Promise<any>;
 
-    top(options: {}, callback: Callback<any>): void;
-    top(callback: Callback<any>): void;
-    top(options?: {}): Promise<any>;
+        top(options: {}, callback: Callback<any>): void;
+        top(callback: Callback<any>): void;
+        top(options?: {}): Promise<any>;
 
-    changes(callback: Callback<any>): void;
-    changes(): Promise<any>;
+        changes(callback: Callback<any>): void;
+        changes(): Promise<any>;
 
-    export(callback: Callback<NodeJS.ReadableStream>): void;
-    export(): Promise<NodeJS.ReadableStream>;
+        export(callback: Callback<NodeJS.ReadableStream>): void;
+        export(): Promise<NodeJS.ReadableStream>;
 
-    start(options: {}, callback: Callback<any>): void;
-    start(callback: Callback<any>): void;
-    start(options?: {}): Promise<any>;
+        start(options: {}, callback: Callback<any>): void;
+        start(callback: Callback<any>): void;
+        start(options?: {}): Promise<any>;
 
-    pause(options: {}, callback: Callback<any>): void;
-    pause(callback: Callback<any>): void;
-    pause(options?: {}): Promise<any>;
+        pause(options: {}, callback: Callback<any>): void;
+        pause(callback: Callback<any>): void;
+        pause(options?: {}): Promise<any>;
 
-    unpause(options: {}, callback: Callback<any>): void;
-    unpause(callback: Callback<any>): void;
-    unpause(options?: {}): Promise<any>;
+        unpause(options: {}, callback: Callback<any>): void;
+        unpause(callback: Callback<any>): void;
+        unpause(options?: {}): Promise<any>;
 
-    exec(options: {}, callback: Callback<any>): void;
-    exec(options: {}): Promise<any>;
+        exec(options: {}, callback: Callback<any>): void;
+        exec(options: {}): Promise<any>;
 
-    commit(options: {}, callback: Callback<any>): void;
-    commit(callback: Callback<any>): void;
-    commit(options?: {}): Promise<any>;
+        commit(options: {}, callback: Callback<any>): void;
+        commit(callback: Callback<any>): void;
+        commit(options?: {}): Promise<any>;
 
-    stop(options: {}, callback: Callback<any>): void;
-    stop(callback: Callback<any>): void;
-    stop(options?: {}): Promise<any>;
+        stop(options: {}, callback: Callback<any>): void;
+        stop(callback: Callback<any>): void;
+        stop(options?: {}): Promise<any>;
 
-    restart(options: {}, callback: Callback<any>): void;
-    restart(callback: Callback<any>): void;
-    restart(options?: {}): Promise<any>;
+        restart(options: {}, callback: Callback<any>): void;
+        restart(callback: Callback<any>): void;
+        restart(options?: {}): Promise<any>;
 
-    kill(options: {}, callback: Callback<any>): void;
-    kill(callback: Callback<any>): void;
-    kill(options?: {}): Promise<any>;
+        kill(options: {}, callback: Callback<any>): void;
+        kill(callback: Callback<any>): void;
+        kill(options?: {}): Promise<any>;
 
-    resize(options: {}, callback: Callback<any>): void;
-    resize(callback: Callback<any>): void;
-    resize(options?: {}): Promise<any>;
+        resize(options: {}, callback: Callback<any>): void;
+        resize(callback: Callback<any>): void;
+        resize(options?: {}): Promise<any>;
 
-    wait(callback: Callback<any>): void;
-    wait(): Promise<any>;
+        wait(callback: Callback<any>): void;
+        wait(): Promise<any>;
 
-    remove(options: {}, callback: Callback<any>): void;
-    remove(callback: Callback<any>): void;
-    remove(options?: {}): Promise<any>;
+        remove(options: {}, callback: Callback<any>): void;
+        remove(callback: Callback<any>): void;
+        remove(options?: {}): Promise<any>;
 
-    /** Deprecated since RAPI v1.20 */
-    copy(options: {}, callback: Callback<any>): void;
-    /** Deprecated since RAPI v1.20 */
-    copy(callback: Callback<any>): void;
-    /** Deprecated since RAPI v1.20 */
-    copy(options?: {}): Promise<any>;
+        /** Deprecated since RAPI v1.20 */
+        copy(options: {}, callback: Callback<any>): void;
+        /** Deprecated since RAPI v1.20 */
+        copy(callback: Callback<any>): void;
+        /** Deprecated since RAPI v1.20 */
+        copy(options?: {}): Promise<any>;
 
-    getArchive(options: {}, callback: Callback<NodeJS.ReadableStream>): void;
-    getArchive(options: {}): Promise<NodeJS.ReadableStream>;
+        getArchive(options: {}, callback: Callback<NodeJS.ReadableStream>): void;
+        getArchive(options: {}): Promise<NodeJS.ReadableStream>;
 
-    infoArchive(options: {}, callback: Callback<any>): void;
-    infoArchive(options: {}): Promise<any>;
+        infoArchive(options: {}, callback: Callback<any>): void;
+        infoArchive(options: {}): Promise<any>;
 
-    /** @param file Filename (will read synchronously), Buffer or stream */
-    putArchive(file: string | Buffer | NodeJS.ReadableStream, options: {}, callback: Callback<NodeJS.WritableStream>): void;
-    putArchive(file: string | Buffer | NodeJS.ReadableStream, options: {}): Promise<NodeJS.ReadWriteStream>;
+        /** @param file Filename (will read synchronously), Buffer or stream */
+        putArchive(
+            file: string | Buffer | NodeJS.ReadableStream,
+            options: {},
+            callback: Callback<NodeJS.WritableStream>,
+        ): void;
+        putArchive(file: string | Buffer | NodeJS.ReadableStream, options: {}): Promise<NodeJS.ReadWriteStream>;
 
-    logs(options: ContainerLogsOptions, callback: Callback<NodeJS.ReadableStream>): void;
-    logs(callback: Callback<NodeJS.ReadableStream>): void;
-    logs(options?: ContainerLogsOptions): Promise<NodeJS.ReadableStream>;
+        logs(options: ContainerLogsOptions, callback: Callback<NodeJS.ReadableStream>): void;
+        logs(callback: Callback<NodeJS.ReadableStream>): void;
+        logs(options?: ContainerLogsOptions): Promise<NodeJS.ReadableStream>;
 
-    stats(options: {}, callback: Callback<ContainerStats>): void;
-    stats(callback: Callback<ContainerStats>): void;
-    stats(options?: {}): Promise<ContainerStats>;
+        stats(options: {}, callback: Callback<ContainerStats>): void;
+        stats(callback: Callback<ContainerStats>): void;
+        stats(options?: {}): Promise<ContainerStats>;
 
-    attach(options: {}, callback: Callback<NodeJS.ReadWriteStream>): void;
-    attach(options: {}): Promise<NodeJS.ReadWriteStream>;
-  }
+        attach(options: {}, callback: Callback<NodeJS.ReadWriteStream>): void;
+        attach(options: {}): Promise<NodeJS.ReadWriteStream>;
+    }
 
-  class Image {
-    constructor(modem: any, name: string);
+    class Image {
+        constructor(modem: any, name: string);
 
-    modem: any;
-    id: string;
+        modem: any;
+        id: string;
 
-    inspect(callback: Callback<ImageInspectInfo>): void;
-    inspect(): Promise<ImageInspectInfo>;
+        inspect(callback: Callback<ImageInspectInfo>): void;
+        inspect(): Promise<ImageInspectInfo>;
 
-    history(callback: Callback<any>): void;
-    history(): Promise<any>;
+        history(callback: Callback<any>): void;
+        history(): Promise<any>;
 
-    get(callback: Callback<NodeJS.ReadableStream>): void;
-    get(): Promise<NodeJS.ReadableStream>;
+        get(callback: Callback<NodeJS.ReadableStream>): void;
+        get(): Promise<NodeJS.ReadableStream>;
 
-    push(options: {}, callback: Callback<NodeJS.ReadableStream>): void;
-    push(callback: Callback<NodeJS.ReadableStream>): void;
-    push(options?: {}): Promise<NodeJS.ReadableStream>;
+        push(options: {}, callback: Callback<NodeJS.ReadableStream>): void;
+        push(callback: Callback<NodeJS.ReadableStream>): void;
+        push(options?: {}): Promise<NodeJS.ReadableStream>;
 
-    tag(options: {}, callback: Callback<any>): void;
-    tag(callback: Callback<any>): void;
-    tag(options?: {}): Promise<any>;
+        tag(options: {}, callback: Callback<any>): void;
+        tag(callback: Callback<any>): void;
+        tag(options?: {}): Promise<any>;
 
-    remove(options: {}, callback: Callback<ImageRemoveInfo>): void;
-    remove(callback: Callback<ImageRemoveInfo>): void;
-    remove(options?: {}): Promise<any>;
-  }
+        remove(options: {}, callback: Callback<ImageRemoveInfo>): void;
+        remove(callback: Callback<ImageRemoveInfo>): void;
+        remove(options?: {}): Promise<any>;
+    }
 
-  class Volume {
-    constructor(modem: any, name: string);
+    class Volume {
+        constructor(modem: any, name: string);
 
-    modem: any;
-    name: string;
+        modem: any;
+        name: string;
 
-    inspect(callback: Callback<VolumeInspectInfo>): void;
-    inspect(): Promise<VolumeInspectInfo>;
+        inspect(callback: Callback<VolumeInspectInfo>): void;
+        inspect(): Promise<VolumeInspectInfo>;
 
-    remove(options: {}, callback: Callback<any>): void;
-    remove(callback: Callback<any>): void;
-    remove(options?: {}): Promise<any>;
-  }
+        remove(options: {}, callback: Callback<any>): void;
+        remove(callback: Callback<any>): void;
+        remove(options?: {}): Promise<any>;
+    }
 
-  class Service {
-    constructor(modem: any, id: string);
+    class Service {
+        constructor(modem: any, id: string);
 
-    modem: any;
-    id: string;
+        modem: any;
+        id: string;
 
-    inspect(callback: Callback<any>): void;
-    inspect(): Promise<any>;
+        inspect(callback: Callback<any>): void;
+        inspect(): Promise<any>;
 
-    remove(options: {}, callback: Callback<any>): void;
-    remove(callback: Callback<any>): void;
-    remove(options?: {}): Promise<any>;
+        remove(options: {}, callback: Callback<any>): void;
+        remove(callback: Callback<any>): void;
+        remove(options?: {}): Promise<any>;
 
-    update(options: {}, callback: Callback<any>): void;
-    update(options: {}): Promise<any>;
+        update(options: {}, callback: Callback<any>): void;
+        update(options: {}): Promise<any>;
 
-    logs(options: ContainerLogsOptions, callback: Callback<NodeJS.ReadableStream>): void;
-    logs(callback: Callback<NodeJS.ReadableStream>): void;
-    logs(options?: ContainerLogsOptions): Promise<NodeJS.ReadableStream>;
-  }
+        logs(options: ContainerLogsOptions, callback: Callback<NodeJS.ReadableStream>): void;
+        logs(callback: Callback<NodeJS.ReadableStream>): void;
+        logs(options?: ContainerLogsOptions): Promise<NodeJS.ReadableStream>;
+    }
 
-  class Task {
-    constructor(modem: any, id: string);
+    class Task {
+        constructor(modem: any, id: string);
 
-    modem: any;
-    id: string;
+        modem: any;
+        id: string;
 
-    inspect(callback: Callback<any>): void;
-    inspect(): Promise<any>;
-  }
+        inspect(callback: Callback<any>): void;
+        inspect(): Promise<any>;
+    }
 
-  class Node {
-    constructor(modem: any, id: string);
+    class Node {
+        constructor(modem: any, id: string);
 
-    modem: any;
-    id: string;
+        modem: any;
+        id: string;
 
-    inspect(callback: Callback<any>): void;
-    inspect(): Promise<any>;
+        inspect(callback: Callback<any>): void;
+        inspect(): Promise<any>;
 
-    update(options: {}, callback: Callback<any>): void;
-    update(callback: Callback<any>): void;
-    update(options?: {}): Promise<any>;
+        update(options: {}, callback: Callback<any>): void;
+        update(callback: Callback<any>): void;
+        update(options?: {}): Promise<any>;
 
-    remove(options: {}, callback: Callback<any>): void;
-    remove(callback: Callback<any>): void;
-    remove(options?: {}): Promise<any>;
-  }
+        remove(options: {}, callback: Callback<any>): void;
+        remove(callback: Callback<any>): void;
+        remove(options?: {}): Promise<any>;
+    }
 
-  class Plugin {
-    constructor(modem: any, name: string, remote?: any);
+    class Plugin {
+        constructor(modem: any, name: string, remote?: any);
 
-    modem: any;
-    name: string;
-    remote: any;
+        modem: any;
+        name: string;
+        remote: any;
 
-    inspect(callback: Callback<PluginInspectInfo>): void;
-    inspect(): Promise<PluginInspectInfo>;
+        inspect(callback: Callback<PluginInspectInfo>): void;
+        inspect(): Promise<PluginInspectInfo>;
 
-    remove(options: {}, callback: Callback<any>): void;
-    remove(callback: Callback<any>): void;
-    remove(options?: {}): Promise<any>;
+        remove(options: {}, callback: Callback<any>): void;
+        remove(callback: Callback<any>): void;
+        remove(options?: {}): Promise<any>;
 
-    privileges(callback: Callback<any>): void;
-    privileges(): Promise<any>;
+        privileges(callback: Callback<any>): void;
+        privileges(): Promise<any>;
 
-    pull(options: {}, callback: Callback<any>): void;
-    pull(options: {}): Promise<any>;
+        pull(options: {}, callback: Callback<any>): void;
+        pull(options: {}): Promise<any>;
 
-    enable(options: {}, callback: Callback<any>): void;
-    enable(callback: Callback<any>): void;
-    enable(options?: {}): Promise<any>;
+        enable(options: {}, callback: Callback<any>): void;
+        enable(callback: Callback<any>): void;
+        enable(options?: {}): Promise<any>;
 
-    disable(options: {}, callback: Callback<any>): void;
-    disable(callback: Callback<any>): void;
-    disable(options?: {}): Promise<any>;
+        disable(options: {}, callback: Callback<any>): void;
+        disable(callback: Callback<any>): void;
+        disable(options?: {}): Promise<any>;
 
-    push(options: {}, callback: Callback<any>): void;
-    push(callback: Callback<any>): void;
-    push(options?: {}): Promise<any>;
+        push(options: {}, callback: Callback<any>): void;
+        push(callback: Callback<any>): void;
+        push(options?: {}): Promise<any>;
 
-    configure(options: {}, callback: Callback<any>): void;
-    configure(callback: Callback<any>): void;
-    configure(options?: {}): Promise<any>;
+        configure(options: {}, callback: Callback<any>): void;
+        configure(callback: Callback<any>): void;
+        configure(options?: {}): Promise<any>;
 
-    upgrade(auth: any, options: {}, callback: Callback<any>): void;
-    upgrade(auth: any, callback: Callback<any>): void;
-    upgrade(auth: any, options?: {}): Promise<any>;
-  }
+        upgrade(auth: any, options: {}, callback: Callback<any>): void;
+        upgrade(auth: any, callback: Callback<any>): void;
+        upgrade(auth: any, options?: {}): Promise<any>;
+    }
 
-  class Secret {
-    constructor(modem: any, id: string);
+    class Secret {
+        constructor(modem: any, id: string);
 
-    modem: any;
-    id: string;
-
-    inspect(callback: Callback<SecretInfo>): void;
-    inspect(): Promise<SecretInfo>;
-
-    update(options: {}, callback: Callback<any>): void;
-    update(callback: Callback<any>): void;
-    update(options?: {}): Promise<any>;
-
-    remove(options: {}, callback: Callback<any>): void;
-    remove(callback: Callback<any>): void;
-    remove(options?: {}): Promise<any>;
-  }
-
-  class Network {
-    constructor(modem: any, id: string);
-
-    modem: any;
-    id: string;
-
-    inspect(callback: Callback<any>): void;
-    inspect(): Promise<any>;
-
-    remove(options: {}, callback: Callback<any>): void;
-    remove(callback: Callback<any>): void;
-    remove(options?: {}): Promise<any>;
-
-    connect(options: {}, callback: Callback<any>): void;
-    connect(callback: Callback<any>): void;
-    connect(options?: {}): Promise<any>;
-
-    disconnect(options: {}, callback: Callback<any>): void;
-    disconnect(callback: Callback<any>): void;
-    disconnect(options?: {}): Promise<any>;
-  }
-
-  class Exec {
-    constructor(modem: any, id: string);
-
-    modem: any;
-    id: string;
-
-    inspect(callback: Callback<any>): void;
-    inspect(): Promise<any>;
-
-    start(options: {}, callback: Callback<any>): void;
-    start(options: {}): Promise<any>;
-
-    resize(options: {}, callback: Callback<any>): void;
-    resize(options: {}): Promise<any>;
-  }
-
-  class Config {
-    constructor(modem: any, id: string);
-
-    modem: any;
-    id: string;
-
-    inspect(callback: Callback<ConfigInfo>): void;
-    inspect(): Promise<ConfigInfo>;
-
-    update(options: {}, callback: Callback<any>): void;
-    update(callback: Callback<any>): void;
-    update(options?: {}): Promise<any>;
-
-    remove(options: {}, callback: Callback<any>): void;
-    remove(callback: Callback<any>): void;
-    remove(options?: {}): Promise<any>;
-  }
-
-  interface ImageInfo {
-    Id: string;
-    ParentId: string;
-    RepoTags: string[];
-    RepoDigests?: string[];
-    Created: number;
-    Size: number;
-    VirtualSize: number;
-    Labels: { [label: string]: string };
-  }
-
-  interface ContainerInfo {
-    Id: string;
-    Names: string[];
-    Image: string;
-    ImageID: string;
-    Command: string;
-    Created: number;
-    Ports: Port[];
-    Labels: { [label: string]: string };
-    State: string;
-    Status: string;
-    HostConfig: {
-      NetworkMode: string;
-    };
-    NetworkSettings: {
-      Networks: { [networkType: string]: NetworkInfo }
-    };
-    Mounts: Array<{
-      Name?: string;
-      Type: string;
-      Source: string;
-      Destination: string;
-      Driver?: string;
-      Mode: string;
-      RW: boolean;
-      Propagation: string;
-    }>;
-  }
-
-  interface Port {
-    IP: string;
-    PrivatePort: number;
-    PublicPort: number;
-    Type: string;
-  }
-
-  interface NetworkInfo {
-    IPAMConfig?: any;
-    Links?: any;
-    Aliases?: any;
-    NetworkID: string;
-    EndpointID: string;
-    Gateway: string;
-    IPAddress: string;
-    IPPrefixLen: number;
-    IPv6Gateway: string;
-    GlobalIPv6Address: string;
-    GlobalIPv6PrefixLen: number;
-    MacAddress: string;
-  }
-
-  // Information returned from inspecting a network
-  interface NetworkInspectInfo {
-    Name: string;
-    Id: string;
-    Created: string;
-    Scope: string;
-    Driver: string;
-    EnableIPv6: boolean;
-    IPAM?: IPAM;
-    Internal: boolean;
-    Attachable: boolean;
-    Ingress: boolean;
-    Containers?: { [id: string]: NetworkContainer };
-    Options?: { [key: string]: string };
-    Labels?: { [key: string]: string };
-  }
-
-  interface NetworkContainer {
-    Name: string;
-    EndpointID: string;
-    MacAddress: string;
-    Ipv4Address: string;
-    IPv6Address: string;
-  }
-
-  /* tslint:disable:interface-name */
-  interface IPAM {
-    Driver: string;
-    Config?: { [key: string]: string };
-    Options?: Array<{ [key: string]: string }>;
-  }
-  /* tslint:enable:interface-name */
-
-  interface VolumeInspectInfo {
-    Name: string;
-    Driver: string;
-    Mountpoint: string;
-    Status?: { [key: string]: string };
-    Labels: { [key: string]: string };
-    Scope: 'local' | 'global';
-    // Field is always present, but sometimes is null
-    Options: { [key: string]: string } | null;
-    // Field is sometimes present, and sometimes null
-    UsageData?: {
-      Size: number;
-      RefCount: number;
-    } | null;
-  }
-
-  interface ContainerInspectInfo {
-    Id: string;
-    Created: string;
-    Path: string;
-    Args: string[];
-    State: {
-      Status: string;
-      Running: boolean;
-      Paused: boolean;
-      Restarting: boolean;
-      OOMKilled: boolean;
-      Dead: boolean;
-      Pid: number;
-      ExitCode: number;
-      Error: string;
-      StartedAt: string;
-      FinishedAt: string;
-      Health?: {
+        modem: any;
+        id: string;
+
+        inspect(callback: Callback<SecretInfo>): void;
+        inspect(): Promise<SecretInfo>;
+
+        update(options: {}, callback: Callback<any>): void;
+        update(callback: Callback<any>): void;
+        update(options?: {}): Promise<any>;
+
+        remove(options: {}, callback: Callback<any>): void;
+        remove(callback: Callback<any>): void;
+        remove(options?: {}): Promise<any>;
+    }
+
+    class Network {
+        constructor(modem: any, id: string);
+
+        modem: any;
+        id: string;
+
+        inspect(callback: Callback<any>): void;
+        inspect(): Promise<any>;
+
+        remove(options: {}, callback: Callback<any>): void;
+        remove(callback: Callback<any>): void;
+        remove(options?: {}): Promise<any>;
+
+        connect(options: {}, callback: Callback<any>): void;
+        connect(callback: Callback<any>): void;
+        connect(options?: {}): Promise<any>;
+
+        disconnect(options: {}, callback: Callback<any>): void;
+        disconnect(callback: Callback<any>): void;
+        disconnect(options?: {}): Promise<any>;
+    }
+
+    class Exec {
+        constructor(modem: any, id: string);
+
+        modem: any;
+        id: string;
+
+        inspect(callback: Callback<any>): void;
+        inspect(): Promise<any>;
+
+        start(options: {}, callback: Callback<any>): void;
+        start(options: {}): Promise<any>;
+
+        resize(options: {}, callback: Callback<any>): void;
+        resize(options: {}): Promise<any>;
+    }
+
+    class Config {
+        constructor(modem: any, id: string);
+
+        modem: any;
+        id: string;
+
+        inspect(callback: Callback<ConfigInfo>): void;
+        inspect(): Promise<ConfigInfo>;
+
+        update(options: {}, callback: Callback<any>): void;
+        update(callback: Callback<any>): void;
+        update(options?: {}): Promise<any>;
+
+        remove(options: {}, callback: Callback<any>): void;
+        remove(callback: Callback<any>): void;
+        remove(options?: {}): Promise<any>;
+    }
+
+    interface ImageInfo {
+        Id: string;
+        ParentId: string;
+        RepoTags: string[];
+        RepoDigests?: string[];
+        Created: number;
+        Size: number;
+        VirtualSize: number;
+        Labels: { [label: string]: string };
+    }
+
+    interface ContainerInfo {
+        Id: string;
+        Names: string[];
+        Image: string;
+        ImageID: string;
+        Command: string;
+        Created: number;
+        Ports: Port[];
+        Labels: { [label: string]: string };
+        State: string;
         Status: string;
-        FailingStreak: number;
-        Log: Array<{
-          Start: string;
-          End: string;
-          ExitCode: number;
-          Output: string;
-        }>;
-      };
-    };
-    Image: string;
-    ResolvConfPath: string;
-    HostnamePath: string;
-    HostsPath: string;
-    LogPath: string;
-    Name: string;
-    RestartCount: number;
-    Driver: string;
-    MountLabel: string;
-    ProcessLabel: string;
-    AppArmorProfile: string;
-    ExecIDs?: any;
-    HostConfig: HostConfig;
-    GraphDriver: {
-      Name: string;
-      Data: {
-        DeviceId: string;
-        DeviceName: string;
-        DeviceSize: string;
-      }
-    };
-    Mounts: Array<{
-      Name?: string;
-      Source: string;
-      Destination: string;
-      Mode: string;
-      RW: boolean;
-      Propagation: string;
-    }>;
-    Config: {
-      Hostname: string;
-      Domainname: string;
-      User: string;
-      AttachStdin: boolean;
-      AttachStdout: boolean;
-      AttachStderr: boolean;
-      ExposedPorts: { [portAndProtocol: string]: {} };
-      Tty: boolean;
-      OpenStdin: boolean;
-      StdinOnce: boolean;
-      Env: string[];
-      Cmd: string[];
-      Image: string;
-      Volumes: { [volume: string]: {} };
-      WorkingDir: string;
-      Entrypoint?: string | string[];
-      OnBuild?: any;
-      Labels: { [label: string]: string }
-    };
-    NetworkSettings: {
-      Bridge: string;
-      SandboxID: string;
-      HairpinMode: boolean;
-      LinkLocalIPv6Address: string;
-      LinkLocalIPv6PrefixLen: number;
-      Ports: {
-        [portAndProtocol: string]: Array<{
-          HostIp: string;
-          HostPort: string;
-        }>;
-      };
-      SandboxKey: string;
-      SecondaryIPAddresses?: any;
-      SecondaryIPv6Addresses?: any;
-      EndpointID: string;
-      Gateway: string;
-      GlobalIPv6Address: string;
-      GlobalIPv6PrefixLen: number;
-      IPAddress: string;
-      IPPrefixLen: number;
-      IPv6Gateway: string;
-      MacAddress: string;
-      Networks: {
-        [type: string]: {
-          IPAMConfig?: any;
-          Links?: any;
-          Aliases?: any;
-          NetworkID: string;
-          EndpointID: string;
-          Gateway: string;
-          IPAddress: string;
-          IPPrefixLen: number;
-          IPv6Gateway: string;
-          GlobalIPv6Address: string;
-          GlobalIPv6PrefixLen: number;
-          MacAddress: string;
+        HostConfig: {
+            NetworkMode: string;
         };
-      };
-      Node?: {
-        ID: string;
+        NetworkSettings: {
+            Networks: { [networkType: string]: NetworkInfo };
+        };
+        Mounts: Array<{
+            Name?: string;
+            Type: string;
+            Source: string;
+            Destination: string;
+            Driver?: string;
+            Mode: string;
+            RW: boolean;
+            Propagation: string;
+        }>;
+    }
+
+    interface Port {
         IP: string;
-        Addr: string;
+        PrivatePort: number;
+        PublicPort: number;
+        Type: string;
+    }
+
+    interface NetworkInfo {
+        IPAMConfig?: any;
+        Links?: any;
+        Aliases?: any;
+        NetworkID: string;
+        EndpointID: string;
+        Gateway: string;
+        IPAddress: string;
+        IPPrefixLen: number;
+        IPv6Gateway: string;
+        GlobalIPv6Address: string;
+        GlobalIPv6PrefixLen: number;
+        MacAddress: string;
+    }
+
+    // Information returned from inspecting a network
+    interface NetworkInspectInfo {
         Name: string;
-        Cpus: number;
-        Memory: number;
-        Labels: any;
-      };
-    };
-  }
+        Id: string;
+        Created: string;
+        Scope: string;
+        Driver: string;
+        EnableIPv6: boolean;
+        IPAM?: IPAM;
+        Internal: boolean;
+        Attachable: boolean;
+        Ingress: boolean;
+        Containers?: { [id: string]: NetworkContainer };
+        Options?: { [key: string]: string };
+        Labels?: { [key: string]: string };
+    }
 
-  interface NetworkStats {
-    [name: string]: {
-      rx_bytes: number;
-      rx_dropped: number;
-      rx_errors: number;
-      rx_packets: number;
-      tx_bytes: number;
-      tx_dropped: number;
-      tx_errors: number;
-      tx_packets: number;
-    };
-  }
+    interface NetworkContainer {
+        Name: string;
+        EndpointID: string;
+        MacAddress: string;
+        Ipv4Address: string;
+        IPv6Address: string;
+    }
 
-  interface CPUStats {
-    cpu_usage: {
-      percpu_usage: number[];
-      usage_in_usermode: number;
-      total_usage: number;
-      usage_in_kernelmode: number;
-    };
-    system_cpu_usage: number;
-    online_cpus: number;
-    throttling_data: {
-      periods: number;
-      throttled_periods: number;
-      throttled_time: number;
-    };
-  }
+    /* tslint:disable:interface-name */
+    interface IPAM {
+        Driver: string;
+        Config?: { [key: string]: string };
+        Options?: Array<{ [key: string]: string }>;
+    }
+    /* tslint:enable:interface-name */
 
-  interface MemoryStats {
-    stats: {
-      total_pgmajfault: number;
-      cache: number;
-      mapped_file: number;
-      total_inactive_file: number;
-      pgpgout: number;
-      rss: number;
-      total_mapped_file: number;
-      writeback: number;
-      unevictable: number;
-      pgpgin: number;
-      total_unevictable: number;
-      pgmajfault: number;
-      total_rss: number;
-      total_rss_huge: number;
-      total_writeback: number;
-      total_inactive_anon: number;
-      rss_huge: number;
-      hierarchical_memory_limit: number;
-      total_pgfault: number;
-      total_active_file: number;
-      active_anon: number;
-      total_active_anon: number;
-      total_pgpgout: number;
-      total_cache: number;
-      inactive_anon: number;
-      active_file: number;
-      pgfault: number;
-      inactive_file: number;
-      total_pgpgin: number;
-    };
-    max_usage: number;
-    usage: number;
-    failcnt: number;
-    limit: number;
-  }
+    interface VolumeInspectInfo {
+        Name: string;
+        Driver: string;
+        Mountpoint: string;
+        Status?: { [key: string]: string };
+        Labels: { [key: string]: string };
+        Scope: 'local' | 'global';
+        // Field is always present, but sometimes is null
+        Options: { [key: string]: string } | null;
+        // Field is sometimes present, and sometimes null
+        UsageData?: {
+            Size: number;
+            RefCount: number;
+        } | null;
+    }
 
-  interface ContainerStats {
-    read: string;
-    pid_stats: {
-      current: number;
-    };
-    networks: NetworkStats;
-    memory_stats: MemoryStats;
-    blkio_stats: {};
-    cpu_stats: CPUStats;
-    precpu_stats: CPUStats;
-  }
+    interface ContainerInspectInfo {
+        Id: string;
+        Created: string;
+        Path: string;
+        Args: string[];
+        State: {
+            Status: string;
+            Running: boolean;
+            Paused: boolean;
+            Restarting: boolean;
+            OOMKilled: boolean;
+            Dead: boolean;
+            Pid: number;
+            ExitCode: number;
+            Error: string;
+            StartedAt: string;
+            FinishedAt: string;
+            Health?: {
+                Status: string;
+                FailingStreak: number;
+                Log: Array<{
+                    Start: string;
+                    End: string;
+                    ExitCode: number;
+                    Output: string;
+                }>;
+            };
+        };
+        Image: string;
+        ResolvConfPath: string;
+        HostnamePath: string;
+        HostsPath: string;
+        LogPath: string;
+        Name: string;
+        RestartCount: number;
+        Driver: string;
+        MountLabel: string;
+        ProcessLabel: string;
+        AppArmorProfile: string;
+        ExecIDs?: any;
+        HostConfig: HostConfig;
+        GraphDriver: {
+            Name: string;
+            Data: {
+                DeviceId: string;
+                DeviceName: string;
+                DeviceSize: string;
+            };
+        };
+        Mounts: Array<{
+            Name?: string;
+            Source: string;
+            Destination: string;
+            Mode: string;
+            RW: boolean;
+            Propagation: string;
+        }>;
+        Config: {
+            Hostname: string;
+            Domainname: string;
+            User: string;
+            AttachStdin: boolean;
+            AttachStdout: boolean;
+            AttachStderr: boolean;
+            ExposedPorts: { [portAndProtocol: string]: {} };
+            Tty: boolean;
+            OpenStdin: boolean;
+            StdinOnce: boolean;
+            Env: string[];
+            Cmd: string[];
+            Image: string;
+            Volumes: { [volume: string]: {} };
+            WorkingDir: string;
+            Entrypoint?: string | string[];
+            OnBuild?: any;
+            Labels: { [label: string]: string };
+        };
+        NetworkSettings: {
+            Bridge: string;
+            SandboxID: string;
+            HairpinMode: boolean;
+            LinkLocalIPv6Address: string;
+            LinkLocalIPv6PrefixLen: number;
+            Ports: {
+                [portAndProtocol: string]: Array<{
+                    HostIp: string;
+                    HostPort: string;
+                }>;
+            };
+            SandboxKey: string;
+            SecondaryIPAddresses?: any;
+            SecondaryIPv6Addresses?: any;
+            EndpointID: string;
+            Gateway: string;
+            GlobalIPv6Address: string;
+            GlobalIPv6PrefixLen: number;
+            IPAddress: string;
+            IPPrefixLen: number;
+            IPv6Gateway: string;
+            MacAddress: string;
+            Networks: {
+                [type: string]: {
+                    IPAMConfig?: any;
+                    Links?: any;
+                    Aliases?: any;
+                    NetworkID: string;
+                    EndpointID: string;
+                    Gateway: string;
+                    IPAddress: string;
+                    IPPrefixLen: number;
+                    IPv6Gateway: string;
+                    GlobalIPv6Address: string;
+                    GlobalIPv6PrefixLen: number;
+                    MacAddress: string;
+                };
+            };
+            Node?: {
+                ID: string;
+                IP: string;
+                Addr: string;
+                Name: string;
+                Cpus: number;
+                Memory: number;
+                Labels: any;
+            };
+        };
+    }
 
-  interface HostConfig {
-    AutoRemove?: boolean;
-    Binds?: string[];
-    ContainerIDFile?: string;
-    LogConfig?: {
-      Type: string;
-      Config: any;
-    };
-    NetworkMode?: string;
-    PortBindings?: any;
-    RestartPolicy?: RestartPolicy;
-    VolumeDriver?: string;
-    VolumesFrom?: any;
-    Mounts?: MountConfig;
-    CapAdd?: any;
-    CapDrop?: any;
-    Dns?: any[];
-    DnsOptions?: any[];
-    DnsSearch?: any[];
-    ExtraHosts?: any;
-    GroupAdd?: string[];
-    IpcMode?: string;
-    Cgroup?: string;
-    Links?: any;
-    OomScoreAdj?: number;
-    PidMode?: string;
-    Privileged?: boolean;
-    PublishAllPorts?: boolean;
-    ReadonlyRootfs?: boolean;
-    SecurityOpt?: any;
-    StorageOpt?: { [option: string]: string };
-    Tmpfs?: { [dir: string]: string };
-    UTSMode?: string;
-    UsernsMode?: string;
-    ShmSize?: number;
-    Sysctls?: { [index: string]: string };
-    Runtime?: string;
-    ConsoleSize?: number[];
-    Isolation?: string;
-    MaskedPaths?: string[];
-    ReadonlyPaths?: string[];
-    CpuShares?: number;
-    CgroupParent?: string;
-    BlkioWeight?: number;
-    BlkioWeightDevice?: any;
-    BlkioDeviceReadBps?: any;
-    BlkioDeviceWriteBps?: any;
-    BlkioDeviceReadIOps?: any;
-    BlkioDeviceWriteIOps?: any;
-    CpuPeriod?: number;
-    CpuQuota?: number;
-    CpusetCpus?: string;
-    CpusetMems?: string;
-    Devices?: any;
-    DeviceCgroupRules?: string[];
-    DeviceRequests?: DeviceRequest[];
-    DiskQuota?: number;
-    KernelMemory?: number;
-    Memory?: number;
-    MemoryReservation?: number;
-    MemorySwap?: number;
-    MemorySwappiness?: number;
-    OomKillDisable?: boolean;
-    PidsLimit?: number;
-    Ulimits?: any;
-  }
+    interface NetworkStats {
+        [name: string]: {
+            rx_bytes: number;
+            rx_dropped: number;
+            rx_errors: number;
+            rx_packets: number;
+            tx_bytes: number;
+            tx_dropped: number;
+            tx_errors: number;
+            tx_packets: number;
+        };
+    }
 
-  interface ImageInspectInfo {
-    Id: string;
-    RepoTags: string[];
-    RepoDigests: string[];
-    Parent: string;
-    Comment: string;
-    Created: string;
-    Container: string;
-    ContainerConfig:
-    {
-      Hostname: string;
-      Domainname: string;
-      User: string;
-      AttachStdin: boolean;
-      AttachStdout: boolean;
-      AttachStderr: boolean;
-      ExposedPorts: { [portAndProtocol: string]: {} };
-      Tty: boolean;
-      OpenStdin: boolean;
-      StdinOnce: boolean;
-      Env: string[];
-      Cmd: string[];
-      ArgsEscaped: boolean;
-      Image: string;
-      Volumes: { [path: string]: {} },
-      WorkingDir: string;
-      Entrypoint?: string | string[];
-      OnBuild?: any[];
-      Labels: { [label: string]: string }
-    };
-    DockerVersion: string;
-    Author: string;
-    Config:
-    {
-      Hostname: string;
-      Domainname: string;
-      User: string;
-      AttachStdin: boolean;
-      AttachStdout: boolean;
-      AttachStderr: boolean;
-      ExposedPorts: { [portAndProtocol: string]: {} }
-      Tty: boolean;
-      OpenStdin: boolean;
-      StdinOnce: boolean;
-      Env: string[];
-      Cmd: string[];
-      ArgsEscaped: boolean;
-      Image: string;
-      Volumes: { [path: string]: {} },
-      WorkingDir: string;
-      Entrypoint?: string | string[];
-      OnBuild: any[];
-      Labels: { [label: string]: string }
-    };
-    Architecture: string;
-    Os: string;
-    Size: number;
-    VirtualSize: number;
-    GraphDriver:
-    {
-      Name: string;
-      Data:
-      {
-        DeviceId: string;
-        DeviceName: string;
-        DeviceSize: string;
-      }
-    };
-    RootFS: {
-      Type: string;
-      Layers?: string[];
-      BaseLayer?: string;
-    };
-  }
+    interface CPUStats {
+        cpu_usage: {
+            percpu_usage: number[];
+            usage_in_usermode: number;
+            total_usage: number;
+            usage_in_kernelmode: number;
+        };
+        system_cpu_usage: number;
+        online_cpus: number;
+        throttling_data: {
+            periods: number;
+            throttled_periods: number;
+            throttled_time: number;
+        };
+    }
 
-  interface AuthConfig {
-    username: string;
-    password: string;
-    serveraddress: string;
-    email?: string;
-  }
+    interface MemoryStats {
+        stats: {
+            total_pgmajfault: number;
+            cache: number;
+            mapped_file: number;
+            total_inactive_file: number;
+            pgpgout: number;
+            rss: number;
+            total_mapped_file: number;
+            writeback: number;
+            unevictable: number;
+            pgpgin: number;
+            total_unevictable: number;
+            pgmajfault: number;
+            total_rss: number;
+            total_rss_huge: number;
+            total_writeback: number;
+            total_inactive_anon: number;
+            rss_huge: number;
+            hierarchical_memory_limit: number;
+            total_pgfault: number;
+            total_active_file: number;
+            active_anon: number;
+            total_active_anon: number;
+            total_pgpgout: number;
+            total_cache: number;
+            inactive_anon: number;
+            active_file: number;
+            pgfault: number;
+            inactive_file: number;
+            total_pgpgin: number;
+        };
+        max_usage: number;
+        usage: number;
+        failcnt: number;
+        limit: number;
+    }
 
-  interface PortBinding {
-    HostIp?: string;
-    HostPort?: string;
-  }
+    interface ContainerStats {
+        read: string;
+        pid_stats: {
+            current: number;
+        };
+        networks: NetworkStats;
+        memory_stats: MemoryStats;
+        blkio_stats: {};
+        cpu_stats: CPUStats;
+        precpu_stats: CPUStats;
+    }
 
-  interface PortMap {
-    [key: string]: PortBinding[];
-  }
+    interface HostConfig {
+        AutoRemove?: boolean;
+        Binds?: string[];
+        ContainerIDFile?: string;
+        LogConfig?: {
+            Type: string;
+            Config: any;
+        };
+        NetworkMode?: string;
+        PortBindings?: any;
+        RestartPolicy?: RestartPolicy;
+        VolumeDriver?: string;
+        VolumesFrom?: any;
+        Mounts?: MountConfig;
+        CapAdd?: any;
+        CapDrop?: any;
+        Dns?: any[];
+        DnsOptions?: any[];
+        DnsSearch?: any[];
+        ExtraHosts?: any;
+        GroupAdd?: string[];
+        IpcMode?: string;
+        Cgroup?: string;
+        Links?: any;
+        OomScoreAdj?: number;
+        PidMode?: string;
+        Privileged?: boolean;
+        PublishAllPorts?: boolean;
+        ReadonlyRootfs?: boolean;
+        SecurityOpt?: any;
+        StorageOpt?: { [option: string]: string };
+        Tmpfs?: { [dir: string]: string };
+        UTSMode?: string;
+        UsernsMode?: string;
+        ShmSize?: number;
+        Sysctls?: { [index: string]: string };
+        Runtime?: string;
+        ConsoleSize?: number[];
+        Isolation?: string;
+        MaskedPaths?: string[];
+        ReadonlyPaths?: string[];
+        CpuShares?: number;
+        CgroupParent?: string;
+        BlkioWeight?: number;
+        BlkioWeightDevice?: any;
+        BlkioDeviceReadBps?: any;
+        BlkioDeviceWriteBps?: any;
+        BlkioDeviceReadIOps?: any;
+        BlkioDeviceWriteIOps?: any;
+        CpuPeriod?: number;
+        CpuQuota?: number;
+        CpusetCpus?: string;
+        CpusetMems?: string;
+        Devices?: any;
+        DeviceCgroupRules?: string[];
+        DeviceRequests?: DeviceRequest[];
+        DiskQuota?: number;
+        KernelMemory?: number;
+        Memory?: number;
+        MemoryReservation?: number;
+        MemorySwap?: number;
+        MemorySwappiness?: number;
+        OomKillDisable?: boolean;
+        PidsLimit?: number;
+        Ulimits?: any;
+    }
 
-  interface RestartPolicy {
-    Name: string;
-    MaximumRetryCount?: number;
-  }
+    interface ImageInspectInfo {
+        Id: string;
+        RepoTags: string[];
+        RepoDigests: string[];
+        Parent: string;
+        Comment: string;
+        Created: string;
+        Container: string;
+        ContainerConfig: {
+            Hostname: string;
+            Domainname: string;
+            User: string;
+            AttachStdin: boolean;
+            AttachStdout: boolean;
+            AttachStderr: boolean;
+            ExposedPorts: { [portAndProtocol: string]: {} };
+            Tty: boolean;
+            OpenStdin: boolean;
+            StdinOnce: boolean;
+            Env: string[];
+            Cmd: string[];
+            ArgsEscaped: boolean;
+            Image: string;
+            Volumes: { [path: string]: {} };
+            WorkingDir: string;
+            Entrypoint?: string | string[];
+            OnBuild?: any[];
+            Labels: { [label: string]: string };
+        };
+        DockerVersion: string;
+        Author: string;
+        Config: {
+            Hostname: string;
+            Domainname: string;
+            User: string;
+            AttachStdin: boolean;
+            AttachStdout: boolean;
+            AttachStderr: boolean;
+            ExposedPorts: { [portAndProtocol: string]: {} };
+            Tty: boolean;
+            OpenStdin: boolean;
+            StdinOnce: boolean;
+            Env: string[];
+            Cmd: string[];
+            ArgsEscaped: boolean;
+            Image: string;
+            Volumes: { [path: string]: {} };
+            WorkingDir: string;
+            Entrypoint?: string | string[];
+            OnBuild: any[];
+            Labels: { [label: string]: string };
+        };
+        Architecture: string;
+        Os: string;
+        Size: number;
+        VirtualSize: number;
+        GraphDriver: {
+            Name: string;
+            Data: {
+                DeviceId: string;
+                DeviceName: string;
+                DeviceSize: string;
+            };
+        };
+        RootFS: {
+            Type: string;
+            Layers?: string[];
+            BaseLayer?: string;
+        };
+    }
 
-  type LoggingDriverType =
-    | "json-file"
-    | "syslog"
-    | "journald"
-    | "gelf"
-    | "fluentd"
-    | "awslogs"
-    | "splunk"
-    | "etwlogs"
-    | "none";
+    interface AuthConfig {
+        username: string;
+        password: string;
+        serveraddress: string;
+        email?: string;
+    }
 
-  interface LogConfig {
-    Type: LoggingDriverType;
-    Config?: { [key: string]: string };
-  }
+    interface PortBinding {
+        HostIp?: string;
+        HostPort?: string;
+    }
 
-  interface DeviceMapping {
-    PathOnHost: string;
-    PathInContainer: string;
-    CgroupPermissions: string;
-  }
+    interface PortMap {
+        [key: string]: PortBinding[];
+    }
 
-  interface DeviceRequest {
-    Driver?: string;
-    Count?: number;
-    DeviceIDs?: string[];
-    Capabilities?: string[][];
-    Options?: { [key: string]: string };
-  }
+    interface RestartPolicy {
+        Name: string;
+        MaximumRetryCount?: number;
+    }
 
-  /* tslint:disable:interface-name */
-  interface IPAMConfig {
-    IPv4Address?: string;
-    IPv6Address?: string;
-    LinkLocalIPs?: string[];
-  }
-  /* tslint:enable:interface-name */
+    type LoggingDriverType =
+        | 'json-file'
+        | 'syslog'
+        | 'journald'
+        | 'gelf'
+        | 'fluentd'
+        | 'awslogs'
+        | 'splunk'
+        | 'etwlogs'
+        | 'none';
 
-  interface EndpointSettings {
-    IPAMConfig?: IPAMConfig;
-    Links?: string[];
-    Aliases?: string[];
-    NetworkID?: string;
-    EndpointID?: string;
-    Gateway?: string;
-    IPAddress?: string;
-    IPPrefixLen?: number;
-    IPv6Gateway?: string;
-    GlobalIPv6Address?: string;
-    GlobalIPV6PrefixLen?: number;
-    MacAddress?: string;
-    DriverOpts?: { [key: string]: string };
-  }
+    interface LogConfig {
+        Type: LoggingDriverType;
+        Config?: { [key: string]: string };
+    }
 
-  interface EndpointsConfig {
-    [key: string]: EndpointSettings;
-  }
+    interface DeviceMapping {
+        PathOnHost: string;
+        PathInContainer: string;
+        CgroupPermissions: string;
+    }
 
-  type MountType =
-    | "bind"
-    | "volume"
-    | "tmpfs";
+    interface DeviceRequest {
+        Driver?: string;
+        Count?: number;
+        DeviceIDs?: string[];
+        Capabilities?: string[][];
+        Options?: { [key: string]: string };
+    }
 
-  type MountConsistency =
-    | "default"
-    | "consistent"
-    | "cached"
-    | "delegated";
+    /* tslint:disable:interface-name */
+    interface IPAMConfig {
+        IPv4Address?: string;
+        IPv6Address?: string;
+        LinkLocalIPs?: string[];
+    }
+    /* tslint:enable:interface-name */
 
-  type MountPropagation =
-    | "private"
-    | "rprivate"
-    | "shared"
-    | "rshared"
-    | "slave"
-    | "rslave";
+    interface EndpointSettings {
+        IPAMConfig?: IPAMConfig;
+        Links?: string[];
+        Aliases?: string[];
+        NetworkID?: string;
+        EndpointID?: string;
+        Gateway?: string;
+        IPAddress?: string;
+        IPPrefixLen?: number;
+        IPv6Gateway?: string;
+        GlobalIPv6Address?: string;
+        GlobalIPV6PrefixLen?: number;
+        MacAddress?: string;
+        DriverOpts?: { [key: string]: string };
+    }
 
-  interface MountSettings {
-    Target: string;
-    Source: string;
-    Type: MountType;
-    ReadOnly ?: boolean;
-    Consistency ?: MountConsistency;
-    BindOptions ?: {
-      Propagation: MountPropagation;
-    };
-    VolumeOptions ?: {
-      NoCopy: boolean;
-      Labels: { [label: string]: string };
-      DriverConfig: {
-          Name: string;
-          Options: { [option: string]: string};
-      };
-    };
-    TmpfsOptions ?: {
-      SizeBytes: number;
-      Mode: number;
-    };
-  }
+    interface EndpointsConfig {
+        [key: string]: EndpointSettings;
+    }
 
-  type MountConfig = MountSettings[];
+    type MountType = 'bind' | 'volume' | 'tmpfs';
 
-  interface ContainerCreateOptions {
-    name?: string;
-    Hostname?: string;
-    Domainname?: string;
-    User?: string;
-    AttachStdin?: boolean;
-    AttachStdout?: boolean;
-    AttachStderr?: boolean;
-    Tty?: boolean;
-    OpenStdin?: boolean;
-    StdinOnce?: boolean;
-    Env?: string[];
-    Cmd?: string[];
-    Entrypoint?: string | string[];
-    Image?: string;
-    Labels?: { [label: string]: string };
-    Volumes?: { [volume: string]: {} };
-    WorkingDir?: string;
-    NetworkDisabled?: boolean;
-    MacAddress?: boolean;
-    ExposedPorts?: { [port: string]: {} };
-    StopSignal?: string;
-    StopTimeout?: number;
-    HostConfig?: HostConfig;
-    NetworkingConfig?: {
-      EndpointsConfig?: EndpointsConfig;
-    };
-  }
+    type MountConsistency = 'default' | 'consistent' | 'cached' | 'delegated';
 
-  interface KeyObject {
-    pem: string | Buffer;
-    passphrase?: string;
-  }
+    type MountPropagation = 'private' | 'rprivate' | 'shared' | 'rshared' | 'slave' | 'rslave';
 
-  interface DockerOptions {
-    socketPath?: string;
-    host?: string;
-    port?: number | string;
-    ca?: string | string[] | Buffer | Buffer[];
-    cert?: string | string[] | Buffer | Buffer[];
-    key?: string | string[] | Buffer | Buffer[] | KeyObject[];
-    protocol?: "https" | "http";
-    timeout?: number;
-    version?: string;
-    Promise?: typeof Promise;
-  }
+    interface MountSettings {
+        Target: string;
+        Source: string;
+        Type: MountType;
+        ReadOnly?: boolean;
+        Consistency?: MountConsistency;
+        BindOptions?: {
+            Propagation: MountPropagation;
+        };
+        VolumeOptions?: {
+            NoCopy: boolean;
+            Labels: { [label: string]: string };
+            DriverConfig: {
+                Name: string;
+                Options: { [option: string]: string };
+            };
+        };
+        TmpfsOptions?: {
+            SizeBytes: number;
+            Mode: number;
+        };
+    }
 
-  interface GetEventsOptions {
-    since?: number;
-    until?: number;
-    filters?: string;
-  }
+    type MountConfig = MountSettings[];
 
-  interface SecretVersion {
-    Index: number;
-  }
+    interface ContainerCreateOptions {
+        name?: string;
+        Hostname?: string;
+        Domainname?: string;
+        User?: string;
+        AttachStdin?: boolean;
+        AttachStdout?: boolean;
+        AttachStderr?: boolean;
+        Tty?: boolean;
+        OpenStdin?: boolean;
+        StdinOnce?: boolean;
+        Env?: string[];
+        Cmd?: string[];
+        Entrypoint?: string | string[];
+        Image?: string;
+        Labels?: { [label: string]: string };
+        Volumes?: { [volume: string]: {} };
+        WorkingDir?: string;
+        NetworkDisabled?: boolean;
+        MacAddress?: boolean;
+        ExposedPorts?: { [port: string]: {} };
+        StopSignal?: string;
+        StopTimeout?: number;
+        HostConfig?: HostConfig;
+        NetworkingConfig?: {
+            EndpointsConfig?: EndpointsConfig;
+        };
+    }
 
-  interface ServiceSpec {
-    Name: string;
-  }
+    interface KeyObject {
+        pem: string | Buffer;
+        passphrase?: string;
+    }
 
-  interface SecretInfo {
-    ID: string;
-    Version: SecretVersion;
-    CreatedAt: string;
-    UpdatedAt?: string;
-    Spec?: ServiceSpec;
-  }
+    interface DockerOptions {
+        socketPath?: string;
+        host?: string;
+        port?: number | string;
+        ca?: string | string[] | Buffer | Buffer[];
+        cert?: string | string[] | Buffer | Buffer[];
+        key?: string | string[] | Buffer | Buffer[] | KeyObject[];
+        protocol?: 'https' | 'http';
+        timeout?: number;
+        version?: string;
+        Promise?: typeof Promise;
+    }
 
-  interface ConfigInfo {
-    ID: string;
-    Version: SecretVersion;
-    CreatedAt: string;
-    UpdatedAt?: string;
-    Spec?: ConfigSpec;
-  }
+    interface GetEventsOptions {
+        since?: number;
+        until?: number;
+        filters?: string;
+    }
 
-  interface ConfigSpec {
-    Name: string;
-    Labels: { [label: string]: string };
-    Data: string;
-  }
+    interface SecretVersion {
+        Index: number;
+    }
 
-  interface ConfigVersion {
-    Index: number;
-  }
+    interface ServiceSpec {
+        Name: string;
+    }
 
-  interface PluginInfo {
-    Id?: string;
-    Name: string;
-    Enabled: boolean;
-    Settings: PluginSettings;
-    PluginReference?: string;
-    Config: PluginConfig;
-  }
+    interface SecretInfo {
+        ID: string;
+        Version: SecretVersion;
+        CreatedAt: string;
+        UpdatedAt?: string;
+        Spec?: ServiceSpec;
+    }
 
-  type PluginInspectInfo = PluginInfo;
+    interface ConfigInfo {
+        ID: string;
+        Version: SecretVersion;
+        CreatedAt: string;
+        UpdatedAt?: string;
+        Spec?: ConfigSpec;
+    }
 
-  interface PluginSettings {
-    Mounts: PluginMount[];
-    Env: string[];
-    Args: string[];
-    Devices: PluginDevice[];
-  }
+    interface ConfigSpec {
+        Name: string;
+        Labels: { [label: string]: string };
+        Data: string;
+    }
 
-  interface PluginConfig {
-    Description: string;
-    Documentation: string;
-    Interface: any;
-    Entrypoint: string[];
-    WorkDir: string;
-    User?: User;
-    Network: Network;
-    Linux: Linux;
-    PropagatedMount: string;
-    Mounts: PluginMount[];
-    Env: PluginEnv[];
-    Args: Args;
-    rootfs: any;
-  }
+    interface ConfigVersion {
+        Index: number;
+    }
 
-  interface Interface {
-    Types: PluginInterfaceType[];
-    Socket: string;
-  }
+    interface PluginInfo {
+        Id?: string;
+        Name: string;
+        Enabled: boolean;
+        Settings: PluginSettings;
+        PluginReference?: string;
+        Config: PluginConfig;
+    }
 
-  interface PluginInterfaceType {
-    Prefix: string;
-    Capability: string;
-    Version: string;
-  }
+    type PluginInspectInfo = PluginInfo;
 
-  interface PluginMount {
-    Name: string;
-    Description: string;
-    Settable: string[];
-    Source: string;
-    Destination: string;
-    Type: string;
-    Options: string[];
-  }
+    interface PluginSettings {
+        Mounts: PluginMount[];
+        Env: string[];
+        Args: string[];
+        Devices: PluginDevice[];
+    }
 
-  interface Linux {
-    Capabilities: string[];
-    AllowAllDevices: boolean;
-    Devices: PluginDevice[];
-  }
+    interface PluginConfig {
+        Description: string;
+        Documentation: string;
+        Interface: any;
+        Entrypoint: string[];
+        WorkDir: string;
+        User?: User;
+        Network: Network;
+        Linux: Linux;
+        PropagatedMount: string;
+        Mounts: PluginMount[];
+        Env: PluginEnv[];
+        Args: Args;
+        rootfs: any;
+    }
 
-  interface PluginDevice {
-    Name: string;
-    Description: string;
-    Settable: string[];
-    Path: string;
-  }
+    interface Interface {
+        Types: PluginInterfaceType[];
+        Socket: string;
+    }
 
-  interface Network {
-    Type: string;
-  }
+    interface PluginInterfaceType {
+        Prefix: string;
+        Capability: string;
+        Version: string;
+    }
 
-  interface PluginEnv {
-    Name: string;
-    Description: string;
-    Settable: string[];
-    Value: string;
-  }
+    interface PluginMount {
+        Name: string;
+        Description: string;
+        Settable: string[];
+        Source: string;
+        Destination: string;
+        Type: string;
+        Options: string[];
+    }
 
-  interface Args {
-    Name: string;
-    Description: string;
-    Settable: string[];
-    Value: string;
-  }
+    interface Linux {
+        Capabilities: string[];
+        AllowAllDevices: boolean;
+        Devices: PluginDevice[];
+    }
 
-  interface User {
-    UID: number;
-    GID: number;
-  }
+    interface PluginDevice {
+        Name: string;
+        Description: string;
+        Settable: string[];
+        Path: string;
+    }
 
-  interface ImageRemoveInfo {
-    Untagged: string;
-    Deleted: string;
-  }
+    interface Network {
+        Type: string;
+    }
 
-  interface PruneImagesInfo {
-    ImagesDeleted: ImageRemoveInfo[];
-    SpaceReclaimed: number;
-  }
+    interface PluginEnv {
+        Name: string;
+        Description: string;
+        Settable: string[];
+        Value: string;
+    }
 
-  interface PruneVolumesInfo {
-    VolumesDeleted: string[];
-    SpaceReclaimed: number;
-  }
+    interface Args {
+        Name: string;
+        Description: string;
+        Settable: string[];
+        Value: string;
+    }
 
-  interface PruneContainersInfo {
-    ContainersDeleted: string[];
-    SpaceReclaimed: number;
-  }
+    interface User {
+        UID: number;
+        GID: number;
+    }
 
-  interface PruneNetworksInfo {
-    NetworksDeleted: string[];
-  }
+    interface ImageRemoveInfo {
+        Untagged: string;
+        Deleted: string;
+    }
 
-  interface ContainerLogsOptions {
-    stdout?: boolean;
-    stderr?: boolean;
-    follow?: boolean;
-    since?: number;
-    details?: boolean;
-    tail?: number;
-    timestamps?: boolean;
-  }
+    interface PruneImagesInfo {
+        ImagesDeleted: ImageRemoveInfo[];
+        SpaceReclaimed: number;
+    }
 
-  interface ImageBuildContext {
-    context: string;
-    src: string[];
-  }
+    interface PruneVolumesInfo {
+        VolumesDeleted: string[];
+        SpaceReclaimed: number;
+    }
 
-  interface DockerVersion {
-    ApiVersion: string;
-    Arch: string;
-    BuildTime: Date;
-    Components: Array<{
-      Details: {
+    interface PruneContainersInfo {
+        ContainersDeleted: string[];
+        SpaceReclaimed: number;
+    }
+
+    interface PruneNetworksInfo {
+        NetworksDeleted: string[];
+    }
+
+    interface ContainerLogsOptions {
+        stdout?: boolean;
+        stderr?: boolean;
+        follow?: boolean;
+        since?: number;
+        details?: boolean;
+        tail?: number;
+        timestamps?: boolean;
+    }
+
+    interface ImageBuildContext {
+        context: string;
+        src: string[];
+    }
+
+    interface DockerVersion {
         ApiVersion: string;
         Arch: string;
         BuildTime: Date;
-        Experimental: string;
+        Components: Array<{
+            Details: {
+                ApiVersion: string;
+                Arch: string;
+                BuildTime: Date;
+                Experimental: string;
+                GitCommit: string;
+                GoVersion: string;
+                KernelVersion: string;
+                Os: string;
+            };
+            Name: string;
+            Version: string;
+        }>;
         GitCommit: string;
         GoVersion: string;
         KernelVersion: string;
+        MinAPIVersion: string;
         Os: string;
-      };
-      Name: string;
-      Version: string;
-    }>;
-    GitCommit: string;
-    GoVersion: string;
-    KernelVersion: string;
-    MinAPIVersion: string;
-    Os: string;
-    Platform: {
-      Name: string;
-    };
-    Version: string;
-  }
+        Platform: {
+            Name: string;
+        };
+        Version: string;
+    }
 }
 
 type Callback<T> = (error?: any, result?: T) => void;
 
 declare class Dockerode {
-  constructor(options?: Dockerode.DockerOptions);
+    constructor(options?: Dockerode.DockerOptions);
 
-  createContainer(options: Dockerode.ContainerCreateOptions, callback: Callback<Dockerode.Container>): void;
-  createContainer(options: Dockerode.ContainerCreateOptions): Promise<Dockerode.Container>;
+    createContainer(options: Dockerode.ContainerCreateOptions, callback: Callback<Dockerode.Container>): void;
+    createContainer(options: Dockerode.ContainerCreateOptions): Promise<Dockerode.Container>;
 
-  createImage(options: {}, callback: Callback<NodeJS.ReadableStream>): void;
-  createImage(auth: any, options: {}, callback: Callback<NodeJS.ReadableStream>): void;
-  createImage(options: {}): Promise<NodeJS.ReadableStream>;
-  createImage(auth: any, options: {}): Promise<NodeJS.ReadableStream>;
+    createImage(options: {}, callback: Callback<NodeJS.ReadableStream>): void;
+    createImage(auth: any, options: {}, callback: Callback<NodeJS.ReadableStream>): void;
+    createImage(options: {}): Promise<NodeJS.ReadableStream>;
+    createImage(auth: any, options: {}): Promise<NodeJS.ReadableStream>;
 
-  loadImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<NodeJS.ReadableStream>): void;
-  loadImage(file: string | NodeJS.ReadableStream, callback: Callback<NodeJS.ReadableStream>): void;
-  loadImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<NodeJS.ReadableStream>;
+    loadImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<NodeJS.ReadableStream>): void;
+    loadImage(file: string | NodeJS.ReadableStream, callback: Callback<NodeJS.ReadableStream>): void;
+    loadImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<NodeJS.ReadableStream>;
 
-  importImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<NodeJS.ReadableStream>): void;
-  importImage(file: string | NodeJS.ReadableStream, callback: Callback<NodeJS.ReadableStream>): void;
-  importImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<NodeJS.ReadableStream>;
+    importImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<NodeJS.ReadableStream>): void;
+    importImage(file: string | NodeJS.ReadableStream, callback: Callback<NodeJS.ReadableStream>): void;
+    importImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<NodeJS.ReadableStream>;
 
-  checkAuth(options: any, callback: Callback<any>): void;
-  checkAuth(options: any): Promise<any>;
+    checkAuth(options: any, callback: Callback<any>): void;
+    checkAuth(options: any): Promise<any>;
 
-  buildImage(file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext, options: {}, callback: Callback<NodeJS.ReadableStream>): void;
-  buildImage(file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext, callback: Callback<NodeJS.ReadableStream>): void;
-  buildImage(file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext, options?: {}): Promise<NodeJS.ReadableStream>;
+    buildImage(
+        file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext,
+        options: {},
+        callback: Callback<NodeJS.ReadableStream>,
+    ): void;
+    buildImage(
+        file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext,
+        callback: Callback<NodeJS.ReadableStream>,
+    ): void;
+    buildImage(
+        file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext,
+        options?: {},
+    ): Promise<NodeJS.ReadableStream>;
 
-  getContainer(id: string): Dockerode.Container;
+    getContainer(id: string): Dockerode.Container;
 
-  getImage(name: string): Dockerode.Image;
+    getImage(name: string): Dockerode.Image;
 
-  getVolume(name: string): Dockerode.Volume;
+    getVolume(name: string): Dockerode.Volume;
 
-  getPlugin(name: string, remote: any): Dockerode.Plugin;
+    getPlugin(name: string, remote: any): Dockerode.Plugin;
 
-  getService(id: string): Dockerode.Service;
+    getService(id: string): Dockerode.Service;
 
-  getTask(id: string): Dockerode.Task;
+    getTask(id: string): Dockerode.Task;
 
-  getNode(id: string): Dockerode.Node;
+    getNode(id: string): Dockerode.Node;
 
-  getNetwork(id: string): Dockerode.Network;
+    getNetwork(id: string): Dockerode.Network;
 
-  getSecret(id: string): Dockerode.Secret;
+    getSecret(id: string): Dockerode.Secret;
 
-  getExec(id: string): Dockerode.Exec;
+    getExec(id: string): Dockerode.Exec;
 
-  getConfig(id: string): Dockerode.Config;
+    getConfig(id: string): Dockerode.Config;
 
-  listContainers(options: {}, callback: Callback<Dockerode.ContainerInfo[]>): void;
-  listContainers(callback: Callback<Dockerode.ContainerInfo[]>): void;
-  listContainers(options?: {}): Promise<Dockerode.ContainerInfo[]>;
+    listContainers(options: {}, callback: Callback<Dockerode.ContainerInfo[]>): void;
+    listContainers(callback: Callback<Dockerode.ContainerInfo[]>): void;
+    listContainers(options?: {}): Promise<Dockerode.ContainerInfo[]>;
 
-  listImages(options: {}, callback: Callback<Dockerode.ImageInfo[]>): void;
-  listImages(callback: Callback<Dockerode.ImageInfo[]>): void;
-  listImages(options?: {}): Promise<Dockerode.ImageInfo[]>;
+    listImages(options: {}, callback: Callback<Dockerode.ImageInfo[]>): void;
+    listImages(callback: Callback<Dockerode.ImageInfo[]>): void;
+    listImages(options?: {}): Promise<Dockerode.ImageInfo[]>;
 
-  listServices(options: {}, callback: Callback<any[]>): void;
-  listServices(callback: Callback<any[]>): void;
-  listServices(options?: {}): Promise<any[]>;
+    listServices(options: {}, callback: Callback<any[]>): void;
+    listServices(callback: Callback<any[]>): void;
+    listServices(options?: {}): Promise<any[]>;
 
-  listNodes(options: {}, callback: Callback<any[]>): void;
-  listNodes(callback: Callback<any[]>): void;
-  listNodes(options?: {}): Promise<any[]>;
+    listNodes(options: {}, callback: Callback<any[]>): void;
+    listNodes(callback: Callback<any[]>): void;
+    listNodes(options?: {}): Promise<any[]>;
 
-  listTasks(options: {}, callback: Callback<any[]>): void;
-  listTasks(callback: Callback<any[]>): void;
-  listTasks(options?: {}): Promise<any[]>;
+    listTasks(options: {}, callback: Callback<any[]>): void;
+    listTasks(callback: Callback<any[]>): void;
+    listTasks(options?: {}): Promise<any[]>;
 
-  listSecrets(options: {}, callback: Callback<Dockerode.SecretInfo[]>): void;
-  listSecrets(callback: Callback<Dockerode.SecretInfo[]>): void;
-  listSecrets(options?: {}): Promise<Dockerode.SecretInfo[]>;
+    listSecrets(options: {}, callback: Callback<Dockerode.SecretInfo[]>): void;
+    listSecrets(callback: Callback<Dockerode.SecretInfo[]>): void;
+    listSecrets(options?: {}): Promise<Dockerode.SecretInfo[]>;
 
-  listPlugins(options: {}, callback: Callback<Dockerode.PluginInfo[]>): void;
-  listPlugins(callback: Callback<Dockerode.PluginInfo[]>): void;
-  listPlugins(options?: {}): Promise<Dockerode.PluginInfo[]>;
+    listPlugins(options: {}, callback: Callback<Dockerode.PluginInfo[]>): void;
+    listPlugins(callback: Callback<Dockerode.PluginInfo[]>): void;
+    listPlugins(options?: {}): Promise<Dockerode.PluginInfo[]>;
 
-  listVolumes(options: {}, callback: Callback<{
-    Volumes: Dockerode.VolumeInspectInfo[];
-    Warnings: string[];
-  }>): void;
-  listVolumes(callback: Callback<{
-    Volumes: Dockerode.VolumeInspectInfo[];
-    Warnings: string[];
-  }>): void;
-  listVolumes(options?: {}): Promise<{
-    Volumes: Dockerode.VolumeInspectInfo[];
-    Warnings: string[];
-  }>;
+    listVolumes(
+        options: {},
+        callback: Callback<{
+            Volumes: Dockerode.VolumeInspectInfo[];
+            Warnings: string[];
+        }>,
+    ): void;
+    listVolumes(
+        callback: Callback<{
+            Volumes: Dockerode.VolumeInspectInfo[];
+            Warnings: string[];
+        }>,
+    ): void;
+    listVolumes(options?: {}): Promise<{
+        Volumes: Dockerode.VolumeInspectInfo[];
+        Warnings: string[];
+    }>;
 
-  listNetworks(options: {}, callback: Callback<any[]>): void;
-  listNetworks(callback: Callback<any[]>): void;
-  listNetworks(options?: {}): Promise<any[]>;
+    listNetworks(options: {}, callback: Callback<any[]>): void;
+    listNetworks(callback: Callback<any[]>): void;
+    listNetworks(options?: {}): Promise<any[]>;
 
-  listConfigs(options: {}, callback: Callback<Dockerode.ConfigInfo[]>): void;
-  listConfigs(callback: Callback<Dockerode.ConfigInfo[]>): void;
-  listConfigs(options?: {}): Promise<Dockerode.ConfigInfo[]>;
+    listConfigs(options: {}, callback: Callback<Dockerode.ConfigInfo[]>): void;
+    listConfigs(callback: Callback<Dockerode.ConfigInfo[]>): void;
+    listConfigs(options?: {}): Promise<Dockerode.ConfigInfo[]>;
 
-  createSecret(options: {}, callback: Callback<any>): void;
-  createSecret(options: {}): Promise<any>;
+    createSecret(options: {}, callback: Callback<any>): void;
+    createSecret(options: {}): Promise<any>;
 
-  createConfig(options: {}, callback: Callback<any>): void;
-  createConfig(options: {}): Promise<any>;
+    createConfig(options: {}, callback: Callback<any>): void;
+    createConfig(options: {}): Promise<any>;
 
-  createPlugin(options: {}, callback: Callback<any>): void;
-  createPlugin(options: {}): Promise<any>;
+    createPlugin(options: {}, callback: Callback<any>): void;
+    createPlugin(options: {}): Promise<any>;
 
-  createVolume(options: {}, callback: Callback<any>): void;
-  createVolume(options: {}): Promise<any>;
+    createVolume(options: {}, callback: Callback<any>): void;
+    createVolume(options: {}): Promise<any>;
 
-  createService(options: {}, callback: Callback<any>): void;
-  createService(options: {}): Promise<any>;
+    createService(options: {}, callback: Callback<any>): void;
+    createService(options: {}): Promise<any>;
 
-  createNetwork(options: {}, callback: Callback<any>): void;
-  createNetwork(options: {}): Promise<any>;
+    createNetwork(options: {}, callback: Callback<any>): void;
+    createNetwork(options: {}): Promise<any>;
 
-  searchImages(options: {}, callback: Callback<any>): void;
-  searchImages(options: {}): Promise<any>;
+    searchImages(options: {}, callback: Callback<any>): void;
+    searchImages(options: {}): Promise<any>;
 
-  pruneImages(options: {}, callback: Callback<Dockerode.PruneImagesInfo>): void;
-  pruneImages(callback: Callback<Dockerode.PruneImagesInfo>): void;
-  pruneImages(options?: {}): Promise<Dockerode.PruneImagesInfo>;
+    pruneImages(options: {}, callback: Callback<Dockerode.PruneImagesInfo>): void;
+    pruneImages(callback: Callback<Dockerode.PruneImagesInfo>): void;
+    pruneImages(options?: {}): Promise<Dockerode.PruneImagesInfo>;
 
-  pruneContainers(options: {}, callback: Callback<Dockerode.PruneContainersInfo>): void;
-  pruneContainers(callback: Callback<Dockerode.PruneContainersInfo>): void;
-  pruneContainers(options?: {}): Promise<Dockerode.PruneContainersInfo>;
+    pruneContainers(options: {}, callback: Callback<Dockerode.PruneContainersInfo>): void;
+    pruneContainers(callback: Callback<Dockerode.PruneContainersInfo>): void;
+    pruneContainers(options?: {}): Promise<Dockerode.PruneContainersInfo>;
 
-  pruneVolumes(options: {}, callback: Callback<Dockerode.PruneVolumesInfo>): void;
-  pruneVolumes(callback: Callback<Dockerode.PruneVolumesInfo>): void;
-  pruneVolumes(options?: {}): Promise<Dockerode.PruneVolumesInfo>;
+    pruneVolumes(options: {}, callback: Callback<Dockerode.PruneVolumesInfo>): void;
+    pruneVolumes(callback: Callback<Dockerode.PruneVolumesInfo>): void;
+    pruneVolumes(options?: {}): Promise<Dockerode.PruneVolumesInfo>;
 
-  pruneNetworks(options: {}, callback: Callback<Dockerode.PruneNetworksInfo>): void;
-  pruneNetworks(callback: Callback<Dockerode.PruneNetworksInfo>): void;
-  pruneNetworks(options?: {}): Promise<Dockerode.PruneNetworksInfo>;
+    pruneNetworks(options: {}, callback: Callback<Dockerode.PruneNetworksInfo>): void;
+    pruneNetworks(callback: Callback<Dockerode.PruneNetworksInfo>): void;
+    pruneNetworks(options?: {}): Promise<Dockerode.PruneNetworksInfo>;
 
-  info(callback: Callback<any>): void;
-  info(): Promise<any>;
+    info(callback: Callback<any>): void;
+    info(): Promise<any>;
 
-  df(callback: Callback<any>): void;
-  df(): Promise<any>;
+    df(callback: Callback<any>): void;
+    df(): Promise<any>;
 
-  version(callback: Callback<Dockerode.DockerVersion>): void;
-  version(): Promise<Dockerode.DockerVersion>;
+    version(callback: Callback<Dockerode.DockerVersion>): void;
+    version(): Promise<Dockerode.DockerVersion>;
 
-  ping(callback: Callback<any>): void;
-  ping(): Promise<any>;
+    ping(callback: Callback<any>): void;
+    ping(): Promise<any>;
 
-  getEvents(options: Dockerode.GetEventsOptions, callback: Callback<NodeJS.ReadableStream>): void;
-  getEvents(callback: Callback<NodeJS.ReadableStream>): void;
-  getEvents(options?: Dockerode.GetEventsOptions): Promise<NodeJS.ReadableStream>;
+    getEvents(options: Dockerode.GetEventsOptions, callback: Callback<NodeJS.ReadableStream>): void;
+    getEvents(callback: Callback<NodeJS.ReadableStream>): void;
+    getEvents(options?: Dockerode.GetEventsOptions): Promise<NodeJS.ReadableStream>;
 
-  pull(repoTag: string, options: {}, callback: Callback<any>, auth?: {}): Dockerode.Image;
-  pull(repoTag: string, options: {}, auth?: {}): Promise<any>;
+    pull(repoTag: string, options: {}, callback: Callback<any>, auth?: {}): Dockerode.Image;
+    pull(repoTag: string, options: {}, auth?: {}): Promise<any>;
 
-  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream | NodeJS.WritableStream[], createOptions: {}, startOptions: {}, callback: Callback<any>): events.EventEmitter;
-  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream | NodeJS.WritableStream[], startOptions: {}, callback: Callback<any>): events.EventEmitter;
-  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream | NodeJS.WritableStream[], callback: Callback<any>): events.EventEmitter;
-  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream | NodeJS.WritableStream[], createOptions: {}, callback: Callback<any>): events.EventEmitter;
-  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream | NodeJS.WritableStream[], createOptions?: {}, startOptions?: {}): Promise<any>;
+    run(
+        image: string,
+        cmd: string[],
+        outputStream: NodeJS.WritableStream | NodeJS.WritableStream[],
+        createOptions: {},
+        startOptions: {},
+        callback: Callback<any>,
+    ): events.EventEmitter;
+    run(
+        image: string,
+        cmd: string[],
+        outputStream: NodeJS.WritableStream | NodeJS.WritableStream[],
+        startOptions: {},
+        callback: Callback<any>,
+    ): events.EventEmitter;
+    run(
+        image: string,
+        cmd: string[],
+        outputStream: NodeJS.WritableStream | NodeJS.WritableStream[],
+        callback: Callback<any>,
+    ): events.EventEmitter;
+    run(
+        image: string,
+        cmd: string[],
+        outputStream: NodeJS.WritableStream | NodeJS.WritableStream[],
+        createOptions: {},
+        callback: Callback<any>,
+    ): events.EventEmitter;
+    run(
+        image: string,
+        cmd: string[],
+        outputStream: NodeJS.WritableStream | NodeJS.WritableStream[],
+        createOptions?: {},
+        startOptions?: {},
+    ): Promise<any>;
 
-  swarmInit(options: {}, callback: Callback<any>): void;
-  swarmInit(options: {}): Promise<any>;
+    swarmInit(options: {}, callback: Callback<any>): void;
+    swarmInit(options: {}): Promise<any>;
 
-  swarmJoin(options: {}, callback: Callback<any>): void;
-  swarmJoin(options: {}): Promise<any>;
+    swarmJoin(options: {}, callback: Callback<any>): void;
+    swarmJoin(options: {}): Promise<any>;
 
-  swarmLeave(options: {}, callback: Callback<any>): void;
-  swarmLeave(options: {}): Promise<any>;
+    swarmLeave(options: {}, callback: Callback<any>): void;
+    swarmLeave(options: {}): Promise<any>;
 
-  swarmUpdate(options: {}, callback: Callback<any>): void;
-  swarmUpdate(options: {}): Promise<any>;
+    swarmUpdate(options: {}, callback: Callback<any>): void;
+    swarmUpdate(options: {}): Promise<any>;
 
-  swarmInspect(callback: Callback<any>): void;
-  swarmInspect(): Promise<any>;
+    swarmInspect(callback: Callback<any>): void;
+    swarmInspect(): Promise<any>;
 
-  modem: any;
+    modem: any;
 }
 
 export = Dockerode;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -944,7 +944,35 @@ declare namespace Dockerode {
     interface GetEventsOptions {
         since?: number;
         until?: number;
-        filters?: string;
+        filters?:
+            | string
+            | {
+                  config?: string;
+                  container?: string[];
+                  daemon?: string[];
+                  event?: string[];
+                  image?: string[];
+                  label?: string[];
+                  network?: string[];
+                  node?: string[];
+                  plugin?: string[];
+                  scope?: Array<'local' | 'swarm'>;
+                  secret?: string[];
+                  service?: string[];
+                  type?: Array<
+                      | 'container'
+                      | 'image'
+                      | 'volume'
+                      | 'network'
+                      | 'daemon'
+                      | 'plugin'
+                      | 'service'
+                      | 'node'
+                      | 'secret'
+                      | 'config'
+                  >;
+                  volume?: string[];
+              };
     }
 
     interface SecretVersion {


### PR DESCRIPTION
I added a separate initial commit that runs prettier on the files as covered in https://github.com/DefinitelyTyped/DefinitelyTyped/blob/bc6280c39eaf2f533e0e6591fc9260609e310a38/README.md#common-mistakes I can remove that commit if desired but wanted to match the guidelines

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
* The command getEvents maps to for docker is https://docs.docker.com/engine/api/v1.37/#operation/SystemEvents which accepts "A JSON encoded value of filters (a `map[string][]string`) to process on the event list."
* The options are passed through docker-modem and will be automatically stringified if necessary: 
https://github.com/apocas/docker-modem/blob/v2.1.1/lib/modem.js#L425-L435
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
