### PR TITLE
Integrate sinon with @sinonjs/fake-timers, with fixes

### DIFF
--- a/types/jest-sinon/tsconfig.json
+++ b/types/jest-sinon/tsconfig.json
@@ -13,6 +13,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/karma-chai-sinon/tsconfig.json
+++ b/types/karma-chai-sinon/tsconfig.json
@@ -13,6 +13,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/mochaccino/tsconfig.json
+++ b/types/mochaccino/tsconfig.json
@@ -13,6 +13,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/mock-req-res/tsconfig.json
+++ b/types/mock-req-res/tsconfig.json
@@ -13,6 +13,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/should-sinon/tsconfig.json
+++ b/types/should-sinon/tsconfig.json
@@ -13,6 +13,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/sinon-as-promised/tsconfig.json
+++ b/types/sinon-as-promised/tsconfig.json
@@ -13,6 +13,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/sinon-chai/tsconfig.json
+++ b/types/sinon-chai/tsconfig.json
@@ -13,6 +13,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/sinon-chai/v2/tsconfig.json
+++ b/types/sinon-chai/v2/tsconfig.json
@@ -16,7 +16,8 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
         "paths": {
-          "sinon-chai": [ "sinon-chai/v2" ]
+          "sinon-chai": [ "sinon-chai/v2" ],
+          "@sinonjs/fake-timers": [ "sinonjs__fake-timers" ]
         }
     },
     "files": [

--- a/types/sinon-chrome/tsconfig.json
+++ b/types/sinon-chrome/tsconfig.json
@@ -14,6 +14,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/sinon-express-mock/tsconfig.json
+++ b/types/sinon-express-mock/tsconfig.json
@@ -13,6 +13,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/sinon-mongoose/tsconfig.json
+++ b/types/sinon-mongoose/tsconfig.json
@@ -13,6 +13,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/sinon-stub-promise/tsconfig.json
+++ b/types/sinon-stub-promise/tsconfig.json
@@ -13,6 +13,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/sinon-test/tsconfig.json
+++ b/types/sinon-test/tsconfig.json
@@ -13,6 +13,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Sinon 7.5
+// Type definitions for Sinon 9.0
 // Project: https://sinonjs.org
 // Definitions by: William Sears <https://github.com/mrbigdog2u>
 //                 Jonathan Little <https://github.com/rationull>
@@ -13,6 +13,8 @@
 //                 Roey Berman <https://github.com/bergundy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
+
+import * as FakeTimers from '@sinonjs/fake-timers';
 
 // sinon uses DOM dependencies which are absent in browser-less environment like node.js
 // to avoid compiler errors this monkey patch is used
@@ -725,84 +727,17 @@ declare namespace Sinon {
         (obj: any): SinonMock;
     }
 
-    type SinonTimerId = number | { id: number };
+    type SinonTimerId = FakeTimers.TimerId;
 
-    interface SinonFakeTimers {
-        now: number;
-        loopLimit: number;
-
-        setTimeout(callback: (...args: any[]) => void, timeout: number, ...args: any[]): SinonTimerId;
-        clearTimeout(id: SinonTimerId): void;
-
-        setInterval(callback: (...args: any[]) => void, timeout: number, ...args: any[]): SinonTimerId;
-        clearInterval(id: SinonTimerId): void;
-
-        setImmediate(callback: (...args: any[]) => void, ...args: any[]): SinonTimerId;
-        clearImmediate(id: SinonTimerId): void;
-
-        requestAnimationFrame(callback: (time: number) => void): SinonTimerId;
-        cancelAnimationFrame(id: SinonTimerId): void;
-
-        nextTick(callback: (...args: any[]) => void, ...args: any[]): void;
-        queueMicrotask(callback: () => void): void;
-
-        requestIdleCallback(func: (...args: any[]) => void, timeout?: number, ...args: any[]): SinonTimerId;
-        cancelIdleCallback(timerId: SinonTimerId): void;
-
-        /**
-         * Tick the clock ahead time milliseconds.
-         * Causes all timers scheduled within the affected time range to be called.
-         * time may be the number of milliseconds to advance the clock by or a human-readable string.
-         * Valid string formats are “08” for eight seconds, “01:00” for one minute and “02:34:10” for two hours, 34 minutes and ten seconds.
-         * time may be negative, which causes the clock to change but won’t fire any callbacks.
-         * @param ms
-         */
-        tick(ms: number | string): number;
-        /**
-         * Advances the clock to the the moment of the first scheduled timer, firing it.
-         */
-        next(): number;
-        /**
-         * This runs all pending timers until there are none remaining. If new timers are added while it is executing they will be run as well.
-         * This makes it easier to run asynchronous tests to completion without worrying about the number of timers they use, or the delays in those timers.
-         */
-        runAll(): number;
-        runToLast(): number;
-        reset(): void;
-        runMicrotasks(): void;
-        runToFrame(): number;
-
-        Date(): Date;
-        Date(year: number): Date;
-        Date(year: number, month: number): Date;
-        Date(year: number, month: number, day: number): Date;
-        Date(year: number, month: number, day: number, hour: number): Date;
-        Date(year: number, month: number, day: number, hour: number, minute: number): Date;
-        Date(year: number, month: number, day: number, hour: number, minute: number, second: number): Date;
-        Date(year: number, month: number, day: number, hour: number, minute: number, second: number, ms: number): Date;
-
-        /**
-         * Restore the faked methods.
-         * Call in e.g. tearDown.
-         */
-        restore(): void;
-        uninstall(): void;
-
-        /**
-         * Simulate the user changing the system clock while your program is running. It changes the 'now' timestamp
-         * without affecting timers, intervals or immediates.
-         * @param now The new 'now' in unix milliseconds
-         */
-        setSystemTime(now: number): void;
-        /**
-         * Simulate the user changing the system clock while your program is running. It changes the 'now' timestamp
-         * without affecting timers, intervals or immediates.
-         * @param now The new 'now' as a JavaScript Date
-         */
-        setSystemTime(date: Date): void;
-
-        countTimers(): number;
-    }
+    type SinonFakeTimers = FakeTimers.InstalledMethods &
+        FakeTimers.NodeClock &
+        FakeTimers.BrowserClock & {
+            /**
+             * Restore the faked methods.
+             * Call in e.g. tearDown.
+             */
+            restore(): void;
+        };
 
     interface SinonFakeTimersConfig {
         now: number | Date;

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -156,17 +156,17 @@ function testClock() {
 
     clock.tick(1);
     clock.tick('00:10');
-    clock.tickAsync(500).then((val: number) => val.toExponential());
-    clock.tickAsync('500').then((val: number) => val.toExponential());
+    clock.tickAsync(500).then(val => val.toExponential());
+    clock.tickAsync('500').then(val => val.toExponential());
 
     clock.next();
-    clock.nextAsync().then((val: number) => val.toExponential());
+    clock.nextAsync().then(val => val.toExponential());
 
     clock.runAll();
-    clock.runAllAsync().then((val: number) => val.toExponential());
+    clock.runAllAsync().then(val => val.toExponential());
 
     clock.runToLast();
-    clock.runToLastAsync().then((val: number) => val.toExponential());
+    clock.runToLastAsync().then(val => val.toExponential());
 
     clock.reset();
     clock.runMicrotasks();

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -153,11 +153,21 @@ function testClock() {
     clock.cancelAnimationFrame(animTimer);
 
     clock.nextTick(fn);
+
     clock.tick(1);
     clock.tick('00:10');
+    clock.tickAsync(500).then((val: number) => val.toExponential());
+    clock.tickAsync('500').then((val: number) => val.toExponential());
+
     clock.next();
+    clock.nextAsync().then((val: number) => val.toExponential());
+
     clock.runAll();
+    clock.runAllAsync().then((val: number) => val.toExponential());
+
     clock.runToLast();
+    clock.runToLastAsync().then((val: number) => val.toExponential());
+
     clock.reset();
     clock.runMicrotasks();
     clock.runToFrame();

--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -1,3 +1,5 @@
+import * as FakeTimers from '@sinonjs/fake-timers';
+
 // sinon uses DOM dependencies which are absent in browser-less environment like node.js
 // to avoid compiler errors this monkey patch is used
 // see more details in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11351
@@ -758,119 +760,17 @@ declare namespace Sinon {
         (obj: any): SinonMock;
     }
 
-    type SinonTimerId = number | { id: number };
+    type SinonTimerId = FakeTimers.TimerId;
 
-    interface SinonFakeTimers {
-        now: number;
-        loopLimit: number;
-
-        setTimeout<TArgs extends any[] = any[]>(
-            callback: (...args: TArgs) => void,
-            timeout: number,
-            ...args: TArgs
-        ): SinonTimerId;
-        clearTimeout(id: SinonTimerId): void;
-
-        setInterval<TArgs extends any[] = any[]>(
-            callback: (...args: TArgs) => void,
-            timeout: number,
-            ...args: TArgs
-        ): SinonTimerId;
-        clearInterval(id: SinonTimerId): void;
-
-        setImmediate<TArgs extends any[] = any[]>(
-            callback: (...args: TArgs) => void,
-            ...args: TArgs
-        ): SinonTimerId;
-        clearImmediate(id: SinonTimerId): void;
-
-        requestAnimationFrame(callback: (time: number) => void): SinonTimerId;
-        cancelAnimationFrame(id: SinonTimerId): void;
-
-        nextTick<TArgs extends any[] = any[]>(
-            callback: (...args: TArgs) => void,
-            ...args: TArgs): void;
-        queueMicrotask(callback: () => void): void;
-
-        requestIdleCallback<TArgs extends any[] = any[]>(func: (...args: TArgs) => void, timeout?: number, ...args:
-            TArgs): SinonTimerId;
-        cancelIdleCallback(timerId: SinonTimerId): void;
-
-        /**
-         * Tick the clock ahead time milliseconds.
-         * Causes all timers scheduled within the affected time range to be called.
-         * time may be the number of milliseconds to advance the clock by or a human-readable string.
-         * Valid string formats are “08” for eight seconds, “01:00” for one minute and “02:34:10” for two hours, 34 minutes and ten seconds.
-         * time may be negative, which causes the clock to change but won’t fire any callbacks.
-         * @param ms
-         */
-        tick(ms: number | string): number;
-        /**
-         * Advances the clock to the the moment of the first scheduled timer, firing it.
-         */
-        next(): number;
-        /**
-         * This runs all pending timers until there are none remaining. If new timers are added while it is executing they will be run as well.
-         * This makes it easier to run asynchronous tests to completion without worrying about the number of timers they use, or the delays in those timers.
-         */
-        runAll(): number;
-        runToLast(): number;
-        reset(): void;
-        runMicrotasks(): void;
-        runToFrame(): number;
-
-        Date(): Date;
-        Date(year: number): Date;
-        Date(year: number, month: number): Date;
-        Date(year: number, month: number, day: number): Date;
-        Date(year: number, month: number, day: number, hour: number): Date;
-        Date(
-            year: number,
-            month: number,
-            day: number,
-            hour: number,
-            minute: number
-        ): Date;
-        Date(
-            year: number,
-            month: number,
-            day: number,
-            hour: number,
-            minute: number,
-            second: number
-        ): Date;
-        Date(
-            year: number,
-            month: number,
-            day: number,
-            hour: number,
-            minute: number,
-            second: number,
-            ms: number
-        ): Date;
-
-        /**
-         * Restore the faked methods.
-         * Call in e.g. tearDown.
-         */
-        restore(): void;
-        uninstall(): void;
-
-        /**
-         * Simulate the user changing the system clock while your program is running. It changes the 'now' timestamp
-         * without affecting timers, intervals or immediates.
-         * @param now The new 'now' in unix milliseconds
-         */
-        setSystemTime(now: number): void;
-        /**
-         * Simulate the user changing the system clock while your program is running. It changes the 'now' timestamp
-         * without affecting timers, intervals or immediates.
-         * @param now The new 'now' as a JavaScript Date
-         */
-        setSystemTime(date: Date): void;
-
-        countTimers(): number;
-    }
+    type SinonFakeTimers = FakeTimers.InstalledMethods &
+        FakeTimers.NodeClock &
+        FakeTimers.BrowserClock & {
+            /**
+             * Restore the faked methods.
+             * Call in e.g. tearDown.
+             */
+            restore(): void;
+        };
 
     interface SinonFakeTimersConfig {
         now: number | Date;

--- a/types/sinon/ts3.1/sinon-tests.ts
+++ b/types/sinon/ts3.1/sinon-tests.ts
@@ -160,11 +160,21 @@ function testClock() {
     clock.cancelAnimationFrame(animTimer);
 
     clock.nextTick(fn);
+
     clock.tick(1);
     clock.tick('00:10');
+    clock.tickAsync(500).then((val: number) => val.toExponential());
+    clock.tickAsync('500').then((val: number) => val.toExponential());
+
     clock.next();
+    clock.nextAsync().then((val: number) => val.toExponential());
+
     clock.runAll();
+    clock.runAllAsync().then((val: number) => val.toExponential());
+
     clock.runToLast();
+    clock.runToLastAsync().then((val: number) => val.toExponential());
+
     clock.reset();
     clock.runMicrotasks();
     clock.runToFrame();

--- a/types/sinon/ts3.1/sinon-tests.ts
+++ b/types/sinon/ts3.1/sinon-tests.ts
@@ -163,17 +163,17 @@ function testClock() {
 
     clock.tick(1);
     clock.tick('00:10');
-    clock.tickAsync(500).then((val: number) => val.toExponential());
-    clock.tickAsync('500').then((val: number) => val.toExponential());
+    clock.tickAsync(500).then(val => val.toExponential());
+    clock.tickAsync('500').then(val => val.toExponential());
 
     clock.next();
-    clock.nextAsync().then((val: number) => val.toExponential());
+    clock.nextAsync().then(val => val.toExponential());
 
     clock.runAll();
-    clock.runAllAsync().then((val: number) => val.toExponential());
+    clock.runAllAsync().then(val => val.toExponential());
 
     clock.runToLast();
-    clock.runToLastAsync().then((val: number) => val.toExponential());
+    clock.runToLastAsync().then(val => val.toExponential());
 
     clock.reset();
     clock.runMicrotasks();

--- a/types/sinon/ts3.1/tsconfig.json
+++ b/types/sinon/ts3.1/tsconfig.json
@@ -15,6 +15,11 @@
             "../../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/sinon/tsconfig.json
+++ b/types/sinon/tsconfig.json
@@ -15,6 +15,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/sinonjs__fake-timers/index.d.ts
+++ b/types/sinonjs__fake-timers/index.d.ts
@@ -8,368 +8,380 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-/**
- * Names of clock methods that may be faked by install.
- */
-export type FakeMethod =
-    | 'setTimeout'
-    | 'clearTimeout'
-    | 'setImmediate'
-    | 'clearImmediate'
-    | 'setInterval'
-    | 'clearInterval'
-    | 'Date'
-    | 'nextTick'
-    | 'hrtime'
-    | 'requestAnimationFrame'
-    | 'cancelAnimationFrame'
-    | 'requestIdleCallback'
-    | 'cancelIdleCallback';
-
-/**
- * Global methods avaliable to every clock and also as standalone methods (inside `timers` global object).
- */
-export interface GlobalTimers<TTimerId extends TimerId> {
+// tslint:disable-next-line no-single-declare-module
+declare module '@sinonjs/fake-timers' {
     /**
-     * Schedules a callback to be fired once timeout milliseconds have ticked by.
-     *
-     * @param callback   Callback to be fired.
-     * @param timeout   How many ticks to wait to run the callback.
-     * @param args   Any extra arguments to pass to the callback.
-     * @returns Time identifier for cancellation.
+     * Names of clock methods that may be faked by install.
      */
-    setTimeout: (callback: () => void, timeout: number, ...args: any[]) => TTimerId;
+    type FakeMethod =
+        | 'setTimeout'
+        | 'clearTimeout'
+        | 'setImmediate'
+        | 'clearImmediate'
+        | 'setInterval'
+        | 'clearInterval'
+        | 'Date'
+        | 'nextTick'
+        | 'hrtime'
+        | 'requestAnimationFrame'
+        | 'cancelAnimationFrame'
+        | 'requestIdleCallback'
+        | 'cancelIdleCallback';
 
     /**
-     * Clears a timer, as long as it was created using setTimeout.
-     *
-     * @param id   Timer ID or object.
+     * Global methods avaliable to every clock and also as standalone methods (inside `timers` global object).
      */
-    clearTimeout: (id: TimerId) => void;
+    interface GlobalTimers<TTimerId extends TimerId> {
+        /**
+         * Schedules a callback to be fired once timeout milliseconds have ticked by.
+         *
+         * @param callback   Callback to be fired.
+         * @param timeout   How many ticks to wait to run the callback.
+         * @param args   Any extra arguments to pass to the callback.
+         * @returns Time identifier for cancellation.
+         */
+        setTimeout: (callback: (...args: any[]) => void, timeout: number, ...args: any[]) => TTimerId;
+
+        /**
+         * Clears a timer, as long as it was created using setTimeout.
+         *
+         * @param id   Timer ID or object.
+         */
+        clearTimeout: (id: TTimerId) => void;
+
+        /**
+         * Schedules a callback to be fired every time timeout milliseconds have ticked by.
+         *
+         * @param callback   Callback to be fired.
+         * @param timeout   How many ticks to wait between callbacks.
+         * @param args   Any extra arguments to pass to the callback.
+         * @returns Time identifier for cancellation.
+         */
+        setInterval: (callback: (...args: any[]) => void, timeout: number, ...args: any[]) => TTimerId;
+
+        /**
+         * Clears a timer, as long as it was created using setInterval.
+         *
+         * @param id   Timer ID or object.
+         */
+        clearInterval: (id: TTimerId) => void;
+
+        /**
+         * Schedules the callback to be fired once 0 milliseconds have ticked by.
+         *
+         * @param callback   Callback to be fired.
+         * @param args   Any extra arguments to pass to the callback.
+         * @remarks You'll still have to call clock.tick() for the callback to fire.
+         * @remarks If called during a tick the callback won't fire until 1 millisecond has ticked by.
+         */
+        setImmediate: (callback: (...args: any[]) => void, ...args: any[]) => TTimerId;
+
+        /**
+         * Clears a timer, as long as it was created using setImmediate.
+         *
+         * @param id   Timer ID or object.
+         */
+        clearImmediate: (id: TTimerId) => void;
+
+        /**
+         * Implements the Date object but using this clock to provide the correct time.
+         */
+        Date: typeof Date;
+    }
 
     /**
-     * Schedules a callback to be fired every time timeout milliseconds have ticked by.
-     *
-     * @param callback   Callback to be fired.
-     * @param timeout   How many ticks to wait between callbacks.
-     * @param args   Any extra arguments to pass to the callback.
-     * @returns Time identifier for cancellation.
+     * Timer object used in node.
      */
-    setInterval: (callback: () => void, timeout: number, ...args: any[]) => TTimerId;
+    interface NodeTimer {
+        /**
+         * Stub method call. Does nothing.
+         */
+        ref(): void;
+
+        /**
+         * Stub method call. Does nothing.
+         */
+        unref(): void;
+    }
 
     /**
-     * Clears a timer, as long as it was created using setInterval.
-     *
-     * @param id   Timer ID or object.
+     * Timer identifier for clock scheduling.
      */
-    clearInterval: (id: TTimerId) => void;
+    type TimerId = number | NodeTimer;
 
     /**
-     * Schedules the callback to be fired once 0 milliseconds have ticked by.
-     *
-     * @param callback   Callback to be fired.
-     * @remarks You'll still have to call clock.tick() for the callback to fire.
-     * @remarks If called during a tick the callback won't fire until 1 millisecond has ticked by.
+     * Controls the flow of time.
      */
-    setImmediate: (callback: () => void) => TTimerId;
+    interface FakeClock<TTimerId extends TimerId> extends GlobalTimers<TTimerId> {
+        /**
+         * Current clock time.
+         */
+        now: number;
+
+        /**
+         * Don't know what this prop is for, but it was included in the clocks that `createClock` or
+         * `install` return (it is never used in the code, for now).
+         */
+        timeouts: {};
+
+        /**
+         * Maximum number of timers that will be run when calling runAll().
+         */
+        loopLimit: number;
+
+        /**
+         * Schedule callback to run in the next animation frame.
+         *
+         * @param callback   Callback to be fired.
+         * @returns Request id.
+         */
+        requestAnimationFrame: (callback: (time: number) => void) => TTimerId;
+
+        /**
+         * Cancel animation frame request.
+         *
+         * @param id   The id returned from requestAnimationFrame method.
+         */
+        cancelAnimationFrame: (id: TTimerId) => void;
+
+        /**
+         * Queues the callback to be fired during idle periods to perform background and low priority work on the main event loop.
+         *
+         * @param callback   Callback to be fired.
+         * @param timeout   The maximum number of ticks before the callback must be fired.
+         * @remarks Callbacks which have a timeout option will be fired no later than time in milliseconds.
+         */
+        requestIdleCallback: (callback: () => void, timeout?: number) => TTimerId;
+
+        /**
+         * Clears a timer, as long as it was created using requestIdleCallback.
+         *
+         * @param id   Timer ID or object.
+         */
+        cancelIdleCallback: (id: TTimerId) => void;
+
+        /**
+         * Get the number of waiting timers.
+         *
+         * @returns number of waiting timers.
+         */
+        countTimers: () => number;
+
+        /**
+         * Advances the clock to the the moment of the first scheduled timer, firing it.
+         * @returns Fake milliseconds since the unix epoch.
+         */
+        next: () => number;
+
+        /**
+         * Advances the clock to the the moment of the first scheduled timer, firing it.
+         *
+         * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
+         * @returns Fake milliseconds since the unix epoch.
+         */
+        nextAsync: () => Promise<number>;
+
+        /**
+         * Advance the clock, firing callbacks if necessary.
+         *
+         * @param time   How many ticks to advance by.
+         * @returns Fake milliseconds since the unix epoch.
+         */
+        tick: (time: number | string) => number;
+
+        /**
+         * Advance the clock, firing callbacks if necessary.
+         *
+         * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
+         *
+         * @param time   How many ticks to advance by.
+         * @returns Fake milliseconds since the unix epoch.
+         */
+        tickAsync: (time: number | string) => Promise<number>;
+
+        /**
+         * Removes all timers and tick without firing them and restore now to its original value.
+         */
+        reset: () => void;
+
+        /**
+         * Runs all pending timers until there are none remaining.
+         *
+         * @remarks  If new timers are added while it is executing they will be run as well.
+         * @returns Fake milliseconds since the unix epoch.
+         */
+        runAll: () => number;
+
+        /**
+         * Runs all pending timers until there are none remaining.
+         *
+         * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
+         *
+         * @remarks  If new timers are added while it is executing they will be run as well.
+         * @returns Fake milliseconds since the unix epoch.
+         */
+        runAllAsync: () => Promise<number>;
+
+        /**
+         * Advanced the clock to the next animation frame while firing all scheduled callbacks.
+         * @returns Fake milliseconds since the unix epoch.
+         */
+        runToFrame: () => number;
+
+        /**
+         * Takes note of the last scheduled timer when it is run, and advances the clock to
+         * that time firing callbacks as necessary.
+         * @returns Fake milliseconds since the unix epoch.
+         */
+        runToLast: () => number;
+
+        /**
+         * Takes note of the last scheduled timer when it is run, and advances the clock to
+         * that time firing callbacks as necessary.
+         *
+         * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
+         * @returns Fake milliseconds since the unix epoch.
+         */
+        runToLastAsync: () => Promise<number>;
+
+        /**
+         * Simulates a user changing the system clock.
+         *
+         * @param now   New system time.
+         * @remarks This affects the current time but it does not in itself cause timers to fire.
+         */
+        setSystemTime: (now?: number | Date) => void;
+    }
 
     /**
-     * Clears a timer, as long as it was created using setImmediate.
-     *
-     * @param id   Timer ID or object.
+     * Fake clock for a browser environment.
      */
-    clearImmediate: (id: TTimerId) => void;
-
-    /**
-     * Implements the Date object but using this clock to provide the correct time.
-     */
-    Date: typeof Date;
-}
-
-/**
- * Timer object used in node.
- */
-export interface NodeTimer {
-    /**
-     * Stub method call. Does nothing.
-     */
-    ref(): void;
-
-    /**
-     * Stub method call. Does nothing.
-     */
-    unref(): void;
-}
-
-/**
- * Timer identifier for clock scheduling.
- */
-export type TimerId = number | NodeTimer;
-
-/**
- * Controls the flow of time.
- */
-export interface FakeClock<TTimerId extends TimerId> extends GlobalTimers<TTimerId> {
-    /**
-     * Current clock time.
-     */
-    now: number;
-
-    /**
-     * Don't know what this prop is for, but it was included in the clocks that `createClock` or
-     * `install` return (it is never used in the code, for now).
-     */
-    timeouts: {};
-
-    /**
-     * Maximum number of timers that will be run when calling runAll().
-     */
-    loopLimit: number;
-
-    /**
-     * Schedule callback to run in the next animation frame.
-     *
-     * @param callback   Callback to be fired.
-     * @returns Request id.
-     */
-    requestAnimationFrame: (callback: (time: number) => void) => TTimerId;
-
-    /**
-     * Cancel animation frame request.
-     *
-     * @param id   The id returned from requestAnimationFrame method.
-     */
-    cancelAnimationFrame: (id: TTimerId) => void;
-
-    /**
-     * Queues the callback to be fired during idle periods to perform background and low priority work on the main event loop.
-     *
-     * @param callback   Callback to be fired.
-     * @param timeout   The maximum number of ticks before the callback must be fired.
-     * @remarks Callbacks which have a timeout option will be fired no later than time in milliseconds.
-     */
-    requestIdleCallback: (callback: () => void, timeout?: number) => TTimerId;
-
-    /**
-     * Clears a timer, as long as it was created using requestIdleCallback.
-     *
-     * @param id   Timer ID or object.
-     */
-    cancelIdleCallback: (id: TTimerId) => void;
-
-    /**
-     * Get the number of waiting timers.
-     *
-     * @returns number of waiting timers.
-     */
-    countTimers: () => number;
-
-    /**
-     * Advances the clock to the the moment of the first scheduled timer, firing it.
-     */
-    next: () => void;
-
-    /**
-     * Advances the clock to the the moment of the first scheduled timer, firing it.
-     *
-     * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
-     */
-    nextAsync: () => Promise<void>;
-
-    /**
-     * Advance the clock, firing callbacks if necessary.
-     *
-     * @param time   How many ticks to advance by.
-     */
-    tick: (time: number | string) => void;
-
-    /**
-     * Advance the clock, firing callbacks if necessary.
-     *
-     * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
-     *
-     * @param time   How many ticks to advance by.
-     */
-    tickAsync: (time: number | string) => Promise<void>;
-
-    /**
-     * Removes all timers and tick without firing them and restore now to its original value.
-     */
-    reset: () => void;
-
-    /**
-     * Runs all pending timers until there are none remaining.
-     *
-     * @remarks  If new timers are added while it is executing they will be run as well.
-     */
-    runAll: () => void;
-
-    /**
-     * Runs all pending timers until there are none remaining.
-     *
-     * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
-     *
-     * @remarks  If new timers are added while it is executing they will be run as well.
-     */
-    runAllAsync: () => Promise<void>;
-
-    /**
-     * Advanced the clock to the next animation frame while firing all scheduled callbacks.
-     */
-    runToFrame: () => void;
-
-    /**
-     * Takes note of the last scheduled timer when it is run, and advances the clock to
-     * that time firing callbacks as necessary.
-     */
-    runToLast: () => void;
-
-    /**
-     * Takes note of the last scheduled timer when it is run, and advances the clock to
-     * that time firing callbacks as necessary.
-     *
-     * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
-     */
-    runToLastAsync: () => Promise<void>;
-
-    /**
-     * Simulates a user changing the system clock.
-     *
-     * @param now   New system time.
-     * @remarks This affects the current time but it does not in itself cause timers to fire.
-     */
-    setSystemTime: (now?: number | Date) => void;
-}
-
-/**
- * Fake clock for a browser environment.
- */
-export type BrowserClock = FakeClock<number> & {
-    /**
-     * Mimics performance.now().
-     */
-    performance: {
-        now: () => number;
+    type BrowserClock = FakeClock<number> & {
+        /**
+         * Mimics performance.now().
+         */
+        performance: {
+            now: () => number;
+        };
     };
-};
 
-/**
- * Fake clock for a Node environment.
- */
-export type NodeClock = FakeClock<NodeTimer> & {
     /**
-     * Mimicks process.hrtime().
+     * Fake clock for a Node environment.
+     */
+    type NodeClock = FakeClock<NodeTimer> & {
+        /**
+         * Mimicks process.hrtime().
+         *
+         * @param prevTime   Previous system time to calculate time elapsed.
+         * @returns High resolution real time as [seconds, nanoseconds].
+         */
+        hrtime(prevTime?: [number, number]): [number, number];
+
+        /**
+         * Mimics process.nextTick() explicitly dropping additional arguments.
+         */
+        queueMicrotask: (callback: () => void) => void;
+
+        /**
+         * Simulates process.nextTick().
+         */
+        nextTick: (callback: (...args: any[]) => void, ...args: any[]) => void;
+
+        /**
+         * Run all pending microtasks scheduled with nextTick.
+         */
+        runMicrotasks: () => void;
+    };
+
+    /**
+     * Clock object created by @sinonjs/fake-timers.
+     */
+    type Clock = BrowserClock | NodeClock;
+
+    /**
+     * Additional methods that installed clock have.
+     */
+    interface InstalledMethods {
+        /**
+         * Restores the original methods on the context that was passed to FakeTimers.install,
+         * or the native timers if no context was given.
+         */
+        uninstall: () => void;
+
+        methods: FakeMethod[];
+    }
+
+    /**
+     * Clock object created by calling `install();`.
+     */
+    type InstalledClock = Clock & InstalledMethods;
+
+    /**
+     * Creates a clock.
      *
-     * @param prevTime   Previous system time to calculate time elapsed.
-     * @returns High resolution real time as [seconds, nanoseconds].
+     * @param now   Current time for the clock.
+     * @param loopLimit    Maximum number of timers that will be run when calling runAll()
+     *                     before assuming that we have an infinite loop and throwing an error
+     *                     (by default, 1000).
+     * @remarks The default epoch is 0.
      */
-    hrtime(prevTime?: [number, number]): [number, number];
+    function createClock(now?: number | Date, loopLimit?: number): Clock;
+
+    interface FakeTimerInstallOpts {
+        /**
+         * Installs fake timers onto the specified target context (default: global)
+         */
+        target?: any;
+
+        /**
+         * Installs fake timers with the specified unix epoch (default: 0)
+         */
+        now?: number | Date;
+
+        /**
+         * An array with explicit function names to hijack. When not set, @sinonjs/fake-timers will automatically fake all methods except nextTick
+         * e.g., FakeTimers.install({ toFake: ["setTimeout", "nextTick"]}) will fake only setTimeout and nextTick
+         */
+        toFake?: FakeMethod[];
+
+        /**
+         * The maximum number of timers that will be run when calling runAll() (default: 1000)
+         */
+        loopLimit?: number;
+
+        /**
+         * Tells @sinonjs/fake-timers to increment mocked time automatically based on the real system time shift (e.g. the mocked time will be incremented by
+         * 20ms for every 20ms change in the real system time) (default: false)
+         */
+        shouldAdvanceTime?: boolean;
+
+        /**
+         * Relevant only when using with shouldAdvanceTime: true. increment mocked time by advanceTimeDelta ms every advanceTimeDelta ms change
+         * in the real system time (default: 20)
+         */
+        advanceTimeDelta?: number;
+    }
 
     /**
-     * Mimics process.nextTick() explicitly dropping additional arguments.
+     * Creates a clock and installs it globally.
+     *
+     * @param [opts]   Options for the fake timer.
      */
-    queueMicrotask: (callback: () => void) => void;
+    function install(opts?: FakeTimerInstallOpts): InstalledClock;
+
+    interface FakeTimerWithContext {
+        timers: GlobalTimers<TimerId>;
+        createClock: (now?: number | Date, loopLimit?: number) => Clock;
+        install: (opts?: FakeTimerInstallOpts) => InstalledClock;
+        withGlobal: (global: object) => FakeTimerWithContext;
+    }
 
     /**
-     * Simulates process.nextTick().
+     * Apply new context to fake timers.
+     *
+     * @param global   New context to apply like `window` (in browsers) or `global` (in node).
      */
-    nextTick: (callback: () => void) => void;
+    function withGlobal(global: object): FakeTimerWithContext;
 
-    /**
-     * Run all pending microtasks scheduled with nextTick.
-     */
-    runMicrotasks: () => void;
-};
-
-/**
- * Clock object created by @sinonjs/fake-timers.
- */
-export type Clock = BrowserClock | NodeClock;
-
-/**
- * Additional methods that installed clock have.
- */
-export interface InstalledMethods {
-    /**
-     * Restores the original methods on the context that was passed to FakeTimers.install,
-     * or the native timers if no context was given.
-     */
-    uninstall: () => void;
-
-    methods: FakeMethod[];
+    const timers: GlobalTimers<TimerId>;
 }
-
-/**
- * Clock object created by calling `install();`.
- */
-export type InstalledClock = Clock & InstalledMethods;
-
-/**
- * Creates a clock.
- *
- * @param now   Current time for the clock.
- * @param loopLimit    Maximum number of timers that will be run when calling runAll()
- *                     before assuming that we have an infinite loop and throwing an error
- *                     (by default, 1000).
- * @remarks The default epoch is 0.
- */
-export function createClock(now?: number | Date, loopLimit?: number): Clock;
-
-export interface FakeTimerInstallOpts {
-    /**
-     * Installs fake timers onto the specified target context (default: global)
-     */
-    target?: any;
-
-    /**
-     * Installs fake timers with the specified unix epoch (default: 0)
-     */
-    now?: number | Date;
-
-    /**
-     * An array with explicit function names to hijack. When not set, @sinonjs/fake-timers will automatically fake all methods except nextTick
-     * e.g., FakeTimers.install({ toFake: ["setTimeout", "nextTick"]}) will fake only setTimeout and nextTick
-     */
-    toFake?: FakeMethod[];
-
-    /**
-     * The maximum number of timers that will be run when calling runAll() (default: 1000)
-     */
-    loopLimit?: number;
-
-    /**
-     * Tells @sinonjs/fake-timers to increment mocked time automatically based on the real system time shift (e.g. the mocked time will be incremented by
-     * 20ms for every 20ms change in the real system time) (default: false)
-     */
-    shouldAdvanceTime?: boolean;
-
-    /**
-     * Relevant only when using with shouldAdvanceTime: true. increment mocked time by advanceTimeDelta ms every advanceTimeDelta ms change
-     * in the real system time (default: 20)
-     */
-    advanceTimeDelta?: number;
-}
-
-/**
- * Creates a clock and installs it globally.
- *
- * @param now   Current time for the clock, as with FakeTimers.createClock().
- * @param toFake   Names of methods that should be faked.
- */
-export function install(opts?: FakeTimerInstallOpts): InstalledClock;
-
-export interface FakeTimerWithContext {
-    timers: GlobalTimers<TimerId>;
-    createClock: (now?: number | Date, loopLimit?: number) => Clock;
-    install: (opts?: FakeTimerInstallOpts) => InstalledClock;
-    withGlobal: (global: object) => FakeTimerWithContext;
-}
-
-/**
- * Apply new context to fake timers.
- *
- * @param global   New context to apply like `window` (in browsers) or `global` (in node).
- */
-export function withGlobal(global: object): FakeTimerWithContext;
-
-export const timers: GlobalTimers<TimerId>;

--- a/types/sinonjs__fake-timers/index.d.ts
+++ b/types/sinonjs__fake-timers/index.d.ts
@@ -8,380 +8,377 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-// tslint:disable-next-line no-single-declare-module
-declare module '@sinonjs/fake-timers' {
+/**
+ * Names of clock methods that may be faked by install.
+ */
+export type FakeMethod =
+    | 'setTimeout'
+    | 'clearTimeout'
+    | 'setImmediate'
+    | 'clearImmediate'
+    | 'setInterval'
+    | 'clearInterval'
+    | 'Date'
+    | 'nextTick'
+    | 'hrtime'
+    | 'requestAnimationFrame'
+    | 'cancelAnimationFrame'
+    | 'requestIdleCallback'
+    | 'cancelIdleCallback';
+
+/**
+ * Global methods avaliable to every clock and also as standalone methods (inside `timers` global object).
+ */
+export interface GlobalTimers<TTimerId extends TimerId> {
     /**
-     * Names of clock methods that may be faked by install.
-     */
-    type FakeMethod =
-        | 'setTimeout'
-        | 'clearTimeout'
-        | 'setImmediate'
-        | 'clearImmediate'
-        | 'setInterval'
-        | 'clearInterval'
-        | 'Date'
-        | 'nextTick'
-        | 'hrtime'
-        | 'requestAnimationFrame'
-        | 'cancelAnimationFrame'
-        | 'requestIdleCallback'
-        | 'cancelIdleCallback';
-
-    /**
-     * Global methods avaliable to every clock and also as standalone methods (inside `timers` global object).
-     */
-    interface GlobalTimers<TTimerId extends TimerId> {
-        /**
-         * Schedules a callback to be fired once timeout milliseconds have ticked by.
-         *
-         * @param callback   Callback to be fired.
-         * @param timeout   How many ticks to wait to run the callback.
-         * @param args   Any extra arguments to pass to the callback.
-         * @returns Time identifier for cancellation.
-         */
-        setTimeout: (callback: (...args: any[]) => void, timeout: number, ...args: any[]) => TTimerId;
-
-        /**
-         * Clears a timer, as long as it was created using setTimeout.
-         *
-         * @param id   Timer ID or object.
-         */
-        clearTimeout: (id: TTimerId) => void;
-
-        /**
-         * Schedules a callback to be fired every time timeout milliseconds have ticked by.
-         *
-         * @param callback   Callback to be fired.
-         * @param timeout   How many ticks to wait between callbacks.
-         * @param args   Any extra arguments to pass to the callback.
-         * @returns Time identifier for cancellation.
-         */
-        setInterval: (callback: (...args: any[]) => void, timeout: number, ...args: any[]) => TTimerId;
-
-        /**
-         * Clears a timer, as long as it was created using setInterval.
-         *
-         * @param id   Timer ID or object.
-         */
-        clearInterval: (id: TTimerId) => void;
-
-        /**
-         * Schedules the callback to be fired once 0 milliseconds have ticked by.
-         *
-         * @param callback   Callback to be fired.
-         * @param args   Any extra arguments to pass to the callback.
-         * @remarks You'll still have to call clock.tick() for the callback to fire.
-         * @remarks If called during a tick the callback won't fire until 1 millisecond has ticked by.
-         */
-        setImmediate: (callback: (...args: any[]) => void, ...args: any[]) => TTimerId;
-
-        /**
-         * Clears a timer, as long as it was created using setImmediate.
-         *
-         * @param id   Timer ID or object.
-         */
-        clearImmediate: (id: TTimerId) => void;
-
-        /**
-         * Implements the Date object but using this clock to provide the correct time.
-         */
-        Date: typeof Date;
-    }
-
-    /**
-     * Timer object used in node.
-     */
-    interface NodeTimer {
-        /**
-         * Stub method call. Does nothing.
-         */
-        ref(): void;
-
-        /**
-         * Stub method call. Does nothing.
-         */
-        unref(): void;
-    }
-
-    /**
-     * Timer identifier for clock scheduling.
-     */
-    type TimerId = number | NodeTimer;
-
-    /**
-     * Controls the flow of time.
-     */
-    interface FakeClock<TTimerId extends TimerId> extends GlobalTimers<TTimerId> {
-        /**
-         * Current clock time.
-         */
-        now: number;
-
-        /**
-         * Don't know what this prop is for, but it was included in the clocks that `createClock` or
-         * `install` return (it is never used in the code, for now).
-         */
-        timeouts: {};
-
-        /**
-         * Maximum number of timers that will be run when calling runAll().
-         */
-        loopLimit: number;
-
-        /**
-         * Schedule callback to run in the next animation frame.
-         *
-         * @param callback   Callback to be fired.
-         * @returns Request id.
-         */
-        requestAnimationFrame: (callback: (time: number) => void) => TTimerId;
-
-        /**
-         * Cancel animation frame request.
-         *
-         * @param id   The id returned from requestAnimationFrame method.
-         */
-        cancelAnimationFrame: (id: TTimerId) => void;
-
-        /**
-         * Queues the callback to be fired during idle periods to perform background and low priority work on the main event loop.
-         *
-         * @param callback   Callback to be fired.
-         * @param timeout   The maximum number of ticks before the callback must be fired.
-         * @remarks Callbacks which have a timeout option will be fired no later than time in milliseconds.
-         */
-        requestIdleCallback: (callback: () => void, timeout?: number) => TTimerId;
-
-        /**
-         * Clears a timer, as long as it was created using requestIdleCallback.
-         *
-         * @param id   Timer ID or object.
-         */
-        cancelIdleCallback: (id: TTimerId) => void;
-
-        /**
-         * Get the number of waiting timers.
-         *
-         * @returns number of waiting timers.
-         */
-        countTimers: () => number;
-
-        /**
-         * Advances the clock to the the moment of the first scheduled timer, firing it.
-         * @returns Fake milliseconds since the unix epoch.
-         */
-        next: () => number;
-
-        /**
-         * Advances the clock to the the moment of the first scheduled timer, firing it.
-         *
-         * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
-         * @returns Fake milliseconds since the unix epoch.
-         */
-        nextAsync: () => Promise<number>;
-
-        /**
-         * Advance the clock, firing callbacks if necessary.
-         *
-         * @param time   How many ticks to advance by.
-         * @returns Fake milliseconds since the unix epoch.
-         */
-        tick: (time: number | string) => number;
-
-        /**
-         * Advance the clock, firing callbacks if necessary.
-         *
-         * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
-         *
-         * @param time   How many ticks to advance by.
-         * @returns Fake milliseconds since the unix epoch.
-         */
-        tickAsync: (time: number | string) => Promise<number>;
-
-        /**
-         * Removes all timers and tick without firing them and restore now to its original value.
-         */
-        reset: () => void;
-
-        /**
-         * Runs all pending timers until there are none remaining.
-         *
-         * @remarks  If new timers are added while it is executing they will be run as well.
-         * @returns Fake milliseconds since the unix epoch.
-         */
-        runAll: () => number;
-
-        /**
-         * Runs all pending timers until there are none remaining.
-         *
-         * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
-         *
-         * @remarks  If new timers are added while it is executing they will be run as well.
-         * @returns Fake milliseconds since the unix epoch.
-         */
-        runAllAsync: () => Promise<number>;
-
-        /**
-         * Advanced the clock to the next animation frame while firing all scheduled callbacks.
-         * @returns Fake milliseconds since the unix epoch.
-         */
-        runToFrame: () => number;
-
-        /**
-         * Takes note of the last scheduled timer when it is run, and advances the clock to
-         * that time firing callbacks as necessary.
-         * @returns Fake milliseconds since the unix epoch.
-         */
-        runToLast: () => number;
-
-        /**
-         * Takes note of the last scheduled timer when it is run, and advances the clock to
-         * that time firing callbacks as necessary.
-         *
-         * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
-         * @returns Fake milliseconds since the unix epoch.
-         */
-        runToLastAsync: () => Promise<number>;
-
-        /**
-         * Simulates a user changing the system clock.
-         *
-         * @param now   New system time.
-         * @remarks This affects the current time but it does not in itself cause timers to fire.
-         */
-        setSystemTime: (now?: number | Date) => void;
-    }
-
-    /**
-     * Fake clock for a browser environment.
-     */
-    type BrowserClock = FakeClock<number> & {
-        /**
-         * Mimics performance.now().
-         */
-        performance: {
-            now: () => number;
-        };
-    };
-
-    /**
-     * Fake clock for a Node environment.
-     */
-    type NodeClock = FakeClock<NodeTimer> & {
-        /**
-         * Mimicks process.hrtime().
-         *
-         * @param prevTime   Previous system time to calculate time elapsed.
-         * @returns High resolution real time as [seconds, nanoseconds].
-         */
-        hrtime(prevTime?: [number, number]): [number, number];
-
-        /**
-         * Mimics process.nextTick() explicitly dropping additional arguments.
-         */
-        queueMicrotask: (callback: () => void) => void;
-
-        /**
-         * Simulates process.nextTick().
-         */
-        nextTick: (callback: (...args: any[]) => void, ...args: any[]) => void;
-
-        /**
-         * Run all pending microtasks scheduled with nextTick.
-         */
-        runMicrotasks: () => void;
-    };
-
-    /**
-     * Clock object created by @sinonjs/fake-timers.
-     */
-    type Clock = BrowserClock | NodeClock;
-
-    /**
-     * Additional methods that installed clock have.
-     */
-    interface InstalledMethods {
-        /**
-         * Restores the original methods on the context that was passed to FakeTimers.install,
-         * or the native timers if no context was given.
-         */
-        uninstall: () => void;
-
-        methods: FakeMethod[];
-    }
-
-    /**
-     * Clock object created by calling `install();`.
-     */
-    type InstalledClock = Clock & InstalledMethods;
-
-    /**
-     * Creates a clock.
+     * Schedules a callback to be fired once timeout milliseconds have ticked by.
      *
-     * @param now   Current time for the clock.
-     * @param loopLimit    Maximum number of timers that will be run when calling runAll()
-     *                     before assuming that we have an infinite loop and throwing an error
-     *                     (by default, 1000).
-     * @remarks The default epoch is 0.
+     * @param callback   Callback to be fired.
+     * @param timeout   How many ticks to wait to run the callback.
+     * @param args   Any extra arguments to pass to the callback.
+     * @returns Time identifier for cancellation.
      */
-    function createClock(now?: number | Date, loopLimit?: number): Clock;
-
-    interface FakeTimerInstallOpts {
-        /**
-         * Installs fake timers onto the specified target context (default: global)
-         */
-        target?: any;
-
-        /**
-         * Installs fake timers with the specified unix epoch (default: 0)
-         */
-        now?: number | Date;
-
-        /**
-         * An array with explicit function names to hijack. When not set, @sinonjs/fake-timers will automatically fake all methods except nextTick
-         * e.g., FakeTimers.install({ toFake: ["setTimeout", "nextTick"]}) will fake only setTimeout and nextTick
-         */
-        toFake?: FakeMethod[];
-
-        /**
-         * The maximum number of timers that will be run when calling runAll() (default: 1000)
-         */
-        loopLimit?: number;
-
-        /**
-         * Tells @sinonjs/fake-timers to increment mocked time automatically based on the real system time shift (e.g. the mocked time will be incremented by
-         * 20ms for every 20ms change in the real system time) (default: false)
-         */
-        shouldAdvanceTime?: boolean;
-
-        /**
-         * Relevant only when using with shouldAdvanceTime: true. increment mocked time by advanceTimeDelta ms every advanceTimeDelta ms change
-         * in the real system time (default: 20)
-         */
-        advanceTimeDelta?: number;
-    }
+    setTimeout: (callback: (...args: any[]) => void, timeout: number, ...args: any[]) => TTimerId;
 
     /**
-     * Creates a clock and installs it globally.
+     * Clears a timer, as long as it was created using setTimeout.
      *
-     * @param [opts]   Options for the fake timer.
+     * @param id   Timer ID or object.
      */
-    function install(opts?: FakeTimerInstallOpts): InstalledClock;
-
-    interface FakeTimerWithContext {
-        timers: GlobalTimers<TimerId>;
-        createClock: (now?: number | Date, loopLimit?: number) => Clock;
-        install: (opts?: FakeTimerInstallOpts) => InstalledClock;
-        withGlobal: (global: object) => FakeTimerWithContext;
-    }
+    clearTimeout: (id: TTimerId) => void;
 
     /**
-     * Apply new context to fake timers.
+     * Schedules a callback to be fired every time timeout milliseconds have ticked by.
      *
-     * @param global   New context to apply like `window` (in browsers) or `global` (in node).
+     * @param callback   Callback to be fired.
+     * @param timeout   How many ticks to wait between callbacks.
+     * @param args   Any extra arguments to pass to the callback.
+     * @returns Time identifier for cancellation.
      */
-    function withGlobal(global: object): FakeTimerWithContext;
+    setInterval: (callback: (...args: any[]) => void, timeout: number, ...args: any[]) => TTimerId;
 
-    const timers: GlobalTimers<TimerId>;
+    /**
+     * Clears a timer, as long as it was created using setInterval.
+     *
+     * @param id   Timer ID or object.
+     */
+    clearInterval: (id: TTimerId) => void;
+
+    /**
+     * Schedules the callback to be fired once 0 milliseconds have ticked by.
+     *
+     * @param callback   Callback to be fired.
+     * @param args   Any extra arguments to pass to the callback.
+     * @remarks You'll still have to call clock.tick() for the callback to fire.
+     * @remarks If called during a tick the callback won't fire until 1 millisecond has ticked by.
+     */
+    setImmediate: (callback: (...args: any[]) => void, ...args: any[]) => TTimerId;
+
+    /**
+     * Clears a timer, as long as it was created using setImmediate.
+     *
+     * @param id   Timer ID or object.
+     */
+    clearImmediate: (id: TTimerId) => void;
+
+    /**
+     * Implements the Date object but using this clock to provide the correct time.
+     */
+    Date: typeof Date;
 }
+
+/**
+ * Timer object used in node.
+ */
+export interface NodeTimer {
+    /**
+     * Stub method call. Does nothing.
+     */
+    ref(): void;
+
+    /**
+     * Stub method call. Does nothing.
+     */
+    unref(): void;
+}
+
+/**
+ * Timer identifier for clock scheduling.
+ */
+export type TimerId = number | NodeTimer;
+
+/**
+ * Controls the flow of time.
+ */
+export interface FakeClock<TTimerId extends TimerId> extends GlobalTimers<TTimerId> {
+    /**
+     * Current clock time.
+     */
+    now: number;
+
+    /**
+     * Don't know what this prop is for, but it was included in the clocks that `createClock` or
+     * `install` return (it is never used in the code, for now).
+     */
+    timeouts: {};
+
+    /**
+     * Maximum number of timers that will be run when calling runAll().
+     */
+    loopLimit: number;
+
+    /**
+     * Schedule callback to run in the next animation frame.
+     *
+     * @param callback   Callback to be fired.
+     * @returns Request id.
+     */
+    requestAnimationFrame: (callback: (time: number) => void) => TTimerId;
+
+    /**
+     * Cancel animation frame request.
+     *
+     * @param id   The id returned from requestAnimationFrame method.
+     */
+    cancelAnimationFrame: (id: TTimerId) => void;
+
+    /**
+     * Queues the callback to be fired during idle periods to perform background and low priority work on the main event loop.
+     *
+     * @param callback   Callback to be fired.
+     * @param timeout   The maximum number of ticks before the callback must be fired.
+     * @remarks Callbacks which have a timeout option will be fired no later than time in milliseconds.
+     */
+    requestIdleCallback: (callback: () => void, timeout?: number) => TTimerId;
+
+    /**
+     * Clears a timer, as long as it was created using requestIdleCallback.
+     *
+     * @param id   Timer ID or object.
+     */
+    cancelIdleCallback: (id: TTimerId) => void;
+
+    /**
+     * Get the number of waiting timers.
+     *
+     * @returns number of waiting timers.
+     */
+    countTimers: () => number;
+
+    /**
+     * Advances the clock to the the moment of the first scheduled timer, firing it.
+     * @returns Fake milliseconds since the unix epoch.
+     */
+    next: () => number;
+
+    /**
+     * Advances the clock to the the moment of the first scheduled timer, firing it.
+     *
+     * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
+     * @returns Fake milliseconds since the unix epoch.
+     */
+    nextAsync: () => Promise<number>;
+
+    /**
+     * Advance the clock, firing callbacks if necessary.
+     *
+     * @param time   How many ticks to advance by.
+     * @returns Fake milliseconds since the unix epoch.
+     */
+    tick: (time: number | string) => number;
+
+    /**
+     * Advance the clock, firing callbacks if necessary.
+     *
+     * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
+     *
+     * @param time   How many ticks to advance by.
+     * @returns Fake milliseconds since the unix epoch.
+     */
+    tickAsync: (time: number | string) => Promise<number>;
+
+    /**
+     * Removes all timers and tick without firing them and restore now to its original value.
+     */
+    reset: () => void;
+
+    /**
+     * Runs all pending timers until there are none remaining.
+     *
+     * @remarks  If new timers are added while it is executing they will be run as well.
+     * @returns Fake milliseconds since the unix epoch.
+     */
+    runAll: () => number;
+
+    /**
+     * Runs all pending timers until there are none remaining.
+     *
+     * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
+     *
+     * @remarks  If new timers are added while it is executing they will be run as well.
+     * @returns Fake milliseconds since the unix epoch.
+     */
+    runAllAsync: () => Promise<number>;
+
+    /**
+     * Advanced the clock to the next animation frame while firing all scheduled callbacks.
+     * @returns Fake milliseconds since the unix epoch.
+     */
+    runToFrame: () => number;
+
+    /**
+     * Takes note of the last scheduled timer when it is run, and advances the clock to
+     * that time firing callbacks as necessary.
+     * @returns Fake milliseconds since the unix epoch.
+     */
+    runToLast: () => number;
+
+    /**
+     * Takes note of the last scheduled timer when it is run, and advances the clock to
+     * that time firing callbacks as necessary.
+     *
+     * Also breaks the event loop, allowing any scheduled promise callbacks to execute _before_ running the timers.
+     * @returns Fake milliseconds since the unix epoch.
+     */
+    runToLastAsync: () => Promise<number>;
+
+    /**
+     * Simulates a user changing the system clock.
+     *
+     * @param now   New system time.
+     * @remarks This affects the current time but it does not in itself cause timers to fire.
+     */
+    setSystemTime: (now?: number | Date) => void;
+}
+
+/**
+ * Fake clock for a browser environment.
+ */
+export type BrowserClock = FakeClock<number> & {
+    /**
+     * Mimics performance.now().
+     */
+    performance: {
+        now: () => number;
+    };
+};
+
+/**
+ * Fake clock for a Node environment.
+ */
+export type NodeClock = FakeClock<NodeTimer> & {
+    /**
+     * Mimicks process.hrtime().
+     *
+     * @param prevTime   Previous system time to calculate time elapsed.
+     * @returns High resolution real time as [seconds, nanoseconds].
+     */
+    hrtime(prevTime?: [number, number]): [number, number];
+
+    /**
+     * Mimics process.nextTick() explicitly dropping additional arguments.
+     */
+    queueMicrotask: (callback: () => void) => void;
+
+    /**
+     * Simulates process.nextTick().
+     */
+    nextTick: (callback: (...args: any[]) => void, ...args: any[]) => void;
+
+    /**
+     * Run all pending microtasks scheduled with nextTick.
+     */
+    runMicrotasks: () => void;
+};
+
+/**
+ * Clock object created by @sinonjs/fake-timers.
+ */
+export type Clock = BrowserClock | NodeClock;
+
+/**
+ * Additional methods that installed clock have.
+ */
+export interface InstalledMethods {
+    /**
+     * Restores the original methods on the context that was passed to FakeTimers.install,
+     * or the native timers if no context was given.
+     */
+    uninstall: () => void;
+
+    methods: FakeMethod[];
+}
+
+/**
+ * Clock object created by calling `install();`.
+ */
+export type InstalledClock = Clock & InstalledMethods;
+
+/**
+ * Creates a clock.
+ *
+ * @param now   Current time for the clock.
+ * @param loopLimit    Maximum number of timers that will be run when calling runAll()
+ *                     before assuming that we have an infinite loop and throwing an error
+ *                     (by default, 1000).
+ * @remarks The default epoch is 0.
+ */
+export function createClock(now?: number | Date, loopLimit?: number): Clock;
+
+export interface FakeTimerInstallOpts {
+    /**
+     * Installs fake timers onto the specified target context (default: global)
+     */
+    target?: any;
+
+    /**
+     * Installs fake timers with the specified unix epoch (default: 0)
+     */
+    now?: number | Date;
+
+    /**
+     * An array with explicit function names to hijack. When not set, @sinonjs/fake-timers will automatically fake all methods except nextTick
+     * e.g., FakeTimers.install({ toFake: ["setTimeout", "nextTick"]}) will fake only setTimeout and nextTick
+     */
+    toFake?: FakeMethod[];
+
+    /**
+     * The maximum number of timers that will be run when calling runAll() (default: 1000)
+     */
+    loopLimit?: number;
+
+    /**
+     * Tells @sinonjs/fake-timers to increment mocked time automatically based on the real system time shift (e.g. the mocked time will be incremented by
+     * 20ms for every 20ms change in the real system time) (default: false)
+     */
+    shouldAdvanceTime?: boolean;
+
+    /**
+     * Relevant only when using with shouldAdvanceTime: true. increment mocked time by advanceTimeDelta ms every advanceTimeDelta ms change
+     * in the real system time (default: 20)
+     */
+    advanceTimeDelta?: number;
+}
+
+/**
+ * Creates a clock and installs it globally.
+ *
+ * @param [opts]   Options for the fake timer.
+ */
+export function install(opts?: FakeTimerInstallOpts): InstalledClock;
+
+export interface FakeTimerWithContext {
+    timers: GlobalTimers<TimerId>;
+    createClock: (now?: number | Date, loopLimit?: number) => Clock;
+    install: (opts?: FakeTimerInstallOpts) => InstalledClock;
+    withGlobal: (global: object) => FakeTimerWithContext;
+}
+
+/**
+ * Apply new context to fake timers.
+ *
+ * @param global   New context to apply like `window` (in browsers) or `global` (in node).
+ */
+export function withGlobal(global: object): FakeTimerWithContext;
+
+export const timers: GlobalTimers<TimerId>;

--- a/types/sinonjs__fake-timers/sinonjs__fake-timers-tests.ts
+++ b/types/sinonjs__fake-timers/sinonjs__fake-timers-tests.ts
@@ -1,4 +1,4 @@
-import FakeTimers = require('sinonjs__fake-timers');
+import * as FakeTimers from '@sinonjs/fake-timers';
 
 const global: FakeTimers.FakeTimerWithContext = FakeTimers.withGlobal({});
 const timers: FakeTimers.GlobalTimers<FakeTimers.TimerId> = FakeTimers.timers;
@@ -86,17 +86,17 @@ browserClock.tick('08');
 nodeClock.tick(7);
 nodeClock.tick('08:03');
 
-browserClock.tickAsync(7).then(() => {});
-browserClock.tickAsync('08').then(() => {});
+browserClock.tickAsync(7).then((val: number) => val.toExponential());
+browserClock.tickAsync('08').then((val: number) => val.toExponential());
 
-nodeClock.tickAsync(7).then(() => {});
-nodeClock.tickAsync('08:03').then(() => {});
+nodeClock.tickAsync(7).then((val: number) => val.toExponential());
+nodeClock.tickAsync('08:03').then((val: number) => val.toExponential());
 
 browserClock.next();
 nodeClock.next();
 
-browserClock.nextAsync().then(() => {});
-nodeClock.nextAsync().then(() => {});
+browserClock.nextAsync().then((val: number) => val.toExponential());
+nodeClock.nextAsync().then((val: number) => val.toExponential());
 
 browserClock.reset();
 nodeClock.reset();
@@ -104,8 +104,8 @@ nodeClock.reset();
 browserClock.runAll();
 nodeClock.runAll();
 
-browserClock.runAllAsync().then(() => {});
-nodeClock.runAllAsync().then(() => {});
+browserClock.runAllAsync().then((val: number) => val.toExponential());
+nodeClock.runAllAsync().then((val: number) => val.toExponential());
 
 nodeClock.runMicrotasks();
 
@@ -115,8 +115,8 @@ nodeClock.runToFrame();
 browserClock.runToLast();
 nodeClock.runToLast();
 
-browserClock.runToLastAsync().then(() => {});
-nodeClock.runToLastAsync().then(() => {});
+browserClock.runToLastAsync().then(val => val.toExponential());
+nodeClock.runToLastAsync().then(val => val.toExponential());
 
 browserClock.setSystemTime();
 browserClock.setSystemTime(7);

--- a/types/sinonjs__fake-timers/sinonjs__fake-timers-tests.ts
+++ b/types/sinonjs__fake-timers/sinonjs__fake-timers-tests.ts
@@ -86,17 +86,17 @@ browserClock.tick('08');
 nodeClock.tick(7);
 nodeClock.tick('08:03');
 
-browserClock.tickAsync(7).then((val: number) => val.toExponential());
-browserClock.tickAsync('08').then((val: number) => val.toExponential());
+browserClock.tickAsync(7).then(val => val.toExponential());
+browserClock.tickAsync('08').then(val => val.toExponential());
 
-nodeClock.tickAsync(7).then((val: number) => val.toExponential());
-nodeClock.tickAsync('08:03').then((val: number) => val.toExponential());
+nodeClock.tickAsync(7).then(val => val.toExponential());
+nodeClock.tickAsync('08:03').then(val => val.toExponential());
 
 browserClock.next();
 nodeClock.next();
 
-browserClock.nextAsync().then((val: number) => val.toExponential());
-nodeClock.nextAsync().then((val: number) => val.toExponential());
+browserClock.nextAsync().then(val => val.toExponential());
+nodeClock.nextAsync().then(val => val.toExponential());
 
 browserClock.reset();
 nodeClock.reset();
@@ -104,8 +104,8 @@ nodeClock.reset();
 browserClock.runAll();
 nodeClock.runAll();
 
-browserClock.runAllAsync().then((val: number) => val.toExponential());
-nodeClock.runAllAsync().then((val: number) => val.toExponential());
+browserClock.runAllAsync().then(val => val.toExponential());
+nodeClock.runAllAsync().then(val => val.toExponential());
 
 nodeClock.runMicrotasks();
 

--- a/types/sinonjs__fake-timers/tsconfig.json
+++ b/types/sinonjs__fake-timers/tsconfig.json
@@ -14,6 +14,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },


### PR DESCRIPTION
Currently @types/sinon is missing async methods. PR #43139 provides missing async clocks, which this PR also does. I had already started the work (~11 hour difference, go figure), so I'll PR this alternative implementation which provides:

- refactor `SinonFakeTimers` to use external `@sinonjs/fake-timers` types, only need to update in one place now; `sinon@9` replaced `lolex` with `@sinonjs/fake-timers`: https://github.com/sinonjs/sinon/commit/10a9182bfe27b357460e80089f0539091ab1c16e
- makes available `async` clock method variants
- increase arity of callbacks within `@sinonjs/fake-timers`
- fixes a few method signatures in `@sinonjs/fake-timers`

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sinonjs/sinon/blob/v9.0.1/lib/sinon/util/fake-timers.js, https://github.com/sinonjs/fake-timers, https://sinonjs.org/releases/v9.0.1/fake-timers/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

cc @43081j 