### PR TITLE
Added missing fields to google.visualization TableOptions

### DIFF
--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -1116,7 +1116,7 @@ declare namespace google {
             height?: string;
             page?: string;
             pageSize?: number;
-            pagingButtons?: number | 'both' | 'prev' | 'next';
+            pagingButtons?: number | 'both' | 'prev' | 'next' | 'auto';
             rtlTable?: boolean;
             scrollLeftStartPosition?: number;
             showRowNumber?: boolean;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -1112,9 +1112,11 @@ declare namespace google {
             alternatingRowStyle?: boolean;
             cssClassNames?: CssClassNames;
             firstRowNumber?: number;
+            frozenColumns?: number;
             height?: string;
             page?: string;
             pageSize?: number;
+            pagingButtons?: number | 'both' | 'prev' | 'next';
             rtlTable?: boolean;
             scrollLeftStartPosition?: number;
             showRowNumber?: boolean;


### PR DESCRIPTION
Added missing fields to google.visualization TableOptions

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/chart/interactive/docs/gallery/table
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (These options have been present since 2016)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
