### PR TITLE
fix(clownface): correct the use of generics

### DIFF
--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -2,21 +2,21 @@
 // Project: https://github.com/rdf-ext/clownface
 // Definitions by: tpluscode <https://github.com/tpluscode>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.2
 
 import { Term, DatasetCore, Quad_Graph, NamedNode, BlankNode, Literal } from 'rdf-js';
 import { Context } from './lib/Context';
 
 declare namespace clownface {
-    type TermOrClownface = Clownface | Term;
-    type TermOrLiteral = TermOrClownface | string | number | boolean;
+    type TermOrClownface<X extends Term = Term> = Clownface | X;
+    type TermOrLiteral<X extends Term = Term> = TermOrClownface<X> | string | number | boolean;
 
     type AddCallback<D extends DatasetCore, X extends Term> = (added: SingleContextClownface<D, X>) => void;
     type SingleOrArray<T> = T | T[];
     type SingleOrOneElementArray<T> = T | [T];
 
-    type SingleOrArrayOfTerms = SingleOrArray<TermOrClownface>;
-    type SingleOrArrayOfTermsOrLiterals = SingleOrArray<TermOrLiteral>;
+    type SingleOrArrayOfTerms<X extends Term> = SingleOrArray<TermOrClownface<X>>;
+    type SingleOrArrayOfTermsOrLiterals<X extends Term> = SingleOrArray<TermOrLiteral<X>>;
 
     interface NodeOptions {
         type?: 'BlankNode' | 'Literal' | 'NamedNode';
@@ -77,28 +77,22 @@ declare namespace clownface {
         namedNode(value: SingleOrOneElementArray<string | NamedNode>): SingleContextClownface<D, NamedNode>;
         namedNode(values: Array<string | NamedNode>): SafeClownface<D, NamedNode>;
 
-        // tslint:disable:no-unnecessary-generics
-        in<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-        out<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
+        in(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D>;
+        out(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D>;
 
-        has<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTermsOrLiterals): SafeClownface<D, X>;
+        has<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>): SafeClownface<D, X>;
 
-        addIn<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, objectOrCallback?: SingleOrOneElementArray<TermOrLiteral> | AddCallback<D, X>): SingleContextClownface<D, X>;
-        addIn<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, object: SingleOrOneElementArray<TermOrLiteral>, callback: AddCallback<D, X>): SingleContextClownface<D, X>;
-        addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
-        addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
+        addIn(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): SafeClownface<D, T>;
+        addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SafeClownface<D, T>;
 
-        addOut<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, objectOrCallback?: SingleOrOneElementArray<TermOrLiteral> | AddCallback<D, X>): SingleContextClownface<D, X>;
-        addOut<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, object: SingleOrOneElementArray<TermOrLiteral>, callback: AddCallback<D, X>): SingleContextClownface<D, X>;
-        addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
-        addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
+        addOut(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): SafeClownface<D, T>;
+        addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SafeClownface<D, T>;
 
-        addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTermsOrLiterals, callback?: AddCallback<D, X>): SafeClownface<D, X>;
+        addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SafeClownface<D, T>;
 
-        deleteIn<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-        deleteOut<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-        deleteList<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
-        // tslint:enable:no-unnecessary-generics
+        deleteIn(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
+        deleteOut(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
+        deleteList(predicates: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
     }
 
     interface SafeClownface<D extends DatasetCore = DatasetCore, T extends Term = Term> extends Clownface<D, T> {
@@ -114,6 +108,20 @@ declare namespace clownface {
         readonly value: string;
         readonly values: [string];
         readonly _context: [Context<D, T>];
+
+        filter(cb: (quad: SingleContextClownface<D, T>) => boolean): SingleContextClownface<D, T>;
+
+        addIn(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): SingleContextClownface<D, T>;
+        addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SingleContextClownface<D, T>;
+
+        addOut(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): SingleContextClownface<D, T>;
+        addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SingleContextClownface<D, T>;
+
+        addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SingleContextClownface<D, T>;
+
+        deleteIn(predicates?: SingleOrArrayOfTerms<Term>): SingleContextClownface<D, T>;
+        deleteOut(predicates?: SingleOrArrayOfTerms<Term>): SingleContextClownface<D, T>;
+        deleteList(predicates: SingleOrArrayOfTerms<Term>): SingleContextClownface<D, T>;
     }
 }
 

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/rdf-ext/clownface
 // Definitions by: tpluscode <https://github.com/tpluscode>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.2
+// TypeScript Version: 3.4
 
 import { Term, DatasetCore, Quad_Graph, NamedNode, BlankNode, Literal } from 'rdf-js';
 import { Context } from './lib/Context';
@@ -12,8 +12,8 @@ declare namespace clownface {
     type TermOrLiteral<X extends Term = Term> = TermOrClownface<X> | string | number | boolean;
 
     type AddCallback<D extends DatasetCore, X extends Term> = (added: SingleContextClownface<D, X>) => void;
-    type SingleOrArray<T> = T | T[];
-    type SingleOrOneElementArray<T> = T | [T];
+    type SingleOrArray<T> = T | readonly T[];
+    type SingleOrOneElementArray<T> = T | readonly [T];
 
     type SingleOrArrayOfTerms<X extends Term> = SingleOrArray<TermOrClownface<X>>;
     type SingleOrArrayOfTermsOrLiterals<X extends Term> = SingleOrArray<TermOrLiteral<X>>;

--- a/types/clownface/lib/Clownface.d.ts
+++ b/types/clownface/lib/Clownface.d.ts
@@ -52,28 +52,22 @@ declare class Clownface<D extends DatasetCore = DatasetCore, T extends Term = Te
     namedNode(value: SingleOrOneElementArray<string | NamedNode>): SingleContextClownface<D, NamedNode>;
     namedNode(values: Array<string | NamedNode>): SafeClownface<D, NamedNode>;
 
-    // tslint:disable:no-unnecessary-generics
-    in<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-    out<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
+    in(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D>;
+    out(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D>;
 
-    has<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTermsOrLiterals): SafeClownface<D, X>;
+    has<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>): SafeClownface<D, X>;
 
-    addIn<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, objectOrCallback?: SingleOrOneElementArray<TermOrLiteral> | AddCallback<D, X>): SingleContextClownface<D, X>;
-    addIn<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, object: SingleOrOneElementArray<TermOrLiteral>, callback: AddCallback<D, X>): SingleContextClownface<D, X>;
-    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
-    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
+    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals<X> | AddCallback<D, X>): SafeClownface<D, T>;
+    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback: AddCallback<D, X>): SafeClownface<D, T>;
 
-    addOut<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, objectOrCallback?: SingleOrOneElementArray<TermOrLiteral> | AddCallback<D, X>): SingleContextClownface<D, X>;
-    addOut<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, object: SingleOrOneElementArray<TermOrLiteral>, callback: AddCallback<D, X>): SingleContextClownface<D, X>;
-    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
-    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
+    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals<X> | AddCallback<D, X>): SafeClownface<D, T>;
+    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback: AddCallback<D, X>): SafeClownface<D, T>;
 
-    addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTerms, callback?: AddCallback<D, X>): SafeClownface<D, X>;
+    addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTerms<X>, callback?: AddCallback<D, X>): SafeClownface<D, T>;
 
-    deleteIn<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-    deleteOut<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-    deleteList<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
-    // tslint:enable:no-unnecessary-generics
+    deleteIn(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
+    deleteOut(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
+    deleteList(predicates: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
 }
 
 export = Clownface;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/rdf-ext/clownface/blob/master/lib/Clownface.js#L237>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
