### PR TITLE
fix types for lucene: change Node.termLocation definition

### DIFF
--- a/types/lucene/index.d.ts
+++ b/types/lucene/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for lucene 2.1
 // Project: https://github.com/bripkens/lucene#readme
 // Definitions by: Ben Grynhaus <https://github.com/bengry>
+//                 Hugo Muller <https://github.com/HugoMuller>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface TermLocation {
@@ -18,7 +19,10 @@ export interface Node {
     regex: boolean;
     similarity: null;
     term: string;
-    termLocation: TermLocation;
+    termLocation: {
+        start: TermLocation;
+        end: TermLocation;
+    };
 }
 
 export type Operator = '<implicit>' | 'NOT' | 'OR' | 'AND' | 'AND NOT' | 'OR NOT';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [term location computation](https://github.com/bripkens/lucene/blob/v2.1.1/lib/queryParser.js#L533), called [l.258](https://github.com/bripkens/lucene/blob/v2.1.1/lib/queryParser.js#L258), [l.281](https://github.com/bripkens/lucene/blob/v2.1.1/lib/queryParser.js#L281) and [l.291](https://github.com/bripkens/lucene/blob/v2.1.1/lib/queryParser.js#L291)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.