### PR TITLE
add SecureBuffer secure attribute to sodium-native

### DIFF
--- a/types/sodium-native/index.d.ts
+++ b/types/sodium-native/index.d.ts
@@ -1367,7 +1367,7 @@ export interface CryptoHashSha512Wrap {
 
 export interface SecureBuffer extends Buffer {
     /**
-     * To check if a buffer is a "secure" buffer, you can call access the getter buffer.secure which will be true
+     * To check if a `buffer` is a "secure" `buffer`, you can access the getter `buffer.secure` which will be `true`.
      */
     secure: boolean;
 }

--- a/types/sodium-native/index.d.ts
+++ b/types/sodium-native/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for sodium-native 2.3
 // Project: https://github.com/sodium-friends/sodium-native
 // Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions by: nshcore <https://github.com/nshcore>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/sodium-native/index.d.ts
+++ b/types/sodium-native/index.d.ts
@@ -215,25 +215,25 @@ export function sodium_munlock(buffer: Buffer): void;
  * Allocate a buffer of `size` which is memory protected. See [libsodium docs](https://download.libsodium.org/doc/memory_management#guarded-heap-allocations) for details. Be aware that many Buffer
  * methods may break the security guarantees of `sodium.sodium_malloc`'ed memory. To check if a `Buffer` is a "secure" buffer, you can call access the getter `buffer.secure` which will be `true`.
  */
-export function sodium_malloc(size: number): Buffer;
+export function sodium_malloc(size: number): SecureBuffer;
 
 /**
  * Make `buffer` allocated using `sodium.sodium_malloc` inaccessible, crashing the process if any access is attempted.
  * Note that this will have no effect for normal `Buffer`s.
  */
-export function sodium_mprotect_noaccess(buffer: Buffer): void;
+export function sodium_mprotect_noaccess(buffer: SecureBuffer): void;
 
 /**
  * Make `buffer` allocated using `sodium.sodium_malloc` read-only, crashing the process if any writing is attempted.
  * Note that this will have no effect for normal `Buffer`s.
  */
-export function sodium_mprotect_readonly(buffer: Buffer): void;
+export function sodium_mprotect_readonly(buffer: SecureBuffer): void;
 
 /**
  * Make `buffer` allocated using `sodium.sodium_malloc` read-write, undoing `sodium_mprotect_noaccess` or `sodium_mprotect_readonly`.
  * Note that this will have no effect for normal `Buffer`s.
  */
-export function sodium_mprotect_readwrite(buffer: Buffer): void;
+export function sodium_mprotect_readwrite(buffer: SecureBuffer): void;
 
 /**
  * Generate a random 32-bit unsigned integer `[0, 0xffffffff]` (both inclusive)
@@ -1363,4 +1363,11 @@ export interface CryptoHashSha512Wrap {
      * The generated hash is stored in `output`.
      */
     final(output: Buffer): void;
+}
+
+export interface SecureBuffer extends Buffer {
+    /**
+     * To check if a buffer is a "secure" buffer, you can call access the getter buffer.secure which will be true
+     */
+    secure: boolean;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://sodium-friends.github.io/docs/docs/memoryprotection#sodium_malloc
https://github.com/sodium-friends/sodium-native/blob/master/test/memory.js#L81
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

Sodium-natives malloc function that secures a buffer adds a new property to buffer object called 

"secure"

`buffer.secure `

which is a boolean indicating if the buffer is secure or not, this is not present in the type defs from this repo.

@SEE https://github.com/sodium-friends/sodium-native/blob/master/test/memory.js#L81
@SEE https://sodium-friends.github.io/docs/docs/memoryprotection#sodium_malloc

there is also functions that "have no effect on normal buffers" these function params have been updated to allow the "SecureBuffer" type