### PR TITLE
add typings for browser-image-compression

### DIFF
--- a/types/browser-image-compression/browser-image-compression-tests.ts
+++ b/types/browser-image-compression/browser-image-compression-tests.ts
@@ -1,14 +1,22 @@
 import imageCompression = require('browser-image-compression');
 
-const file = new File([''], 'image.jpg', { type: 'image/jpeg' });
+async function handleImageUpload({ target }: { target: EventTarget & { files: FileList } }) {
+  const imageFile = target.files[0];
+  console.log('originalFile instanceof Blob', imageFile instanceof Blob); // true
+  console.log(`originalFile size ${imageFile.size / 1024 / 1024} MB`);
 
-(async () => {
-  const compressedFile = await imageCompression(file, {
+  const options = {
     maxSizeMB: 1,
     maxWidthOrHeight: 1920,
-    useWebWorker: false,
-    maxIteration: 10,
-    exifOrientation: -2,
-    onProgress: (p: number) => {}
-  });
-})();
+    useWebWorker: true
+  };
+  try {
+    const compressedFile = await imageCompression(imageFile, options);
+    console.log('compressedFile instanceof Blob', compressedFile instanceof Blob); // true
+    console.log(`compressedFile size ${compressedFile.size / 1024 / 1024} MB`); // smaller than maxSizeMB
+
+    // await uploadToServer(compressedFile); // write your own logic
+  } catch (error) {
+    console.log(error);
+  }
+}

--- a/types/browser-image-compression/browser-image-compression-tests.ts
+++ b/types/browser-image-compression/browser-image-compression-tests.ts
@@ -1,0 +1,14 @@
+import imageCompression = require('browser-image-compression');
+
+const file = new File([''], 'image.jpg', { type: 'image/jpeg' });
+
+(async () => {
+  const compressedFile = await imageCompression(file, {
+    maxSizeMB: 1,
+    maxWidthOrHeight: 1920,
+    useWebWorker: false,
+    maxIteration: 10,
+    exifOrientation: -2,
+    onProgress: (p: number) => {}
+  });
+})();

--- a/types/browser-image-compression/index.d.ts
+++ b/types/browser-image-compression/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for browser-image-compression 1.0
+// Project: https://github.com/Donaldcwl/browser-image-compression
+// Definitions by: Donald <https://github.com/Donaldcwl>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface Options {
+    /** @default Number.POSITIVE_INFINITY */
+    maxSizeMB?: number;
+    /** @default undefined */
+    maxWidthOrHeight?: number;
+    /** @default false */
+    useWebWorker?: boolean;
+    /** @default 10 */
+    maxIteration?: number;
+    /** Default to be the exif orientation from the image file */
+    exifOrientation?: number;
+    /** A function takes one progress argument (progress from 0 to 100) */
+    onProgress?: (progress: number) => void;
+    /** Default to be the original mime type from the image file */
+    fileType?: string;
+}
+
+declare function imageCompression(image: File | Blob, options: Options): Promise<File | Blob>;
+
+export = imageCompression;

--- a/types/browser-image-compression/index.d.ts
+++ b/types/browser-image-compression/index.d.ts
@@ -22,4 +22,6 @@ interface Options {
 
 declare function imageCompression(image: File | Blob, options: Options): Promise<File | Blob>;
 
+export as namespace imageCompression;
+
 export = imageCompression;

--- a/types/browser-image-compression/tsconfig.json
+++ b/types/browser-image-compression/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "esModuleInterop": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "browser-image-compression-tests.ts"
+    ]
+}

--- a/types/browser-image-compression/tslint.json
+++ b/types/browser-image-compression/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.