### PR TITLE
Allow other expected values to be nested in jasmine.objectContaining for TypeScript 3.1+

### DIFF
--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1042,6 +1042,9 @@ describe("jasmine.objectContaining", () => {
         a: number;
         b: number;
         bar: string;
+        nested: {
+            child: string;
+        };
     }
     var foo: fooType;
 
@@ -1049,7 +1052,10 @@ describe("jasmine.objectContaining", () => {
         foo = {
             a: 1,
             b: 2,
-            bar: "baz"
+            bar: "baz",
+            nested: {
+                child: 'child-baz'
+            }
         };
     });
 
@@ -1063,7 +1069,7 @@ describe("jasmine.objectContaining", () => {
             foo: 2,
         }));
 
-        // Contrary to the test in ../jasmine-tests.ts, this does not cause an error
+        // Contrary to the test in v2/jasmine-tests.ts, this does not cause an error
         // even though `b` is defined as number in fooType.
         //
         // This is because the type definition of jasmine.Expected<T> matches the return type of jasmine.objectContaining(),
@@ -1082,6 +1088,21 @@ describe("jasmine.objectContaining", () => {
         expect(foo).not.toEqual(jasmine.objectContaining<fooType>({
             bar: '',
             foo: 1, // $ExpectError
+        }));
+    });
+
+    it("matches objects with jasmine matchers as property values when providing a generic type", () => {
+        expect(foo).not.toEqual(jasmine.objectContaining<fooType>({
+            b: jasmine.any(Number),
+            bar: jasmine.stringMatching('ba'),
+        }));
+    });
+
+    it("matches objects with jasmine matchers as nested property values when providing a generic type", () => {
+        expect(foo).not.toEqual(jasmine.objectContaining<fooType>({
+            nested: jasmine.objectContaining({
+                child: jasmine.stringMatching('child')
+            })
         }));
     });
 

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1053,20 +1053,35 @@ describe("jasmine.objectContaining", () => {
         };
     });
 
-    it("matches objects with the expect key/value pairs", () => {
-        // not explictly providing the type on objectContaining only guards against
-        // missmatching types on know properties
+    it("matches objects with the correct type for known properties", () => {
+        // not explicitly providing the type on objectContaining only guards against
+        // mismatching types on known properties
+
+        // this does not cause an error as the compiler cannot infer the type completely
         expect(foo).not.toEqual(jasmine.objectContaining({
             a: 37,
-            foo: 2, // <-- this does not cause an error as the compiler cannot infer the type completely
-            // b: '123', <-- this would cause an error as `b` defined as number in fooType
+            foo: 2,
         }));
 
-        // explictly providing the type on objectContaining makes the guard more precise
+        // Contrary to the test in ../jasmine-tests.ts, this does not cause an error
+        // even though `b` is defined as number in fooType.
+        //
+        // This is because the type definition of jasmine.Expected<T> matches the return type of jasmine.objectContaining(),
+        // which is jasmine.ObjectContaining<{ a: number; b: string; }>
+        //
+        // Not sure how to fix this without breaking backwards compatibility in type definitions, so I'll let it be for the moment
+        expect(foo).not.toEqual(jasmine.objectContaining({
+            a: 37,
+            b: '123',
+        }));
+    });
+
+    it("matches objects with the exact property names when providing a generic type", () => {
+        // explicitly providing the type on objectContaining makes the guard more precise
         // as misspelled properties are detected as well
         expect(foo).not.toEqual(jasmine.objectContaining<fooType>({
             bar: '',
-            // foo: 1, <-- this would cause an error as `foo` is not defined in fooType
+            foo: 1, // $ExpectError
         }));
     });
 

--- a/types/jasmine/ts3.1/index.d.ts
+++ b/types/jasmine/ts3.1/index.d.ts
@@ -266,7 +266,7 @@ declare namespace jasmine {
 
     function arrayContaining<T>(sample: ArrayLike<T>): ArrayContaining<T>;
     function arrayWithExactContents<T>(sample: ArrayLike<T>): ArrayContaining<T>;
-    function objectContaining<T>(sample: Partial<T>): ObjectContaining<T>;
+    function objectContaining<T>(sample: {[K in keyof T]?: ExpectedRecursive<T[K]>}): ObjectContaining<T>;
 
     function setDefaultSpyStrategy<Fn extends Func = Func>(and: SpyAnd<Fn>): void;
     function createSpy<Fn extends Func>(name?: string, originalFn?: Fn): Spy<Fn>;
@@ -311,7 +311,7 @@ declare namespace jasmine {
         new?(sample: ArrayLike<T>): ArrayLike<T>;
     }
 
-    interface ObjectContaining<T> extends AsymmetricMatcher<any> {
+    interface ObjectContaining<T> extends AsymmetricMatcher<T> {
         new?(sample: {[K in keyof T]?: any}): {[K in keyof T]?: any};
 
         jasmineMatches(other: any, mismatchKeys: any[], mismatchValues: any[]): boolean;

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -1042,6 +1042,9 @@ describe("jasmine.objectContaining", () => {
         a: number;
         b: number;
         bar: string;
+        nested: {
+            child: string;
+        };
     }
     var foo: fooType;
 
@@ -1049,7 +1052,10 @@ describe("jasmine.objectContaining", () => {
         foo = {
             a: 1,
             b: 2,
-            bar: "baz"
+            bar: "baz",
+            nested: {
+                child: 'child-baz'
+            },
         };
     });
 
@@ -1063,7 +1069,7 @@ describe("jasmine.objectContaining", () => {
             foo: 2,
         }));
 
-        // Contrary to the test in ../jasmine-tests.ts, this does not cause an error
+        // Contrary to the test in ../v2/jasmine-tests.ts, this does not cause an error
         // even though `b` is defined as number in fooType.
         //
         // This is because the type definition of jasmine.Expected<T> matches the return type of jasmine.objectContaining(),
@@ -1082,6 +1088,21 @@ describe("jasmine.objectContaining", () => {
         expect(foo).not.toEqual(jasmine.objectContaining<fooType>({
             bar: '',
             foo: 1, // $ExpectError
+        }));
+    });
+
+    it("matches objects with jasmine matchers as property values when providing a generic type", () => {
+        expect(foo).not.toEqual(jasmine.objectContaining<fooType>({
+            b: jasmine.any(Number),
+            bar: jasmine.stringMatching('ba'),
+        }));
+    });
+
+    it("matches objects with jasmine matchers as nested property values when providing a generic type", () => {
+        expect(foo).not.toEqual(jasmine.objectContaining<fooType>({
+            nested: jasmine.objectContaining({
+                child: jasmine.stringMatching('child')
+            })
         }));
     });
 

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -1053,20 +1053,35 @@ describe("jasmine.objectContaining", () => {
         };
     });
 
-    it("matches objects with the expect key/value pairs", () => {
-        // not explictly providing the type on objectContaining only guards against
-        // missmatching types on know properties
+    it("matches objects with the correct type for known properties", () => {
+        // not explicitly providing the type on objectContaining only guards against
+        // mismatching types on known properties
+
+        // this does not cause an error as the compiler cannot infer the type completely
         expect(foo).not.toEqual(jasmine.objectContaining({
             a: 37,
-            foo: 2, // <-- this does not cause an error as the compiler cannot infer the type completely
-            // b: '123', <-- this would cause an error as `b` defined as number in fooType
+            foo: 2,
         }));
 
-        // explictly providing the type on objectContaining makes the guard more precise
+        // Contrary to the test in ../jasmine-tests.ts, this does not cause an error
+        // even though `b` is defined as number in fooType.
+        //
+        // This is because the type definition of jasmine.Expected<T> matches the return type of jasmine.objectContaining(),
+        // which is jasmine.ObjectContaining<{ a: number; b: string; }>
+        //
+        // Not sure how to fix this without breaking backwards compatibility in type definitions, so I'll let it be for the moment
+        expect(foo).not.toEqual(jasmine.objectContaining({
+            a: 37,
+            b: '123',
+        }));
+    });
+
+    it("matches objects with the exact property names when providing a generic type", () => {
+        // explicitly providing the type on objectContaining makes the guard more precise
         // as misspelled properties are detected as well
         expect(foo).not.toEqual(jasmine.objectContaining<fooType>({
             bar: '',
-            // foo: 1, <-- this would cause an error as `foo` is not defined in fooType
+            foo: 1, // $ExpectError
         }));
     });
 

--- a/types/jasmine/v2/jasmine-tests.ts
+++ b/types/jasmine/v2/jasmine-tests.ts
@@ -758,20 +758,30 @@ describe("jasmine.objectContaining", () => {
         };
     });
 
-    it("matches objects with the expect key/value pairs", () => {
-        // not explictly providing the type on objectContaining only guards against
-        // missmatching types on know properties
+    it("matches objects with the correct type for known properties", () => {
+        // not explicitly providing the type on objectContaining only guards against
+        // mismatching types on known properties
+
+        // this does not cause an error as the compiler cannot infer the type completely
         expect(foo).not.toEqual(jasmine.objectContaining({
             a: 37,
-            foo: 2, // <-- this does not cause an error as the compiler cannot infer the type completely
-            // b: '123', <-- this would cause an error as `b` defined as number in fooType
+            foo: 2,
         }));
 
-        // explictly providing the type on objectContaining makes the guard more precise
+        // this causes an error as `b` defined as number in fooType
+        // $ExpectError
+        expect(foo).not.toEqual(jasmine.objectContaining({
+            a: 37,
+            b: '123',
+        }));
+    });
+
+    it("matches objects with the exact property names when providing a generic type", () => {
+        // explicitly providing the type on objectContaining makes the guard more precise
         // as misspelled properties are detected as well
         expect(foo).not.toEqual(jasmine.objectContaining<fooType>({
             bar: '',
-            // foo: 1, <-- this would cause an error as `foo` is not defined in fooType
+            foo: 1, // $ExpectError
         }));
     });
 


### PR DESCRIPTION
This PR contains:
- improved unit tests for jasmine.objectContaining, using $ExpectError
- the fix of #42073, which was only made for TypeScript < 3.1

NOTE: turns out one of the commented-out remarks in the old unit tests was not working as intended on the default (jasmine 3) types. I left it as-is, since I don't know how to fix this without restricting the Expected<T> definition and potentially breaking backwards compatibility.

-------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jasmine/jasmine/blob/8d53f4d202f86a11cbd3496469a1c5afd10cb836/spec/core/asymmetric_equality/ObjectContainingSpec.js#L49
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.