### PR TITLE
Adding type definitions for aws-kcl library

### DIFF
--- a/types/aws-kcl/aws-kcl-tests.ts
+++ b/types/aws-kcl/aws-kcl-tests.ts
@@ -1,4 +1,4 @@
-import * as kcl from 'aws-kcl';
+import kcl from 'aws-kcl';
 
 // Example used from https://github.com/awslabs/amazon-kinesis-client-nodejs
 const recordProcessor = {

--- a/types/aws-kcl/aws-kcl-tests.ts
+++ b/types/aws-kcl/aws-kcl-tests.ts
@@ -1,0 +1,50 @@
+import kcl, { InitializeInput, ProcessRecordsInput, LeaseLossInput, ShardEndedInput, Callback } from 'aws-kcl';
+
+// Example used from https://github.com/awslabs/amazon-kinesis-client-nodejs
+const recordProcessor = {
+    initialize(_initializeInput: InitializeInput, completeCallback: Callback) {
+        completeCallback();
+    },
+
+    processRecords(processRecordsInput: ProcessRecordsInput, completeCallback: Callback) {
+        if (!processRecordsInput || !processRecordsInput.records) {
+            completeCallback();
+            return;
+        }
+
+        const records = processRecordsInput.records;
+        let record;
+        let sequenceNumber;
+
+        for (record of records) {
+            sequenceNumber = record.sequenceNumber;
+            const partitionKey = record.partitionKey;
+            const data = new Buffer(record.data, 'base64').toString();
+            console.log(partitionKey, data);
+        }
+
+        if (!sequenceNumber) {
+            completeCallback();
+            return;
+        }
+        processRecordsInput.checkpointer.checkpoint(
+            sequenceNumber,
+            (_err: string | undefined, _checkpointedSequenceNumber: string) => {
+                completeCallback();
+            },
+        );
+    },
+
+    leaseLost(_leaseLostInput: LeaseLossInput, completeCallback: Callback) {
+        completeCallback();
+    },
+
+    shardEnded(shardEndedInput: ShardEndedInput, completeCallback: Callback) {
+        shardEndedInput.checkpointer.checkpoint((_err?: string) => {
+            completeCallback();
+        });
+        completeCallback();
+    },
+};
+
+kcl(recordProcessor).run();

--- a/types/aws-kcl/aws-kcl-tests.ts
+++ b/types/aws-kcl/aws-kcl-tests.ts
@@ -1,12 +1,12 @@
-import kcl, { InitializeInput, ProcessRecordsInput, LeaseLossInput, ShardEndedInput, Callback } from 'aws-kcl';
+import * as kcl from 'aws-kcl';
 
 // Example used from https://github.com/awslabs/amazon-kinesis-client-nodejs
 const recordProcessor = {
-    initialize(_initializeInput: InitializeInput, completeCallback: Callback) {
+    initialize(_initializeInput: kcl.InitializeInput, completeCallback: kcl.Callback) {
         completeCallback();
     },
 
-    processRecords(processRecordsInput: ProcessRecordsInput, completeCallback: Callback) {
+    processRecords(processRecordsInput: kcl.ProcessRecordsInput, completeCallback: kcl.Callback) {
         if (!processRecordsInput || !processRecordsInput.records) {
             completeCallback();
             return;
@@ -35,11 +35,11 @@ const recordProcessor = {
         );
     },
 
-    leaseLost(_leaseLostInput: LeaseLossInput, completeCallback: Callback) {
+    leaseLost(_leaseLostInput: kcl.LeaseLossInput, completeCallback: kcl.Callback) {
         completeCallback();
     },
 
-    shardEnded(shardEndedInput: ShardEndedInput, completeCallback: Callback) {
+    shardEnded(shardEndedInput: kcl.ShardEndedInput, completeCallback: kcl.Callback) {
         shardEndedInput.checkpointer.checkpoint((_err?: string) => {
             completeCallback();
         });

--- a/types/aws-kcl/index.d.ts
+++ b/types/aws-kcl/index.d.ts
@@ -1,0 +1,133 @@
+// Type definitions for aws-kcl 2.0
+// Project: https://github.com/awslabs/amazon-kinesis-client-nodejs
+// Definitions by: Vlad Shlosberg <https://github.com/vshlos>
+//                 Foqal <https://github.com/foqal>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+import * as fs from "fs";
+
+export type Callback = () => void;
+
+export type CheckpointCallback = (error: string | undefined, checkpointedSequenceNumber: string) => void;
+
+export interface Checkpointer {
+    /**
+     * Checkpoints at a given sequence number.
+     * @param sequenceNumber        Sequence number of the record to checkpoint;
+     * @param callback              Function that is invoked after the checkpoint operation completes.
+     */
+    checkpoint(sequenceNumber: string, callback: CheckpointCallback): void;
+
+    /**
+     * Checkpoints at the checkpoint will be at the end of the most
+     * recently-delivered list of records.
+     * @param callback              Function that is invoked after the checkpoint
+     *                              operation completes.
+     */
+    checkpoint(callback: CheckpointCallback): void;
+}
+
+export interface InitializeInput {
+    shardId: string;
+    sequenceNumber?: string;
+    subSequenceNumber?: number;
+}
+
+export interface CheckpointInput {
+    checkpointer: Checkpointer;
+}
+
+export interface Record {
+    data: string;
+    partitionKey: string;
+    sequenceNumber: string;
+}
+
+export interface ProcessRecordsInput extends CheckpointInput {
+    records: Record[];
+    millisBehindLatest?: number;
+}
+
+export interface LeaseLossInput {} // tslint:disable-line:no-empty-interface
+
+export interface ShardEndedInput extends CheckpointInput {} // tslint:disable-line:no-empty-interface
+
+export interface RecordProcessor {
+    /**
+     * Called once by the KCL before any calls to processRecords. Any initialization
+     * logic for record processing can go here.
+     *
+     * @param initializeInput - Initialization related information.
+     * @param completeCallback - The callback that must be invoked
+     *          once the initialization operation is complete.
+     */
+    initialize(initializeInput: InitializeInput, completeCallback: Callback): void;
+
+    /**
+     * Called by KCL with a list of records to be processed and checkpointed.
+     * A record looks like:
+     *
+     * The checkpointer can optionally be used to checkpoint a particular sequence
+     * number (from a record). If checkpointing, the checkpoint must always be
+     * invoked before calling `completeCallback` for processRecords. Moreover,
+     * `completeCallback` should only be invoked once the checkpoint operation
+     * callback is received.
+     *
+     * @param processRecordsInput       Process records information with
+     *             array of records that are to be processed.
+     * @param completeCallback          The callback that must be invoked
+     *             once all records are processed and checkpoint (optional) is
+     *             complete.
+     */
+    processRecords(processRecordsInput: ProcessRecordsInput, completeCallback: Callback): void;
+
+    /**
+     * Called by the KCL to indicate that this record processor should shut down.
+     * After the lease lost operation is complete, there will not be any more calls to
+     * any other functions of this record processor. Clients should not attempt to
+     * checkpoint because the lease has been lost by this Worker.
+     *
+     * @param leaseLostInput    Lease lost information.
+     * @param completeCallback  The callback must be invoked once lease
+     *             lost operations are completed.
+     */
+    leaseLost(leaseLostInput: LeaseLossInput, completeCallback: Callback): void;
+    /**
+     * Called by the KCL to indicate that this record processor should shutdown.
+     * After the shard ended operation is complete, there will not be any more calls to
+     * any other functions of this record processor. Clients are required to checkpoint
+     * at this time. This indicates that the current record processor has finished
+     * processing and new record processors for the children will be created.
+     *
+     * @param shardEndedInput       ShardEnded information.
+     * @param completeCallback      The callback must be invoked once shard
+     *               ended operations are completed.
+     */
+    shardEnded(shardEndedInput: ShardEndedInput, completeCallback: Callback): void;
+}
+
+interface KCLInput {
+    recordProcessor: RecordProcessor;
+    version: symbol;
+}
+
+export class KCLManager {
+    constructor(
+        kclManagerInput: KCLInput,
+        inputFile?: fs.ReadStream,
+        outputFile?: fs.WriteStream,
+        errorFile?: fs.WriteStream,
+    );
+    checkpoint(sequenceNumber: string): void;
+    run(): void;
+}
+
+declare function KCLProcess(
+    recordProcessor: RecordProcessor,
+    inputFile?: fs.ReadStream,
+    outputFile?: fs.WriteStream,
+    errorFile?: fs.WriteStream,
+): KCLManager;
+
+export default KCLProcess;

--- a/types/aws-kcl/index.d.ts
+++ b/types/aws-kcl/index.d.ts
@@ -5,129 +5,132 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
+
 import * as fs from "fs";
 
-export type Callback = () => void;
-
-export type CheckpointCallback = (error: string | undefined, checkpointedSequenceNumber: string) => void;
-
-export interface Checkpointer {
-    /**
-     * Checkpoints at a given sequence number.
-     * @param sequenceNumber        Sequence number of the record to checkpoint;
-     * @param callback              Function that is invoked after the checkpoint operation completes.
-     */
-    checkpoint(sequenceNumber: string, callback: CheckpointCallback): void;
-
-    /**
-     * Checkpoints at the checkpoint will be at the end of the most
-     * recently-delivered list of records.
-     * @param callback              Function that is invoked after the checkpoint
-     *                              operation completes.
-     */
-    checkpoint(callback: CheckpointCallback): void;
-}
-
-export interface InitializeInput {
-    shardId: string;
-    sequenceNumber?: string;
-    subSequenceNumber?: number;
-}
-
-export interface CheckpointInput {
-    checkpointer: Checkpointer;
-}
-
-export interface Record {
-    data: string;
-    partitionKey: string;
-    sequenceNumber: string;
-}
-
-export interface ProcessRecordsInput extends CheckpointInput {
-    records: Record[];
-    millisBehindLatest?: number;
-}
-
-export interface LeaseLossInput {} // tslint:disable-line:no-empty-interface
-
-export interface ShardEndedInput extends CheckpointInput {} // tslint:disable-line:no-empty-interface
-
-export interface RecordProcessor {
-    /**
-     * Called once by the KCL before any calls to processRecords. Any initialization
-     * logic for record processing can go here.
-     *
-     * @param initializeInput - Initialization related information.
-     * @param completeCallback - The callback that must be invoked
-     *          once the initialization operation is complete.
-     */
-    initialize(initializeInput: InitializeInput, completeCallback: Callback): void;
-
-    /**
-     * Called by KCL with a list of records to be processed and checkpointed.
-     * A record looks like:
-     *
-     * The checkpointer can optionally be used to checkpoint a particular sequence
-     * number (from a record). If checkpointing, the checkpoint must always be
-     * invoked before calling `completeCallback` for processRecords. Moreover,
-     * `completeCallback` should only be invoked once the checkpoint operation
-     * callback is received.
-     *
-     * @param processRecordsInput       Process records information with
-     *             array of records that are to be processed.
-     * @param completeCallback          The callback that must be invoked
-     *             once all records are processed and checkpoint (optional) is
-     *             complete.
-     */
-    processRecords(processRecordsInput: ProcessRecordsInput, completeCallback: Callback): void;
-
-    /**
-     * Called by the KCL to indicate that this record processor should shut down.
-     * After the lease lost operation is complete, there will not be any more calls to
-     * any other functions of this record processor. Clients should not attempt to
-     * checkpoint because the lease has been lost by this Worker.
-     *
-     * @param leaseLostInput    Lease lost information.
-     * @param completeCallback  The callback must be invoked once lease
-     *             lost operations are completed.
-     */
-    leaseLost(leaseLostInput: LeaseLossInput, completeCallback: Callback): void;
-    /**
-     * Called by the KCL to indicate that this record processor should shutdown.
-     * After the shard ended operation is complete, there will not be any more calls to
-     * any other functions of this record processor. Clients are required to checkpoint
-     * at this time. This indicates that the current record processor has finished
-     * processing and new record processors for the children will be created.
-     *
-     * @param shardEndedInput       ShardEnded information.
-     * @param completeCallback      The callback must be invoked once shard
-     *               ended operations are completed.
-     */
-    shardEnded(shardEndedInput: ShardEndedInput, completeCallback: Callback): void;
-}
-
-interface KCLInput {
-    recordProcessor: RecordProcessor;
-    version: symbol;
-}
-
-export class KCLManager {
-    constructor(
-        kclManagerInput: KCLInput,
-        inputFile?: fs.ReadStream,
-        outputFile?: fs.WriteStream,
-        errorFile?: fs.WriteStream,
-    );
-    checkpoint(sequenceNumber: string): void;
-    run(): void;
-}
+export = KCLProcess;
 
 declare function KCLProcess(
-    recordProcessor: RecordProcessor,
+    recordProcessor: KCLProcess.RecordProcessor,
     inputFile?: fs.ReadStream,
     outputFile?: fs.WriteStream,
     errorFile?: fs.WriteStream,
-): KCLManager;
+): KCLProcess.KCLManager;
 
-export default KCLProcess;
+declare namespace KCLProcess {
+    type Callback = () => void;
+
+    type CheckpointCallback = (error: string | undefined, checkpointedSequenceNumber: string) => void;
+
+    interface Checkpointer {
+        /**
+         * Checkpoints at a given sequence number.
+         * @param sequenceNumber        Sequence number of the record to checkpoint;
+         * @param callback              Function that is invoked after the checkpoint operation completes.
+         */
+        checkpoint(sequenceNumber: string, callback: CheckpointCallback): void;
+
+        /**
+         * Checkpoints at the checkpoint will be at the end of the most
+         * recently-delivered list of records.
+         * @param callback              Function that is invoked after the checkpoint
+         *                              operation completes.
+         */
+        checkpoint(callback: CheckpointCallback): void;
+    }
+
+    interface InitializeInput {
+        shardId: string;
+        sequenceNumber?: string;
+        subSequenceNumber?: number;
+    }
+
+    interface CheckpointInput {
+        checkpointer: Checkpointer;
+    }
+
+    interface Record {
+        data: string;
+        partitionKey: string;
+        sequenceNumber: string;
+    }
+
+    interface ProcessRecordsInput extends CheckpointInput {
+        records: Record[];
+        millisBehindLatest?: number;
+    }
+
+    interface LeaseLossInput {} // tslint:disable-line:no-empty-interface
+
+    interface ShardEndedInput extends CheckpointInput {} // tslint:disable-line:no-empty-interface
+
+    interface RecordProcessor {
+        /**
+         * Called once by the KCL before any calls to processRecords. Any initialization
+         * logic for record processing can go here.
+         *
+         * @param initializeInput - Initialization related information.
+         * @param completeCallback - The callback that must be invoked
+         *          once the initialization operation is complete.
+         */
+        initialize(initializeInput: InitializeInput, completeCallback: Callback): void;
+
+        /**
+         * Called by KCL with a list of records to be processed and checkpointed.
+         * A record looks like:
+         *
+         * The checkpointer can optionally be used to checkpoint a particular sequence
+         * number (from a record). If checkpointing, the checkpoint must always be
+         * invoked before calling `completeCallback` for processRecords. Moreover,
+         * `completeCallback` should only be invoked once the checkpoint operation
+         * callback is received.
+         *
+         * @param processRecordsInput       Process records information with
+         *             array of records that are to be processed.
+         * @param completeCallback          The callback that must be invoked
+         *             once all records are processed and checkpoint (optional) is
+         *             complete.
+         */
+        processRecords(processRecordsInput: ProcessRecordsInput, completeCallback: Callback): void;
+
+        /**
+         * Called by the KCL to indicate that this record processor should shut down.
+         * After the lease lost operation is complete, there will not be any more calls to
+         * any other functions of this record processor. Clients should not attempt to
+         * checkpoint because the lease has been lost by this Worker.
+         *
+         * @param leaseLostInput    Lease lost information.
+         * @param completeCallback  The callback must be invoked once lease
+         *             lost operations are completed.
+         */
+        leaseLost(leaseLostInput: LeaseLossInput, completeCallback: Callback): void;
+        /**
+         * Called by the KCL to indicate that this record processor should shutdown.
+         * After the shard ended operation is complete, there will not be any more calls to
+         * any other functions of this record processor. Clients are required to checkpoint
+         * at this time. This indicates that the current record processor has finished
+         * processing and new record processors for the children will be created.
+         *
+         * @param shardEndedInput       ShardEnded information.
+         * @param completeCallback      The callback must be invoked once shard
+         *               ended operations are completed.
+         */
+        shardEnded(shardEndedInput: ShardEndedInput, completeCallback: Callback): void;
+    }
+
+    interface KCLInput {
+        recordProcessor: RecordProcessor;
+        version: symbol;
+    }
+
+    class KCLManager {
+        constructor(
+            kclManagerInput: KCLInput,
+            inputFile?: fs.ReadStream,
+            outputFile?: fs.WriteStream,
+            errorFile?: fs.WriteStream,
+        );
+        checkpoint(sequenceNumber: string): void;
+        run(): void;
+    }
+}

--- a/types/aws-kcl/tsconfig.json
+++ b/types/aws-kcl/tsconfig.json
@@ -14,7 +14,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",

--- a/types/aws-kcl/tsconfig.json
+++ b/types/aws-kcl/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "aws-kcl-tests.ts"
+    ]
+}

--- a/types/aws-kcl/tslint.json
+++ b/types/aws-kcl/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

