### PR TITLE
[styled-system__css] allow null 

### DIFF
--- a/types/styled-system__css/index.d.ts
+++ b/types/styled-system__css/index.d.ts
@@ -403,7 +403,8 @@ export type SystemStyleObject =
     | CSSPseudoSelectorProps
     | CSSSelectorObject
     | VariantProperty
-    | UseThemeFunction;
+    | UseThemeFunction
+    | null;
 
 /**
  * Helper to define theme values.

--- a/types/styled-system__css/styled-system__css-tests.ts
+++ b/types/styled-system__css/styled-system__css-tests.ts
@@ -246,3 +246,6 @@ css({
 css({
     zIndex: 'base',
 })(theme);
+
+// ignores null
+css(null);


### PR DESCRIPTION
Related to PR: #42961

styled-system/css does not work with `ResponsiveValue` of @types/styled-system v5.1.9.
When I use custom type that using `ResponsiveValue` within styled-system/css, ts shows an error(`Type 'null' is not assignable to type 'SystemStyleObject'`).
https://codesandbox.io/s/typesstyled-system-v519-systemstyleobject-i3mpu

I guess that `styled-system/css` should allow null if ResponsiveValue  of styled-system allows null.



- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


