### PR TITLE
@types/mailparser Fix nullability of ParsedEmail fields

### DIFF
--- a/types/mailparser/index.d.ts
+++ b/types/mailparser/index.d.ts
@@ -177,7 +177,7 @@ interface ParsedMail {
 	/**
 	 * An array of attachments.
 	 */
-	attachments?: Attachment[];
+	attachments: Attachment[];
 	/**
 	 * A Map object with lowercase header keys.
 	 *
@@ -203,15 +203,15 @@ interface ParsedMail {
 	/**
 	 * The plaintext body of the message.
 	 */
-	text: string;
+	text?: string;
 	/**
 	 * The plaintext body of the message formatted as HTML.
 	 */
-	textAsHtml: string;
+	textAsHtml?: string;
 	/**
 	 * The subject line.
 	 */
-	subject: string;
+	subject?: string;
 	/**
 	 * An array of referenced Message-ID values.
 	 *
@@ -225,11 +225,11 @@ interface ParsedMail {
 	/**
 	 * An address object for the `To:` header.
 	 */
-	to: AddressObject;
+	to?: AddressObject;
 	/**
 	 * An address object for the `From:` header.
 	 */
-	from: AddressObject;
+	from?: AddressObject;
 	/**
 	 * An address object for the `Cc:` header.
 	 */


### PR DESCRIPTION
| [Documentation](https://nodemailer.com/extras/mailparser/#mail-object) | Nullable for real | Current Types                            | Right? |
| ---------------------------------------------------------------------- | ----------------- | ---------------------------------------- | ------ |
| `headers`                                                              | NO                | `headers: Headers`                       | YES    |
| `subject`                                                              | YES               | `subject: string`                        | NO     |
| `from`                                                                 | YES               | `from: AddressObject`                    | NO     |
| `to`                                                                   | YES               | `to: AddressObject`                      | NO     |
| `cc`                                                                   | YES               | `cc?: AddressObject`                     | YES    |
| `bcc`                                                                  | YES               | `bcc?: AddressObject`                    | YES    |
| `date`                                                                 | YES               | `date?: Date`                            | YES    |
| `messageId`                                                            | YES               | `messageId?: string`                     | YES    |
| `inReplyTo`                                                            | YES               | `inReplyTo?: string`                     | YES    |
| `reply-to`                                                             | YES               | `replyTo?: AddressObject`                | YES    |
| `references`                                                           | YES               | `references?: string[]`                  | YES    |
| `html`                                                                 | NO                | `html: string OR boolean`                | YES    |
| `text`                                                                 | YES               | `text: string`                           | NO     |
| `textAsHtml`                                                           | YES               | `textAsHtml: string`                     | NO     |
| `attachments`                                                          | NO                | `attachments?: Attachment[]`             | NO     |
|                                                                        | NO                | `headerLines: HeaderLines`               | YES    |
|                                                                        | YES               | `priority?: 'normal' OR 'low' OR 'high'` | YES    |

I used the following program to determine the `Nullable for real` column:

```ts
import mailparser from "mailparser";

(async () => {
  const email = await mailparser.simpleParser("");
  console.log(JSON.stringify(email, null, 2));
  console.log("headers: ", JSON.stringify(email.headers, null, 2));
  console.log("subject: ", JSON.stringify(email.subject, null, 2));
  console.log("from: ", JSON.stringify(email.from, null, 2));
  console.log("to: ", JSON.stringify(email.to, null, 2));
  console.log("cc: ", JSON.stringify(email.cc, null, 2));
  console.log("bcc: ", JSON.stringify(email.bcc, null, 2));
  console.log("date: ", JSON.stringify(email.date, null, 2));
  console.log("messageId: ", JSON.stringify(email.messageId, null, 2));
  console.log("inReplyTo: ", JSON.stringify(email.inReplyTo, null, 2));
  console.log("reply-to: ", JSON.stringify(email.replyTo, null, 2));
  console.log("references: ", JSON.stringify(email.references, null, 2));
  console.log("html: ", JSON.stringify(email.html, null, 2));
  console.log("text: ", JSON.stringify(email.text, null, 2));
  console.log("textAsHtml: ", JSON.stringify(email.textAsHtml, null, 2));
  console.log("attachments: ", JSON.stringify(email.attachments, null, 2));

  console.log("headerLines: ", JSON.stringify(email.headerLines, null, 2));
  console.log("priority: ", JSON.stringify(email.priority, null, 2));
})();
```

This is the output I got:

```
{
  "attachments": [],
  "headers": {},
  "headerLines": [
    {
      "key": "",
      "line": ""
    }
  ],
  "html": false
}
headers:  {}
subject:  undefined
from:  undefined
to:  undefined
cc:  undefined
bcc:  undefined
date:  undefined
messageId:  undefined
inReplyTo:  undefined
reply-to:  undefined
references:  undefined
html:  false
text:  undefined
textAsHtml:  undefined
attachments:  []
headerLines:  [
  {
    "key": "",
    "line": ""
  }
]
priority:  undefined
```


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see above
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
