### PR TITLE
declare namespace for react-shadow-dom-retarget-events

### DIFF
--- a/types/react-shadow-dom-retarget-events/index.d.ts
+++ b/types/react-shadow-dom-retarget-events/index.d.ts
@@ -15,3 +15,5 @@ export = retargetEvents;
  * A bug is filed at [#10422](https://github.com/facebook/react/issues/10422).
  */
 declare function retargetEvents(shadowRoot: ShadowRoot): void;
+
+declare namespace retargetEvents {}

--- a/types/react-shadow-dom-retarget-events/react-shadow-dom-retarget-events-tests.tsx
+++ b/types/react-shadow-dom-retarget-events/react-shadow-dom-retarget-events-tests.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import retargetEvents from 'react-shadow-dom-retarget-events';
+import retargetEvents = require('react-shadow-dom-retarget-events');
 
 class App extends React.Component {
     render() {
-  	    return <div onClick={() => alert('I have been clicked')}>Click me</div>;
+        return <div onClick={() => alert('I have been clicked')}>Click me</div>;
     }
 }
 
@@ -14,7 +14,7 @@ class MyCustomElement extends HTMLElement {
         const mountPoint = document.createElement('span');
         const shadowRoot = this.attachShadow({ mode: 'open' });
         shadowRoot.appendChild(mountPoint);
-        ReactDOM.render(<App/>, mountPoint);
+        ReactDOM.render(<App />, mountPoint);
         retargetEvents(shadowRoot);
     }
 }

--- a/types/react-shadow-dom-retarget-events/tsconfig.json
+++ b/types/react-shadow-dom-retarget-events/tsconfig.json
@@ -16,7 +16,6 @@
         "noEmit": true,
         "strictFunctionTypes": true,
         "jsx": "react",
-        "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [


### PR DESCRIPTION
It’s a commonjs module. `esModuleInterop` has been removed from `tsconfig.json` to ensure it stays this way.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/spring-media/react-shadow-dom-retarget-events/blob/master/index.js#L20
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.