### PR TITLE
feat(carbon-components-react): add 'align' to Accordion

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+    Accordion,
     AccordionItem,
     DataTable,
     DataTableCustomRenderProps,
@@ -20,6 +21,10 @@ import {
     TextInput,
 } from 'carbon-components-react';
 import Link from 'carbon-components-react/lib/components/UIShell/Link';
+
+// Accordion
+const accordionAlignmentStart = <Accordion align={'start'} />;
+const accordionAlignmentEnd = <Accordion align={'end'} />;
 
 // AccordionItem
 const titleNode = (

--- a/types/carbon-components-react/lib/components/Accordion/Accordion.d.ts
+++ b/types/carbon-components-react/lib/components/Accordion/Accordion.d.ts
@@ -6,7 +6,10 @@ interface InheritedProps {
     className?: ReactAttr["className"],
 }
 
-export interface AccordionProps extends InheritedProps { }
+export interface AccordionProps extends InheritedProps {
+    /** Specify the alignment of the accordion heading title and chevron. */
+    align?: 'start' | 'end'
+}
 
 declare const Accordion: React.FC<AccordionProps>;
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/pull/4754
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. -> still many other changes needed
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
