### PR TITLE
Add a typesVersions redirect for RSVP in advance of TS3.9

### DIFF
--- a/types/rsvp/package.json
+++ b/types/rsvp/package.json
@@ -1,0 +1,11 @@
+{
+    "private": true,
+    "types": "index",
+    "typesVersions": {
+        ">=3.9.0-0": {
+            "*": [
+                "ts3.9/*"
+            ]
+        }
+    }
+}

--- a/types/rsvp/ts3.9/index.d.ts
+++ b/types/rsvp/ts3.9/index.d.ts
@@ -1,0 +1,496 @@
+// NOTE: These definitions support RSVP and TypeScript 3.9.
+
+// These types are derived in large part from the Microsoft-supplied types for
+// ES2015 Promises. They have been tweaked to support RSVP's extensions to the
+// Promises A+ spec and the additional helper functions it supplies.
+
+declare namespace RSVP {
+    // All the Promise methods essentially flatten existing promises, so that
+    // you don't end up with `Promise<Promise<Promise<string>>>` if you happen
+    // to return another `Promise` from a `.then()` invocation, etc. So all of
+    // them can take a type or a promise-like/then-able type.
+    type Arg<T> = T | PromiseLike<T>;
+
+    // RSVP supplies status for promises in certain places.
+    enum State {
+        fulfilled = 'fulfilled',
+        rejected = 'rejected',
+        pending = 'pending',
+    }
+
+    type Resolved<T> = {
+        state: State.fulfilled;
+        value: T;
+    };
+
+    type Rejected<T = any> = {
+        state: State.rejected;
+        reason: T;
+    };
+
+    type Pending = {
+        state: State.pending;
+    };
+
+    type PromiseState<T> = Resolved<T> | Rejected | Pending;
+
+    type Deferred<T> = {
+        promise: Promise<T>;
+        resolve: (value?: RSVP.Arg<T>) => void;
+        reject: (reason?: any) => void;
+    };
+
+    interface InstrumentEvent {
+        guid: string; // guid of promise. Must be globally unique, not just within the implementation
+        childGuid: string; // child of child promise (for chained via `then`)
+        eventName: string; // one of ['created', 'chained', 'fulfilled', 'rejected']
+        detail: any; // fulfillment value or rejection reason, if applicable
+        label: string; // label passed to promise's constructor
+        timeStamp: number; // milliseconds elapsed since 1 January 1970 00:00:00 UTC up until now
+    }
+
+    interface ObjectWithEventMixins {
+        on(
+            eventName: 'created' | 'chained' | 'fulfilled' | 'rejected',
+            listener: (event: InstrumentEvent) => void
+        ): void;
+        on(eventName: 'error', errorHandler: (reason: any) => void): void;
+        on(eventName: string, callback: (value: any) => void): void;
+        off(eventName: string, callback?: (value: any) => void): void;
+        trigger(eventName: string, options?: any, label?: string): void;
+    }
+
+    class EventTarget {
+        /** `RSVP.EventTarget.mixin` extends an object with EventTarget methods. */
+        static mixin(object: object): ObjectWithEventMixins;
+
+        /** Registers a callback to be executed when `eventName` is triggered */
+        static on(
+            eventName: 'created' | 'chained' | 'fulfilled' | 'rejected',
+            listener: (event: InstrumentEvent) => void
+        ): void;
+        static on(eventName: 'error', errorHandler: (reason: any) => void): void;
+        static on(eventName: string, callback: (value: any) => void): void;
+
+        /**
+         * You can use `off` to stop firing a particular callback for an event.
+         *
+         * If you don't pass a `callback` argument to `off`, ALL callbacks for the
+         * event will not be executed when the event fires.
+         */
+        static off(eventName: string, callback?: (value: any) => void): void;
+
+        /**
+         * Use `trigger` to fire custom events.
+         *
+         * You can also pass a value as a second argument to `trigger` that will be
+         * passed as an argument to all event listeners for the event
+         */
+        static trigger(eventName: string, options?: any, label?: string): void;
+    }
+
+    class Promise<T> implements PromiseLike<T> {
+        constructor(
+            executor: (resolve: (value?: RSVP.Arg<T>) => void, reject: (reason?: any) => void) => void,
+            label?: string
+        );
+
+        new<T>(
+            executor: (resolve: (value?: RSVP.Arg<T>) => void, reject: (reason?: any) => void) => void
+        ): RSVP.Promise<T>;
+
+        then<TResult1 = T, TResult2 = never>(
+            onFulfilled?: ((value: awaited T) => TResult1 | PromiseLike<TResult1>) | undefined | null,
+            onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null,
+            label?: string
+        ): RSVP.Promise<TResult1 | TResult2>;
+
+        catch<TResult = never>(
+            onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null,
+            label?: string
+        ): RSVP.Promise<T | TResult>;
+
+        finally<U>(onFinally?: U | PromiseLike<U>): RSVP.Promise<T>;
+
+        readonly [Symbol.toStringTag]: 'Promise';
+
+        static all<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            values: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>, Arg<T8>, Arg<T9>, Arg<T10>],
+            label?: string
+        ): RSVP.Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>;
+        static all<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            values: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>, Arg<T8>, Arg<T9>],
+            label?: string
+        ): RSVP.Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>;
+        static all<T1, T2, T3, T4, T5, T6, T7, T8>(
+            values: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>, Arg<T8>],
+            label?: string
+        ): RSVP.Promise<[T1, T2, T3, T4, T5, T6, T7, T8]>;
+        static all<T1, T2, T3, T4, T5, T6, T7>(
+            values: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>],
+            label?: string
+        ): RSVP.Promise<[T1, T2, T3, T4, T5, T6, T7]>;
+        static all<T1, T2, T3, T4, T5, T6>(
+            values: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>],
+            label?: string
+        ): RSVP.Promise<[T1, T2, T3, T4, T5, T6]>;
+        static all<T1, T2, T3, T4, T5>(
+            values: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>],
+            label?: string
+        ): RSVP.Promise<[T1, T2, T3, T4, T5]>;
+        static all<T1, T2, T3, T4>(
+            values: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>],
+            label?: string
+        ): RSVP.Promise<[T1, T2, T3, T4]>;
+        static all<T1, T2, T3>(values: [Arg<T1>, Arg<T2>, Arg<T3>], label?: string): RSVP.Promise<[T1, T2, T3]>;
+        static all<T1, T2>(values: [Arg<T1>, Arg<T2>], label?: string): Promise<[T1, T2]>;
+        static all<T>(values: (Arg<T>)[], label?: string): RSVP.Promise<T[]>;
+
+        static race<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            values: [
+                Arg<T1>,
+                Arg<T2>,
+                Arg<T3>,
+                Arg<T4>,
+                Arg<T5>,
+                Arg<T6>,
+                Arg<T7>,
+                Arg<T8>,
+                Arg<T9>,
+                T10 | PromiseLike<T10>
+            ],
+            label?: string
+        ): RSVP.Promise<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10>;
+        static race<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            values: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>, Arg<T8>, Arg<T9>],
+            label?: string
+        ): RSVP.Promise<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
+        static race<T1, T2, T3, T4, T5, T6, T7, T8>(
+            values: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>, Arg<T8>],
+            label?: string
+        ): RSVP.Promise<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8>;
+        static race<T1, T2, T3, T4, T5, T6, T7>(
+            values: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>],
+            label?: string
+        ): RSVP.Promise<T1 | T2 | T3 | T4 | T5 | T6 | T7>;
+        static race<T1, T2, T3, T4, T5, T6>(
+            values: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>],
+            label?: string
+        ): RSVP.Promise<T1 | T2 | T3 | T4 | T5 | T6>;
+        static race<T1, T2, T3, T4, T5>(
+            values: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>],
+            label?: string
+        ): RSVP.Promise<T1 | T2 | T3 | T4 | T5>;
+        static race<T1, T2, T3, T4>(
+            values: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>],
+            label?: string
+        ): RSVP.Promise<T1 | T2 | T3 | T4>;
+        static race<T1, T2, T3>(values: [Arg<T1>, Arg<T2>, Arg<T3>], label?: string): RSVP.Promise<T1 | T2 | T3>;
+        static race<T1, T2>(values: [Arg<T1>, Arg<T2>], label?: string): RSVP.Promise<T1 | T2>;
+        static race<T>(values: (Arg<T>)[], label?: string): RSVP.Promise<T>;
+
+        static reject(reason?: any, label?: string): RSVP.Promise<never>;
+
+        static resolve<T>(value?: Arg<T>, label?: string): RSVP.Promise<T>;
+        static resolve(): RSVP.Promise<void>;
+
+        /**
+         * @deprecated
+         */
+        static cast: typeof RSVP.Promise.resolve;
+    }
+
+    const all: typeof Promise.all;
+    const race: typeof Promise.race;
+    const reject: typeof Promise.reject;
+    const resolve: typeof Promise.resolve;
+    function rethrow(reason: any): void;
+
+    const cast: typeof Promise.cast;
+
+    const on: typeof EventTarget.on;
+    const off: typeof EventTarget.off;
+
+    // ----- denodeify ----- //
+    // Here be absurd things because we don't have variadic types. All of
+    // this will go away if we can ever write this:
+    //
+    //     denodeify<...T, ...A>(
+    //         nodeFunc: (...args: ...A, callback: (err: any, ...cbArgs: ...T) => any) => void,
+    //         options?: false
+    //     ): (...args: ...A) => RSVP.Promise<...T>
+    //
+    // That day, however, may never come. So, in the meantime, we do this.
+
+    function denodeify<T1, T2, T3, A>(
+        nodeFunc: (arg1: A, callback: (err: any, data1: T1, data2: T2, data3: T3) => void) => void,
+        options?: false
+    ): (arg1: A) => RSVP.Promise<T1>;
+
+    function denodeify<T1, T2, A>(
+        nodeFunc: (arg1: A, callback: (err: any, data1: T1, data2: T2) => void) => void,
+        options?: false
+    ): (arg1: A) => RSVP.Promise<T1>;
+
+    function denodeify<T, A>(
+        nodeFunc: (arg1: A, callback: (err: any, data: T) => void) => void,
+        options?: false
+    ): (arg1: A) => RSVP.Promise<T>;
+
+    function denodeify<T1, T2, T3, A>(
+        nodeFunc: (arg1: A, callback: (err: any, data1: T1, data2: T2, data3: T3) => void) => void,
+        options: true
+    ): (arg1: A) => RSVP.Promise<[T1, T2, T3]>;
+
+    function denodeify<T1, T2, A>(
+        nodeFunc: (arg1: A, callback: (err: any, data1: T1, data2: T2) => void) => void,
+        options: true
+    ): (arg1: A) => RSVP.Promise<[T1, T2]>;
+
+    function denodeify<T, A>(
+        nodeFunc: (arg1: A, callback: (err: any, data: T) => void) => void,
+        options: true
+    ): (arg1: A) => RSVP.Promise<[T]>;
+
+    function denodeify<T1, T2, T3, A, K1 extends string, K2 extends string, K3 extends string>(
+        nodeFunc: (arg1: A, callback: (err: any, data1: T1, data2: T2, data3: T3) => void) => void,
+        options: [K1, K2, K3]
+    ): (arg1: A) => RSVP.Promise<{ [K in K1]: T1 } & { [K in K2]: T2 } & { [K in K3]: T3 }>;
+
+    function denodeify<T1, T2, A, K1 extends string, K2 extends string>(
+        nodeFunc: (arg1: A, callback: (err: any, data1: T1, data2: T2) => void) => void,
+        options: [K1, K2]
+    ): (arg1: A) => RSVP.Promise<{ [K in K1]: T1 } & { [K in K2]: T2 }>;
+
+    function denodeify<T, A, K1 extends string>(
+        nodeFunc: (arg1: A, callback: (err: any, data: T) => void) => void,
+        options: [K1]
+    ): (arg1: A) => RSVP.Promise<{ [K in K1]: T }>;
+
+    // ----- hash and hashSettled ----- //
+    function hash<T>(object: { [P in keyof T]: Arg<T[P]> }, label?: string): RSVP.Promise<T>;
+    function hashSettled<T>(
+        object: { [P in keyof T]: Arg<T[P]> },
+        label?: string
+    ): RSVP.Promise<{ [P in keyof T]: PromiseState<T[P]> }>;
+
+    function allSettled<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>, Arg<T8>, Arg<T9>, Arg<T10>],
+        label?: string
+    ): RSVP.Promise<
+        [
+            PromiseState<T1>,
+            PromiseState<T2>,
+            PromiseState<T3>,
+            PromiseState<T4>,
+            PromiseState<T5>,
+            PromiseState<T6>,
+            PromiseState<T7>,
+            PromiseState<T8>,
+            PromiseState<T9>
+        ]
+    >;
+    function allSettled<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>, Arg<T8>, Arg<T9>],
+        label?: string
+    ): RSVP.Promise<
+        [
+            PromiseState<T1>,
+            PromiseState<T2>,
+            PromiseState<T3>,
+            PromiseState<T4>,
+            PromiseState<T5>,
+            PromiseState<T6>,
+            PromiseState<T7>,
+            PromiseState<T8>,
+            PromiseState<T9>
+        ]
+    >;
+    function allSettled<T1, T2, T3, T4, T5, T6, T7, T8>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>, Arg<T8>],
+        label?: string
+    ): RSVP.Promise<
+        [
+            PromiseState<T1>,
+            PromiseState<T2>,
+            PromiseState<T3>,
+            PromiseState<T4>,
+            PromiseState<T5>,
+            PromiseState<T6>,
+            PromiseState<T7>,
+            PromiseState<T8>
+        ]
+    >;
+    function allSettled<T1, T2, T3, T4, T5, T6, T7>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>],
+        label?: string
+    ): RSVP.Promise<
+        [
+            PromiseState<T1>,
+            PromiseState<T2>,
+            PromiseState<T3>,
+            PromiseState<T4>,
+            PromiseState<T5>,
+            PromiseState<T6>,
+            PromiseState<T7>
+        ]
+    >;
+    function allSettled<T1, T2, T3, T4, T5, T6>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>],
+        label?: string
+    ): RSVP.Promise<
+        [PromiseState<T1>, PromiseState<T2>, PromiseState<T3>, PromiseState<T4>, PromiseState<T5>, PromiseState<T6>]
+    >;
+    function allSettled<T1, T2, T3, T4, T5>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>],
+        label?: string
+    ): RSVP.Promise<[PromiseState<T1>, PromiseState<T2>, PromiseState<T3>, PromiseState<T4>, PromiseState<T5>]>;
+    function allSettled<T1, T2, T3, T4>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>],
+        label?: string
+    ): RSVP.Promise<[PromiseState<T1>, PromiseState<T2>, PromiseState<T3>, PromiseState<T4>]>;
+    function allSettled<T1, T2, T3>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>],
+        label?: string
+    ): RSVP.Promise<[PromiseState<T1>, PromiseState<T2>, PromiseState<T3>]>;
+    function allSettled<T1, T2>(
+        entries: [Arg<T1>, Arg<T2>],
+        label?: string
+    ): RSVP.Promise<[PromiseState<T1>, PromiseState<T2>]>;
+    function allSettled<T>(entries: Arg<T>[], label?: string): RSVP.Promise<[PromiseState<T>]>;
+
+    function map<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, U>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>, Arg<T8>, Arg<T9>, Arg<T10>],
+        mapFn: (item: T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10) => U,
+        label?: string
+    ): RSVP.Promise<Array<U> & { length: 10 }>;
+
+    function map<T1, T2, T3, T4, T5, T6, T7, T8, T9, U>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>, Arg<T8>, Arg<T9>],
+        mapFn: (item: T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9) => U,
+        label?: string
+    ): RSVP.Promise<Array<U> & { length: 9 }>;
+    function map<T1, T2, T3, T4, T5, T6, T7, T8, U>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>, Arg<T8>],
+        mapFn: (item: T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8) => U,
+        label?: string
+    ): RSVP.Promise<Array<U> & { length: 8 }>;
+    function map<T1, T2, T3, T4, T5, T6, T7, U>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>],
+        mapFn: (item: T1 | T2 | T3 | T4 | T5 | T6 | T7) => U,
+        label?: string
+    ): RSVP.Promise<Array<U> & { length: 7 }>;
+    function map<T1, T2, T3, T4, T5, T6, U>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>],
+        mapFn: (item: T1 | T2 | T3 | T4 | T5 | T6) => U,
+        label?: string
+    ): RSVP.Promise<Array<U> & { length: 6 }>;
+    function map<T1, T2, T3, T4, T5, U>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>],
+        mapFn: (item: T1 | T2 | T3 | T4 | T5) => U,
+        label?: string
+    ): RSVP.Promise<Array<U> & { length: 5 }>;
+    function map<T1, T2, T3, T4, U>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>],
+        mapFn: (item: T1 | T2 | T3 | T4) => U,
+        label?: string
+    ): RSVP.Promise<Array<U> & { length: 4 }>;
+    function map<T1, T2, T3, U>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>],
+        mapFn: (item: T1 | T2 | T3) => U,
+        label?: string
+    ): RSVP.Promise<Array<U> & { length: 3 }>;
+    function map<T1, T2, U>(
+        entries: [Arg<T1>, Arg<T2>],
+        mapFn: (item: T1 | T2) => U,
+        label?: string
+    ): RSVP.Promise<Array<U> & { length: 2 }>;
+    function map<T, U>(
+        entries: Arg<T>[],
+        mapFn: (item: T) => U,
+        label?: string
+    ): RSVP.Promise<Array<U> & { length: 1 }>;
+
+    function filter<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>, Arg<T8>, Arg<T9>, Arg<T10>],
+        filterFn: (item: T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10) => boolean,
+        label?: string
+    ): RSVP.Promise<Array<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10>>;
+    function filter<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>, Arg<T8>, Arg<T9>],
+        filterFn: (item: T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9) => boolean,
+        label?: string
+    ): RSVP.Promise<Array<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>>;
+    function filter<T1, T2, T3, T4, T5, T6, T7, T8>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>, Arg<T8>],
+        filterFn: (item: T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8) => boolean,
+        label?: string
+    ): RSVP.Promise<Array<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8>>;
+    function filter<T1, T2, T3, T4, T5, T6, T7>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>, Arg<T7>],
+        filterFn: (item: T1 | T2 | T3 | T4 | T5 | T6 | T7) => boolean,
+        label?: string
+    ): RSVP.Promise<Array<T1 | T2 | T3 | T4 | T5 | T6 | T7>>;
+    function filter<T1, T2, T3, T4, T5, T6>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>, Arg<T6>],
+        filterFn: (item: T1 | T2 | T3 | T4 | T5 | T6) => boolean,
+        label?: string
+    ): RSVP.Promise<Array<T1 | T2 | T3 | T4 | T5 | T6> & { length: 6 }>;
+    function filter<T1, T2, T3, T4, T5>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>, Arg<T5>],
+        filterFn: (item: T1 | T2 | T3 | T4 | T5) => boolean,
+        label?: string
+    ): RSVP.Promise<Array<T1 | T2 | T3 | T4 | T5>>;
+    function filter<T1, T2, T3, T4>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>, Arg<T4>],
+        filterFn: (item: T1 | T2 | T3 | T4) => boolean,
+        label?: string
+    ): RSVP.Promise<Array<T1 | T2 | T3 | T4>>;
+    function filter<T1, T2, T3>(
+        entries: [Arg<T1>, Arg<T2>, Arg<T3>],
+        filterFn: (item: T1 | T2 | T3) => boolean,
+        label?: string
+    ): RSVP.Promise<Array<T1 | T2 | T3>>;
+    function filter<T1, T2>(
+        entries: [Arg<T1>, Arg<T2>],
+        filterFn: (item: T1 | T2) => boolean,
+        label?: string
+    ): RSVP.Promise<Array<T1 | T2>>;
+    function filter<T>(entries: Arg<T>[], filterFn: (item: T) => boolean, label?: string): RSVP.Promise<Array<T>>;
+
+    function defer<T>(label?: string): Deferred<T>;
+
+    function configure<T>(name: string): T;
+    function configure<T>(name: string, value: T): void;
+
+    function asap<T, U>(callback: (callbackArg: T) => U, arg: T): void;
+
+    const async: typeof asap;
+}
+
+export default RSVP;
+
+export interface Promise<T> extends RSVP.Promise<T> {}
+export const Promise: typeof RSVP.Promise;
+
+export interface EventTarget extends RSVP.EventTarget {}
+export const EventTarget: typeof RSVP.EventTarget;
+
+export const asap: typeof RSVP.asap;
+export const cast: typeof RSVP.cast;
+export const all: typeof RSVP.all;
+export const allSettled: typeof RSVP.allSettled;
+export const race: typeof RSVP.race;
+export const hash: typeof RSVP.hash;
+export const hashSettled: typeof RSVP.hashSettled;
+export const rethrow: typeof RSVP.rethrow;
+export const defer: typeof RSVP.defer;
+export const denodeify: typeof RSVP.denodeify;
+export const configure: typeof RSVP.configure;
+export const on: typeof RSVP.on;
+export const off: typeof RSVP.off;
+export const resolve: typeof RSVP.resolve;
+export const reject: typeof RSVP.reject;
+export const map: typeof RSVP.map;
+export const async: typeof RSVP.async;
+export const filter: typeof RSVP.filter;

--- a/types/rsvp/ts3.9/rsvp-tests.ts
+++ b/types/rsvp/ts3.9/rsvp-tests.ts
@@ -1,0 +1,334 @@
+import RSVP, { all, race, resolve, Promise as RPromise, EventTarget as REventTarget } from 'rsvp';
+
+/** Static assertion that `value` has type `T` */
+// Disable tslint here b/c the generic is used to let us do a type coercion and
+// validate that coercion works for the type value "passed into" the function.
+// tslint:disable-next-line:no-unnecessary-generics
+declare function assertType<T>(value: T): void;
+
+let rsvpPromise: RPromise<number[]> = RSVP.resolve([1, 2, 3]);
+rsvpPromise = Promise.resolve([1, 2, 3]) as PromiseLike<number[]>; // $ExpectError
+
+new RPromise<number>((res, rej) => {
+    res(3); // $ExpectType void
+    rej('oops'); // $ExpectType void
+});
+
+const et = REventTarget.mixin({});
+type etType = keyof typeof et; // $ExpectType "on" | "off" | "trigger"
+et.on('error', handler => {}); // $ExpectType void
+et.off('error', handler => {}); // $ExpectType void
+et.trigger('error'); // $ExpectType void
+et.trigger('error', '12', 34); // $ExpectError
+
+async function testAsyncAwait() {
+    const awaitedNothing = await RSVP.resolve();
+    const awaitedValue = await RSVP.resolve('just a value');
+
+    async function returnsAPromise(): RSVP.Promise<string> {
+        return RSVP.resolve('look, a string');
+    }
+
+    assertType<RSVP.Promise<string>>(returnsAPromise());
+    assertType<string>(await returnsAPromise());
+}
+
+function testCast() {
+    RSVP.Promise.cast('foo').then(value => {
+        assertType<string>(value);
+    });
+
+    RSVP.cast(42).then(value => {
+        assertType<number>(value);
+    });
+}
+
+function testConfigure() {
+    assertType<void>(RSVP.configure('name', { with: 'some value' }));
+    assertType<{}>(RSVP.configure('name'));
+}
+
+function testAsap() {
+    const result = RSVP.asap(something => {
+        console.log(something);
+    }, 'srsly');
+
+    assertType<void>(result);
+}
+
+function testAsync() {
+    const result = RSVP.async(something => {
+        console.log(something);
+    }, 'rly srsly');
+
+    assertType<void>(result);
+}
+
+function testPromise() {
+    const promiseOfString = new RSVP.Promise((resolve: any, reject: any) => resolve('some string'));
+    assertType<RSVP.Promise<number>>(promiseOfString.then((s: string) => s.length));
+}
+
+function testPromiseWithLabel() {
+    new RSVP.Promise((resolve: any, reject: any) => resolve('foo'), 'my promise');
+}
+
+function testAll() {
+    const imported = all([]);
+    const empty = RSVP.Promise.all([]);
+
+    const everyPromise = RSVP.all(['string', RSVP.resolve(42), RSVP.resolve({ hash: 'with values' })]);
+
+    assertType<RSVP.Promise<[string, number, { hash: string }]>>(everyPromise);
+
+    const anyFailure = RSVP.all([12, 'strings', RSVP.reject('anywhere')]);
+    assertType<RSVP.Promise<{}>>(anyFailure);
+
+    let promise1 = RSVP.resolve(1);
+    let promise2 = RSVP.resolve('2');
+    let promise3 = RSVP.resolve({ key: 13 });
+    RSVP.Promise.all([promise1, promise2, promise3], 'my label').then(function(array) {
+        assertType<number>(array[0]);
+        assertType<string>(array[1]);
+        assertType<{ key: number }>(array[2]);
+    });
+}
+
+function testAllSettled() {
+    const resolved1 = RSVP.resolve(1);
+    const resolved2 = RSVP.resolve('wat');
+    const rejected = RSVP.reject(new Error('oh teh noes'));
+    const pending = new RSVP.Promise<{ neato: string }>((resolve, reject) => {
+        if ('something') {
+            resolve({ neato: 'yay' });
+        } else {
+            reject('nay');
+        }
+    });
+
+    // Types flow into resolution properly
+    RSVP.allSettled([resolved1, resolved2, rejected, pending]).then(states => {
+        assertType<RSVP.PromiseState<number>>(states[0]);
+        assertType<RSVP.PromiseState<string>>(states[1]);
+        assertType<RSVP.PromiseState<never>>(states[2]);
+        assertType<RSVP.PromiseState<{ neato: string }>>(states[3]);
+    });
+
+    // Switching on state gives the correctly available items.
+    RSVP.allSettled([resolved1, resolved2, rejected, pending]).then(states => {
+        states.forEach(element => {
+            switch (element.state) {
+                case RSVP.State.fulfilled:
+                    assertType<RSVP.Resolved<typeof element.value>>(element);
+                    break;
+
+                case RSVP.State.rejected:
+                    assertType<RSVP.Rejected<typeof element.reason>>(element);
+                    break;
+
+                case RSVP.State.pending:
+                    assertType<RSVP.Pending>(element);
+                    break;
+
+                default:
+                    // Someday maybe TS will have exhaustiveness checks.
+                    break;
+            }
+        });
+    });
+}
+
+function testDefer() {
+    let deferred = RSVP.defer<string>();
+    deferred.resolve('Success!');
+    deferred.promise.then(function(value) {
+        assertType<string>(value);
+    });
+}
+
+// Using this to differentiate the types cleanly
+type A1 = Array<{ arg: boolean }>;
+type D1 = number;
+type D2 = string;
+type D3 = { some: boolean };
+
+declare const nodeFn1Arg1CbParam: (arg1: A1, callback: (err: any, data: D1) => void) => void;
+declare const nodeFn1Arg2CbParam: (arg1: A1, callback: (err: any, data1: D1, data2: D2) => void) => void;
+declare const nodeFn1Arg3CbParam: (arg1: A1, callback: (err: any, data1: D1, data2: D2, data3: D3) => void) => void;
+
+function testDenodeify() {
+    // version with no `options` or `options: false`, and single T
+    assertType<(value: A1) => RSVP.Promise<D1>>(RSVP.denodeify(nodeFn1Arg1CbParam));
+    assertType<(value: A1) => RSVP.Promise<D1>>(RSVP.denodeify(nodeFn1Arg1CbParam, false));
+
+    // version with no `options` or `options: false`, and multiple T
+    assertType<(value: A1) => RSVP.Promise<D1>>(RSVP.denodeify(nodeFn1Arg2CbParam));
+    assertType<(value: A1) => RSVP.Promise<D1>>(RSVP.denodeify(nodeFn1Arg3CbParam));
+    assertType<(value: A1) => RSVP.Promise<D1>>(RSVP.denodeify(nodeFn1Arg2CbParam, false));
+    assertType<(value: A1) => RSVP.Promise<D1>>(RSVP.denodeify(nodeFn1Arg3CbParam, false));
+
+    // version with `options: true` and single or multiple T
+    assertType<(value: A1) => RSVP.Promise<[D1]>>(RSVP.denodeify(nodeFn1Arg1CbParam, true));
+    assertType<(value: A1) => RSVP.Promise<[D1, D2]>>(RSVP.denodeify(nodeFn1Arg2CbParam, true));
+    assertType<(value: A1) => RSVP.Promise<[D1, D2, D3]>>(RSVP.denodeify(nodeFn1Arg3CbParam, true));
+
+    // We can't actually map the key names here, because we would need full-on
+    // dependent typing to use the *values of an array* as the keys of the
+    // resulting object.
+    assertType<(value: A1) => RSVP.Promise<{ first: D1 }>>(RSVP.denodeify(nodeFn1Arg1CbParam, ['first']));
+    assertType<(value: A1) => RSVP.Promise<{ first: D1; second: D2 }>>(
+        RSVP.denodeify(nodeFn1Arg2CbParam, ['first', 'second'])
+    );
+    assertType<(value: A1) => RSVP.Promise<{ first: D1; second: D2; third: D3 }>>(
+        RSVP.denodeify(nodeFn1Arg3CbParam, ['first', 'second', 'third'])
+    );
+
+    const foo = RSVP.denodeify(nodeFn1Arg2CbParam, ['quux', 'baz']);
+    foo([{ arg: true }]).then(value => {
+        console.log(value.quux + 1);
+        console.log(value.baz.length);
+    });
+}
+
+function testFilter() {
+    RSVP.filter([RSVP.resolve(1), RSVP.resolve(2)], item => item > 1, 'over one').then(results => {
+        assertType<number[]>(results);
+    });
+
+    RSVP.filter(
+        [RSVP.resolve('a string'), RSVP.resolve(112233)],
+        item => String(item).length < 10,
+        'short string'
+    ).then(results => {
+        assertType<Array<string | number>>(results);
+    });
+
+    // This is the best we can do: we can't actually write the full type here,
+    // which would be `assertType<never>(results)`, but TS can't infer that.
+    const isString = (item: any): item is string => typeof item === 'string';
+    RSVP.filter([RSVP.reject('for any reason')], isString).then(results => {
+        assertType<{}>(results);
+    });
+}
+
+function testHash() {
+    let promises = {
+        myPromise: RSVP.resolve(1),
+        yourPromise: RSVP.resolve('2'),
+        theirPromise: RSVP.resolve({ key: 3 }),
+        notAPromise: 4,
+    };
+    RSVP.hash(promises, 'my label').then(function(hash) {
+        assertType<number>(hash.myPromise);
+        assertType<string>(hash.yourPromise);
+        assertType<{ key: number }>(hash.theirPromise);
+        assertType<number>(hash.notAPromise);
+    });
+}
+
+function testHashSettled() {
+    function isFulfilled<T>(state: RSVP.PromiseState<T>): state is RSVP.Resolved<T> {
+        return state.state === RSVP.State.fulfilled;
+    }
+    let promises = {
+        myPromise: RSVP.Promise.resolve(1),
+        yourPromise: RSVP.Promise.resolve('2'),
+        theirPromise: RSVP.Promise.resolve({ key: 3 }),
+        notAPromise: 4,
+    };
+    RSVP.hashSettled(promises).then(function(hash) {
+        if (isFulfilled(hash.myPromise)) {
+            assertType<number>(hash.myPromise.value);
+        }
+        if (isFulfilled(hash.yourPromise)) {
+            assertType<string>(hash.yourPromise.value);
+        }
+        if (isFulfilled(hash.theirPromise)) {
+            assertType<{ key: number }>(hash.theirPromise.value);
+        }
+        if (isFulfilled(hash.notAPromise)) {
+            assertType<number>(hash.notAPromise.value);
+        }
+    });
+}
+
+function testMap() {
+    RSVP.map([RSVP.resolve(1), RSVP.resolve(2)], item => item + 1, 'add one').then(results => {
+        assertType<number[]>(results);
+        assertType<{ length: 2 }>(results);
+    });
+
+    RSVP.map([RSVP.resolve('a string'), RSVP.resolve(112233)], String).then(results => {
+        assertType<string[]>(results);
+        assertType<{ length: 2 }>(results);
+    });
+
+    // This is the best we can do: we can't actually write the full type here,
+    // which would be `assertType<never>(results)`, but TS can't infer that.
+    RSVP.map([RSVP.reject('for any reason')], String).then(results => {
+        assertType<{}>(results);
+    });
+}
+
+function testRace() {
+    const imported = race([]);
+    const firstPromise = RSVP.race([{ notAPromise: true }, RSVP.resolve({ some: 'value' })]);
+    assertType<RSVP.Promise<{ notAPromise: boolean } | { some: string }>>(firstPromise);
+
+    let promise1 = RSVP.resolve(1);
+    let promise2 = RSVP.resolve('2');
+    RSVP.Promise.race([promise1, promise2], 'my label').then(function(result) {
+        assertType<string | number>(result);
+    });
+}
+
+function testReject() {
+    assertType<RSVP.Promise<never>>(RSVP.reject());
+    assertType<RSVP.Promise<never>>(RSVP.reject('this is a string'));
+
+    RSVP.reject({ ok: false }).catch(reason => {
+        console.log(`${reason} could be anything`);
+    });
+    RSVP.reject({ ok: false }, 'some label').catch((reason: any) => reason.ok);
+
+    let promise = RSVP.Promise.reject(new Error('WHOOPS'));
+}
+
+function testResolve() {
+    assertType<RSVP.Promise<void>>(RSVP.resolve());
+    assertType<RSVP.Promise<string>>(RSVP.resolve('this is a string'));
+    assertType<RSVP.Promise<string>>(RSVP.resolve(RSVP.resolve('nested')));
+    assertType<RSVP.Promise<string>>(RSVP.resolve(Promise.resolve('nested')));
+
+    let promise = RSVP.Promise.resolve(1);
+    let imported = resolve(1);
+}
+
+function testRethrow() {
+    RSVP.reject(new Error('all the badness'))
+        .catch(RSVP.rethrow)
+        .then(value => {
+            assertType<void>(value);
+        })
+        .catch(reason => {
+            if (reason instanceof Error) {
+                console.log(reason);
+            }
+        });
+}
+
+function testOnAndOff() {
+    RSVP.on('error', (reason: Error) => {
+        console.log(`it was an error: ${reason}`);
+    });
+
+    RSVP.off('whatever', (value: any) => {
+        console.log(
+            `any old value will do: ${value !== undefined && value !== null ? value.toString() : 'even undefined'}`
+        );
+    });
+}
+
+function testAssignableToPromise() {
+    const promise: Promise<number> = RSVP.resolve(0);
+}

--- a/types/rsvp/ts3.9/tsconfig.json
+++ b/types/rsvp/ts3.9/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": false,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rsvp-tests.ts"
+    ]
+}

--- a/types/rsvp/ts3.9/tslint.json
+++ b/types/rsvp/ts3.9/tslint.json
@@ -1,0 +1,18 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "array-type": false,
+        "callable-types": false,
+        "interface-over-type-literal": false,
+        "no-empty-interface": false,
+        "no-redundant-jsdoc": false,
+        "no-redundant-undefined": false,
+        "no-unnecessary-class": false,
+        "no-unnecessary-generics": false,
+        "no-unnecessary-qualifier": false,
+        "no-void-expression": false,
+        "only-arrow-functions": false,
+        "prefer-const": false,
+        "prefer-method-signature": false
+    }
+}


### PR DESCRIPTION
In TypeScript 3.9 we will be introducing a new `awaited` type operator along with updates to the definition of `Promise` and `PromiseLike` that cause incompatibilities with the definition of `Promise` in RSVP. This PR adds a `"typesVersions"` redirection for TS 3.9+ in advance of the upcoming TypeScript 3.9 beta.