### PR TITLE
Offscreencanvas: Remove references to interfaces which these interface conforms to

### DIFF
--- a/types/offscreencanvas/index.d.ts
+++ b/types/offscreencanvas/index.d.ts
@@ -8,7 +8,7 @@
 /// <reference types="webgl2" />
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-transfercontroltooffscreen
-interface HTMLCanvasElement extends HTMLElement {
+interface HTMLCanvasElement {
     transferControlToOffscreen(): OffscreenCanvas;
 }
 
@@ -60,20 +60,19 @@ declare function createImageBitmap(image: ImageBitmapSource | OffscreenCanvas, s
                                    sw: number, sh: number): Promise<ImageBitmap>;
 
 // OffscreenCanvas should be a part of Transferable => extend all postMessage methods
-interface Worker extends EventTarget, AbstractWorker {
+interface Worker {
     postMessage(message: any, transfer?: Array<Transferable | OffscreenCanvas>): void;
 }
 
-interface ServiceWorker extends EventTarget, AbstractWorker {
+interface ServiceWorker {
     postMessage(message: any, transfer?: Array<Transferable | OffscreenCanvas>): void;
 }
 
-interface MessagePort extends EventTarget {
+interface MessagePort {
     postMessage(message: any, transfer?: Array<Transferable | OffscreenCanvas>): void;
 }
 
-interface Window extends EventTarget, WindowSessionStorage, WindowLocalStorage, WindowConsole,
-    GlobalEventHandlers, WindowOrWorkerGlobalScope, WindowEventHandlers {
+interface Window {
     postMessage(message: any, targetOrigin: string, transfer?: Array<Transferable | OffscreenCanvas>): void;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Because we removed `WindowConsole` in the Dom, this broke on master - these interface merging declarations don't need to include the `extends` in order to work as expected. 👍 