### PR TITLE
node-forge: Add `pkcs7.createEnvelopedData`

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -13,6 +13,7 @@
 //                 Sascha Zarhuber  <https://github.com/saschazar21>
 //                 Rogier Schouten  <https://github.com/rogierschouten>
 //                 Ivan Aseev       <https://github.com/aseevia>
+//                 Wiktor Kwapisiewicz <https://github.com/wiktor-k>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -678,6 +679,15 @@ declare module "node-forge" {
         }
 
         function createSignedData(): PkcsSignedData;
+
+        interface PkcsEnvelopedData {
+            content?: string | util.ByteBuffer;
+            addRecipient(certificate: pki.Certificate): void;
+            encrypt(): void;
+            toAsn1(): asn1.Asn1;
+        }
+
+        function createEnvelopedData(): PkcsEnvelopedData;
     }
 
     namespace pkcs5 {

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -405,3 +405,12 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
         encoding: 'binary'
     });
 }
+
+{
+    let p7 = forge.pkcs7.createEnvelopedData();
+    let cert = forge.pki.certificateFromPem('PEM');
+    p7.addRecipient(cert);
+    p7.content = forge.util.createBuffer('content');
+    p7.encrypt();
+    let asn1: forge.asn1.Asn1 = p7.toAsn1();
+}


### PR DESCRIPTION
This patch adds typings for `createEnvelopedData` function of `pkcs7` module and tests that are lifted directly from the README.

See: https://github.com/digitalbazaar/forge#pkcs7

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/digitalbazaar/forge#pkcs7
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
