### PR TITLE
Component emitter event

### DIFF
--- a/types/component-emitter/component-emitter-tests.ts
+++ b/types/component-emitter/component-emitter-tests.ts
@@ -50,3 +50,30 @@ emitter.listeners('some-recurring-event')
 emitter.hasListeners('some-recurring-event')
 
 emitter.emit('some-event').emit("I can use chaining!")
+
+let recurlyEmitter: Emitter<'change' | 'field:submit'> = new Emitter();
+
+recurlyEmitter.on('change', handleSomeRecurringEvent);
+// $ExpectError
+recurlyEmitter.on('some-recurring-event', handleSomeRecurringEvent);
+
+recurlyEmitter.once('field:submit', (event_data: any) => {console.log('handle some-single-shot-event')})
+// $ExpectError
+recurlyEmitter.once('some-single-shot-event', (event_data: any) => {console.log('handle some-single-shot-event')})
+
+recurlyEmitter.off()
+recurlyEmitter.off('change')
+// $ExpectError
+recurlyEmitter.off('some-recurring-event')
+
+recurlyEmitter.emit('field:submit', event_data)
+// $ExpectError
+recurlyEmitter.emit('some-recurring-event', event_data)
+
+recurlyEmitter.listeners('change')
+// $ExpectError
+recurlyEmitter.listeners('some-recurring-event')
+
+recurlyEmitter.hasListeners("field:submit");
+// $ExpectError
+recurlyEmitter.hasListeners('some-recurring-event')

--- a/types/component-emitter/index.d.ts
+++ b/types/component-emitter/index.d.ts
@@ -5,13 +5,13 @@
 
 // TypeScript Version: 2.2
 
-interface Emitter {
-    on(event: string, listener: Function): Emitter;
-    once(event: string, listener: Function): Emitter;
-    off(event?: string, listener?: Function): Emitter;
-    emit(event: string, ...args: any[]): Emitter;
-    listeners(event: string): Function[];
-    hasListeners(event: string): boolean;
+interface Emitter<Event = string> {
+    on(event: Event, listener: Function): Emitter;
+    once(event: Event, listener: Function): Emitter;
+    off(event?: Event, listener?: Function): Emitter;
+    emit(event: Event, ...args: any[]): Emitter;
+    listeners(event: Event): Function[];
+    hasListeners(event: Event): boolean;
 }
 
 declare const Emitter: {


### PR DESCRIPTION
**Original stale PR here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41172**

Adding a generic `Event` type to allow consumers to pass in more restrictive typing for their emitter's events, most likely an enum or union of strings. If no generic is passed in, `Event` is typed as a string by default, preventing this from being a breaking change and allowing current usage to persist.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
