### PR TITLE
Update definitions for @types/istanbul-lib-source-maps 

### DIFF
--- a/types/istanbul-lib-source-maps/index.d.ts
+++ b/types/istanbul-lib-source-maps/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for istanbul-lib-source-maps 1.2
+// Type definitions for istanbul-lib-source-maps 4.0
 // Project: https://istanbul.js.org, https://github.com/istanbuljs/istanbuljs
 // Definitions by: Jason Cheatham <https://github.com/jason0x43>
+//                 Sridhar Mallela <https://github.com/sridharmallela>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -8,36 +9,37 @@ import { CoverageMap } from 'istanbul-lib-coverage';
 import { RawSourceMap } from 'source-map';
 
 export function createSourceMapStore(
-	options?: Partial<MapStoreOptions>
+    options?: Partial<MapStoreOptions>
 ): MapStore;
 
 export interface MapStoreOptions {
-	verbose: boolean;
-	baseDir: string;
-	sourceStore: 'memory' | 'file';
-	tmpdir: string;
+    verbose: boolean;
+    baseDir: string;
+    sourceStore: 'memory' | 'file';
+    tmpdir: string;
 }
 
 export interface MapStore {
-	baseDir: string | null;
-	verbose: boolean;
-	sourceStore: SourceStore;
-	data: {
-		[filepath: string]: {
-			type: string;
-			data: any;
-		};
-	};
+    baseDir: string | null;
+    verbose: boolean;
+    sourceStore: SourceStore;
+    data: {
+        [filepath: string]: {
+            type: string;
+            data: any;
+        };
+    };
 
-	registerURL(transformedFilePath: string, sourceMapUrl: string): void;
-	registerMap(filename: string, sourceMap: RawSourceMap): void;
-	transformCoverage(
-		coverageMap: CoverageMap
-	): { map: CoverageMap; sourceFinder(path: string): string };
-	dispose(): void;
+    registerURL(transformedFilePath: string, sourceMapUrl: string): void;
+    registerMap(filename: string, sourceMap: RawSourceMap): void;
+    getSourceMapSync(filePath: string): any;
+    addInputSourceMapsSync(coverageData: any): void;
+    sourceFinder(filePath: string): string;
+    transformCoverage(coverageMap: CoverageMap): CoverageMap;
+    dispose(): void;
 }
 
 export class SourceStore {
-	getSource(filepath: string): string | null;
-	registerSource(filepath: string, sourceText: string): void;
+    getSource(filepath: string): string | null;
+    registerSource(filepath: string, sourceText: string): void;
 }

--- a/types/istanbul-lib-source-maps/index.d.ts
+++ b/types/istanbul-lib-source-maps/index.d.ts
@@ -8,9 +8,7 @@
 import { CoverageMap } from 'istanbul-lib-coverage';
 import { RawSourceMap } from 'source-map';
 
-export function createSourceMapStore(
-    options?: Partial<MapStoreOptions>
-): MapStore;
+export function createSourceMapStore(options?: Partial<MapStoreOptions>): MapStore;
 
 export interface MapStoreOptions {
     verbose: boolean;

--- a/types/istanbul-lib-source-maps/istanbul-lib-source-maps-tests.ts
+++ b/types/istanbul-lib-source-maps/istanbul-lib-source-maps-tests.ts
@@ -8,17 +8,17 @@ const store = createSourceMapStore({
     verbose: false,
     baseDir: 'foo',
     sourceStore: 'memory',
-    tmpdir: 'foo'
+    tmpdir: 'foo',
 });
 
 store.data['foo'].type.trim();
 
 const sourceMap: RawSourceMap = {
-    version: 1 as any as string, // Fixed by https://github.com/mozilla/source-map/pull/293 but the fix is not yet published
+    version: (1 as any) as string, // Fixed by https://github.com/mozilla/source-map/pull/293 but the fix is not yet published
     sources: ['foo', 'bar'],
     names: ['foo', 'bar'],
     mappings: 'foo',
-    file: 'foo'
+    file: 'foo',
 };
 store.registerMap('foo', sourceMap);
 

--- a/types/istanbul-lib-source-maps/istanbul-lib-source-maps-tests.ts
+++ b/types/istanbul-lib-source-maps/istanbul-lib-source-maps-tests.ts
@@ -1,24 +1,24 @@
-import { createSourceMapStore } from 'istanbul-lib-source-maps';
 import { CoverageMap } from 'istanbul-lib-coverage';
 import { RawSourceMap } from 'source-map';
+import { createSourceMapStore } from 'istanbul-lib-source-maps';
 
 createSourceMapStore();
 createSourceMapStore({});
 const store = createSourceMapStore({
-	verbose: false,
-	baseDir: 'foo',
-	sourceStore: 'memory',
-	tmpdir: 'foo'
+    verbose: false,
+    baseDir: 'foo',
+    sourceStore: 'memory',
+    tmpdir: 'foo'
 });
 
 store.data['foo'].type.trim();
 
 const sourceMap: RawSourceMap = {
-	version: 1 as any as string, // Fixed by https://github.com/mozilla/source-map/pull/293 but the fix is not yet published
-	sources: ['foo', 'bar'],
-	names: ['foo', 'bar'],
-	mappings: 'foo',
-	file: 'foo'
+    version: 1 as any as string, // Fixed by https://github.com/mozilla/source-map/pull/293 but the fix is not yet published
+    sources: ['foo', 'bar'],
+    names: ['foo', 'bar'],
+    mappings: 'foo',
+    file: 'foo'
 };
 store.registerMap('foo', sourceMap);
 
@@ -26,13 +26,12 @@ store.registerURL('foo', 'foo');
 
 const map = new CoverageMap({});
 const transformed = store.transformCoverage(map);
-transformed.map.data;
-transformed.sourceFinder('foo').trim();
+transformed.data;
 
 store.dispose();
 
 store.sourceStore.registerSource('foo', 'bar');
 const source = store.sourceStore.getSource('foo');
 if (source != null) {
-	source.trim();
+    source.trim();
 }


### PR DESCRIPTION
Updated type definitions for istanbul-lib-source-maps version 4.x, as transform method now returns only coverage map

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/istanbuljs/istanbuljs/tree/master/packages/istanbul-lib-source-maps
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.