### PR TITLE
feat(merge-img): new type definition v2.1

### DIFF
--- a/types/merge-img/index.d.ts
+++ b/types/merge-img/index.d.ts
@@ -1,0 +1,88 @@
+// Type definitions for merge-img 2.1
+// Project: https://github.com/preco21/merge-img#readme
+// Definitions by: Piotr Błażejewicz (Peter Blazejewicz) <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import Jimp = require('jimp');
+
+/**
+ * Merges given images into a single image in right order.
+ * This will be helpful in a situation when you have to generate a preview of multiple images into a single image.
+ * This module is based on Jimp for image processing.
+ */
+export default function mergeImg(
+    images: Array<string | ImageDescriptor | Buffer | Jimp>,
+    options?: Options,
+): Promise<Jimp>;
+
+export interface ImageDescriptor {
+    /**
+     * A single image source to concat
+     */
+    src: string | Buffer;
+    /**
+     * x offset to affect this image
+     * @default 0
+     */
+    offsetX?: number;
+    /**
+     * y offset to affect this image
+     * @default 0
+     */
+    offsetY?: number;
+}
+
+export interface Options {
+    /**
+     * Direction of the merged image. If this value is true, the images will be merged vertically (column).
+     * Otherwise, the images will be merged horizontally (row)
+     * @default false
+     */
+    direction?: boolean;
+    /**
+     * Default background color represented by RGBA hex value.
+     * @default 0x00000000
+     */
+    color?: number;
+    /**
+     * Aligning of given images. If the images are not all the same size, images will be sorted to largest image
+     * @default 'start'
+     */
+    align?: 'start' | 'center' | 'end';
+    /**
+     * Offset in pixels between each image
+     * @default 0
+     */
+    offset?: number;
+    /**
+     * Margin of the result image.
+     * If `number` or `string` is passed, it will be considered as standard
+     * css shorthand properties (e.g. '40 40 0 10')
+     */
+    margin?: number | string | MarginOptions;
+}
+
+export interface MarginOptions {
+    /**
+     * Margin on top side of result image
+     * @default 0
+     */
+    top?: number;
+    /**
+     * Margin on right side of result image
+     * @default 0
+     */
+    right?: number;
+    /**
+     * Margin on bottom side of result image
+     * @default 0
+     */
+    bottom?: number;
+    /**
+     * Margin on left side of result image
+     * @default 0
+     */
+    left?: number;
+}

--- a/types/merge-img/merge-img-tests.ts
+++ b/types/merge-img/merge-img-tests.ts
@@ -1,0 +1,45 @@
+import mergeImg from 'merge-img';
+import { resolve } from 'path';
+const fixturePath = resolve(__dirname, 'fixtures');
+
+mergeImg(['image-1.png', 'image-2.jpg']).then(img => {
+    // Save image as file
+    img.write('out.png', () => console.log('done'));
+});
+
+mergeImg([
+    {
+        src: `${fixturePath}/example.png`,
+        offsetX: 5,
+    },
+    {
+        src: `${fixturePath}/example.png`,
+        offsetX: 10,
+    },
+]);
+
+mergeImg([`${fixturePath}/example.png`, `${fixturePath}/example.png`], {
+    direction: true,
+    color: 0xffffffff,
+    align: 'center',
+    offset: 10,
+});
+mergeImg([
+    {
+        src: `${fixturePath}/example.png`,
+        offsetY: 20,
+    },
+    {
+        src: `${fixturePath}/example.png`,
+        offsetX: 100,
+        offsetY: 150,
+    },
+]);
+mergeImg([`${fixturePath}/example.png`, `${fixturePath}/example.png`], {
+    margin: {
+        top: 40,
+        right: 40,
+        bottom: 0,
+        left: 10,
+    },
+});

--- a/types/merge-img/package.json
+++ b/types/merge-img/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "jimp": "^0.9.5"
+    }
+}

--- a/types/merge-img/tsconfig.json
+++ b/types/merge-img/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "merge-img-tests.ts"
+    ]
+}

--- a/types/merge-img/tslint.json
+++ b/types/merge-img/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition type file
- tests

Used in BacktopJS tool:
https://github.com/preco21/merge-img#readme

~~Depends on:
microsoft/types-publisher#754~~

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. 
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.