### PR TITLE
Fix broken export of MockEnvironment type

### DIFF
--- a/types/relay-test-utils/index.d.ts
+++ b/types/relay-test-utils/index.d.ts
@@ -1,13 +1,11 @@
 // Type definitions for relay-test-utils 6.0
 // Project: https://relay.dev
 // Definitions by: Renan Machado <https://github.com/renanmav>
+//               : Stephen Pittman <https://github.com/Stephen2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.3
 
-import * as MockEnvironment from './lib/RelayModernMockEnvironment';
-export { MockEnvironment };
-
-export { createMockEnvironment } from './lib/RelayModernMockEnvironment';
+export * from './lib/RelayModernMockEnvironment';
 
 import * as MockPayloadGenerator from './lib/RelayMockPayloadGenerator';
 export { MockPayloadGenerator };

--- a/types/relay-test-utils/index.d.ts
+++ b/types/relay-test-utils/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for relay-test-utils 6.0
 // Project: https://relay.dev
 // Definitions by: Renan Machado <https://github.com/renanmav>
-//               : Stephen Pittman <https://github.com/Stephen2>
+//                 Stephen Pittman <https://github.com/Stephen2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.3
 

--- a/types/relay-test-utils/lib/RelayModernMockEnvironment.d.ts
+++ b/types/relay-test-utils/lib/RelayModernMockEnvironment.d.ts
@@ -14,9 +14,9 @@ import {
     MissingFieldHandler,
 } from 'relay-runtime';
 
-type OperationMockResolver = (operation: OperationDescriptor) => GraphQLResponse | Error | null;
+export type OperationMockResolver = (operation: OperationDescriptor) => GraphQLResponse | Error | null;
 
-interface MockFunctions {
+export interface MockFunctions {
     clearCache: () => void;
     cachePayload: (
         request: ConcreteRequest | OperationDescriptor,
@@ -42,12 +42,12 @@ interface MockFunctions {
     queueOperationResolver: (resolver: OperationMockResolver) => void;
 }
 
-interface MockEnvironment {
+export interface MockEnvironment {
     mock: MockFunctions;
     mockClear: () => void;
 }
 
-interface RelayMockEnvironment extends MockEnvironment, IEnvironment {
+export interface RelayMockEnvironment extends MockEnvironment, IEnvironment {
     configName: string | null | undefined;
     revertUpdate(update: OptimisticUpdate): void;
     replaceUpdate(update: OptimisticUpdate, newUpdate: OptimisticUpdate): void;
@@ -95,5 +95,3 @@ export function createMockEnvironment(config?: {
     operationTracker?: OperationTracker;
     operationLoader?: OperationLoader;
 }): RelayMockEnvironment;
-
-export {};

--- a/types/relay-test-utils/relay-test-utils-tests.tsx
+++ b/types/relay-test-utils/relay-test-utils-tests.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { MockEnvironment, MockPayloadGenerator, unwrapContainer } from 'relay-test-utils';
+import { MockEnvironment, MockPayloadGenerator, createMockEnvironment, unwrapContainer } from 'relay-test-utils';
 import { createFragmentContainer, graphql, QueryRenderer } from 'react-relay';
 
-const environment = MockEnvironment.createMockEnvironment();
+const environment = createMockEnvironment();
 
 environment.mock.resolveMostRecentOperation(operation => {
     MockPayloadGenerator.generate(operation);
@@ -34,3 +34,5 @@ function TestQueryRenderer() {
         />
     );
 }
+
+const mockEnvironment: MockEnvironment = createMockEnvironment();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.