### PR TITLE
fix(rsocket-flowable): makes Flowable.error() and Flowable.never() return Flowable<never>

### DIFF
--- a/types/rsocket-flowable/Flowable.d.ts
+++ b/types/rsocket-flowable/Flowable.d.ts
@@ -5,8 +5,8 @@ export type Source<T> = (subscriber: ISubscriber<T>) => void;
  */
 export default class Flowable<T> implements IPublisher<T> {
     static just<U>(...values: U[]): Flowable<U>;
-    static error(error: Error): Flowable<{}>;
-    static never(): Flowable<{}>;
+    static error(error: Error): Flowable<never>;
+    static never(): Flowable<never>;
     constructor(source: Source<T>, max?: number);
     subscribe(subscriberOrCallback?: Partial<ISubscriber<T>> | ((a: T) => void)): void;
     lift<R>(onSubscribeLift: (subscriber: ISubscriber<R>) => ISubscriber<T>): Flowable<R>;


### PR DESCRIPTION
Same as #42584, but this time for `Flowable`.

---
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rsocket/rsocket-js/pull/79
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.  (N/A, new version of rsocket-flowable is not yet released)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
