### PR TITLE
types for apicalypse, igdb-api-node

### DIFF
--- a/types/apicalypse/apicalypse-tests.ts
+++ b/types/apicalypse/apicalypse-tests.ts
@@ -1,0 +1,56 @@
+import Apicalypse from 'apicalypse';
+
+// $ExpectType Apicalypse
+Apicalypse({
+    baseURL: 'https://my-api.url',
+    queryMethod: 'url',
+    auth: {
+        username: 'user',
+        password: 'pass',
+    },
+    headers: {
+        Accept: 'application/json',
+    },
+    responseType: 'json',
+    timeout: 30000,
+});
+
+// $ExpectType Promise<AxiosResponse<any>>
+Apicalypse()
+    .fields('id,slug,name')
+    .fields(['rating', 'popularity'])
+    .sort('rating desc')
+    .sort('name', 'asc')
+    .limit(10)
+    .offset(20)
+    .where('rating > 0; popularity > 10')
+    .where(['popularity < 100', 'first_release_date > 788918400'])
+    .request('/games');
+
+// $ExpectType Promise<any[]>
+Apicalypse()
+    .search('title')
+    .requestAll('/games');
+
+// $ExpectType Promise<any[]>
+Apicalypse()
+    .search('title')
+    .requestAll('/games', {});
+
+// $ExpectType Promise<any[]>
+Apicalypse()
+    .search('title')
+    .requestAll('/games', {
+        concurrency: 2,
+        delay: 500,
+    });
+
+// $ExpectType Apicalypse
+Apicalypse().multi([
+    Apicalypse()
+        .query('/games', 'game')
+        .where('id == 1081'),
+    Apicalypse()
+        .query('/achievements', 'achievements')
+        .where('game_id == 1081'),
+]);

--- a/types/apicalypse/index.d.ts
+++ b/types/apicalypse/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for apicalypse 0.1
+// Project: https://github.com/igdb/node-apicalypse
+// Definitions by: Susam <https://github.com/susam-projects>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { AxiosRequestConfig, AxiosResponse } from 'axios';
+
+export interface Apicalypse {
+    request(url: string): Promise<AxiosResponse>;
+    requestAll(url: string, options?: RequestAllConfig): Promise<any[]>;
+
+    multi(queries: ReadonlyArray<Apicalypse>): Apicalypse;
+    query(endpoint: string, name: string): Apicalypse;
+
+    fields(fields: string | ReadonlyArray<string>): Apicalypse;
+    sort(field: string, direction?: SortDirection): Apicalypse;
+    limit(limit: number): Apicalypse;
+    offset(offset: number): Apicalypse;
+    search(search: string): Apicalypse;
+    where(filters: string | ReadonlyArray<string>): Apicalypse;
+}
+
+export interface RequestAllConfig {
+    concurrency?: number;
+    delay?: number;
+}
+
+export type SortDirection = 'asc' | 'desc';
+
+declare function apicalypseFactory(options?: ApicalypseConfig): Apicalypse;
+declare function apicalypseFactory(rawQueryString: string, options?: ApicalypseConfig): Apicalypse;
+
+export interface ApicalypseConfig extends AxiosRequestConfig {
+    queryMethod?: QueryMethod;
+}
+
+export type QueryMethod = 'body' | 'url';
+
+export default apicalypseFactory;

--- a/types/apicalypse/package.json
+++ b/types/apicalypse/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "axios": "^0.19.0"
+    }
+}

--- a/types/apicalypse/tsconfig.json
+++ b/types/apicalypse/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "apicalypse-tests.ts"
+    ]
+}

--- a/types/apicalypse/tslint.json
+++ b/types/apicalypse/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/igdb-api-node/igdb-api-node-tests.ts
+++ b/types/igdb-api-node/igdb-api-node-tests.ts
@@ -1,0 +1,15 @@
+import igdb, { getTagNumber } from 'igdb-api-node';
+import { Apicalypse } from 'apicalypse';
+
+// $ExpectType number
+getTagNumber(5, 1234);
+
+// $ExpectType Apicalypse
+igdb();
+// $ExpectType Apicalypse
+igdb('test-api-key');
+// $ExpectType Apicalypse
+igdb('test-api-key', {
+    queryMethod: 'url',
+    method: 'get',
+});

--- a/types/igdb-api-node/index.d.ts
+++ b/types/igdb-api-node/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for igdb-api-node 4.0
+// Project: https://github.com/igdb/igdb-api-node
+// Definitions by: Susam <https://github.com/susam-projects>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Apicalypse, ApicalypseConfig } from 'apicalypse';
+
+export function getTagNumber(category: number, id: number): number;
+
+declare function igdb(apiKey?: string, opts?: ApicalypseConfig): Apicalypse;
+export default igdb;

--- a/types/igdb-api-node/tsconfig.json
+++ b/types/igdb-api-node/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "igdb-api-node-tests.ts"
+    ]
+}

--- a/types/igdb-api-node/tslint.json
+++ b/types/igdb-api-node/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
These are the types for two libs. I included both in single PR, because the second lib depends of the first.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
