### PR TITLE
[ws] Add types for once/off/removeListener

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -238,11 +238,29 @@ declare namespace WebSocket {
         on(event: 'close' | 'listening', cb: (this: Server) => void): this;
         on(event: string | symbol, listener: (this: Server, ...args: any[]) => void): this;
 
+        once(event: 'connection', cb: (this: Server, socket: WebSocket, request: http.IncomingMessage) => void): this;
+        once(event: 'error', cb: (this: Server, error: Error) => void): this;
+        once(event: 'headers', cb: (this: Server, headers: string[], request: http.IncomingMessage) => void): this;
+        once(event: 'close' | 'listening', cb: (this: Server) => void): this;
+        once(event: string | symbol, listener: (...args: any[]) => void): this;
+
+        off(event: 'connection', cb: (this: Server, socket: WebSocket, request: http.IncomingMessage) => void): this;
+        off(event: 'error', cb: (this: Server, error: Error) => void): this;
+        off(event: 'headers', cb: (this: Server, headers: string[], request: http.IncomingMessage) => void): this;
+        off(event: 'close' | 'listening', cb: (this: Server) => void): this;
+        off(event: string | symbol, listener: (this: Server, ...args: any[]) => void): this;
+
         addListener(event: 'connection', cb: (client: WebSocket) => void): this;
         addListener(event: 'error', cb: (err: Error) => void): this;
         addListener(event: 'headers', cb: (headers: string[], request: http.IncomingMessage) => void): this;
         addListener(event: 'close' | 'listening', cb: () => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+        removeListener(event: 'connection', cb: (client: WebSocket) => void): this;
+        removeListener(event: 'error', cb: (err: Error) => void): this;
+        removeListener(event: 'headers', cb: (headers: string[], request: http.IncomingMessage) => void): this;
+        removeListener(event: 'close' | 'listening', cb: () => void): this;
+        removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 
     // WebSocket stream

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -27,9 +27,11 @@ import * as url from 'url';
         ws.send('something', (error?: Error) => {});
         ws.send('something', {}, (error?: Error) => {});
     });
-
-    wss.on('upgrade', (res) => {
-        console.log(`response: ${Object.keys(res)}`);
+    wss.once('connection', (ws, req) => {
+        ws.send('something');
+    });
+    wss.off('connection', (ws, req) => {
+        ws.send('something');
     });
 }
 


### PR DESCRIPTION
This PR adds overloads for once/off/removeListener that are procided by NodeJS's EventEmitter to the Server of ws.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - ws.Server: https://github.com/websockets/ws/blob/master/doc/ws.md#class-websocketserver
    - EventEmitter: https://nodejs.org/api/events.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
