### PR TITLE
Add typings for geopoint

### DIFF
--- a/types/geopoint/geopoint-tests.ts
+++ b/types/geopoint/geopoint-tests.ts
@@ -1,0 +1,21 @@
+import GeoPoint = require("geopoint");
+
+function test() {
+    const geopoint: GeoPoint = new GeoPoint(2.33, 4.66, false);
+
+    const boundingCoords: [GeoPoint, GeoPoint] = geopoint.boundingCoordinates(5, 12, true);
+
+    const distanceTo: number = geopoint.distanceTo(new GeoPoint(4.20, 6.9));
+
+    const latitude: number = geopoint.latitude(false);
+
+    const longitude: number = geopoint.longitude(true);
+
+    const degToRad: number = GeoPoint.degreesToRadians(1);
+
+    const kmToMiles: number = GeoPoint.kilometersToMiles(13.33333);
+
+    const milesToKm: number = GeoPoint.milesToKilometers(666);
+
+    const radToDeg: number = GeoPoint.radiansToDegrees(3);
+}

--- a/types/geopoint/index.d.ts
+++ b/types/geopoint/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for geopoint 1.0
+// Project: https://github.com/davidwood/node-geopoint
+// Definitions by: Varg Industries <https://github.com/vargind>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = GeoPoint;
+
+declare class GeoPoint {
+    constructor(lat: number, lon: number, inRadians?: boolean);
+
+    boundingCoordinates(distance: number, radius: number, inKilometers?: boolean): [GeoPoint, GeoPoint];
+
+    distanceTo(point: GeoPoint, inKilometers?: boolean): number;
+
+    latitude(inRadians?: boolean): number;
+
+    longitude(inRadians?: boolean): number;
+
+    static degreesToRadians(value: number): number;
+
+    static kilometersToMiles(value: number): number;
+
+    static milesToKilometers(value: number): number;
+
+    static radiansToDegrees(value: number): number;
+}

--- a/types/geopoint/tsconfig.json
+++ b/types/geopoint/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "geopoint-tests.ts"
+    ]
+}

--- a/types/geopoint/tslint.json
+++ b/types/geopoint/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This adds a type definition for the `geopoint` npm package

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

