### PR TITLE
[swagger-ui-express] fix swagger options key

### DIFF
--- a/types/swagger-ui-express/index.d.ts
+++ b/types/swagger-ui-express/index.d.ts
@@ -24,7 +24,7 @@ export interface SwaggerUiOptions {
     customSiteTitle?: string;
     explorer?: boolean;
     isExplorer?: boolean;
-    options?: SwaggerOptions;
+    swaggerOptions?: SwaggerOptions;
     swaggerUrl?: string;
     swaggerUrls?: string[];
 }

--- a/types/swagger-ui-express/swagger-ui-express-tests.ts
+++ b/types/swagger-ui-express/swagger-ui-express-tests.ts
@@ -87,3 +87,11 @@ app.get(
 const swaggerHtml = swaggerUi.generateHTML(swaggerDocument, swaggerUiOpts);
 
 app.use('/api-docs-html1', swaggerUi.serveFiles(swaggerDocument, swaggerUiOpts));
+
+const uiOptsWithSwaggerOpts = {
+    swaggerOptions: {
+        validatorUrl: null
+    }
+};
+
+swaggerUi.setup(swaggerDocument, uiOptsWithSwaggerOpts);


### PR DESCRIPTION
The purpose of this PR is to correct the property key for swagger options.
As it can be seen in the [source code](https://github.com/scottie1984/swagger-ui-express/blob/98f40f8d93254703b641e48e7d94b87e0ac479c7/index.js#L142) the property should be named `swaggerOptions` instead of `options`.

By the way, the package README:
https://www.npmjs.com/package/swagger-ui-express#custom-swagger-options
contains a usage example that relies on the `swaggerOptions` key.
