### PR TITLE
Updated -- react-query adding QueryResult status

### DIFF
--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -46,6 +46,7 @@ export interface QueryOptionsPaginated<TResult> extends QueryOptions<TResult> {
 }
 
 export interface QueryResult<TResult, TVariables> {
+    status: 'loading' | 'error' | 'success' | 'manual';
     data: null | TResult;
     error: null | Error;
     isLoading: boolean;


### PR DESCRIPTION
Added status to **react-query** QueryResult interface.
Take a look at react-query returns  docs at: https://github.com/tannerlinsley/react-query#returns 
According to provided documents They updated useQuery to retrieve result status.
Feel free to ask me for more related changes if needed!
