### PR TITLE
[react-instantsearch] update to v6

### DIFF
--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -185,9 +185,7 @@ export interface AutocompleteExposed {
 }
 
 // tslint:disable-next-line:no-unnecessary-generics
-export function connectAutoComplete<TDoc = BasicDoc>(
-  stateless: React.StatelessComponent<AutocompleteProvided<TDoc>>
-): React.ComponentClass<AutocompleteExposed>;
+export function connectAutoComplete<TDoc = BasicDoc>(stateless: React.StatelessComponent<AutocompleteProvided<TDoc>>): React.ComponentClass<AutocompleteExposed>;
 export function connectAutoComplete<Props extends AutocompleteProvided<TDoc>, TDoc = BasicDoc>(
   Composed: React.ComponentType<Props>
 ): ConnectedComponentClass<Props, AutocompleteProvided<TDoc>, AutocompleteExposed>;
@@ -340,9 +338,7 @@ export interface HitsProvided<THit> {
  * https://community.algolia.com/react-instantsearch/connectors/connectHits.html
  */
 // tslint:disable-next-line:no-unnecessary-generics
-export function connectHits<THit = BasicDoc>(
-  stateless: React.StatelessComponent<HitsProvided<THit>>
-): React.ComponentClass;
+export function connectHits<THit = BasicDoc>(stateless: React.StatelessComponent<HitsProvided<THit>>): React.ComponentClass;
 export function connectHits<TProps extends HitsProvided<THit>, THit>(
   ctor: React.ComponentType<TProps>
 ): ConnectedComponentClass<TProps, HitsProvided<THit>>;

--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -203,6 +203,7 @@ export type Refinement = {
   value: RefinementValue;
 } & (
   | {
+      items: undefined;
       currentRefinement: string;
     }
   | {

--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -170,6 +170,9 @@ export function translatable(defaultTranslations: {
  */
 export class Configure extends React.Component<any, any> {}
 
+export class ExperimentalConfigureRelatedItems extends React.Component<any, any> {}
+export class QueryRuleContext extends React.Component<any, any> {}
+
 // Connectors
 export interface AutocompleteProvided<TDoc = BasicDoc> {
   hits: Array<Hit<TDoc>>;
@@ -696,6 +699,11 @@ interface HighlightResultPrimitive {
   matchedWords: string[];
   fullyHighlighted?: boolean;
 }
+
+export function EXPERIMENTAL_connectConfigureRelatedItems(Composed: React.ComponentType<any>): React.ComponentClass<any>;
+export function connectQueryRules(Composed: React.ComponentType<any>): React.ComponentClass<any>;
+export function connectHitInsights(Composed: React.ComponentType<any>): React.ComponentClass<any>;
+export function connectVoiceSearch(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 
 // Turn off automatic exports - so we don't export internal types like Omit<>
 export {};

--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -1,5 +1,5 @@
-// Type definitions for react-instantsearch-core 5.2
-// Project: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react, https://community.algolia.com/react-instantsearch/
+// Type definitions for react-instantsearch-core 6.3
+// Project: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react
 // Definitions by: Gordon Burgett <https://github.com/gburgett>
 //                 Justin Powell <https://github.com/jpowell>
 //                 David Furlong <https://github.com/davidfurlong>
@@ -12,25 +12,26 @@ import * as React from 'react';
 import { SearchParameters } from 'algoliasearch-helper';
 
 // Core
-/**
- * Creates a specialized root InstantSearch component. It accepts
- * an algolia client and a specification of the root Element.
- * @param defaultAlgoliaClient - a function that builds an Algolia client
- * @param root - the defininition of the root of an InstantSearch sub tree.
- * @returns an InstantSearch root
- */
-export function createInstantSearch(
-  defaultAlgoliaClient: (appId: string, apiKey: string, options: { _useRequestCache: boolean }) => object,
-  root: object
-): React.ComponentClass<any>;
+export interface InstantSearchProps {
+  searchClient: any;
+  indexName: string;
+  createURL?: (...args: any[]) => any;
+  searchState?: any;
+  refresh?: boolean;
+  onSearchStateChange?: (...args: any[]) => any;
+  onSearchParameters?: (...args: any[]) => any;
+  resultsState?: any;
+  stalledSearchDelay?: number;
+}
 
 /**
- * Creates a specialized root Index component. It accepts
- * a specification of the root Element.
- * @param defaultRoot - the defininition of the root of an Index sub tree.
- * @return a Index root
+ * <InstantSearch> is the root component of all React InstantSearch implementations. It provides all the connected components (aka widgets) a means to interact with the searchState.
+ *
+ * https://www.algolia.com/doc/api-reference/widgets/instantsearch/react/
  */
-export function createIndex(defaultRoot: object): React.ComponentClass<any>;
+export class InstantSearch extends React.Component<InstantSearchProps> {}
+
+export class Index extends React.Component<any> {}
 
 export interface ConnectorSearchResults<TDoc = BasicDoc> {
   results: AllSearchResults<TDoc>;
@@ -60,7 +61,7 @@ export interface ConnectorDescription<TProvided, TExposed> {
     searchState: SearchState,
     searchResults: ConnectorSearchResults<any>,
     metadata: any,
-    resultsFacetValues: any,
+    resultsFacetValues: any
   ): TProvided;
 
   /**
@@ -68,12 +69,7 @@ export interface ConnectorDescription<TProvided, TExposed> {
    * It takes in the current props of the higher-order component, the search state of all widgets, as well as all arguments passed
    * to the refine and createURL props of stateful widgets, and returns a new state.
    */
-  refine?(
-    this: React.Component<TExposed>,
-    props: TExposed,
-    searchState: SearchState,
-    ...args: any[],
-  ): SearchState;
+  refine?(this: React.Component<TExposed>, props: TExposed, searchState: SearchState, ...args: any[]): SearchState;
 
   /**
    * This method applies the current props and state to the provided SearchParameters, and returns a new SearchParameters. The SearchParameters
@@ -86,7 +82,7 @@ export interface ConnectorDescription<TProvided, TExposed> {
     this: React.Component<TExposed>,
     searchParameters: SearchParameters,
     props: TExposed,
-    searchState: SearchState,
+    searchState: SearchState
   ): SearchParameters;
 
   /**
@@ -98,11 +94,7 @@ export interface ConnectorDescription<TProvided, TExposed> {
    * The CurrentRefinements widget leverages this mechanism in order to allow any widget to declare the filters it has applied. If you want to add
    * your own filter, declare a filters property on your widget’s metadata
    */
-  getMetadata?(
-    this: React.Component<TExposed>,
-    props: TExposed,
-    searchState: SearchState,
-    ...args: any[]): any;
+  getMetadata?(this: React.Component<TExposed>, props: TExposed, searchState: SearchState, ...args: any[]): any;
 
   /**
    * This method needs to be implemented if you want to have the ability to perform a search for facet values inside your widget.
@@ -110,11 +102,7 @@ export interface ConnectorDescription<TProvided, TExposed> {
    * props of stateful widgets, and returns an object of the shape: {facetName: string, query: string, maxFacetHits?: number}. The default value for the
    * maxFacetHits is the one set by the API which is 10.
    */
-  searchForFacetValues?(
-      this: React.Component<TExposed>,
-      searchState: SearchState,
-      nextRefinement?: any,
-    ): any;
+  searchForFacetValues?(this: React.Component<TExposed>, searchState: SearchState, nextRefinement?: any): any;
 
   /**
    * This method is called when a widget is about to unmount in order to clean the searchState.
@@ -126,9 +114,10 @@ export interface ConnectorDescription<TProvided, TExposed> {
   cleanUp?(this: React.Component<TExposed>, props: TExposed, searchState: SearchState): SearchState;
 }
 
-export type ConnectorProvided<TProvided> = TProvided &
-  { refine: (...args: any[]) => any, createURL: (...args: any[]) => string } &
-  { searchForItems: (...args: any[]) => any };
+export type ConnectorProvided<TProvided> = TProvided & {
+  refine: (...args: any[]) => any;
+  createURL: (...args: any[]) => string;
+} & { searchForItems: (...args: any[]) => any };
 
 /**
  * Connectors are the HOC used to transform React components
@@ -141,18 +130,16 @@ export type ConnectorProvided<TProvided> = TProvided &
  * an instantsearch connected one.
  */
 export function createConnector<TProvided = {}, TExposed = {}>(
-  connectorDesc: ConnectorDescription<TProvided, TExposed>,
-): (
-    (stateless: React.StatelessComponent<ConnectorProvided<TProvided>>) => React.ComponentClass<TExposed>
-  ) & (
-    <TProps extends Partial<ConnectorProvided<TProvided>>>(Composed: React.ComponentType<TProps>) =>
-      ConnectedComponentClass<TProps, ConnectorProvided<TProvided>, TExposed>
-  );
+  connectorDesc: ConnectorDescription<TProvided, TExposed>
+): ((stateless: React.StatelessComponent<ConnectorProvided<TProvided>>) => React.ComponentClass<TExposed>) &
+  (<TProps extends Partial<ConnectorProvided<TProvided>>>(
+    Composed: React.ComponentType<TProps>
+  ) => ConnectedComponentClass<TProps, ConnectorProvided<TProvided>, TExposed>);
 
 // Utils
 export const HIGHLIGHT_TAGS: {
-  highlightPreTag: string,
-  highlightPostTag: string,
+  highlightPreTag: string;
+  highlightPostTag: string;
 };
 export const version: string;
 
@@ -163,9 +150,11 @@ export interface TranslatableExposed {
   translations?: { [key: string]: string | ((...args: any[]) => string) };
 }
 
-export function translatable(defaultTranslations: { [key: string]: string | ((...args: any[]) => string) }):
-  <TProps extends TranslatableProvided>(ctor: React.ComponentType<TProps>) =>
-    ConnectedComponentClass<TProps, TranslatableProvided, TranslatableExposed>;
+export function translatable(defaultTranslations: {
+  [key: string]: string | ((...args: any[]) => string);
+}): <TProps extends TranslatableProvided>(
+  ctor: React.ComponentType<TProps>
+) => ConnectedComponentClass<TProps, TranslatableProvided, TranslatableExposed>;
 
 // Widgets
 /**
@@ -193,9 +182,12 @@ export interface AutocompleteExposed {
 }
 
 // tslint:disable-next-line:no-unnecessary-generics
-export function connectAutoComplete<TDoc = BasicDoc>(stateless: React.StatelessComponent<AutocompleteProvided<TDoc>>): React.ComponentClass<AutocompleteExposed>;
-export function connectAutoComplete<Props extends AutocompleteProvided<TDoc>, TDoc = BasicDoc>(Composed: React.ComponentType<Props>):
-  ConnectedComponentClass<Props, AutocompleteProvided<TDoc>, AutocompleteExposed>;
+export function connectAutoComplete<TDoc = BasicDoc>(
+  stateless: React.StatelessComponent<AutocompleteProvided<TDoc>>
+): React.ComponentClass<AutocompleteExposed>;
+export function connectAutoComplete<Props extends AutocompleteProvided<TDoc>, TDoc = BasicDoc>(
+  Composed: React.ComponentType<Props>
+): ConnectedComponentClass<Props, AutocompleteProvided<TDoc>, AutocompleteExposed>;
 
 export function connectBreadcrumb(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 export function connectConfigure(Composed: React.ComponentType<any>): React.ComponentClass<any>;
@@ -206,12 +198,15 @@ export type Refinement = {
   index: string;
   id: string;
   value: RefinementValue;
-} & ({
-  currentRefinement: string;
-} | {
-  items: Array<{ label: string, value: RefinementValue }>;
-  currentRefinement: string[];
-});
+} & (
+  | {
+      currentRefinement: string;
+    }
+  | {
+      items: Array<{ label: string; value: RefinementValue }>;
+      currentRefinement: string[];
+    }
+);
 
 export type RefinementValue = (searchState: SearchState) => SearchState;
 
@@ -240,15 +235,15 @@ export interface CurrentRefinementsProvided {
 }
 
 export function connectCurrentRefinements(
-  stateless: React.StatelessComponent<CurrentRefinementsProvided>,
+  stateless: React.StatelessComponent<CurrentRefinementsProvided>
 ): React.ComponentClass<CurrentRefinementsExposed>;
 export function connectCurrentRefinements<TProps extends Partial<CurrentRefinementsProvided>>(
-  Composed: React.ComponentType<TProps>,
+  Composed: React.ComponentType<TProps>
 ): ConnectedComponentClass<TProps, CurrentRefinementsProvided, CurrentRefinementsExposed>;
 
 export interface NESW {
-  northEast: { lat: number, lng: number };
-  southWest: { lat: number, lng: number };
+  northEast: { lat: number; lng: number };
+  southWest: { lat: number; lng: number };
 }
 
 export interface GeoSearchExposed {
@@ -266,7 +261,7 @@ export interface GeoSearchProvided<THit = any> {
   /** the refinement currently applied */
   currentRefinement: NESW;
   /** the position of the search */
-  position: { lat: number, lng: number };
+  position: { lat: number; lng: number };
 }
 /**
  * The GeoSearch connector provides the logic to build a widget that will display the results on a map.
@@ -275,8 +270,12 @@ export interface GeoSearchProvided<THit = any> {
  *
  * https://community.algolia.com/react-instantsearch/connectors/connectGeoSearch.html
  */
-export function connectGeoSearch(stateless: React.StatelessComponent<GeoSearchProvided>): React.ComponentClass<GeoSearchExposed>;
-export function connectGeoSearch<TProps extends Partial<GeoSearchProvided<THit>>, THit>(ctor: React.ComponentType<TProps>): ConnectedComponentClass<TProps, GeoSearchProvided<THit>, GeoSearchExposed>;
+export function connectGeoSearch(
+  stateless: React.StatelessComponent<GeoSearchProvided>
+): React.ComponentClass<GeoSearchExposed>;
+export function connectGeoSearch<TProps extends Partial<GeoSearchProvided<THit>>, THit>(
+  ctor: React.ComponentType<TProps>
+): ConnectedComponentClass<TProps, GeoSearchProvided<THit>, GeoSearchExposed>;
 
 export function connectHierarchicalMenu(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 
@@ -303,7 +302,7 @@ export interface HighlightProvided<TDoc = any> {
     highlightProperty: string;
     preTag?: string;
     postTag?: string;
-  }): Array<{value: string, isHighlighted: boolean}>;
+  }): Array<{ value: string; isHighlighted: boolean }>;
 }
 
 interface HighlightPassedThru<TDoc = any> {
@@ -317,8 +316,12 @@ export type HighlightProps<TDoc = any> = HighlightProvided<TDoc> & HighlightPass
 /**
  * connectHighlight connector provides the logic to create an highlighter component that will retrieve, parse and render an highlighted attribute from an Algolia hit.
  */
-export function connectHighlight<TDoc = any>(stateless: React.StatelessComponent<HighlightProps<TDoc>>): React.ComponentClass<HighlightPassedThru<TDoc>>;
-export function connectHighlight<TProps extends Partial<HighlightProps<TDoc>>, TDoc>(ctor: React.ComponentType<TProps>): ConnectedComponentClass<TProps, HighlightProvided<TDoc>>;
+export function connectHighlight<TDoc = any>(
+  stateless: React.StatelessComponent<HighlightProps<TDoc>>
+): React.ComponentClass<HighlightPassedThru<TDoc>>;
+export function connectHighlight<TProps extends Partial<HighlightProps<TDoc>>, TDoc>(
+  ctor: React.ComponentType<TProps>
+): ConnectedComponentClass<TProps, HighlightProvided<TDoc>>;
 
 export interface HitsProvided<THit> {
   /** the records that matched the search state */
@@ -333,8 +336,12 @@ export interface HitsProvided<THit> {
  * https://community.algolia.com/react-instantsearch/connectors/connectHits.html
  */
 // tslint:disable-next-line:no-unnecessary-generics
-export function connectHits<THit = BasicDoc>(stateless: React.StatelessComponent<HitsProvided<THit>>): React.ComponentClass;
-export function connectHits<TProps extends HitsProvided<THit>, THit>(ctor: React.ComponentType<TProps>): ConnectedComponentClass<TProps, HitsProvided<THit>>;
+export function connectHits<THit = BasicDoc>(
+  stateless: React.StatelessComponent<HitsProvided<THit>>
+): React.ComponentClass;
+export function connectHits<TProps extends HitsProvided<THit>, THit>(
+  ctor: React.ComponentType<TProps>
+): ConnectedComponentClass<TProps, HitsProvided<THit>>;
 
 export function connectHitsPerPage(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 
@@ -355,10 +362,12 @@ export interface InfiniteHitsProvided<THit = any> {
  * https://community.algolia.com/react-instantsearch/connectors/connectInfiniteHits.html
  */
 export function connectInfiniteHits(Composed: React.ComponentType<InfiniteHitsProvided>): React.ComponentClass;
-export function connectInfiniteHits<TProps extends Partial<InfiniteHitsProvided<THit>>, THit>(ctor: React.ComponentType<TProps>): ConnectedComponentClass<TProps, InfiniteHitsProvided<THit>>;
+export function connectInfiniteHits<TProps extends Partial<InfiniteHitsProvided<THit>>, THit>(
+  ctor: React.ComponentType<TProps>
+): ConnectedComponentClass<TProps, InfiniteHitsProvided<THit>>;
 
 export interface MenuProvided {
-  items: Array<{ count: number, isRefined: boolean, label: string, value: string }>;
+  items: Array<{ count: number; isRefined: boolean; label: string; value: string }>;
   currentRefinement: string;
   refine: (...args: any[]) => any;
   createURL: (...args: any[]) => any;
@@ -380,11 +389,13 @@ export interface MenuExposed {
  * https://community.algolia.com/react-instantsearch/connectors/connectMenu.html
  */
 export function connectMenu(stateless: React.StatelessComponent<MenuProvided>): React.ComponentClass<MenuExposed>;
-export function connectMenu<TProps extends Partial<MenuProvided>>(ctor: React.ComponentType<TProps>): ConnectedComponentClass<TProps, MenuProvided, MenuExposed>;
+export function connectMenu<TProps extends Partial<MenuProvided>>(
+  ctor: React.ComponentType<TProps>
+): ConnectedComponentClass<TProps, MenuProvided, MenuExposed>;
 
 export interface NumericMenuProvided {
   /** the list of ranges the NumericMenu can display. */
-  items: Array<{isRefined: boolean, label: string, value: string, noRefinement: boolean}>;
+  items: Array<{ isRefined: boolean; label: string; value: string; noRefinement: boolean }>;
   /**
    * the refinement currently applied. follow the shape of a string with a pattern of '{start}:{end}' which corresponds to the current selected item.
    * For instance, when the selected item is {start: 10, end: 20}, the searchState of the widget is '10:20'. When start isn’t defined, the searchState
@@ -417,8 +428,12 @@ export interface NumericMenuExposed {
  *
  * https://community.algolia.com/react-instantsearch/connectors/connectNumericMenu.html
  */
-export function connectNumericMenu(stateless: React.StatelessComponent<NumericMenuProvided>): React.ComponentClass<NumericMenuExposed>;
-export function connectNumericMenu<TProps extends Partial<NumericMenuProvided>>(ctor: React.ComponentType<TProps>): ConnectedComponentClass<TProps, NumericMenuProvided, NumericMenuExposed>;
+export function connectNumericMenu(
+  stateless: React.StatelessComponent<NumericMenuProvided>
+): React.ComponentClass<NumericMenuExposed>;
+export function connectNumericMenu<TProps extends Partial<NumericMenuProvided>>(
+  ctor: React.ComponentType<TProps>
+): ConnectedComponentClass<TProps, NumericMenuProvided, NumericMenuExposed>;
 
 export function connectPagination(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 export function connectPoweredBy(Composed: React.ComponentType<any>): React.ComponentClass<any>;
@@ -435,7 +450,7 @@ export interface RefinementListProvided {
    * The list of items the RefinementList can display.
    * If isFromSearch is false, the hit properties like _highlightResult are undefined
    */
-  items: Array<Hit<{ count: number, isRefined: boolean, label: string, value: string[] }>>;
+  items: Array<Hit<{ count: number; isRefined: boolean; label: string; value: string[] }>>;
   /** a function to toggle a search inside items values */
   searchForItems: (...args: any[]) => any;
   /** a boolean that says if the items props contains facet values from the global search or from the search inside items. */
@@ -471,9 +486,12 @@ export interface RefinementListExposed {
  *
  * https://community.algolia.com/react-instantsearch/connectors/connectRefinementList.html
  */
-export function connectRefinementList(stateless: React.StatelessComponent<RefinementListProvided>): React.ComponentClass<RefinementListExposed>;
-export function connectRefinementList<TProps extends Partial<RefinementListProvided>>(ctor: React.ComponentType<TProps>):
-  ConnectedComponentClass<TProps, RefinementListProvided, RefinementListExposed>;
+export function connectRefinementList(
+  stateless: React.StatelessComponent<RefinementListProvided>
+): React.ComponentClass<RefinementListExposed>;
+export function connectRefinementList<TProps extends Partial<RefinementListProvided>>(
+  ctor: React.ComponentType<TProps>
+): ConnectedComponentClass<TProps, RefinementListProvided, RefinementListExposed>;
 
 export function connectScrollTo(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 
@@ -489,8 +507,12 @@ export interface SearchBoxExposed {
   /** Provide a default value for the query */
   defaultRefinement?: string;
 }
-export function connectSearchBox(stateless: React.StatelessComponent<SearchBoxProvided>): React.ComponentClass<SearchBoxExposed>;
-export function connectSearchBox<TProps extends Partial<SearchBoxProvided>>(ctor: React.ComponentType<TProps>): ConnectedComponentClass<TProps, SearchBoxProvided, SearchBoxExposed>;
+export function connectSearchBox(
+  stateless: React.StatelessComponent<SearchBoxProvided>
+): React.ComponentClass<SearchBoxExposed>;
+export function connectSearchBox<TProps extends Partial<SearchBoxProvided>>(
+  ctor: React.ComponentType<TProps>
+): ConnectedComponentClass<TProps, SearchBoxProvided, SearchBoxExposed>;
 
 export function connectSortBy(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 
@@ -520,10 +542,10 @@ export interface StateResultsProvided<TDoc = BasicDoc> {
  *
  * https://community.algolia.com/react-instantsearch/connectors/connectStateResults.html
  */
-export function connectStateResults(
-  stateless: React.StatelessComponent<StateResultsProvided>): React.ComponentClass;
+export function connectStateResults(stateless: React.StatelessComponent<StateResultsProvided>): React.ComponentClass;
 export function connectStateResults<TProps extends Partial<StateResultsProvided<any>>>(
-  ctor: React.ComponentType<TProps>): ConnectedComponentClass<TProps, StateResultsProvided>;
+  ctor: React.ComponentType<TProps>
+): ConnectedComponentClass<TProps, StateResultsProvided>;
 
 interface StatsProvided {
   nbHits: number;
@@ -531,8 +553,9 @@ interface StatsProvided {
 }
 
 export function connectStats(stateless: React.StatelessComponent<StatsProvided>): React.ComponentClass;
-export function connectStats<TProps extends Partial<StatsProvided>>(ctor: React.ComponentType<TProps>):
-  ConnectedComponentClass<TProps, StatsProvided>;
+export function connectStats<TProps extends Partial<StatsProvided>>(
+  ctor: React.ComponentType<TProps>
+): ConnectedComponentClass<TProps, StatsProvided>;
 
 export function connectToggleRefinement(Composed: React.ComponentType<any>): React.ComponentClass<any>;
 
@@ -546,8 +569,9 @@ export interface AlgoliaError {
 
 type Omit<T1, T2> = Pick<T1, Exclude<keyof T1, keyof T2>>;
 
-export type ConnectedComponentClass<TProps, TProvidedProps, TExposedProps = {}>
-  = React.ComponentClass<Omit<TProps, TProvidedProps> & TExposedProps>;
+export type ConnectedComponentClass<TProps, TProvidedProps, TExposedProps = {}> = React.ComponentClass<
+  Omit<TProps, TProvidedProps> & TExposedProps
+>;
 
 /**
  * The searchState contains all widgets states. If a widget uses an attribute,
@@ -562,26 +586,26 @@ export interface SearchState {
     [key: string]: {
       min: number;
       max: number;
-    }
+    };
   };
   configure?: {
     aroundLatLng: boolean;
     [key: string]: any;
   };
   refinementList?: {
-    [key: string]: string[]
+    [key: string]: string[];
   };
   hierarchicalMenu?: {
-    [key: string]: string
+    [key: string]: string;
   };
   menu?: {
-    [key: string]: string
+    [key: string]: string;
   };
   multiRange?: {
-    [key: string]: string
+    [key: string]: string;
   };
   toggle?: {
-    [key: string]: boolean
+    [key: string]: boolean;
   };
   hitsPerPage?: number;
   sortBy?: string;
@@ -591,9 +615,9 @@ export interface SearchState {
   indices?: {
     [index: string]: {
       configure: {
-        hitsPerPage: number,
-      },
-    }
+        hitsPerPage: number;
+      };
+    };
   };
 }
 
@@ -601,7 +625,9 @@ export interface SearchState {
  * The most basic possible document in an Algolia index:
  * a set of string-value pairs.
  */
-export interface BasicDoc { [k: string]: string; }
+export interface BasicDoc {
+  [k: string]: string;
+}
 
 /**
  * The shape of the searchResults object provided
@@ -647,25 +673,20 @@ export type Hit<TDoc = BasicDoc> = TDoc & {
    * any searchable attributes, this object will only contain those keys and others
    * will not exist.
    */
-  '_highlightResult': HighlightResult<TDoc>;
+  _highlightResult: HighlightResult<TDoc>;
 };
 
-export type HighlightResult<TDoc> =
-  TDoc extends { [k: string]: any } ?
-    { [K in keyof TDoc]?: HighlightResultField<TDoc[K]> } :
-    never;
+export type HighlightResult<TDoc> = TDoc extends { [k: string]: any }
+  ? { [K in keyof TDoc]?: HighlightResultField<TDoc[K]> }
+  : never;
 
-type HighlightResultField<TField> =
-  TField extends Array<infer TItem> ?
-    HighlightResultArray<TItem> :
-    TField extends string ?
-      HighlightResultPrimitive :
-      HighlightResult<TField>;
+type HighlightResultField<TField> = TField extends Array<infer TItem>
+  ? HighlightResultArray<TItem>
+  : TField extends string
+  ? HighlightResultPrimitive
+  : HighlightResult<TField>;
 
-type HighlightResultArray<TItem> =
-  TItem extends string ?
-    HighlightResultPrimitive[] :
-    Array<HighlightResult<TItem>>;
+type HighlightResultArray<TItem> = TItem extends string ? HighlightResultPrimitive[] : Array<HighlightResult<TItem>>;
 
 interface HighlightResultPrimitive {
   /** the value of the facet highlighted (html) */

--- a/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
+++ b/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
@@ -322,7 +322,8 @@ import {
             return <>{refinement.items.map(i => renderRefinement(i.label, i.value, refine))}</>;
           }
 
-          return renderRefinement(refinement.currentRefinement, refinement.value, refine);
+          // typescript pre 3.2 doesn't infer this correctly yet, which is no big deal IMO
+          return renderRefinement(refinement.currentRefinement as string, refinement.value, refine);
         })}
       </>
     );

--- a/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
+++ b/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
@@ -319,12 +319,11 @@ import {
            * nested items object that contains a label and a value function to use to remove a single filter.
            * https://community.algolia.com/react-instantsearch/connectors/connectCurrentRefinements.html
            */
-          if ('items' in refinement) {
+          if (refinement.items) {
             str = refinement.currentRefinement; // $ExpectError
             return <>{refinement.items.map(i => renderRefinement(i.label, i.value, refine))}</>;
           }
 
-          console.log(refinement.items); // $ExpectError
           return renderRefinement(refinement.currentRefinement, refinement.value, refine);
         })}
       </>

--- a/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
+++ b/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {
-  createInstantSearch,
-  createIndex,
+  InstantSearch,
+  Index,
   createConnector,
   SearchResults,
   connectStateResults,
@@ -25,21 +25,11 @@ import {
   StateResultsProvided,
   ConnectorSearchResults,
   BasicDoc,
-  AllSearchResults
+  AllSearchResults,
 } from 'react-instantsearch-core';
 
 () => {
-  const InstantSearch = createInstantSearch(() => ({}), {Root: 'div', props: {className: `widget`}});
-
-  <InstantSearch appId={'test'} apiKey={'test'}>
-    <div></div>
-  </InstantSearch>;
-};
-
-() => {
-  const Index = createIndex({Root: 'div', props: {className: `widget`}});
-
-  <Index indexName={'test'} root={{Root: 'div', props: {className: `widget`}}}>
+  <Index indexName={'test'} indexId="id">
     <div></div>
   </Index>;
 };
@@ -72,10 +62,10 @@ import {
         queryAndPage: [newQuery, newPage],
       };
     },
-  })((props) =>
+  })(props => (
     <div>
-      The query is {props.query}, the page is {props.page}.
-      This is an error: {
+      The query is {props.query}, the page is {props.page}. This is an error:{' '}
+      {
         props.somethingElse // $ExpectError
       }
       {/*
@@ -97,7 +87,7 @@ import {
       */}
       <button onClick={() => props.refine('instantsearch', 15)} />
     </div>
-  );
+  ));
 
   <CoolWidget>
     <div></div>
@@ -121,8 +111,7 @@ import {
     getProvidedProps(props, searchState) {
       // Since the `queryAndPage` searchState entry isn't necessarily defined, we need
       // to default its value.
-      const [query, page] = searchState.queryAndPage ||
-        [props.defaultRefinement, props.startAtPage];
+      const [query, page] = searchState.queryAndPage || [props.defaultRefinement, props.startAtPage];
 
       // Connect the underlying component to the `queryAndPage` searchState entry.
       return {
@@ -144,10 +133,10 @@ import {
     },
   });
 
-  const TypedCoolWidgetStateless = typedCoolConnector((props) =>
+  const TypedCoolWidgetStateless = typedCoolConnector(props => (
     <div>
-      The query is {props.query}, the page is {props.page}.
-      This is an error: {
+      The query is {props.query}, the page is {props.page}. This is an error:{' '}
+      {
         props.somethingElse // $ExpectError
       }
       {/*
@@ -169,21 +158,18 @@ import {
       */}
       <button onClick={() => props.refine('instantsearch', 15)} />
     </div>
-  );
+  ));
 
-  <TypedCoolWidgetStateless
-      defaultRefinement={'asdf'}
-      startAtPage={10}
-      />;
+  <TypedCoolWidgetStateless defaultRefinement={'asdf'} startAtPage={10} />;
 
   const TypedCoolWidget = typedCoolConnector(
     class extends React.Component<ConnectorProvided<Provided> & { passThruName: string }> {
       render() {
         const props = this.props;
-        return <div>
-          The query is {props.query}, the page is {props.page}.
-          The name is {props.passThruName}
-          {/*
+        return (
+          <div>
+            The query is {props.query}, the page is {props.page}. The name is {props.passThruName}
+            {/*
             Clicking on this button will update the searchState to:
             {
               ...otherSearchState,
@@ -191,8 +177,8 @@ import {
               page: 20,
             }
           */}
-          <button onClick={() => props.refine('algolia', 20)} />
-          {/*
+            <button onClick={() => props.refine('algolia', 20)} />
+            {/*
             Clicking on this button will update the searchState to:
             {
               ...otherSearchState,
@@ -200,16 +186,14 @@ import {
               page: 15,
             }
           */}
-          <button onClick={() => props.refine('instantsearch', 15)} />
-        </div>;
+            <button onClick={() => props.refine('instantsearch', 15)} />
+          </div>
+        );
       }
     }
   );
 
-  <TypedCoolWidget
-    defaultRefinement={'asdf'}
-    startAtPage={10}
-    passThruName={'test'} />;
+  <TypedCoolWidget defaultRefinement={'asdf'} startAtPage={10} passThruName={'test'} />;
 };
 
 () => {
@@ -226,71 +210,73 @@ import {
     additionalProp: string;
   }
 
-  const Stateless = connectStateResults(
-    ({
-      searchResults,
-      additionalProp, // $ExpectError
-    }) => (<div>
-      <h1>{additionalProp}</h1>
-      {searchResults.hits.map((h) => {
-        return <span>{h._highlightResult.field1!.value}</span>;
-      })}
-    </div>)
-  );
-
-  <Stateless />;
-  <Stateless additionalProp='test' />; // $ExpectError
-
-  const StatelessWithType = ({ additionalProp, searchResults }: StateResultsProps) =>
+  const Stateless = connectStateResults((
+    { searchResults, additionalProp } // $ExpectError
+  ) => (
     <div>
       <h1>{additionalProp}</h1>
-      {searchResults.hits.map((h) => {
+      {searchResults.hits.map(h => {
+        return <span>{h._highlightResult.field1!.value}</span>;
+      })}
+    </div>
+  ));
+
+  <Stateless />;
+  <Stateless additionalProp="test" />; // $ExpectError
+
+  const StatelessWithType = ({ additionalProp, searchResults }: StateResultsProps) => (
+    <div>
+      <h1>{additionalProp}</h1>
+      {searchResults.hits.map(h => {
         // $ExpectType string
         const compound = h._highlightResult.field3!.compound!.value;
         return <span>{compound}</span>;
       })}
-    </div>;
+    </div>
+  );
   const ComposedStatelessWithType = connectStateResults(StatelessWithType);
 
   <ComposedStatelessWithType />; // $ExpectError
 
-  <ComposedStatelessWithType additionalProp='test' />;
+  <ComposedStatelessWithType additionalProp="test" />;
 
   class MyComponent extends React.Component<StateResultsProps> {
     render() {
       const { additionalProp, searchResults } = this.props;
-      return <div>
-      <h1>{additionalProp}</h1>
-      {searchResults.hits.map((h) => {
-        // $ExpectType string[]
-        const words = h._highlightResult.field3!.compound!.matchedWords;
-        return <span>{h.field2}: {words.join(',')}</span>;
-      })}
-    </div>;
+      return (
+        <div>
+          <h1>{additionalProp}</h1>
+          {searchResults.hits.map(h => {
+            // $ExpectType string[]
+            const words = h._highlightResult.field3!.compound!.matchedWords;
+            return (
+              <span>
+                {h.field2}: {words.join(',')}
+              </span>
+            );
+          })}
+        </div>
+      );
     }
   }
   const ComposedMyComponent = connectStateResults(MyComponent);
 
   <ComposedMyComponent />; // $ExpectError
 
-  <ComposedMyComponent additionalProp='test' />;
+  <ComposedMyComponent additionalProp="test" />;
 };
 
 () => {
-  const InstantSearch = createInstantSearch(
-    () => null, // $ExpectError
-    {}
-  );
+  <InstantSearch searchClient={{}} indexName="xxx" />;
+
+  <InstantSearch indexName="xxx" />; // $ExpectError
 };
 
 // https://community.algolia.com/react-instantsearch/guide/Connectors.html
 () => {
-  const MySearchBox = ({currentRefinement, refine}: SearchBoxProvided) =>
-    <input
-      type="text"
-      value={currentRefinement}
-      onChange={e => refine(e.target.value)}
-    />;
+  const MySearchBox = ({ currentRefinement, refine }: SearchBoxProvided) => (
+    <input type="text" value={currentRefinement} onChange={e => refine(e.target.value)} />
+  );
 
   // `ConnectedSearchBox` renders a `<MySearchBox>` widget that is connected to
   // the <InstantSearch> state, providing it with `currentRefinement` and `refine` props for
@@ -299,34 +285,34 @@ import {
 };
 
 () => {
-  const MyCurrentRefinements = ({refine, items, query}: CurrentRefinementsProvided) =>
+  const MyCurrentRefinements = ({ refine, items, query }: CurrentRefinementsProvided) => (
     <>
-      {items.map((refinement) => (
-        <div key={refinement.id} onClick={() => refine(refinement.value) }>
+      {items.map(refinement => (
+        <div key={refinement.id} onClick={() => refine(refinement.value)}>
           <label>{refinement.label}</label>
         </div>
       ))}
-    </>;
+    </>
+  );
 
   const ConnectedCurrentRefinements = connectCurrentRefinements(MyCurrentRefinements);
 
-  <ConnectedCurrentRefinements clearsQuery={true} transformItems={(item) => item} />;
+  <ConnectedCurrentRefinements clearsQuery={true} transformItems={item => item} />;
 };
 
 () => {
-  function renderRefinement(
-    label: string,
-    value: Refinement['value'],
-    refine: CurrentRefinementsProvided['refine'],
-  ) {
-    return <button className="badge badge-secondary" onClick={() => refine(value)}>
+  function renderRefinement(label: string, value: Refinement['value'], refine: CurrentRefinementsProvided['refine']) {
+    return (
+      <button className="badge badge-secondary" onClick={() => refine(value)}>
         {label}
-      </button>;
+      </button>
+    );
   }
 
-  const MyCurrentRefinements = connectCurrentRefinements(({refine, items, query}: CurrentRefinementsProvided) => {
-    return <>
-        {items.map((refinement) => {
+  const MyCurrentRefinements = connectCurrentRefinements(({ refine, items, query }: CurrentRefinementsProvided) => {
+    return (
+      <>
+        {items.map(refinement => {
           let str: string = refinement.currentRefinement; // $ExpectError
           /*
            * When existing several refinements for the same atribute name, then you get a
@@ -335,75 +321,71 @@ import {
            */
           if ('items' in refinement) {
             str = refinement.currentRefinement; // $ExpectError
-            return <>
-              {refinement.items.map((i) => renderRefinement(i.label, i.value, refine))}
-            </>;
+            return <>{refinement.items.map(i => renderRefinement(i.label, i.value, refine))}</>;
           }
 
           console.log(refinement.items); // $ExpectError
           return renderRefinement(refinement.currentRefinement, refinement.value, refine);
         })}
-      </>;
+      </>
+    );
   });
 };
 
 () => {
-  const MyRefinementList = ({items, refine}: RefinementListProvided) =>
+  const MyRefinementList = ({ items, refine }: RefinementListProvided) => (
     <>
-      {items.map((item) => (
-        <button onClick={() => refine(item.value)}>
-          {item.label}
-        </button>
+      {items.map(item => (
+        <button onClick={() => refine(item.value)}>{item.label}</button>
       ))}
-    </>;
+    </>
+  );
   const ConnectedRefinementList = connectRefinementList(MyRefinementList);
 
-  <ConnectedRefinementList attribute={'test'} searchable={true} operator={'and'}
-    showMore={true} limit={8} showMoreLimit={99} />;
+  <ConnectedRefinementList
+    attribute={'test'}
+    searchable={true}
+    operator={'and'}
+    showMore={true}
+    limit={8}
+    showMoreLimit={99}
+  />;
 };
 
 () => {
   interface MyDoc {
     a: 1;
     b: {
-      c: '2'
+      c: '2';
     };
   }
 
-  const CustomHighlight = connectHighlight<MyDoc>(
-    ({ highlight, attribute, hit }) => {
-      const highlights = highlight({
-        highlightProperty: '_highlightResult',
-        attribute,
-        hit
-      });
+  const CustomHighlight = connectHighlight<MyDoc>(({ highlight, attribute, hit }) => {
+    const highlights = highlight({
+      highlightProperty: '_highlightResult',
+      attribute,
+      hit,
+    });
 
-      return <>
-        {highlights.map(part => part.isHighlighted ? (
-          <mark>{part.value}</mark>
-        ) : (
-          <span>{part.value}</span>
-        ))
-      }</>;
-    }
-  );
+    return <>{highlights.map(part => (part.isHighlighted ? <mark>{part.value}</mark> : <span>{part.value}</span>))}</>;
+  });
 
   class CustomHighlight2 extends React.Component<HighlightProps & { limit: number }> {
     render() {
-      const {highlight, attribute, hit, limit} = this.props;
+      const { highlight, attribute, hit, limit } = this.props;
       const highlights = highlight({
         highlightProperty: '_highlightResult',
         attribute,
-        hit
+        hit,
       });
 
-      return <>
-        {highlights.slice(0, limit).map(part => part.isHighlighted ? (
-          <mark>{part.value}</mark>
-        ) : (
-          <span>{part.value}</span>
-        ))
-      }</>;
+      return (
+        <>
+          {highlights
+            .slice(0, limit)
+            .map(part => (part.isHighlighted ? <mark>{part.value}</mark> : <span>{part.value}</span>))}
+        </>
+      );
     }
   }
   const ConnectedCustomHighlight2 = connectHighlight(CustomHighlight2);
@@ -439,18 +421,19 @@ import {
 };
 
 () => {
-  type Props = SearchBoxProvided & TranslatableProvided & {
-    className?: string
-    showLoadingIndicator?: boolean
+  type Props = SearchBoxProvided &
+    TranslatableProvided & {
+      className?: string;
+      showLoadingIndicator?: boolean;
 
-    submit?: JSX.Element;
-    reset?: JSX.Element;
-    loadingIndicator?: JSX.Element;
+      submit?: JSX.Element;
+      reset?: JSX.Element;
+      loadingIndicator?: JSX.Element;
 
-    onSubmit?: (event: React.SyntheticEvent<HTMLFormElement>) => any;
-    onReset?: (event: React.SyntheticEvent<HTMLFormElement>) => any;
-    onChange?: (event: React.SyntheticEvent<HTMLInputElement>) => any;
-  };
+      onSubmit?: (event: React.SyntheticEvent<HTMLFormElement>) => any;
+      onReset?: (event: React.SyntheticEvent<HTMLFormElement>) => any;
+      onChange?: (event: React.SyntheticEvent<HTMLInputElement>) => any;
+    };
   interface State {
     query: string | null;
   }
@@ -488,7 +471,7 @@ import {
         onSubmit(e);
       }
       return false;
-    }
+    };
 
     onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const { onChange } = this.props;
@@ -499,7 +482,7 @@ import {
       if (onChange) {
         onChange(event);
       }
-    }
+    };
 
     onReset = (event: React.FormEvent<HTMLFormElement>) => {
       const { refine, onReset } = this.props;
@@ -511,27 +494,17 @@ import {
       if (onReset) {
         onReset(event);
       }
-    }
+    };
 
     render() {
-      const {
-        className,
-        translate,
-        loadingIndicator,
-        submit,
-        reset,
-      } = this.props;
+      const { className, translate, loadingIndicator, submit, reset } = this.props;
       const query = this.getQuery();
 
-      const isSearchStalled =
-        this.props.showLoadingIndicator && this.props.isSearchStalled;
+      const isSearchStalled = this.props.showLoadingIndicator && this.props.isSearchStalled;
 
-      const isCurrentQuerySubmitted =
-        query && query === this.props.currentRefinement;
+      const isCurrentQuerySubmitted = query && query === this.props.currentRefinement;
 
-      const button =
-        isSearchStalled ? 'loading' :
-          isCurrentQuerySubmitted ? 'reset' : 'submit';
+      const button = isSearchStalled ? 'loading' : isCurrentQuerySubmitted ? 'reset' : 'submit';
 
       return (
         <div className={className}>
@@ -559,8 +532,7 @@ import {
             >
               {reset}
             </button>
-            <span className={`${className}-loadingIndicator`}
-              hidden={button !== 'loading'}>
+            <span className={`${className}-loadingIndicator`} hidden={button !== 'loading'}>
               {loadingIndicator}
             </span>
             <input
@@ -592,10 +564,13 @@ import {
 
   const ConnectedSearchBox = connectSearchBox(TranslatableSearchBox);
 
-  <ConnectedSearchBox className="ais-search"
+  <ConnectedSearchBox
+    className="ais-search"
     loadingIndicator={<i className="material-icons">search</i>}
-    onSubmit={(evt) => { console.log('submitted', evt); }}
-     />;
+    onSubmit={evt => {
+      console.log('submitted', evt);
+    }}
+  />;
 };
 
 // can we recreate connectStateResults from source using the createConnector typedef?
@@ -606,12 +581,13 @@ import {
       : context.ais.mainTargetedIndex;
   }
 
-  function getResults<TDoc>(searchResults: { results: AllSearchResults<TDoc> }, context: any): SearchResults<TDoc> | null | undefined {
-    const {results} = searchResults;
+  function getResults<TDoc>(
+    searchResults: { results: AllSearchResults<TDoc> },
+    context: any
+  ): SearchResults<TDoc> | null | undefined {
+    const { results } = searchResults;
     if (results && !results.hits) {
-      return results[getIndexId(context)]
-        ? results[getIndexId(context)]
-        : null;
+      return results[getIndexId(context)] ? results[getIndexId(context)] : null;
     } else {
       return results ? results : null;
     }

--- a/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
+++ b/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
@@ -322,8 +322,10 @@ import {
             return <>{refinement.items.map(i => renderRefinement(i.label, i.value, refine))}</>;
           }
 
-          // typescript pre 3.2 doesn't infer this correctly yet, which is no big deal IMO
-          return renderRefinement(refinement.currentRefinement as string, refinement.value, refine);
+          // extra assert for typescript < 3.2
+          if (typeof refinement.currentRefinement === 'string') {
+            return renderRefinement(refinement.currentRefinement, refinement.value, refine);
+          }
         })}
       </>
     );

--- a/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
+++ b/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
@@ -313,14 +313,12 @@ import {
     return (
       <>
         {items.map(refinement => {
-          let str: string = refinement.currentRefinement; // $ExpectError
           /*
            * When existing several refinements for the same atribute name, then you get a
            * nested items object that contains a label and a value function to use to remove a single filter.
            * https://community.algolia.com/react-instantsearch/connectors/connectCurrentRefinements.html
            */
           if (refinement.items) {
-            str = refinement.currentRefinement; // $ExpectError
             return <>{refinement.items.map(i => renderRefinement(i.label, i.value, refine))}</>;
           }
 

--- a/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
+++ b/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
@@ -471,7 +471,7 @@ import {
         onSubmit(e);
       }
       return false;
-    };
+    }
 
     onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const { onChange } = this.props;
@@ -482,7 +482,7 @@ import {
       if (onChange) {
         onChange(event);
       }
-    };
+    }
 
     onReset = (event: React.FormEvent<HTMLFormElement>) => {
       const { refine, onReset } = this.props;
@@ -494,7 +494,7 @@ import {
       if (onReset) {
         onReset(event);
       }
-    };
+    }
 
     render() {
       const { className, translate, loadingIndicator, submit, reset } = this.props;

--- a/types/react-instantsearch-dom/index.d.ts
+++ b/types/react-instantsearch-dom/index.d.ts
@@ -148,7 +148,7 @@ export type VoiceListeningState = {
   status: Status;
   transcript: string;
   isSpeechFinal: boolean;
-  errorCode?: SpeechRecognitionErrorCode;
+  errorCode?: any;
 };
 
 export type VoiceSearchHelper = {

--- a/types/react-instantsearch-dom/index.d.ts
+++ b/types/react-instantsearch-dom/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-instantsearch 5.2
+// Type definitions for react-instantsearch 6.3
 // Project: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react, https://community.algolia.com/react-instantsearch/
 // Definitions by: Gordon Burgett <https://github.com/gburgett>
 //                 Justin Powell <https://github.com/jpowell>
@@ -17,6 +17,9 @@ export { HIGHLIGHT_TAGS } from 'react-instantsearch-core';
 export { translatable } from 'react-instantsearch-core';
 
 // Widget
+export { Index } from 'react-instantsearch-core';
+export { InstantSearch } from 'react-instantsearch-core';
+export { InstantSearchProps } from 'react-instantsearch-core';
 export { Configure } from 'react-instantsearch-core';
 
 // Connectors
@@ -51,43 +54,11 @@ interface CommonWidgetProps {
    *
    * https://community.algolia.com/react-instantsearch/guide/i18n.html
    */
-  translations?: { [key: string]: string | ((...args: any[]) => any) };
-}
-
-interface InstantSearchBaseProps {
-  indexName: string;
-  createURL?: (...args: any[]) => any;
-  searchState?: any;
-  refresh?: boolean;
-  onSearchStateChange?: (...args: any[]) => any;
-  onSearchParameters?: (...args: any[]) => any;
-  resultsState?: any;
-  stalledSearchDelay?: number;
-  root?: {
-    Root: string | ((...args: any[]) => any);
-    props?: object;
+  translations?: {
+    [key: string]: string | ((...args: any[]) => any);
   };
 }
 
-export interface UsingSearchClientProps extends InstantSearchBaseProps {
-  searchClient: any;
-}
-
-export interface UsingManualInfoProps extends InstantSearchBaseProps {
-  apiKey: string;
-  appId: string;
-  algoliaClient?: any;
-}
-
-export type InstantSearchProps = UsingSearchClientProps | UsingManualInfoProps;
-
-/**
- * <InstantSearch> is the root component of all React InstantSearch implementations. It provides all the connected components (aka widgets) a means to interact with the searchState.
- *
- * https://community.algolia.com/react-instantsearch/widgets/%3CInstantSearch%3E.html
- */
-export class InstantSearch extends React.Component<InstantSearchProps> {}
-export class Index extends React.Component<any> {}
 export class Breadcrumb extends React.Component<any> {}
 export class ClearRefinements extends React.Component<any> {}
 export class CurrentRefinements extends React.Component<any> {}
@@ -144,5 +115,9 @@ export class SortBy extends React.Component<any> {}
 /**
  * The Stats component displays the total number of matching hits and the time it took to get them (time spent in the Algolia server).
  */
-export class Stats extends React.Component<{translations?: { [key: string]: (n: number, ms: number) => string }}> {}
+export class Stats extends React.Component<{
+  translations?: {
+    [key: string]: (n: number, ms: number) => string;
+  };
+}> {}
 export class ToggleRefinement extends React.Component<any> {}

--- a/types/react-instantsearch-dom/index.d.ts
+++ b/types/react-instantsearch-dom/index.d.ts
@@ -135,27 +135,28 @@ export class QueryRuleCustomData extends React.Component<any> {}
 export function getInsightsAnonymousUserToken(): string | undefined;
 export function createClassNames(baseName: string): (...elements: string[]) => string | string[];
 
-export type VoiceSearchHelperParams = {
+export interface VoiceSearchHelperParams {
   searchAsYouSpeak: boolean;
   language?: string;
   onQueryChange: (query: string) => void;
   onStateChange: () => void;
-};
+}
 
 export type Status = 'initial' | 'askingPermission' | 'waiting' | 'recognizing' | 'finished' | 'error';
 
-export type VoiceListeningState = {
+export interface VoiceListeningState {
   status: Status;
   transcript: string;
   isSpeechFinal: boolean;
   errorCode?: any;
-};
+}
 
-export type VoiceSearchHelper = {
+export interface VoiceSearchHelper {
   getState: () => VoiceListeningState;
   isBrowserSupported: () => boolean;
   isListening: () => boolean;
   toggleListening: () => void;
   dispose: () => void;
-};
+}
+
 export function createVoiceSearchHelper(params: VoiceSearchHelperParams): VoiceSearchHelper;

--- a/types/react-instantsearch-dom/index.d.ts
+++ b/types/react-instantsearch-dom/index.d.ts
@@ -148,7 +148,7 @@ export interface VoiceListeningState {
   status: Status;
   transcript: string;
   isSpeechFinal: boolean;
-  errorCode?: any;
+  errorCode?: "no-speech" | "aborted" | "audio-capture" | "network" | "not-allowed" | "service-not-allowed" | "bad-grammar" | "language-not-supported";
 }
 
 export interface VoiceSearchHelper {

--- a/types/react-instantsearch-dom/index.d.ts
+++ b/types/react-instantsearch-dom/index.d.ts
@@ -21,6 +21,8 @@ export { Index } from 'react-instantsearch-core';
 export { InstantSearch } from 'react-instantsearch-core';
 export { InstantSearchProps } from 'react-instantsearch-core';
 export { Configure } from 'react-instantsearch-core';
+export { ExperimentalConfigureRelatedItems } from 'react-instantsearch-core';
+export { QueryRuleContext } from 'react-instantsearch-core';
 
 // Connectors
 export { connectAutoComplete } from 'react-instantsearch-core';
@@ -45,6 +47,9 @@ export { connectSortBy } from 'react-instantsearch-core';
 export { connectStateResults } from 'react-instantsearch-core';
 export { connectStats } from 'react-instantsearch-core';
 export { connectToggleRefinement } from 'react-instantsearch-core';
+export { EXPERIMENTAL_connectConfigureRelatedItems } from 'react-instantsearch-core';
+export { connectHitInsights } from 'react-instantsearch-core';
+export { connectQueryRules } from 'react-instantsearch-core';
 
 // DOM
 interface CommonWidgetProps {
@@ -121,3 +126,36 @@ export class Stats extends React.Component<{
   };
 }> {}
 export class ToggleRefinement extends React.Component<any> {}
+
+export class VoiceSearch extends React.Component<any> {}
+
+export class QueryRuleCustomData extends React.Component<any> {}
+
+// helper functions
+export function getInsightsAnonymousUserToken(): string | undefined;
+export function createClassNames(baseName: string): (...elements: string[]) => string | string[];
+
+export type VoiceSearchHelperParams = {
+  searchAsYouSpeak: boolean;
+  language?: string;
+  onQueryChange: (query: string) => void;
+  onStateChange: () => void;
+};
+
+export type Status = 'initial' | 'askingPermission' | 'waiting' | 'recognizing' | 'finished' | 'error';
+
+export type VoiceListeningState = {
+  status: Status;
+  transcript: string;
+  isSpeechFinal: boolean;
+  errorCode?: SpeechRecognitionErrorCode;
+};
+
+export type VoiceSearchHelper = {
+  getState: () => VoiceListeningState;
+  isBrowserSupported: () => boolean;
+  isListening: () => boolean;
+  toggleListening: () => void;
+  dispose: () => void;
+};
+export function createVoiceSearchHelper(params: VoiceSearchHelperParams): VoiceSearchHelper;

--- a/types/react-instantsearch-dom/react-instantsearch-dom-tests.tsx
+++ b/types/react-instantsearch-dom/react-instantsearch-dom-tests.tsx
@@ -1,25 +1,23 @@
 import * as React from 'react';
-import { InstantSearch, Hits, Highlight, SearchBox, RefinementList, CurrentRefinements, ClearRefinements, Pagination, Menu, Configure, Index } from 'react-instantsearch/dom';
+import {
+  InstantSearch,
+  Hits,
+  Highlight,
+  SearchBox,
+  RefinementList,
+  CurrentRefinements,
+  ClearRefinements,
+  Pagination,
+  Menu,
+  Configure,
+  Index
+} from 'react-instantsearch/dom';
 import { Hit, connectRefinementList, connectMenu } from 'react-instantsearch-core';
 
 // DOM
-// https://community.algolia.com/react-instantsearch/Getting_started.html
 () => {
-  const App1 = () => (
-    <InstantSearch
-      appId="latency"
-      apiKey="3d9875e51fbd20c7754e65422f7ce5e1"
-      indexName="bestbuy"
-    >
-      <Search />
-    </InstantSearch>
-  );
-
-  const App2 = () => (
-    <InstantSearch
-      searchClient={{}}
-      indexName="bestbuy"
-    >
+  const App = () => (
+    <InstantSearch searchClient={{}} indexName="bestbuy">
       <Search />
     </InstantSearch>
   );
@@ -88,10 +86,7 @@ import { Hit, connectRefinementList, connectMenu } from 'react-instantsearch-cor
 
   function App() {
     return (
-      <InstantSearch
-        indexName="instant_search"
-        searchClient={{}}
-      >
+      <InstantSearch indexName="instant_search" searchClient={{}}>
         <Hits hitComponent={Hit} />
       </InstantSearch>
     );
@@ -136,14 +131,8 @@ import { Hit, connectRefinementList, connectMenu } from 'react-instantsearch-cor
 // https://community.algolia.com/react-instantsearch/guide/i18n.html
 () => {
   const App = () => (
-    <InstantSearch
-      indexName="..."
-      searchClient={{}}
-    >
-      <Menu
-        attribute="fruits"
-        translations={{ showMore: 'Voir plus' }}
-      />
+    <InstantSearch indexName="..." searchClient={{}}>
+      <Menu attribute="fruits" translations={{ showMore: 'Voir plus' }} />
     </InstantSearch>
   );
 };
@@ -170,10 +159,7 @@ import { Hit, connectRefinementList, connectMenu } from 'react-instantsearch-cor
 // https://community.algolia.com/react-instantsearch/guide/Default_refinements.html
 () => {
   const App = () => (
-    <InstantSearch
-      indexName="..."
-      searchClient={{}}
-    >
+    <InstantSearch indexName="..." searchClient={{}}>
       <SearchBox defaultRefinement="hi" />
       <Menu attribute="fruits" defaultRefinement="Orange" />
     </InstantSearch>
@@ -209,41 +195,28 @@ import { Hit, connectRefinementList, connectMenu } from 'react-instantsearch-cor
 
 () => {
   // https://community.algolia.com/react-instantsearch/guide/Search_parameters.html
-  <InstantSearch
-    indexName="indexName"
-    searchClient={{}}
-  >
-    <Configure distinct={1}/>
+  <InstantSearch indexName="indexName" searchClient={{}}>
+    <Configure distinct={1} />
     // widgets
   </InstantSearch>;
 };
 
-(() => {
-  function onSearchBoxChange(event: React.SyntheticEvent<HTMLInputElement>) {
-  }
+() => {
+  function onSearchBoxChange(event: React.SyntheticEvent<HTMLInputElement>) {}
 
-  function onSearchBoxReset(event: React.SyntheticEvent<HTMLFormElement>) {
-  }
+  function onSearchBoxReset(event: React.SyntheticEvent<HTMLFormElement>) {}
 
-  function onSearchBoxSubmit(event: React.SyntheticEvent<HTMLFormElement>) {
-  }
+  function onSearchBoxSubmit(event: React.SyntheticEvent<HTMLFormElement>) {}
 
-  <SearchBox
-      onChange={onSearchBoxChange} onReset={onSearchBoxReset} onSubmit={onSearchBoxSubmit}
-      submit={<></>} />;
-});
+  <SearchBox onChange={onSearchBoxChange} onReset={onSearchBoxReset} onSubmit={onSearchBoxSubmit} submit={<></>} />;
+};
 
-import { createInstantSearch } from 'react-instantsearch-dom/server';
+import { findResultsState } from 'react-instantsearch-dom/server';
 // import { createServer } from 'http';
 declare function createServer(handler: (req: any, res: any) => any): any;
 import { renderToString } from 'react-dom/server';
 
-() => {
-  // https://community.algolia.com/react-instantsearch/guide/Server-side_rendering.html
-
-  // Now we create a dedicated `InstantSearch` component
-  const { InstantSearch, findResultsState } = createInstantSearch();
-
+const test = () => {
   class App extends React.Component<any> {
     render() {
       return (
@@ -261,12 +234,12 @@ import { renderToString } from 'react-dom/server';
   }
 
   const server = createServer(async (req, res) => {
-    const searchState = {query: 'chair'};
-    const resultsState = await findResultsState(App, {searchState});
-    const appInitialState = {searchState, resultsState};
+    const searchState = { query: 'chair' };
+    const resultsState = await findResultsState(App, { searchState });
+    const appInitialState = { searchState, resultsState };
     const appAsString = renderToString(<App {...appInitialState} />);
     res.send(
-  `
+      `
   <!doctype html>
   <html>
     <body>

--- a/types/react-instantsearch-dom/server.d.ts
+++ b/types/react-instantsearch-dom/server.d.ts
@@ -1,14 +1,3 @@
 import * as React from 'react';
 
-/**
- * Creates a specialized root InstantSearch component. It accepts
- * an algolia client and a specification of the root Element.
- * @param defaultAlgoliaClient - a function that builds an Algolia client
- * @returns an InstantSearch root
- */
-export function createInstantSearch(
-  defaultAlgoliaClient?: (appId: string, apiKey: string, options: { _useRequestCache: boolean }) => object
-): {
-  InstantSearch: React.ComponentClass<any>;
-  findResultsState(App: React.ComponentType<any>, props: any): Promise<any>
-};
+export function findResultsState(App: React.ComponentType<any>, props: any): Promise<any>;

--- a/types/react-instantsearch-native/index.d.ts
+++ b/types/react-instantsearch-native/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-instantsearch-native 5.3
+// Type definitions for react-instantsearch-native 6.3
 // Project: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react, https://community.algolia.com/react-instantsearch
 // Definitions by: Gordon Burgett <https://github.com/gburgett>
 //                 Justin Powell <https://github.com/jpowell>
@@ -16,6 +16,9 @@ export { translatable } from 'react-instantsearch-core';
 
 // Widget
 export { Configure } from 'react-instantsearch-core';
+export { InstantSearch } from 'react-instantsearch-core';
+export { InstantSearchProps } from 'react-instantsearch-core';
+export { Index } from 'react-instantsearch-core';
 
 // Connectors
 export { connectAutoComplete } from 'react-instantsearch-core';
@@ -40,38 +43,3 @@ export { connectSortBy } from 'react-instantsearch-core';
 export { connectStateResults } from 'react-instantsearch-core';
 export { connectStats } from 'react-instantsearch-core';
 export { connectToggleRefinement } from 'react-instantsearch-core';
-
-// Native
-interface InstantSearchBaseProps {
-    indexName: string;
-    createURL?: (...args: any[]) => any;
-    searchState?: any;
-    refresh?: boolean;
-    onSearchStateChange?: (...args: any[]) => any;
-    onSearchParameters?: (...args: any[]) => any;
-    resultsState?: any;
-    root?: {
-        Root: string | ((...args: any[]) => any);
-        props: any;
-    };
-}
-
-export interface UsingSearchClientProps extends InstantSearchBaseProps {
-    searchClient: any;
-}
-
-export interface UsingManualInfoProps extends InstantSearchBaseProps {
-    apiKey: string;
-    appId: string;
-    algoliaClient?: any;
-}
-
-export type InstantSearchProps = UsingSearchClientProps | UsingManualInfoProps;
-/**
- * <InstantSearch> is the root component of all React InstantSearch implementations. It provides all the connected components (aka widgets) a means to interact with the searchState.
- *
- * https://community.algolia.com/react-instantsearch/widgets/%3CInstantSearch%3E.html
- */
-export class InstantSearch extends React.Component<InstantSearchProps> {}
-
-export class Index extends React.Component<any> {}

--- a/types/react-instantsearch-native/react-instantsearch-native-tests.tsx
+++ b/types/react-instantsearch-native/react-instantsearch-native-tests.tsx
@@ -1,43 +1,10 @@
 import * as React from "react";
 
-import { SearchBox, Hits, Highlight, Menu } from "react-instantsearch-dom";
+import { SearchBox, Hits } from "react-instantsearch-dom";
 import { InstantSearch, Index, connectStateResults } from 'react-instantsearch-native';
 import { values } from 'lodash';
 
 // https://community.algolia.com/react-instantsearch/guide/Conditional_display.html
-const App1 = () => (
-  <InstantSearch appId="" apiKey="" indexName="first">
-    <SearchBox />
-    <AllResults>
-      <div>
-        <Index indexName="first">
-          <IndexResults>
-            <div>
-              <div>first: </div>
-              <Hits />
-            </div>
-          </IndexResults>
-        </Index>
-        <Index indexName="second">
-          <IndexResults>
-            <div>
-              <div>second: </div>
-              <Hits />
-            </div>
-          </IndexResults>
-        </Index>
-        <Index indexName="third">
-          <IndexResults>
-            <div>
-              <div>third: </div>
-              <Hits />
-            </div>
-          </IndexResults>
-        </Index>
-      </div>
-    </AllResults>
-  </InstantSearch>
-);
 
 const App2 = () => (
   <InstantSearch searchClient={{}} indexName="first">

--- a/types/react-instantsearch/index.d.ts
+++ b/types/react-instantsearch/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-instantsearch 5.2
+// Type definitions for react-instantsearch 6.3
 // Project: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react
 // Definitions by: Gordon Burgett <https://github.com/gburgett>
 //                 Justin Powell <https://github.com/jpowell>

--- a/types/react-instantsearch/react-instantsearch-tests.tsx
+++ b/types/react-instantsearch/react-instantsearch-tests.tsx
@@ -2,8 +2,7 @@ import * as React from "react";
 
 import { connectMenu, connectRefinementList, connectStateResults, SearchState } from "react-instantsearch/connectors";
 import { InstantSearch, SearchBox, Index, Hits, Highlight, Menu } from "react-instantsearch/dom";
-import { orderBy, omit, values } from 'lodash';
-import { createInstantSearch } from "react-instantsearch-core";
+import { values } from 'lodash';
 
 // https://community.algolia.com/react-instantsearch/guide/Search_state.html
 () => {
@@ -323,21 +322,6 @@ import { createInstantSearch } from "react-instantsearch-core";
       children as React.ReactElement
     );
   });
-};
-
-// https://github.com/algolia/react-instantsearch/blob/master/packages/react-instantsearch-dom/src/widgets/InstantSearch.js
-() => {
-  const InstantSearch = createInstantSearch(
-    () => ({}),
-    {
-      Root: 'div',
-      props: {
-        className: 'ais-InstantSearch__root',
-      },
-    }
-  );
-
-  <InstantSearch />;
 };
 
 () => {

--- a/types/react-instantsearch/server.d.ts
+++ b/types/react-instantsearch/server.d.ts
@@ -1,1 +1,1 @@
-export { createInstantSearch } from 'react-instantsearch-dom/server';
+export { findResultsState } from 'react-instantsearch-dom/server';


### PR DESCRIPTION
- createIndex & createInstantSearch no longer exist, replaced by the component in -core
- InstantSearch no longer accepts appId & apiKey
- InstantSearch no longer accepts `root` (& neither Index, but that wasn't typed)
- /server API has changed, now exposes directly `findResultsState`

fixes https://github.com/algolia/react-instantsearch/issues/2900

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/react/#upgrade-from-v5-to-v6
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
