### PR TITLE
[react-native-webrtc/react-native-webrtc] getUserMedia improper return type

### DIFF
--- a/types/react-native-webrtc/index.d.ts
+++ b/types/react-native-webrtc/index.d.ts
@@ -238,7 +238,7 @@ export class mediaDevices {
 
     static enumerateDevices(): Promise<any>;
 
-    static getUserMedia(constraints: MediaStreamConstraints): MediaStream;
+    static getUserMedia(constraints: MediaStreamConstraints): Promise<MediaStream | boolean>;
 }
 
 export function registerGlobals(): void;


### PR DESCRIPTION
When I was developing I noticed the getUserMedia was returning a promise and this was not documented in ts.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/react-native-webrtc/react-native-webrtc/blob/master/getUserMedia.js#L42>
