### PR TITLE
Created new typings for o9n

### DIFF
--- a/types/o9n/index.d.ts
+++ b/types/o9n/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for o9n 2.0
+// Project: https://github.com/chmanie/o9n#readme
+// Definitions by: Corbin Crutchley <https://github.com/crutchcorn>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="w3c-screen-orientation" />
+
+interface Orientation extends ScreenOrientation {
+    install(): undefined;
+    onchange: ((this: ScreenOrientation, ev: any) => any) | null;
+}
+
+declare const OrientationObj: Orientation;
+
+export = OrientationObj;

--- a/types/o9n/o9n-tests.ts
+++ b/types/o9n/o9n-tests.ts
@@ -1,0 +1,11 @@
+import * as orientation from 'o9n';
+
+const isLandscape = orientation.type.startsWith('landscape');
+
+orientation.addEventListener('change', () => {});
+
+orientation.lock('landscape').then(() => {});
+
+orientation.unlock();
+
+orientation.install();

--- a/types/o9n/tsconfig.json
+++ b/types/o9n/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "o9n-tests.ts"
+    ]
+}

--- a/types/o9n/tslint.json
+++ b/types/o9n/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
I noticed that there were some errors in the dependency of `w3-screen-orientation` during linting. I figured I'd open the PR to see some feedback on how I can fix this (or if it's even within scope)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
