### PR TITLE
@types/react-map-gl: change `schema` to `scheme` in SourceProps

### DIFF
--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -464,7 +464,7 @@ export interface SourceProps {
     tiles?: string[];
     tileSize?: number;
     bounds?: number[];
-    schema?: 'xyz' | 'tms';
+    scheme?: 'xyz' | 'tms';
     minzoom?: number;
     maxzoom?: number;
     attribution?: string;

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -105,7 +105,7 @@ class MyMap extends React.Component<{}, State> {
                         captureDoubleClick={true}
                     />
 
-                    <Source type="geojson" data={geojson} scheme={undefined}>
+                    <Source type="geojson" data={geojson}>
                         <Layer
                             type="point"
                             paint={{

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -105,7 +105,7 @@ class MyMap extends React.Component<{}, State> {
                         captureDoubleClick={true}
                     />
 
-                    <Source type="geojson" data={geojson}>
+                    <Source type="geojson" data={geojson} scheme={undefined}>
                         <Layer
                             type="point"
                             paint={{

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -114,6 +114,22 @@ class MyMap extends React.Component<{}, State> {
                             }}
                         ></Layer>
                     </Source>
+                    <Source
+                        id="raster-tiles-source"
+                        type="raster"
+                        scheme="tms"
+                        tiles={["path/to/tiles/{z}/{x}/{y}.png"]}
+                        tileSize={256}
+                    >
+                        <Layer
+                            id="raster-layer"
+                            type="raster"
+                            source="raster-tiles"
+                            paint={{}}
+                            minzoom={0}
+                            maxzoom={22}
+                        ></Layer>
+                    </Source>
                 </InteractiveMap>
                 <StaticMap
                     {...this.state.viewport}

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -124,7 +124,7 @@ class MyMap extends React.Component<{}, State> {
                         <Layer
                             id="raster-layer"
                             type="raster"
-                            source="raster-tiles"
+                            source="raster-tiles-source"
                             paint={{}}
                             minzoom={0}
                             maxzoom={22}


### PR DESCRIPTION
Mapbox GL JS accepts an optional `scheme` enum. In the SourceProps type definition this option is called `schema`, causing the prop to be ignored by mapbox gl js and defaulting to `xyz`.  [Ref](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster-scheme)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.