### PR TITLE
feat: add typings for A11yValue in RN

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-native 0.61
+// Type definitions for react-native 0.62
 // Project: https://github.com/facebook/react-native
 // Definitions by: Eloy Durán <https://github.com/alloy>
 //                 HuHuanming <https://github.com/huhuanming>
@@ -2050,6 +2050,11 @@ export interface AccessibilityProps extends AccessibilityPropsAndroid, Accessibi
      * An accessibility hint helps users understand what will happen when they perform an action on the accessibility element when that result is not obvious from the accessibility label.
      */
     accessibilityHint?: string;
+    /**
+     * Represents the current value of a component. It can be a textual description of a component's value, or for range-based components, such as sliders and progress bars,
+     * it contains range information (minimum, current, and maximum).
+     */
+    accessibilityValue?: AccessibilityValue;
 
     /**
      * When `accessible` is true, the system will try to invoke this function when the user performs an accessibility custom action.
@@ -2129,6 +2134,28 @@ export interface AccessibilityState {
      *  When present, informs accessible tools the element is expanded or collapsed
      */
     expanded?: boolean;
+}
+
+export interface AccessibilityValue {
+    /**
+     * The minimum value of this component's range. (should be an integer)
+     */
+    min?: number,
+
+    /**
+     * The maximum value of this component's range. (should be an integer)
+     */
+    max?: number,
+
+    /**
+     * The current value of this component's range. (should be an integer)
+     */
+    now?: number,
+
+    /**
+     * A textual description of this component's value. (will override minimum, current, and maximum if set)
+     */
+    text?: string,
 }
 
 export type AccessibilityRole =

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -873,6 +873,7 @@ class AccessibilityTest extends React.Component {
                 accessibilityStates={["selected"]}
                 accessibilityState={{checked: true}}
                 accessibilityHint="Very importent header"
+                accessibilityValue={{ min: 60, max: 120, now: 80 }}
                 onMagicTap={() => {}}
                 onAccessibilityEscape={() => {}}
             >


### PR DESCRIPTION
Added type definition for `accessibilityValue` which is available in React Native 0.62.x. Since this version of React Native isn't stable just yet, we should probably hold off with merging it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactnative.dev/docs/accessibility#accessibilitystate-ios-android, https://github.com/facebook/react-native/blob/8553e1acc4195479190971cc7a3ffaa0ed37a5e0/Libraries/Components/View/ViewAccessibility.js#L66-L86
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
