### PR TITLE
[react-redux] Add ref and children props to Connected Components

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -20,7 +20,9 @@
 // TypeScript Version: 3.0
 
 import {
+    ClassAttributes,
     Component,
+    ComponentClass,
     ComponentType,
     StatelessComponent,
     Context,
@@ -97,7 +99,9 @@ export type Shared<
     };
 
 // Infers prop type from component C
-export type GetProps<C> = C extends ComponentType<infer P> ? P : never;
+export type GetProps<C> = C extends ComponentType<infer P>
+    ? C extends ComponentClass<P> ? ClassAttributes<C> & P : P
+    : never;
 
 // Applies LibraryManagedAttributes (proper handling of defaultProps
 // and propTypes), as well as defines WrappedComponent.

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -26,7 +26,8 @@ import {
     ComponentType,
     StatelessComponent,
     Context,
-    NamedExoticComponent
+    NamedExoticComponent,
+    ReactNode
 } from 'react';
 
 import {
@@ -100,7 +101,7 @@ export type Shared<
 
 // Infers prop type from component C
 export type GetProps<C> = C extends ComponentType<infer P>
-    ? C extends ComponentClass<P> ? ClassAttributes<C> & P : P
+    ? (C extends ComponentClass<P> ? ClassAttributes<C> & P : P) & { children?: ReactNode }
     : never;
 
 // Applies LibraryManagedAttributes (proper handling of defaultProps

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -26,8 +26,7 @@ import {
     ComponentType,
     StatelessComponent,
     Context,
-    NamedExoticComponent,
-    ReactNode
+    NamedExoticComponent
 } from 'react';
 
 import {
@@ -101,7 +100,7 @@ export type Shared<
 
 // Infers prop type from component C
 export type GetProps<C> = C extends ComponentType<infer P>
-    ? (C extends ComponentClass<P> ? ClassAttributes<C> & P : P) & { children?: ReactNode }
+    ? C extends ComponentClass<P> ? ClassAttributes<C> & P : P
     : never;
 
 // Applies LibraryManagedAttributes (proper handling of defaultProps

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1473,3 +1473,35 @@ function testConnectReturnType() {
     const myHoc2 = <P, >(C: React.FC<P>): React.ComponentType<P> => C;
     myHoc2(Test);
 }
+
+function testRef() {
+    const FunctionalComponent: React.FC = () => null;
+    const ForwardedFunctionalComponent = React.forwardRef<string>(() => null);
+    class ClassComponent extends React.Component {}
+
+    const ConnectedFunctionalComponent = connect()(FunctionalComponent);
+    const ConnectedForwardedFunctionalComponent = connect()(ForwardedFunctionalComponent);
+    const ConnectedClassComponent = connect()(ClassComponent);
+
+    // Should not be able to pass any type of ref to a FunctionalComponent
+    // ref is not a valid property
+    <ConnectedFunctionalComponent ref={React.createRef<any>()}></ConnectedFunctionalComponent>; // $ExpectError
+    <ConnectedFunctionalComponent ref={(ref: any) => {}}></ConnectedFunctionalComponent>; // $ExpectError
+    <ConnectedFunctionalComponent ref={''}></ConnectedFunctionalComponent>; // $ExpectError
+
+    // Should be able to pass modern refs to a ForwardRefExoticComponent
+    const modernRef: React.Ref<string> | undefined = undefined;
+    <ConnectedForwardedFunctionalComponent ref={modernRef}></ConnectedForwardedFunctionalComponent>;
+    // Should not be able to use legacy string refs
+    <ConnectedForwardedFunctionalComponent ref={''}></ConnectedForwardedFunctionalComponent>; // $ExpectError
+    // ref type should agree with type of the fowarded ref
+    <ConnectedForwardedFunctionalComponent ref={React.createRef<number>()}></ConnectedForwardedFunctionalComponent>; // $ExpectError
+    <ConnectedForwardedFunctionalComponent ref={(ref: number) => {}}></ConnectedForwardedFunctionalComponent>; // $ExpectError
+
+    // Should be able to use all refs including legacy string
+    const classLegacyRef: React.LegacyRef<typeof ClassComponent> | undefined = undefined;
+    <ConnectedClassComponent ref={classLegacyRef}></ConnectedClassComponent>;
+    // ref type should be the typeof the wrapped component
+    <ConnectedClassComponent ref={React.createRef<string>()}></ConnectedClassComponent>; // $ExpectError
+    <ConnectedClassComponent ref={(ref: string) => {}}></ConnectedClassComponent>; // $ExpectError
+}

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1505,3 +1505,15 @@ function testRef() {
     <ConnectedClassComponent ref={React.createRef<string>()}></ConnectedClassComponent>; // $ExpectError
     <ConnectedClassComponent ref={(ref: string) => {}}></ConnectedClassComponent>; // $ExpectError
 }
+
+function testChildren() {
+    const FunctionalComponent: React.FC = () => null;
+    class ClassComponent extends React.Component {}
+
+    const ConnectedFunctionalComponent = connect()(FunctionalComponent);
+    const ConnectedClassComponent = connect()(ClassComponent);
+
+    // Allow passing of children to connected components
+    <ConnectedFunctionalComponent>{'child'}</ConnectedFunctionalComponent>;
+    <ConnectedClassComponent>{'child'}</ConnectedClassComponent>;
+}

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1505,15 +1505,3 @@ function testRef() {
     <ConnectedClassComponent ref={React.createRef<string>()}></ConnectedClassComponent>; // $ExpectError
     <ConnectedClassComponent ref={(ref: string) => {}}></ConnectedClassComponent>; // $ExpectError
 }
-
-function testChildren() {
-    const FunctionalComponent: React.FC = () => null;
-    class ClassComponent extends React.Component {}
-
-    const ConnectedFunctionalComponent = connect()(FunctionalComponent);
-    const ConnectedClassComponent = connect()(ClassComponent);
-
-    // Allow passing of children to connected components
-    <ConnectedFunctionalComponent>{'child'}</ConnectedFunctionalComponent>;
-    <ConnectedClassComponent>{'child'}</ConnectedClassComponent>;
-}


### PR DESCRIPTION
Issue:
Connected components should be able to accept refs and children, but with the current definition both do not exist in the connect components' props.

Fixing the types to accept `children` is done by adding an optional `children` property to all connected components. 

The fix for `ref` requires some additional logic since not all wrapped components can accept refs and those that can can take different types of refs:
- Functional components cannot take any refs. This is currently working as expected.
- Functional components that are wrapped with React.forwardRef can accept all ref types except string refs. This is also working as expected since the wrapped component is of type FowardRefExoticComponent which already has `ref` in its prop types.
- Class components can take all ref types including string types. This does not work with the current definitions and requires us to explicitly add `ref` to the components prop types.

Considerations:
`connect()` require the `forwardRef` option to be passed in order to forward the ref to the wrapped component [2], but the typings in this PR will still expose the `ref` prop on the connected component regardless. This is actually existing behavior for function component using `React.forwardRef` so no attempt was made to change the type based on the option value. Additionally while it might be possible to do with some overloads on connect, it would be a breaking change. 

PR Template:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
[1]https://reactjs.org/docs/glossary.html#refs
[2]https://react-redux.js.org/api/connect#forwardref-boolean