### PR TITLE
[react-query] Update API to 1.10.0

### DIFF
--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -165,7 +165,7 @@ export type InfiniteQueryFunctionWithVariables<
         | _.List.Concat<TKey, TVariables>
 ) => Promise<TResult>;
 
-export interface QueryOptions<TResult> {
+export interface BaseQueryOptions {
     /**
      * Set this to `true` to disable automatic refetching when the query mounts or changes query keys.
      * To refetch the query, use the `refetch` method returned from the `useQuery` instance.
@@ -185,9 +185,12 @@ export interface QueryOptions<TResult> {
     refetchOnWindowFocus?: boolean;
     refetchOnMount?: boolean;
     onError?: (err: unknown) => void;
+    suspense?: boolean;
+}
+
+export interface QueryOptions<TResult> extends BaseQueryOptions {
     onSuccess?: (data: TResult) => void;
     onSettled?: (data: TResult | undefined, error: unknown | null) => void;
-    suspense?: boolean;
     initialData?: TResult;
 }
 
@@ -265,23 +268,6 @@ export interface MutationResult<TResults> {
     reset: () => void;
 }
 
-// export function setQueryData(
-//     queryKey: string | [string, object],
-//     data: any,
-//     options?: {
-//         shouldRefetch?: boolean;
-//     },
-// ): void | Promise<void>;
-
-// export function refetchQuery(
-//     queryKey: string | [string, object] | [string, false],
-//     force?: {
-//         force?: boolean;
-//     },
-// ): Promise<void>;
-
-// export function refetchAllQueries(options?: { force?: boolean; includeInactive: boolean }): Promise<void>;
-
 /**
  * A hook that returns the number of the quiries that your application is loading or fetching in the background
  * (useful for app-wide loading indicators).
@@ -293,14 +279,26 @@ export const ReactQueryConfigProvider: React.ComponentType<{
     config?: ReactQueryProviderConfig;
 }>;
 
-export interface ReactQueryProviderConfig {
-    retry?: number;
-    retryDelay?: (attempt: number) => number;
-    staleTime?: number;
-    cacheTime?: number;
+export interface ReactQueryProviderConfig extends BaseQueryOptions {
+    /** Defaults to the value of `suspense` if not defined otherwise */
+    useErrorBoundary?: boolean;
+    throwOnError?: boolean;
     refetchAllOnWindowFocus?: boolean;
-    refetchInterval?: false | number;
-    suspense?: boolean;
+    queryKeySerializerFn?: (
+        queryKey: QueryKeyPart[] | string | false | undefined | (() => QueryKeyPart[] | string | false | undefined),
+    ) => [string, QueryKeyPart[]] | [];
+
+    onMutate?: (variables: unknown) => Promise<unknown> | unknown;
+    onSuccess?: (data: unknown, variables?: unknown) => void;
+    onError?: (err: unknown, snapshotValue?: unknown) => void;
+    onSettled?: (data: unknown | undefined, error: unknown | null, snapshotValue?: unknown) => void;
 }
 
-// export function clearQueryCache(): void;
+export type ConsoleFunction = (...args: any[]) => void;
+export interface ConsoleObject {
+    log: ConsoleFunction;
+    warn: ConsoleFunction;
+    error: ConsoleFunction;
+}
+
+export function setConsole(consoleObject: ConsoleObject): void;

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -260,7 +260,7 @@ export type MutationFunction<TResults, TVariables> = (variables: TVariables) => 
 
 export interface MutateOptions<TResult, TVariables> {
     onSuccess?: (data: TResult, variables: TVariables) => Promise<void> | void;
-    onError?: (error: any, variables: TVariables, snapshotValue: unknown) => Promise<void> | void;
+    onError?: (error: unknown, variables: TVariables, snapshotValue: unknown) => Promise<void> | void;
     onSettled?: (
         data: undefined | TResult,
         error: unknown | null,

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -101,7 +101,9 @@ export type AnyVariables =
     | readonly [any, any, any, any]
     | readonly [any, any, any, any, any];
 
-type QueryFunctionParams<TKey extends AnyQueryKey, TVariables extends AnyVariables> = TKey extends readonly [infer T1]
+export type QueryFunctionParams<TKey extends AnyQueryKey, TVariables extends AnyVariables> = TKey extends readonly [
+    infer T1,
+]
     ? Parameters<(key: T1, ...variables: TVariables) => void>
     : TKey extends readonly [infer T1, infer T2]
     ? Parameters<(key1: T1, key2: T2, ...variables: TVariables) => void>

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -196,23 +196,59 @@ export interface QueryResultBase<TResult> {
     refetch: ({ force, throwOnError }?: { force?: boolean; throwOnError?: boolean }) => Promise<TResult>;
 }
 
-export interface QueryResult<TResult> extends QueryResultBase<TResult> {
-    data: undefined | TResult;
+export interface QuerySuccessResult<TResult> extends QueryResultBase<TResult> {
+    status: 'success';
+    data: TResult;
+    error: null;
 }
 
-export interface PaginatedQueryResult<TResult> extends QueryResultBase<TResult> {
-    resolvedData: undefined | TResult;
-    latestData: undefined | TResult;
+export interface QueryErrorResult<TResult> extends QueryResultBase<TResult> {
+    status: 'error';
+    data: TResult | undefined; // even when error, data can have stale data
+    error: unknown;
 }
 
-export interface InfiniteQueryResult<TResult, TMoreVariable> extends QueryResultBase<TResult> {
+export interface QueryLoadingResult<TResult> extends QueryResultBase<TResult> {
+    status: 'loading';
+    data: TResult | undefined; // even when error, data can have stale data
+    error: unknown | null; // it still can be error
+}
+
+export type QueryResult<TResult> =
+    | QuerySuccessResult<TResult>
+    | QueryErrorResult<TResult>
+    | QueryLoadingResult<TResult>;
+
+export interface PaginatedQuerySuccessResult<TResult> extends QueryResultBase<TResult> {
+    status: 'success';
+    resolvedData: TResult;
+    latestData: TResult;
+    error: null;
+}
+
+export interface PaginatedQueryErrorResult<TResult> extends QueryResultBase<TResult> {
+    status: 'error';
+    resolvedData: undefined | TResult; // even when error, data can have stale data
+    latestData: undefined | TResult; // even when error, data can have stale data
+    error: unknown;
+}
+
+export interface PaginatedQueryLoadingResult<TResult> extends QueryResultBase<TResult> {
+    status: 'loading';
+    resolvedData: undefined | TResult; // even when error, data can have stale data
+    latestData: undefined | TResult; // even when error, data can have stale data
+    error: unknown | null; // it still can be error
+}
+
+export type PaginatedQueryResult<TResult> =
+    | PaginatedQuerySuccessResult<TResult>
+    | PaginatedQueryErrorResult<TResult>
+    | PaginatedQueryLoadingResult<TResult>;
+
+export interface InfiniteQueryResult<TResult, TMoreVariable> extends QueryResultBase<TResult[]> {
     data: TResult[];
     isFetchingMore: boolean;
     fetchMore: (moreVariable?: TMoreVariable | false) => Promise<TResult[]> | undefined;
-}
-
-export interface PrefetchQueryOptions<TResult> extends QueryOptions<TResult> {
-    force?: boolean;
 }
 
 export function useMutation<TResults, TVariables = undefined>(

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -133,7 +133,7 @@ export function useInfiniteQuery<
 }): InfiniteQueryResult<TResult, TMoreVariable>;
 
 export type QueryKeyPart = string | object | boolean | number | null | readonly QueryKeyPart[] | null | undefined;
-export type AnyQueryKey = readonly [QueryKeyPart, ...QueryKeyPart[]]; // this forces the key to be inferred as a tuple
+export type AnyQueryKey = readonly [string, ...QueryKeyPart[]]; // this forces the key to be inferred as a tuple
 export type AnyVariables = readonly [] | readonly [any, ...any[]]; // this forces the variables to be inferred as a tuple
 
 export type QueryFunction<TResult, TKey extends AnyQueryKey> = (...key: TKey) => Promise<TResult>;

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -212,7 +212,7 @@ export interface QueryResult<TResult> extends QueryResultBase<TResult> {
 
 export interface PaginatedQueryResult<TResult> extends QueryResultBase<TResult> {
     resolvedData: undefined | TResult;
-    latestDate: undefined | TResult;
+    latestData: undefined | TResult;
 }
 
 export interface InfiniteQueryResult<TResult, TMoreVariable> extends QueryResultBase<TResult> {
@@ -231,7 +231,7 @@ export interface PrefetchQueryOptions<TResult> extends QueryOptions<TResult> {
     force?: boolean;
 }
 
-export function useMutation<TResults, TVariables>(
+export function useMutation<TResults, TVariables = undefined>(
     mutationFn: MutationFunction<TResults, TVariables>,
     mutationOptions?: MutationOptions<TResults, TVariables>,
 ): [MutateFunction<TResults, TVariables>, MutationResult<TResults>];
@@ -255,10 +255,9 @@ export interface MutationOptions<TResult, TVariables> extends MutateOptions<TRes
     useErrorBoundary?: boolean;
 }
 
-export type MutateFunction<TResult, TVariables> = (
-    variables?: TVariables,
-    options?: MutateOptions<TResult, TVariables>,
-) => Promise<TResult>;
+export type MutateFunction<TResult, TVariables> = undefined extends TVariables
+    ? (variables?: TVariables, options?: MutateOptions<TResult, TVariables>) => Promise<TResult>
+    : (variables: TVariables, options?: MutateOptions<TResult, TVariables>) => Promise<TResult>;
 
 export interface MutationResult<TResults> {
     status: 'idle' | 'loading' | 'error' | 'success';

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -268,7 +268,14 @@ export interface MutationResult<TResults> {
     reset: () => void;
 }
 
-export type CachedQuery = QueryResultBase<unknown>;
+export interface CachedQuery {
+    queryKey: AnyQueryKey;
+    queryVariables: AnyVariables;
+    queryFn: (...args: any[]) => unknown;
+    config: QueryOptions<unknown>;
+    state: unknown;
+    setData(dataOrUpdater: unknown | ((oldData: unknown | undefined) => unknown)): void;
+}
 
 export interface QueryCache {
     prefetchQuery<TResult, TKey extends AnyQueryKey>(
@@ -319,10 +326,10 @@ export interface QueryCache {
         queryKeyOrPredicateFn: AnyQueryKey | string | ((query: CachedQuery) => boolean),
         { exact }?: { exact?: boolean },
     ): Promise<void>;
-    // getQueries
-    // getQuery
-    // subscribe
-    // isFetching
+    getQuery(queryKey: AnyQueryKey): CachedQuery | undefined;
+    getQueries(queryKey: AnyQueryKey): CachedQuery[];
+    isFetching: number;
+    subscribe(callback: (queryCache: QueryCache) => void): () => void;
     clear(): CachedQuery[];
 }
 

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-query 1.1.0
+// Type definitions for react-query 1.1
 // Project: https://github.com/tannerlinsley/react-query
 // Definitions by: Lukasz Fiszer <https://github.com/lukaszfiszer>
 //                 Jace Hensley <https://github.com/jacehensley>
@@ -25,14 +25,14 @@ export function useQuery<TResult, TKey extends string>(
 export function useQuery<TResult, TKey extends AnyQueryKey, TVariables extends AnyVariables>(
     queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
     variables: TVariables,
-    queryFn: QueryFunction<TResult, TKey>,
+    queryFn: QueryFunctionWithVariables<TResult, TKey, TVariables>,
     config?: QueryOptions<TResult>,
 ): QueryResult<TResult>;
 
 export function useQuery<TResult, TKey extends string, TVariables extends AnyVariables>(
     queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
     variables: TVariables,
-    queryFn: QueryFunction<TResult, [TKey]>,
+    queryFn: QueryFunctionWithVariables<TResult, [TKey], TVariables>,
     config?: QueryOptions<TResult>,
 ): QueryResult<TResult>;
 
@@ -44,7 +44,7 @@ export function useQuery<TResult, TKey extends AnyQueryKey, TVariables extends A
 }: {
     queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined);
     variables?: TVariables;
-    queryFn: QueryFunction<TResult, TKey>;
+    queryFn: QueryFunctionWithVariables<TResult, TKey, TVariables>;
     config?: QueryOptions<TResult>;
 }): QueryResult<TResult>;
 
@@ -64,14 +64,14 @@ export function usePaginatedQuery<TResult, TKey extends string>(
 export function usePaginatedQuery<TResult, TKey extends AnyQueryKey, TVariables extends AnyVariables>(
     queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
     variables: TVariables,
-    queryFn: QueryFunction<TResult, TKey>,
+    queryFn: QueryFunctionWithVariables<TResult, TKey, TVariables>,
     config?: QueryOptions<TResult>,
 ): QueryResultPaginated<TResult>;
 
 export function usePaginatedQuery<TResult, TKey extends string, TVariables extends AnyVariables>(
     queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
     variables: TVariables,
-    queryFn: QueryFunction<TResult, [TKey]>,
+    queryFn: QueryFunctionWithVariables<TResult, [TKey], TVariables>,
     config?: QueryOptions<TResult>,
 ): QueryResultPaginated<TResult>;
 
@@ -83,7 +83,7 @@ export function usePaginatedQuery<TResult, TKey extends AnyQueryKey, TVariables 
 }: {
     queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined);
     variables?: TVariables;
-    queryFn: QueryFunction<TResult, TKey>;
+    queryFn: QueryFunctionWithVariables<TResult, TKey, TVariables>;
     config?: QueryOptions<TResult>;
 }): QueryResultPaginated<TResult>;
 
@@ -100,16 +100,21 @@ export type AnyVariables =
     | readonly [any, any, any]
     | readonly [any, any, any, any]
     | readonly [any, any, any, any, any];
-// export type QueryKey<TVariables> =
-//     | string
-//     | [string, TVariables]
-//     | false
-//     | null
-//     | undefined
-//     | QueryKeyFunction<TVariables>;
-// export type QueryKeyFunction<TVariables> = () => string | [string, TVariables] | false | null | undefined;
+
+type QueryFunctionParams<TKey extends AnyQueryKey, TVariables extends AnyVariables> = TKey extends readonly [infer T1]
+    ? Parameters<(key: T1, ...variables: TVariables) => void>
+    : TKey extends readonly [infer T1, infer T2]
+    ? Parameters<(key1: T1, key2: T2, ...variables: TVariables) => void>
+    : TKey extends readonly [infer T1, infer T2, infer T3]
+    ? Parameters<(key1: T1, key2: T2, key3: T3, ...variables: TVariables) => void>
+    : TKey extends readonly [infer T1, infer T2, infer T3, infer T4]
+    ? Parameters<(key1: T1, key2: T2, key3: T3, key4: T4, ...variables: TVariables) => void>
+    : never;
 
 export type QueryFunction<TResult, TKey extends AnyQueryKey> = (...key: TKey) => Promise<TResult>;
+export type QueryFunctionWithVariables<TResult, TKey extends AnyQueryKey, TVariables extends AnyVariables> = (
+    ...key: QueryFunctionParams<TKey, TVariables>
+) => Promise<TResult>;
 
 export interface QueryOptions<TResult> {
     /**

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -133,18 +133,8 @@ export function useInfiniteQuery<
 }): InfiniteQueryResult<TResult, TMoreVariable>;
 
 export type QueryKeyPart = string | object | boolean | number | null | readonly QueryKeyPart[] | null | undefined;
-export type AnyQueryKey =
-    | readonly [QueryKeyPart]
-    | readonly [QueryKeyPart, QueryKeyPart]
-    | readonly [QueryKeyPart, QueryKeyPart, QueryKeyPart]
-    | readonly [QueryKeyPart, QueryKeyPart, QueryKeyPart, QueryKeyPart];
-export type AnyVariables =
-    | readonly []
-    | readonly [any]
-    | readonly [any, any]
-    | readonly [any, any, any]
-    | readonly [any, any, any, any]
-    | readonly [any, any, any, any, any];
+export type AnyQueryKey = readonly [QueryKeyPart, ...QueryKeyPart[]]; // this forces the key to be inferred as a tuple
+export type AnyVariables = readonly [] | readonly [any, ...any[]]; // this forces the variables to be inferred as a tuple
 
 export type QueryFunction<TResult, TKey extends AnyQueryKey> = (...key: TKey) => Promise<TResult>;
 export type QueryFunctionWithVariables<TResult, TKey extends AnyQueryKey, TVariables extends AnyVariables> = (
@@ -220,12 +210,6 @@ export interface InfiniteQueryResult<TResult, TMoreVariable> extends QueryResult
     isFetchingMore: boolean;
     fetchMore: (moreVariable?: TMoreVariable | false) => Promise<TResult[]> | undefined;
 }
-
-// export function prefetchQuery<TResult, TVariables extends object>(
-//     queryKey: QueryKey<TVariables>,
-//     queryFn: QueryFunction<TResult, TVariables>,
-//     options?: PrefetchQueryOptions<TResult>,
-// ): Promise<TResult>;
 
 export interface PrefetchQueryOptions<TResult> extends QueryOptions<TResult> {
     force?: boolean;

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -95,6 +95,43 @@ export function useInfiniteQuery<TResult, TKey extends AnyQueryKey, TMoreVariabl
     config?: InfiniteQueryOptions<TResult, TMoreVariable>,
 ): InfiniteQueryResult<TResult, TMoreVariable>;
 
+export function useInfiniteQuery<TResult, TKey extends string, TMoreVariable>(
+    queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+    queryFn: InfiniteQueryFunction<TResult, [TKey], TMoreVariable>,
+    config?: InfiniteQueryOptions<TResult, TMoreVariable>,
+): InfiniteQueryResult<TResult, TMoreVariable>;
+
+export function useInfiniteQuery<TResult, TKey extends AnyQueryKey, TVariables extends AnyVariables, TMoreVariable>(
+    queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+    variables: TVariables,
+    queryFn: InfiniteQueryFunctionWithVariables<TResult, TKey, TVariables, TMoreVariable>,
+    config?: InfiniteQueryOptions<TResult, TMoreVariable>,
+): InfiniteQueryResult<TResult, TMoreVariable>;
+
+export function useInfiniteQuery<TResult, TKey extends string, TVariables extends AnyVariables, TMoreVariable>(
+    queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+    variables: TVariables,
+    queryFn: InfiniteQueryFunctionWithVariables<TResult, [TKey], TVariables, TMoreVariable>,
+    config?: InfiniteQueryOptions<TResult, TMoreVariable>,
+): InfiniteQueryResult<TResult, TMoreVariable>;
+
+export function useInfiniteQuery<
+    TResult,
+    TKey extends AnyQueryKey,
+    TMoreVariable,
+    TVariables extends AnyVariables = []
+>({
+    queryKey,
+    variables,
+    queryFn,
+    config,
+}: {
+    queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined);
+    variables?: TVariables;
+    queryFn: InfiniteQueryFunctionWithVariables<TResult, TKey, TVariables, TMoreVariable>;
+    config?: InfiniteQueryOptions<TResult, TMoreVariable>;
+}): InfiniteQueryResult<TResult, TMoreVariable>;
+
 export type QueryKeyPart = string | object | boolean | number | null | readonly QueryKeyPart[] | null | undefined;
 export type AnyQueryKey =
     | readonly [QueryKeyPart]
@@ -109,28 +146,23 @@ export type AnyVariables =
     | readonly [any, any, any, any]
     | readonly [any, any, any, any, any];
 
-export type QueryFunctionParams<TKey extends AnyQueryKey, TVariables extends AnyVariables> = _.List.Concat<
-    TKey,
-    TVariables
->;
-// Simplified concatenation of parameters
-// TKey extends readonly [infer T1]
-//     ? Parameters<(key: T1, ...variables: TVariables) => void>
-//     : TKey extends readonly [infer T1, infer T2]
-//     ? Parameters<(key1: T1, key2: T2, ...variables: TVariables) => void>
-//     : TKey extends readonly [infer T1, infer T2, infer T3]
-//     ? Parameters<(key1: T1, key2: T2, key3: T3, ...variables: TVariables) => void>
-//     : TKey extends readonly [infer T1, infer T2, infer T3, infer T4]
-//     ? Parameters<(key1: T1, key2: T2, key3: T3, key4: T4, ...variables: TVariables) => void>
-//     : never;
-
 export type QueryFunction<TResult, TKey extends AnyQueryKey> = (...key: TKey) => Promise<TResult>;
 export type QueryFunctionWithVariables<TResult, TKey extends AnyQueryKey, TVariables extends AnyVariables> = (
-    ...key: QueryFunctionParams<TKey, TVariables>
+    ...key: _.List.Concat<TKey, TVariables>
 ) => Promise<TResult>;
 
 export type InfiniteQueryFunction<TResult, TKey extends AnyQueryKey, TMoreVariable> = (
     ...keysAndMore: _.List.Append<TKey, TMoreVariable> | TKey
+) => Promise<TResult>;
+export type InfiniteQueryFunctionWithVariables<
+    TResult,
+    TKey extends AnyQueryKey,
+    TVariables extends AnyVariables,
+    TMoreVariable
+> = (
+    ...keysAndVariablesAndMore:
+        | _.List.Append<_.List.Concat<TKey, TVariables>, TMoreVariable>
+        | _.List.Concat<TKey, TVariables>
 ) => Promise<TResult>;
 
 export interface QueryOptions<TResult> {

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -268,6 +268,66 @@ export interface MutationResult<TResults> {
     reset: () => void;
 }
 
+export type CachedQuery = QueryResultBase<unknown>;
+
+export interface QueryCache {
+    prefetchQuery<TResult, TKey extends AnyQueryKey>(
+        queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+        queryFn: QueryFunction<TResult, TKey>,
+        config?: QueryOptions<TResult>,
+    ): Promise<TResult>;
+
+    prefetchQuery<TResult, TKey extends string>(
+        queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+        queryFn: QueryFunction<TResult, [TKey]>,
+        config?: QueryOptions<TResult>,
+    ): Promise<TResult>;
+
+    prefetchQuery<TResult, TKey extends AnyQueryKey, TVariables extends AnyVariables>(
+        queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+        variables: TVariables,
+        queryFn: QueryFunctionWithVariables<TResult, TKey, TVariables>,
+        config?: QueryOptions<TResult>,
+    ): Promise<TResult>;
+
+    prefetchQuery<TResult, TKey extends string, TVariables extends AnyVariables>(
+        queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+        variables: TVariables,
+        queryFn: QueryFunctionWithVariables<TResult, [TKey], TVariables>,
+        config?: QueryOptions<TResult>,
+    ): Promise<TResult>;
+
+    prefetchQuery<TResult, TKey extends AnyQueryKey, TVariables extends AnyVariables = []>({
+        queryKey,
+        variables,
+        queryFn,
+        config,
+    }: {
+        queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined);
+        variables?: TVariables;
+        queryFn: QueryFunctionWithVariables<TResult, TKey, TVariables>;
+        config?: QueryOptions<TResult>;
+    }): Promise<TResult>;
+
+    getQueryData(key: AnyQueryKey | string): unknown | undefined;
+    setQueryData(key: AnyQueryKey | string, dataOrUpdater: unknown | ((oldData: unknown | undefined) => unknown)): void;
+    refetchQueries(
+        queryKeyOrPredicateFn: AnyQueryKey | string | ((query: CachedQuery) => boolean),
+        { exact, throwOnError, force }?: { exact?: boolean; throwOnError?: boolean; force?: boolean },
+    ): Promise<void>;
+    removeQueries(
+        queryKeyOrPredicateFn: AnyQueryKey | string | ((query: CachedQuery) => boolean),
+        { exact }?: { exact?: boolean },
+    ): Promise<void>;
+    // getQueries
+    // getQuery
+    // subscribe
+    // isFetching
+    clear(): CachedQuery[];
+}
+
+export const queryCache: QueryCache;
+
 /**
  * A hook that returns the number of the quiries that your application is loading or fetching in the background
  * (useful for app-wide loading indicators).

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -5,6 +5,7 @@
 //                 Matteo Frana <https://github.com/matteofrana>
 //                 Igor Oleinikov <https://github.com/igorbek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
 
 import * as React from 'react';
 
@@ -129,9 +130,9 @@ export interface QueryOptions<TResult> {
     refetchIntervalInBackground?: boolean;
     refetchOnWindowFocus?: boolean;
     refetchOnMount?: boolean;
-    onError?: (err: any) => void;
+    onError?: (err: unknown) => void;
     onSuccess?: (data: TResult) => void;
-    onSettled?: (data: TResult | undefined, error: any | null) => void;
+    onSettled?: (data: TResult | undefined, error: unknown | null) => void;
     suspense?: boolean;
     initialData?: TResult;
 }
@@ -141,19 +142,19 @@ export interface QueryOptionsPaginated<TResult> extends QueryOptions<TResult> {
     getCanFetchMore: (lastPage: TResult, allPages: TResult[]) => boolean;
 }
 
-export interface QueryResultBase {
+export interface QueryResultBase<TResult> {
     status: 'loading' | 'error' | 'success';
-    error: null | Error;
+    error: null | unknown;
     isFetching: boolean;
     failureCount: number;
-    refetch: ({ force, throwOnError }?: { force?: boolean; throwOnError?: boolean }) => void;
+    refetch: ({ force, throwOnError }?: { force?: boolean; throwOnError?: boolean }) => Promise<TResult>;
 }
 
-export interface QueryResult<TResult> extends QueryResultBase {
+export interface QueryResult<TResult> extends QueryResultBase<TResult> {
     data: undefined | TResult;
 }
 
-export interface QueryResultPaginated<TResult> extends QueryResultBase {
+export interface QueryResultPaginated<TResult> extends QueryResultBase<TResult> {
     resolvedData: undefined | TResult;
     latestDate: undefined | TResult;
 }

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -196,10 +196,10 @@ export interface QueryResultBase<TResult> {
     refetch: ({ force, throwOnError }?: { force?: boolean; throwOnError?: boolean }) => Promise<TResult>;
 }
 
-export interface QuerySuccessResult<TResult> extends QueryResultBase<TResult> {
-    status: 'success';
-    data: TResult;
-    error: null;
+export interface QueryLoadingResult<TResult> extends QueryResultBase<TResult> {
+    status: 'loading';
+    data: TResult | undefined; // even when error, data can have stale data
+    error: unknown | null; // it still can be error
 }
 
 export interface QueryErrorResult<TResult> extends QueryResultBase<TResult> {
@@ -208,22 +208,22 @@ export interface QueryErrorResult<TResult> extends QueryResultBase<TResult> {
     error: unknown;
 }
 
-export interface QueryLoadingResult<TResult> extends QueryResultBase<TResult> {
-    status: 'loading';
-    data: TResult | undefined; // even when error, data can have stale data
-    error: unknown | null; // it still can be error
+export interface QuerySuccessResult<TResult> extends QueryResultBase<TResult> {
+    status: 'success';
+    data: TResult;
+    error: null;
 }
 
 export type QueryResult<TResult> =
-    | QuerySuccessResult<TResult>
+    | QueryLoadingResult<TResult>
     | QueryErrorResult<TResult>
-    | QueryLoadingResult<TResult>;
+    | QuerySuccessResult<TResult>;
 
-export interface PaginatedQuerySuccessResult<TResult> extends QueryResultBase<TResult> {
-    status: 'success';
-    resolvedData: TResult;
-    latestData: TResult;
-    error: null;
+export interface PaginatedQueryLoadingResult<TResult> extends QueryResultBase<TResult> {
+    status: 'loading';
+    resolvedData: undefined | TResult; // even when error, data can have stale data
+    latestData: undefined | TResult; // even when error, data can have stale data
+    error: unknown | null; // it still can be error
 }
 
 export interface PaginatedQueryErrorResult<TResult> extends QueryResultBase<TResult> {
@@ -233,17 +233,17 @@ export interface PaginatedQueryErrorResult<TResult> extends QueryResultBase<TRes
     error: unknown;
 }
 
-export interface PaginatedQueryLoadingResult<TResult> extends QueryResultBase<TResult> {
-    status: 'loading';
-    resolvedData: undefined | TResult; // even when error, data can have stale data
-    latestData: undefined | TResult; // even when error, data can have stale data
-    error: unknown | null; // it still can be error
+export interface PaginatedQuerySuccessResult<TResult> extends QueryResultBase<TResult> {
+    status: 'success';
+    resolvedData: TResult;
+    latestData: TResult;
+    error: null;
 }
 
 export type PaginatedQueryResult<TResult> =
-    | PaginatedQuerySuccessResult<TResult>
+    | PaginatedQueryLoadingResult<TResult>
     | PaginatedQueryErrorResult<TResult>
-    | PaginatedQueryLoadingResult<TResult>;
+    | PaginatedQuerySuccessResult<TResult>;
 
 export interface InfiniteQueryResult<TResult, TMoreVariable> extends QueryResultBase<TResult[]> {
     data: TResult[];
@@ -279,13 +279,43 @@ export type MutateFunction<TResult, TVariables> = undefined extends TVariables
     ? (variables?: TVariables, options?: MutateOptions<TResult, TVariables>) => Promise<TResult>
     : (variables: TVariables, options?: MutateOptions<TResult, TVariables>) => Promise<TResult>;
 
-export interface MutationResult<TResults> {
+export interface MutationResultBase<TResult> {
     status: 'idle' | 'loading' | 'error' | 'success';
-    data: undefined | TResults;
+    data: undefined | TResult;
     error: null | unknown;
-    promise: Promise<TResults>;
+    promise: Promise<TResult>;
     reset: () => void;
 }
+
+export interface IdleMutationResult<TResult> extends MutationResultBase<TResult> {
+    status: 'idle';
+    data: undefined;
+    error: null;
+}
+
+export interface LoadingMutationResult<TResult> extends MutationResultBase<TResult> {
+    status: 'loading';
+    data: undefined;
+    error: undefined;
+}
+
+export interface ErrorMutationResult<TResult> extends MutationResultBase<TResult> {
+    status: 'error';
+    data: undefined;
+    error: unknown;
+}
+
+export interface SuccessMutationResult<TResult> extends MutationResultBase<TResult> {
+    status: 'success';
+    data: TResult;
+    error: undefined;
+}
+
+export type MutationResult<TResult> =
+    | IdleMutationResult<TResult>
+    | LoadingMutationResult<TResult>
+    | ErrorMutationResult<TResult>
+    | SuccessMutationResult<TResult>;
 
 export interface CachedQuery {
     queryKey: AnyQueryKey;

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -1,32 +1,126 @@
-// Type definitions for react-query 0.3
+// Type definitions for react-query 1.1.0
 // Project: https://github.com/tannerlinsley/react-query
 // Definitions by: Lukasz Fiszer <https://github.com/lukaszfiszer>
 //                 Jace Hensley <https://github.com/jacehensley>
 //                 Matteo Frana <https://github.com/matteofrana>
+//                 Igor Oleinikov <https://github.com/igorbek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ComponentType } from 'react';
+import * as React from 'react';
 
-// overloaded useQuery function with pagination
-export function useQuery<TResult, TVariables extends object>(
-    queryKey: QueryKey<TVariables>,
-    queryFn: QueryFunction<TResult, TVariables>,
-    options: QueryOptionsPaginated<TResult>
-): QueryResultPaginated<TResult, TVariables>;
+// overloaded useQuery function
+export function useQuery<TResult, TKey extends AnyQueryKey>(
+    queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+    queryFn: QueryFunction<TResult, TKey>,
+    config?: QueryOptions<TResult>,
+): QueryResult<TResult>;
 
-export function useQuery<TResult, TVariables extends object>(
-    queryKey: QueryKey<TVariables>,
-    queryFn: QueryFunction<TResult, TVariables>,
-    options?: QueryOptions<TResult>
-): QueryResult<TResult, TVariables>;
+export function useQuery<TResult, TKey extends string>(
+    queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+    queryFn: QueryFunction<TResult, [TKey]>,
+    config?: QueryOptions<TResult>,
+): QueryResult<TResult>;
 
-export type QueryKey<TVariables> = string | [string, TVariables] | false | null | QueryKeyFunction<TVariables>;
-export type QueryKeyFunction<TVariables> = () => string | [string, TVariables] | false | null;
+export function useQuery<TResult, TKey extends AnyQueryKey, TVariables extends AnyVariables>(
+    queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+    variables: TVariables,
+    queryFn: QueryFunction<TResult, TKey>,
+    config?: QueryOptions<TResult>,
+): QueryResult<TResult>;
 
-export type QueryFunction<TResult, TVariables extends object> = (variables: TVariables) => Promise<TResult>;
+export function useQuery<TResult, TKey extends string, TVariables extends AnyVariables>(
+    queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+    variables: TVariables,
+    queryFn: QueryFunction<TResult, [TKey]>,
+    config?: QueryOptions<TResult>,
+): QueryResult<TResult>;
+
+export function useQuery<TResult, TKey extends AnyQueryKey, TVariables extends AnyVariables = []>({
+    queryKey,
+    variables,
+    queryFn,
+    config,
+}: {
+    queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined);
+    variables?: TVariables;
+    queryFn: QueryFunction<TResult, TKey>;
+    config?: QueryOptions<TResult>;
+}): QueryResult<TResult>;
+
+// usePaginatedQuery
+export function usePaginatedQuery<TResult, TKey extends AnyQueryKey>(
+    queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+    queryFn: QueryFunction<TResult, TKey>,
+    config?: QueryOptions<TResult>,
+): QueryResultPaginated<TResult>;
+
+export function usePaginatedQuery<TResult, TKey extends string>(
+    queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+    queryFn: QueryFunction<TResult, [TKey]>,
+    config?: QueryOptions<TResult>,
+): QueryResultPaginated<TResult>;
+
+export function usePaginatedQuery<TResult, TKey extends AnyQueryKey, TVariables extends AnyVariables>(
+    queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+    variables: TVariables,
+    queryFn: QueryFunction<TResult, TKey>,
+    config?: QueryOptions<TResult>,
+): QueryResultPaginated<TResult>;
+
+export function usePaginatedQuery<TResult, TKey extends string, TVariables extends AnyVariables>(
+    queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined),
+    variables: TVariables,
+    queryFn: QueryFunction<TResult, [TKey]>,
+    config?: QueryOptions<TResult>,
+): QueryResultPaginated<TResult>;
+
+export function usePaginatedQuery<TResult, TKey extends AnyQueryKey, TVariables extends AnyVariables = []>({
+    queryKey,
+    variables,
+    queryFn,
+    config,
+}: {
+    queryKey: TKey | false | null | undefined | (() => TKey | false | null | undefined);
+    variables?: TVariables;
+    queryFn: QueryFunction<TResult, TKey>;
+    config?: QueryOptions<TResult>;
+}): QueryResultPaginated<TResult>;
+
+export type QueryKeyPart = string | object | boolean | number | null | readonly QueryKeyPart[] | null | undefined;
+export type AnyQueryKey =
+    | readonly [QueryKeyPart]
+    | readonly [QueryKeyPart, QueryKeyPart]
+    | readonly [QueryKeyPart, QueryKeyPart, QueryKeyPart]
+    | readonly [QueryKeyPart, QueryKeyPart, QueryKeyPart, QueryKeyPart];
+export type AnyVariables =
+    | readonly []
+    | readonly [any]
+    | readonly [any, any]
+    | readonly [any, any, any]
+    | readonly [any, any, any, any]
+    | readonly [any, any, any, any, any];
+// export type QueryKey<TVariables> =
+//     | string
+//     | [string, TVariables]
+//     | false
+//     | null
+//     | undefined
+//     | QueryKeyFunction<TVariables>;
+// export type QueryKeyFunction<TVariables> = () => string | [string, TVariables] | false | null | undefined;
+
+export type QueryFunction<TResult, TKey extends AnyQueryKey> = (...key: TKey) => Promise<TResult>;
 
 export interface QueryOptions<TResult> {
+    /**
+     * Set this to `true` to disable automatic refetching when the query mounts or changes query keys.
+     * To refetch the query, use the `refetch` method returned from the `useQuery` instance.
+     */
     manual?: boolean;
+    /**
+     * If `false`, failed queries will not retry by default.
+     * If `true`, failed queries will retry infinitely.
+     * If set to an integer number, e.g. 3, failed queries will retry until the failed query count meets that number.
+     */
     retry?: boolean | number;
     retryDelay?: (retryAttempt: number) => number;
     staleTime?: number;
@@ -34,8 +128,10 @@ export interface QueryOptions<TResult> {
     refetchInterval?: false | number;
     refetchIntervalInBackground?: boolean;
     refetchOnWindowFocus?: boolean;
+    refetchOnMount?: boolean;
     onError?: (err: any) => void;
     onSuccess?: (data: TResult) => void;
+    onSettled?: (data: TResult | undefined, error: any | null) => void;
     suspense?: boolean;
     initialData?: TResult;
 }
@@ -45,88 +141,91 @@ export interface QueryOptionsPaginated<TResult> extends QueryOptions<TResult> {
     getCanFetchMore: (lastPage: TResult, allPages: TResult[]) => boolean;
 }
 
-export interface QueryResult<TResult, TVariables> {
-    data: null | TResult;
+export interface QueryResultBase {
+    status: 'loading' | 'error' | 'success';
     error: null | Error;
-    isLoading: boolean;
     isFetching: boolean;
-    isCached: boolean;
     failureCount: number;
-    refetch: (arg?: {variables?: TVariables, merge?: (...args: any[]) => any, disableThrow?: boolean}) => Promise<void>;
+    refetch: ({ force, throwOnError }?: { force?: boolean; throwOnError?: boolean }) => void;
 }
 
-export interface QueryResultPaginated<TResult, TVariables> extends QueryResult<TResult[], TVariables> {
-    isFetchingMore: boolean;
-    canFetchMore: boolean;
-    fetchMore: (variables?: TVariables) => Promise<TResult>;
+export interface QueryResult<TResult> extends QueryResultBase {
+    data: undefined | TResult;
 }
 
-export function prefetchQuery<TResult, TVariables extends object>(
-    queryKey: QueryKey<TVariables>,
-    queryFn: QueryFunction<TResult, TVariables>,
-    options?: PrefetchQueryOptions<TResult>
-): Promise<TResult>;
+export interface QueryResultPaginated<TResult> extends QueryResultBase {
+    resolvedData: undefined | TResult;
+    latestDate: undefined | TResult;
+}
+
+// export function prefetchQuery<TResult, TVariables extends object>(
+//     queryKey: QueryKey<TVariables>,
+//     queryFn: QueryFunction<TResult, TVariables>,
+//     options?: PrefetchQueryOptions<TResult>,
+// ): Promise<TResult>;
 
 export interface PrefetchQueryOptions<TResult> extends QueryOptions<TResult> {
     force?: boolean;
 }
 
-export function useMutation<TResults, TVariables extends object>(
+export function useMutation<TResults, TVariables>(
     mutationFn: MutationFunction<TResults, TVariables>,
-    mutationOptions?: MutationOptions
+    mutationOptions?: MutationOptions<TResults, TVariables>,
 ): [MutateFunction<TResults, TVariables>, MutationResult<TResults>];
 
-export type MutationFunction<TResults, TVariables extends object> = (
-    variables: TVariables,
-) => Promise<TResults>;
+export type MutationFunction<TResults, TVariables> = (variables: TVariables) => Promise<TResults>;
 
-export interface MutationOptions {
-    refetchQueries?: Array<string | [string, object]>;
-    refetchQueriesOnFailure?: boolean;
+export interface MutateOptions<TResult, TVariables> {
+    onSuccess?: (data: TResult, variables: TVariables) => Promise<void> | void;
+    onError?: (error: any, variables: TVariables, snapshotValue: unknown) => Promise<void> | void;
+    onSettled?: (
+        data: undefined | TResult,
+        error: unknown | null,
+        variables: TVariables,
+        snapshotValue?: unknown,
+    ) => Promise<void> | void;
+    throwOnError?: boolean;
 }
 
-export type MutateFunction<TResults, TVariables extends object> = (
+export interface MutationOptions<TResult, TVariables> extends MutateOptions<TResult, TVariables> {
+    onMutate?: (variables: TVariables) => Promise<unknown> | unknown;
+    useErrorBoundary?: boolean;
+}
+
+export type MutateFunction<TResult, TVariables> = (
     variables?: TVariables,
-    options?: {
-        updateQuery?: string | [string, object],
-        waitForRefetchQueries?: boolean;
-    }
-) => Promise<TResults>;
+    options?: MutateOptions<TResult, TVariables>,
+) => Promise<TResult>;
 
 export interface MutationResult<TResults> {
-    data: TResults | null;
-    isLoading: boolean;
-    error: null | Error;
+    status: 'idle' | 'loading' | 'error' | 'success';
+    data: undefined | TResults;
+    error: null | unknown;
     promise: Promise<TResults>;
     reset: () => void;
 }
 
-export function setQueryData(
-    queryKey: string | [string, object],
-    data: any,
-    options?: {
-        shouldRefetch?: boolean
-    }
-): void | Promise<void>;
+// export function setQueryData(
+//     queryKey: string | [string, object],
+//     data: any,
+//     options?: {
+//         shouldRefetch?: boolean;
+//     },
+// ): void | Promise<void>;
 
-export function refetchQuery(
-    queryKey: string | [string, object] | [string, false],
-    force?: {
-        force?: boolean
-    }
-): Promise<void>;
+// export function refetchQuery(
+//     queryKey: string | [string, object] | [string, false],
+//     force?: {
+//         force?: boolean;
+//     },
+// ): Promise<void>;
 
-export function refetchAllQueries(
-    options?: {
-        force?: boolean,
-        includeInactive: boolean
-    }
-): Promise<void>;
+// export function refetchAllQueries(options?: { force?: boolean; includeInactive: boolean }): Promise<void>;
 
 export function useIsFetching(): boolean;
 
 export const ReactQueryConfigProvider: React.ComponentType<{
-    config?: ReactQueryProviderConfig
+    config?: ReactQueryProviderConfig;
 }>;
 
 export interface ReactQueryProviderConfig {
@@ -139,4 +238,4 @@ export interface ReactQueryProviderConfig {
     suspense?: boolean;
 }
 
-export function clearQueryCache(): void;
+// export function clearQueryCache(): void;

--- a/types/react-query/package.json
+++ b/types/react-query/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "ts-toolbelt": "*"
+    }
+}

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -184,7 +184,7 @@ function pr42830() {
 
     // corrected
     // querySimple.error; // $ExpectType Error | null
-    querySimple.error; // $ExpectType unknown | null
+    querySimple.error; // $ExpectType unknown
 
     querySimple.isFetching; // $ExpectType boolean
     querySimple.failureCount; // $ExpectType number

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -2,10 +2,10 @@ import { useMutation, useQuery, usePaginatedQuery } from 'react-query';
 
 // Query - simple case
 const querySimple = useQuery('todos', () => Promise.resolve('test'));
-querySimple.data; // $ExpectType string | null
-querySimple.error; // $ExpectType Error | null
+querySimple.data; // $ExpectType string | undefined
+querySimple.error; // $ExpectType unknown
 querySimple.isFetching; // $ExpectType boolean
-querySimple.refetch(); // $ExpectType Promise<void>
+querySimple.refetch(); // $ExpectType Promise<string>
 querySimple.fetchMore; // $ExpectError
 querySimple.canFetchMore; // $ExpectError
 querySimple.isFetchingMore; // $ExpectError
@@ -17,8 +17,8 @@ const queryVariables = useQuery(['todos', { param }, 10], (key, variables, id) =
 );
 
 queryVariables.data; // $ExpectType boolean | undefined
-queryVariables.refetch(); // $ExpectType Promise<void>
-queryVariables.refetch({ force: true }); // $ExpectError
+queryVariables.refetch(); // $ExpectType Promise<boolean>
+queryVariables.refetch({ force: true }); // $ExpectType Promise<boolean>
 
 const queryFn1 = (name: string, params: { bar: string }) => Promise.resolve(10);
 const queryFn2 = () => Promise.resolve('test');
@@ -52,11 +52,9 @@ queryNested.data; // $ExpectType number | undefined
 // Paginated mode
 const queryPaginated = usePaginatedQuery('key', () => Promise.resolve({ data: [1, 2, 3], next: true }), {
     refetchInterval: 1000,
-    //paginated: true,
-    //getCanFetchMore: (lastPage, allPages) => lastPage.next,
 });
-queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; }[] | undefined
-queryPaginated.latestDate; // $ExpectType { data: number[]; next: boolean; }[] | undefined
+queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; } | undefined
+queryPaginated.latestDate; // $ExpectType { data: number[]; next: boolean; } | undefined
 queryPaginated.data; // $ExpectError
 
 // Simple mutation

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -346,27 +346,25 @@ function pr42830() {
 
     // Discriminated union over status
     if (mutationState.status === 'idle') {
-        // disabled
-        // mutationState.data; // $ExpectType undefined
-        // mutationState.error; // $ExpectType null
+        mutationState.data; // $ExpectType undefined
+        mutationState.error; // $ExpectType null
     }
 
     if (mutationState.status === 'loading') {
-        // disabled
-        // mutationState.data; // $ExpectType undefined
+        mutationState.data; // $ExpectType undefined
+        // corrected
         // mutationState.error; // $ExpectType null
+        mutationState.error; // $ExpectType undefined
     }
 
     if (mutationState.status === 'error') {
-        // disabled
-        // mutationState.data; // $ExpectType undefined
-        // mutationState.error; // $ExpectType any
+        mutationState.data; // $ExpectType undefined
+        mutationState.error; // $ExpectType unknown
     }
 
     if (mutationState.status === 'success') {
-        // disabled
-        // mutationState.data; // $ExpectType string[]
-        // mutationState.error; // $ExpectType null
+        mutationState.data; // $ExpectType string[]
+        mutationState.error; // $ExpectType undefined
     }
 
     // Mutation variables

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -1,4 +1,12 @@
-import { useMutation, useQuery, usePaginatedQuery, useInfiniteQuery } from 'react-query';
+import {
+    useMutation,
+    useQuery,
+    usePaginatedQuery,
+    useInfiniteQuery,
+    useIsFetching,
+    setConsole,
+    ReactQueryProviderConfig,
+} from 'react-query';
 
 // Query - simple case
 const querySimple = useQuery('todos', () => Promise.resolve('test'));
@@ -141,3 +149,17 @@ mutateWithVars(
 );
 
 mutateWithVars({ param: 'test' }); // $ExpectError
+
+useIsFetching(); // $ExpectType number
+
+setConsole({ log, error: log, warn: log });
+
+const globalConfig: ReactQueryProviderConfig = {
+    onError(err, snapshot) {
+        log('Error', err, snapshot);
+    },
+    onMutate(variables) {
+        log(variables);
+    },
+    suspense: true,
+};

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -1,66 +1,76 @@
-import { useMutation, useQuery } from "react-query";
-
-const queryFn = () => Promise.resolve();
+import { useMutation, useQuery, usePaginatedQuery } from 'react-query';
 
 // Query - simple case
-const querySimple = useQuery('todos',
-    () => Promise.resolve('test'));
+const querySimple = useQuery('todos', () => Promise.resolve('test'));
 querySimple.data; // $ExpectType string | null
 querySimple.error; // $ExpectType Error | null
-querySimple.isLoading; // $ExpectType boolean
+querySimple.isFetching; // $ExpectType boolean
 querySimple.refetch(); // $ExpectType Promise<void>
-queryPaginated.fetchMore; // $ExpectError
-queryPaginated.canFetchMore; // $ExpectError
-queryPaginated.isFetchingMore; // $ExpectError
+querySimple.fetchMore; // $ExpectError
+querySimple.canFetchMore; // $ExpectError
+querySimple.isFetchingMore; // $ExpectError
 
 // Query Variables
 const param = 'test';
-const queryVariables = useQuery(['todos', {param}],
-    (variables) => Promise.resolve(variables.param === 'test'));
+const queryVariables = useQuery(['todos', { param }, 10], (key, variables, id) =>
+    Promise.resolve(variables.param === 'test'),
+);
 
-queryVariables.data; // $ExpectType boolean | null
-queryVariables.refetch({variables: {param: 'foo'}}); // $ExpectType Promise<void>
-queryVariables.refetch({variables: {other: 'foo'}}); // $ExpectError
+queryVariables.data; // $ExpectType boolean | undefined
+queryVariables.refetch(); // $ExpectType Promise<void>
+queryVariables.refetch({ force: true }); // $ExpectError
+
+const queryFn1 = (name: string, params: { bar: string }) => Promise.resolve(10);
+const queryFn2 = () => Promise.resolve('test');
 
 // Query with falsey query key
-useQuery(false && ['foo', { bar: 'baz' }], queryFn);
+useQuery(false && ['foo', { bar: 'baz' }], queryFn1);
+useQuery(false && ['foo', { bar: 'baz' }], queryFn2);
+useQuery({
+    queryKey: false && ['foo', { bar: 'baz' }],
+    queryFn: queryFn1,
+});
 
 // Query with query key function
-useQuery(() => ['foo', { bar: 'baz' }], queryFn);
+useQuery(() => ['foo', { bar: 'baz' }], queryFn1);
+useQuery(() => ['foo', { bar: 'baz' }], queryFn2);
 
 // Query with nested variabes
-const queryNested = useQuery(['key', {
-    nested: {
-        props: [1, 2]
-    }
-}], (variables) => Promise.resolve(variables.nested.props[0]));
-queryNested.data; // $ExpectType number | null
+const queryNested = useQuery(
+    [
+        'key',
+        {
+            nested: {
+                props: [1, 2],
+            },
+        },
+    ],
+    (key, variables) => Promise.resolve(variables.nested.props[0]),
+);
+queryNested.data; // $ExpectType number | undefined
 
 // Paginated mode
-const queryPaginated = useQuery('key', () => Promise.resolve({data: [1, 2, 3], next: true}), {
+const queryPaginated = usePaginatedQuery('key', () => Promise.resolve({ data: [1, 2, 3], next: true }), {
     refetchInterval: 1000,
-    paginated: true,
-    getCanFetchMore: (lastPage, allPages) => lastPage.next
+    //paginated: true,
+    //getCanFetchMore: (lastPage, allPages) => lastPage.next,
 });
-queryPaginated.data; // $ExpectType { data: number[]; next: boolean; }[] | null
-queryPaginated.fetchMore; // $ExpectType (variables?: {} | undefined) => Promise<{ data: number[]; next: boolean; }> || (variables?: object | undefined) => Promise<{ data: number[]; next: boolean; }>
-queryPaginated.canFetchMore; // $ExpectType boolean
-queryPaginated.isFetchingMore; // $ExpectType boolean
-
-// Paginated mode - check if getCanFetchMore is required
-useQuery('key', () => Promise.resolve(), {paginated: true}); // $ExpectError
+queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; }[] | undefined
+queryPaginated.latestDate; // $ExpectType { data: number[]; next: boolean; }[] | undefined
+queryPaginated.data; // $ExpectError
 
 // Simple mutation
 const mutation = () => Promise.resolve(['foo', 1]);
 
 const [mutate] = useMutation(mutation, {
-    refetchQueries: ['todos', ['todo', { id: 5 }], 'reminders'],
-    refetchQueriesOnFailure: false
+    // refetchQueries: ['todos', ['todo', { id: 5 }], 'reminders'],
+    // refetchQueriesOnFailure: false,
 });
 mutate();
 mutate(undefined, {
-    updateQuery: 'query',
-    waitForRefetchQueries: false
+    throwOnError: true,
+    // updateQuery: 'query',
+    // waitForRefetchQueries: false,
 });
 
 // Invalid mutatation funciton
@@ -68,16 +78,21 @@ useMutation((arg1: string, arg2: string) => Promise.resolve()); // $ExpectError
 useMutation((arg1: string) => null); // $ExpectError
 
 // Mutation with variables
-const [mutateWithVars] = useMutation(
-    ({param}: {param: number}) => Promise.resolve(Boolean(param)),
+const [mutateWithVars] = useMutation(({ param }: { param: number }) => Promise.resolve(Boolean(param)), {
+    useErrorBoundary: true,
+    // refetchQueries: ['todos', ['todo', { id: 5 }], 'reminders'],
+    // refetchQueriesOnFailure: false,
+});
+
+mutateWithVars(
+    { param: 1 },
     {
-    refetchQueries: ['todos', ['todo', { id: 5 }], 'reminders'],
-    refetchQueriesOnFailure: false
-});
+        async onSuccess(data) {
+            data; // $ExpectType boolean
+        },
+        // updateQuery: 'query',
+        // waitForRefetchQueries: false,
+    },
+);
 
-mutateWithVars({param: 1}, {
-  updateQuery: 'query',
-  waitForRefetchQueries: false
-});
-
-mutateWithVars({param: 'test'}); // $ExpectError
+mutateWithVars({ param: 'test' }); // $ExpectError

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -23,6 +23,8 @@ const param = 'test';
 const queryVariables = useQuery(['todos', { param }, 10], (key, variables, id) =>
     Promise.resolve(variables.param === 'test'),
 );
+// first element in the key must be a string
+useQuery([10, 'a'], async (id, key) => id); // $ExpectError
 
 queryVariables.data; // $ExpectType boolean | undefined
 queryVariables.refetch(); // $ExpectType Promise<boolean>

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, usePaginatedQuery } from 'react-query';
+import { useMutation, useQuery, usePaginatedQuery, useInfiniteQuery } from 'react-query';
 
 // Query - simple case
 const querySimple = useQuery('todos', () => Promise.resolve('test'));
@@ -62,6 +62,28 @@ const queryPaginated = usePaginatedQuery('key', () => Promise.resolve({ data: [1
 queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; } | undefined
 queryPaginated.latestDate; // $ExpectType { data: number[]; next: boolean; } | undefined
 queryPaginated.data; // $ExpectError
+
+async function fetchWithCursor(key: string, cursor?: string) {
+    return [1, 2, 3];
+}
+
+useInfiniteQuery<number[], [string], string>(['key'], fetchWithCursor, {
+    getFetchMore: (last, all) => 'next',
+});
+useInfiniteQuery(['key'], fetchWithCursor, {
+    getFetchMore: (last: number[], all: number[][]) => 'next',
+});
+const infiniteQuery = useInfiniteQuery(['key'], fetchWithCursor, {
+    getFetchMore: (last: number[], all: number[][]) => 'next',
+});
+// The next example does not work; the type for cursor does not get inferred.
+// useInfiniteQuery(['key'], fetchWithCursor, {
+//     getFetchMore: (last, all) => 'string',
+// });
+
+infiniteQuery.data; // $ExpectType number[][]
+infiniteQuery.fetchMore(); // $ExpectType Promise<number[][]> | undefined
+infiniteQuery.fetchMore('next'); // $ExpectType Promise<number[][]> | undefined
 
 // Simple mutation
 const mutation = () => Promise.resolve(['foo', 1]);

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -62,8 +62,8 @@ queryNested.data; // $ExpectType number | undefined
 useQuery(['key', { a: 1 }], [{ b: { x: 1 } }, { c: { x: 1 } }], (
     key1, // $ExpectType string
     key2, // ExpectType { a: number }
-    var1, // $ExpectType { b: { x: number } }
-    var2, // $ExpectType { c: { x: number } }
+    var1, // $ExpectType { b: { x: number; }; }
+    var2, // $ExpectType { c: { x: number; }; }
 ) => Promise.resolve(key1 === 'key' && key2.a === 1 && var1.b.x === 1 && var2.c.x === 1));
 
 // custom key
@@ -87,7 +87,7 @@ useQuery(
     ) => 100,
 ).data; // $ExpectType number | undefined
 
-// the following example cannot work properly, as it would require concatenating tuples with infinite ends
+// the following example cannot work properly, as it would require concatenating tuples with infinite tails.
 // ts-toolbelt library's `List.Concat` cannot do the job. It would be possible to do with `typescript-tuple` and additional trick.
 // useQuery<number, typeof longKey, typeof longVariables>(longKey, longVariables, async (
 //     key,        // $ExpectType string // <-- currently boolean?!
@@ -102,6 +102,25 @@ const queryPaginated = usePaginatedQuery('key', () => Promise.resolve({ data: [1
 queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; } | undefined
 queryPaginated.latestData; // $ExpectType { data: number[]; next: boolean; } | undefined
 queryPaginated.data; // $ExpectError
+
+// Discriminated union over status
+if (queryPaginated.status === 'loading') {
+    queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; } | undefined
+    queryPaginated.latestData; // $ExpectType { data: number[]; next: boolean; } | undefined
+    queryPaginated.error; // $ExpectType unknown
+}
+
+if (queryPaginated.status === 'error') {
+    queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; } | undefined
+    queryPaginated.latestData; // $ExpectType { data: number[]; next: boolean; } | undefined
+    queryPaginated.error; // $ExpectType unknown
+}
+
+if (queryPaginated.status === 'success') {
+    queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; }
+    queryPaginated.latestData; // $ExpectType { data: number[]; next: boolean; }
+    queryPaginated.error; // $ExpectType null
+}
 
 async function fetchWithCursor(key: string, cursor?: string) {
     return [1, 2, 3];
@@ -233,21 +252,20 @@ function pr42830() {
 
     // Discriminated union over status
     if (queryResult.status === 'loading') {
-        // disabled
-        // queryResult.data; // $ExpectType undefined
-        // queryResult.error; // $ExpectType null
+        queryResult.data; // $ExpectType string[] | undefined
+        queryResult.error; // $ExpectType unknown
     }
 
     if (queryResult.status === 'error') {
         // disabled
-        // queryResult.data; // $ExpectType undefined
-        // queryResult.error; // $ExpectType Error
+        queryResult.data; // $ExpectType string[] | undefined
+        queryResult.error; // $ExpectType unknown
     }
 
     if (queryResult.status === 'success') {
         // disabled
-        // queryResult.data; // $ExpectType string[]
-        // queryResult.error; // $ExpectType null
+        queryResult.data; // $ExpectType string[]
+        queryResult.error; // $ExpectType null
     }
 
     // Query with falsey query key

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -8,244 +8,254 @@ import {
     ReactQueryProviderConfig,
 } from 'react-query';
 
-// Query - simple case
-const querySimple = useQuery('todos', () => Promise.resolve('test'));
-querySimple.data; // $ExpectType string | undefined
-querySimple.error; // $ExpectType unknown
-querySimple.isFetching; // $ExpectType boolean
-querySimple.refetch(); // $ExpectType Promise<string>
-querySimple.fetchMore; // $ExpectError
-querySimple.canFetchMore; // $ExpectError
-querySimple.isFetchingMore; // $ExpectError
+function simpleQuery() {
+    // Query - simple case
+    const querySimple = useQuery('todos', () => Promise.resolve('test'));
+    querySimple.data; // $ExpectType string | undefined
+    querySimple.error; // $ExpectType unknown
+    querySimple.isFetching; // $ExpectType boolean
+    querySimple.refetch(); // $ExpectType Promise<string>
+    querySimple.fetchMore; // $ExpectError
+    querySimple.canFetchMore; // $ExpectError
+    querySimple.isFetchingMore; // $ExpectError
+}
 
-// Query Variables
-const param = 'test';
-const queryVariables = useQuery(['todos', { param }, 10], (key, variables, id) =>
-    Promise.resolve(variables.param === 'test'),
-);
-// first element in the key must be a string
-useQuery([10, 'a'], async (id, key) => id); // $ExpectError
+function queryWithVariables() {
+    // Query Variables
+    const param = 'test';
+    const queryVariables = useQuery(['todos', { param }, 10], (key, variables, id) =>
+        Promise.resolve(variables.param === 'test'),
+    );
 
-queryVariables.data; // $ExpectType boolean | undefined
-queryVariables.refetch(); // $ExpectType Promise<boolean>
-queryVariables.refetch({ force: true }); // $ExpectType Promise<boolean>
+    queryVariables.data; // $ExpectType boolean | undefined
+    queryVariables.refetch(); // $ExpectType Promise<boolean>
+    queryVariables.refetch({ force: true }); // $ExpectType Promise<boolean>
+}
 
-const queryFn1 = (name: string, params: { bar: string }) => Promise.resolve(10);
-const queryFn2 = () => Promise.resolve('test');
+function invalidSimpleQuery() {
+    // first element in the key must be a string
+    useQuery([10, 'a'], async (id, key) => id); // $ExpectError
+}
 
-declare const condition: boolean;
+function conditionalQuery(condition: boolean) {
+    const queryFn1 = (name: string, params: { bar: string }) => Promise.resolve(10);
+    const queryFn2 = () => Promise.resolve('test');
 
-// Query with falsey query key
-useQuery(condition && ['foo', { bar: 'baz' }], queryFn1);
-useQuery(condition && ['foo', { bar: 'baz' }], queryFn2);
-useQuery({
-    queryKey: condition && ['foo', { bar: 'baz' }],
-    queryFn: queryFn1,
-});
+    // Query with falsey query key
+    useQuery(condition && ['foo', { bar: 'baz' }], queryFn1);
+    useQuery(condition && ['foo', { bar: 'baz' }], queryFn2);
+    useQuery({
+        queryKey: condition && ['foo', { bar: 'baz' }],
+        queryFn: queryFn1,
+    });
 
-// Query with query key function
-useQuery(() => ['foo', { bar: 'baz' }], queryFn1);
-useQuery(() => ['foo', { bar: 'baz' }], queryFn2);
+    // Query with query key function
+    useQuery(() => ['foo', { bar: 'baz' }], queryFn1);
+    useQuery(() => ['foo', { bar: 'baz' }], queryFn2);
+}
 
-// Query with nested variabes
-const queryNested = useQuery(
-    [
-        'key',
-        {
-            nested: {
-                props: [1, 2],
+function queryWithNestedKey() {
+    // Query with nested variabes
+    const queryNested = useQuery(
+        [
+            'key',
+            {
+                nested: {
+                    props: [1, 2],
+                },
             },
-        },
-    ],
-    (key, variables) => Promise.resolve(variables.nested.props[0]),
-);
-queryNested.data; // $ExpectType number | undefined
+        ],
+        (key, variables) => Promise.resolve(variables.nested.props[0]),
+    );
+    queryNested.data; // $ExpectType number | undefined
+}
 
-useQuery(['key', { a: 1 }], [{ b: { x: 1 } }, { c: { x: 1 } }], (
-    key1, // $ExpectType string
-    key2, // ExpectType { a: number }
-    var1, // $ExpectType { b: { x: number; }; }
-    var2, // $ExpectType { c: { x: number; }; }
-) => Promise.resolve(key1 === 'key' && key2.a === 1 && var1.b.x === 1 && var2.c.x === 1));
+function queryWithComplexKeysAndVariables() {
+    useQuery(['key', { a: 1 }], [{ b: { x: 1 } }, { c: { x: 1 } }], (
+        key1, // $ExpectType string
+        key2, // ExpectType { a: number }
+        var1, // $ExpectType { b: { x: number; }; }
+        var2, // $ExpectType { c: { x: number; }; }
+    ) => Promise.resolve(key1 === 'key' && key2.a === 1 && var1.b.x === 1 && var2.c.x === 1));
 
-// custom key
-const longKey: [string, ...number[]] = ['key', 1, 2, 3, 4, 5];
-useQuery(
-    longKey,
-    async (
-        key, // $ExpectType string
-        ...ids // $ExpectType number[]
-    ) => 100,
-).data; // $ExpectType number | undefined
+    // custom key
+    const longKey: [string, ...number[]] = ['key', 1, 2, 3, 4, 5];
+    useQuery(
+        longKey,
+        async (
+            key, // $ExpectType string
+            ...ids // $ExpectType number[]
+        ) => 100,
+    ).data; // $ExpectType number | undefined
 
-const longVariables: [boolean, ...object[]] = [true, {}];
-useQuery(
-    ['key'],
-    longVariables,
-    async (
-        key, // $ExpectType string
-        var1, // $ExpectType boolean
-        ...vars // $ExpectType object[]
-    ) => 100,
-).data; // $ExpectType number | undefined
+    const longVariables: [boolean, ...object[]] = [true, {}];
+    useQuery(
+        ['key'],
+        longVariables,
+        async (
+            key, // $ExpectType string
+            var1, // $ExpectType boolean
+            ...vars // $ExpectType object[]
+        ) => 100,
+    ).data; // $ExpectType number | undefined
 
-// the following example cannot work properly, as it would require concatenating tuples with infinite tails.
-// ts-toolbelt library's `List.Concat` cannot do the job. It would be possible to do with `typescript-tuple` and additional trick.
-// useQuery<number, typeof longKey, typeof longVariables>(longKey, longVariables, async (
-//     key,        // $ExpectType string // <-- currently boolean?!
-//     keyOrVar,   // $ExpectType number | boolean // <-- currently object
-//     ...rest     // $ExpectType number | object  // <-- currently object[]
-// ) => 100).data; // $ExpectType number | undefined
+    // the following example cannot work properly, as it would require concatenating tuples with infinite tails.
+    // ts-toolbelt library's `List.Concat` cannot do the job. It would be possible to do with `typescript-tuple` and additional trick.
+    // useQuery<number, typeof longKey, typeof longVariables>(longKey, longVariables, async (
+    //     key,        // $ExpectType string // <-- currently boolean?!
+    //     keyOrVar,   // $ExpectType number | boolean // <-- currently object
+    //     ...rest     // $ExpectType number | object  // <-- currently object[]
+    // ) => 100).data; // $ExpectType number | undefined
+}
 
-// Paginated mode
-const queryPaginated = usePaginatedQuery('key', () => Promise.resolve({ data: [1, 2, 3], next: true }), {
-    refetchInterval: 1000,
-});
-queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; } | undefined
-queryPaginated.latestData; // $ExpectType { data: number[]; next: boolean; } | undefined
-queryPaginated.data; // $ExpectError
-
-// Discriminated union over status
-if (queryPaginated.status === 'loading') {
+function paginatedQuery() {
+    // Paginated mode
+    const queryPaginated = usePaginatedQuery('key', () => Promise.resolve({ data: [1, 2, 3], next: true }), {
+        refetchInterval: 1000,
+    });
     queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; } | undefined
     queryPaginated.latestData; // $ExpectType { data: number[]; next: boolean; } | undefined
-    queryPaginated.error; // $ExpectType unknown
+    queryPaginated.data; // $ExpectError
+
+    // Discriminated union over status
+    if (queryPaginated.status === 'loading') {
+        queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; } | undefined
+        queryPaginated.latestData; // $ExpectType { data: number[]; next: boolean; } | undefined
+        queryPaginated.error; // $ExpectType unknown
+    }
+
+    if (queryPaginated.status === 'error') {
+        queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; } | undefined
+        queryPaginated.latestData; // $ExpectType { data: number[]; next: boolean; } | undefined
+        queryPaginated.error; // $ExpectType unknown
+    }
+
+    if (queryPaginated.status === 'success') {
+        queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; }
+        queryPaginated.latestData; // $ExpectType { data: number[]; next: boolean; }
+        queryPaginated.error; // $ExpectType null
+    }
 }
 
-if (queryPaginated.status === 'error') {
-    queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; } | undefined
-    queryPaginated.latestData; // $ExpectType { data: number[]; next: boolean; } | undefined
-    queryPaginated.error; // $ExpectType unknown
+function simpleInfiniteQuery(condition: boolean) {
+    async function fetchWithCursor(key: string, cursor?: string) {
+        return [1, 2, 3];
+    }
+    function getFetchMore(last: number[], all: number[][]) {
+        return last.length ? String(all.length + 1) : false;
+    }
+
+    useInfiniteQuery<number[], [string], string>(['key'], fetchWithCursor, {
+        getFetchMore: (
+            last, // $ExpectType number[]
+            all, // $ExpectType number[][]
+        ) => 'next',
+    });
+    useInfiniteQuery(['key'], fetchWithCursor, { getFetchMore });
+    useInfiniteQuery('key', fetchWithCursor, { getFetchMore });
+    useInfiniteQuery(() => condition && 'key', fetchWithCursor, { getFetchMore });
+
+    const infiniteQuery = useInfiniteQuery(['key'], fetchWithCursor, { getFetchMore });
+
+    // The next example does not work; the type for cursor does not get inferred.
+    // useInfiniteQuery(['key'], fetchWithCursor, {
+    //     getFetchMore: (last, all) => 'string',
+    // });
+
+    infiniteQuery.data; // $ExpectType number[][]
+    infiniteQuery.fetchMore(); // $ExpectType Promise<number[][]> | undefined
+    infiniteQuery.fetchMore('next'); // $ExpectType Promise<number[][]> | undefined
 }
 
-if (queryPaginated.status === 'success') {
-    queryPaginated.resolvedData; // $ExpectType { data: number[]; next: boolean; }
-    queryPaginated.latestData; // $ExpectType { data: number[]; next: boolean; }
-    queryPaginated.error; // $ExpectType null
-}
-
-async function fetchWithCursor(key: string, cursor?: string) {
-    return [1, 2, 3];
-}
-function getFetchMore(last: number[], all: number[][]) {
-    return last.length ? String(all.length + 1) : false;
-}
-
-useInfiniteQuery<number[], [string], string>(['key'], fetchWithCursor, {
-    getFetchMore: (last, all) => 'next',
-});
-useInfiniteQuery(['key'], fetchWithCursor, { getFetchMore });
-useInfiniteQuery('key', fetchWithCursor, { getFetchMore });
-useInfiniteQuery(() => condition && 'key', fetchWithCursor, { getFetchMore });
-const infiniteQuery = useInfiniteQuery(['key'], fetchWithCursor, { getFetchMore });
-// The next example does not work; the type for cursor does not get inferred.
-// useInfiniteQuery(['key'], fetchWithCursor, {
-//     getFetchMore: (last, all) => 'string',
-// });
-
-infiniteQuery.data; // $ExpectType number[][]
-infiniteQuery.fetchMore(); // $ExpectType Promise<number[][]> | undefined
-infiniteQuery.fetchMore('next'); // $ExpectType Promise<number[][]> | undefined
-
-async function fetchWithCursor2(key: string, debuglog?: (...args: any[]) => void, cursor?: string) {
-    if (debuglog) debuglog(key, cursor);
-    return [1, 2, 3];
-}
 function log(...args: any[]) {}
 
-useInfiniteQuery<number[], [string], [undefined | ((...args: any[]) => void)], string>(
-    ['key'],
-    [undefined],
-    fetchWithCursor2,
-    {
-        getFetchMore: (last, all) => 'next',
-    },
-);
-useInfiniteQuery(['key'], [log], fetchWithCursor2, { getFetchMore });
-useInfiniteQuery('key', [log], fetchWithCursor2, { getFetchMore });
-useInfiniteQuery(() => condition && 'key', [log], fetchWithCursor2, { getFetchMore });
+function infiniteQueryWithVariables(condition: boolean) {
+    async function fetchWithCursor2(key: string, debuglog?: (...args: any[]) => void, cursor?: string) {
+        if (debuglog) debuglog(key, cursor);
+        return [1, 2, 3];
+    }
+    function getFetchMore(last: number[], all: number[][]) {
+        return last.length ? String(all.length + 1) : false;
+    }
 
-// Simple mutation
-const mutation = () => Promise.resolve(['foo', 1]);
-
-const [mutate] = useMutation(mutation, {
-    // refetchQueries: ['todos', ['todo', { id: 5 }], 'reminders'],
-    // refetchQueriesOnFailure: false,
-});
-mutate();
-mutate(undefined, {
-    throwOnError: true,
-    // updateQuery: 'query',
-    // waitForRefetchQueries: false,
-});
-
-// Invalid mutatation funciton
-useMutation((arg1: string, arg2: string) => Promise.resolve()); // $ExpectError
-useMutation((arg1: string) => null); // $ExpectError
-
-// Mutation with variables
-const [mutateWithVars] = useMutation(({ param }: { param: number }) => Promise.resolve(Boolean(param)), {
-    useErrorBoundary: true,
-    // refetchQueries: ['todos', ['todo', { id: 5 }], 'reminders'],
-    // refetchQueriesOnFailure: false,
-});
-
-mutateWithVars(
-    { param: 1 },
-    {
-        async onSuccess(data) {
-            data; // $ExpectType boolean
+    useInfiniteQuery<number[], [string], [undefined | ((...args: any[]) => void)], string>(
+        ['key'],
+        [undefined],
+        fetchWithCursor2,
+        {
+            getFetchMore: (last, all) => 'next',
         },
-        // updateQuery: 'query',
-        // waitForRefetchQueries: false,
-    },
-);
+    );
 
-mutateWithVars({ param: 'test' }); // $ExpectError
+    useInfiniteQuery(['key'], [log], fetchWithCursor2, { getFetchMore });
+    useInfiniteQuery('key', [log], fetchWithCursor2, { getFetchMore });
+    useInfiniteQuery(() => condition && 'key', [log], fetchWithCursor2, { getFetchMore });
+}
 
-useIsFetching(); // $ExpectType number
+function simpleMutation() {
+    // Simple mutation
+    const mutation = () => Promise.resolve(['foo', 'bar']);
 
-setConsole({ log, error: log, warn: log });
+    const [mutate] = useMutation(mutation, {
+        onSuccess(result) {
+            result; // $ExpectType string[]
+        },
+    });
+    mutate();
+    mutate(undefined, {
+        throwOnError: true,
+        onSettled(result, error) {
+            result; // $ExpectType string[] | undefined
+            error; // $ExpectType unknown
+        },
+    });
 
-const globalConfig: ReactQueryProviderConfig = {
-    onError(err, snapshot) {
-        log('Error', err, snapshot);
-    },
-    onMutate(variables) {
-        log(variables);
-    },
-    suspense: true,
-};
+    // Invalid mutatation funciton
+    useMutation((arg1: string, arg2: string) => Promise.resolve()); // $ExpectError
+    useMutation((arg1: string) => null); // $ExpectError
+}
 
-// Tests from PR #42830
-function pr42830() {
-    const queryFn = () => Promise.resolve(true);
+function mutationWithVariables() {
+    // Mutation with variables
+    const [mutateWithVars] = useMutation(({ param }: { param: number }) => Promise.resolve(Boolean(param)), {
+        useErrorBoundary: true,
+        onMutate(variables) {
+            variables; // $ExpectType { param: number; }
+            return { snapshot: variables.param };
+        },
+    });
 
-    // const queryKey1: QueryKey = 'key';
-    // const queryKey2: QueryKey = ['key', 1];
-    // const queryKey3: QueryKey = ['key', { foo: 'bar' }];
-    // const queryKey4: QueryKey = ['key', { foo: 'bar' }, 123];
+    mutateWithVars(
+        { param: 1 },
+        {
+            async onSuccess(data) {
+                data; // $ExpectType boolean
+            },
+        },
+    );
 
-    // const invalidKey1: QueryKey = [{ foo: 'bar' }]; // $ExpectError
-    // const invalidKey2: QueryKey = 123; // $ExpectError
+    mutateWithVars({ param: 'test' }); // $ExpectError
+}
 
-    // Query - simple case
-    const querySimple = useQuery('todos', (key: string) => Promise.resolve(key));
+function helpers() {
+    useIsFetching(); // $ExpectType number
 
-    querySimple.status; // $ExpectType "loading" | "error" | "success"
-    querySimple.data; // $ExpectType string | undefined
+    setConsole({ log, error: log, warn: log });
+}
 
-    // corrected
-    // querySimple.error; // $ExpectType Error | null
-    querySimple.error; // $ExpectType unknown
+function globalConfig() {
+    const globalConfig: ReactQueryProviderConfig = {
+        onError(err, snapshot) {
+            log('Error', err, snapshot);
+        },
+        onMutate(variables) {
+            log(variables);
+        },
+        suspense: true,
+    };
+}
 
-    querySimple.isFetching; // $ExpectType boolean
-    querySimple.failureCount; // $ExpectType number
-
-    // correct
-    // querySimple.refetch({force: true, thrownOnError: true}); // $ExpectType void
-    querySimple.refetch({ force: true, throwOnError: true }); // $ExpectType Promise<string>
-
+function dataDiscriminatedUnion() {
     // Query Variables
     const param = 'test';
     const queryResult = useQuery(['todos', { param }], (key, variables) => Promise.resolve([param]));
@@ -269,74 +279,9 @@ function pr42830() {
         queryResult.data; // $ExpectType string[]
         queryResult.error; // $ExpectType null
     }
+}
 
-    // Query with falsey query key
-    useQuery(false && ['foo', { bar: 'baz' }], queryFn);
-
-    // Query with nested variabes
-    const queryNested = useQuery(
-        [
-            'key',
-            {
-                nested: {
-                    props: [1, 2],
-                },
-            },
-        ],
-        (key, variables) => Promise.resolve(variables.nested.props[0]),
-    );
-    queryNested.data; // $ExpectType number | undefined
-
-    // Query key arrays
-    useQuery(['todo', 123, { key: 'foo' }], (key, arg1, arg2) => {
-        key; // $ExpectType string
-        arg1; // $ExpectType number
-        arg2; // $ExpectType { key: string; }
-        return Promise.resolve();
-    });
-
-    // Query with query key function
-    useQuery(
-        () => ['todo', 123, 'foo'],
-        (
-            key, // $ExpectType string
-            arg1, // $ExpectType number
-            arg2, // $ExpectType string
-        ) => Promise.resolve(),
-    );
-
-    // Paginated Query
-    const queryPaginated = usePaginatedQuery(['key', 0], (key, page) => Promise.resolve({ data: [1, 2, 3] }));
-    queryPaginated.resolvedData; // $ExpectType { data: number[]; } | undefined
-    queryPaginated.latestData; // $ExpectType { data: number[]; } | undefined
-    // corrected
-    // queryPaginated.error; // $ExpectType Error | null
-    queryPaginated.error; // $ExpectType unknown
-    queryPaginated.isFetching; // $ExpectType boolean
-
-    // Infinite Query
-    // corrected
-    // const infiniteQuery = useInfiniteQuery(['projects', 0], (key, cursor) => {
-    // if key is [string, number] then function must take (key: string, id: number, cursor?: number)
-    const infiniteQuery = useInfiniteQuery(
-        ['projects', 0],
-        (key, id, cursor: number = 0) => {
-            // added
-            key; // $ExpectType string
-            id; // $ExpectType number
-            return Promise.resolve({
-                nextCursor: cursor + 1,
-            });
-        },
-        {
-            getFetchMore: (lastGroup, allGroups) => lastGroup.nextCursor,
-        },
-    );
-
-    infiniteQuery.fetchMore(10);
-    infiniteQuery.fetchMore({ page: 20 }); // $ExpectError
-
-    // Simple mutation
+function mutationStatusDiscriminatedUnion() {
     const mutation = () => Promise.resolve(['foo', 'bar']);
     const [mutate, mutationState] = useMutation(mutation);
     mutate();
@@ -368,27 +313,4 @@ function pr42830() {
         mutationState.data; // $ExpectType string[]
         mutationState.error; // $ExpectType undefined
     }
-
-    // Mutation variables
-    const [mutateWithVars] = useMutation((variable: number) => Promise.resolve());
-    // enabled
-    // TODO: handle required argument of mutationFn
-    // mutateWithVars(); // $ExpectError
-    mutateWithVars(); // $ExpectError
-    mutateWithVars(1);
-    mutateWithVars(1, 2); // $ExpectError
-    mutateWithVars('foo'); // $ExpectError
-
-    // Mutate fn with optional vars
-    const [mutateWithOptionalVar] = useMutation((variable: number = 1) => Promise.resolve());
-    // corrected
-    // mutateWithVars();
-    mutateWithOptionalVar();
-    // corrected
-    // mutateWithVars(1);
-    mutateWithOptionalVar(1);
-
-    // Invalid mutatation funciton
-    useMutation((arg1: string, arg2: string) => Promise.resolve()); // $ExpectError
-    useMutation((arg1: string) => null); // $ExpectError
 }

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -52,7 +52,7 @@ const queryNested = useQuery(
 queryNested.data; // $ExpectType number | undefined
 
 useQuery(['key', { a: 1 }], [{ b: true }, { c: 'c' }], (key1, key2, var1, var2) =>
-    Promise.resolve(key1 === 'key' && key2.a === 1 && var1.b === true && var2.c === 'c'),
+    Promise.resolve(key1 === 'key' && key2.a === 1 && var1.b && var2.c === 'c'),
 );
 
 // Paginated mode

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -66,16 +66,17 @@ queryPaginated.data; // $ExpectError
 async function fetchWithCursor(key: string, cursor?: string) {
     return [1, 2, 3];
 }
+function getFetchMore(last: number[], all: number[][]) {
+    return last.length ? String(all.length + 1) : false;
+}
 
 useInfiniteQuery<number[], [string], string>(['key'], fetchWithCursor, {
     getFetchMore: (last, all) => 'next',
 });
-useInfiniteQuery(['key'], fetchWithCursor, {
-    getFetchMore: (last: number[], all: number[][]) => 'next',
-});
-const infiniteQuery = useInfiniteQuery(['key'], fetchWithCursor, {
-    getFetchMore: (last: number[], all: number[][]) => 'next',
-});
+useInfiniteQuery(['key'], fetchWithCursor, { getFetchMore });
+useInfiniteQuery('key', fetchWithCursor, { getFetchMore });
+useInfiniteQuery(() => condition && 'key', fetchWithCursor, { getFetchMore });
+const infiniteQuery = useInfiniteQuery(['key'], fetchWithCursor, { getFetchMore });
 // The next example does not work; the type for cursor does not get inferred.
 // useInfiniteQuery(['key'], fetchWithCursor, {
 //     getFetchMore: (last, all) => 'string',
@@ -84,6 +85,24 @@ const infiniteQuery = useInfiniteQuery(['key'], fetchWithCursor, {
 infiniteQuery.data; // $ExpectType number[][]
 infiniteQuery.fetchMore(); // $ExpectType Promise<number[][]> | undefined
 infiniteQuery.fetchMore('next'); // $ExpectType Promise<number[][]> | undefined
+
+async function fetchWithCursor2(key: string, debuglog?: (...args: any[]) => void, cursor?: string) {
+    if (debuglog) debuglog(key, cursor);
+    return [1, 2, 3];
+}
+function log(...args: any[]) {}
+
+useInfiniteQuery<number[], [string], [undefined | ((...args: any[]) => void)], string>(
+    ['key'],
+    [undefined],
+    fetchWithCursor2,
+    {
+        getFetchMore: (last, all) => 'next',
+    },
+);
+useInfiniteQuery(['key'], [log], fetchWithCursor2, { getFetchMore });
+useInfiniteQuery('key', [log], fetchWithCursor2, { getFetchMore });
+useInfiniteQuery(() => condition && 'key', [log], fetchWithCursor2, { getFetchMore });
 
 // Simple mutation
 const mutation = () => Promise.resolve(['foo', 1]);

--- a/types/react-query/react-query-tests.ts
+++ b/types/react-query/react-query-tests.ts
@@ -23,11 +23,13 @@ queryVariables.refetch({ force: true }); // $ExpectType Promise<boolean>
 const queryFn1 = (name: string, params: { bar: string }) => Promise.resolve(10);
 const queryFn2 = () => Promise.resolve('test');
 
+declare const condition: boolean;
+
 // Query with falsey query key
-useQuery(false && ['foo', { bar: 'baz' }], queryFn1);
-useQuery(false && ['foo', { bar: 'baz' }], queryFn2);
+useQuery(condition && ['foo', { bar: 'baz' }], queryFn1);
+useQuery(condition && ['foo', { bar: 'baz' }], queryFn2);
 useQuery({
-    queryKey: false && ['foo', { bar: 'baz' }],
+    queryKey: condition && ['foo', { bar: 'baz' }],
     queryFn: queryFn1,
 });
 
@@ -48,6 +50,10 @@ const queryNested = useQuery(
     (key, variables) => Promise.resolve(variables.nested.props[0]),
 );
 queryNested.data; // $ExpectType number | undefined
+
+useQuery(['key', { a: 1 }], [{ b: true }, { c: 'c' }], (key1, key2, var1, var2) =>
+    Promise.resolve(key1 === 'key' && key2.a === 1 && var1.b === true && var2.c === 'c'),
+);
 
 // Paginated mode
 const queryPaginated = usePaginatedQuery('key', () => Promise.resolve({ data: [1, 2, 3], next: true }), {


### PR DESCRIPTION
- breaking changes in API introduced in 1.0

Fixes #42678
Alternate to #42830

- [x] `useQuery`
  - [x] use variables in the query function
- [x] `usePaginatedQuery`
- [x] `useInfiniteQuery` (_type inference is not ideal; with untyped inlined functions, TS cannot infer type for 'more variable'_)
- [x] `useMutation`
- [x] `queryCache`
- [x] `useIsFetching`
- [x] `ReactQueryConfigProvider`
- [x] `setConsole`

Also added test cases from #42830. It seems a few cases that didn't work there now work here. The only missing feature is results based on discriminated unions where you can conclude `data != undefined` when `status == 'success'`. I don't think that is a good assumption and the future would worth it, because there are might be cases with the stale state.
