### PR TITLE
Add types for uplot 1.0

### DIFF
--- a/types/uplot/index.d.ts
+++ b/types/uplot/index.d.ts
@@ -1,0 +1,158 @@
+// Type definitions for uPlot 1.0
+// Project: https://github.com/leeoniya/uPlot
+// Definitions by: Leo Bernard <https://github.com/leolabs>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.4
+
+// Types taken from https://github.com/leeoniya/uPlot/pull/153, all credit goes to Bob Klosinski <https://github.com/fluxin>
+
+type CanvasStrokeStyle = CanvasRenderingContext2D['strokeStyle'];
+type CanvasLineWidth = CanvasRenderingContext2D['lineWidth'];
+type CanvasFillStyle = CanvasRenderingContext2D['fillStyle'];
+type CanvasLineDash = number[];
+
+declare class UPlot {
+    constructor(opts: UPlot.Options, data: UPlot.Data, ctx: HTMLElement);
+    readonly width: number;
+    readonly height: number;
+    readonly ctx: CanvasRenderingContext2D;
+    readonly bbox: UPlot.BBox;
+    readonly select: UPlot.BBox;
+
+    redraw(): void;
+    batch(): void;
+    destroy(): void;
+
+    setData(data: UPlot.Data, something?: boolean): void;
+    setScale(scale: string, limits: { min: number; max: number }): void;
+    setCursor(cursor: string): void;
+    setSelect(opts: UPlot.SelectOpts, unknown?: boolean): void;
+    setSize(size: { width: number; height: number }): void;
+
+    posToIdx(left: number): number;
+    posToVal(leftTop: number, scaleKey: string): number;
+    valToPos(val: number, scaleKey: string): number;
+}
+
+declare namespace UPlot {
+    type Data = readonly number[][];
+    interface BBox {
+        left: number;
+        top: number;
+        width: number;
+        height: number;
+    }
+    interface Options {
+        title?: string;
+        id?: string;
+        class?: string;
+        width: number;
+        height: number;
+        series: Series[];
+        scales?: ScaleMap;
+        axes?: Axis[];
+        hooks?: Hooks;
+        plugins?: Array<{
+            hooks: Hooks;
+        }>;
+        select?: {
+            show: boolean;
+        };
+        legend?: {
+            show?: boolean;
+        };
+    }
+
+    interface SelectOpts {
+        show?: number;
+        left?: number;
+        width?: number;
+        top?: number;
+        height?: number;
+    }
+
+    interface Cursor {
+        show?: boolean;
+        points?: {
+            show: boolean | (() => boolean);
+        };
+        x: number;
+        y: number;
+        drag: {
+            setSelect: () => void;
+            setScale: () => void;
+            x: number;
+            y: number;
+        };
+        sync: {
+            key: string;
+            setSeries: () => void;
+        };
+        focus: {};
+        lock: boolean;
+    }
+
+    interface ScaleMap {
+        [key: string]: Scale;
+    }
+
+    type ValueFunction = (u: UPlot, v: number) => void;
+    interface Series {
+        show?: boolean;
+        spanGaps?: boolean;
+        label?: string;
+        band?: boolean;
+        stroke?: CanvasStrokeStyle;
+        width?: CanvasLineWidth;
+        fill?: CanvasFillStyle;
+        dash?: CanvasLineDash;
+        value?: ValueFunction;
+    }
+    interface Axis {
+        show?: boolean;
+        label?: string;
+        labelSize?: number;
+        labelFont?: string;
+        font?: string;
+        gap?: number;
+        size?: number;
+        stroke?: CanvasStrokeStyle;
+        grid?: GridOpts;
+        ticks?: TickOpts;
+    }
+    interface GridOpts {
+        show?: boolean;
+        stroke?: CanvasStrokeStyle;
+        width?: number;
+        dash?: CanvasLineDash;
+    }
+    interface TickOpts {
+        show?: boolean;
+        stroke?: CanvasStrokeStyle;
+        width?: number;
+        dash?: number[];
+        size?: number;
+    }
+    interface Scale {
+        auto?: boolean;
+        range?: [number, number];
+        time?: boolean;
+        distr?: number;
+        stroke?: CanvasStrokeStyle;
+    }
+    type SpaceFunction = (self: Axis, scaleMin: number, scaleMax: number, dim: number) => number;
+    type AxisValueFunction = (self: Axis, ticks: ReadonlyArray<number>, space: number) => string[];
+    type IncrFunction = (self: Axis) => number[];
+    interface Axis {
+        scale?: string;
+        space?: number | SpaceFunction;
+        incrs?: number[] | IncrFunction;
+        values?: Array<[number, string, number, string]> | AxisValueFunction;
+    }
+    interface Hooks {
+        init?: Array<(u: UPlot, opts: Options, data: Data) => void>;
+        setSelect?: Array<(self: UPlot) => void>;
+    }
+}
+
+export = UPlot;

--- a/types/uplot/index.d.ts
+++ b/types/uplot/index.d.ts
@@ -6,11 +6,6 @@
 
 // Types taken from https://github.com/leeoniya/uPlot/pull/153, all credit goes to Bob Klosinski <https://github.com/fluxin>
 
-type CanvasStrokeStyle = CanvasRenderingContext2D['strokeStyle'];
-type CanvasLineWidth = CanvasRenderingContext2D['lineWidth'];
-type CanvasFillStyle = CanvasRenderingContext2D['fillStyle'];
-type CanvasLineDash = number[];
-
 declare class UPlot {
     constructor(opts: UPlot.Options, data: UPlot.Data, ctx: HTMLElement);
     readonly width: number;
@@ -35,6 +30,11 @@ declare class UPlot {
 }
 
 declare namespace UPlot {
+    type CanvasStrokeStyle = CanvasRenderingContext2D['strokeStyle'];
+    type CanvasLineWidth = CanvasRenderingContext2D['lineWidth'];
+    type CanvasFillStyle = CanvasRenderingContext2D['fillStyle'];
+    type CanvasLineDash = number[];
+
     type Data = readonly number[][];
     interface BBox {
         left: number;
@@ -44,9 +44,13 @@ declare namespace UPlot {
     }
     interface Options {
         title?: string;
+        /** optional HTML attribute to set on the chart's container <div> (uplot.root) */
         id?: string;
+        /** optional HTML attribute to set on the chart's container <div> (uplot.root) */
         class?: string;
+        /** width of the plotting area, excluding title or legend dimensions */
         width: number;
+        /** height of the plotting area, excluding title or legend dimensions */
         height: number;
         series: Series[];
         scales?: ScaleMap;
@@ -99,6 +103,7 @@ declare namespace UPlot {
     type ValueFunction = (u: UPlot, v: number) => void;
     interface Series {
         show?: boolean;
+        /** set to true to connect null data points */
         spanGaps?: boolean;
         label?: string;
         band?: boolean;

--- a/types/uplot/tsconfig.json
+++ b/types/uplot/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "esModuleInterop": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "uplot-tests.ts"
+    ]
+}

--- a/types/uplot/tslint.json
+++ b/types/uplot/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/uplot/uplot-tests.ts
+++ b/types/uplot/uplot-tests.ts
@@ -1,0 +1,40 @@
+import UPlot, { Data } from 'uplot';
+
+const data: Data = [
+    [1546300800, 1546387200], // x-values (timestamps)
+    [35, 71], // y-values (series 1)
+    [90, 15], // y-values (series 2)
+];
+
+const plot = new UPlot(
+    {
+        title: 'My Chart',
+        id: 'chart1',
+        class: 'my-chart',
+        width: 800,
+        height: 600,
+        series: [
+            {},
+            {
+                // initial toggled state (optional)
+                show: true,
+
+                spanGaps: false,
+
+                // in-legend display
+                label: 'RAM',
+                value: (self, rawValue) => '$' + rawValue.toFixed(2),
+
+                // series style
+                stroke: 'red',
+                width: 1,
+                fill: 'rgba(255, 0, 0, 0.3)',
+                dash: [10, 5],
+            },
+        ],
+    },
+    data,
+    document.body,
+);
+
+plot.redraw();


### PR DESCRIPTION
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.