### PR TITLE
[twilio-video] correct global `isSupported` type

### DIFF
--- a/types/twilio-video/index.d.ts
+++ b/types/twilio-video/index.d.ts
@@ -5,6 +5,7 @@
 //                 katashin <https://github.com/ktsn>
 //                 Benjamin Santalucia <https://github.com/ben8p>
 //                 Erick Delfin <https://github.com/nifled>
+//                 Adam Montgomery <https://github.com/howitzer-industries>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -487,6 +488,7 @@ export class VideoTrack extends Track {
  * Global (https://media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta1/docs/global.html)
  */
 export const version: string;
+export const isSupported: boolean;
 
 /** Members */
 export type AudioCodec = 'isac' | 'opus' | 'PCMA' | 'PCMU';
@@ -498,7 +500,6 @@ export function connect(token: string, options?: ConnectOptions): Promise<Room>;
 export function createLocalAudioTrack(options?: CreateLocalTrackOptions): Promise<LocalAudioTrack>;
 export function createLocalTracks(options?: CreateLocalTracksOptions): Promise<LocalTrack[]>;
 export function createLocalVideoTrack(options?: CreateLocalTrackOptions): Promise<LocalVideoTrack>;
-export function isSupported(): boolean;
 export function rewriteLocalTrackIds(room: Room, trackStats: LocalTrackStats[]): LocalTrackStats[];
 
 /** Type Definitions */


### PR DESCRIPTION
it’s not actually a function, it’s a boolean property: https://media.twiliocdn.com/sdk/js/video/releases/2.3.0/docs/module-twilio-video.html

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://media.twiliocdn.com/sdk/js/video/releases/2.3.0/docs/module-twilio-video.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
