### PR TITLE
Express: improve `req.query` type

### DIFF
--- a/types/easy-session/easy-session-tests.ts
+++ b/types/easy-session/easy-session-tests.ts
@@ -49,7 +49,7 @@ app.get('/hasrole', function (req, res, next) {
 });
 
 app.post('/setrole', function (req, res, next) {
-    req.session.setRole(req.query.role);
+    req.session.setRole(req.query.role as string);
     res.send(200);
 });
 

--- a/types/express-paginate/express-paginate-tests.ts
+++ b/types/express-paginate/express-paginate-tests.ts
@@ -12,7 +12,7 @@ app.get('/users', async (req, res, next) => {
     return findAndCountAll({limit: req.query.limit, offset: req.skip})
         .then(results => {
             const itemCount = results.count;
-            const pageCount = Math.ceil(results.count / req.query.limit);
+            const pageCount = Math.ceil(results.count / (req.query.limit as number));
             res.render('users/all_users', {
                 users: results.rows,
                 pageCount,
@@ -20,7 +20,7 @@ app.get('/users', async (req, res, next) => {
                 currentPageHref: paginate.href(req)(false, req.params),
                 // Instead of exposing this to the html template, we'll test this here and pass a static number
                 hasNextPages: paginate.hasNextPages(req)(pageCount),
-                pages: paginate.getArrayPages(req)(3, pageCount, req.query.page)
+                pages: paginate.getArrayPages(req)(3, pageCount, req.query.page as number)
             });
         }).catch(next);
 });

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -58,3 +58,7 @@ app.post<never, { foo: string }, { bar: number }>('/', (req, res) => {
     res.json({ baz: "fail" }); // $ExpectError
     req.body.baz; // $ExpectError
 });
+
+app.get("/", (req) => {
+    req.query.foo; // $ExpectType {} | null | undefined
+});

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -463,7 +463,12 @@ export interface Request<P extends Params = ParamsDictionary, ResBody = any, Req
 
     params: P;
 
-    query: any;
+    query: {
+        [key: string]:
+            // The value type here is a "poor man's `unknown`". When these types support TypeScript
+            // 3.0+, we can replace this with `unknown`.
+            {} | null | undefined
+    };
 
     route: any;
 

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -161,6 +161,11 @@ namespace express_tests {
         req.params.bar; // $ExpectError
     });
 
+    // Params can be a custom type that conforms to constraint and can be specified via an explicit param type (express)
+    router.get('/', req => {
+        req.query.foo; // $ExpectType {} | null | undefined
+    });
+
     // Params cannot be a custom type that does not conform to constraint
     router.get<{ foo: number }>('/:foo', () => {}); // $ExpectError
 

--- a/types/passport-jwt/passport-jwt-tests.ts
+++ b/types/passport-jwt/passport-jwt-tests.ts
@@ -33,7 +33,7 @@ opts.jwtFromRequest = ExtractJwt.fromUrlQueryParameter('param_name');
 opts.jwtFromRequest = ExtractJwt.fromAuthHeaderWithScheme('param_name');
 opts.jwtFromRequest = ExtractJwt.fromExtractors([ExtractJwt.fromHeader('x-api-key'), ExtractJwt.fromBodyField('field_name'), ExtractJwt.fromUrlQueryParameter('param_name')]);
 opts.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken();
-opts.jwtFromRequest = (req: Request) => { return req.query.token; };
+opts.jwtFromRequest = (req: Request) => { return req.query.token as string; };
 opts.secretOrKey = new Buffer('secret');
 
 declare function findUser(condition: {id: string}, callback: (error: any, user :any) => void): void;


### PR DESCRIPTION
- `any` disables all type checking. `unknown` should be used instead:
  ```ts
  declare const any: any;
  any.foo.bar; // no compile error, but runtime exception!
  ```
- We can't use `unknown` because these types don't yet target TS 3+, so I used `PoorMansUnknown` (`{} | null | undefined`) instead, which achieves the same thing.
- [The docs suggest `req.query` will always be an object](https://expressjs.com/en/api.html#req.query).
- The exact type of the object values is unknown, because it can be configured via [`query parser`](https://expressjs.com/en/api.html#app-settings-property).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
- - https://expressjs.com/en/api.html#req.query
- - https://expressjs.com/en/api.html#app-settings-property (see `query parser`)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
