### PR TITLE
[@types/http-proxy] Fix localAddress type

### DIFF
--- a/types/http-proxy/index.d.ts
+++ b/types/http-proxy/index.d.ts
@@ -207,7 +207,7 @@ declare namespace Server {
     /** Specify whether you want to ignore the proxy path of the incoming request. */
     ignorePath?: boolean;
     /** Local interface string to bind for outgoing connections. */
-    localAddress?: boolean;
+    localAddress?: string;
     /** Changes the origin of the host header to the target URL. */
     changeOrigin?: boolean;
     /** specify whether you want to keep letter case of response header key */


### PR DESCRIPTION
localAddress is not a boolean, it's a string as even stated in it's description.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/http-proxy#options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
