### PR TITLE
feat(pngjs): update 'this' scope binding in events

### DIFF
--- a/types/pngjs/index.d.ts
+++ b/types/pngjs/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/lukeapage/pngjs
 // Definitions by: Jason Cheatham <https://github.com/jason0x43>
 //                 Florian Keller <https://github.com/ffflorian>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -47,11 +48,11 @@ export class PNG extends Duplex {
         deltaY?: number,
     ): PNG;
 
-    on(event: 'metadata', callback: (metadata: Metadata) => void): this;
-    on(event: 'parsed', callback: (data: Buffer) => void): this;
-    on(event: 'error', callback: (error: Error) => void): this;
-    on(event: 'close', callback: () => void): this;
-    on(event: string, callback: (...args: any[]) => void): this;
+    on(event: 'metadata', callback: (this: PNG, metadata: Metadata) => void): this;
+    on(event: 'parsed', callback: (this: PNG, data: Buffer) => void): this;
+    on(event: 'error', callback: (this: PNG, error: Error) => void): this;
+    on(event: 'close', callback: (this: PNG) => void): this;
+    on(event: string, callback: (this: PNG, ...args: any[]) => void): this;
 
     pack(): PNG;
 

--- a/types/pngjs/pngjs-tests.ts
+++ b/types/pngjs/pngjs-tests.ts
@@ -1,5 +1,6 @@
 import { PNG } from 'pngjs';
 import { createDeflate } from 'zlib';
+import fs = require('fs');
 
 const pngs = [
     new PNG(),
@@ -45,16 +46,35 @@ png.bitblt(pngs[1], 1, 1, 1, 1, 1, 1);
 png.on('metadata', metadata => {
     metadata.bpp === 1;
 });
+png.on('metadata', function(metadata) {
+    this; // $ExpectType PNG
+    this.width === metadata.width;
+    this.height === metadata.height;
+});
 png.on('parsed', data => {
     data.byteLength === 1;
+});
+png.on('parsed', function(data) {
+    this; // $ExpectType PNG
+    this.adjustGamma();
+    this.pack().pipe(fs.createWriteStream('out.png'));
 });
 png.on('error', error => {
     error === new Error('testing');
 });
+png.on('error', function(error) {
+    this; // $ExpectType PNG
+});
 png.on('closed', () => {
     // closed
 });
+png.on('closed', function() {
+    this; // $ExpectType PNG
+});
 png.on('foo', () => {});
+png.on('foo', function() {
+    this; // $ExpectType PNG
+});
 
 png.pack().adjustGamma();
 


### PR DESCRIPTION
- modify core events defintiioin to handle 'this' scope
- test updated for non-arrow syntax usage with events scoped to PNG

https://github.com/lukeapage/pngjs#async-api

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lukeapage/pngjs#async-api