### PR TITLE
added typings for cytoscape-edgehandles

### DIFF
--- a/types/cytoscape-edgehandles/cytoscape-edgehandles-tests.ts
+++ b/types/cytoscape-edgehandles/cytoscape-edgehandles-tests.ts
@@ -1,8 +1,8 @@
-import * as edgehandles from 'cytoscape-edgehandles';
-import * as cytoscape from 'cytoscape';
+import edgehandles from 'cytoscape-edgehandles';
+import cytoscape from 'cytoscape';
 
 const cy = cytoscape();
-cytoscape.use(edgehandles);
+cytoscape.use(edgehandles.ext);
 
 const api = cy.edgehandles();
 api.destroy();

--- a/types/cytoscape-edgehandles/cytoscape-edgehandles-tests.ts
+++ b/types/cytoscape-edgehandles/cytoscape-edgehandles-tests.ts
@@ -1,5 +1,5 @@
-import edgehandles from 'cytoscape-edgehandles';
-import cytoscape from 'cytoscape';
+import edgehandles = require('cytoscape-edgehandles');
+import cytoscape = require('cytoscape');
 
 const cy = cytoscape();
 cytoscape.use(edgehandles.ext);

--- a/types/cytoscape-edgehandles/cytoscape-edgehandles-tests.ts
+++ b/types/cytoscape-edgehandles/cytoscape-edgehandles-tests.ts
@@ -1,0 +1,8 @@
+import * as edgehandles from 'cytoscape-edgehandles';
+import * as cytoscape from 'cytoscape';
+
+const cy = cytoscape();
+cytoscape.use(edgehandles);
+
+const api = cy.edgehandles();
+api.destroy();

--- a/types/cytoscape-edgehandles/index.d.ts
+++ b/types/cytoscape-edgehandles/index.d.ts
@@ -3,11 +3,9 @@
 // Definitions by: o-su <https://github.com/o-su>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as cy from 'cytoscape';
+import cy from 'cytoscape';
 
-declare namespace edgehandles {
-    const ext: cy.Ext;
-}
+declare const ext: cy.Ext;
 
 declare module 'cytoscape' {
     interface Core {
@@ -58,5 +56,3 @@ declare module 'cytoscape' {
         destroy: () => void;
     }
 }
-
-export = edgehandles.ext;

--- a/types/cytoscape-edgehandles/index.d.ts
+++ b/types/cytoscape-edgehandles/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: o-su <https://github.com/o-su>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import cy from 'cytoscape';
+import cy = require('cytoscape');
 
-declare const ext: cy.Ext;
+export const ext: cy.Ext;
 
 declare module 'cytoscape' {
     interface Core {

--- a/types/cytoscape-edgehandles/index.d.ts
+++ b/types/cytoscape-edgehandles/index.d.ts
@@ -1,0 +1,62 @@
+// Type definitions for cytoscape-edgehandles 3.6
+// Project: https://github.com/cytoscape/cytoscape.js-edgehandles
+// Definitions by: o-su <https://github.com/o-su>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as cy from 'cytoscape';
+
+declare namespace edgehandles {
+    const ext: cy.Ext;
+}
+
+declare module 'cytoscape' {
+    interface Core {
+        edgehandles: (options?: EdgeHandlesOptions) => EdgeHandlesApi;
+    }
+
+    interface EdgeHandlesOptions {
+        preview?: boolean; // whether to show added edges preview before releasing selection
+        hoverDelay?: number; // time spent hovering over a target node before it is considered selected
+        handleNodes?: string; // selector/filter function for whether edges can be made from a given node
+        snap?: boolean; // when enabled, the edge can be drawn by just moving close to a target node
+        snapThreshold?: number; // the target node must be less than or equal to this many pixels away from the cursor/finger
+        snapFrequency?: number; // the number of times per second (Hz) that snap checks done (lower is less expensive)
+        noEdgeEventsInDraw?: boolean; // set events:no to edges during draws, prevents mouseouts on compounds
+        disableBrowserGestures?: boolean; // during an edge drawing gesture, disable browser gestures such as two-finger trackpad swipe and pinch-to-zoom
+        handlePosition?: (node: NodeSingular) => string; // sets the position of the handle in the format of "X-AXIS Y-AXIS" such as "left top", "middle top"
+        handleInDrawMode?: boolean; // whether to show the handle in draw mode
+        // can return 'flat' for flat edges between nodes or 'node' for intermediate node between them, returning null/undefined means an edge can't be added between the two nodes
+        edgeType?: (sourceNode: NodeSingular, targetNode: NodeSingular) => string | undefined;
+        loopAllowed?: (node: NodeSingular) => boolean; // for the specified node, return whether edges from itself to itself are allowed
+        nodeLoopOffset?: number; // offset for edgeType: 'node' loops
+        // for edges between the specified source and target, return element object to be passed to cy.add() for intermediary node
+        nodeParams?: (sourceNode: NodeSingular, targetNode: NodeSingular) => any;
+        edgeParams?: (sourceNode: NodeSingular, targetNode: NodeSingular, i: number) => any;
+        ghostEdgeParams?: () => any; // return element object to be passed to cy.add() for the ghost edge
+        show?: (sourceNode: NodeSingular) => void; // fired when handle is shown
+        hide?: (sourceNode: NodeSingular) => void; // fired when the handle is hidden
+        start?: (sourceNode: NodeSingular) => void; // fired when edgehandles interaction starts (drag on handle)
+        complete?: (sourceNode: NodeSingular, targetNode: NodeSingular, addedEles: EdgeCollection) => void; // fired when edgehandles is done and elements are added
+        stop?: (sourceNode: NodeSingular) => void; // fired when edgehandles interaction is stopped (either complete with added edges or incomplete)
+        cancel?: (sourceNode: NodeSingular, cancelledTargets: any) => void; // fired when edgehandles are cancelled (incomplete gesture)
+        hoverover?: (sourceNode: NodeSingular, targetNode: NodeSingular) => void; // fired when a target is hovered
+        hoverout?: (sourceNode: NodeSingular, targetNode: NodeSingular) => void; // fired when a target isn't hovered anymore
+        previewon?: (sourceNode: NodeSingular, targetNode: NodeSingular, previewEles: EdgeCollection) => void; // fired when preview is shown
+        previewoff?: (sourceNode: NodeSingular, targetNode: NodeSingular, previewEles: EdgeCollection) => void; // fired when preview is hidden
+        drawon?: () => void; // fired when draw mode enabled
+        drawoff?: () => void; // fired when draw mode disabled
+    }
+
+    interface EdgeHandlesApi {
+        start: (sourceNode: string) => void; // manually start the gesture (as if the handle were already held)
+        stop: () => void; // manually completes or cancels the gesture
+        hide: () => void; // remove the handle node from the graph
+        disable: () => void; // disables edgehandles behaviour
+        enable: () => void; // enables edgehandles behaviour
+        enableDrawMode: () => void; // turn on draw mode (the entire node body acts like the handle)
+        disableDrawMode: () => void; // turn off draw mode
+        destroy: () => void;
+    }
+}
+
+export = edgehandles.ext;

--- a/types/cytoscape-edgehandles/tsconfig.json
+++ b/types/cytoscape-edgehandles/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "dom"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "cytoscape-edgehandles-tests.ts"]
+}

--- a/types/cytoscape-edgehandles/tsconfig.json
+++ b/types/cytoscape-edgehandles/tsconfig.json
@@ -8,6 +8,7 @@
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": ["../"],
+        "esModuleInterop": true,
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/cytoscape-edgehandles/tsconfig.json
+++ b/types/cytoscape-edgehandles/tsconfig.json
@@ -8,7 +8,6 @@
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": ["../"],
-        "esModuleInterop": true,
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/cytoscape-edgehandles/tslint.json
+++ b/types/cytoscape-edgehandles/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
