### PR TITLE
[js-yaml] fix: add missing listener option

### DIFF
--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -49,10 +49,10 @@ export interface LoadOptions {
 	/** compatibility with JSON.parse behaviour. */
 	json?: boolean;
 	/** listener for parse events */
-	listener?: (eventType: EventType, state: State) => void
+	listener?: (eventType: EventType, state: State) => void;
 }
 
-export type EventType = 'open' | 'close'
+export type EventType = 'open' | 'close';
 
 export interface State {
 	input: string;

--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -49,7 +49,7 @@ export interface LoadOptions {
 	/** compatibility with JSON.parse behaviour. */
 	json?: boolean;
 	/** listener for parse events */
-	listener?: (eventType: EventType, state: State) => void;
+	listener?(this: State, eventType: EventType, state: State): void;
 }
 
 export type EventType = 'open' | 'close';

--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -48,6 +48,28 @@ export interface LoadOptions {
 	schema?: SchemaDefinition;
 	/** compatibility with JSON.parse behaviour. */
 	json?: boolean;
+	/** listener for parse events */
+	listener?: (eventType: EventType, state: State) => void
+}
+
+export type EventType = 'open' | 'close'
+
+export interface State {
+	input: string;
+	filename: string | null;
+	schema: SchemaDefinition;
+	onWarning: (this: null, e: YAMLException) => void;
+	json: boolean;
+	length: number;
+	position: number;
+	line: number;
+	lineStart: number;
+	lineIndent: number;
+	version: null | number;
+	checkLineBreaks: boolean;
+	kind: string;
+	result: any;
+	implicitTypes: Type[];
 }
 
 export interface DumpOptions {

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -68,6 +68,12 @@ loadOpts = {
 loadOpts = {
 	schema: yaml.DEFAULT_SAFE_SCHEMA,
 };
+loadOpts = {
+	listener: (eventType, state) => {
+        state.position;
+        state.result;
+    },
+};
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -69,10 +69,12 @@ loadOpts = {
 	schema: yaml.DEFAULT_SAFE_SCHEMA,
 };
 loadOpts = {
-	listener: (eventType, state) => {
-        state.position;
-        state.result;
-    },
+	listener(eventType: yaml.EventType, state) {
+		this; // $ExpectType State
+		state; // $ExpectType State
+		state.position;
+		state.result;
+	},
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/nodeca/js-yaml/blob/master/test/issues/0248-listener.js
https://github.com/nodeca/js-yaml/blob/master/lib/js-yaml/loader.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
