### PR TITLE
feat(types): add carbon__icon-helpers

### DIFF
--- a/types/carbon__icon-helpers/carbon__icon-helpers-tests.ts
+++ b/types/carbon__icon-helpers/carbon__icon-helpers-tests.ts
@@ -1,0 +1,26 @@
+import { defaultAttributes, getAttributes, formatAttributes, toString, toSvg } from '@carbon/icon-helpers';
+
+defaultAttributes.focusable; // $Expect 'false'
+defaultAttributes.preserveAspectRatio; // $Expect 'xMidYMid meet'
+getAttributes({ width: 16, height: 16 }); // $ExpectType IconAttributes
+formatAttributes({ width: 16, height: 16 }); // $ExpectType string
+toString(); // $Expect string
+toString({
+    elem: 'svg',
+    attrs: { width: 16, height: 16 },
+    content: [
+        { elem: 'path', attrs: { d: '' } },
+        { elem: 'circle', attrs: { cx: '', cy: '', r: '' } },
+        { elem: 'rect', attrs: { width: '', height: '', x: '', y: '', rx: '' } },
+    ],
+}); // $Expect string
+toSvg(); // $ExpectType SVGSVGElement
+toSvg({
+    elem: 'svg',
+    attrs: { width: 16, height: 16 },
+    content: [
+        { elem: 'path', attrs: { d: '' } },
+        { elem: 'circle', attrs: { cx: '', cy: '', r: '' } },
+        { elem: 'rect', attrs: { width: '', height: '', x: '', y: '', rx: '' } },
+    ],
+}); // $Expect SVGSVGElement

--- a/types/carbon__icon-helpers/index.d.ts
+++ b/types/carbon__icon-helpers/index.d.ts
@@ -1,0 +1,56 @@
+// Type definitions for @carbon/icon-helpers 10.6
+// Project: https://github.com/carbon-design-system/carbon/blob/master/packages/icon-helpers
+// Definitions by: Eric Liu <https://github.com/metonym>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.8
+
+export interface Path {
+    elem: 'path';
+    attrs: { d: string };
+}
+
+export interface Circle {
+    elem: 'circle';
+    attrs: { cx: string; cy: string; r: string };
+}
+
+export interface Rect {
+    elem: 'rect';
+    attrs: { width: string; height: string; x: string; y: string; rx: string };
+}
+
+export type IconSize = 16 | 20 | 24 | 32;
+
+export type IconContent = Array<Path | Circle | Rect>;
+
+export interface IconAttributes extends Record<string, any> {
+    'aria-hidden'?: boolean;
+    'aria-label'?: string;
+    'aria-labelledby'?: string;
+    class?: string;
+    focusable?: 'true' | 'false';
+    height: IconSize;
+    id?: string;
+    preserveAspectRatio?: string | 'xMidYMid meet';
+    role?: 'img';
+    style?: string;
+    tabindex?: string;
+    title?: string;
+    viewBox?: string;
+    width: IconSize;
+}
+
+export interface Descriptor {
+    elem?: string | 'svg';
+    attrs?: IconAttributes | {};
+    content?: IconContent | [];
+}
+
+export const defaultAttributes: {
+    focusable: 'false';
+    preserveAspectRatio: 'xMidYMid meet';
+};
+export function getAttributes(attributes: IconAttributes): IconAttributes;
+export function formatAttributes(attributes: IconAttributes): string;
+export function toString(descriptor?: Descriptor): string;
+export function toSvg(descriptor?: Descriptor): SVGSVGElement;

--- a/types/carbon__icon-helpers/tsconfig.json
+++ b/types/carbon__icon-helpers/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "lib": ["es6", "DOM"],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": ["../"],
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true,
+      "paths": {
+          "@carbon/icon-helpers": ["carbon__icon-helpers"]
+      }
+  },
+  "files": ["index.d.ts", "carbon__icon-helpers-tests.ts"]
+}

--- a/types/carbon__icon-helpers/tslint.json
+++ b/types/carbon__icon-helpers/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
