### PR TITLE
refactor(arcgis-js-api): add optional return type for Collection#Filter and Collection#Flatten

### DIFF
--- a/types/arcgis-js-api/arcgis-js-api-tests.ts
+++ b/types/arcgis-js-api/arcgis-js-api-tests.ts
@@ -25,4 +25,9 @@ class MapController {
       zoom: 13
     });
   }
+
+  filter_with_custom_return_type() {
+    // $ExpectType Collection<FeatureLayer>
+    const filteredLayers = this.map.layers.filter<__esri.FeatureLayer>(l => l.type === "feature");
+  }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N.A.

---

Right now using Collection#Filter will not change the return type of that filter, despite a filter being able to change what is in the collection.
By allowing the option to pass in a generic to the filter function (that defaults to the already existing T) this can be solved.

The added test shows a sample where this added functionality would be useful. It prevents needing to cast `map.layers` with `as __esri.Collection<__esri.FeatureLayer>`, which is admittedly pretty ugly and unreliable syntax. Since this `<R = T>` syntax is also present in functions such as `Collection#Map` I decided to also add it to `Collection#Flatten` for completions sake since that one can also modify the return type of the Collection. 
