### PR TITLE
ember-cli-htmlbars: create type definition for library

### DIFF
--- a/types/ember-cli-htmlbars/ember-cli-htmlbars-tests.ts
+++ b/types/ember-cli-htmlbars/ember-cli-htmlbars-tests.ts
@@ -1,0 +1,5 @@
+import { TemplateFactory, hbs } from 'ember-cli-htmlbars';
+
+const result = hbs`<NeatoComponent @args={{this.coolio}} />`; // $ExpectType TemplateFactory
+const shouldError = hbs(12); // $ExpectError
+const shouldAlsoError = hbs('12'); // $ExpectError

--- a/types/ember-cli-htmlbars/index.d.ts
+++ b/types/ember-cli-htmlbars/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for ember-cli-htmlbars 4.2
+// Project: https://github.com/ember-cli/ember-cli-htmlbars
+// Definitions by: Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
+//                 Mike North <https://github.com/mike-north>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Using the same "brand" as the types for `htmlbars-inline-precompile` for
+// backwards compatibility. The actual value of the brand doesn't matter; it is
+// only important that it (a) is distinct and (b) interoperates with existing
+// uses of the `hbs` export from `htmlbars-inline-precompile`.
+export interface TemplateFactory {
+    __htmlbars_inline_precompile_template_factory: any;
+}
+
+export function hbs(tagged: TemplateStringsArray): TemplateFactory;

--- a/types/ember-cli-htmlbars/tsconfig.json
+++ b/types/ember-cli-htmlbars/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ember-cli-htmlbars-tests.ts"
+    ]
+}

--- a/types/ember-cli-htmlbars/tslint.json
+++ b/types/ember-cli-htmlbars/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Resolves typed-ember/ember-cli-typescript#983