### PR TITLE
[gaze] Add typing for gaze

### DIFF
--- a/types/gaze/gaze-tests.ts
+++ b/types/gaze/gaze-tests.ts
@@ -1,0 +1,29 @@
+import gaze = require('gaze');
+
+gaze('**/*.js', null, (err, watcher) => {
+    watcher.watched();
+    watcher.relative('./', false);
+});
+gaze(['stylesheets/*.css', 'images/**/*.png'], {
+    interval: 5,
+    debounceDelay: 10,
+    mode: "auto",
+    cwd: './'
+}, (err, watcher) => {
+    watcher.add(['js/*.js']);
+});
+
+const gazeInstance = new gaze.Gaze('**/*.js', null, (err, watcher) => {
+    watcher.add('file.js');
+    watcher.close();
+    watcher.emit('ready');
+    watcher.remove('file.js');
+    watcher.watched();
+    watcher.relative('.', true);
+});
+gazeInstance.add('file.js');
+gazeInstance.close();
+gazeInstance.emit('ready');
+gazeInstance.remove('file.js');
+gazeInstance.watched();
+gazeInstance.relative('.', true);

--- a/types/gaze/index.d.ts
+++ b/types/gaze/index.d.ts
@@ -1,0 +1,75 @@
+// Type definitions for gaze 1.1
+// Project: https://github.com/shama/gaze
+// Definitions by:  Adam Zerella <https://github.com/adamzerella>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.1
+
+type Mode = 'auto' | 'watch' | 'poll';
+
+interface Options {
+    /**
+     * Interval to pass to fs.watchFile.
+     */
+    interval?: number;
+    /**
+     * Delay for events called in succession for the same file/event in milliseconds.
+     */
+    debounceDelay?: number;
+    /**
+     * Force the watch mode. Either 'auto' (default),
+     * 'watch' (force native events), or 'poll' (force stat polling).
+     */
+    mode?: Mode;
+    /**
+     * The current working directory to base file patterns from. Default is `process.cwd()`.
+     */
+    cwd?: string;
+}
+
+declare namespace gaze {
+    class Gaze {
+        constructor(
+            patterns: string | string[],
+            options?: Options | null,
+            callback?: (error: Error | null, watcher: Gaze) => void
+        );
+
+        /**
+         * Wrapper for EventEmitter.emit. `added`|`changed`|`renamed`|`deleted` events will also trigger the `all` event.
+         */
+        emit(event: string, ...args: any): boolean;
+
+        /**
+         * Unwatch all files and reset the watch instance.
+         */
+        close(): void;
+
+        /**
+         * Adds file(s) patterns to be watched.
+         */
+        add(patterns: string | string[]): void;
+
+        /**
+         * Removes a file or directory from being watched. Does not recurse directories.
+         */
+        remove(filepath: string): void;
+
+        /**
+         * Returns the currently watched files.
+         */
+        watched(): string[];
+
+        /**
+         * Returns the currently watched files with relative paths.
+         */
+        relative(dir: string, unixify: boolean): string[];
+    }
+}
+
+declare function gaze(
+    patterns: string | string[],
+    options?: Options | null,
+    callback?: (error: Error | null, watcher: gaze.Gaze) => void
+): void;
+
+export = gaze;

--- a/types/gaze/tsconfig.json
+++ b/types/gaze/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+        "es6"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": [
+        "../"
+      ],
+      "types": [
+
+      ],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+      "index.d.ts",
+      "gaze-tests.ts"
+    ]
+}

--- a/types/gaze/tslint.json
+++ b/types/gaze/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

I'm not sure if their is a better way to handle the wrapper function `emit(...)` here, `emit(event: string, ...args: any): boolean;` is wrapping EventEmitter.emit() from the `events` Node API.