### PR TITLE
feat(koa): fix attachment definition

### DIFF
--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -29,6 +29,7 @@ import * as Keygrip from "keygrip";
 import * as compose from "koa-compose";
 import { Socket, ListenOptions } from "net";
 import * as url from "url";
+import * as contentDisposition from "content-disposition";
 
 declare interface ContextDelegatedRequest {
     /**
@@ -347,9 +348,10 @@ declare interface ContextDelegatedResponse {
     redirect(url: string, alt?: string): void;
 
     /**
-     * Set Content-Disposition header to "attachment" with optional `filename`.
+     * Set Content-Disposition to "attachment" to signal the client to prompt for download.
+     * Optionally specify the filename of the download and some options.
      */
-    attachment(filename: string): void;
+    attachment(filename?: string, options?: contentDisposition.Options): void;
 
     /**
      * Return the response mime type void of

--- a/types/koa/test/default.ts
+++ b/types/koa/test/default.ts
@@ -48,6 +48,11 @@ app.use((ctx, next) => {
 app.use(ctx => {
     ctx.body = 'Hello World';
     ctx.body = ctx.URL.toString();
+    ctx.attachment();
+    ctx.attachment('path/to/tobi.png');
+    ctx.attachment('path/to/tobi.png', {
+        type: 'inline'
+    });
 });
 
 app.listen(3000);


### PR DESCRIPTION
- `filename` is optional
- `options` are optional and typed via `content-disposition` (which is a
dependency used by koa

https://github.com/koajs/koa/blob/ed84ee50da8ae3cd08056f944d061e00d06ed87f/History.md#260--2018-10-23

/cc @christianbundy

Thanks!

Fixes: #43357

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/koa/blob/ed84ee50da8ae3cd08056f944d061e00d06ed87f/History.md#260--2018-10-23