### PR TITLE
[react] Port ElementRef utility type from Flow

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -82,8 +82,6 @@ declare namespace React {
         | ((props: P) => ReactElement | null)
         | (new (props: P) => Component<P, any>);
 
-    type Key = string | number;
-
     interface RefObject<T> {
         readonly current: T | null;
     }
@@ -128,6 +126,8 @@ declare namespace React {
         : never;
 
     type ComponentState = any;
+
+    type Key = string | number;
 
     /**
      * @internal You shouldn't need to use this type since you never see these attributes

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -90,6 +90,32 @@ declare namespace React {
     type RefCallback<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"];
     type Ref<T> = RefCallback<T> | RefObject<T> | null;
     type LegacyRef<T> = string | Ref<T>;
+    /**
+     * Gets the instance type for a React element. The instance will be different for various component types:
+     *
+     * - React class components will be the class instance. So if you had `class Foo extends React.Component<{}> {}`
+     *   and used `React.ElementRef<typeof Foo>` then the type would be the instance of `Foo`.
+     * - React stateless functional components do not have a backing instance and so `React.ElementRef<typeof Bar>`
+     *   (when `Bar` is `function Bar() {}`) will give you the `undefined` type.
+     * - JSX intrinsics like `div` will give you their DOM instance. For `React.ElementRef<'div'>` that would be
+     *   `HTMLDivElement`. For `React.ElementRef<'input'>` that would be `HTMLInputElement`.
+     *
+     * `C` must be the type _of_ a React component so you need to use typeof as in React.ElementRef<typeof MyComponent>.
+     */
+    type ElementRef<
+        C extends
+            | ComponentClass<any>
+            | FunctionComponent<any>
+            | keyof JSX.IntrinsicElements
+    > = C extends ComponentClass<any>
+        ? InstanceType<C>
+        : C extends FunctionComponent<any>
+        ? undefined
+        : C extends keyof JSX.IntrinsicElements
+        ? JSX.IntrinsicElements[C] extends DOMAttributes<infer E>
+            ? E
+            : never
+        : never;
 
     type ComponentState = any;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -109,21 +109,21 @@ declare namespace React {
      */
     type ElementRef<
         C extends
-            | { new (props: any): Component<any> }
-            | (() => ReactElement | null)
-            | keyof JSX.IntrinsicElements
             | ForwardRefExoticComponent<any>
-    > = C extends { new (props: any): Component<any> }
+            | { new (props: any): Component<any> }
+            | ((props: any, context?: any) => ReactElement | null)
+            | keyof JSX.IntrinsicElements
+    > = C extends ForwardRefExoticComponent<infer FP>
+        ? FP extends RefAttributes<infer FC>
+            ? FC
+            : never
+        : C extends { new (props: any): Component<any> }
         ? InstanceType<C>
-        : C extends (() => ReactElement | null)
+        : C extends ((props: any, context?: any) => ReactElement | null)
         ? undefined
         : C extends keyof JSX.IntrinsicElements
         ? JSX.IntrinsicElements[C] extends DOMAttributes<infer E>
             ? E
-            : never
-        : C extends ForwardRefExoticComponent<infer FP>
-        ? FP extends RefAttributes<infer FC>
-            ? FC
             : never
         : never;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -104,12 +104,12 @@ declare namespace React {
      */
     type ElementRef<
         C extends
-            | ComponentClass<any>
-            | FunctionComponent<any>
+            | { new (props: any): React.Component<any> }
+            | (() => JSX.Element)
             | keyof JSX.IntrinsicElements
-    > = C extends ComponentClass<any>
+    > = C extends { new (props: any): React.Component<any> }
         ? InstanceType<C>
-        : C extends FunctionComponent<any>
+        : C extends (() => JSX.Element)
         ? undefined
         : C extends keyof JSX.IntrinsicElements
         ? JSX.IntrinsicElements[C] extends DOMAttributes<infer E>

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -99,21 +99,31 @@ declare namespace React {
      *   (when `Bar` is `function Bar() {}`) will give you the `undefined` type.
      * - JSX intrinsics like `div` will give you their DOM instance. For `React.ElementRef<'div'>` that would be
      *   `HTMLDivElement`. For `React.ElementRef<'input'>` that would be `HTMLInputElement`.
+     * - React stateless functional components that forward a `ref` will give you the `ElementRef` of the forwarded
+     *   to component.
      *
      * `C` must be the type _of_ a React component so you need to use typeof as in React.ElementRef<typeof MyComponent>.
+     * 
+     * @todo In Flow, this works a little different with forwarded refs and the `AbstractComponent` that
+     *       `React.forwardRef()` returns.
      */
     type ElementRef<
         C extends
-            | { new (props: any): React.Component<any> }
+            | { new (props: any): Component<any> }
             | (() => JSX.Element)
             | keyof JSX.IntrinsicElements
-    > = C extends { new (props: any): React.Component<any> }
+            | ForwardRefExoticComponent<any>
+    > = C extends { new (props: any): Component<any> }
         ? InstanceType<C>
         : C extends (() => JSX.Element)
         ? undefined
         : C extends keyof JSX.IntrinsicElements
         ? JSX.IntrinsicElements[C] extends DOMAttributes<infer E>
             ? E
+            : never
+        : C extends ForwardRefExoticComponent<infer FP>
+        ? FP extends RefAttributes<infer FC>
+            ? FC
             : never
         : never;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -103,19 +103,19 @@ declare namespace React {
      *   to component.
      *
      * `C` must be the type _of_ a React component so you need to use typeof as in React.ElementRef<typeof MyComponent>.
-     * 
+     *
      * @todo In Flow, this works a little different with forwarded refs and the `AbstractComponent` that
      *       `React.forwardRef()` returns.
      */
     type ElementRef<
         C extends
             | { new (props: any): Component<any> }
-            | (() => JSX.Element)
+            | (() => ReactElement | null)
             | keyof JSX.IntrinsicElements
             | ForwardRefExoticComponent<any>
     > = C extends { new (props: any): Component<any> }
         ? InstanceType<C>
-        : C extends (() => JSX.Element)
+        : C extends (() => ReactElement | null)
         ? undefined
         : C extends keyof JSX.IntrinsicElements
         ? JSX.IntrinsicElements[C] extends DOMAttributes<infer E>

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -440,6 +440,11 @@ function RefCarryingComponent() {
     );
 }
 
+type RefComponentAsRef = React.ElementRef<typeof RefComponent>; // $ExpectType RefComponent
+type RefCarryingComponentAsRef = React.ElementRef<typeof RefCarryingComponent>; // $ExpectType undefined
+type HTMLIntrinsicAsRef = React.ElementRef<'div'>; // $ExpectType HTMLDivElement
+type SVGIntrinsicAsRef = React.ElementRef<'svg'>; // $ExpectType SVGSVGElement
+
 //
 // Attributes
 // --------------------------------------------------------------------------

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -441,15 +441,16 @@ function RefCarryingComponent() {
 }
 
 const MemoizedForwardingRefComponent = React.memo(ForwardingRefComponent);
-const LazyRefComponent = React.lazy(() => Promise.resolve({ default: RefComponent }));
+const LazyComponent = React.lazy(() => Promise.resolve({ default: RefComponent }));
 
-type RefComponentAsRef = React.ElementRef<typeof RefComponent>; // $ExpectType RefComponent
-type RefCarryingComponentAsRef = React.ElementRef<typeof RefCarryingComponent>; // $ExpectType undefined
+type ClassComponentAsRef = React.ElementRef<typeof RefComponent>; // $ExpectType RefComponent
+type FunctionComponentWithoutPropsAsRef = React.ElementRef<typeof RefCarryingComponent>; // $ExpectType undefined
+type FunctionComponentWithPropsAsRef = React.ElementRef<typeof FunctionComponent>; // $ExpectType undefined
 type HTMLIntrinsicAsRef = React.ElementRef<'div'>; // $ExpectType HTMLDivElement
 type SVGIntrinsicAsRef = React.ElementRef<'svg'>; // $ExpectType SVGSVGElement
 type ForwardingRefComponentAsRef = React.ElementRef<typeof ForwardingRefComponent>; // $ExpectType RefComponent
 type MemoizedForwardingRefComponentAsRef = React.ElementRef<typeof MemoizedForwardingRefComponent>; // $ExpectType RefComponent
-type LazyForwardingRefComponentAsRef = React.ElementRef<typeof LazyRefComponent>; // $ExpectType RefComponent
+type LazyComponentAsRef = React.ElementRef<typeof LazyComponent>; // $ExpectType RefComponent
 
 //
 // Attributes

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -444,6 +444,7 @@ type RefComponentAsRef = React.ElementRef<typeof RefComponent>; // $ExpectType R
 type RefCarryingComponentAsRef = React.ElementRef<typeof RefCarryingComponent>; // $ExpectType undefined
 type HTMLIntrinsicAsRef = React.ElementRef<'div'>; // $ExpectType HTMLDivElement
 type SVGIntrinsicAsRef = React.ElementRef<'svg'>; // $ExpectType SVGSVGElement
+type ForwardingRefComponentAsRef = React.ElementRef<typeof ForwardingRefComponent>; // $ExpectType RefComponent
 
 //
 // Attributes

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -440,11 +440,14 @@ function RefCarryingComponent() {
     );
 }
 
+const MemoizedForwardingRefComponent = React.memo(ForwardingRefComponent);
+
 type RefComponentAsRef = React.ElementRef<typeof RefComponent>; // $ExpectType RefComponent
 type RefCarryingComponentAsRef = React.ElementRef<typeof RefCarryingComponent>; // $ExpectType undefined
 type HTMLIntrinsicAsRef = React.ElementRef<'div'>; // $ExpectType HTMLDivElement
 type SVGIntrinsicAsRef = React.ElementRef<'svg'>; // $ExpectType SVGSVGElement
 type ForwardingRefComponentAsRef = React.ElementRef<typeof ForwardingRefComponent>; // $ExpectType RefComponent
+type MemoizedForwardingRefComponentAsRef = React.ElementRef<typeof MemoizedForwardingRefComponent>; // $ExpectType RefComponent
 
 //
 // Attributes

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -441,6 +441,7 @@ function RefCarryingComponent() {
 }
 
 const MemoizedForwardingRefComponent = React.memo(ForwardingRefComponent);
+const LazyRefComponent = React.lazy(() => Promise.resolve({ default: RefComponent }));
 
 type RefComponentAsRef = React.ElementRef<typeof RefComponent>; // $ExpectType RefComponent
 type RefCarryingComponentAsRef = React.ElementRef<typeof RefCarryingComponent>; // $ExpectType undefined
@@ -448,6 +449,7 @@ type HTMLIntrinsicAsRef = React.ElementRef<'div'>; // $ExpectType HTMLDivElement
 type SVGIntrinsicAsRef = React.ElementRef<'svg'>; // $ExpectType SVGSVGElement
 type ForwardingRefComponentAsRef = React.ElementRef<typeof ForwardingRefComponent>; // $ExpectType RefComponent
 type MemoizedForwardingRefComponentAsRef = React.ElementRef<typeof MemoizedForwardingRefComponent>; // $ExpectType RefComponent
+type LazyForwardingRefComponentAsRef = React.ElementRef<typeof LazyRefComponent>; // $ExpectType RefComponent
 
 //
 // Attributes

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -554,8 +554,11 @@ const mappedChildrenArray2 = React.Children.map(numberChildren, num => num);
 const mappedChildrenArray3 = React.Children.map(elementChildren, element => element);
 // $ExpectType (string | Element)[]
 const mappedChildrenArray4 = React.Children.map(mixedChildren, elementOrString => elementOrString);
-// $ExpectType Key[]
+// This test uses a conditional type because otherwise it gets flaky and can resolve to either Key or ReactText, both
+// of which are aliases for `string | number`.
 const mappedChildrenArray5 = React.Children.map(singlePluralChildren, element => element.key);
+// $ExpectType true
+type mappedChildrenArray5Type = typeof mappedChildrenArray5 extends React.Key[] ? true : false;
 // $ExpectType string[]
 const mappedChildrenArray6 = React.Children.map(renderPropsChildren, element => element.name);
 // The return type may not be an array

--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -61,9 +61,9 @@ export type ReferenceLinePosition = 'start' | 'middle' | 'end';
 export type PickedCSSStyleDeclarationKeys =
     'alignmentBaseline' | 'baselineShift' | 'clip' | 'clipPath' | 'clipRule' | 'color' |
     'colorInterpolationFilters' | 'cursor' | 'direction' | 'display' | 'dominantBaseline' |
-    'enableBackground' | 'fill' | 'fillRule' | 'filter' | 'floodColor' |
+    'fill' | 'fillRule' | 'filter' | 'floodColor' |
     'floodOpacity' | 'font' | 'fontFamily' | 'fontStretch' | 'fontStyle' | 'fontVariant' |
-    'glyphOrientationHorizontal' | 'glyphOrientationVertical' | 'letterSpacing' | 'lightingColor' |
+    'glyphOrientationVertical' | 'letterSpacing' | 'lightingColor' |
     'markerEnd' | 'markerMid' | 'markerStart' | 'mask' | 'overflow' | 'pointerEvents' |
     'stopColor' | 'strokeDasharray' | 'strokeLinecap' | 'strokeLinejoin' | 'textAnchor' |
     'textDecoration' | 'unicodeBidi' | 'visibility' | 'writingMode' | 'transform';


### PR DESCRIPTION
Flow doc: https://flow.org/en/docs/react/types/#toc-react-elementref

In short, this utility type makes it easy to get the type a `ref` would have, given a component type. While not-essential, it will make keeping up-to-date with [upstream React code](https://github.com/facebook/react/search?q=ElementRef&unscoped_q=ElementRef) simpler; or more specifically [react-native](https://github.com/facebook/react-native/search?l=JavaScript&q=ElementRef).

I am currently introducing it in [a test for the react-native typings](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43179/files#diff-b7f9493068068c65a8ac15953df610f5R934).