### PR TITLE
[express]: adding generics for query type

### DIFF
--- a/types/easy-session/easy-session-tests.ts
+++ b/types/easy-session/easy-session-tests.ts
@@ -49,7 +49,7 @@ app.get('/hasrole', function (req, res, next) {
 });
 
 app.post('/setrole', function (req, res, next) {
-    req.session.setRole(req.query.role);
+    req.session.setRole(req.query.role as string);
     res.send(200);
 });
 

--- a/types/express-paginate/express-paginate-tests.ts
+++ b/types/express-paginate/express-paginate-tests.ts
@@ -12,7 +12,7 @@ app.get('/users', async (req, res, next) => {
     return findAndCountAll({limit: req.query.limit, offset: req.skip})
         .then(results => {
             const itemCount = results.count;
-            const pageCount = Math.ceil(results.count / req.query.limit as number);
+            const pageCount = Math.ceil(results.count / parseInt(req.query.limit as string, 10));
             res.render('users/all_users', {
                 users: results.rows,
                 pageCount,
@@ -20,7 +20,7 @@ app.get('/users', async (req, res, next) => {
                 currentPageHref: paginate.href(req)(false, req.params),
                 // Instead of exposing this to the html template, we'll test this here and pass a static number
                 hasNextPages: paginate.hasNextPages(req)(pageCount),
-                pages: paginate.getArrayPages(req)(3, pageCount, req.query.page as number)
+                pages: paginate.getArrayPages(req)(3, pageCount, parseInt(req.query.page as string, 10))
             });
         }).catch(next);
 });

--- a/types/express-paginate/express-paginate-tests.ts
+++ b/types/express-paginate/express-paginate-tests.ts
@@ -12,7 +12,7 @@ app.get('/users', async (req, res, next) => {
     return findAndCountAll({limit: req.query.limit, offset: req.skip})
         .then(results => {
             const itemCount = results.count;
-            const pageCount = Math.ceil(results.count / req.query.limit);
+            const pageCount = Math.ceil(results.count / req.query.limit as number);
             res.render('users/all_users', {
                 users: results.rows,
                 pageCount,
@@ -20,7 +20,7 @@ app.get('/users', async (req, res, next) => {
                 currentPageHref: paginate.href(req)(false, req.params),
                 // Instead of exposing this to the html template, we'll test this here and pass a static number
                 hasNextPages: paginate.hasNextPages(req)(pageCount),
-                pages: paginate.getArrayPages(req)(3, pageCount, req.query.page)
+                pages: paginate.getArrayPages(req)(3, pageCount, req.query.page as number)
             });
         }).catch(next);
 });

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -32,6 +32,17 @@ app.get<{ foo: string }>('/:foo', req => {
 // Params cannot be a custom type that does not conform to constraint
 app.get<{ foo: number }>('/:foo', () => {}); // $ExpectError
 
+// Query can be a custom type
+app.get<{}, any, any, {q: string}>('/:foo', req => {
+    req.query.q; // $ExpectType string
+    req.query.a; // $ExpectError
+});
+
+// Query will be defaulted to any
+app.get('/:foo', req => {
+    req.query; // $ExpectType any
+});
+
 // Default types
 app.post("/", (req, res) => {
     req.params[0]; // $ExpectType string

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -38,9 +38,9 @@ app.get<{}, any, any, {q: string}>('/:foo', req => {
     req.query.a; // $ExpectError
 });
 
-// Query will be defaulted to any
+// Query will be defaulted to Query type
 app.get('/:foo', req => {
-    req.query; // $ExpectType any
+    req.query; // $ExpectType Query
 });
 
 // Default types

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -40,26 +40,26 @@ export interface ParamsDictionary { [key: string]: string; }
 export type ParamsArray = string[];
 export type Params = ParamsDictionary | ParamsArray;
 
-export interface RequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any> {
+export interface RequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any> {
     // tslint:disable-next-line callable-types (This is extended from and can't extend from a type alias in ts<2.2
-    (req: Request<P, ResBody, ReqBody>, res: Response<ResBody>, next: NextFunction): any;
+    (req: Request<P, ResBody, ReqBody, ReqQuery>, res: Response<ResBody>, next: NextFunction): any;
 }
 
-export type ErrorRequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any> = (err: any, req: Request<P, ResBody, ReqBody>, res: Response<ResBody>, next: NextFunction) => any;
+export type ErrorRequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any> = (err: any, req: Request<P, ResBody, ReqBody, ReqQuery>, res: Response<ResBody>, next: NextFunction) => any;
 
 export type PathParams = string | RegExp | Array<string | RegExp>;
 
-export type RequestHandlerParams<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any>
-    = RequestHandler<P, ResBody, ReqBody>
-    | ErrorRequestHandler<P, ResBody, ReqBody>
+export type RequestHandlerParams<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any>
+    = RequestHandler<P, ResBody, ReqBody, ReqQuery>
+    | ErrorRequestHandler<P, ResBody, ReqBody, ReqQuery>
     | Array<RequestHandler<P>
     | ErrorRequestHandler<P>>;
 
 export interface IRouterMatcher<T, Method extends 'all' | 'get' | 'post' | 'put' | 'delete' | 'patch' | 'options' | 'head' = any> {
     // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
-    <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any>(path: PathParams, ...handlers: Array<RequestHandler<P, ResBody, ReqBody>>): T;
+    <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any>(path: PathParams, ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery>>): T;
     // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
-    <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any>(path: PathParams, ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody>>): T;
+    <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any>(path: PathParams, ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery>>): T;
     (path: PathParams, subApplication: Application): T;
 }
 
@@ -209,7 +209,7 @@ export type Errback = (err: Error) => void;
  *     app.get<ParamsArray>(/user\/(.*)/, (req, res) => res.send(req.params[0]));
  *     app.get<ParamsArray>('/user/*', (req, res) => res.send(req.params[0]));
  */
-export interface Request<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any> extends http.IncomingMessage, Express.Request {
+export interface Request<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any> extends http.IncomingMessage, Express.Request {
     /**
      * Return request header.
      *
@@ -463,7 +463,7 @@ export interface Request<P extends Params = ParamsDictionary, ResBody = any, Req
 
     params: P;
 
-    query: any;
+    query: ReqQuery;
 
     route: any;
 

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -45,7 +45,8 @@ export interface RequestHandler<P extends Params = ParamsDictionary, ResBody = a
     (req: Request<P, ResBody, ReqBody, ReqQuery>, res: Response<ResBody>, next: NextFunction): any;
 }
 
-export type ErrorRequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any> = (err: any, req: Request<P, ResBody, ReqBody, ReqQuery>, res: Response<ResBody>, next: NextFunction) => any;
+export type ErrorRequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any> =
+    (err: any, req: Request<P, ResBody, ReqBody, ReqQuery>, res: Response<ResBody>, next: NextFunction) => any;
 
 export type PathParams = string | RegExp | Array<string | RegExp>;
 

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -40,17 +40,19 @@ export interface ParamsDictionary { [key: string]: string; }
 export type ParamsArray = string[];
 export type Params = ParamsDictionary | ParamsArray;
 
-export interface RequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any> {
+export interface Query { [key: string]: string | string[] | Query | Query[]; }
+
+export interface RequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query> {
     // tslint:disable-next-line callable-types (This is extended from and can't extend from a type alias in ts<2.2
     (req: Request<P, ResBody, ReqBody, ReqQuery>, res: Response<ResBody>, next: NextFunction): any;
 }
 
-export type ErrorRequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any> =
+export type ErrorRequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query> =
     (err: any, req: Request<P, ResBody, ReqBody, ReqQuery>, res: Response<ResBody>, next: NextFunction) => any;
 
 export type PathParams = string | RegExp | Array<string | RegExp>;
 
-export type RequestHandlerParams<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any>
+export type RequestHandlerParams<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query>
     = RequestHandler<P, ResBody, ReqBody, ReqQuery>
     | ErrorRequestHandler<P, ResBody, ReqBody, ReqQuery>
     | Array<RequestHandler<P>
@@ -58,9 +60,9 @@ export type RequestHandlerParams<P extends Params = ParamsDictionary, ResBody = 
 
 export interface IRouterMatcher<T, Method extends 'all' | 'get' | 'post' | 'put' | 'delete' | 'patch' | 'options' | 'head' = any> {
     // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
-    <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any>(path: PathParams, ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery>>): T;
+    <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query>(path: PathParams, ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery>>): T;
     // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
-    <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any>(path: PathParams, ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery>>): T;
+    <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query>(path: PathParams, ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery>>): T;
     (path: PathParams, subApplication: Application): T;
 }
 
@@ -210,7 +212,7 @@ export type Errback = (err: Error) => void;
  *     app.get<ParamsArray>(/user\/(.*)/, (req, res) => res.send(req.params[0]));
  *     app.get<ParamsArray>('/user/*', (req, res) => res.send(req.params[0]));
  */
-export interface Request<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any> extends http.IncomingMessage, Express.Request {
+export interface Request<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query> extends http.IncomingMessage, Express.Request {
     /**
      * Return request header.
      *

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -40,6 +40,7 @@ export interface ParamsDictionary { [key: string]: string; }
 export type ParamsArray = string[];
 export type Params = ParamsDictionary | ParamsArray;
 
+// Return type of qs.parse, the default query parser (https://expressjs.com/en/api.html#app-settings-property).
 export interface Query { [key: string]: string | string[] | Query | Query[]; }
 
 export interface RequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query> {

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -164,6 +164,17 @@ namespace express_tests {
     // Params cannot be a custom type that does not conform to constraint
     router.get<{ foo: number }>('/:foo', () => {}); // $ExpectError
 
+    // Query can be a custom type
+    router.get('/:foo', (req: express.Request<{}, any, any , {q: string}>) => {
+        req.query.q; // $ExpectType string
+        req.query.a; // $ExpectError
+    });
+
+    // Query will be defaulted to any
+    router.get('/:foo', (req: express.Request<{}>) => {
+        req.query; // $ExpectType any
+    });
+
     // Response will default to any type
     router.get("/", (req: Request, res: express.Response) => {
         res.json({});

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -172,7 +172,7 @@ namespace express_tests {
 
     // Query will be defaulted to any
     router.get('/:foo', (req: express.Request<{}>) => {
-        req.query; // $ExpectType any
+        req.query; // $ExpectType Query
     });
 
     // Response will default to any type

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -97,7 +97,7 @@ declare namespace e {
     interface IRouterMatcher<T> extends core.IRouterMatcher<T> { }
     interface MediaType extends core.MediaType { }
     interface NextFunction extends core.NextFunction { }
-    interface Request<P extends core.Params = core.ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any> extends core.Request<P, ResBody, ReqBody, ReqQuery> { }
+    interface Request<P extends core.Params = core.ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = core.Query> extends core.Request<P, ResBody, ReqBody, ReqQuery> { }
     interface RequestHandler<P extends core.Params = core.ParamsDictionary> extends core.RequestHandler<P> { }
     interface RequestParamHandler extends core.RequestParamHandler { }
     export interface Response<ResBody = any> extends core.Response<ResBody> { }

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -97,7 +97,7 @@ declare namespace e {
     interface IRouterMatcher<T> extends core.IRouterMatcher<T> { }
     interface MediaType extends core.MediaType { }
     interface NextFunction extends core.NextFunction { }
-    interface Request<P extends core.Params = core.ParamsDictionary> extends core.Request<P> { }
+    interface Request<P extends core.Params = core.ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any> extends core.Request<P, ResBody, ReqBody, ReqQuery> { }
     interface RequestHandler<P extends core.Params = core.ParamsDictionary> extends core.RequestHandler<P> { }
     interface RequestParamHandler extends core.RequestParamHandler { }
     export interface Response<ResBody = any> extends core.Response<ResBody> { }

--- a/types/ghost-storage-base/ghost-storage-base-tests.ts
+++ b/types/ghost-storage-base/ghost-storage-base-tests.ts
@@ -41,5 +41,5 @@ storage.getSanitizedFileName('IMAGE.jpg'); // $ExpectType string
 
 storage.exists('tmp/123456.jpg', '/'); // $ExpectType Promise<boolean>
 storage.save(image, '/'); // $ExpectType Promise<string>
-storage.serve(); // $ExpectType (req: Request<ParamsDictionary, any, any, any>, res: Response<any>, next: NextFunction) => void
+storage.serve(); // $ExpectType (req: Request<ParamsDictionary, any, any, Query>, res: Response<any>, next: NextFunction) => void
 storage.delete('tmp/123456.jpg', '/'); // $ExpectType Promise<boolean>

--- a/types/ghost-storage-base/ghost-storage-base-tests.ts
+++ b/types/ghost-storage-base/ghost-storage-base-tests.ts
@@ -41,5 +41,5 @@ storage.getSanitizedFileName('IMAGE.jpg'); // $ExpectType string
 
 storage.exists('tmp/123456.jpg', '/'); // $ExpectType Promise<boolean>
 storage.save(image, '/'); // $ExpectType Promise<string>
-storage.serve(); // $ExpectType (req: Request<ParamsDictionary>, res: Response<any>, next: NextFunction) => void
+storage.serve(); // $ExpectType (req: Request<ParamsDictionary, any, any, any>, res: Response<any>, next: NextFunction) => void
 storage.delete('tmp/123456.jpg', '/'); // $ExpectType Promise<boolean>

--- a/types/passport-jwt/passport-jwt-tests.ts
+++ b/types/passport-jwt/passport-jwt-tests.ts
@@ -33,7 +33,7 @@ opts.jwtFromRequest = ExtractJwt.fromUrlQueryParameter('param_name');
 opts.jwtFromRequest = ExtractJwt.fromAuthHeaderWithScheme('param_name');
 opts.jwtFromRequest = ExtractJwt.fromExtractors([ExtractJwt.fromHeader('x-api-key'), ExtractJwt.fromBodyField('field_name'), ExtractJwt.fromUrlQueryParameter('param_name')]);
 opts.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken();
-opts.jwtFromRequest = (req: Request) => { return req.query.token; };
+opts.jwtFromRequest = (req: Request) => { return req.query.token as string; };
 opts.secretOrKey = new Buffer('secret');
 
 declare function findUser(condition: {id: string}, callback: (error: any, user :any) => void): void;


### PR DESCRIPTION
express-serve-static-core has the Request.query type as `any`. This pull request will make the type generic and allow the caller to define the expected type.

**Migration guide:** 
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43434#issuecomment-607181516

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
