### PR TITLE
MUI-Datatables: Update to let text labels and download options to be partials.

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -31,7 +31,7 @@ export interface MUIDataTableState {
     columns: MUIDataTableColumnState[];
     count: number;
     data: any[];
-    displayData: Array<{ dataIndex: number; data: any[] }>;
+    displayData: Array<{dataIndex: number; data: any[]}>;
     expandedRows: MUIDataTableStateRows;
     filterData: any[];
     filterList: string[][];
@@ -120,15 +120,8 @@ export interface MUIDataTableColumnState extends MUIDataTableColumnOptions {
 }
 
 export interface MUIDataTableColumnOptions {
-    customBodyRender?: (
-        value: any,
-        tableMeta: MUIDataTableMeta,
-        updateValue: (s: any, c: any, p: any) => any,
-    ) => string | React.ReactNode;
-    customHeadRender?: (
-        columnMeta: MUIDataTableCustomHeadRenderer,
-        updateDirection: (params: any) => any,
-    ) => string | React.ReactNode;
+    customBodyRender?: (value: any, tableMeta: MUIDataTableMeta, updateValue: (s: any, c: any, p: any) => any) => string | React.ReactNode;
+    customHeadRender?: (columnMeta: MUIDataTableCustomHeadRenderer, updateDirection: (params: any) => any) => string | React.ReactNode;
     customFilterListRender?: (value: any) => string;
     display?: 'true' | 'false' | 'excluded';
     download?: boolean;
@@ -155,7 +148,7 @@ export interface MUIDataTableIsRowCheck {
         {
             index: number;
             dataIndex: number;
-        },
+        }
     ];
 }
 
@@ -168,7 +161,7 @@ export interface MUIDataTableOptions {
         page: number,
         rowsPerPage: number,
         changeRowsPerPage: () => any,
-        changePage: number,
+        changePage: number
     ) => React.ReactNode;
     customRowRender?: (data: any[], dataIndex: number, rowIndex: number) => React.ReactNode;
     customSearch?: (searchQuery: string, currentRow: any[], columns: any[]) => boolean;
@@ -176,7 +169,7 @@ export interface MUIDataTableOptions {
         searchText: string,
         handleSearch: any,
         hideSearch: any,
-        options: any,
+        options: any
     ) => React.Component | JSX.Element;
     customSort?: (data: any[], colIndex: number, order: string) => any[];
     customToolbar?: () => React.ReactNode;
@@ -186,14 +179,14 @@ export interface MUIDataTableOptions {
             lookup: { [key: number]: boolean };
         },
         displayData: Array<{ data: any[]; dataIndex: number }>,
-        setSelectedRows: (rows: number[]) => void,
+        setSelectedRows: (rows: number[]) => void
     ) => React.ReactNode;
     disableToolbarSelect?: boolean;
     download?: boolean;
     downloadOptions?: Partial<{
         filename: string;
         separator: string;
-        filterOptions: { useDisplayedColumnsOnly?: boolean; useDisplayedRowsOnly?: boolean };
+        filterOptions: Partial<{ useDisplayedColumnsOnly: boolean; useDisplayedRowsOnly?: boolean }>;
     }>;
     elevation?: number;
     expandableRows?: boolean;
@@ -209,7 +202,7 @@ export interface MUIDataTableOptions {
     isRowSelectable?: (dataIndex: number, selectedRows?: MUIDataTableIsRowCheck) => boolean;
     onCellClick?: (
         colData: any,
-        cellMeta: { colIndex: number; rowIndex: number; dataIndex: number; event: React.MouseEvent },
+        cellMeta: { colIndex: number; rowIndex: number; dataIndex: number; event: React.MouseEvent }
     ) => void;
     onChangePage?: (currentPage: number) => void;
     onChangeRowsPerPage?: (numberOfRows: number) => void;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -31,7 +31,7 @@ export interface MUIDataTableState {
     columns: MUIDataTableColumnState[];
     count: number;
     data: any[];
-    displayData: Array<{dataIndex: number; data: any[]}>;
+    displayData: Array<{ dataIndex: number; data: any[] }>;
     expandedRows: MUIDataTableStateRows;
     filterData: any[];
     filterList: string[][];
@@ -120,8 +120,15 @@ export interface MUIDataTableColumnState extends MUIDataTableColumnOptions {
 }
 
 export interface MUIDataTableColumnOptions {
-    customBodyRender?: (value: any, tableMeta: MUIDataTableMeta, updateValue: (s: any, c: any, p: any) => any) => string | React.ReactNode;
-    customHeadRender?: (columnMeta: MUIDataTableCustomHeadRenderer, updateDirection: (params: any) => any) => string | React.ReactNode;
+    customBodyRender?: (
+        value: any,
+        tableMeta: MUIDataTableMeta,
+        updateValue: (s: any, c: any, p: any) => any,
+    ) => string | React.ReactNode;
+    customHeadRender?: (
+        columnMeta: MUIDataTableCustomHeadRenderer,
+        updateDirection: (params: any) => any,
+    ) => string | React.ReactNode;
     customFilterListRender?: (value: any) => string;
     display?: 'true' | 'false' | 'excluded';
     download?: boolean;
@@ -148,7 +155,7 @@ export interface MUIDataTableIsRowCheck {
         {
             index: number;
             dataIndex: number;
-        }
+        },
     ];
 }
 
@@ -161,7 +168,7 @@ export interface MUIDataTableOptions {
         page: number,
         rowsPerPage: number,
         changeRowsPerPage: () => any,
-        changePage: number
+        changePage: number,
     ) => React.ReactNode;
     customRowRender?: (data: any[], dataIndex: number, rowIndex: number) => React.ReactNode;
     customSearch?: (searchQuery: string, currentRow: any[], columns: any[]) => boolean;
@@ -169,7 +176,7 @@ export interface MUIDataTableOptions {
         searchText: string,
         handleSearch: any,
         hideSearch: any,
-        options: any
+        options: any,
     ) => React.Component | JSX.Element;
     customSort?: (data: any[], colIndex: number, order: string) => any[];
     customToolbar?: () => React.ReactNode;
@@ -179,7 +186,7 @@ export interface MUIDataTableOptions {
             lookup: { [key: number]: boolean };
         },
         displayData: Array<{ data: any[]; dataIndex: number }>,
-        setSelectedRows: (rows: number[]) => void
+        setSelectedRows: (rows: number[]) => void,
     ) => React.ReactNode;
     disableToolbarSelect?: boolean;
     download?: boolean;
@@ -202,7 +209,7 @@ export interface MUIDataTableOptions {
     isRowSelectable?: (dataIndex: number, selectedRows?: MUIDataTableIsRowCheck) => boolean;
     onCellClick?: (
         colData: any,
-        cellMeta: { colIndex: number; rowIndex: number; dataIndex: number; event: React.MouseEvent }
+        cellMeta: { colIndex: number; rowIndex: number; dataIndex: number; event: React.MouseEvent },
     ) => void;
     onChangePage?: (currentPage: number) => void;
     onChangeRowsPerPage?: (numberOfRows: number) => void;
@@ -255,7 +262,7 @@ export interface MUIDataTableOptions {
     setRowProps?: (row: any[], rowIndex: number) => object;
     sort?: boolean;
     sortFilterList?: boolean;
-    textLabels?: MUIDataTableTextLabels;
+    textLabels?: Partial<MUIDataTableTextLabels>;
     viewColumns?: boolean;
 }
 

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -190,11 +190,11 @@ export interface MUIDataTableOptions {
     ) => React.ReactNode;
     disableToolbarSelect?: boolean;
     download?: boolean;
-    downloadOptions?: {
+    downloadOptions?: Partial<{
         filename: string;
         separator: string;
-        filterOptions?: { useDisplayedColumnsOnly: boolean; useDisplayedRowsOnly: boolean };
-    };
+        filterOptions: { useDisplayedColumnsOnly?: boolean; useDisplayedRowsOnly?: boolean };
+    }>;
     elevation?: number;
     expandableRows?: boolean;
     expandableRowsOnClick?: boolean;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -186,7 +186,7 @@ export interface MUIDataTableOptions {
     downloadOptions?: Partial<{
         filename: string;
         separator: string;
-        filterOptions: Partial<{ useDisplayedColumnsOnly: boolean; useDisplayedRowsOnly?: boolean }>;
+        filterOptions: Partial<{ useDisplayedColumnsOnly: boolean; useDisplayedRowsOnly: boolean }>;
     }>;
     elevation?: number;
     expandableRows?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gregnb/mui-datatables/blob/master/src/MUIDataTable.js#L285

Its deep merging defaults with provided options so it is natural to make this a partial. 
