### PR TITLE
[react-native-snap-carousel] make non-required props optional in PaginationProps

### DIFF
--- a/types/react-native-snap-carousel/index.d.ts
+++ b/types/react-native-snap-carousel/index.d.ts
@@ -340,15 +340,15 @@ export interface PaginationProps {
     /**
      * Length of dot animation (milliseconds)
      */
-    animatedDuration: number;
+    animatedDuration?: number;
     /**
      * Controls "bounciness"/overshoot on dot animation
      */
-    animatedFriction: number;
+    animatedFriction?: number;
     /**
      * Controls speed dot animation
      */
-    animatedTension: number;
+    animatedTension?: number;
     /**
      * Number of dots to display
      */
@@ -373,7 +373,7 @@ export interface PaginationProps {
     /**
      * Delay in ms, from the start of the touch, before onPressIn is called on dot
      */
-    delayPressInDot: number;
+    delayPressInDot?: number;
     /**
      * Background color of the active dot.
      * Use this if you want to animate the change between active and inactive colors,


### PR DESCRIPTION
Some properties of PaginationProps are not optional even though the package documentation says they are not required (see [PaginationProps doc](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PAGINATION.md#props)).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [PaginationProps doc](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PAGINATION.md#props)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
