### PR TITLE
cypress-cucumber-preprocessor: Fix defineParameterType definition

### DIFF
--- a/types/cypress-cucumber-preprocessor/index.d.ts
+++ b/types/cypress-cucumber-preprocessor/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for cypress-cucumber-preprocessor 1.14
 // Project: https://github.com/TheBrainFamily/cypress-cucumber-preprocessor
-// Definitions by: Alec Brunelle <https://github.com/aleccool213>, Falcon Taylor-Carter <https://github.com/falconertc>
+// Definitions by: Alec Brunelle <https://github.com/aleccool213>
+//                 Falcon Taylor-Carter <https://github.com/falconertc>
+//                 Jens Peters <https://github.com/jp7677>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/cypress-cucumber-preprocessor/steps/index.d.ts
+++ b/types/cypress-cucumber-preprocessor/steps/index.d.ts
@@ -1,10 +1,19 @@
+export interface Transform {
+    regexp: RegExp;
+    transformer(...arg: string[]): any;
+    useForSnippets?: boolean;
+    preferForRegexpMatch?: boolean;
+    name?: string;
+    typeName?: string; // deprecated
+}
+
 export function given(expression: RegExp | string, implementation: (...args: any[]) => void): void;
 export function when(expression: RegExp | string, implementation: (...args: any[]) => void): void;
 export function then(expression: RegExp | string, implementation: (...args: any[]) => void): void;
 export function and(expression: RegExp | string, implementation: (...args: any[]) => void): void;
 export function but(expression: RegExp | string, implementation: (...args: any[]) => void): void;
 export function defineStep(expression: RegExp | string, implementation: (...args: any[]) => void): void;
-export function defineParameterType(): void;
+export function defineParameterType(parameterType: Transform): void;
 
 // Aliased versions of the above funcs.
 export function Given(expression: RegExp | string, implementation: (...args: any[]) => void): void;


### PR DESCRIPTION
* cypress-cucumber-preprocessor: Add Transform type definition and use it for defineParameterType definition

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/TheBrainFamily/cypress-cucumber-preprocessor/issues/323
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (this is not related to a new version)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. (this is no substantial change)

This PR fixes the defineParameterType definition from https://github.com/TheBrainFamily/cypress-cucumber-preprocessor as discussed in https://github.com/TheBrainFamily/cypress-cucumber-preprocessor/issues/323