### PR TITLE
Fix @reach/router .useMatch types. Path params are added to the returned object

### DIFF
--- a/types/reach__router/index.d.ts
+++ b/types/reach__router/index.d.ts
@@ -4,6 +4,7 @@
 //                 A.Mokhtar <https://github.com/xMokAx>,
 //                 Awwit <https://github.com/awwit>
 //                 wroughtec <https://github.com/wroughtec>
+//                 O.Jackman <https://github.com/chilledoj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -161,4 +162,4 @@ export function useNavigate(): NavigateFn;
 
 export function useParams(): any;
 
-export function useMatch(pathname: string): null | { uri: string; path: string };
+export function useMatch(pathname: string): null | { uri: string; path: string, [param: string]: string };

--- a/types/reach__router/reach__router-tests.tsx
+++ b/types/reach__router/reach__router-tests.tsx
@@ -7,7 +7,8 @@ import {
     LocationProvider,
     RouteComponentProps,
     Router,
-    Redirect
+    Redirect,
+    useMatch
 } from '@reach/router';
 
 interface DashParams {
@@ -22,6 +23,13 @@ const Dash = (props: RouteComponentProps<DashParams>) => (
 
 const NotFound = (props: RouteComponentProps) => <div>Route not found</div>;
 
+const UseMatchCheck = (props: RouteComponentProps) => {
+    const match = useMatch('/params/:one');
+    return (
+        <div>{match ? match.one : 'NO PATH PARAM' }</div>
+    );
+};
+
 render(
     <Router className="my-class">
         <Router component="div">
@@ -32,6 +40,7 @@ render(
         </Router>
         <Home path="/" />
         <Dash path="/default/:id" />
+        <UseMatchCheck path="/params/*" />
         <NotFound default />
 
         <Link to="/somepath" rel="noopener noreferrer" target="_blank" />


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  [@reach/router useMatch](https://reach.tech/router/api/useMatch)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
