### PR TITLE
Make RedisStore a class and expose RedisStoreOptions in rate-limit-redis

### DIFF
--- a/types/rate-limit-redis/index.d.ts
+++ b/types/rate-limit-redis/index.d.ts
@@ -11,7 +11,7 @@ import IORedis = require('ioredis');
 import { Store, StoreIncrementCallback } from 'express-rate-limit';
 
 declare namespace RedisStore {
-    interface RedisStoreOptions {
+    interface Options {
         expiry?: number;
         prefix?: string;
         resetExpiryOnChange?: boolean;
@@ -21,7 +21,7 @@ declare namespace RedisStore {
 }
 
 declare class RedisStore implements Store {
-    constructor(options?: RedisStore.RedisStoreOptions);
+    constructor(options?: RedisStore.Options);
     incr(key: string, cb: StoreIncrementCallback): void;
     decrement(key: string): void;
     resetKey(key: string): void;

--- a/types/rate-limit-redis/index.d.ts
+++ b/types/rate-limit-redis/index.d.ts
@@ -8,18 +8,27 @@
 
 import { RedisClient } from 'redis';
 import IORedis = require('ioredis');
-import { Store } from 'express-rate-limit';
+import { Store, StoreIncrementCallback } from 'express-rate-limit';
 
-interface RedisStoreOptions {
-    expiry?: number;
-    prefix?: string;
-    resetExpiryOnChange?: boolean;
-    client?: RedisClient | IORedis.Redis;
-    redisURL?: string;
+declare namespace RedisStore {
+    interface RedisStoreOptions {
+        expiry?: number;
+        prefix?: string;
+        resetExpiryOnChange?: boolean;
+        client?: RedisClient | IORedis.Redis;
+        redisURL?: string;
+    }
 }
 
-declare var RedisStore: {
-    new (options?: RedisStoreOptions): Store;
-};
+declare class RedisStore implements Store {
+    constructor(options?: RedisStore.RedisStoreOptions);
+    incr(key: string, cb: StoreIncrementCallback): void;
+    decrement(key: string): void;
+    resetKey(key: string): void;
+    // rate-limit-redis 1.7.0 doesn't actually implement resetAll() and
+    // express-rate-limit 5.1.1 doesn't actually call it, but it's required by
+    // the Store interface so it's included here.
+    resetAll(): void;
+}
 
 export = RedisStore;

--- a/types/rate-limit-redis/rate-limit-redis-tests.ts
+++ b/types/rate-limit-redis/rate-limit-redis-tests.ts
@@ -1,39 +1,38 @@
 import { RedisClient } from 'redis';
 import IORedis = require('ioredis');
 import RedisStore from 'rate-limit-redis';
-import { Store } from 'express-rate-limit';
 
-let store: Store;
+let store: RedisStore;
 
-// $ExpectType Store
+// $ExpectType RedisStore
 store = new RedisStore();
 
-// $ExpectType Store
+// $ExpectType RedisStore
 store = new RedisStore({
     expiry: 1000,
 });
 
-// $ExpectType Store
+// $ExpectType RedisStore
 store = new RedisStore({
     prefix: 'types',
 });
 
-// $ExpectType Store
+// $ExpectType RedisStore
 store = new RedisStore({
     resetExpiryOnChange: false,
 });
 
-// $ExpectType Store
+// $ExpectType RedisStore
 store = new RedisStore({
     client: new RedisClient({}),
 });
 
-// $ExpectType Store
+// $ExpectType RedisStore
 store = new RedisStore({
     client: new IORedis({}),
 });
 
-// $ExpectType Store
+// $ExpectType RedisStore
 store = new RedisStore({
     redisURL: 'redis://localhost:6379',
 });


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/rate-limit-redis. Rate Limit Redis is used like a class with "new" and implements a TypeScript interface, so it should be declared as a class. This allows users to declare the type of the variable returned from "new RedisStore({})".
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.