### PR TITLE
Add types for libqp

### DIFF
--- a/types/libqp/index.d.ts
+++ b/types/libqp/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for libqp 1.1
+// Project: https://github.com/nodemailer/libqp
+// Definitions by: Chris. Webster <https://github.com/webstech>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+import { Transform, TransformOptions } from "stream";
+
+/** Encodes a Buffer or String into a Quoted-Printable encoded string */
+export function encode(buffer: string | Buffer): string;
+
+/** Decodes a Quoted-Printable encoded string to a Buffer object */
+export function decode(input: string): Buffer;
+
+/** Adds soft line breaks to a Quoted-Printable string */
+export function wrap(str: string, lineLength?: number): string;
+
+/** Extend options to add lineLength */
+export interface EncoderOptions extends TransformOptions {
+    lineLength?: number;
+}
+
+/** Create a transform stream for encoding data to Quoted-Printable encoding */
+export class Encoder extends Transform {
+    constructor(opts?: EncoderOptions);
+}
+
+/** Create a transform stream for decoding Quoted-Printable encoded strings */
+export class Decoder extends Transform {
+    constructor(opts?: TransformOptions);
+}

--- a/types/libqp/libqp-tests.ts
+++ b/types/libqp/libqp-tests.ts
@@ -1,0 +1,40 @@
+import * as libqp from "libqp";
+import { Readable, Writable } from "stream";
+
+const encodeText = "jõgeva";
+const encoded = libqp.encode(encodeText);
+console.log(libqp.encode(encodeText));
+
+const decodeText =
+`This string contains quoted printables for the various ranges of utf-8.
+=31=32=33=34
+two byte /=[CDcd][0-9A-Fa-f]/=c2=a9
+three byte /=[Ee][0-9A-Fa-f]/=e1=99=ad
+four byte /=[Ff][0-7]/=f0=90=8d=88
+`;
+
+const body = libqp.decode(decodeText);
+
+const wrapped = libqp.wrap(`abc ${encoded}`, 10);
+
+const encoder = new libqp.Encoder();
+const decoder = new libqp.Decoder();
+
+const buffer = Buffer.from(encodeText);
+
+const readable = new Readable();
+readable._read = () => {}; // _read is required but you can noop it
+readable.push(buffer);
+readable.push(null);
+
+const writable = new Writable({
+    // tslint:disable-next-line: variable-name
+    write(chunk, _encoding, callback) {
+        console.log(chunk.toString());
+        callback();
+    }
+});
+
+readable.pipe(encoder);
+encoder.pipe(decoder);
+decoder.pipe(writable);

--- a/types/libqp/tsconfig.json
+++ b/types/libqp/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "libqp-tests.ts"
+    ]
+}

--- a/types/libqp/tslint.json
+++ b/types/libqp/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
typescript enable the libqp functions

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [n] Create it with `dts-gen --dt`, not by basing it on an existing project.  Modeled on existing headers including nodemail/lib/qp.d.ts
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
