### PR TITLE
jquery PromiseBase/Deferred should not be assignable to Promise

### DIFF
--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -6762,7 +6762,14 @@ function JQuery_jqXHR() {
         }
     }
 
+    // A JQuery.Promise2 is not Promise/A+ compliant and should not be compatible with an ECMA2015 native promise.
+    // APIs that can accept a JQuery.Promise2 should use `PromiseLike`
     function compatibleWithPromise(): Promise<any> {
+        // $ExpectError
+        return p;
+    }
+
+    function compatibleWithPromiseLike(): PromiseLike<any> {
         return p;
     }
 
@@ -7318,7 +7325,14 @@ function JQuery_Promise3() {
         return s;
     }
 
+    // A JQuery.Promise2 is not Promise/A+ compliant and should not be compatible with an ECMA2015 native promise.
+    // APIs that can accept a JQuery.Promise2 should use `PromiseLike`
     function compatibleWithPromise(): Promise<any> {
+        // $ExpectError
+        return p;
+    }
+
+    function compatibleWithPromiseLike(): PromiseLike<any> {
         return p;
     }
 
@@ -7463,7 +7477,14 @@ function JQuery_Promise2(p: JQuery.Promise2<string, Error, number, JQuery, strin
         return s;
     }
 
+    // A JQuery.Promise2 is not Promise/A+ compliant and should not be compatible with an ECMA2015 native promise.
+    // APIs that can accept a JQuery.Promise2 should use `PromiseLike`
     function compatibleWithPromise(): Promise<any> {
+        // $ExpectError
+        return p;
+    }
+
+    function compatibleWithPromiseLike(): PromiseLike<any> {
         return p;
     }
 
@@ -7584,7 +7605,14 @@ function JQuery_Promise(p: JQuery.Promise<string, Error, number>) {
         return s;
     }
 
+    // A JQuery.Promise2 is not Promise/A+ compliant and should not be compatible with an ECMA2015 native promise.
+    // APIs that can accept a JQuery.Promise2 should use `PromiseLike`
     function compatibleWithPromise(): Promise<any> {
+        // $ExpectError
+        return p;
+    }
+
+    function compatibleWithPromiseLike(): PromiseLike<any> {
         return p;
     }
 }

--- a/types/jquery/misc.d.ts
+++ b/types/jquery/misc.d.ts
@@ -1160,29 +1160,6 @@ callbacks.fire( "world" );
      */
     interface Thenable<T> extends PromiseLike<T> { }
 
-    // NOTE: This is a private copy of the global Promise interface. It is used by JQuery.PromiseBase to indicate compatibility with other Promise implementations.
-    //       The global Promise interface cannot be used directly as it may be modified, as in the case of @types/bluebird-global.
-    /**
-     * Represents the completion of an asynchronous operation
-     */
-    interface _Promise<T> {
-        readonly [Symbol.toStringTag]: "Promise";
-        /**
-         * Attaches callbacks for the resolution and/or rejection of the Promise.
-         * @param onfulfilled The callback to execute when the Promise is resolved.
-         * @param onrejected The callback to execute when the Promise is rejected.
-         * @returns A Promise for the completion of which ever callback is executed.
-         */
-        then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
-                                             onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null): _Promise<TResult1 | TResult2>;
-        /**
-         * Attaches a callback for only the rejection of the Promise.
-         * @param onrejected The callback to execute when the Promise is rejected.
-         * @returns A Promise for the completion of the callback.
-         */
-        catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null): _Promise<T | TResult>;
-    }
-
     // Type parameter guide
     // --------------------
     // Each type parameter represents a parameter in one of the three possible callbacks.
@@ -1205,7 +1182,7 @@ callbacks.fire( "world" );
     interface PromiseBase<TR, TJ, TN,
         UR, UJ, UN,
         VR, VJ, VN,
-        SR, SJ, SN> extends _Promise<TR>, PromiseLike<TR> {
+        SR, SJ, SN> {
         /**
          * Add handlers to be called when the Deferred object is either resolved or rejected.
          * @param alwaysCallback A function, or array of functions, that is called when the Deferred is resolved or rejected.


### PR DESCRIPTION
At some point JQuery's `PromiseBase` interface was made to be assignment-compatible with the native ES2015 `Promise` interface. However, this is inherently unsound at runtime. The reason for this is that JQuery's `Deferred` and other promise-like types derived from `PromiseBase` are not Promise/A+ compliant, while the native ES2015 `Promise` *is* Promise/A+ compliant. The key difference lies in how a Promise/A+-compliant promise *adopts the state* of any promise-like value it is resolved with, a behavior commonly also known as "recursive unwrap". If you were to pass a JQuery promise into an API that expected a valid Promise/A+-compatible promise, that API might expect promise resolution to recursively unwrap the resolved value until it reaches a non-promise value.

The `PromiseLike` interface in TypeScript exists to describe APIs that meet the bare minimum to be called a "promise", but are not necessarily Promise/A+ compliant. This PR reverts the changes made to allow a JQuery `Promise` to be assignment compatible with the native `Promise`, and instead relies on structural compatibility with `PromiseLike`. The recent effort to add the `awaited` type to TypeScript 3.9 brought this incompatibility to the fore. Although `awaited` is being pushed out beyond TS3.9 as we continue to asses its impact, it would be advisable to address this inconsistency now.

With this change, it is recommended that anyone who intends to pass a JQuery promise into an API that expects a native ES2015 `Promise` carefully inspect their usages and convert the promise using `Promise.resolve` if the type is compatible. We found at least one case of a JQuery promise that would result in a native promise that would never resolve in the `JQuery.Animation` type, as it *resolves to itself*. Passing a `JQuery.Animation` into `Promise.resolve()` would result in an invalid promise as it would fail to unwrap the resolved value into a non-promise value.

Here are some examples of this compatibility issue in action:

**Example 1 - Deferred `.resolve()` does not unwrap**
```js
// jQuery
var d1 = $.Deferred();
d1.resolve("test");

var d2 = $.Deferred();
d2.resolve(d1);
d2.then(r => {
    console.log(r === "test");  // false
    console.log(r === d1);      // true
});

// ES2015
var p1 = new Promise(resolve => resolve("test"));
var p2 = new Promise(resolve => resolve(p1));
p2.then(r => {
    console.log(r === "test");  // true
    console.log(r === p1);      // false
});
```

**Example 2 - Deferred `.then()` does not recursively unwrap**
```js
// jQuery
var d1 = $.Deferred();
d1.resolve("test");

var d2 = $.Deferred();
d2.resolve(d1);

var d3 = $.Deferred();
d3.resolve();
d3.then(r => d2).then(r => {
    console.log(r === "test"); // false
    console.log(r === d1); // true
});

// ES2015
var p1 = new Promise(resolve => resolve("test"));
var p2 = new Promise(resolve => resolve(p1));
var p3 = new Promise(resolve => resolve());
p3.then(r => p2).then(r => {
    console.log(r === "test"); // true
    console.log(r === p1); // false
});
```

**Example 3 - Deferred does not have a `Symbol.toStringTag`**
```js
// JQuery
console.log(Symbol.toStringTag in $.Deferred()); // false

// ES2015
console.log(Symbol.toStringTag in new Promise()); // true
```