### PR TITLE
[@types/leaflet] L.Util.bind() causes Argument of type '(done: L.DoneCallback, tile: HTMLElement) => void' is not assignable to parameter of type '() => void'

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1952,7 +1952,7 @@ export namespace Util {
     function extend(dest: any, ...src: any[]): any;
 
     function create(proto: object | null, properties?: PropertyDescriptorMap): any;
-    function bind(fn: () => void, ...obj: any[]): () => void;
+    function bind(fn: (...args: any[]) => void, ...obj: any[]): () => void;
     function stamp(obj: any): number;
     function throttle(fn: () => void, time: number, context: any): () => void;
     function wrapNum(num: number, range: number[], includeMax?: boolean): number;

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -808,6 +808,8 @@ export class TileLayer extends GridLayer {
     setUrl(url: string, noRedraw?: boolean): this;
     getTileUrl(coords: L.Coords): string;
 
+    protected _tileOnLoad(done: L.DoneCallback, tile: HTMLElement): void;
+    protected _tileOnError(done: L.DoneCallback, tile: HTMLElement, e: Error): void;
     protected _abortLoading(): void;
     protected _getZoomForUrl(): number;
 

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -741,6 +741,16 @@ export class ExtendedTileLayer extends L.TileLayer {
 		return super.createTile(newCoords, done);
 	}
 
+	overrideCreateTile(coords: L.Coords, done: L.DoneCallback) {
+		// adapted from TileLayer's implementation
+		const tile = document.createElement('img');
+
+		L.DomEvent.on(tile, 'load', L.Util.bind(this._tileOnLoad, this, done, tile));
+		L.DomEvent.on(tile, 'error', L.Util.bind(this._tileOnError, this, done, tile));
+
+		return tile;
+	}
+
 	getTileUrl(coords: L.Coords) {
 		return super.getTileUrl(coords);
 	}

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -661,6 +661,8 @@ L.Util.create({});
 L.Util.create(null, { foo: { writable: true, value: 'bar' } });
 
 L.Util.bind(() => {}, {});
+const fnWithArguments = (done: L.DoneCallback, tile: HTMLElement): void => {};
+L.Util.bind(fnWithArguments, {}, {} as L.DoneCallback, {} as HTMLElement);
 L.Util.stamp({});
 L.Util.throttle(() => {}, 123, {});
 L.Util.wrapNum(123, []);


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Leaflet/Leaflet/blob/e213469a296ea00e6f9e6e6beb49d081e8d1c4fe/src/layer/tile/TileLayer.js#L139-L140

Compiling code similar to above causes:
> Argument of type '(done: L.DoneCallback, tile: HTMLElement) => void' is not assignable to parameter of type '() => void'.