### PR TITLE
types for Yandex.Metrika Tag API

### DIFF
--- a/types/yandex-metrika-tag/index.d.ts
+++ b/types/yandex-metrika-tag/index.d.ts
@@ -10,12 +10,12 @@ declare namespace ym {
         (counterId: number, eventName: 'init', parameters: InitParameters): void;
         (counterId: number, eventName: 'addFileExtension', extensions: string | string[]): void;
         // tslint:disable-next-line no-unnecessary-generics
-        <CTX extends any>(counterId: number, eventName: 'extLink', url: string, options?: ExtLinkOptions<CTX>): void;
+        <CTX>(counterId: number, eventName: 'extLink', url: string, options?: ExtLinkOptions<CTX>): void;
         // tslint:disable-next-line no-unnecessary-generics
-        <CTX extends any>(counterId: number, eventName: 'file', url: string, options?: FileOptions<CTX>): void;
+        <CTX>(counterId: number, eventName: 'file', url: string, options?: FileOptions<CTX>): void;
         (counterId: number, eventName: 'getClientID', cb: (clientID: string) => void): void;
         // tslint:disable-next-line no-unnecessary-generics
-        <CTX extends any>(counterId: number, eventName: 'hit', url: string, options?: HitOptions<CTX>): void;
+        <CTX>(counterId: number, eventName: 'hit', url: string, options?: HitOptions<CTX>): void;
         /** @deprecated */
         (
             counterId: number,
@@ -26,10 +26,10 @@ declare namespace ym {
             params?: VisitParameters,
         ): void;
         // tslint:disable-next-line no-unnecessary-generics
-        <CTX extends any>(counterId: number, eventName: 'notBounce', options?: NotBounceOptions<CTX>): void;
+        <CTX>(counterId: number, eventName: 'notBounce', options?: NotBounceOptions<CTX>): void;
         (counterId: number, eventName: 'params', parameters: VisitParameters | VisitParameters[]): void;
         // tslint:disable-next-line no-unnecessary-generics
-        <CTX extends any>(
+        <CTX>(
             counterId: number,
             eventName: 'reachGoal',
             target: string,

--- a/types/yandex-metrika-tag/index.d.ts
+++ b/types/yandex-metrika-tag/index.d.ts
@@ -1,0 +1,100 @@
+// Type definitions for Yandex.Metrika Tag API
+// Project: https://yandex.ru/support/metrica/code/counter-initialize.html
+// Definitions by: hikiko4ern <https://github.com/hikiko4ern>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare var ym: ym.Event;
+
+declare namespace ym {
+    interface Event {
+        (counterId: number, eventName: 'init', parameters: InitParameters): void;
+        (counterId: number, eventName: 'addFileExtension', extensions: string | string[]): void;
+        // tslint:disable-next-line no-unnecessary-generics
+        <CTX extends any>(counterId: number, eventName: 'extLink', url: string, options?: ExtLinkOptions<CTX>): void;
+        // tslint:disable-next-line no-unnecessary-generics
+        <CTX extends any>(counterId: number, eventName: 'file', url: string, options?: FileOptions<CTX>): void;
+        (counterId: number, eventName: 'getClientID', cb: (clientID: string) => void): void;
+        // tslint:disable-next-line no-unnecessary-generics
+        <CTX extends any>(counterId: number, eventName: 'hit', url: string, options?: HitOptions<CTX>): void;
+        /** @deprecated */
+        (
+            counterId: number,
+            eventName: 'hit',
+            url: string,
+            title?: string,
+            referer?: string,
+            params?: VisitParameters,
+        ): void;
+        // tslint:disable-next-line no-unnecessary-generics
+        <CTX extends any>(counterId: number, eventName: 'notBounce', options?: NotBounceOptions<CTX>): void;
+        (counterId: number, eventName: 'params', parameters: VisitParameters | VisitParameters[]): void;
+        // tslint:disable-next-line no-unnecessary-generics
+        <CTX extends any>(
+            counterId: number,
+            eventName: 'reachGoal',
+            target: string,
+            params?: VisitParameters,
+            callback?: (this: CTX) => void,
+            ctx?: CTX,
+        ): void;
+        (counterId: number, eventName: 'replacePhones'): void;
+        (counterId: number, eventName: 'setUserID', userID: string): void;
+        (counterId: number, eventName: 'userParams', parameters: UserParameters): void;
+    }
+
+    interface VisitParameters {
+        order_price?: number;
+        currency?: string;
+        [key: string]: any;
+    }
+
+    interface UserParameters {
+        UserID?: number;
+        [key: string]: any;
+    }
+
+    interface InitParameters {
+        accurateTrackBounce?: boolean | number;
+        childIframe?: boolean;
+        clickmap?: boolean;
+        defer?: boolean;
+        ecommerce?: boolean | string | any[];
+        params?: VisitParameters | VisitParameters[];
+        userParams?: UserParameters;
+        trackHash?: boolean;
+        trackLinks?: boolean;
+        trustedDomains?: string[];
+        type?: number;
+        ut?: 'noindex';
+        webvisor?: boolean;
+        triggerEvent?: boolean;
+    }
+
+    interface ExtLinkOptions<CTX> {
+        callback?(this: CTX): void;
+        ctx?: CTX;
+        params?: VisitParameters;
+        title?: string;
+    }
+
+    interface FileOptions<CTX> {
+        callback?(this: CTX): void;
+        ctx?: CTX;
+        params?: VisitParameters;
+        referer?: string;
+        title?: string;
+    }
+
+    interface HitOptions<CTX> {
+        callback?(this: CTX): void;
+        ctx?: CTX;
+        params?: VisitParameters;
+        referer?: string;
+        title?: string;
+    }
+
+    interface NotBounceOptions<CTX> {
+        callback?(this: CTX): void;
+        ctx?: CTX;
+    }
+}

--- a/types/yandex-metrika-tag/index.d.ts
+++ b/types/yandex-metrika-tag/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Yandex.Metrika Tag API
+// Type definitions for non-npm package Yandex.Metrika Tag API 2.0
 // Project: https://yandex.ru/support/metrica/code/counter-initialize.html
 // Definitions by: hikiko4ern <https://github.com/hikiko4ern>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/yandex-metrika-tag/tsconfig.json
+++ b/types/yandex-metrika-tag/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "yandex-metrika-tag-tests.ts"
+    ]
+}

--- a/types/yandex-metrika-tag/tslint.json
+++ b/types/yandex-metrika-tag/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json", 
+    "rules": {
+        "dt-header": false,
+        "npm-naming": false
+    }
+}

--- a/types/yandex-metrika-tag/tslint.json
+++ b/types/yandex-metrika-tag/tslint.json
@@ -1,7 +1,1 @@
-{
-    "extends": "dtslint/dt.json", 
-    "rules": {
-        "dt-header": false,
-        "npm-naming": false
-    }
-}
+{ "extends": "dtslint/dt.json" }

--- a/types/yandex-metrika-tag/yandex-metrika-tag-tests.ts
+++ b/types/yandex-metrika-tag/yandex-metrika-tag-tests.ts
@@ -1,0 +1,120 @@
+const counterID = 123456;
+
+ym; // $ExpectType Event
+
+// $ExpectError
+ym('badID', 'init');
+
+// $ExpectError
+ym(counterID, 'noSuchMethod');
+
+// $ExpectError
+ym(counterID, 'init');
+
+// $ExpectType void
+ym(counterID, 'init', {});
+
+// $ExpectError
+ym(counterID, 'init', {
+    unknownProp: 'test',
+});
+
+// $ExpectError
+ym(counterID, 'init', {
+    ut: 'bad ut',
+});
+
+// $ExpectType void
+ym(counterID, 'init', {
+    ut: 'noindex',
+});
+
+// $ExpectType void
+ym(counterID, 'hit', '/page', 'Page title');
+
+// $ExpectError
+ym(counterID, 'addFileExtenstion');
+
+// $ExpectType void
+ym(counterID, 'file', '/some/path');
+
+// $ExpectType void
+ym(counterID, 'file', '/download/nothing.7z', {
+    callback() {
+        // $ExpectType string
+        this;
+    },
+    ctx: 'test',
+    referer: '/url',
+    params: { order_price: 200, currency: 'UAH' },
+});
+
+// $ExpectError
+ym(counterID, 'extLink', 'https://some.site', {
+    callback: null,
+    ctx: { a: 'b' },
+    title: 'some title',
+    params: { order_price: 10 },
+});
+
+// $ExpectType void
+ym(counterID, 'setUserID', '123456');
+
+// $ExpectError
+ym(counterID, 'setUserID', 123456);
+
+// $ExpectType void
+ym(counterID, 'notBounce');
+
+// $ExpectType void
+ym(counterID, 'reachGoal', 'target');
+
+// $ExpectError
+ym(counterID, 'reachGoal', 111);
+
+// $ExpectError
+ym(counterID, 'reachGoal', null);
+
+// $ExpectError
+ym(counterID, 'reachGoal', 'someGoal', null);
+
+// $ExpectType void
+ym(
+    counterID,
+    'reachGoal',
+    'someGoal',
+    undefined,
+    function() {
+        // $ExpectType number
+        this;
+    },
+    111,
+);
+
+// $ExpectError
+ym(counterID, 'params');
+
+// $ExpectType void
+ym(counterID, 'params', {
+    order_price: 100,
+    currency: 'USD',
+    customKey: 'some data',
+});
+
+// $ExpectError
+ym(counterID, 'userParams');
+
+// $ExpectType void
+ym(counterID, 'userParams', {
+    UserID: 111,
+    anotherKey: undefined,
+    andAnother: {
+        mood: 'happy',
+    },
+});
+
+// $ExpectType void
+ym(counterID, 'replacePhones');
+
+// $ExpectError
+ym(counterID, 'replacePhones', 'anotherParam');


### PR DESCRIPTION
Header taken from [facebook-pixel types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/facebook-pixel/index.d.ts).

- - -

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
