### PR TITLE
[mapbox-gl] Format existing code with prettier

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -30,7 +30,7 @@ declare namespace mapboxgl {
     /**
      * Maximum number of images (raster tiles, sprites, icons) to load in parallel, which affects performance in raster-heavy maps.
      * 16 by default.
-    */
+     */
     let maxParallelImageRequests: number;
 
     export function supported(options?: { failIfMajorPerformanceCaveat?: boolean }): boolean;
@@ -46,37 +46,108 @@ declare namespace mapboxgl {
 
     type PluginStatus = 'unavailable' | 'loading' | 'loaded' | 'error';
 
-    type LngLatLike = LngLat | { lng: number; lat: number; } | { lon: number; lat: number; } | [number, number];
+    type LngLatLike = LngLat | { lng: number; lat: number } | { lon: number; lat: number } | [number, number];
     type LngLatBoundsLike = LngLatBounds | [LngLatLike, LngLatLike] | [number, number, number, number];
     type PointLike = Point | [number, number];
 
     type ExpressionName =
         // Types
-        | 'array' | 'boolean' | 'collator' | 'format' | 'literal' | 'number' | 'object' | 'string'
-        | 'to-boolean' | 'to-color' | 'to-number' | 'to-string' | 'typeof'
+        | 'array'
+        | 'boolean'
+        | 'collator'
+        | 'format'
+        | 'literal'
+        | 'number'
+        | 'object'
+        | 'string'
+        | 'to-boolean'
+        | 'to-color'
+        | 'to-number'
+        | 'to-string'
+        | 'typeof'
         // Feature data
-        | 'feature-state' | 'geometry-type' | 'id' | 'line-progress' | 'properties'
+        | 'feature-state'
+        | 'geometry-type'
+        | 'id'
+        | 'line-progress'
+        | 'properties'
         // Lookup
-        | 'at' | 'get' | 'has' | 'length'
+        | 'at'
+        | 'get'
+        | 'has'
+        | 'length'
         // Decision
-        | '!' | '!=' | '<' | '<=' | '==' | '>' | '>=' | 'all' | 'any' | 'case' | 'match' | 'coalesce'
+        | '!'
+        | '!='
+        | '<'
+        | '<='
+        | '=='
+        | '>'
+        | '>='
+        | 'all'
+        | 'any'
+        | 'case'
+        | 'match'
+        | 'coalesce'
         // Ramps, scales, curves
-        | 'interpolate' | 'interpolate-hcl' | 'interpolate-lab' | 'step'
+        | 'interpolate'
+        | 'interpolate-hcl'
+        | 'interpolate-lab'
+        | 'step'
         // Variable binding
-        | 'let' | 'var'
+        | 'let'
+        | 'var'
         // String
-        | 'concat' | 'downcase' | 'is-supported-script' | 'resolved-locale' | 'upcase'
+        | 'concat'
+        | 'downcase'
+        | 'is-supported-script'
+        | 'resolved-locale'
+        | 'upcase'
         // Color
-        | 'rgb' | 'rgba'
+        | 'rgb'
+        | 'rgba'
         // Math
-        | '-' | '*' | '/' | '%' | '^' | '+' | 'abs' | 'acos' | 'asin' | 'atan' | 'ceil' | 'cos' | 'e'
-        | 'floor' | 'ln' | 'ln2' | 'log10' | 'log2' | 'max' | 'min' | 'pi' | 'round' | 'sin' | 'sqrt' | 'tan'
+        | '-'
+        | '*'
+        | '/'
+        | '%'
+        | '^'
+        | '+'
+        | 'abs'
+        | 'acos'
+        | 'asin'
+        | 'atan'
+        | 'ceil'
+        | 'cos'
+        | 'e'
+        | 'floor'
+        | 'ln'
+        | 'ln2'
+        | 'log10'
+        | 'log2'
+        | 'max'
+        | 'min'
+        | 'pi'
+        | 'round'
+        | 'sin'
+        | 'sqrt'
+        | 'tan'
         // Zoom, Heatmap
-        | 'zoom' | 'heatmap-density';
+        | 'zoom'
+        | 'heatmap-density';
 
-    type Expression = [ExpressionName, ...any[]]
+    type Expression = [ExpressionName, ...any[]];
 
-    type Anchor = 'center' | 'left' | 'right' | 'top' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+    type Anchor =
+        | 'center'
+        | 'left'
+        | 'right'
+        | 'top'
+        | 'bottom'
+        | 'top-left'
+        | 'top-right'
+        | 'bottom-left'
+        | 'bottom-right';
 
     /**
      * Map
@@ -84,7 +155,10 @@ declare namespace mapboxgl {
     export class Map extends Evented {
         constructor(options?: MapboxOptions);
 
-        addControl(control: Control | IControl, position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'): this;
+        addControl(
+            control: Control | IControl,
+            position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left',
+        ): this;
 
         removeControl(control: Control | IControl): this;
 
@@ -140,7 +214,10 @@ declare namespace mapboxgl {
          * @param pointOrBox The geometry of the query region: either a single point or southwest and northeast points describing a bounding box. Omitting this parameter (i.e. calling Map#queryRenderedFeatures with zero arguments, or with only a  options argument) is equivalent to passing a bounding box encompassing the entire map viewport.
          * @param options
          */
-        queryRenderedFeatures(pointOrBox?: PointLike | [PointLike, PointLike], options?: { layers?: string[], filter?: any[], validate?: boolean }): MapboxGeoJSONFeature[];
+        queryRenderedFeatures(
+            pointOrBox?: PointLike | [PointLike, PointLike],
+            options?: { layers?: string[]; filter?: any[]; validate?: boolean },
+        ): MapboxGeoJSONFeature[];
 
         /**
          * Returns an array of GeoJSON Feature objects representing features within the specified vector tile or GeoJSON source that satisfy the query parameters.
@@ -158,10 +235,10 @@ declare namespace mapboxgl {
                 sourceLayer?: string;
                 filter?: any[];
                 validate?: boolean;
-            }
+            },
         ): MapboxGeoJSONFeature[];
 
-        setStyle(style: mapboxgl.Style | string, options?: { diff?: boolean, localIdeographFontFamily?: string }): this;
+        setStyle(style: mapboxgl.Style | string, options?: { diff?: boolean; localIdeographFontFamily?: string }): this;
 
         getStyle(): mapboxgl.Style;
 
@@ -177,7 +254,15 @@ declare namespace mapboxgl {
 
         getSource(id: string): AnySourceImpl;
 
-        addImage(name: string, image: HTMLImageElement | ArrayBufferView | { width: number, height: number, data: Uint8Array | Uint8ClampedArray } | ImageData, options?: { pixelRatio?: number, sdf?: boolean }): this;
+        addImage(
+            name: string,
+            image:
+                | HTMLImageElement
+                | ArrayBufferView
+                | { width: number; height: number; data: Uint8Array | Uint8ClampedArray }
+                | ImageData,
+            options?: { pixelRatio?: number; sdf?: boolean },
+        ): this;
 
         hasImage(name: string): boolean;
 
@@ -213,7 +298,10 @@ declare namespace mapboxgl {
 
         getLight(): mapboxgl.Light;
 
-        setFeatureState(feature: FeatureIdentifier | mapboxgl.MapboxGeoJSONFeature, state: { [key: string]: any }): void;
+        setFeatureState(
+            feature: FeatureIdentifier | mapboxgl.MapboxGeoJSONFeature,
+            state: { [key: string]: any },
+        ): void;
 
         getFeatureState(feature: FeatureIdentifier | mapboxgl.MapboxGeoJSONFeature): { [key: string]: any };
 
@@ -273,7 +361,13 @@ declare namespace mapboxgl {
 
         fitBounds(bounds: LngLatBoundsLike, options?: mapboxgl.FitBoundsOptions, eventData?: mapboxgl.EventData): this;
 
-        fitScreenCoordinates(p0: PointLike, p1: PointLike, bearing: number, options?: AnimationOptions & CameraOptions, eventData?: EventData): this;
+        fitScreenCoordinates(
+            p0: PointLike,
+            p1: PointLike,
+            bearing: number,
+            options?: AnimationOptions & CameraOptions,
+            eventData?: EventData,
+        ): this;
 
         jumpTo(options: mapboxgl.CameraOptions, eventData?: mapboxgl.EventData): this;
 
@@ -285,15 +379,27 @@ declare namespace mapboxgl {
 
         stop(): this;
 
-        on<T extends keyof MapLayerEventType>(type: T, layer: string, listener: (ev: MapLayerEventType[T] & EventData) => void): this;
+        on<T extends keyof MapLayerEventType>(
+            type: T,
+            layer: string,
+            listener: (ev: MapLayerEventType[T] & EventData) => void,
+        ): this;
         on<T extends keyof MapEventType>(type: T, listener: (ev: MapEventType[T] & EventData) => void): this;
         on(type: string, listener: (ev: any) => void): this;
 
-        once<T extends keyof MapLayerEventType>(type: T, layer: string, listener: (ev: MapLayerEventType[T] & EventData) => void): this;
+        once<T extends keyof MapLayerEventType>(
+            type: T,
+            layer: string,
+            listener: (ev: MapLayerEventType[T] & EventData) => void,
+        ): this;
         once<T extends keyof MapEventType>(type: T, listener: (ev: MapEventType[T] & EventData) => void): this;
         once(type: string, listener: (ev: any) => void): this;
 
-        off<T extends keyof MapLayerEventType>(type: T, layer: string, listener: (ev: MapLayerEventType[T] & EventData) => void): this;
+        off<T extends keyof MapLayerEventType>(
+            type: T,
+            layer: string,
+            listener: (ev: MapLayerEventType[T] & EventData) => void,
+        ): this;
         off<T extends keyof MapEventType>(type: T, listener: (ev: MapEventType[T] & EventData) => void): this;
         off(type: string, listener: (ev: any) => void): this;
 
@@ -379,11 +485,11 @@ declare namespace mapboxgl {
         doubleClickZoom?: boolean;
 
         /** If `true`, the map's position (zoom, center latitude, center longitude, bearing, and pitch) will be synced with the hash fragment of the page's URL.
-        * For example, `http://path/to/my/page.html#2.59/39.26/53.07/-24.1/60`.
-        * An additional string may optionally be provided to indicate a parameter-styled hash,
-        * e.g. http://path/to/my/page.html#map=2.59/39.26/53.07/-24.1/60&foo=bar, where foo
-        * is a custom parameter and bar is an arbitrary hash distinct from the map hash.
-        * */
+         * For example, `http://path/to/my/page.html#2.59/39.26/53.07/-24.1/60`.
+         * An additional string may optionally be provided to indicate a parameter-styled hash,
+         * e.g. http://path/to/my/page.html#map=2.59/39.26/53.07/-24.1/60&foo=bar, where foo
+         * is a custom parameter and bar is an arbitrary hash distinct from the map hash.
+         * */
         hash?: boolean | string;
 
         /**
@@ -412,7 +518,7 @@ declare namespace mapboxgl {
          * see `src/ui/default_locale.js` for an example with all supported string IDs.
          * The object may specify all UI strings (thereby adding support for a new translation) or
          * only a subset of strings (thereby patching the default translation table).
-        */
+         */
         locale?: { [key: string]: string };
 
         /**
@@ -436,13 +542,13 @@ declare namespace mapboxgl {
         maxBounds?: LngLatBoundsLike;
 
         /** Maximum pitch of the map */
-        maxPitch?: number,
+        maxPitch?: number;
 
         /** Maximum zoom of the map */
         maxZoom?: number;
 
         /** Minimum pitch of the map */
-        minPitch?: number,
+        minPitch?: number;
 
         /** Minimum zoom of the map */
         minZoom?: number;
@@ -560,9 +666,9 @@ declare namespace mapboxgl {
     }
 
     export interface FeatureIdentifier {
-        id?: string | number,
-        source: string
-        sourceLayer?: string
+        id?: string | number;
+        source: string;
+        sourceLayer?: string;
     }
 
     /**
@@ -616,7 +722,7 @@ declare namespace mapboxgl {
      * DragRotateHandler
      */
     export class DragRotateHandler {
-        constructor(map: mapboxgl.Map, options?: { bearingSnap?: number, pitchWithRotate?: boolean });
+        constructor(map: mapboxgl.Map, options?: { bearingSnap?: number; pitchWithRotate?: boolean });
 
         isEnabled(): boolean;
 
@@ -681,18 +787,13 @@ declare namespace mapboxgl {
     /**
      * Control
      */
-    export class Control extends Evented {
-    }
+    export class Control extends Evented {}
 
     /**
      * Navigation
      */
     export class NavigationControl extends Control {
-		constructor(options?: {
-            showCompass?: boolean;
-            showZoom?: boolean;
-            visualizePitch?: boolean;
-        });
+        constructor(options?: { showCompass?: boolean; showZoom?: boolean; visualizePitch?: boolean });
     }
 
     export class PositionOptions {
@@ -705,7 +806,13 @@ declare namespace mapboxgl {
      * Geolocate
      */
     export class GeolocateControl extends Control {
-        constructor(options?: { positionOptions?: PositionOptions, fitBoundsOptions?: FitBoundsOptions, trackUserLocation?: boolean, showAccuracyCircle?: boolean, showUserLocation?: boolean });
+        constructor(options?: {
+            positionOptions?: PositionOptions;
+            fitBoundsOptions?: FitBoundsOptions;
+            trackUserLocation?: boolean;
+            showAccuracyCircle?: boolean;
+            showUserLocation?: boolean;
+        });
         trigger(): boolean;
     }
 
@@ -713,14 +820,14 @@ declare namespace mapboxgl {
      * Attribution
      */
     export class AttributionControl extends Control {
-        constructor(options?: { compact?: boolean, customAttribution?: string | string[] });
+        constructor(options?: { compact?: boolean; customAttribution?: string | string[] });
     }
 
     /**
      * Scale
      */
     export class ScaleControl extends Control {
-        constructor(options?: { maxWidth?: number, unit?: string })
+        constructor(options?: { maxWidth?: number; unit?: string });
 
         setUnit(unit: 'imperial' | 'metric' | 'nautical'): void;
     }
@@ -822,13 +929,13 @@ declare namespace mapboxgl {
         closeOnClick?: boolean;
 
         /**
-        * @param {boolean} [options.closeOnMove=false] If `true`, the popup will closed when the map moves.
-        */
+         * @param {boolean} [options.closeOnMove=false] If `true`, the popup will closed when the map moves.
+         */
         closeOnMove?: boolean;
 
         anchor?: Anchor;
 
-        offset?: number | PointLike | { [key: string]: PointLike; };
+        offset?: number | PointLike | { [key: string]: PointLike };
 
         className?: string;
 
@@ -857,12 +964,12 @@ declare namespace mapboxgl {
     }
 
     export interface Light {
-        'anchor'?: 'map' | 'viewport';
-        'position'?: number[];
+        anchor?: 'map' | 'viewport';
+        position?: number[];
         'position-transition'?: Transition;
-        'color'?: string;
+        color?: string;
         'color-transition'?: Transition;
-        'intensity'?: number;
+        intensity?: number;
         'intensity-transition'?: Transition;
     }
 
@@ -870,11 +977,25 @@ declare namespace mapboxgl {
         [sourceName: string]: AnySourceData;
     }
 
-    export type PromoteIdSpecification = {[key: string]: string} | string;
+    export type PromoteIdSpecification = { [key: string]: string } | string;
 
-    export type AnySourceData = GeoJSONSourceRaw | VideoSourceRaw | ImageSourceRaw | CanvasSourceRaw | VectorSource | RasterSource | RasterDemSource
+    export type AnySourceData =
+        | GeoJSONSourceRaw
+        | VideoSourceRaw
+        | ImageSourceRaw
+        | CanvasSourceRaw
+        | VectorSource
+        | RasterSource
+        | RasterDemSource;
 
-    export type AnySourceImpl = GeoJSONSource | VideoSource | ImageSource | CanvasSource | VectorSource | RasterSource | RasterDemSource
+    export type AnySourceImpl =
+        | GeoJSONSource
+        | VideoSource
+        | ImageSource
+        | CanvasSource
+        | VectorSource
+        | RasterSource
+        | RasterDemSource;
 
     export interface Source {
         type: 'vector' | 'raster' | 'raster-dem' | 'geojson' | 'image' | 'video' | 'canvas';
@@ -897,9 +1018,17 @@ declare namespace mapboxgl {
 
         getClusterExpansionZoom(clusterId: number, callback: (error: any, zoom: number) => void): this;
 
-        getClusterChildren(clusterId: number, callback: (error: any, features: GeoJSON.Feature<GeoJSON.Geometry>[]) => void): this;
+        getClusterChildren(
+            clusterId: number,
+            callback: (error: any, features: GeoJSON.Feature<GeoJSON.Geometry>[]) => void,
+        ): this;
 
-        getClusterLeaves(cluserId: number, limit: number, offset: number, callback: (error: any, features: GeoJSON.Feature<GeoJSON.Geometry>[]) => void): this;
+        getClusterLeaves(
+            cluserId: number,
+            limit: number,
+            offset: number,
+            callback: (error: any, features: GeoJSON.Feature<GeoJSON.Geometry>[]) => void,
+        ): this;
     }
 
     export interface GeoJSONSourceOptions {
@@ -1120,7 +1249,7 @@ declare namespace mapboxgl {
         toString(): string;
 
         /** Returns a boolean */
-        isEmpty(): boolean
+        isEmpty(): boolean;
 
         /** Convert an array to a LngLatBounds object, or return an existing LngLatBounds object unchanged. */
         static convert(input: LngLatBoundsLike): mapboxgl.LngLatBounds;
@@ -1129,7 +1258,7 @@ declare namespace mapboxgl {
     /**
      * Point
      */
-        // Todo: Pull out class to seperate definition for Module "point-geometry"
+    // Todo: Pull out class to seperate definition for Module "point-geometry"
     export class Point {
         x: number;
         y: number;
@@ -1257,33 +1386,33 @@ declare namespace mapboxgl {
         /** A string indicating the part of the Marker that should be positioned closest to the coordinate set via Marker.setLngLat.
          * Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`.
          * The default value os `'center'`
-        */
+         */
         anchor?: Anchor;
 
         /** The color to use for the default marker if options.element is not provided. The default is light blue (#3FB1CE). */
-        color?: string
+        color?: string;
 
         /** A boolean indicating whether or not a marker is able to be dragged to a new position on the map. The default value is false */
         draggable?: boolean;
 
         /** The rotation angle of the marker in degrees, relative to its `rotationAlignment` setting. A positive value will rotate the marker clockwise.
          * The default value is 0.
-        */
-        rotation?: number,
+         */
+        rotation?: number;
 
         /** `map` aligns the `Marker`'s rotation relative to the map, maintaining a bearing as the map rotates.
          * `viewport` aligns the `Marker`'s rotation relative to the viewport, agnostic to map rotations.
          * `auto` is equivalent to `viewport`.
          * The default value is `auto`
-        */
-        rotationAlignment?: Alignment,
+         */
+        rotationAlignment?: Alignment;
 
         /** `map` aligns the `Marker` to the plane of the map.
          * `viewport` aligns the `Marker` to the plane of the viewport.
          * `auto` automatically matches the value of `rotationAlignment`.
          * The default value is `auto`.
          */
-        pitchAlignment?: Alignment
+        pitchAlignment?: Alignment;
     }
 
     /**
@@ -1323,7 +1452,8 @@ declare namespace mapboxgl {
     }
 
     export class MapMouseEvent extends MapboxEvent<MouseEvent> {
-        type: 'mousedown'
+        type:
+            | 'mousedown'
             | 'mouseup'
             | 'click'
             | 'dblclick'
@@ -1341,12 +1471,10 @@ declare namespace mapboxgl {
         defaultPrevented: boolean;
     }
 
-    export type MapLayerMouseEvent = MapMouseEvent & { features?: MapboxGeoJSONFeature[]; };
+    export type MapLayerMouseEvent = MapMouseEvent & { features?: MapboxGeoJSONFeature[] };
 
     export class MapTouchEvent extends MapboxEvent<TouchEvent> {
-        type: 'touchstart'
-            | 'touchend'
-            | 'touchcancel';
+        type: 'touchstart' | 'touchend' | 'touchcancel';
 
         point: Point;
         lngLat: LngLat;
@@ -1357,7 +1485,7 @@ declare namespace mapboxgl {
         defaultPrevented: boolean;
     }
 
-    export type MapLayerTouchEvent = MapTouchEvent & { features?: MapboxGeoJSONFeature[]; };
+    export type MapLayerTouchEvent = MapTouchEvent & { features?: MapboxGeoJSONFeature[] };
 
     export class MapWheelEvent extends MapboxEvent<WheelEvent> {
         type: 'wheel';
@@ -1367,9 +1495,7 @@ declare namespace mapboxgl {
     }
 
     export interface MapBoxZoomEvent extends MapboxEvent<MouseEvent> {
-        type: 'boxzoomstart'
-            | 'boxzoomend'
-            | 'boxzoomcancel';
+        type: 'boxzoomstart' | 'boxzoomend' | 'boxzoomcancel';
 
         boxZoomBounds: LngLatBounds;
     }
@@ -1461,7 +1587,7 @@ declare namespace mapboxgl {
     // In practice center is always a {lat, lng} object.
     export type CameraForBoundsResult = Required<Pick<CameraOptions, 'zoom' | 'bearing'>> & {
         /** Map center */
-        center: {lng: number; lat: number};
+        center: { lng: number; lat: number };
     };
 
     /**
@@ -1551,7 +1677,7 @@ declare namespace mapboxgl {
         pitchend: MapboxEvent<MouseEvent | TouchEvent | undefined>;
 
         wheel: MapWheelEvent;
-    }
+    };
 
     export type MapLayerEventType = {
         click: MapLayerMouseEvent;
@@ -1568,9 +1694,18 @@ declare namespace mapboxgl {
         touchstart: MapLayerTouchEvent;
         touchend: MapLayerTouchEvent;
         touchcancel: MapLayerTouchEvent;
-    }
+    };
 
-    export type AnyLayout = BackgroundLayout | FillLayout | FillExtrusionLayout | LineLayout | SymbolLayout | RasterLayout | CircleLayout | HeatmapLayout | HillshadeLayout;
+    export type AnyLayout =
+        | BackgroundLayout
+        | FillLayout
+        | FillExtrusionLayout
+        | LineLayout
+        | SymbolLayout
+        | RasterLayout
+        | CircleLayout
+        | HeatmapLayout
+        | HillshadeLayout;
 
     export type AnyPaint =
         | BackgroundPaint
@@ -1585,7 +1720,16 @@ declare namespace mapboxgl {
 
     export interface Layer {
         id: string;
-        type?: 'fill' | 'line' | 'symbol' | 'circle' | 'fill-extrusion' | 'raster' | 'background' | 'heatmap' | 'hillshade';
+        type?:
+            | 'fill'
+            | 'line'
+            | 'symbol'
+            | 'circle'
+            | 'fill-extrusion'
+            | 'raster'
+            | 'background'
+            | 'heatmap'
+            | 'hillshade';
 
         metadata?: any;
         ref?: string;
@@ -1681,7 +1825,7 @@ declare namespace mapboxgl {
         base?: number;
         type?: 'identity' | 'exponential' | 'interval' | 'categorical';
         default?: any;
-        'colorSpace'?: 'rgb' | 'lab' | 'hcl';
+        colorSpace?: 'rgb' | 'lab' | 'hcl';
     }
 
     type Visibility = 'visible' | 'none';
@@ -1690,8 +1834,7 @@ declare namespace mapboxgl {
         visibility?: Visibility;
     }
 
-    export interface BackgroundLayout extends Layout {
-    }
+    export interface BackgroundLayout extends Layout {}
 
     export interface BackgroundPaint {
         'background-color'?: string | Expression;
@@ -1721,8 +1864,7 @@ declare namespace mapboxgl {
         'fill-pattern-transition'?: Transition;
     }
 
-    export interface FillExtrusionLayout extends Layout {
-    }
+    export interface FillExtrusionLayout extends Layout {}
 
     export interface FillExtrusionPaint {
         'fill-extrusion-opacity'?: number | Expression;
@@ -1845,8 +1987,7 @@ declare namespace mapboxgl {
         'text-translate-anchor'?: 'map' | 'viewport';
     }
 
-    export interface RasterLayout extends Layout {
-    }
+    export interface RasterLayout extends Layout {}
 
     export interface RasterPaint {
         'raster-opacity'?: number | Expression;
@@ -1866,8 +2007,7 @@ declare namespace mapboxgl {
         'circle-sort-key'?: number;
     }
 
-    export interface CircleLayout extends Layout {
-    }
+    export interface CircleLayout extends Layout {}
 
     export interface CirclePaint {
         'circle-radius'?: number | StyleFunction | Expression;
@@ -1891,8 +2031,7 @@ declare namespace mapboxgl {
         'circle-stroke-opacity-transition'?: Transition;
     }
 
-    export interface HeatmapLayout extends Layout {
-    }
+    export interface HeatmapLayout extends Layout {}
 
     export interface HeatmapPaint {
         'heatmap-radius'?: number | StyleFunction | Expression;
@@ -1905,8 +2044,7 @@ declare namespace mapboxgl {
         'heatmap-opacity-transition'?: Transition;
     }
 
-    export interface HillshadeLayout extends Layout {
-    }
+    export interface HillshadeLayout extends Layout {}
 
     export interface HillshadePaint {
         'hillshade-illumination-direction'?: number | Expression;

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -41,327 +41,306 @@ expectType<void>(mapboxgl.setRTLTextPlugin('http://github.com', e => {}, false))
  * Display a Map
  */
 let map = new mapboxgl.Map({
-	container: 'map',
-	style: 'mapbox://styles/mapbox/streets-v8',
-	center: [-50, 50],
-	zoom: 10,
-	minZoom: 1,
+    container: 'map',
+    style: 'mapbox://styles/mapbox/streets-v8',
+    center: [-50, 50],
+    zoom: 10,
+    minZoom: 1,
     maxZoom: 2,
     minPitch: 0,
     maxPitch: 60,
-	interactive: true,
-	attributionControl: true,
-	customAttribution: '© YourCo',
-	bearingSnap: 7,
-	scrollZoom: true,
-	maxBounds: [[-100,-90],[100,90]],
-	boxZoom: true,
-	dragRotate: false,
-	dragPan: true,
-	antialias: true,
-	accessToken: 'some-token',
+    interactive: true,
+    attributionControl: true,
+    customAttribution: '© YourCo',
+    bearingSnap: 7,
+    scrollZoom: true,
+    maxBounds: [
+        [-100, -90],
+        [100, 90],
+    ],
+    boxZoom: true,
+    dragRotate: false,
+    dragPan: true,
+    antialias: true,
+    accessToken: 'some-token',
     locale: {
         'FullscreenControl.Enter': 'Розгорнути на весь екран',
-        'FullscreenControl.Exit': 'Вийти з повоноеранного режиму'
-    }
+        'FullscreenControl.Exit': 'Вийти з повоноеранного режиму',
+    },
 });
 
 /**
  * Initialize map with bounds
  */
 expectType<mapboxgl.MapboxOptions>({
-	container: 'map',
-	bounds: new mapboxgl.LngLatBounds([-100, -90, 100, 90]),
-	fitBoundsOptions: {
-		padding: 0,
-		offset: new mapboxgl.Point(0, 0),
-		linear: true,
-		maxZoom: 22,
-		easing: time => time
-	}
+    container: 'map',
+    bounds: new mapboxgl.LngLatBounds([-100, -90, 100, 90]),
+    fitBoundsOptions: {
+        padding: 0,
+        offset: new mapboxgl.Point(0, 0),
+        linear: true,
+        maxZoom: 22,
+        easing: time => time,
+    },
 });
 expectType<mapboxgl.MapboxOptions>({
-	container: 'map',
-	bounds: [[-100, -90], [100, 90]],
-	fitBoundsOptions: {
-		offset: [0, 0]
-	}
+    container: 'map',
+    bounds: [
+        [-100, -90],
+        [100, 90],
+    ],
+    fitBoundsOptions: {
+        offset: [0, 0],
+    },
 });
 expectType<mapboxgl.MapboxOptions>({
-	container: 'map',
-	bounds: [-100, -90, 100, 90]
+    container: 'map',
+    bounds: [-100, -90, 100, 90],
 });
 
 /**
  * Create and style marker clusters
  */
 map.on('load', function() {
-
-	// Add a new source from our GeoJSON data and set the
-	// 'cluster' option to true.
-	map.addSource("data", {
-		type: "geojson",
-		data: "/data.geojson",
-		cluster: true,
-		clusterMaxZoom: 14, // Max zoom to cluster points on
-		clusterRadius: 50 // Radius of each cluster when clustering points (defaults to 50)
-	});
-
-	map.addLayer({
-		"id": "layer",
-		"type": "symbol",
-		"source": "data",
-		"layout": {
-			"icon-image": "marker-15",
-			"text-field": ['get', 'property']
-		}
-	});
-
-	var layers: [number, string][] = [
-		[150, '#f28cb1'],
-		[20, '#f1f075'],
-		[0, '#51bbd6']
-	];
-
-	layers.forEach(function (layer, i) {
-		map.addLayer({
-			"id": "cluster-" + i,
-			"type": "circle",
-			"source": "data",
-			"paint": {
-				"circle-color": layer[1],
-				"circle-radius": 18
-			},
-			"filter": i == 0 ?
-				[">=", "point_count", layer[0]] :
-				["all",
-					[">=", "point_count", layer[0]],
-					["<", "point_count", layers[i - 1][0]]]
-		});
-	});
-
-	// Add a layer for the clusters' count labels
-	map.addLayer({
-		"id": "cluster-count",
-		"type": "symbol",
-		"source": "data",
-		"layout": {
-			"text-field": "{point_count}",
-			"text-font": [
-				"DIN Offc Pro Medium",
-				"Arial Unicode MS Bold"
-			],
-			"text-size": 12
-		}
-	});
-
-    /**
-    * Add a GeoJSON line
-    */
-	map.addSource("route", {
-		"type": "geojson",
-		"data": {
-			"type": "Feature",
-			"properties": {},
-			"geometry": {
-				"type": "LineString",
-				"coordinates": [
-					[-122.48369693756104, 37.83381888486939],
-					[-122.48348236083984, 37.83317489144141],
-					[-122.48339653015138, 37.83270036637107],
-					[-122.48356819152832, 37.832056363179625],
-					[-122.48404026031496, 37.83114119107971],
-					[-122.48404026031496, 37.83049717427869],
-					[-122.48348236083984, 37.829920943955045],
-					[-122.48356819152832, 37.82954808664175],
-					[-122.48507022857666, 37.82944639795659],
-					[-122.48610019683838, 37.82880236636284],
-					[-122.48695850372314, 37.82931081282506],
-					[-122.48700141906738, 37.83080223556934],
-					[-122.48751640319824, 37.83168351665737],
-					[-122.48803138732912, 37.832158048267786],
-					[-122.48888969421387, 37.83297152392784],
-					[-122.48987674713133, 37.83263257682617],
-					[-122.49043464660643, 37.832937629287755],
-					[-122.49125003814696, 37.832429207817725],
-					[-122.49163627624512, 37.832564787218985],
-					[-122.49223709106445, 37.83337825839438],
-					[-122.49378204345702, 37.83368330777276]
-				]
-			}
-        },
-        promoteId: {"original": "COUNTY"}
-	});
-
-	map.addLayer({
-		"id": "route",
-		"type": "line",
-		"source": "route",
-		"layout": {
-			"line-join": "round",
-			"line-cap": "round"
-		},
-		"paint": {
-			"line-color": "#888",
-			"line-width": 8,
-            "line-dasharray": [
-                "step",
-                [
-                    "zoom"
-                ],
-                [
-                    "literal",
-                    [
-                        1,
-                        0
-                    ]
-                ],
-                15,
-                [
-                    "literal",
-                    [
-                        1.75,
-                        1
-                    ]
-                ]
-            ]
-		}
-	});
-
-    // Add a vector source
-    map.addSource("vector-source", {
-        type: "vector",
-        promoteId: {"original": "COUNTY"}
+    // Add a new source from our GeoJSON data and set the
+    // 'cluster' option to true.
+    map.addSource('data', {
+        type: 'geojson',
+        data: '/data.geojson',
+        cluster: true,
+        clusterMaxZoom: 14, // Max zoom to cluster points on
+        clusterRadius: 50, // Radius of each cluster when clustering points (defaults to 50)
     });
 
-	// Add a custom layer
-	map.addLayer({
-		id: 'custom',
-		type: 'custom',
-		renderingMode: '3d',
-		onRemove: function(map, gl) {
-			map;  // $ExpectType Map
-			gl;  // $ExpectType WebGLRenderingContext
-		},
-		render: function(gl, matrix) {
-			gl;  // $ExpectType WebGLRenderingContext
-			matrix;  // $ExpectType number[]
-		},
-	});
+    map.addLayer({
+        id: 'layer',
+        type: 'symbol',
+        source: 'data',
+        layout: {
+            'icon-image': 'marker-15',
+            'text-field': ['get', 'property'],
+        },
+    });
+
+    var layers: [number, string][] = [
+        [150, '#f28cb1'],
+        [20, '#f1f075'],
+        [0, '#51bbd6'],
+    ];
+
+    layers.forEach(function(layer, i) {
+        map.addLayer({
+            id: 'cluster-' + i,
+            type: 'circle',
+            source: 'data',
+            paint: {
+                'circle-color': layer[1],
+                'circle-radius': 18,
+            },
+            filter:
+                i == 0
+                    ? ['>=', 'point_count', layer[0]]
+                    : ['all', ['>=', 'point_count', layer[0]], ['<', 'point_count', layers[i - 1][0]]],
+        });
+    });
+
+    // Add a layer for the clusters' count labels
+    map.addLayer({
+        id: 'cluster-count',
+        type: 'symbol',
+        source: 'data',
+        layout: {
+            'text-field': '{point_count}',
+            'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
+            'text-size': 12,
+        },
+    });
+
+    /**
+     * Add a GeoJSON line
+     */
+    map.addSource('route', {
+        type: 'geojson',
+        data: {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'LineString',
+                coordinates: [
+                    [-122.48369693756104, 37.83381888486939],
+                    [-122.48348236083984, 37.83317489144141],
+                    [-122.48339653015138, 37.83270036637107],
+                    [-122.48356819152832, 37.832056363179625],
+                    [-122.48404026031496, 37.83114119107971],
+                    [-122.48404026031496, 37.83049717427869],
+                    [-122.48348236083984, 37.829920943955045],
+                    [-122.48356819152832, 37.82954808664175],
+                    [-122.48507022857666, 37.82944639795659],
+                    [-122.48610019683838, 37.82880236636284],
+                    [-122.48695850372314, 37.82931081282506],
+                    [-122.48700141906738, 37.83080223556934],
+                    [-122.48751640319824, 37.83168351665737],
+                    [-122.48803138732912, 37.832158048267786],
+                    [-122.48888969421387, 37.83297152392784],
+                    [-122.48987674713133, 37.83263257682617],
+                    [-122.49043464660643, 37.832937629287755],
+                    [-122.49125003814696, 37.832429207817725],
+                    [-122.49163627624512, 37.832564787218985],
+                    [-122.49223709106445, 37.83337825839438],
+                    [-122.49378204345702, 37.83368330777276],
+                ],
+            },
+        },
+        promoteId: { original: 'COUNTY' },
+    });
+
+    map.addLayer({
+        id: 'route',
+        type: 'line',
+        source: 'route',
+        layout: {
+            'line-join': 'round',
+            'line-cap': 'round',
+        },
+        paint: {
+            'line-color': '#888',
+            'line-width': 8,
+            'line-dasharray': ['step', ['zoom'], ['literal', [1, 0]], 15, ['literal', [1.75, 1]]],
+        },
+    });
+
+    // Add a vector source
+    map.addSource('vector-source', {
+        type: 'vector',
+        promoteId: { original: 'COUNTY' },
+    });
+
+    // Add a custom layer
+    map.addLayer({
+        id: 'custom',
+        type: 'custom',
+        renderingMode: '3d',
+        onRemove: function(map, gl) {
+            map; // $ExpectType Map
+            gl; // $ExpectType WebGLRenderingContext
+        },
+        render: function(gl, matrix) {
+            gl; // $ExpectType WebGLRenderingContext
+            matrix; // $ExpectType number[]
+        },
+    });
 });
 
 // FlyTo
 map.flyTo({
-	center: [0, 0],
-	zoom: 10,
-	speed: 0.5,
-	curve: 1,
-	screenSpeed: 1,
-	easing: function(t: number) {
-		return t;
-	},
-	maxDuration: 1
+    center: [0, 0],
+    zoom: 10,
+    speed: 0.5,
+    curve: 1,
+    screenSpeed: 1,
+    easing: function(t: number) {
+        return t;
+    },
+    maxDuration: 1,
 });
 
 // QueryRenderedFeatures
-const features = map.queryRenderedFeatures(
-	[0, 0],
-	{ layers: ['custom' ], validate: false }
-);
-features // $ExpectType MapboxGeoJSONFeature[]
+const features = map.queryRenderedFeatures([0, 0], { layers: ['custom'], validate: false });
+features; // $ExpectType MapboxGeoJSONFeature[]
 
 /**
  * GeoJSONSource
  */
 var geoJSONSourceObj = new mapboxgl.GeoJSONSource({
-	data: {
-		"type": "FeatureCollection",
-		"features": [{
-			"type": "Feature",
-			"properties": null,
-			"geometry": {
-				"type": "Point",
-				"coordinates": [-50, 0]
-			}
-		}]
-	}
+    data: {
+        type: 'FeatureCollection',
+        features: [
+            {
+                type: 'Feature',
+                properties: null,
+                geometry: {
+                    type: 'Point',
+                    coordinates: [-50, 0],
+                },
+            },
+        ],
+    },
 });
 map.addSource('some id', geoJSONSourceObj); // add
-map.removeSource('some id');  // remove
+map.removeSource('some id'); // remove
 
 /**
  * ImageSource
  */
 var imageSourceObj = new mapboxgl.ImageSource({
-	url: '/foo.png',
-	coordinates: [
-		[-76.54335737228394, 39.18579907229748],
-		[-76.52803659439087, 39.1838364847587],
-		[-76.5295386314392, 39.17683392507606],
-		[-76.54520273208618, 39.17876344106642]
-	]
+    url: '/foo.png',
+    coordinates: [
+        [-76.54335737228394, 39.18579907229748],
+        [-76.52803659439087, 39.1838364847587],
+        [-76.5295386314392, 39.17683392507606],
+        [-76.54520273208618, 39.17876344106642],
+    ],
 });
 map.addSource('some id', imageSourceObj); // add
-map.removeSource('some id');  // remove
+map.removeSource('some id'); // remove
 
 imageSourceObj.updateImage({
-	url: '/foo.png',
-	coordinates: [
-		[-76.54335737228394, 39.18579907229748],
-		[-76.52803659439087, 39.1838364847587],
-		[-76.5295386314392, 39.17683392507606],
-		[-76.54520273208618, 39.17876344106642]
-	]
+    url: '/foo.png',
+    coordinates: [
+        [-76.54335737228394, 39.18579907229748],
+        [-76.52803659439087, 39.1838364847587],
+        [-76.5295386314392, 39.17683392507606],
+        [-76.54520273208618, 39.17876344106642],
+    ],
 });
 
 imageSourceObj.setCoordinates([
-	[-76.54335737228394, 39.18579907229748],
-	[-76.52803659439087, 39.1838364847587],
-	[-76.5295386314392, 39.17683392507606],
-	[-76.54520273208618, 39.17876344106642]
+    [-76.54335737228394, 39.18579907229748],
+    [-76.52803659439087, 39.1838364847587],
+    [-76.5295386314392, 39.17683392507606],
+    [-76.54520273208618, 39.17876344106642],
 ]);
 
 /**
  * Video Source
  */
 var videoSourceObj = new mapboxgl.VideoSource({
-	urls: [
-		'/blah.mp4',
-		'/blah.webm'
-	],
-	coordinates: [
-		[-76.54335737228394, 39.18579907229748],
-		[-76.52803659439087, 39.1838364847587],
-		[-76.5295386314392, 39.17683392507606],
-		[-76.54520273208618, 39.17876344106642]
-	]
+    urls: ['/blah.mp4', '/blah.webm'],
+    coordinates: [
+        [-76.54335737228394, 39.18579907229748],
+        [-76.52803659439087, 39.1838364847587],
+        [-76.5295386314392, 39.17683392507606],
+        [-76.54520273208618, 39.17876344106642],
+    ],
 });
 map.addSource('some id', videoSourceObj); // add
-map.removeSource('some id');  // remove
+map.removeSource('some id'); // remove
 
 /**
  * Add Raster Source /// made URL optional to allow only tiles.
  */
 map.addSource('radar', {
-	type: 'raster',
-	tiles: ['https://nowcoast.noaa.gov/arcgis/services/nowcoast/radar_meteo_imagery_nexrad_time/MapServer/WmsServer?bbox={bbox-epsg-3857}&service=WMS&request=GetMap&version=1.3.0&layers=1&styles=&format=image/png&transparent=true&height=256&width=256&crs=EPSG:3857'],
-	tileSize: 256
+    type: 'raster',
+    tiles: [
+        'https://nowcoast.noaa.gov/arcgis/services/nowcoast/radar_meteo_imagery_nexrad_time/MapServer/WmsServer?bbox={bbox-epsg-3857}&service=WMS&request=GetMap&version=1.3.0&layers=1&styles=&format=image/png&transparent=true&height=256&width=256&crs=EPSG:3857',
+    ],
+    tileSize: 256,
 });
 
 map.addLayer({
-	id: 'radar',
-	type: 'raster',
-	source: 'radar',
-	paint: {}
+    id: 'radar',
+    type: 'raster',
+    source: 'radar',
+    paint: {},
 });
 
 /**
  * Manipulate feature state
  */
 let featureIdentifier = {
-	id: 1337,
-	source: 'source-id',
-	sourceLayer: 'liam-was-here'
+    id: 1337,
+    source: 'source-id',
+    sourceLayer: 'liam-was-here',
 };
 expectType<mapboxgl.FeatureIdentifier>(featureIdentifier);
 map.setFeatureState(featureIdentifier, { someState: true, someOtherState: 123 });
@@ -375,24 +354,24 @@ map.removeFeatureState(featureIdentifier);
 const popupOptions: mapboxgl.PopupOptions = {
     closeOnClick: false,
     closeOnMove: true,
-	closeButton: true,
-	anchor: 'top-right',
-	offset: {
-		'top': [0,0] as [number, number],
-		'bottom': [25,-50] as [number, number]
-	},
-	className: 'custom-class',
-	maxWidth: '400px'
+    closeButton: true,
+    anchor: 'top-right',
+    offset: {
+        top: [0, 0] as [number, number],
+        bottom: [25, -50] as [number, number],
+    },
+    className: 'custom-class',
+    maxWidth: '400px',
 };
 
 const popup = new mapboxgl.Popup(popupOptions)
-	.setLngLat([-50, 50])
-	.trackPointer()
-	.setHTML('<h1>Hello World!</h1>')
-	.setMaxWidth('none')
-	.addTo(map);
+    .setLngLat([-50, 50])
+    .trackPointer()
+    .setHTML('<h1>Hello World!</h1>')
+    .setMaxWidth('none')
+    .addTo(map);
 popup.getMaxWidth();
-popup.getElement();  // $ExpectType HTMLElement
+popup.getElement(); // $ExpectType HTMLElement
 popup.addClassName('class1');
 popup.removeClassName('class2');
 popup.toggleClassName('class3');
@@ -401,246 +380,221 @@ popup.toggleClassName('class3');
  * Add an image
  */
 var mapStyle: mapboxgl.Style = {
-	"version": 8,
-	"name": "Dark",
-	"sources": {
-		"mapbox": {
-			"type": "vector",
-            "url": "mapbox://mapbox.mapbox-streets-v6"
-		},
-		"overlay": {
-			"type": "image",
-			"url": "/mapbox-gl-js/assets/radar.gif",
-			"coordinates": [
-				[-50, 40],
-				[0, 40],
-				[0, 0],
-				[-50, 0]
-			]
-		}
-	},
-	"sprite": "mapbox://sprites/mapbox/dark-v8",
-	"glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
-	"layers": [
-		{
-			"id": "background",
-			"type": "background",
-			"paint": {"background-color": "#111"}
-		},
-		{
-			"id": "water",
-			"source": "mapbox",
-			"source-layer": "water",
-			"type": "fill",
-			"paint": {"fill-color": "#2c2c2c"}
-		},
-		{
-			"id": "boundaries",
-			"source": "mapbox",
-			"source-layer": "admin",
-			"type": "line",
-			"paint": {"line-color": "#797979", "line-dasharray": [2, 2, 6, 2]},
-			"filter": ["all", ["==", "maritime", 0]],
-		},
-		{
-			"id": "overlay",
-			"source": "overlay",
-			"type": "raster",
-			"paint": {"raster-opacity": 0.85}
-		},
-		{
-			"id": "cities",
-			"source": "mapbox",
-			"source-layer": "place_label",
-			"type": "symbol",
-			"layout": {
-				"text-field": "{name_en}",
-				"text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"],
-				"text-size": {"stops": [[4, 9], [6, 12]]}
-			},
-			"paint": {
-				"text-color": "#969696",
-				"text-halo-width": 2,
-				"text-halo-color": "rgba(0, 0, 0, 0.85)"
-			}
-		},
-		{
-			"id": "states",
-			"source": "mapbox",
-			"source-layer": "state_label",
-			"type": "symbol",
-			"layout": {
-				"text-transform": "uppercase",
-				"text-field": "{name_en}",
-                "text-font": [
-                    "step",
-                    [
-                        "zoom"
+    version: 8,
+    name: 'Dark',
+    sources: {
+        mapbox: {
+            type: 'vector',
+            url: 'mapbox://mapbox.mapbox-streets-v6',
+        },
+        overlay: {
+            type: 'image',
+            url: '/mapbox-gl-js/assets/radar.gif',
+            coordinates: [
+                [-50, 40],
+                [0, 40],
+                [0, 0],
+                [-50, 0],
+            ],
+        },
+    },
+    sprite: 'mapbox://sprites/mapbox/dark-v8',
+    glyphs: 'mapbox://fonts/mapbox/{fontstack}/{range}.pbf',
+    layers: [
+        {
+            id: 'background',
+            type: 'background',
+            paint: { 'background-color': '#111' },
+        },
+        {
+            id: 'water',
+            source: 'mapbox',
+            'source-layer': 'water',
+            type: 'fill',
+            paint: { 'fill-color': '#2c2c2c' },
+        },
+        {
+            id: 'boundaries',
+            source: 'mapbox',
+            'source-layer': 'admin',
+            type: 'line',
+            paint: { 'line-color': '#797979', 'line-dasharray': [2, 2, 6, 2] },
+            filter: ['all', ['==', 'maritime', 0]],
+        },
+        {
+            id: 'overlay',
+            source: 'overlay',
+            type: 'raster',
+            paint: { 'raster-opacity': 0.85 },
+        },
+        {
+            id: 'cities',
+            source: 'mapbox',
+            'source-layer': 'place_label',
+            type: 'symbol',
+            layout: {
+                'text-field': '{name_en}',
+                'text-font': ['DIN Offc Pro Bold', 'Arial Unicode MS Bold'],
+                'text-size': {
+                    stops: [
+                        [4, 9],
+                        [6, 12],
                     ],
-                    [
-                        "literal",
-                        [
-                            "DIN Offc Pro Regular",
-                            "Arial Unicode MS Regular"
-                        ]
-                    ],
+                },
+            },
+            paint: {
+                'text-color': '#969696',
+                'text-halo-width': 2,
+                'text-halo-color': 'rgba(0, 0, 0, 0.85)',
+            },
+        },
+        {
+            id: 'states',
+            source: 'mapbox',
+            'source-layer': 'state_label',
+            type: 'symbol',
+            layout: {
+                'text-transform': 'uppercase',
+                'text-field': '{name_en}',
+                'text-font': [
+                    'step',
+                    ['zoom'],
+                    ['literal', ['DIN Offc Pro Regular', 'Arial Unicode MS Regular']],
                     8,
                     [
-                        "step",
-                        [
-                            "get",
-                            "symbolrank"
-                        ],
-                        [
-                            "literal",
-                            [
-                                "DIN Offc Pro Medium",
-                                "Arial Unicode MS Regular"
-                            ]
-                        ],
+                        'step',
+                        ['get', 'symbolrank'],
+                        ['literal', ['DIN Offc Pro Medium', 'Arial Unicode MS Regular']],
                         11,
-                        [
-                            "literal",
-                            [
-                                "DIN Offc Pro Regular",
-                                "Arial Unicode MS Regular"
-                            ]
-                        ]
-                    ]
-                ],
-                "text-justify": [
-                    "step",
-                    [
-                        "zoom"
+                        ['literal', ['DIN Offc Pro Regular', 'Arial Unicode MS Regular']],
                     ],
+                ],
+                'text-justify': [
+                    'step',
+                    ['zoom'],
                     [
-                        "match",
-                        [
-                            "get",
-                            "text_anchor"
-                        ],
-                        [
-                            "bottom",
-                            "top"
-                        ],
-                        "center",
-                        [
-                            "left",
-                            "bottom-left",
-                            "top-left"
-                        ],
-                        "left",
-                        [
-                            "right",
-                            "bottom-right",
-                            "top-right"
-                        ],
-                        "right",
-                        "center"
+                        'match',
+                        ['get', 'text_anchor'],
+                        ['bottom', 'top'],
+                        'center',
+                        ['left', 'bottom-left', 'top-left'],
+                        'left',
+                        ['right', 'bottom-right', 'top-right'],
+                        'right',
+                        'center',
                     ],
                     8,
-                    "center"
+                    'center',
                 ],
-				"text-letter-spacing": 0.15,
-				"text-max-width": 7,
-				"text-size": {"stops": [[4, 10], [6, 14]]}
-			},
-			"filter": [">=", "area", 80000],
-			"paint": {
-				"text-color": "#969696",
-				"text-halo-width": 2,
-				"text-halo-color": "rgba(0, 0, 0, 0.85)"
-			}
-		}
-	]
+                'text-letter-spacing': 0.15,
+                'text-max-width': 7,
+                'text-size': {
+                    stops: [
+                        [4, 10],
+                        [6, 14],
+                    ],
+                },
+            },
+            filter: ['>=', 'area', 80000],
+            paint: {
+                'text-color': '#969696',
+                'text-halo-width': 2,
+                'text-halo-color': 'rgba(0, 0, 0, 0.85)',
+            },
+        },
+    ],
 };
 
 /**
  * Add video
  */
 var videoStyle: mapboxgl.Style = {
-	"version": 8,
-	"sources": {
-		"satellite": {
-			"type": "raster",
-			"url": "mapbox://mapbox.satellite",
-			"tileSize": 256
-		},
-		"video": {
-			"type": "video",
-			"urls": ["drone.mp4", "drone.webm"],
-			"coordinates": [
-				[-122.51596391201019, 37.56238816766053],
-				[-122.51467645168304, 37.56410183312965],
-				[-122.51309394836426, 37.563391708549425],
-				[-122.51423120498657, 37.56161849366671]
-			]
-		}
-	},
-	"layers": [{
-		"id": "background",
-		"type": "background",
-		"paint": {
-			"background-color": "rgb(4,7,14)"
-		}
-	}, {
-		"id": "satellite",
-		"type": "raster",
-		"source": "satellite"
-	}, {
-		"id": "video",
-		"type": "raster",
-		"source": "video"
-	}]
+    version: 8,
+    sources: {
+        satellite: {
+            type: 'raster',
+            url: 'mapbox://mapbox.satellite',
+            tileSize: 256,
+        },
+        video: {
+            type: 'video',
+            urls: ['drone.mp4', 'drone.webm'],
+            coordinates: [
+                [-122.51596391201019, 37.56238816766053],
+                [-122.51467645168304, 37.56410183312965],
+                [-122.51309394836426, 37.563391708549425],
+                [-122.51423120498657, 37.56161849366671],
+            ],
+        },
+    },
+    layers: [
+        {
+            id: 'background',
+            type: 'background',
+            paint: {
+                'background-color': 'rgb(4,7,14)',
+            },
+        },
+        {
+            id: 'satellite',
+            type: 'raster',
+            source: 'satellite',
+        },
+        {
+            id: 'video',
+            type: 'raster',
+            source: 'video',
+        },
+    ],
 };
 
 map = new mapboxgl.Map({
-	container: 'map',
-	minZoom: 14,
-	zoom: 17,
-	center: [-122.514426, 37.562984],
-	bearing: -96,
-	style: mapStyle,
-	hash: false
-});
-
-map = new mapboxgl.Map({
-	container: 'map',
-	minZoom: 14,
-	zoom: 17,
-	center: [-122.514426, 37.562984],
-	bearing: -96,
-	style: videoStyle,
-	hash: false
+    container: 'map',
+    minZoom: 14,
+    zoom: 17,
+    center: [-122.514426, 37.562984],
+    bearing: -96,
+    style: mapStyle,
+    hash: false,
 });
 
 map = new mapboxgl.Map({
     container: 'map',
-	hash: 'customHash'
+    minZoom: 14,
+    zoom: 17,
+    center: [-122.514426, 37.562984],
+    bearing: -96,
+    style: videoStyle,
+    hash: false,
+});
+
+map = new mapboxgl.Map({
+    container: 'map',
+    hash: 'customHash',
 });
 
 /**
  * Marker
  */
 let marker = new mapboxgl.Marker(undefined, {
-        element: undefined,
-        offset: [10, 0],
-        anchor: 'bottom-right',
-        color: 'green',
-        draggable: false,
-        rotation: 15,
-        rotationAlignment: 'map',
-        pitchAlignment: 'viewport'
-    })
-	.setLngLat([-50,50])
-	.addTo(map);
+    element: undefined,
+    offset: [10, 0],
+    anchor: 'bottom-right',
+    color: 'green',
+    draggable: false,
+    rotation: 15,
+    rotationAlignment: 'map',
+    pitchAlignment: 'viewport',
+})
+    .setLngLat([-50, 50])
+    .addTo(map);
 
 marker.remove();
 
 /*
  * LngLatBounds
  */
-let bool:boolean;
+let bool: boolean;
 let bounds = new mapboxgl.LngLatBounds();
 bool = bounds.isEmpty();
 expectType<boolean>(bounds.contains([37, 50]));
@@ -648,7 +602,7 @@ expectType<boolean>(bounds.contains([37, 50]));
 /*
  * GeolocateControl
  */
-const geolocateControl = new mapboxgl.GeolocateControl({showAccuracyCircle: true});
+const geolocateControl = new mapboxgl.GeolocateControl({ showAccuracyCircle: true });
 
 /*
  * AttributionControl
@@ -662,7 +616,7 @@ attributionControl.on('click', () => {});
 new mapboxgl.FullscreenControl();
 new mapboxgl.FullscreenControl(null);
 new mapboxgl.FullscreenControl({});
-new mapboxgl.FullscreenControl({container: document.querySelector('body')});
+new mapboxgl.FullscreenControl({ container: document.querySelector('body') });
 
 declare var lnglat: mapboxgl.LngLat;
 declare var lnglatlike: mapboxgl.LngLatLike;
@@ -671,29 +625,30 @@ declare var mercatorcoordinate: mapboxgl.MercatorCoordinate;
 declare var pointlike: mapboxgl.PointLike;
 
 function expectType<T>(value: T) {
-	return value;
+    return value;
 }
 
+// prettier-ignore
 interface EitherType {
-	<A>(a: A): A;
-	<A, B>(a: A, b: B): A | B;
-	<A, B, C>(a: A, b: B, c: C): A | B | C;
-	<A, B, C, D>(a: A, b: B, c: C, d: D): A | B | C | D;
-	<A, B, C, D, E>(a: A, b: B, c: C, d: D, e: E): A | B | C | D | E;
-	<A, B, C, D, E, F>(a: A, b: B, c: C, d: D, e: E, f: F): A | B | C | D | E | F;
-	<A, B, C, D, E, F, G>(a: A, b: B, c: C, d: D, e: E, f: F, g: G): A | B | C | D | E | F | G;
-	<A, B, C, D, E, F, G, H>(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H): A | B | C | D | E | F | G | H;
-	<A, B, C, D, E, F, G, H, I>(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I): A | B | C | D | E | F | G | H | I;
-	/* Add more as needed */
+    <A>(a: A): A;
+    <A, B>(a: A, b: B): A | B;
+    <A, B, C>(a: A, b: B, c: C): A | B | C;
+    <A, B, C, D>(a: A, b: B, c: C, d: D): A | B | C | D;
+    <A, B, C, D, E>(a: A, b: B, c: C, d: D, e: E): A | B | C | D | E;
+    <A, B, C, D, E, F>(a: A, b: B, c: C, d: D, e: E, f: F): A | B | C | D | E | F;
+    <A, B, C, D, E, F, G>(a: A, b: B, c: C, d: D, e: E, f: F, g: G): A | B | C | D | E | F | G;
+    <A, B, C, D, E, F, G, H>(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H): A | B | C | D | E | F | G | H;
+    <A, B, C, D, E, F, G, H, I>(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I): A | B | C | D | E | F | G | H | I;
+    /* Add more as needed */
 }
 
 /**
-* Takes a variable amount of arguments and returns a new
-* type that is a union of all the provided argument types. Useful to test properties
-* that accept multiple types
-*/
+ * Takes a variable amount of arguments and returns a new
+ * type that is a union of all the provided argument types. Useful to test properties
+ * that accept multiple types
+ */
 const eitherType: EitherType = () => {
-	/* let the compiler handle things */
+    /* let the compiler handle things */
 };
 
 /*
@@ -752,11 +707,11 @@ expectType<mapboxgl.Point>(mapboxgl.Point.convert(pointlike));
 
 new mapboxgl.MercatorCoordinate(0, 0);
 new mapboxgl.MercatorCoordinate(0, 0, 0);
-mercatorcoordinate.toAltitude();  // $ExpectType number
-mercatorcoordinate.toLngLat();  // $ExpectType LngLat
-mapboxgl.MercatorCoordinate.fromLngLat(lnglatlike);  // $ExpectType MercatorCoordinate
+mercatorcoordinate.toAltitude(); // $ExpectType number
+mercatorcoordinate.toLngLat(); // $ExpectType LngLat
+mapboxgl.MercatorCoordinate.fromLngLat(lnglatlike); // $ExpectType MercatorCoordinate
 mapboxgl.MercatorCoordinate.fromLngLat(lnglatlike, 0); // $ExpectType MercatorCoordinate
-mercatorcoordinate.meterInMercatorCoordinateUnits();  // $ExpectType number
+mercatorcoordinate.meterInMercatorCoordinateUnits(); // $ExpectType number
 
 /*
  * TransformRequestFunction
@@ -764,38 +719,38 @@ mercatorcoordinate.meterInMercatorCoordinateUnits();  // $ExpectType number
 
 expectType<mapboxgl.TransformRequestFunction>((url: string) => ({ url }));
 expectType<mapboxgl.TransformRequestFunction>((url: string, resourceType: mapboxgl.ResourceType) => ({
-	url,
-	credentials: 'same-origin',
-	headers: { 'Accept-Encoding': 'compress' },
-	method: 'POST',
-	collectResourceTiming: true,
- }));
+    url,
+    credentials: 'same-origin',
+    headers: { 'Accept-Encoding': 'compress' },
+    method: 'POST',
+    collectResourceTiming: true,
+}));
 
 /*
  * Map
  */
 
 let padding: mapboxgl.PaddingOptions = {
-	top: 0,
-	bottom: 0,
-	left: 0,
-	right: 0,
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
 };
 let animOpts: mapboxgl.AnimationOptions = {
-    essential: true
+    essential: true,
 };
 let cameraOpts: mapboxgl.CameraOptions = {
-	around: lnglatlike,
-	center: lnglatlike,
-	bearing: 0,
-	pitch: 0,
-	zoom: 0,
+    around: lnglatlike,
+    center: lnglatlike,
+    bearing: 0,
+    pitch: 0,
+    zoom: 0,
 };
 let cameraForBoundsOpts: mapboxgl.CameraForBoundsOptions = {
-	offset: pointlike,
-	maxZoom: 10,
-	padding,
-	...cameraOpts,
+    offset: pointlike,
+    maxZoom: 10,
+    padding,
+    ...cameraOpts,
 };
 
 expectType<mapboxgl.CameraForBoundsResult | undefined>(map.cameraForBounds(lnglatboundslike));
@@ -812,285 +767,363 @@ expectType<void>(map.triggerRepaint());
  */
 
 // General events
-expectType<mapboxgl.Map>(map.on('load', (ev) => {
-	expectType<mapboxgl.MapboxEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<undefined>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('remove', (ev) => {
-	expectType<mapboxgl.MapboxEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<undefined>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('render', (ev) => {
-	expectType<mapboxgl.MapboxEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<undefined>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('resize', (ev) => {
-	expectType<mapboxgl.MapboxEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<undefined>(ev.originalEvent);
-}));
+expectType<mapboxgl.Map>(
+    map.on('load', ev => {
+        expectType<mapboxgl.MapboxEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<undefined>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('remove', ev => {
+        expectType<mapboxgl.MapboxEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<undefined>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('render', ev => {
+        expectType<mapboxgl.MapboxEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<undefined>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('resize', ev => {
+        expectType<mapboxgl.MapboxEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<undefined>(ev.originalEvent);
+    }),
+);
 
 // Error event
-expectType<mapboxgl.Map>(map.on('error', (ev) => {
-	expectType<mapboxgl.ErrorEvent>(ev);
-	expectType<Error>(ev.error);
-	expectType<undefined>(ev.originalEvent);
-}));
+expectType<mapboxgl.Map>(
+    map.on('error', ev => {
+        expectType<mapboxgl.ErrorEvent>(ev);
+        expectType<Error>(ev.error);
+        expectType<undefined>(ev.originalEvent);
+    }),
+);
 
 // Mouse events
-expectType<mapboxgl.Map>(map.on('mousedown', (ev) => {
-	expectType<mapboxgl.MapMouseEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<mapboxgl.LngLat>(ev.lngLat);
-	expectType<mapboxgl.Point>(ev.point);
+expectType<mapboxgl.Map>(
+    map.on('mousedown', ev => {
+        expectType<mapboxgl.MapMouseEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<mapboxgl.LngLat>(ev.lngLat);
+        expectType<mapboxgl.Point>(ev.point);
 
-	expectType<void>(ev.preventDefault());
-	expectType<boolean>(ev.defaultPrevented);
+        expectType<void>(ev.preventDefault());
+        expectType<boolean>(ev.defaultPrevented);
 
-	expectType<MouseEvent>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('mouseup', (ev) => {
-	expectType<mapboxgl.MapMouseEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<mapboxgl.LngLat>(ev.lngLat);
-	expectType<mapboxgl.Point>(ev.point);
+        expectType<MouseEvent>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('mouseup', ev => {
+        expectType<mapboxgl.MapMouseEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<mapboxgl.LngLat>(ev.lngLat);
+        expectType<mapboxgl.Point>(ev.point);
 
-	expectType<void>(ev.preventDefault());
-	expectType<boolean>(ev.defaultPrevented);
+        expectType<void>(ev.preventDefault());
+        expectType<boolean>(ev.defaultPrevented);
 
-	expectType<MouseEvent>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('click', (ev) => {
-	expectType<mapboxgl.MapMouseEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<mapboxgl.LngLat>(ev.lngLat);
-	expectType<mapboxgl.Point>(ev.point);
+        expectType<MouseEvent>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('click', ev => {
+        expectType<mapboxgl.MapMouseEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<mapboxgl.LngLat>(ev.lngLat);
+        expectType<mapboxgl.Point>(ev.point);
 
-	expectType<void>(ev.preventDefault());
-	expectType<boolean>(ev.defaultPrevented);
+        expectType<void>(ev.preventDefault());
+        expectType<boolean>(ev.defaultPrevented);
 
-	expectType<MouseEvent>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('dblclick', (ev) => {
-	expectType<mapboxgl.MapMouseEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<mapboxgl.LngLat>(ev.lngLat);
-	expectType<mapboxgl.Point>(ev.point);
+        expectType<MouseEvent>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('dblclick', ev => {
+        expectType<mapboxgl.MapMouseEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<mapboxgl.LngLat>(ev.lngLat);
+        expectType<mapboxgl.Point>(ev.point);
 
-	expectType<void>(ev.preventDefault());
-	expectType<boolean>(ev.defaultPrevented);
+        expectType<void>(ev.preventDefault());
+        expectType<boolean>(ev.defaultPrevented);
 
-	expectType<MouseEvent>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('mousemove', (ev) => {
-	expectType<mapboxgl.MapMouseEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<mapboxgl.LngLat>(ev.lngLat);
-	expectType<mapboxgl.Point>(ev.point);
+        expectType<MouseEvent>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('mousemove', ev => {
+        expectType<mapboxgl.MapMouseEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<mapboxgl.LngLat>(ev.lngLat);
+        expectType<mapboxgl.Point>(ev.point);
 
-	expectType<void>(ev.preventDefault());
-	expectType<boolean>(ev.defaultPrevented);
+        expectType<void>(ev.preventDefault());
+        expectType<boolean>(ev.defaultPrevented);
 
-	expectType<MouseEvent>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('mouseover', (ev) => {
-	expectType<mapboxgl.MapMouseEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<mapboxgl.LngLat>(ev.lngLat);
-	expectType<mapboxgl.Point>(ev.point);
+        expectType<MouseEvent>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('mouseover', ev => {
+        expectType<mapboxgl.MapMouseEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<mapboxgl.LngLat>(ev.lngLat);
+        expectType<mapboxgl.Point>(ev.point);
 
-	expectType<void>(ev.preventDefault());
-	expectType<boolean>(ev.defaultPrevented);
+        expectType<void>(ev.preventDefault());
+        expectType<boolean>(ev.defaultPrevented);
 
-	expectType<MouseEvent>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('mouseout', (ev) => {
-	expectType<mapboxgl.MapMouseEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<mapboxgl.LngLat>(ev.lngLat);
-	expectType<mapboxgl.Point>(ev.point);
+        expectType<MouseEvent>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('mouseout', ev => {
+        expectType<mapboxgl.MapMouseEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<mapboxgl.LngLat>(ev.lngLat);
+        expectType<mapboxgl.Point>(ev.point);
 
-	expectType<void>(ev.preventDefault());
-	expectType<boolean>(ev.defaultPrevented);
+        expectType<void>(ev.preventDefault());
+        expectType<boolean>(ev.defaultPrevented);
 
-	expectType<MouseEvent>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('contextmenu', (ev) => {
-	expectType<mapboxgl.MapMouseEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<mapboxgl.LngLat>(ev.lngLat);
-	expectType<mapboxgl.Point>(ev.point);
+        expectType<MouseEvent>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('contextmenu', ev => {
+        expectType<mapboxgl.MapMouseEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<mapboxgl.LngLat>(ev.lngLat);
+        expectType<mapboxgl.Point>(ev.point);
 
-	expectType<void>(ev.preventDefault());
-	expectType<boolean>(ev.defaultPrevented);
+        expectType<void>(ev.preventDefault());
+        expectType<boolean>(ev.defaultPrevented);
 
-	expectType<MouseEvent>(ev.originalEvent);
-}));
+        expectType<MouseEvent>(ev.originalEvent);
+    }),
+);
 
 // Touch events
-expectType<mapboxgl.Map>(map.on('touchcancel', (ev) => {
-	expectType<mapboxgl.MapTouchEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<mapboxgl.LngLat>(ev.lngLat);
-	expectType<mapboxgl.LngLat[]>(ev.lngLats);
-	expectType<mapboxgl.Point>(ev.point);
-	expectType<mapboxgl.Point[]>(ev.points);
+expectType<mapboxgl.Map>(
+    map.on('touchcancel', ev => {
+        expectType<mapboxgl.MapTouchEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<mapboxgl.LngLat>(ev.lngLat);
+        expectType<mapboxgl.LngLat[]>(ev.lngLats);
+        expectType<mapboxgl.Point>(ev.point);
+        expectType<mapboxgl.Point[]>(ev.points);
 
-	expectType<void>(ev.preventDefault());
-	expectType<boolean>(ev.defaultPrevented);
+        expectType<void>(ev.preventDefault());
+        expectType<boolean>(ev.defaultPrevented);
 
-	expectType<TouchEvent>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('touchmove', (ev) => {
-	expectType<mapboxgl.MapTouchEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<mapboxgl.LngLat>(ev.lngLat);
-	expectType<mapboxgl.LngLat[]>(ev.lngLats);
-	expectType<mapboxgl.Point>(ev.point);
-	expectType<mapboxgl.Point[]>(ev.points);
+        expectType<TouchEvent>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('touchmove', ev => {
+        expectType<mapboxgl.MapTouchEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<mapboxgl.LngLat>(ev.lngLat);
+        expectType<mapboxgl.LngLat[]>(ev.lngLats);
+        expectType<mapboxgl.Point>(ev.point);
+        expectType<mapboxgl.Point[]>(ev.points);
 
-	expectType<void>(ev.preventDefault());
-	expectType<boolean>(ev.defaultPrevented);
+        expectType<void>(ev.preventDefault());
+        expectType<boolean>(ev.defaultPrevented);
 
-	expectType<TouchEvent>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('touchend', (ev) => {
-	expectType<mapboxgl.MapTouchEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<mapboxgl.LngLat>(ev.lngLat);
-	expectType<mapboxgl.LngLat[]>(ev.lngLats);
-	expectType<mapboxgl.Point>(ev.point);
-	expectType<mapboxgl.Point[]>(ev.points);
+        expectType<TouchEvent>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('touchend', ev => {
+        expectType<mapboxgl.MapTouchEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<mapboxgl.LngLat>(ev.lngLat);
+        expectType<mapboxgl.LngLat[]>(ev.lngLats);
+        expectType<mapboxgl.Point>(ev.point);
+        expectType<mapboxgl.Point[]>(ev.points);
 
-	expectType<void>(ev.preventDefault());
-	expectType<boolean>(ev.defaultPrevented);
+        expectType<void>(ev.preventDefault());
+        expectType<boolean>(ev.defaultPrevented);
 
-	expectType<TouchEvent>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('touchstart', (ev) => {
-	expectType<mapboxgl.MapTouchEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<mapboxgl.LngLat>(ev.lngLat);
-	expectType<mapboxgl.LngLat[]>(ev.lngLats);
-	expectType<mapboxgl.Point>(ev.point);
-	expectType<mapboxgl.Point[]>(ev.points);
+        expectType<TouchEvent>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('touchstart', ev => {
+        expectType<mapboxgl.MapTouchEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<mapboxgl.LngLat>(ev.lngLat);
+        expectType<mapboxgl.LngLat[]>(ev.lngLats);
+        expectType<mapboxgl.Point>(ev.point);
+        expectType<mapboxgl.Point[]>(ev.points);
 
-	expectType<void>(ev.preventDefault());
-	expectType<boolean>(ev.defaultPrevented);
+        expectType<void>(ev.preventDefault());
+        expectType<boolean>(ev.defaultPrevented);
 
-	expectType<TouchEvent>(ev.originalEvent);
-}));
+        expectType<TouchEvent>(ev.originalEvent);
+    }),
+);
 
 // Context events
-expectType<mapboxgl.Map>(map.on('webglcontextlost', (ev) => {
-	expectType<mapboxgl.MapContextEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<WebGLContextEvent>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('webglcontextrestored', (ev) => {
-	expectType<mapboxgl.MapContextEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<WebGLContextEvent>(ev.originalEvent);
-}));
+expectType<mapboxgl.Map>(
+    map.on('webglcontextlost', ev => {
+        expectType<mapboxgl.MapContextEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<WebGLContextEvent>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('webglcontextrestored', ev => {
+        expectType<mapboxgl.MapContextEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<WebGLContextEvent>(ev.originalEvent);
+    }),
+);
 
 // Data events
-expectType<mapboxgl.Map>(map.on('dataloading', (ev) => {
-	expectType<mapboxgl.MapDataEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<undefined>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('data', (ev) => {
-	expectType<mapboxgl.MapDataEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<undefined>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('tiledataloading', (ev) => {
-	expectType<mapboxgl.MapDataEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<undefined>(ev.originalEvent);
-}));
-expectType<mapboxgl.Map>(map.on('sourcedataloading', (ev) => {
-	expectType<mapboxgl.MapSourceDataEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<undefined>(ev.originalEvent);
-	expectType<'source'>(ev.dataType);
-}));
-expectType<mapboxgl.Map>(map.on('sourcedata', (ev) => {
-	expectType<mapboxgl.MapSourceDataEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<undefined>(ev.originalEvent);
-	expectType<'source'>(ev.dataType);
-}));
-expectType<mapboxgl.Map>(map.on('styledataloading', (ev) => {
-	expectType<mapboxgl.MapStyleDataEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<undefined>(ev.originalEvent);
-	expectType<'style'>(ev.dataType);
-}));
-expectType<mapboxgl.Map>(map.on('styledata', (ev) => {
-	expectType<mapboxgl.MapStyleDataEvent>(ev);
-	expectType<mapboxgl.Map>(ev.target);
-	expectType<undefined>(ev.originalEvent);
-	expectType<'style'>(ev.dataType);
-}));
+expectType<mapboxgl.Map>(
+    map.on('dataloading', ev => {
+        expectType<mapboxgl.MapDataEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<undefined>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('data', ev => {
+        expectType<mapboxgl.MapDataEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<undefined>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('tiledataloading', ev => {
+        expectType<mapboxgl.MapDataEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<undefined>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('sourcedataloading', ev => {
+        expectType<mapboxgl.MapSourceDataEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<undefined>(ev.originalEvent);
+        expectType<'source'>(ev.dataType);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('sourcedata', ev => {
+        expectType<mapboxgl.MapSourceDataEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<undefined>(ev.originalEvent);
+        expectType<'source'>(ev.dataType);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('styledataloading', ev => {
+        expectType<mapboxgl.MapStyleDataEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<undefined>(ev.originalEvent);
+        expectType<'style'>(ev.dataType);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('styledata', ev => {
+        expectType<mapboxgl.MapStyleDataEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<undefined>(ev.originalEvent);
+        expectType<'style'>(ev.dataType);
+    }),
+);
 
 // Layer events
-expectType<mapboxgl.Map>(map.on('click', 'text', (ev) => {
-	expectType<mapboxgl.MapLayerMouseEvent>(ev);
-	expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
-}));
-expectType<mapboxgl.Map>(map.on('dblclick', 'text', (ev) => {
-	expectType<mapboxgl.MapLayerMouseEvent>(ev);
-	expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
-}));
-expectType<mapboxgl.Map>(map.on('mousedown', 'text', (ev) => {
-	expectType<mapboxgl.MapLayerMouseEvent>(ev);
-	expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
-}));
-expectType<mapboxgl.Map>(map.on('mouseup', 'text', (ev) => {
-	expectType<mapboxgl.MapLayerMouseEvent>(ev);
-	expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
-}));
-expectType<mapboxgl.Map>(map.on('mousemove', 'text', (ev) => {
-	expectType<mapboxgl.MapLayerMouseEvent>(ev);
-	expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
-}));
-expectType<mapboxgl.Map>(map.on('mouseenter', 'text', (ev) => {
-	expectType<mapboxgl.MapLayerMouseEvent>(ev);
-	expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
-}));
-expectType<mapboxgl.Map>(map.on('mouseleave', 'text', (ev) => {
-	expectType<mapboxgl.MapLayerMouseEvent>(ev);
-	expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
-}));
-expectType<mapboxgl.Map>(map.on('mouseover', 'text', (ev) => {
-	expectType<mapboxgl.MapLayerMouseEvent>(ev);
-	expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
-}));
-expectType<mapboxgl.Map>(map.on('mouseout', 'text', (ev) => {
-	expectType<mapboxgl.MapLayerMouseEvent>(ev);
-	expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
-}));
-expectType<mapboxgl.Map>(map.on('contextmenu', 'text', (ev) => {
-	expectType<mapboxgl.MapLayerMouseEvent>(ev);
-	expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
-}));
+expectType<mapboxgl.Map>(
+    map.on('click', 'text', ev => {
+        expectType<mapboxgl.MapLayerMouseEvent>(ev);
+        expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('dblclick', 'text', ev => {
+        expectType<mapboxgl.MapLayerMouseEvent>(ev);
+        expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('mousedown', 'text', ev => {
+        expectType<mapboxgl.MapLayerMouseEvent>(ev);
+        expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('mouseup', 'text', ev => {
+        expectType<mapboxgl.MapLayerMouseEvent>(ev);
+        expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('mousemove', 'text', ev => {
+        expectType<mapboxgl.MapLayerMouseEvent>(ev);
+        expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('mouseenter', 'text', ev => {
+        expectType<mapboxgl.MapLayerMouseEvent>(ev);
+        expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('mouseleave', 'text', ev => {
+        expectType<mapboxgl.MapLayerMouseEvent>(ev);
+        expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('mouseover', 'text', ev => {
+        expectType<mapboxgl.MapLayerMouseEvent>(ev);
+        expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('mouseout', 'text', ev => {
+        expectType<mapboxgl.MapLayerMouseEvent>(ev);
+        expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('contextmenu', 'text', ev => {
+        expectType<mapboxgl.MapLayerMouseEvent>(ev);
+        expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
+    }),
+);
 
-expectType<mapboxgl.Map>(map.on('touchstart', 'text', (ev) => {
-	expectType<mapboxgl.MapLayerTouchEvent>(ev);
-	expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
-}));
-expectType<mapboxgl.Map>(map.on('touchend', 'text', (ev) => {
-	expectType<mapboxgl.MapLayerTouchEvent>(ev);
-	expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
-}));
-expectType<mapboxgl.Map>(map.on('touchcancel', 'text', (ev) => {
-	expectType<mapboxgl.MapLayerTouchEvent>(ev);
-	expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
-}));
+expectType<mapboxgl.Map>(
+    map.on('touchstart', 'text', ev => {
+        expectType<mapboxgl.MapLayerTouchEvent>(ev);
+        expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('touchend', 'text', ev => {
+        expectType<mapboxgl.MapLayerTouchEvent>(ev);
+        expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
+    }),
+);
+expectType<mapboxgl.Map>(
+    map.on('touchcancel', 'text', ev => {
+        expectType<mapboxgl.MapLayerTouchEvent>(ev);
+        expectType<mapboxgl.MapboxGeoJSONFeature[] | undefined>(ev.features);
+    }),
+);
 
 /*
  * Expression
@@ -1098,9 +1131,10 @@ expectType<mapboxgl.Map>(map.on('touchcancel', 'text', (ev) => {
 expectType<mapboxgl.Expression>(['id']);
 expectType<mapboxgl.Expression>(['get', 'property']);
 expectType<mapboxgl.Expression>([
-	'format',
-	['concat', ['get', 'name'], '\n'], {},
-	['concat', ['get', 'area'], 'foobar', { 'font-scale': 0.8 }]
+    'format',
+    ['concat', ['get', 'name'], '\n'],
+    {},
+    ['concat', ['get', 'area'], 'foobar', { 'font-scale': 0.8 }],
 ]);
 const expression = expectType<mapboxgl.Expression>(['coalesce', ['get', 'property'], ['get', 'property']]);
 


### PR DESCRIPTION
This is a followup for a previous PR I've made (#43385). The code style used in this package was a bit inconsistent, so I though I could format it using prettier (using the code standards already in place in this project).

~~I think it's best to first merge #43385. After that I can rebase this branch to make sure there is no weird formatting left (since I had to disable my editor auto-formatting while making my previous PR)~~
Done! The changes seem extensive but is basically just prettier and convert all the tabs to spaces (the test file was a mix of tabs and spaces). Quite safe 👍 


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

