### PR TITLE
[jsforce] Add missing jsforce connection types

### DIFF
--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -65,10 +65,69 @@ export interface UserInfo {
     url: string;
 }
 
-// IdentityInfo is a large object of identity information that is not typed in jsforce documentation.
+// The identity URL is a RESTful API to query for additional information
+// about users, such as their username, email address, and org ID.
+// It also returns endpoints that the client can talk to,
+// such as photos for profiles and accessible API endpoints.
+// https://help.salesforce.com/articleView?id=remoteaccess_using_openid.htm
 // https://jsforce.github.io/jsforce/doc/Connection.html#identity
 export interface IdentityInfo {
-    [key:string]: any
+    id: string;
+    asserted_user: boolean;
+    user_id: string;
+    organization_id: string;
+    username: string;
+    nick_name: string;
+    display_name: string;
+    email: string;
+    email_verified: boolean;
+    first_name: string | null;
+    last_name: string;
+    timezone: string;
+    photos: {
+        picture: string;
+        thumbnail: string;
+    };
+    addr_street: string | null;
+    addr_city: string | null;
+    addr_state: string | null;
+    addr_country: string | null;
+    addr_zip: string | null;
+    mobile_phone: string | null;
+    mobile_phone_verified: boolean;
+    is_lightning_login_user: boolean;
+    status: {
+        created_date: Date | null;
+        body: string | null;
+    };
+    urls: {
+        enterprise: string;
+        metadata: string;
+        partner: string;
+        rest: string;
+        sobjects: string;
+        search: string;
+        query: string;
+        recent: string;
+        tooling_soap: string;
+        tooling_rest: string;
+        profile: string;
+        feeds: string;
+        groups: string;
+        users: string;
+        feed_items: string;
+        feed_elements: string;
+        custom_domain?: string;
+    };
+    active: boolean;
+    user_type: string;
+    language: string;
+    locale: string;
+    utcOffset: number;
+    last_modified_date: Date;
+    is_app_installed: boolean;
+    // And possible other attributes.
+    [key: string]: any;
 }
 
 export abstract class RestApi {

--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -65,6 +65,12 @@ export interface UserInfo {
     url: string;
 }
 
+// IdentityInfo is a large object of identity information that is not typed in jsforce documentation.
+// https://jsforce.github.io/jsforce/doc/Connection.html#identity
+export interface IdentityInfo {
+    [key:string]: any
+}
+
 export abstract class RestApi {
     get(path: string, options: object, callback: () => object): Promise<object>;
     post(path: string, body: object, options: object, callback: () => object): Promise<object>;
@@ -167,6 +173,7 @@ export class Connection extends BaseConnection {
     instanceUrl: string;
     version: string;
     accessToken: string;
+    refreshToken?: string;
     initialize(options?: ConnectionOptions): void;
     queryAll<T>(soql: string, options?: object, callback?: (err: Error, result: QueryResult<T>) => void): Query<QueryResult<T>>;
     authorize(code: string, callback?: (err: Error, res: UserInfo) => void): Promise<UserInfo>;
@@ -180,6 +187,7 @@ export class Connection extends BaseConnection {
     logoutBySoap(revoke: boolean, callback?: (err: Error, res: undefined) => void): Promise<void>;
     logoutBySoap(callback?: (err: Error, res: undefined) => void): Promise<void>;
     limits(callback?: (err: Error, res: undefined) => void): Promise<LimitsInfo>;
+    identity(callback?: (err: Error, res: IdentityInfo) => void): Promise<IdentityInfo>;
 }
 
 export class Tooling extends BaseConnection {

--- a/types/jsforce/index.d.ts
+++ b/types/jsforce/index.d.ts
@@ -11,7 +11,7 @@
 //                 Doug Ayers <https://github.com/douglascayers>
 //                 Arlo Godfrey <https://github.com/Arlodotexe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.7
 
 export * from './api/analytics';
 export * from './api/apex';

--- a/types/jsforce/jsforce-tests.ts
+++ b/types/jsforce/jsforce-tests.ts
@@ -20,6 +20,16 @@ const salesforceConnection: sf.Connection = new sf.Connection({
     },
 });
 
+async function testIdentity(connection: sf.Connection) {
+    // Callback style.
+    connection.identity((err: Error | null, identityInfo: sf.IdentityInfo) => {
+    });
+    // Promise style.
+    const userInfo = await connection.identity();
+    userInfo.id; // $ExpectType string
+    userInfo.active; // $ExpectType boolean
+}
+
 async function testSObject(connection: sf.Connection) {
     interface DummyRecord {
         thing: boolean;


### PR DESCRIPTION
In working with the jsforce library I noticed that many of the types are missing or inconsistent. This PR addresses some of the issues I've found when working with a Connection instance object.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: /https://jsforce.github.io/jsforce/doc/Connection.html#identity
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
