### PR TITLE
[css-font-loading-module] Make FontFaceSet extend EventTarget and add FontFaceSetLoadEvent

### DIFF
--- a/types/css-font-loading-module/css-font-loading-module-tests.ts
+++ b/types/css-font-loading-module/css-font-loading-module-tests.ts
@@ -18,4 +18,12 @@ contexts.forEach(context => {
     const b: boolean = context.fonts.check("12px Example", "ß");
     const c: Promise<FontFace[]> = context.fonts.load("12px MyFont", "ß").then();
     const d: Promise<typeof context.fonts> = context.fonts.ready.then();
+    const e: FontFaceSetLoadEvent = new FontFaceSetLoadEvent('loading', {fontfaces: []});
+    context.fonts.addEventListener('loading', (evt) => {
+        evt.fontfaces;
+    });
+    context.fonts.onloadingdone = (evt) => {
+        evt.fontfaces;
+    };
+    context.fonts.dispatchEvent(e);
 });

--- a/types/css-font-loading-module/index.d.ts
+++ b/types/css-font-loading-module/index.d.ts
@@ -6,7 +6,6 @@
 export type FontFaceLoadStatus = 'unloaded' | 'loading' | 'loaded' | 'error';
 export type FontFaceSetLoadStatus = 'loading' | 'loaded';
 export type BinaryData = ArrayBuffer | ArrayBufferView;
-export type EventHandler = (event: Event) => void;
 
 export interface FontFaceDescriptors {
     style?: string;
@@ -17,11 +16,27 @@ export interface FontFaceDescriptors {
     featureSettings?: string;
 }
 
-export interface FontFaceSet extends Set<FontFace> {
+export interface FontFaceSetLoadEventInit extends EventInit {
+    fontfaces?: FontFace[];
+}
+
+export interface FontFaceSetEventMap {
+    "loading": (this: FontFaceSet, event: FontFaceSetLoadEvent) => any;
+    "loadingdone": (this: FontFaceSet, event: FontFaceSetLoadEvent) => any;
+    "loadingerror": (this: FontFaceSet, event: FontFaceSetLoadEvent) => any;
+}
+
+export interface FontFaceSet extends Set<FontFace>, EventTarget {
     // events for when loading state changes
-    onloading: EventHandler;
-    onloadingdone: EventHandler;
-    onloadingerror: EventHandler;
+    onloading: ((this: FontFaceSet, event: FontFaceSetLoadEvent) => any) | null;
+    onloadingdone: ((this: FontFaceSet, event: FontFaceSetLoadEvent) => any) | null;
+    onloadingerror: ((this: FontFaceSet, event: FontFaceSetLoadEvent) => any) | null;
+
+    // EventTarget
+    addEventListener<K extends keyof FontFaceSetEventMap>(type: K, listener: FontFaceSetEventMap[K], options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof FontFaceSetEventMap>(type: K, listener: FontFaceSetEventMap[K], options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 
     // check and start loads if appropriate
     // and fulfill promise when all loads complete
@@ -53,6 +68,11 @@ declare global {
         display: string;
         readonly status: FontFaceLoadStatus;
         readonly loaded: Promise<FontFace>;
+    }
+
+    class FontFaceSetLoadEvent extends Event {
+        constructor(type: string, eventInitDict?: FontFaceSetLoadEventInit);
+        readonly fontfaces: FontFace[];
     }
 
     interface Document {


### PR DESCRIPTION

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://drafts.csswg.org/css-font-loading/#FontFaceSet-interface
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
