### PR TITLE
[webpack] ProgressPlugin - Add additional constructor overload

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1832,7 +1832,33 @@ declare namespace webpack {
     }
 
     class ProgressPlugin extends Plugin {
-        constructor(options?: (percentage: number, msg: string, moduleProgress?: string, activeModules?: string, moduleName?: string) => void);
+        constructor(options?: Partial<ProgressPlugin.Options>);
+        constructor(callback?: ProgressPlugin.Callback);
+    }
+
+    namespace ProgressPlugin {
+        type Callback = (percentage: number, msg: string, moduleProgress?: string, activeModules?: string, moduleName?: string) => void;
+
+        interface Options {
+            /** Shows active modules count and one active module in progress message. */
+            activeModules: boolean;
+            /** Shows entries count in progress message. */
+            entries: boolean;
+            /** Provide a handler function which will be called when hooks report progress. */
+            handler: Callback;
+            /** Shows modules count in progress message. */
+            modules: boolean;
+            /** A minimum modules count to start with. Takes effect when modules property is enabled. */
+            modulesCount: number;
+            /** Tells ProgressPlugin to collect profile data for progress steps. */
+            profile: boolean;
+            /** Shows the count of dependencies in progress message. */
+            dependencies: boolean;
+            /** A minimum dependencies count to start with. Takes effect when dependencies property is enabled. */
+            dependenciesCount: number;
+            /** Tells ProgressPlugin how to calculate progress percentage. */
+            percentBy: 'entries' | 'dependencies' | 'modules' | null;
+        }
     }
 
     class EnvironmentPlugin extends Plugin {

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1832,8 +1832,7 @@ declare namespace webpack {
     }
 
     class ProgressPlugin extends Plugin {
-        constructor(options?: Partial<ProgressPlugin.Options>);
-        constructor(callback?: ProgressPlugin.Callback);
+        constructor(options?: Partial<ProgressPlugin.Options> | ProgressPlugin.Callback);
     }
 
     namespace ProgressPlugin {

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -508,6 +508,17 @@ plugin = new webpack.EnvironmentPlugin(['a', 'b']);
 plugin = new webpack.EnvironmentPlugin({ a: true, b: 'c' });
 plugin = new webpack.ProgressPlugin((percent: number, message: string) => { });
 plugin = new webpack.ProgressPlugin((percent: number, message: string, moduleProgress?: string, activeModules?: string, moduleName?: string) => { });
+plugin = new webpack.ProgressPlugin({
+    activeModules: true,
+    dependencies: true,
+    dependenciesCount: 5000,
+    entries: true,
+    handler: (a, b, c, d, e) => {},
+    modules: true,
+    modulesCount: 5000,
+    percentBy: null,
+    profile: false
+});
 plugin = new webpack.HashedModuleIdsPlugin();
 plugin = new webpack.HashedModuleIdsPlugin({
     hashFunction: 'sha256',


### PR DESCRIPTION
There are missing types for alternative usage of the `ProgressPlugin`. This adds those types.

Template info:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/plugins/progress-plugin/#providing-object
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
