### PR TITLE
feat(content-disposition): types for self-documenting code

### DIFF
--- a/types/content-disposition/content-disposition-tests.ts
+++ b/types/content-disposition/content-disposition-tests.ts
@@ -1,9 +1,9 @@
-import contentDisposition = require("content-disposition");
+import contentDisposition = require('content-disposition');
 
 const noParams = contentDisposition();
-const withFilenameNoOptions = contentDisposition("EURO rates.txt");
-const withFilenameAndOptions = contentDisposition("€ rates.txt", { type: "attachment", fallback: "EURO rates.txt" });
-const noFilename = contentDisposition(undefined, { type: "attachment", fallback: true });
+const withFilenameNoOptions = contentDisposition('EURO rates.txt');
+const withFilenameAndOptions = contentDisposition('€ rates.txt', { type: 'attachment', fallback: 'EURO rates.txt' });
+const noFilename = contentDisposition(undefined, { type: 'attachment', fallback: true });
 
 const res = contentDisposition.parse('attachment; filename="EURO rates.txt"');
 const type = res.type;

--- a/types/content-disposition/index.d.ts
+++ b/types/content-disposition/index.d.ts
@@ -1,21 +1,53 @@
 // Type definitions for content-disposition 0.5
 // Project: https://github.com/jshttp/content-disposition
 // Definitions by: Stefan Reichel <https://github.com/bomret>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace contentDisposition {
+    /**
+     * Class for parsed Content-Disposition header for v8 optimization
+     */
     interface ContentDisposition {
-        type: string;
+        /**
+         * The disposition type (always lower case)
+         */
+        type: 'attachment' | 'inline' | string;
+        /**
+         * An object of the parameters in the disposition
+         * (name of parameter always lower case and extended versions replace non-extended versions)
+         */
         parameters: any;
     }
 
     interface Options {
-        type?: string;
+        /**
+         * Specifies the disposition type.
+         * This can also be "inline", or any other value (all values except `inline` are treated like attachment,
+         * but can convey additional information if both parties agree to it).
+         * The `type` is normalized to lower-case.
+         * @default 'attachment'
+         */
+        type?: 'attachment' | 'inline' | string;
+        /**
+         * If the filename option is outside ISO-8859-1,
+         * then the file name is actually stored in a supplemental field for clients
+         * that support Unicode file names and a ISO-8859-1 version of the file name is automatically generated
+         * @default true
+         */
         fallback?: string | boolean;
     }
 
+    /**
+     * Parse a Content-Disposition header string
+     */
     function parse(contentDispositionHeader: string): ContentDisposition;
 }
 
+/**
+ * Create an attachment `Content-Disposition` header value using the given file name, if supplied.
+ * The `filename` is optional and if no file name is desired, but you want to specify options, set `filename` to undefined.
+ */
 declare function contentDisposition(filename?: string, options?: contentDisposition.Options): string;
+
 export = contentDisposition;


### PR DESCRIPTION
- adds inline values to self-document types for string literals
- expand documentation

https://github.com/jshttp/content-disposition#api

Thanks!

white-space diffs removed view:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43301/files?diff=unified&w=1

Inline literals serve well as self-documenting code even if reported as 'string', see screenshot below:
<img width="880" alt="Screenshot 2020-03-21 at 20 20 44" src="https://user-images.githubusercontent.com/14539/77234956-6de07a00-6bb2-11ea-834d-6e3eb568f474.png">


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jshttp/content-disposition#api