### PR TITLE
sinon: add async clocks

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -802,6 +802,11 @@ declare namespace Sinon {
         setSystemTime(date: Date): void;
 
         countTimers(): number;
+
+        tickAsync(ms: number | string): Promise<number>;
+        nextAsync(): Promise<number>;
+        runAllAsync(): Promise<number>;
+        runToLastAsync(): Promise<number>;
     }
 
     interface SinonFakeTimersConfig {

--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -870,6 +870,11 @@ declare namespace Sinon {
         setSystemTime(date: Date): void;
 
         countTimers(): number;
+
+        tickAsync(ms: number | string): Promise<number>;
+        nextAsync(): Promise<number>;
+        runAllAsync(): Promise<number>;
+        runToLastAsync(): Promise<number>;
     }
 
     interface SinonFakeTimersConfig {

--- a/types/sinon/ts3.1/sinon-tests.ts
+++ b/types/sinon/ts3.1/sinon-tests.ts
@@ -622,3 +622,17 @@ function testMock() {
     mock.restore();
     mock.verify();
 }
+
+async function testTimers() {
+    const clock = sinon.useFakeTimers();
+    clock.tick('500');
+    clock.tick(500);
+    clock.next();
+    clock.runAll();
+    clock.runToLastAsync();
+    await clock.tickAsync(500);
+    await clock.tickAsync('500');
+    await clock.nextAsync();
+    await clock.runAllAsync();
+    await clock.runToLastAsync();
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sinonjs/fake-timers
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

Updated to add some async clock methods. sinon docs doesn't document them but the sinon-timers ones do.