### PR TITLE
Remove audioTracks from hls.js

### DIFF
--- a/types/hls.js/index.d.ts
+++ b/types/hls.js/index.d.ts
@@ -1711,15 +1711,6 @@ declare class Hls {
      */
     firstLevel: number;
     /**
-     * array of audio tracks exposed in manifest
-     */
-    readonly audioTracks: AudioTrack[];
-    /**
-     * get: returns audio track id
-     * set: sets audio track id (returned by)
-     */
-    audioTrack: number;
-    /**
      * position of live sync point (ie edge of live position minus safety delay defined by hls.config.liveSyncDuration)
      */
     readonly liveSyncPosition: number;


### PR DESCRIPTION
AudioTrackList isn't standard (only supported in IE and Safari), and is removed from the DOM lib in TS 3.9:
microsoft/TSJS-lib-generator#802

This PR removes it from hls.js. I'm not sure this is right; maybe it's should still be supported in hls.js. In that case, the type can be faked locally:

```ts
interface HlsAudioTrack {
    enabled: boolean;
    readonly id: string;
    kind: string;
    readonly label: string;
    language: string;
    readonly sourceBuffer: SourceBuffer | null;
}
```

And that should be compatible with the DOM version for older Typescripts that still have it.