### PR TITLE
[plaid-link] Add destroy method to plaidHandler definition

### DIFF
--- a/types/plaid-link/index.d.ts
+++ b/types/plaid-link/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for non-npm package plaid-link-browser 2.0
 // Project: https://github.com/plaid/link (Does not have to be to GitHub, but prefer linking to a source code repository rather than to a project website.)
 // Definitions by: Aaron Holderman <https://github.com/afholderman>
+//                 Hannes Kindströmmer <https://github.com/brolaugh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/
 // TypeScript Version: 2.4
 

--- a/types/plaid-link/index.d.ts
+++ b/types/plaid-link/index.d.ts
@@ -44,6 +44,7 @@ export namespace Plaid {
     interface LinkHandler {
         open: () => void;
         exit: (options?: ExitOptions) => void;
+        destroy: () => void;
         institutions: Institution[];
     }
 


### PR DESCRIPTION
The plaid handler has a `destroy()` method which is referenced in their documentation: https://plaid.com/docs/#destroy-function

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.