### PR TITLE
fix(react): Reduce error message noise

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -516,7 +516,7 @@ declare namespace React {
     type FC<P = {}> = FunctionComponent<P>;
 
     interface FunctionComponent<P = {}> {
-        (props: PropsWithChildren<P>, context?: any): ReactElement | null;
+        (props: PropsWithChildren<P>, context?: any): ReactElement<any, any> | null;
         propTypes?: WeakValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -244,6 +244,10 @@ const LegacyStatelessComponent3: React.SFC<SCProps> =
 // allows null as props
 const FunctionComponent4: React.FunctionComponent = props => null;
 
+// undesired: Rejects `false` because of https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
+// leaving here to document limitation and inspect error message
+const FunctionComponent5: React.FunctionComponent = () => false; // $ExpectError
+
 // React.createFactory
 const factory: React.CFactory<Props, ModernComponent> =
     React.createFactory(ModernComponent);


### PR DESCRIPTION
We currently can't allow all possible react nodes as return types from render since these are hardcoded into TypeScript. It's therefore very likely that one encounters TypeScript errors that are false alarms e.g. `const FunctionComponent5: React.FunctionComponent = () => false;`. These produce noisy error messages and [frustrated users](https://twitter.com/okonetchnikov/status/1239947247908986881):


With this change we remove the "noise". 

Before: 
![ts-element-node-error-master](https://user-images.githubusercontent.com/12292047/77007371-6461d280-6964-11ea-9d1e-29f398f8376c.png)

After:
![ts-element-node-error-pr](https://user-images.githubusercontent.com/12292047/77007378-675cc300-6964-11ea-9627-088a3c8f2693.png)

in vscode 1.43.0 using typescript 3.8.3