### PR TITLE
[ @types/single-spa-react ] Fix: update added to lifecycles and added React.FunctionComponent as acceptable  loadComponent option

### DIFF
--- a/types/single-spa-react/index.d.ts
+++ b/types/single-spa-react/index.d.ts
@@ -28,5 +28,6 @@ declare namespace SingleSpaReact {
         bootstrap: (props: any) => Promise<void>;
         mount: (props: any) => Promise<void>;
         unmount: (props: any) => Promise<void>;
+        update: (props: any) => Promise<void>;
     }
 }

--- a/types/single-spa-react/index.d.ts
+++ b/types/single-spa-react/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/CanopyTax/single-spa-react, https://github.com/joeldenning/single-spa-react
 // Definitions by: Garrett Smith <https://github.com/Garrett-Smith-iq>
 //                 Chris Dopuch <https://github.com/chrisdopuch>
+//                 Bence Czeii <https://github.com/benceczeili>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/single-spa-react/index.d.ts
+++ b/types/single-spa-react/index.d.ts
@@ -17,8 +17,8 @@ declare namespace SingleSpaReact {
     interface Options {
         React: typeof React;
         ReactDOM: typeof ReactDOM;
-        rootComponent?: React.ComponentClass<any, any>;
-        loadRootComponent?: () => Promise<React.ComponentClass<any, any>>;
+        rootComponent?: React.ComponentClass<any, any> | React.FunctionComponent<any>;
+        loadRootComponent?: () => Promise<React.ComponentClass<any, any>> | Promise<React.FunctionComponent<any>>;
         domElementGetter?: () => Element;
         suppressComponentDidCatchWarning?: boolean;
         parcelCanUpdate?: boolean;

--- a/types/single-spa-react/index.d.ts
+++ b/types/single-spa-react/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for single-spa-react 2.8
+// Type definitions for single-spa-react 2.12
 // Project: https://github.com/CanopyTax/single-spa-react, https://github.com/joeldenning/single-spa-react
 // Definitions by: Garrett Smith <https://github.com/Garrett-Smith-iq>
 //                 Chris Dopuch <https://github.com/chrisdopuch>
 //                 Bence Czeii <https://github.com/benceczeili>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.12
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";

--- a/types/single-spa-react/index.d.ts
+++ b/types/single-spa-react/index.d.ts
@@ -29,6 +29,6 @@ declare namespace SingleSpaReact {
         bootstrap: (props: any) => Promise<void>;
         mount: (props: any) => Promise<void>;
         unmount: (props: any) => Promise<void>;
-        update: (props: any) => Promise<void>;
+        update?: (props: any) => Promise<void>;
     }
 }

--- a/types/single-spa-react/index.d.ts
+++ b/types/single-spa-react/index.d.ts
@@ -4,7 +4,7 @@
 //                 Chris Dopuch <https://github.com/chrisdopuch>
 //                 Bence Czeii <https://github.com/benceczeili>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.12
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://single-spa.js.org/docs/parcels-api#unmount>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

@Garrett-Smith-iq 
@chrisdopuch 