### PR TITLE
[express-redis-cache] Include ExpirationConfig and ExpirationPolicy to expire option

### DIFF
--- a/types/express-redis-cache/express-redis-cache-tests.ts
+++ b/types/express-redis-cache/express-redis-cache-tests.ts
@@ -8,23 +8,30 @@ const cache = expressRedisCache();
 expressRedisCache({ host: 'localhsot', port: 6379, auth_pass: 'passw0rd' });
 expressRedisCache({ client: redis.createClient() });
 
-cache.on('error', (error) => {
+cache.on('error', error => {
     throw new Error('Cache error!');
 });
 
-app.get('/',
+app.get(
+    '/',
     cache.route(), // cache entry name is `cache.prefix + "/"`
-    (req, res, next) => { });
+    (req, res, next) => {},
+);
 
-app.get('/',
+app.get(
+    '/',
     cache.route('home'), // cache entry name is now `cache.prefix + "home"`
-    (req, res, next) => { });
+    (req, res, next) => {},
+);
 
-app.get('/',
+app.get(
+    '/',
     cache.route({ name: 'home' }), // cache entry name is `cache.prefix + "home"`
-    (req, res, next) => { });
+    (req, res, next) => {},
+);
 
-app.get('/user/:userid',
+app.get(
+    '/user/:userid',
     // middleware to define cache name
     (req, res, next) => {
         // set cache name
@@ -36,10 +43,11 @@ app.get('/user/:userid',
     // content middleware
     (req, res) => {
         res.render('user');
-    }
+    },
 );
 
-app.get('/user',
+app.get(
+    '/user',
     // middleware to decide if using cache
     (req, res, next) => {
         // Use only cache if user not signed in
@@ -49,7 +57,7 @@ app.get('/user',
     cache.route(), // this will be skipped if user is signed in
     (req, res) => {
         res.render('user');
-    }
+    },
 );
 
 // Prefix
@@ -57,10 +65,20 @@ expressRedisCache({ prefix: 'test' });
 
 // Expiration
 expressRedisCache({ expire: 60 });
+expressRedisCache({
+    expire: {
+        200: 5000,
+        '4xx': 10,
+        403: 5000,
+        '5xx': 10,
+        xxx: 1,
+    },
+});
 
-app.get('/index.html',
+app.get(
+    '/index.html',
     cache.route({ expire: 5000 }), // cache entry will live 5000 seconds
-    (req, res) => { }
+    (req, res) => {},
 );
 
 // You can also use the number sugar syntax
@@ -68,17 +86,18 @@ cache.route(5000);
 // Or
 cache.route('index', 5000);
 
-app.get('/index.html',
+app.get(
+    '/index.html',
     cache.route({
         expire: {
             200: 5000,
             '4xx': 10,
             403: 5000,
             '5xx': 10,
-            xxx: 1
-        }
+            xxx: 1,
+        },
     }),
-    (req, res) => { }
+    (req, res) => {},
 );
 
 cache.get((error, entries) => {
@@ -92,14 +111,10 @@ cache.add(
     'user:info',
     JSON.stringify({ id: 1, email: 'john@doe.com' }),
     { expire: 60 * 60 * 24, type: 'json' },
-    (error, added) => {}
+    (error, added) => {},
 );
 
-cache.add(
-    'user:info',
-    JSON.stringify({ id: 1, email: 'john@doe.com' }),
-    (error, added) => {}
-);
+cache.add('user:info', JSON.stringify({ id: 1, email: 'john@doe.com' }), (error, added) => {});
 
 cache.del('home', (error, deleted) => {});
 cache.size((error, bytes) => {});

--- a/types/express-redis-cache/index.d.ts
+++ b/types/express-redis-cache/index.d.ts
@@ -55,13 +55,13 @@ declare namespace expressRedisCache {
         [statusCode: string]: number;
     }
 
-    type ExpireOption = number | ExpirationConfig;
     type ExpirationPolicy = (req: express.Request, res: express.Response) => number;
+    type ExpireOption = number | ExpirationConfig | ExpirationPolicy;
 
     interface Options {
         auth_pass?: string;
         client?: redis.RedisClient;
-        expire?: number;
+        expire?: ExpireOption;
         host?: string;
         port?: string | number;
         prefix?: string;
@@ -69,7 +69,7 @@ declare namespace expressRedisCache {
 
     interface RouteOptions {
         name?: string;
-        expire?: ExpireOption | ExpirationPolicy;
+        expire?: ExpireOption;
         binary?: boolean;
     }
 }


### PR DESCRIPTION
Include ExpirationConfig and ExpirationPolicy as possible expire option types.

The `Options.expire` and `RouteOptions.expire` options are treated by the same functions. The Options bassed to the constructor serves as defaults, while you can override this with `RouteOptions`. Also, all three types `number | ExpirationConfig | ExpirationPolicy` are accepted by the expiration handler.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rv-kip/express-redis-cache/blob/master/lib/ExpressRedisCache/route.js#L136
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
