### PR TITLE
Fix typings in @reach/router to include innerRef

### DIFF
--- a/types/reach__router/index.d.ts
+++ b/types/reach__router/index.d.ts
@@ -5,6 +5,7 @@
 //                 Awwit <https://github.com/awwit>
 //                 wroughtec <https://github.com/wroughtec>
 //                 O.Jackman <https://github.com/chilledoj>
+//                 Eyas <https://github.com/Eyas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/reach__router/index.d.ts
+++ b/types/reach__router/index.d.ts
@@ -57,6 +57,8 @@ export interface LinkProps<TState> extends AnchorProps {
     replace?: boolean;
     getProps?: (props: LinkGetProps) => {};
     state?: TState;
+    /** @deprecated If using React >= 16.4, use ref instead. */
+    innerRef?: React.RefCallback<HTMLAnchorElement>;
 }
 
 export interface LinkGetProps {
@@ -86,7 +88,7 @@ export interface MatchProps<TParams> {
 export type MatchRenderFn<TParams> = (props: MatchRenderProps<TParams>) => React.ReactNode;
 
 export interface MatchRenderProps<TParams> {
-    match: null | { uri: string; path: string } & TParams;
+    match: null | ({ uri: string; path: string } & TParams);
     location: WindowLocation;
     navigate: NavigateFn;
 }
@@ -162,4 +164,4 @@ export function useNavigate(): NavigateFn;
 
 export function useParams(): any;
 
-export function useMatch(pathname: string): null | { uri: string; path: string, [param: string]: string };
+export function useMatch(pathname: string): null | { uri: string; path: string; [param: string]: string };

--- a/types/reach__router/reach__router-tests.tsx
+++ b/types/reach__router/reach__router-tests.tsx
@@ -1,15 +1,7 @@
 import * as React from 'react';
 import { render } from 'react-dom';
 
-import {
-    Link,
-    Location,
-    LocationProvider,
-    RouteComponentProps,
-    Router,
-    Redirect,
-    useMatch
-} from '@reach/router';
+import { Link, Location, LocationProvider, RouteComponentProps, Router, Redirect, useMatch } from '@reach/router';
 
 interface DashParams {
     id: string;
@@ -17,17 +9,13 @@ interface DashParams {
 
 const Home = (props: RouteComponentProps) => <div>Home</div>;
 
-const Dash = (props: RouteComponentProps<DashParams>) => (
-    <div>Dash for item ${props.id}</div>
-);
+const Dash = (props: RouteComponentProps<DashParams>) => <div>Dash for item ${props.id}</div>;
 
 const NotFound = (props: RouteComponentProps) => <div>Route not found</div>;
 
 const UseMatchCheck = (props: RouteComponentProps) => {
     const match = useMatch('/params/:one');
-    return (
-        <div>{match ? match.one : 'NO PATH PARAM' }</div>
-    );
+    return <div>{match ? match.one : 'NO PATH PARAM'}</div>;
 };
 
 render(
@@ -50,9 +38,7 @@ render(
             {context => (
                 <>
                     <div>hostname is {context.location.hostname}</div>
-                    <button onClick={(): Promise<void> => context.navigate('/')}>
-                        Go Home
-                    </button>
+                    <button onClick={(): Promise<void> => context.navigate('/')}>Go Home</button>
                 </>
             )}
         </Location>
@@ -60,12 +46,16 @@ render(
             {context => (
                 <>
                     <div>hostname is {context.location.hostname}</div>
-                    <button onClick={(): Promise<void> => context.navigate('/')}>
-                        Go Home
-                    </button>
+                    <button onClick={(): Promise<void> => context.navigate('/')}>Go Home</button>
                 </>
             )}
         </LocationProvider>
     </Router>,
-    document.getElementById('app-root')
+    document.getElementById('app-root'),
 );
+
+const handleRef = (el: HTMLAnchorElement) => {
+    el.focus();
+};
+
+render(<Link innerRef={handleRef} to="./foo"></Link>, document.getElementById('app-root'));


### PR DESCRIPTION
https://reach.tech/router/api/Link

> ## innerRef: func
> Calls up with its inner ref for apps on React <16.4.
> If using React >=16.4, use ref instead.
>
> ```
> <Link to="./" innerRef={node => /* ... */} />
> ```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

**If changing an existing definition:**
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://reach.tech/router/api/Link>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.  **N/A**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. **N/A**
