### PR TITLE
feat(cfn-response) Added noEcho and Promise<void> return type

### DIFF
--- a/types/cfn-response/cfn-response-tests.ts
+++ b/types/cfn-response/cfn-response-tests.ts
@@ -4,9 +4,9 @@ import { CloudFormationCustomResourceEvent, Context } from "aws-lambda";
 declare const event: CloudFormationCustomResourceEvent;
 declare const context: Context;
 
-// $ExpectType void
-cfn.send(event, context, cfn.SUCCESS, { sample: 123 }, "abc");
-// $ExpectType void
+// $ExpectType Promise<void>
+cfn.send(event, context, cfn.SUCCESS, { sample: 123 }, "abc", true);
+// $ExpectType Promise<void>
 cfn.send(event, context, "SUCCESS");
 // $ExpectError
 cfn.send(event, context, "", {});

--- a/types/cfn-response/index.d.ts
+++ b/types/cfn-response/index.d.ts
@@ -15,5 +15,6 @@ export function send(
     context: Context,
     responseStatus: ResponseStatus,
     responseData?: object,
-    physicalResourceId?: string
-): void;
+    physicalResourceId?: string,
+    noEcho?: boolean
+): Promise<void>;


### PR DESCRIPTION
Updated typings to the latest version of cfn-response.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.amazonaws.cn/en_us/AWSCloudFormation/latest/UserGuide/cfn-lambda-function-code-cfnresponsemodule.html#w2ab1c19c25c14b9c15 (unfortunately, the source code on that page is outdated and does not show the `Promise` being returned, however if you create an AWS Lambda function using `AWS::Lambda::Function`'s [ZipFile field](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-zipfile) with `nodejs12.x` as the runtime, you'll get a version of the code that returns `Promise<void>`)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.