### PR TITLE
SortableJS: fix GroupOptions.pull and GroupOptions.put types

### DIFF
--- a/types/sortablejs/index.d.ts
+++ b/types/sortablejs/index.d.ts
@@ -182,11 +182,11 @@ declare namespace Sortable {
         /**
          * ability to move from the list. clone — copy the item, rather than move.
          */
-        pull?: PullResult | ((to: Sortable, from: Sortable) => PullResult);
+        pull?: PullResult | ((to: Sortable, from: Sortable, dragEl: HTMLElement, event: SortableEvent) => PullResult);
         /**
          * whether elements can be added from other lists, or an array of group names from which elements can be taken.
          */
-        put?: PutResult | ((to: Sortable) => PullResult);
+        put?: PutResult | ((to: Sortable, from: Sortable, dragEl: HTMLElement, event: SortableEvent) => PutResult);
         /**
          * a canonical version of pull, created by Sortable
          */

--- a/types/sortablejs/sortablejs-tests.ts
+++ b/types/sortablejs/sortablejs-tests.ts
@@ -325,7 +325,7 @@ Sortable.create(simpleList, {
     group: {
         name: 'bar',
         put: ['qux'],
-        pull: function (to, from) {
+        pull: function (to, from, dragEl, event) {
             return from.el.children.length > 2 || 'clone';
         }
     },
@@ -335,7 +335,7 @@ Sortable.create(simpleList, {
 Sortable.create(simpleList, {
     group: {
         name: 'qux',
-        put: function (to) {
+        put: function (to, from, dragEl, event) {
             return to.el.children.length < 4;
         }
     },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [n/a ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
