### PR TITLE
react-router-dom: Correct type for `ref` in Link<S>

### DIFF
--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -9,7 +9,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { match } from "react-router";
+import { match } from 'react-router';
 import * as React from 'react';
 import * as H from 'history';
 
@@ -39,7 +39,7 @@ export {
 
 export interface BrowserRouterProps {
     basename?: string;
-    getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void);
+    getUserConfirmation?: (message: string, callback: (ok: boolean) => void) => void;
     forceRefresh?: boolean;
     keyLength?: number;
 }
@@ -47,7 +47,7 @@ export class BrowserRouter extends React.Component<BrowserRouterProps, any> {}
 
 export interface HashRouterProps {
     basename?: string;
-    getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void);
+    getUserConfirmation?: (message: string, callback: (ok: boolean) => void) => void;
     hashType?: 'slash' | 'noslash' | 'hashbang';
 }
 export class HashRouter extends React.Component<HashRouterProps, any> {}
@@ -58,23 +58,14 @@ export interface LinkProps<S = H.LocationState> extends React.AnchorHTMLAttribut
     replace?: boolean;
     innerRef?: React.Ref<HTMLAnchorElement>;
 }
-export class Link<S = H.LocationState> extends React.Component<
-  LinkProps<S>,
-  any
-> {}
+export class Link<S = H.LocationState> extends React.Component<LinkProps<S>, any> {}
 
 export interface NavLinkProps<S = H.LocationState> extends LinkProps<S> {
-  activeClassName?: string;
-  activeStyle?: React.CSSProperties;
-  exact?: boolean;
-  strict?: boolean;
-  isActive?<Params extends { [K in keyof Params]?: string }>(
-    match: match<Params>,
-    location: H.Location<S>,
-  ): boolean;
-  location?: H.Location<S>;
+    activeClassName?: string;
+    activeStyle?: React.CSSProperties;
+    exact?: boolean;
+    strict?: boolean;
+    isActive?<Params extends { [K in keyof Params]?: string }>(match: match<Params>, location: H.Location<S>): boolean;
+    location?: H.Location<S>;
 }
-export class NavLink<S = H.LocationState> extends React.Component<
-  NavLinkProps<S>,
-  any
-> {}
+export class NavLink<S = H.LocationState> extends React.Component<NavLinkProps<S>, any> {}

--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -58,7 +58,14 @@ export interface LinkProps<S = H.LocationState> extends React.AnchorHTMLAttribut
     replace?: boolean;
     innerRef?: React.Ref<HTMLAnchorElement>;
 }
-export class Link<S = H.LocationState> extends React.Component<LinkProps<S>, any> {}
+export function Link<S = H.LocationState>(
+    // TODO: Define this as ...params: Parameters<Link<S>> when only TypeScript >= 3.1 support is needed.
+    props: React.PropsWithoutRef<LinkProps<S>> & React.RefAttributes<HTMLAnchorElement>,
+): ReturnType<Link<S>>;
+export interface Link<S = H.LocationState>
+    extends React.ForwardRefExoticComponent<
+        React.PropsWithoutRef<LinkProps<S>> & React.RefAttributes<HTMLAnchorElement>
+    > {}
 
 export interface NavLinkProps<S = H.LocationState> extends LinkProps<S> {
     activeClassName?: string;

--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -7,7 +7,7 @@
 //                 Daniel Nixon <https://github.com/danielnixon>
 //                 Tony Ward <https://github.com/ynotdraw>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 import { match } from 'react-router';
 import * as React from 'react';

--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -75,4 +75,11 @@ export interface NavLinkProps<S = H.LocationState> extends LinkProps<S> {
     isActive?<Params extends { [K in keyof Params]?: string }>(match: match<Params>, location: H.Location<S>): boolean;
     location?: H.Location<S>;
 }
-export class NavLink<S = H.LocationState> extends React.Component<NavLinkProps<S>, any> {}
+export function NavLink<S = H.LocationState>(
+    // TODO: Define this as ...params: Parameters<NavLink<S>> when only TypeScript >= 3.1 support is needed.
+    props: React.PropsWithoutRef<NavLinkProps<S>> & React.RefAttributes<HTMLAnchorElement>,
+): ReturnType<NavLink<S>>;
+export interface NavLink<S = H.LocationState>
+    extends React.ForwardRefExoticComponent<
+        React.PropsWithoutRef<NavLinkProps<S>> & React.RefAttributes<HTMLAnchorElement>
+    > {}

--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -7,7 +7,7 @@
 //                 Daniel Nixon <https://github.com/danielnixon>
 //                 Tony Ward <https://github.com/ynotdraw>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// TypeScript Version: 2.8
 
 import { match } from 'react-router';
 import * as React from 'react';

--- a/types/react-router-dom/react-router-dom-tests.tsx
+++ b/types/react-router-dom/react-router-dom-tests.tsx
@@ -5,19 +5,17 @@ import * as H from 'history';
 const getIsActive = (extraProp: string) => (match: match, location: H.Location) => !!extraProp;
 
 interface Props extends NavLinkProps {
-  extraProp: string;
+    extraProp: string;
 }
 
 export default function(props: Props) {
-  const {extraProp, ...rest} = props;
-  const isActive = getIsActive(extraProp);
-  return (
-    <NavLink {...rest} isActive={isActive}/>
-  );
+    const { extraProp, ...rest } = props;
+    const isActive = getIsActive(extraProp);
+    return <NavLink {...rest} isActive={isActive} />;
 }
 
 type OtherProps = RouteComponentProps<{
-  id: string;
+    id: string;
 }>;
 
 const Component: React.FC<OtherProps> = props => {
@@ -46,4 +44,4 @@ const ref = React.createRef<HTMLAnchorElement>();
 
 <Link to="/url" aria-current="page" />;
 
-<Link<{foo: number}> to={{pathname: "abc", state: {foo: 5}}}  />;
+<Link<{ foo: number }> to={{ pathname: 'abc', state: { foo: 5 } }} />;

--- a/types/react-router-dom/react-router-dom-tests.tsx
+++ b/types/react-router-dom/react-router-dom-tests.tsx
@@ -45,3 +45,5 @@ const ref = React.createRef<HTMLAnchorElement>();
 <Link to="/url" replace={true} ref={ref} />;
 
 <Link to="/url" aria-current="page" />;
+
+<Link<{foo: number}> to={{pathname: "abc", state: {foo: 5}}}  />;

--- a/types/react-router-dom/react-router-dom-tests.tsx
+++ b/types/react-router-dom/react-router-dom-tests.tsx
@@ -38,10 +38,15 @@ const MyLink: React.FC<LinkProps> = props => <Link style={{ color: 'red' }} {...
 const refCallback: React.Ref<HTMLAnchorElement> = node => {};
 <Link to="/url" replace={true} innerRef={refCallback} />;
 <Link to="/url" replace={true} ref={refCallback} />;
+<NavLink to="/url" replace={true} innerRef={refCallback} />;
+<NavLink to="/url" replace={true} ref={refCallback} />;
 const ref = React.createRef<HTMLAnchorElement>();
 <Link to="/url" replace={true} innerRef={ref} />;
 <Link to="/url" replace={true} ref={ref} />;
+<NavLink to="/url" replace={true} innerRef={ref} />;
+<NavLink to="/url" replace={true} ref={ref} />;
 
 <Link to="/url" aria-current="page" />;
 
 <Link<{ foo: number }> to={{ pathname: 'abc', state: { foo: 5 } }} />;
+<NavLink<{ foo: number }> to={{ pathname: 'abc', state: { foo: 5 } }} />;

--- a/types/react-router-dom/react-router-dom-tests.tsx
+++ b/types/react-router-dom/react-router-dom-tests.tsx
@@ -39,7 +39,9 @@ const MyLink: React.FC<LinkProps> = props => <Link style={{ color: 'red' }} {...
 
 const refCallback: React.Ref<HTMLAnchorElement> = node => {};
 <Link to="/url" replace={true} innerRef={refCallback} />;
+<Link to="/url" replace={true} ref={refCallback} />;
 const ref = React.createRef<HTMLAnchorElement>();
 <Link to="/url" replace={true} innerRef={ref} />;
+<Link to="/url" replace={true} ref={ref} />;
 
 <Link to="/url" aria-current="page" />;

--- a/types/react-router-dom/react-router-dom-tests.tsx
+++ b/types/react-router-dom/react-router-dom-tests.tsx
@@ -48,5 +48,9 @@ const ref = React.createRef<HTMLAnchorElement>();
 
 <Link to="/url" aria-current="page" />;
 
-<Link<{ foo: number }> to={{ pathname: 'abc', state: { foo: 5 } }} />;
-<NavLink<{ foo: number }> to={{ pathname: 'abc', state: { foo: 5 } }} />;
+React.createElement<LinkProps<{ foo: number }> & React.RefAttributes<HTMLAnchorElement>>(Link, {
+    to: { pathname: 'abc', state: { foo: 5 } },
+});
+React.createElement<NavLinkProps<{ foo: number }> & React.RefAttributes<HTMLAnchorElement>>(NavLink, {
+    to: { pathname: 'abc', state: { foo: 5 } },
+});


### PR DESCRIPTION
## Description

"ref" can be used rather than "innerRef" to return a ref to the <a>
element inside of <Link>.

See:

1. reacttraining.com/react-router/web/api/Link/innerref-function

    Where it says:

    > As of React Router 5.1, if you are using React 16 you should not
    > need this prop because we forward this ref to the underlying <a>.
    > Use a normal ref instead.Allows access to the underlying ref of the
    > component.

2. https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/modules/Link.js#L74-L121

    Link is the result of forwardRef rather than an actual React class.

    This implies a few things:

    1. It is a function (see the return type of
        React.ForwardRefExoticComponent) rather than a class
    2. Its reference is to an inner <a> element, rather than what's in
      React.Component, which is a Ref to the element itself.

This introduces a potential incompatibility where users can't use
"new Link" anymore. But that reflects reality (Link is callable not
newable).

Since Link was previously exported as a class, we need to continue to
support it being used as both a type and a value. Since Link was
exported as a generic, we need to continue to support that. As a result:

1. Link is exported as a function that happens to implement the type
  corresponding to the result of
  `forwardRef<HTMLAnchorElement, LinkProps<S>>`.

2. Link is still exported as a type (interface) which is the same as
  that of the return value of `forwardRef<...>`.

## Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

**If changing an existing definition:**
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://reacttraining.com/react-router/web/api/Link/innerref-function>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **N/A**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. **Already there.**