### PR TITLE
fix: it should be possible to use latest 0.x knex version

### DIFF
--- a/types/mock-knex/index.d.ts
+++ b/types/mock-knex/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Jesse Zhang <https://github.com/jessezhang91>
 //                 Scott Cooper <https://github.com/scttcper>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.4
 
 /// <reference types="node" />
 

--- a/types/mock-knex/package.json
+++ b/types/mock-knex/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "knex": "> 0.8 < 0.20"
+        "knex": "> 0.8 < 1.0"
     }
 }


### PR DESCRIPTION
Latest knex types support TypeScript >= 3.4