### PR TITLE
Add Document to JQuery.Node type alias

### DIFF
--- a/types/jquery/misc.d.ts
+++ b/types/jquery/misc.d.ts
@@ -4,7 +4,7 @@
 
 declare namespace JQuery {
     type TypeOrArray<T> = T | T[];
-    type Node = Element | Text | Comment | DocumentFragment;
+    type Node = Element | Text | Comment | Document | DocumentFragment;
 
     /**
      * A string is designated htmlString in jQuery documentation when it is used to represent one or more DOM elements, typically to be created and inserted in the document. When passed as an argument of the jQuery() function, the string is identified as HTML if it starts with <tag ... >) and is parsed as such until the final > character. Prior to jQuery 1.9, a string was considered to be HTML if it contained <tag ... > anywhere within the string.


### PR DESCRIPTION
DocumentFragment was added earlier, but Document isn't assignable to DocumentFragment in Typescript 3.9, so both need to be part of the union that makes up Node.