### PR TITLE
[relay-runtime]: allow readonly array elements to be inferred in RecordProxy

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -200,16 +200,10 @@ export { deepFreeze } from './lib/util/deepFreeze';
  * relay-compiler-language-typescript support for fragment references
  */
 
-/**
- * @private
- */
 export interface _RefType<Ref extends string> {
     ' $refType': Ref;
 }
 
-/**
- * @private
- */
 export interface _FragmentRefs<Refs extends string> {
     ' $fragmentRefs': FragmentRefs<Refs>;
 }

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -305,7 +305,7 @@ export type Scheduler = (callback: () => void) => void;
  * allowing different implementations that may e.g. create a changeset of
  * the modifications.
  */
-export type Unarray<T> = T extends Array<infer U> ? U : T;
+export type Unarray<T> = T extends Array<infer U> | ReadonlyArray<infer U> ? U : T;
 export type Primitive = string | number | boolean | null | undefined;
 
 export interface RecordProxy<T = {}> {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This an improvement to use together with relay-compiler generated types
Since relay-compiler generates array types as readonly arrays, it's useful to consider them in `Unarray` type
It's a Non breaking change
Had to turn `no-redundant-jsdoc-2` rule off since it does not recognize `@private` jsdoc tag and couldn't use `tslint:disable-next-line`
This way it will correctly infer from this case:
```typescript
import { Component_prop } from './__generated__/Component_prop.graphql';

const Component: FunctionComponent<{
  prop: Component_prop;
  relay: {
    environment: Environment;
  } & RelayProp;
}> = props => {
  commitLocalUpdate(props.relay.environment, store => {
    const item = store.get<Component_prop>(props.prop.id);
    if(!item) {
      throw new Error('invalid store state');
    }
    const linkedItems = item.getLinkedRecords('Records'); // the element wouldn't be inferred here since it's ReadonlyArray, not Array
    // mutate here
  })
}