### PR TITLE
Shim AudioTrack type removed in TS3.9

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -608,8 +608,17 @@ declare namespace videojs {
         new(player: Player, options?: AudioTrackMenuItemOptions): AudioTrackMenuItem;
     };
 
+    interface VideojsAudioTrack {
+        enabled: boolean;
+        readonly id: string;
+        kind: string;
+        readonly label: string;
+        language: string;
+        readonly sourceBuffer: SourceBuffer | null;
+    }
+
     interface AudioTrackMenuItemOptions extends MenuItemOptions {
-        track?: AudioTrack;
+        track?: VideojsAudioTrack;
     }
 
     /**


### PR DESCRIPTION
AudioTrack isn't standard (only supported in IE and Safari), and is removed from the DOM lib in TS 3.9: microsoft/TSJS-lib-generator#802

This PR puts a copy of the type called VideojsAudioTrack in instead. That should be compatible with the DOM version for older Typescripts, since it's copied directly from the old source.