### PR TITLE
dom-mediacapture-record: remove AudioTrackList

### DIFF
--- a/types/dom-mediacapture-record/index.d.ts
+++ b/types/dom-mediacapture-record/index.d.ts
@@ -58,9 +58,7 @@ declare class MediaRecorder extends EventTarget {
 
     constructor(stream: MediaStream, options?: MediaRecorderOptions);
 
-    addEventListener<K extends keyof MediaRecorderEventMap>(type: K, listener: (this: AudioTrackList, ev: MediaRecorderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof MediaRecorderEventMap>(type: K, listener: (this: AudioTrackList, ev: MediaRecorderEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 
     start(timeslice?: number): void;


### PR DESCRIPTION
AudioTrackList isn't standard ([only supported in IE and Safari](https://caniuse.com/#search=audio%20track)), and is removed from the DOM lib in TS 3.9:
  https://github.com/microsoft/TSJS-lib-generator/pull/802

This PR removes it from dom-mediacapture-record.