### PR TITLE
[easy-rbac] Add typing for easy-rbac

### DIFF
--- a/types/easy-rbac/easy-rbac-tests.ts
+++ b/types/easy-rbac/easy-rbac-tests.ts
@@ -1,0 +1,27 @@
+import RBAC = require('easy-rbac');
+import rbac = require('easy-rbac');
+
+const roles = {
+    manager: {
+        can: ['post:save', 'post:delete', 'account:*'],
+        inherits: ['user']
+    },
+    user: {
+        can: [
+            'post:add',
+            {
+                name: 'post:save',
+                when: async () => true,
+            },
+            'user:create'
+        ],
+        inherits: ['manager']
+    }
+};
+
+const RBACInstance = new RBAC(roles);
+RBACInstance.can(['user', 'manager'], 'post:save', { userId: 1, ownerId: 2 });
+
+const RBACFunction = rbac.create(roles);
+RBACFunction.can('user', 'post:save', { userId: 1, ownerId: 2 });
+RBACFunction.can(['user', 'manager'], 'post:save', { userId: 1 });

--- a/types/easy-rbac/index.d.ts
+++ b/types/easy-rbac/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for easy-rbac 3.1
+// Project: https://github.com/DeadAlready/easy-rbac
+// Definitions by:  Adam Zerella <https://github.com/adamzerella>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface RoleObject {
+    name: string;
+    when: (params: object) => Promise<boolean>;
+}
+
+interface Roles {
+    [key: string]: {
+        can: Array<string|RoleObject>;
+        inherits?: string[];
+    };
+}
+
+type Options = Roles | (() => Promise<Roles>) | Promise<Roles>;
+
+declare class RBAC {
+    constructor(opts: Options);
+    can(role: string|string[]|Roles[], operation: string, params?: object): Promise<boolean>;
+    static create(opts: Options): RBAC;
+}
+
+export = RBAC;

--- a/types/easy-rbac/tsconfig.json
+++ b/types/easy-rbac/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+        "es6"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": [
+        "../"
+      ],
+      "types": [
+
+      ],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+      "index.d.ts",
+      "easy-rbac-tests.ts"
+    ]
+}

--- a/types/easy-rbac/tslint.json
+++ b/types/easy-rbac/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Some typings for the https://www.npmjs.com/package/easy-rbac package :tada: 