### PR TITLE
[fix] added missing parameter for submit KYC

### DIFF
--- a/types/mangopay2-nodejs-sdk/index.d.ts
+++ b/types/mangopay2-nodejs-sdk/index.d.ts
@@ -1480,6 +1480,7 @@ declare namespace MangoPay {
        * The status of this KYC/Dispute document
        */
       Status: "VALIDATION_ASKED";
+      Id: string;
       Tag?: string;
     }
 

--- a/types/mangopay2-nodejs-sdk/mangopay2-nodejs-sdk-tests.ts
+++ b/types/mangopay2-nodejs-sdk/mangopay2-nodejs-sdk-tests.ts
@@ -197,7 +197,7 @@ api.Users.getKycDocument("user-id", "kycDocument-id").then(data => {
   const d = data; // $ExpectType KycDocumentData
 });
 
-api.Users.updateKycDocument("user-id", { Status: "VALIDATION_ASKED" }).then(
+api.Users.updateKycDocument("user-id", { Status: "VALIDATION_ASKED", Id: "kycDocument-id" }).then(
   data => {
     const d = data; // $ExpectType KycDocumentData
   }


### PR DESCRIPTION
Required `Id` key for submit KYC status on MangoPay. Added additional argument inside the interface.
