### PR TITLE
Allow session to be null

### DIFF
--- a/types/cookie-session/index.d.ts
+++ b/types/cookie-session/index.d.ts
@@ -103,7 +103,7 @@ declare namespace CookieSessionInterfaces {
         /**
          * Represents the session for the given request.
          */
-        session?: CookieSessionObject;
+        session?: CookieSessionObject | null;
 
         /**
          * Represents the session options for the current request. These options are a shallow clone of what was provided at middleware construction and can be altered to change cookie setting behavior on a per-request basis.


### PR DESCRIPTION
According to the docs, destroying the session can be done by setting req.session = null

https://github.com/expressjs/cookie-session#destroying-a-session

and the sourcecode where it happens https://github.com/expressjs/cookie-session/blob/master/index.js#L99-L111