### PR TITLE
@types/ssh2 - Fix subsystem event listener (introduced in 2e019e5347)

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -1060,22 +1060,22 @@ export interface Session extends events.EventEmitter {
     /**
      * Emitted when the client has requested an interactive shell.
      */
-    on(event: "shell", listener: (accept: SessionAcceptReject, reject: SessionAcceptReject) => void): this;
+    on(event: "shell", listener: (accept: () => ServerChannel, reject: SessionAcceptReject) => void): this;
 
     /**
      * Emitted when the client has requested execution of a command string.
      */
-    on(event: "exec", listener: (accept: SessionAcceptReject, reject: SessionAcceptReject, info: ExecInfo) => void): this;
+    on(event: "exec", listener: (accept: () => ServerChannel, reject: SessionAcceptReject, info: ExecInfo) => void): this;
 
     /**
      * Emitted when the client has requested the SFTP subsystem.
      */
-    on(event: "sftp", listener: (accept: SessionAcceptReject, reject: SessionAcceptReject) => void): this;
+    on(event: "sftp", listener: (accept: () => SFTPStream, reject: SessionAcceptReject) => void): this;
 
     /**
      * Emitted when the client has requested an arbitrary subsystem.
      */
-    on(event: "subsystem", listener: (accept: SessionAcceptReject, reject: SessionAcceptReject, info: SubsystemInfo) => void): this;
+    on(event: "subsystem", listener: (accept: () => ServerChannel, reject: SessionAcceptReject, info: SubsystemInfo) => void): this;
 
     /**
      * Emitted when the session has closed.


### PR DESCRIPTION
This fixes a bug introduced by commit 2e019e5347 - some subsystems return a channel/stream via accept().

Should fix https://github.com/DefinitelyTyped/DefinitelyTyped/issues/43199
