### PR TITLE
react-native-canvas stroke() has two variants, parameter is optional

### DIFF
--- a/types/react-native-canvas/index.d.ts
+++ b/types/react-native-canvas/index.d.ts
@@ -121,7 +121,7 @@ export interface CanvasRenderingContext2D {
     scale: (x: number, y: number) => void;
     setLineDash: (segments: number[]) => void;
     setTransform: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
-    stroke: (path: Path2D) => void;
+    stroke: (path?: Path2D) => void;
     strokeRect: (x: number, y: number, width: number, height: number) => void;
     strokeText: (text: string, x: number, y: number, maxWidth?: number) => void;
     transform: (a: number, b: number, c: number, d: number, e: number, f: number) => void;


### PR DESCRIPTION
CanvasRenderingContext2d stroke has two variants, with or without parameters
https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/stroke

The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/iddan/react-native-canvas/issues/164

