### PR TITLE
d3-selection: Disable tslint error on TS 3.9

### DIFF
--- a/types/d3-selection/d3-selection-tests.ts
+++ b/types/d3-selection/d3-selection-tests.ts
@@ -836,16 +836,19 @@ newDiv = body.append(function(d, i, g) {
     const index: number = i;
     const group: HTMLBodyElement[] | d3Selection.ArrayLike<HTMLBodyElement> = g;
     console.log('Body element foo property: ', d.foo); // data of type BodyDatum
+    // tslint:disable-next-line:no-unnecessary-type-assertion
     return this.ownerDocument!.createElement('div'); // this-type HTMLBodyElement
 });
 
 // $ExpectError
 newDiv = body.append<HTMLDivElement>(function(d) {
+    // tslint:disable-next-line:no-unnecessary-type-assertion
     return this.ownerDocument!.createElement('a'); // fails, HTMLDivElement expected by type parameter, HTMLAnchorElement returned
 });
 
 // $ExpectError
 newDiv = body.append(function(d) {
+    // tslint:disable-next-line:no-unnecessary-type-assertion
     return this.ownerDocument!.createElement('a'); // fails, HTMLDivElement expected by inference, HTMLAnchorElement returned
 });
 
@@ -870,6 +873,7 @@ const typeValueFunction = function(
   i: number,
   g: HTMLBodyElement[] | d3Selection.ArrayLike<HTMLBodyElement>
 ) {
+    // tslint:disable-next-line:no-unnecessary-type-assertion
     return this.ownerDocument!.createElement('p'); // this-type HTMLParagraphElement
 };
 


### PR DESCRIPTION
DOM updates in 3.9 mean that Typescript now knows that `HTMLBodyElement.ownerDocument` can't actually be null. Previously, a non-null assertion was needed.

Because the tests have to compile on 3.9 AND older versions, I just disabled the rule that disallows unneeded assertions.