### PR TITLE
Add MathNode.content optional property

### DIFF
--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -2,9 +2,10 @@
 // Project: https://mathjs.org/
 // Definitions by: Ilya Shestakov <https://github.com/siavol>,
 //                  Andy Patterson <https://github.com/andnp>,
-//                  Brad Besserman <https://github.com/bradbesserman>
-//                  Pawel Krol <https://github.com/pawkrol>
-//                  Charlee Li <https://github.com/charlee>
+//                  Brad Besserman <https://github.com/bradbesserman>,
+//                  Pawel Krol <https://github.com/pawkrol>,
+//                  Charlee Li <https://github.com/charlee>,
+//                  Mark Wiemer <https://github.com/mark-wiemer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -3072,6 +3073,7 @@ declare namespace math {
         isSymbolNode?: boolean;
         isUpdateNode?: boolean;
         comment?: string;
+        content?: MathNode;
         op?: string;
         fn?: string;
         args?: MathNode[];

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -153,6 +153,12 @@ Expressions examples
         math.evaluate(['f = 3', 'g = 4', 'f * g']);
     }
 
+    // get content of a parenthesis node
+    {
+        const node = math.parse('(1)');
+        const innerNode = node.content;
+    }
+
     // scope can contain both variables and functions
     {
         const scope = { hello: (name: string) => `hello, ${name}!` };


### PR DESCRIPTION
This is used by ParenthesisNode

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/josdejong/mathjs/blob/41efed79d3fcdcd5043952378f089df662d94ab1/src/expression/node/ParenthesisNode.js#L10-L28
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (Not applicable)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. (Not applicable)
