### PR TITLE
feat(luxon): update to 1.22

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for luxon 1.21
+// Type definitions for luxon 1.22
 // Project: https://github.com/moment/luxon#readme
 // Definitions by: Colby DeHart <https://github.com/colbydehart>
 //                 Hyeonseok Yang <https://github.com/FourwingsY>
@@ -9,6 +9,7 @@
 //                 Jason Yu <https://github.com/ycmjason>
 //                 Miklos Danka <https://github.com/mdanka>
 //                 Aitor Pérez Rodal <https://github.com/Aitor1995>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -168,7 +169,13 @@ export class DateTime {
         format: string,
         options?: DateTimeOptions,
     ): ExplainedFormat;
-    static invalid(reason: any): DateTime;
+    /**
+     * Create an invalid DateTime.
+     * @param reason - simple string of why this DateTime is invalid.
+     * Should not contain parameters or anything else data-dependent
+     * @param [explanation=null] - longer explanation, may include parameters and other useful debugging information
+     */
+    static invalid(reason: string, explanation?: string): DateTime;
     static isDateTime(o: any): o is DateTime;
     static local(
         year?: number,

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -288,6 +288,8 @@ DateTime.fromFormat('May 25 1982', 'LLLL dd yyyy'); // $ExpectType DateTime
 DateTime.fromFormat('mai 25 1982', 'LLLL dd yyyy', { locale: 'fr' }); // $ExpectType DateTime
 
 DateTime.fromFormatExplain('Aug 6 1982', 'MMMM d yyyy').regex;
+DateTime.invalid('Timestamp out of range');
+DateTime.invalid('mismatched weekday', "you can't specify both a weekday and a date");
 
 /* Math */
 const d1: DateTime = DateTime.local(2017, 2, 13).plus({ days: 30 });


### PR DESCRIPTION
- missing DateTime factory method
- tests updated
- maintainer added

https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#static-method-invalid
https://github.com/moment/luxon/blob/master/src/datetime.js#L857-L869

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#static-method-invalid
https://github.com/moment/luxon/blob/master/src/datetime.js#L857-L869
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.