### PR TITLE
[element-closest] add types

### DIFF
--- a/types/element-closest/element-closest-tests.ts
+++ b/types/element-closest/element-closest-tests.ts
@@ -1,0 +1,25 @@
+import elementClosest from 'element-closest';
+
+// $ExpectError
+elementClosest(null);
+
+// $ExpectError
+elementClosest(undefined);
+
+// $ExpectError
+elementClosest(100);
+
+// $ExpectError
+elementClosest('test');
+
+// $ExpectError
+elementClosest(false);
+
+// $ExpectError
+elementClosest(true);
+
+// $ExpectError
+elementClosest({});
+
+// $ExpectType void
+elementClosest(window);

--- a/types/element-closest/index.d.ts
+++ b/types/element-closest/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for element-closest 3.0
+// Project: https://github.com/jonathantneal/closest#readme
+// Definitions by: hikiko4ern <https://github.com/hikiko4ern>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+declare function polyfill(window: Window): void;
+
+export = polyfill;

--- a/types/element-closest/tsconfig.json
+++ b/types/element-closest/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "element-closest-tests.ts"
+    ]
+}

--- a/types/element-closest/tslint.json
+++ b/types/element-closest/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

- - -

[jonathantneal/closest](https://github.com/jonathantneal/closest)