### PR TITLE
[webpack-sources] Make CacheSource extends Source

### DIFF
--- a/types/webpack-sources/index.d.ts
+++ b/types/webpack-sources/index.d.ts
@@ -46,14 +46,16 @@ export class CachedSource extends Source {
     _cachedMaps: {
         [prop: string]: RawSourceMap
     };
-    node: (options: any) => SourceNode;
-    listMap: (options: any) => SourceListMap;
 
     constructor(source: Source);
 
     source(): string;
 
     size(): number;
+
+    node(options: any): SourceNode;
+
+    listMap(options: any): SourceListMap;
 
     sourceAndMap(options: any): {
         source: string;

--- a/types/webpack-sources/index.d.ts
+++ b/types/webpack-sources/index.d.ts
@@ -39,7 +39,7 @@ export interface SourceAndMapMixin {
     };
 }
 
-export class CachedSource {
+export class CachedSource extends Source {
     _source: Source;
     _cachedSource: string;
     _cachedSize: number;


### PR DESCRIPTION
By follow the source code here: https://github.com/webpack/webpack-sources/blob/master/lib/CachedSource.js#L37

Note: I don't make it implements SourceAndMapMixin because the method signatures are different