### PR TITLE
[fs-extra] remove function should accept options

### DIFF
--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -14,10 +14,10 @@
 
 /// <reference types="node" />
 
-import * as fs from "fs";
-import Stats = fs.Stats;
+import * as fs from "graceful-fs";
+export * as fs from "graceful-fs";
 
-export * from "fs";
+import Stats = fs.Stats;
 
 export function copy(src: string, dest: string, options?: CopyOptions): Promise<void>;
 export function copy(src: string, dest: string, callback: (err: Error) => void): void;
@@ -115,151 +115,75 @@ export function pathExistsSync(path: string): boolean;
 // fs async methods
 // copied from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/v6/index.d.ts
 
-export function access(path: string | Buffer, callback: (err: NodeJS.ErrnoException) => void): void;
-export function access(path: string | Buffer, mode: number, callback: (err: NodeJS.ErrnoException) => void): void;
 export function access(path: string | Buffer, mode?: number): Promise<void>;
 
-export function appendFile(file: string | Buffer | number, data: any, options: { encoding?: string; mode?: number | string; flag?: string; },
-    callback: (err: NodeJS.ErrnoException) => void): void;
-export function appendFile(file: string | Buffer | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
 export function appendFile(file: string | Buffer | number, data: any, options?: { encoding?: string; mode?: number | string; flag?: string; }): Promise<void>;
 
-export function chmod(path: string | Buffer, mode: string | number, callback: (err: NodeJS.ErrnoException) => void): void;
 export function chmod(path: string | Buffer, mode: string | number): Promise<void>;
 
 export function chown(path: string | Buffer, uid: number, gid: number): Promise<void>;
-export function chown(path: string | Buffer, uid: number, gid: number, callback: (err: NodeJS.ErrnoException) => void): void;
 
-export function close(fd: number, callback: (err: NodeJS.ErrnoException) => void): void;
 export function close(fd: number): Promise<void>;
 
-export function fchmod(fd: number, mode: string | number, callback: (err: NodeJS.ErrnoException) => void): void;
 export function fchmod(fd: number, mode: string | number): Promise<void>;
 
-export function fchown(fd: number, uid: number, gid: number, callback: (err: NodeJS.ErrnoException) => void): void;
 export function fchown(fd: number, uid: number, gid: number): Promise<void>;
 
-export function fdatasync(fd: number, callback: () => void): void;
 export function fdatasync(fd: number): Promise<void>;
 
-export function fstat(fd: number, callback: (err: NodeJS.ErrnoException, stats: Stats) => any): void;
 export function fstat(fd: number): Promise<Stats>;
 
-export function fsync(fd: number, callback: (err: NodeJS.ErrnoException) => void): void;
 export function fsync(fd: number): Promise<void>;
 
-export function ftruncate(fd: number, callback: (err: NodeJS.ErrnoException) => void): void;
-export function ftruncate(fd: number, len: number, callback: (err: NodeJS.ErrnoException) => void): void;
 export function ftruncate(fd: number, len?: number): Promise<void>;
 
-export function futimes(fd: number, atime: number, mtime: number, callback: (err: NodeJS.ErrnoException) => void): void;
-export function futimes(fd: number, atime: Date, mtime: Date, callback: (err: NodeJS.ErrnoException) => void): void;
 export function futimes(fd: number, atime: number, mtime: number): Promise<void>;
 export function futimes(fd: number, atime: Date, mtime: Date): Promise<void>;
 
-export function lchown(path: string | Buffer, uid: number, gid: number, callback: (err: NodeJS.ErrnoException) => void): void;
 export function lchown(path: string | Buffer, uid: number, gid: number): Promise<void>;
 
-export function link(srcpath: string | Buffer, dstpath: string | Buffer, callback: (err: NodeJS.ErrnoException) => void): void;
 export function link(srcpath: string | Buffer, dstpath: string | Buffer): Promise<void>;
 
-export function lstat(path: string | Buffer, callback: (err: NodeJS.ErrnoException, stats: Stats) => any): void;
 export function lstat(path: string | Buffer): Promise<Stats>;
 
-/**
- * Asynchronous mkdir - creates the directory specified in {path}.  Parameter {mode} defaults to 0777.
- *
- * @param callback No arguments other than a possible exception are given to the completion callback.
- */
-export function mkdir(path: string | Buffer, callback: (err: NodeJS.ErrnoException) => void): void;
-/**
- * Asynchronous mkdir - creates the directory specified in {path}.  Parameter {mode} defaults to 0777.
- *
- * @param callback No arguments other than a possible exception are given to the completion callback.
- */
-export function mkdir(path: string | Buffer, mode: number | string, callback: (err: NodeJS.ErrnoException) => void): void;
-export function mkdir(path: string | Buffer): Promise<void>;
+export function mkdir(path: string | Buffer, mode?: number | string): Promise<void>;
 
-export function open(path: string | Buffer, flags: string | number, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;
-export function open(path: string | Buffer, flags: string | number, mode: number, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;
 export function open(path: string | Buffer, flags: string | number, mode?: number): Promise<number>;
 
-export function read(fd: number, buffer: Buffer, offset: number, length: number, position: number | null,
-    callback: (err: NodeJS.ErrnoException, bytesRead: number, buffer: Buffer) => void): void;
 export function read(fd: number, buffer: Buffer, offset: number, length: number, position: number | null): Promise<ReadResult>;
 
-export function readFile(file: string | Buffer | number, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
-export function readFile(file: string | Buffer | number, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
-export function readFile(file: string | Buffer | number, options: { flag?: string; } | { encoding: string; flag?: string; }, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
 export function readFile(file: string | Buffer | number, options: { flag?: string; } | { encoding: string; flag?: string; }): Promise<string>;
 // tslint:disable-next-line:unified-signatures
 export function readFile(file: string | Buffer | number, encoding: string): Promise<string>;
 export function readFile(file: string | Buffer | number): Promise<Buffer>;
 
-export function readdir(path: string | Buffer, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
 export function readdir(path: string | Buffer): Promise<string[]>;
 
-export function readlink(path: string | Buffer, callback: (err: NodeJS.ErrnoException, linkString: string) => any): void;
 export function readlink(path: string | Buffer): Promise<string>;
 
-export function realpath(path: string | Buffer, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => any): void;
-export function realpath(path: string | Buffer, cache: { [path: string]: string }, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => any): void;
 export function realpath(path: string | Buffer, cache?: { [path: string]: string }): Promise<string>;
 
-export function rename(oldPath: string, newPath: string, callback: (err: NodeJS.ErrnoException) => void): void;
 export function rename(oldPath: string, newPath: string): Promise<void>;
 
-/**
- * Asynchronous rmdir - removes the directory specified in {path}
- *
- * @param callback No arguments other than a possible exception are given to the completion callback.
- */
-export function rmdir(path: string | Buffer, callback: (err: NodeJS.ErrnoException) => void): void;
 export function rmdir(path: string | Buffer): Promise<void>;
 
-export function stat(path: string | Buffer, callback: (err: NodeJS.ErrnoException, stats: Stats) => any): void;
 export function stat(path: string | Buffer): Promise<Stats>;
 
-export function symlink(srcpath: string | Buffer, dstpath: string | Buffer, type: FsSymlinkType | undefined, callback: (err: NodeJS.ErrnoException) => void): void;
-export function symlink(srcpath: string | Buffer, dstpath: string | Buffer, callback: (err: NodeJS.ErrnoException) => void): void;
 export function symlink(srcpath: string | Buffer, dstpath: string | Buffer, type?: FsSymlinkType): Promise<void>;
 
-export function truncate(path: string | Buffer, callback: (err: NodeJS.ErrnoException) => void): void;
-export function truncate(path: string | Buffer, len: number, callback: (err: NodeJS.ErrnoException) => void): void;
 export function truncate(path: string | Buffer, len?: number): Promise<void>;
 
-/**
- * Asynchronous unlink - deletes the file specified in {path}
- *
- * @param callback No arguments other than a possible exception are given to the completion callback.
- */
-export function unlink(path: string | Buffer, callback: (err: NodeJS.ErrnoException) => void): void;
 export function unlink(path: string | Buffer): Promise<void>;
 
-export function utimes(path: string | Buffer, atime: number, mtime: number, callback: (err: NodeJS.ErrnoException) => void): void;
-export function utimes(path: string | Buffer, atime: Date, mtime: Date, callback: (err: NodeJS.ErrnoException) => void): void;
 export function utimes(path: string | Buffer, atime: number, mtime: number): Promise<void>;
 export function utimes(path: string | Buffer, atime: Date, mtime: Date): Promise<void>;
 
-export function write(fd: number, buffer: Buffer, offset: number, length: number, position: number | null, callback: (err: NodeJS.ErrnoException, written: number, buffer: Buffer) => void): void;
-export function write(fd: number, buffer: Buffer, offset: number, length: number, callback: (err: NodeJS.ErrnoException, written: number, buffer: Buffer) => void): void;
-export function write(fd: number, data: any, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
-export function write(fd: number, data: any, offset: number, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
-export function write(fd: number, data: any, offset: number, encoding: string, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
 export function write(fd: number, buffer: Buffer, offset?: number, length?: number, position?: number | null): Promise<WriteResult>;
 export function write(fd: number, data: any, offset?: number, encoding?: string): Promise<WriteResult>;
 
-export function writeFile(file: string | Buffer | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
 export function writeFile(file: string | Buffer | number, data: any, options?: WriteFileOptions | string): Promise<void>;
-export function writeFile(file: string | Buffer | number, data: any, options: WriteFileOptions | string, callback: (err: NodeJS.ErrnoException) => void): void;
 
-/**
- * Asynchronous mkdtemp - Creates a unique temporary directory. Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
- *
- * @param callback The created folder path is passed as a string to the callback's second parameter.
- */
 export function mkdtemp(prefix: string): Promise<string>;
-export function mkdtemp(prefix: string, callback: (err: NodeJS.ErrnoException, folder: string) => void): void;
 
 export interface PathEntry {
     path: string;
@@ -308,12 +232,12 @@ export interface ReadOptions {
 
 export interface RemoveOptions {
     maxBusyTries?: number;
-    unlink?: typeof unlink;
-    chmod?: typeof chmod;
-    stat?: typeof stat;
-    lstat?: typeof lstat;
-    rmdir?: typeof rmdir;
-    readdir?: typeof readdir;
+    unlink?: typeof fs.unlink | typeof unlink;
+    chmod?: typeof fs.chmod | typeof chmod;
+    stat?: typeof fs.stat | typeof stat;
+    lstat?: typeof fs.lstat | typeof lstat;
+    rmdir?: typeof fs.rmdir | typeof rmdir;
+    readdir?: typeof fs.readdir | typeof readdir;
     unlinkSync?: typeof fs.unlinkSync;
     chmodSync?: typeof fs.chmodSync;
     statSync?: typeof fs.statSync;

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -115,75 +115,75 @@ export function pathExistsSync(path: string): boolean;
 // fs async methods
 // copied from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/v6/index.d.ts
 
-export function access(path: string | Buffer, mode?: number): Promise<void>;
+declare module "fs" {
+    export function access(path: PathLike, mode?: number): Promise<void>;
 
-export function appendFile(file: string | Buffer | number, data: any, options?: { encoding?: string; mode?: number | string; flag?: string; }): Promise<void>;
+    export function appendFile(file: PathLike | number, data: any, options?: WriteFileOptions): Promise<void>;
 
-export function chmod(path: string | Buffer, mode: string | number): Promise<void>;
+    export function chmod(path: PathLike, mode: string | number): Promise<void>;
 
-export function chown(path: string | Buffer, uid: number, gid: number): Promise<void>;
+    export function chown(path: PathLike, uid: number, gid: number): Promise<void>;
 
-export function close(fd: number): Promise<void>;
+    export function close(fd: number): Promise<void>;
 
-export function fchmod(fd: number, mode: string | number): Promise<void>;
+    export function fchmod(fd: number, mode: string | number): Promise<void>;
 
-export function fchown(fd: number, uid: number, gid: number): Promise<void>;
+    export function fchown(fd: number, uid: number, gid: number): Promise<void>;
 
-export function fdatasync(fd: number): Promise<void>;
+    export function fdatasync(fd: number): Promise<void>;
 
-export function fstat(fd: number): Promise<Stats>;
+    export function fstat(fd: number): Promise<Stats>;
 
-export function fsync(fd: number): Promise<void>;
+    export function fsync(fd: number): Promise<void>;
 
-export function ftruncate(fd: number, len?: number): Promise<void>;
+    export function ftruncate(fd: number, len?: number): Promise<void>;
 
-export function futimes(fd: number, atime: number, mtime: number): Promise<void>;
-export function futimes(fd: number, atime: Date, mtime: Date): Promise<void>;
+    export function futimes(fd: number, atime: string | number | Date, mtime: string | number | Date): Promise<void>;
 
-export function lchown(path: string | Buffer, uid: number, gid: number): Promise<void>;
+    export function lchown(path: PathLike, uid: number, gid: number): Promise<void>;
 
-export function link(srcpath: string | Buffer, dstpath: string | Buffer): Promise<void>;
+    export function link(existingPath: PathLike, newPath: PathLike): Promise<void>;
 
-export function lstat(path: string | Buffer): Promise<Stats>;
+    export function lstat(path: PathLike): Promise<Stats>;
 
-export function mkdir(path: string | Buffer, mode?: number | string): Promise<void>;
+    export function mkdir(path: PathLike, options?: number | string | MakeDirectoryOptions): Promise<void>;
 
-export function open(path: string | Buffer, flags: string | number, mode?: number): Promise<number>;
+    export function open(path: PathLike, flags: string | number, mode?: string | number): Promise<number>;
 
-export function read(fd: number, buffer: Buffer, offset: number, length: number, position: number | null): Promise<ReadResult>;
+    export function read(fd: number, buffer: Buffer, offset: number, length: number, position: number | null): Promise<ReadResult>;
 
-export function readFile(file: string | Buffer | number, options: { flag?: string; } | { encoding: string; flag?: string; }): Promise<string>;
-// tslint:disable-next-line:unified-signatures
-export function readFile(file: string | Buffer | number, encoding: string): Promise<string>;
-export function readFile(file: string | Buffer | number): Promise<Buffer>;
+    export function readFile(path: PathLike | number, options: { flag?: string; } | { encoding: string; flag?: string; }): Promise<string>;
+    // tslint:disable-next-line:unified-signatures
+    export function readFile(path: PathLike | number, encoding: string): Promise<string>;
+    export function readFile(path: PathLike | number): Promise<Buffer>;
 
-export function readdir(path: string | Buffer): Promise<string[]>;
+    export function readdir(path: PathLike): Promise<string[]>;
 
-export function readlink(path: string | Buffer): Promise<string>;
+    export function readlink(path: PathLike): Promise<string>;
 
-export function realpath(path: string | Buffer, cache?: { [path: string]: string }): Promise<string>;
+    export function realpath(path: PathLike, cache?: { [path: string]: string }): Promise<string>;
 
-export function rename(oldPath: string, newPath: string): Promise<void>;
+    export function rename(oldPath: PathLike, newPath: PathLike): Promise<void>;
 
-export function rmdir(path: string | Buffer): Promise<void>;
+    export function rmdir(path: PathLike): Promise<void>;
 
-export function stat(path: string | Buffer): Promise<Stats>;
+    export function stat(path: PathLike): Promise<Stats>;
 
-export function symlink(srcpath: string | Buffer, dstpath: string | Buffer, type?: FsSymlinkType): Promise<void>;
+    export function symlink(target: PathLike, path: PathLike, type: symlink.Type): Promise<void>;
 
-export function truncate(path: string | Buffer, len?: number): Promise<void>;
+    export function truncate(path: PathLike, len?: number): Promise<void>;
 
-export function unlink(path: string | Buffer): Promise<void>;
+    export function unlink(path: PathLike): Promise<void>;
 
-export function utimes(path: string | Buffer, atime: number, mtime: number): Promise<void>;
-export function utimes(path: string | Buffer, atime: Date, mtime: Date): Promise<void>;
+    export function utimes(path: PathLike, atime: string | number | Date, mtime: string | number | Date): Promise<void>;
 
-export function write(fd: number, buffer: Buffer, offset?: number, length?: number, position?: number | null): Promise<WriteResult>;
-export function write(fd: number, data: any, offset?: number, encoding?: string): Promise<WriteResult>;
+    export function write(fd: number, buffer: Buffer, offset?: number, length?: number, position?: number | null): Promise<WriteResult>;
+    export function write(fd: number, data: any, offset?: number, encoding?: string): Promise<WriteResult>;
 
-export function writeFile(file: string | Buffer | number, data: any, options?: WriteFileOptions | string): Promise<void>;
+    export function writeFile(path: PathLike | number, data: any, options: WriteFileOptions): Promise<void>;
 
-export function mkdtemp(prefix: string): Promise<string>;
+    export function mkdtemp(prefix: string, options?: { encoding?: BufferEncoding } | BufferEncoding | "buffer" | { encoding: "buffer" } | { encoding?: string } | string): Promise<string>;
+}
 
 export interface PathEntry {
     path: string;
@@ -232,12 +232,12 @@ export interface ReadOptions {
 
 export interface RemoveOptions {
     maxBusyTries?: number;
-    unlink?: typeof fs.unlink | typeof unlink;
-    chmod?: typeof fs.chmod | typeof chmod;
-    stat?: typeof fs.stat | typeof stat;
-    lstat?: typeof fs.lstat | typeof lstat;
-    rmdir?: typeof fs.rmdir | typeof rmdir;
-    readdir?: typeof fs.readdir | typeof readdir;
+    unlink?: typeof fs.unlink;
+    chmod?: typeof fs.chmod;
+    stat?: typeof fs.stat;
+    lstat?: typeof fs.lstat;
+    rmdir?: typeof fs.rmdir;
+    readdir?: typeof fs.readdir;
     unlinkSync?: typeof fs.unlinkSync;
     chmodSync?: typeof fs.chmodSync;
     statSync?: typeof fs.statSync;

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -8,13 +8,14 @@
 //                 Sang Dang <https://github.com/sangdth>,
 //                 Florian Keller <https://github.com/ffflorian>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 Oganexon <https://github.com/oganexon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
 /// <reference types="node" />
 
 import * as fs from "fs";
-import * as rimraf from "rimraf";
+import * as glob from "glob";
 import Stats = fs.Stats;
 
 export * from "fs";
@@ -67,10 +68,33 @@ export function readJSON(file: string, options: ReadOptions, callback: (err: Err
 export function readJsonSync(file: string, options?: ReadOptions): any;
 export function readJSONSync(file: string, options?: ReadOptions): any;
 
-export function remove(dir: string, options?: rimraf.Options): Promise<void>;
+export function remove(dir: string, options?: remove.Options): Promise<void>;
 export function remove(dir: string, callback: (err: Error) => void): void;
-export function remove(dir: string, options: rimraf.Options, callback: (err: Error) => void): void;
+export function remove(dir: string, options: remove.Options, callback: (err: Error) => void): void;
 export function removeSync(dir: string): void;
+export namespace remove {
+    function sync(path: string, options?: Options): void;
+    interface Options {
+        maxBusyTries?: number;
+        emfileWait?: number;
+        /** @default false */
+        disableGlob?: boolean;
+        glob?: glob.IOptions | false;
+
+        unlink?: typeof unlink;
+        chmod?: typeof chmod;
+        stat?: typeof stat;
+        lstat?: typeof lstat;
+        rmdir?: typeof rmdir;
+        readdir?: typeof readdir;
+        unlinkSync?: typeof fs.unlinkSync;
+        chmodSync?: typeof fs.chmodSync;
+        statSync?: typeof fs.statSync;
+        lstatSync?: typeof fs.lstatSync;
+        rmdirSync?: typeof fs.rmdirSync;
+        readdirSync?: typeof fs.readdirSync;
+    }
+}
 
 export function outputJSON(file: string, data: any, options?: WriteOptions): Promise<void>;
 export function outputJSON(file: string, data: any, options: WriteOptions, callback: (err: Error) => void): void;

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -15,7 +15,6 @@
 /// <reference types="node" />
 
 import * as fs from "fs";
-import * as glob from "glob";
 import Stats = fs.Stats;
 
 export * from "fs";
@@ -309,11 +308,6 @@ export interface ReadOptions {
 
 export interface RemoveOptions {
     maxBusyTries?: number;
-    emfileWait?: number;
-    /** @default false */
-    disableGlob?: boolean;
-    glob?: glob.IOptions | false;
-
     unlink?: typeof unlink;
     chmod?: typeof chmod;
     stat?: typeof stat;

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -67,8 +67,7 @@ export function readJSON(file: string, options: ReadOptions, callback: (err: Err
 export function readJsonSync(file: string, options?: ReadOptions): any;
 export function readJSONSync(file: string, options?: ReadOptions): any;
 
-export function remove(dir: string): Promise<void>;
-export function remove(dir: string, options: rimraf.Options): Promise<void>;
+export function remove(dir: string, options?: rimraf.Options): Promise<void>;
 export function remove(dir: string, callback: (err: Error) => void): void;
 export function remove(dir: string, options: rimraf.Options, callback: (err: Error) => void): void;
 export function removeSync(dir: string): void;

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -14,6 +14,7 @@
 /// <reference types="node" />
 
 import * as fs from "fs";
+import * as rimraf from "rimraf";
 import Stats = fs.Stats;
 
 export * from "fs";
@@ -67,7 +68,9 @@ export function readJsonSync(file: string, options?: ReadOptions): any;
 export function readJSONSync(file: string, options?: ReadOptions): any;
 
 export function remove(dir: string): Promise<void>;
+export function remove(dir: string, options: rimraf.Options): Promise<void>;
 export function remove(dir: string, callback: (err: Error) => void): void;
+export function remove(dir: string, options: rimraf.Options, callback: (err: Error) => void): void;
 export function removeSync(dir: string): void;
 
 export function outputJSON(file: string, data: any, options?: WriteOptions): Promise<void>;

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -68,33 +68,10 @@ export function readJSON(file: string, options: ReadOptions, callback: (err: Err
 export function readJsonSync(file: string, options?: ReadOptions): any;
 export function readJSONSync(file: string, options?: ReadOptions): any;
 
-export function remove(dir: string, options?: remove.Options): Promise<void>;
+export function remove(dir: string, options?: RemoveOptions): Promise<void>;
 export function remove(dir: string, callback: (err: Error) => void): void;
-export function remove(dir: string, options: remove.Options, callback: (err: Error) => void): void;
+export function remove(dir: string, options: RemoveOptions, callback: (err: Error) => void): void;
 export function removeSync(dir: string): void;
-export namespace remove {
-    function sync(path: string, options?: Options): void;
-    interface Options {
-        maxBusyTries?: number;
-        emfileWait?: number;
-        /** @default false */
-        disableGlob?: boolean;
-        glob?: glob.IOptions | false;
-
-        unlink?: typeof unlink;
-        chmod?: typeof chmod;
-        stat?: typeof stat;
-        lstat?: typeof lstat;
-        rmdir?: typeof rmdir;
-        readdir?: typeof readdir;
-        unlinkSync?: typeof fs.unlinkSync;
-        chmodSync?: typeof fs.chmodSync;
-        statSync?: typeof fs.statSync;
-        lstatSync?: typeof fs.lstatSync;
-        rmdirSync?: typeof fs.rmdirSync;
-        readdirSync?: typeof fs.readdirSync;
-    }
-}
 
 export function outputJSON(file: string, data: any, options?: WriteOptions): Promise<void>;
 export function outputJSON(file: string, data: any, options: WriteOptions, callback: (err: Error) => void): void;
@@ -328,6 +305,27 @@ export interface ReadOptions {
     reviver?: any;
     encoding?: string;
     flag?: string;
+}
+
+export interface RemoveOptions {
+    maxBusyTries?: number;
+    emfileWait?: number;
+    /** @default false */
+    disableGlob?: boolean;
+    glob?: glob.IOptions | false;
+
+    unlink?: typeof unlink;
+    chmod?: typeof chmod;
+    stat?: typeof stat;
+    lstat?: typeof lstat;
+    rmdir?: typeof rmdir;
+    readdir?: typeof readdir;
+    unlinkSync?: typeof fs.unlinkSync;
+    chmodSync?: typeof fs.chmodSync;
+    statSync?: typeof fs.statSync;
+    lstatSync?: typeof fs.lstatSync;
+    rmdirSync?: typeof fs.rmdirSync;
+    readdirSync?: typeof fs.readdirSync;
 }
 
 export interface WriteFileOptions {


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/rimraf/index.d.ts
https://github.com/jprichardson/node-fs-extra/blob/master/lib/remove/index.js

The `remove` function is a wrapper around `rimraf`.

Since `rimraf` accept parameters and `remove` is the universal version of it, it should also accept the same parameters.

Example of use:
```javascript
fs.remove(path, {
    glob: { dot: true }
  })
```
