### PR TITLE
[@types/chrome]: Add HAREntry and HARLog to chrome.devtools.network

### DIFF
--- a/types/chrome/har-format/index.d.ts
+++ b/types/chrome/har-format/index.d.ts
@@ -1,0 +1,6 @@
+import { Entry, Log } from 'har-format';
+
+declare global {
+    export type HARFormatEntry = Entry;
+    export type HARFormatLog = Log;
+}

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -14,6 +14,7 @@
 // TypeScript Version: 2.4
 
 /// <reference types="filesystem" />
+/// <reference path="har-format/index.d.ts" />
 
 ////////////////////
 // Global object
@@ -1865,8 +1866,12 @@ declare namespace chrome.devtools.inspectedWindow {
  * Availability: Since Chrome 18.
  */
 declare namespace chrome.devtools.network {
+    /** Represents a HAR entry for a specific finished request. */
+    export interface HAREntry extends HARFormatEntry { }
+    /** Represents a HAR log that contains all known network requests. */
+    export interface HARLog extends HARFormatLog { }
     /** Represents a network request for a document resource (script, image and so on). See HAR Specification for reference. */
-    export interface Request {
+    export interface Request extends chrome.devtools.network.HAREntry {
         /**
          * Returns content of the response body.
          * @param callback A function that receives the response body when the request completes.
@@ -1889,7 +1894,7 @@ declare namespace chrome.devtools.network {
      * function(object harLog) {...};
      * Parameter harLog: A HAR log. See HAR specification for details.
      */
-    export function getHAR(callback: (harLog: Object) => void): void;
+    export function getHAR(callback: (harLog: HARLog) => void): void;
 
     /** Fired when a network request is finished and all request data are available. */
     export var onRequestFinished: RequestFinishedEvent;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -439,3 +439,13 @@ function testStorage() {
         var myOldValue: { x: number } = changes["myKey"].oldValue;
     });
 }
+
+chrome.devtools.network.onRequestFinished.addListener((request: chrome.devtools.network.Request) => {
+    request; // $ExpectType Request
+    console.log('request: ', request);
+});
+
+chrome.devtools.network.getHAR((harLog: chrome.devtools.network.HARLog) => {
+    harLog; // $ExpectType HARLog
+    console.log('harLog: ', harLog)
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://developer.chrome.com/extensions/devtools_network#type-Request
https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/har-format
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
