### PR TITLE
[argparse] Add missing ArgumentParser members

### DIFF
--- a/types/argparse/argparse-tests.ts
+++ b/types/argparse/argparse-tests.ts
@@ -349,3 +349,9 @@ console.log('-----------');
 args = constExample.parseArgs('--foo x --bar --baz y --qux z a b c d e'.split(' '));
 console.dir(args);
 console.log('-----------');
+
+console.log(new (new ArgumentParser()).formatterClass() !== null);
+console.log('-----------');
+
+console.log(new ArgumentParser({ prog: 'foo' }).prog);
+console.log('-----------');

--- a/types/argparse/index.d.ts
+++ b/types/argparse/index.d.ts
@@ -5,6 +5,7 @@
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 Kannan Goundan <https://github.com/cakoose>
 //                 Halvor Holsten Strand <https://github.com/ondkloss>
+//                 Marvin Hagemeister <https://github.com/marvinhagemeister>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -14,6 +15,8 @@ export class ArgumentParser extends ArgumentGroup {
     parseArgs(args?: string[], ns?: Namespace | object): any;
     printUsage(): void;
     printHelp(): void;
+    prog: Required<ArgumentParserOptions>['prog'];
+    formatterClass: Required<ArgumentParserOptions>['formatterClass'];
     formatUsage(): string;
     formatHelp(): string;
     parseKnownArgs(args?: string[], ns?: Namespace | object): any[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/nodeca/argparse/blob/f5757f6c05ff5b707a5565651e2dc070c5483914/lib/argument_parser.js#L72
  - https://github.com/nodeca/argparse/blob/f5757f6c05ff5b707a5565651e2dc070c5483914/lib/argument_parser.js#L79
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.