### PR TITLE
Ensure all members of the typed-ember team are authors on ember* type defs

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Derek Wickern <https://github.com/dwickern>
 //                 Mike North <https://github.com/mike-north>
 //                 Chris Krycho <https://github.com/chriskrycho>
+//                 James C. Davis <https://github.com/jamescdavis>
+//                 Dan Freeman <https://github.com/dfreeman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember-data__serializer/index.d.ts
+++ b/types/ember-data__serializer/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for @ember-data/serializer 3.15
 // Project: https://github.com/emberjs/data
-// Definitions by: Chris Krycho <https://github.com/me>
+// Definitions by: Chris Krycho <https://github.com/chriskrycho>
 //                 Dan Freeman <https://github.com/dfreeman>
 //                 James C. Davis <https://github.com/jamescdavis>
 //                 Mike North <https://github.com/mike-north>

--- a/types/ember-data__store/index.d.ts
+++ b/types/ember-data__store/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for @ember-data/store 3.15
 // Project: https://github.com/emberjs/data
-// Definitions by: Chris Krycho <https://github.com/me>
+// Definitions by: Chris Krycho <https://github.com/chriskrycho>
 //                 Dan Freeman <https://github.com/dfreeman>
 //                 James C. Davis <https://github.com/jamescdavis>
 //                 Mike North <https://github.com/mike-north>

--- a/types/ember-feature-flags/index.d.ts
+++ b/types/ember-feature-flags/index.d.ts
@@ -2,6 +2,9 @@
 // Project: https://github.com/kategengler/ember-feature-flags#readme
 // Definitions by: Frank Tan <https://github.com/tansongyang>
 //                 Mike North <https://github.com/mike-north>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember-mocha/index.d.ts
+++ b/types/ember-mocha/index.d.ts
@@ -3,6 +3,9 @@
 // Definitions by: Derek Wickern <https://github.com/dwickern>
 //                 Simon Ihmig <https://github.com/simonihmig>
 //                 Mike North <https://github.com/mike-north>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/ember-modal-dialog/index.d.ts
+++ b/types/ember-modal-dialog/index.d.ts
@@ -2,6 +2,9 @@
 // Project: https://github.com/yapplabs/ember-modal-dialog#readme
 // Definitions by: Frank Tan <https://github.com/tansongyang>
 //                 Mike North <https://github.com/mike-north>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember-qunit/index.d.ts
+++ b/types/ember-qunit/index.d.ts
@@ -4,6 +4,8 @@
 //                 Mike North <https://github.com/mike-north>
 //                 Steve Calvert <https://github.com/scalvert>
 //                 Dan Freeman <https://github.com/dfreeman>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember-resolver/index.d.ts
+++ b/types/ember-resolver/index.d.ts
@@ -2,6 +2,8 @@
 // Project: https://github.com/ember-cli/ember-resolver#readme
 // Definitions by: Dan Freeman <https://github.com/dfreeman>
 //                 Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember-test-helpers/index.d.ts
+++ b/types/ember-test-helpers/index.d.ts
@@ -2,6 +2,9 @@
 // Project: https://github.com/emberjs/ember-test-helpers#readme
 // Definitions by: Derek Wickern <https://github.com/dwickern>
 //                 Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 James C. Davis <https://github.com/jamescdavis>
+//                 Dan Freeman <https://github.com/dfreeman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember-testing-helpers/index.d.ts
+++ b/types/ember-testing-helpers/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for ember-testing/lib/helpers
 // Project: https://github.com/emberjs/ember.js/tree/master/packages/ember-testing/lib/helpers
 // Definitions by: Chris Krycho <https://github.com/chriskrycho>
+//                 James C. Davis <https://github.com/jamescdavis>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 Mike North <https://github.com/mike-north>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -9,6 +9,8 @@
 //                 Alex LaFroscia <https://github.com/alexlafroscia>
 //                 Mike North <https://github.com/mike-north>
 //                 Bryan Crotaz <https://github.com/BryanCrotaz>
+//                 James C. Davis <https://github.com/jamescdavis>
+//                 Dan Freeman <https://github.com/dfreeman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__application/index.d.ts
+++ b/types/ember__application/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for non-npm package @ember/application 3.0
 // Project: https://emberjs.com/api/ember/3.4/modules/@ember%2Fapplication
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__array/index.d.ts
+++ b/types/ember__array/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for non-npm package @ember/array 3.0
 // Project: https://emberjs.com/api/ember/3.4/modules/@ember%2Farray
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__component/index.d.ts
+++ b/types/ember__component/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for non-npm package @ember/component 3.0
 // Project: https://emberjs.com/api/ember/3.4/modules/@ember%2Fcomponent
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__controller/index.d.ts
+++ b/types/ember__controller/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for non-npm package @ember/controller 3.0
 // Project: https://emberjs.com/api/ember/3.4/modules/@ember%2Fcontroller
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__debug/index.d.ts
+++ b/types/ember__debug/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for non-npm package @ember/debug 3.0
 // Project: https://emberjs.com/api/ember/3.4/modules/@ember%2Fdebug
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__engine/index.d.ts
+++ b/types/ember__engine/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for non-npm package @ember/engine 3.0
 // Project: https://emberjs.com/api/ember/3.4/modules/@ember%2Fengine
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__error/index.d.ts
+++ b/types/ember__error/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for non-npm package @ember/error 3.0
 // Project: https://emberjs.com/api/ember/3.4/modules/@ember%2Ferror
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__object/index.d.ts
+++ b/types/ember__object/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for non-npm package @ember/object 3.1
 // Project: https://emberjs.com/api/ember/3.4/modules/@ember%2Fobject
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__ordered-set/index.d.ts
+++ b/types/ember__ordered-set/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for @ember/ordered-set 2.0
 // Project: https://github.com/emberjs/ember-ordered-set
 // Definitions by: Chris Krycho <https://github.com/chriskrycho>
+//                 Mike North <https://github.com/mike-north>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/ember__polyfills/index.d.ts
+++ b/types/ember__polyfills/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for non-npm package @ember/polyfills 3.0
 // Project: https://emberjs.com/api/ember/3.4/modules/@ember%2Fpolyfills
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__runloop/index.d.ts
+++ b/types/ember__runloop/index.d.ts
@@ -2,6 +2,9 @@
 // Project: https://emberjs.com/api/ember/3.4/modules/@ember%2Frunloop
 // Definitions by: Mike North <https://github.com/mike-north>
 //                 Steve Calvert <https://github.com/scalvert>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__service/index.d.ts
+++ b/types/ember__service/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for non-npm package @ember/service 3.0
 // Project: https://emberjs.com/api/ember/3.4/modules/@ember%2Fservice
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__string/index.d.ts
+++ b/types/ember__string/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for non-npm package @ember/string 3.0
 // Project: https://emberjs.com/api/ember/3.4/modules/@ember%2Fstring
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__template/index.d.ts
+++ b/types/ember__template/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for non-npm package @ember/template 3.0
 // Project: https://emberjs.com/api/ember/3.12/modules/@ember%2Ftemplate
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__test-helpers/index.d.ts
+++ b/types/ember__test-helpers/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Dan Freeman <https://github.com/dfreeman>
 //                 James C. Davis <https://github.com/jamescdavis>
 //                 Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__test/index.d.ts
+++ b/types/ember__test/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for non-npm package @ember/test 3.0
 // Project: https://emberjs.com/api/ember/3.4/modules/@ember%2Ftest
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ember__utils/index.d.ts
+++ b/types/ember__utils/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for non-npm package @ember/utils 3.0
 // Project: http://emberjs.com/
 // Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
This PR does not change any type definitions. It only ensures that all active members of the "typed-ember" team are listed as authors for all ember-related type definitions in DefinitelyTyped so that any of us can help manage these. The active members of typed-ember (@chriskrycho, @dfreeman, @jamescdavis, @mike-north) have committed to being jointly responsible for maintaining type definitions for ember-related packages.
