### PR TITLE
Sync frida-gum typings with Frida 12.8.15

### DIFF
--- a/types/frida-gum/frida-gum-tests.ts
+++ b/types/frida-gum/frida-gum-tests.ts
@@ -1,5 +1,29 @@
 Frida.version; // $ExpectType string
 
+// $ExpectType NativePointer
+const p = ptr(1234);
+
+// $ExpectType NativePointer
+p.sign();
+// $ExpectType NativePointer
+p.sign("ia", 42);
+// $ExpectError
+p.sign("invalid", 42);
+
+// $ExpectType NativePointer
+p.strip();
+// $ExpectType NativePointer
+p.strip("ia");
+// $ExpectError
+p.strip("invalid");
+
+// $ExpectType NativePointer
+p.blend(1337);
+// $ExpectError
+p.blend(ptr(42));
+// $ExpectError
+p.blend();
+
 const otherPuts = new NativeCallback(() => {
     return 0;
 }, "int", ["pointer"]);

--- a/types/frida-gum/index.d.ts
+++ b/types/frida-gum/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package frida-gum 15.1
+// Type definitions for non-npm package frida-gum 15.2
 // Project: https://github.com/frida/frida
 // Definitions by: Ole André Vadla Ravnås <https://github.com/oleavr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -1421,6 +1421,35 @@ declare class NativePointer {
     not(): NativePointer;
 
     /**
+     * Makes a new NativePointer by taking the bits of `this` and adding
+     * pointer authentication bits, creating a signed pointer. This is a
+     * no-op if the current process does not support pointer
+     * authentication, returning `this` instead of a new value.
+     *
+     * @param key The key to use. Defaults to `ia`.
+     * @param data The data to use. Defaults to `0`.
+     */
+    sign(key?: PointerAuthenticationKey, data?: NativePointerValue | UInt64 | Int64 | number | string): NativePointer;
+
+    /**
+     * Makes a new NativePointer by taking the bits of `this` and
+     * removing its pointer authentication bits, creating a raw pointer.
+     * This is a no-op if the current process does not support pointer
+     * authentication, returning `this` instead of a new value.
+     *
+     * @param key The key that was used to sign `this`. Defaults to `ia`.
+     */
+    strip(key?: PointerAuthenticationKey): NativePointer;
+
+    /**
+     * Makes a new NativePointer by taking `this` and blending it with
+     * a constant, which may in turn be passed to `sign()` as `data`.
+     *
+     * @param smallInteger Value to blend with.
+     */
+    blend(smallInteger: number): NativePointer;
+
+    /**
      * Returns a boolean indicating whether `v` is equal to `this`; i.e. it contains the same memory address.
      */
     equals(v: NativePointerValue | UInt64 | Int64 | number | string): boolean;
@@ -1496,6 +1525,8 @@ declare class NativePointer {
     writeUtf16String(value: string): NativePointer;
     writeAnsiString(value: string): NativePointer;
 }
+
+type PointerAuthenticationKey = "ia" | "ib" | "da" | "db";
 
 interface ObjectWrapper {
     handle: NativePointer;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://frida.re/news/2019/12/18/frida-12-8-released/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.