### PR TITLE
fix: using addIn/addOut methods should return single context

### DIFF
--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -209,3 +209,18 @@ const multipleMixedTerms: clownface.SafeClownface<Dataset> = clownface({ dataset
 const ctxTerm: Literal = fromSingleArrayLiteral._context[0].term;
 const ctxGraph: Quad_Graph | undefined = fromSingleArrayLiteral._context[0].graph;
 const ctxDataset: Dataset = fromSingleArrayLiteral._context[0].dataset;
+
+// operating on SingleContextClownface keeps it that way
+const addOutSingle: clownface.SingleContextClownface<Dataset, Literal> = singleNamed.addOut(predicate, 'foo');
+const addOutSingleOneElementObjectArray: clownface.SingleContextClownface<Dataset, Literal> = singleNamed.addOut(predicate, ['foo']);
+const addOutSingleOneElementPredicateArray: clownface.SingleContextClownface<Dataset, Literal> = singleNamed.addOut([predicate]);
+const addOutSingleNoObject: clownface.SingleContextClownface<Dataset> = singleNamed.addOut(predicate);
+const addOutSingleWithCallback: clownface.SingleContextClownface<Dataset, Literal> = singleNamed.addOut(predicate, () => {});
+const addOutSingleWithObjectAndCallback: clownface.SingleContextClownface<Dataset, Literal> = singleNamed.addOut(predicate, 'foo', () => {});
+
+const addInSingle: clownface.SingleContextClownface<Dataset, Literal> = singleNamed.addIn(predicate, 'foo');
+const addInSingleOneElementObjectArray: clownface.SingleContextClownface<Dataset, Literal> = singleNamed.addIn(predicate, ['foo']);
+const addInSingleOneElementPredicateArray: clownface.SingleContextClownface<Dataset, Literal> = singleNamed.addIn([predicate]);
+const addInSingleNoObject: clownface.SingleContextClownface<Dataset> = singleNamed.addIn(predicate);
+const addInSingleWithCallback: clownface.SingleContextClownface<Dataset, Literal> = singleNamed.addIn(predicate, () => {});
+const addInSingleWithObjectAndCallback: clownface.SingleContextClownface<Dataset, Literal> = singleNamed.addIn(predicate, 'foo', () => {});

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -83,9 +83,13 @@ declare namespace clownface {
 
         has<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTermsOrLiterals): SafeClownface<D, X>;
 
+        addIn<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, objectOrCallback?: SingleOrOneElementArray<TermOrLiteral> | AddCallback<D, X>): SingleContextClownface<D, X>;
+        addIn<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, object: SingleOrOneElementArray<TermOrLiteral>, callback: AddCallback<D, X>): SingleContextClownface<D, X>;
         addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
         addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
 
+        addOut<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, objectOrCallback?: SingleOrOneElementArray<TermOrLiteral> | AddCallback<D, X>): SingleContextClownface<D, X>;
+        addOut<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, object: SingleOrOneElementArray<TermOrLiteral>, callback: AddCallback<D, X>): SingleContextClownface<D, X>;
         addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
         addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
 

--- a/types/clownface/lib/Clownface.d.ts
+++ b/types/clownface/lib/Clownface.d.ts
@@ -13,7 +13,8 @@ import {
     WithTerms,
     WithSingleTerm,
     SingleContextClownface,
-    SingleOrOneElementArray
+    SingleOrOneElementArray,
+    TermOrLiteral
 } from '..';
 import { Context } from './Context';
 
@@ -57,9 +58,13 @@ declare class Clownface<D extends DatasetCore = DatasetCore, T extends Term = Te
 
     has<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTermsOrLiterals): SafeClownface<D, X>;
 
+    addIn<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, objectOrCallback?: SingleOrOneElementArray<TermOrLiteral> | AddCallback<D, X>): SingleContextClownface<D, X>;
+    addIn<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, object: SingleOrOneElementArray<TermOrLiteral>, callback: AddCallback<D, X>): SingleContextClownface<D, X>;
     addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
     addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
 
+    addOut<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, objectOrCallback?: SingleOrOneElementArray<TermOrLiteral> | AddCallback<D, X>): SingleContextClownface<D, X>;
+    addOut<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, object: SingleOrOneElementArray<TermOrLiteral>, callback: AddCallback<D, X>): SingleContextClownface<D, X>;
     addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
     addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.