### PR TITLE
[Simplebar] Allow typings to work with strictNullChecks enabled

### DIFF
--- a/types/simplebar/index.d.ts
+++ b/types/simplebar/index.d.ts
@@ -30,7 +30,7 @@ declare namespace SimpleBar {
         scrollbarMaxSize?: number;
     }
 
-    interface ClassNamesOptions {
+    interface KnownClassNamesOptions {
         contentEl?: string;
         contentWrapper?: string;
         offset?: string;
@@ -46,6 +46,9 @@ declare namespace SimpleBar {
         vertical?: string;
         hover?: string;
         dragging?: string;
-        [className: string]: string;
     }
+
+    type ClassNamesOptions = KnownClassNamesOptions & {
+        [className: string]: string;
+    };
 }


### PR DESCRIPTION
Context:
The `ClassNamesOptions` include both known options as well as unknown options (via a index signature). Since the named options are optional, the keys of `ClassNamesOptions` must allow for undefined which is not a valid type for an index signature. When `strictNullChecks` is enabled, we receive errors for each of the known options such as the following:

```
ERROR in node_modules/@types/simplebar/index.d.ts:34:9 - error TS2411: Property 'contentEl' of type 'string | undefined' is not assignable to string index type 'string'.
```

Solution:
This PR changes `ClassNamesOptions` into an intersection type that splits the known and unknown options and allow both scenarios to be handled by this interface.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: this PR
