### PR TITLE
[chart.js] Add return type null to NestedTickOptions callback

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -77,6 +77,10 @@ const chart: Chart = new Chart(ctx, {
                                 return `${value}`;
                             }
 
+                            if (value === 30) {
+                                return undefined;
+                            }
+
                             return null;
                         },
                         sampleSize: 10,

--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -68,7 +68,17 @@ const chart: Chart = new Chart(ctx, {
             xAxes: [
                 {
                     ticks: {
-                        callback: Math.floor,
+                        callback: (value) => {
+                            if (value === 10) {
+                                return Math.floor(value);
+                            }
+
+                            if (value === 20) {
+                                return `${value}`;
+                            }
+
+                            return null;
+                        },
                         sampleSize: 10,
                     },
                     gridLines: {

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -562,7 +562,7 @@ declare namespace Chart {
         backdropPaddingX?: number;
         backdropPaddingY?: number;
         beginAtZero?: boolean;
-        callback?(value: any, index: any, values: any): string | number;
+        callback?(value: number, index: number, values: number[]): string | number | null;
         display?: boolean;
         fontColor?: ChartColor;
         fontFamily?: string;

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -562,7 +562,10 @@ declare namespace Chart {
         backdropPaddingX?: number;
         backdropPaddingY?: number;
         beginAtZero?: boolean;
-        callback?(value: number, index: number, values: number[]): string | number | null;
+        /**
+         * If the callback returns null or undefined the associated grid line will be hidden.
+         */
+        callback?(value: number | string, index: number, values: number[] | string[]): string | number | null | undefined;
         display?: boolean;
         fontColor?: ChartColor;
         fontFamily?: string;


### PR DESCRIPTION
I'm actually having a hard time finding a reference of the `callback` function in the Chart.js documentation but through trial and error I can say that giving the user the ability to return `null`, you can let them have the option to not display that particular tick in the axis.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.