### PR TITLE
Reflect useThemeUI api from theme-ui docs

### DIFF
--- a/types/theme-ui/index.d.ts
+++ b/types/theme-ui/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for theme-ui 0.3
+// Type definitions for theme-ui 0.4
 // Project: https://github.com/system-ui/theme-ui#readme
 // Definitions by: Erik Stockmeier <https://github.com/erikdstock>
 //                 Ifiok Jr. <https://github.com/ifiokjr>
@@ -7,6 +7,7 @@
 //                 Justin Hall <https://github.com/wKovacs64>
 //                 Prateek Kathal <https://github.com/prateekkathal>
 //                 Piotr Monwid-Olechnowicz <https://github.com/hasparus>
+//                 Leo Lin <https://github.com/leocantthinkfoaname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.5
 
@@ -195,7 +196,8 @@ export const Styled: {
 
 interface ThemeUIContext {
     theme: Theme;
-    components: { [P in keyof IntrinsicSxElements]: SxComponent<IntrinsicSxElements[P]> };
+    colorMode: string;
+    setColorMode: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export const Context: React.Context<ThemeUIContext>;

--- a/types/theme-ui/index.d.ts
+++ b/types/theme-ui/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for theme-ui 0.3.1
+// Type definitions for theme-ui 0.3
 // Project: https://github.com/system-ui/theme-ui#readme
 // Definitions by: Erik Stockmeier <https://github.com/erikdstock>
 //                 Ifiok Jr. <https://github.com/ifiokjr>

--- a/types/theme-ui/index.d.ts
+++ b/types/theme-ui/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for theme-ui 0.4
+// Type definitions for theme-ui 0.3.1
 // Project: https://github.com/system-ui/theme-ui#readme
 // Definitions by: Erik Stockmeier <https://github.com/erikdstock>
 //                 Ifiok Jr. <https://github.com/ifiokjr>

--- a/types/theme-ui/index.d.ts
+++ b/types/theme-ui/index.d.ts
@@ -9,7 +9,7 @@
 //                 Piotr Monwid-Olechnowicz <https://github.com/hasparus>
 //                 Leo Lin <https://github.com/leocantthinkfoaname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// TypeScript Version: 3.5
 
 import { SystemStyleObject } from '@styled-system/css';
 import * as CSS from 'csstype';

--- a/types/theme-ui/index.d.ts
+++ b/types/theme-ui/index.d.ts
@@ -9,7 +9,7 @@
 //                 Piotr Monwid-Olechnowicz <https://github.com/hasparus>
 //                 Leo Lin <https://github.com/leocantthinkfoaname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// Minimum TypeScript Version: 3.7
 
 import { SystemStyleObject } from '@styled-system/css';
 import * as CSS from 'csstype';

--- a/types/theme-ui/theme-ui-tests.tsx
+++ b/types/theme-ui/theme-ui-tests.tsx
@@ -1,7 +1,8 @@
 /** @jsx jsx */
-import { Flex, jsx, css, InitializeColorMode, ColorMode, Styled, SxStyleProp, Theme } from 'theme-ui';
+import { Flex, jsx, css, InitializeColorMode, ColorMode, Styled, SxStyleProp, Theme, useThemeUI } from 'theme-ui';
 
 export const Component = () => {
+    const { theme, colorMode, setColorMode } = useThemeUI();
     return (
         <>
             <InitializeColorMode />
@@ -18,7 +19,9 @@ export const Component = () => {
                 Works
             </Styled>
             <div sx={{ bg: 'red' }}>
+                <h1 sx={{ color: theme.colors?.primary }}>Current color mode: {colorMode}</h1>
                 <Flex sx={{ backgroundColor: 'pink' }} />
+                <button onClick={() => setColorMode('another-theme')}>Change Mode</button>
             </div>
         </>
     );

--- a/types/theme-ui/theme-ui-tests.tsx
+++ b/types/theme-ui/theme-ui-tests.tsx
@@ -19,7 +19,9 @@ export const Component = () => {
                 Works
             </Styled>
             <div sx={{ bg: 'red' }}>
-                <h1 sx={{ color: theme.colors?.primary }}>Current color mode: {colorMode}</h1>
+                <h1 sx={{ color: theme ? (theme.colors ? theme.colors.primary : '') : '' }}>
+                    Current color mode: {colorMode}
+                </h1>
                 <Flex sx={{ backgroundColor: 'pink' }} />
                 <button onClick={() => setColorMode('another-theme')}>Change Mode</button>
             </div>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://theme-ui.com/use-theme-ui>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Current type definition doesn't match the api given from official doc ( as shown as the url above ).