### PR TITLE
[lodash] When iterating over objects, infer well-known property names

### DIFF
--- a/types/lodash/ts3.1/common/object.d.ts
+++ b/types/lodash/ts3.1/common/object.d.ts
@@ -1519,6 +1519,10 @@ declare module "../index" {
         /**
          * @see _.mapValues
          */
+        mapValues<T extends object, TResult>(object: T, callback: (value: T[keyof T], key: keyof T, collection: T) => TResult): { [K in keyof T]: TResult };
+        /**
+         * @see _.mapValues
+         */
         mapValues<T extends object, TResult>(obj: T | null | undefined, callback: ObjectIterator<T, TResult>): { [P in keyof T]: TResult };
         /**
          * @see _.mapValues

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -5428,7 +5428,7 @@ fp.now(); // $ExpectType number
     // $ExpectType { a: string; b: string; c: string; }
     _.mapValues(abcObjectRecord, (value, key, collection) => {
         value;  // $ExpectType string
-        key; // $ExpectType string
+        key; // $ExpectType "a" | "b" | "c"
         collection; // $ExpectType Record<"a" | "b" | "c", string>
         return "";
     });
@@ -5463,7 +5463,7 @@ fp.now(); // $ExpectType number
     // $ExpectType { a: string; b: string; c: string; }
     _.mapValues(abcObject, (value, key, collection) => {
         value;  // $ExpectType string | number | boolean
-        key; // $ExpectType string
+        key; // $ExpectType "a" | "b" | "c"
         collection; // $ExpectType AbcObject
         return "";
     });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.15#mapValues
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

**Problem**

Assume an object with well-known properties:

```ts
declare const errors: {
  401: boolean;
  404: boolean;
};
```

And a function that accepts those well-known properties as its argument:

```ts
declare function getErrorMessage(code: 401 | 404 | 500): string;
```

We can't use `getErrorMessage` as the callback argument for `mapValues` because of a TypeScript error.

```ts
// Compile-time error: Argument of type 'string' is not assignable to parameter of type '401 | 404 | 500'.ts(2345)
mapValues(errors, (_, key) => getErrorMessage(key));
```

**Solution**

If we replace `string` with `keyof T`, everything works as expected.

```ts
mapValues(errors, (_, key) => getErrorMessage(key));

declare module 'lodash' {
  interface LoDashStatic {
    mapValues<T extends object, TResult>(object: T, callback: (value: T[keyof T], key: keyof T, collection: T) => TResult): { [K in keyof T]: TResult };
  }
}
```

**Considerations**

1. Because of structural typing, it's not 100% safe to assume that `key` will be of type `keyof T`. See [why](https://stackoverflow.com/questions/55012174/why-doesnt-object-keys-return-a-keyof-type-in-typescript). [Playground illustrating the problem](https://www.typescriptlang.org/play/?ssl=1&ssc=1&pln=18&pc=22#code/JYWwDg9gTgLgBAbziAhmAaigNgVwKYDOcAvnAGZQQhwDkWEAJigQBY0DcAUJw3gMZYUUPMkY4sIuo2ZtEnOHGAA7GHihkUfEQBkIAERkBlGChjA+chQtQZs+AgB4AKnDwAPVUoZEIAIwBW-DAANHBOAEqE4jAAfAAUfoF8MABcYaF82Fi+mgDWaXEAbnZ4aU4A2rl4AJ4QZGEAuqFV1WktdelwfBBYEsnAEEplAJRwALwxYZEE0cNpSOUA0opKcO31Tg1l09EkXArEnIecyqrqmiIAYqbYAKJQlFBECPJwAKwADB9pvhA9eCglFxjmQcEp+oM4ABzPAwe6PACyhAIKBhcW6vDSABYPgBGOAAHzgOKxhPeXzmcAIMCgyihlipAHdgDA+Cw4OjGHhRi8rF1mCIcbiUq8+cIYDgoKsaAAJEAgDii-kEQUfLEivkKcWS6WGaBQaqKvmZFXk75KrWwnW0ADyODABCNVl4GmiaRgLEojLgSjw3vh0DiNAAqkphN0oUpgAAvPAMVwPaBdLkAQhow32JCO3FB4LMkJhMCRBBRMIIcTUjwIaWuJiwAaePNe2qlyDQmFwhAriaeoTiAH1mjVRhNobCG8XS3g4i1hhns5xukpqchqg2iGMGZ9vnAafhgq8AMx4tIaLAqg-ELicQuT1FdkBrnsEDNwAD0b7CnogjKIvn4KA4KahYTsi94rAQwC8Lu36-kAA).
1. This change, if accepted, could be applied to other functions such as `omitBy`. However, because you may have had good reasons _not_ to define object iterators this way, I haven't introduced any other change in this pull request.