### PR TITLE
ember-data: fix default value of for `Snapshot<K>`

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -964,7 +964,7 @@ export namespace DS {
          */
         snapshots(): Snapshot[];
     }
-    class Snapshot<K extends keyof ModelRegistry = any> {
+    class Snapshot<K extends keyof ModelRegistry = keyof ModelRegistry> {
         /**
          * The underlying record for this snapshot. Can be used to access methods and
          * properties defined on the record.

--- a/types/ember-data/v2/index.d.ts
+++ b/types/ember-data/v2/index.d.ts
@@ -924,7 +924,7 @@ export namespace DS {
          */
         snapshots(): any[];
     }
-    class Snapshot<K extends keyof ModelRegistry = any> {
+    class Snapshot<K extends keyof ModelRegistry = keyof ModelRegistry> {
         /**
          * The underlying record for this snapshot. Can be used to access methods and
          * properties defined on the record.


### PR DESCRIPTION
The previous type for `Snapshot<K>` defaulted `K` to `any`, but with a type constraint for `K` that often resolves to `never`: any time the `ModelRegistry` has no entries. `any` is not assignable to `never`, so this always produces a type error with an empty registry.

In general, users have gotten past this by either adding a model to the registry, if they are using Ember Data, or by removing the Ember Data types if they are *not* using Ember Data. Both eliminate the type error! However, the type is strictly *wrong*, and not just in a theoretical sense: it can and *will* break users who have an Ember addon or app which uses Ember Data in a composite TS project, because [TS resolves *all* `@types`][1] unless overridden. For the sub-projects which do not have any entry in the registry, they get the expected type error: "'any' does not satisfy the constraint 'never'"… but of course this is *very* unexpected for those consumers because they're not using the type themselves *at all*!

The appropriate default for `K` here is just `keyof ModelRegistry`: this resolves to `never` when `ModelRegistry` is empty, or the keys of the registry otherwise, which achieves the goal of users never having to specify the key manually. The generic becomes effectively an invisible implementation detail, as it should be.

[1]: https://www.typescriptlang.org/v2/en/tsconfig#types


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)

    I don't actually have any good ideas on how to write a test for this. Anyone else have thoughts? @dfreeman @jamescdavis @mike-north

- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://api.emberjs.com/ember-data/3.17/classes/Snapshot/properties/modelName?anchor=modelName>