### PR TITLE
feat(postcss-reporter): type definition for v6.0

### DIFF
--- a/types/postcss-reporter/index.d.ts
+++ b/types/postcss-reporter/index.d.ts
@@ -1,0 +1,81 @@
+// Type definitions for postcss-reporter 6.0
+// Project: https://github.com/postcss/postcss-reporter#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Plugin, ResultMessage } from 'postcss';
+
+declare namespace postcssReporter {
+    /**
+     * Additional options
+     */
+    interface Options extends DefaultOptions {
+        /**
+         * If true, the plugin will clear the result's messages after it logs them.
+         * This prevents other plugins, or the whatever runner you use, from logging the same information again and causing confusion.
+         * @default false
+         */
+        clearReportedMessages?: boolean;
+        /**
+         * By default, this reporter will format the messages for human legibility in the console.
+         * To use another formatter, pass a function that
+         * - accepts an object containing a messages array and a source string
+         * - returns the string to report
+         */
+        formatter?: (input: { messages: ResultMessage[]; source: string }) => string;
+        /**
+         * If plugins is empty (as it is by default),
+         * the reporter will log messages from every PostCSS plugin.
+         * @default []
+         */
+        plugins?: string[];
+        /**
+         * Provide a filter function. It receives the message object and returns a truthy or falsy value,
+         * indicating whether that particular message should be reported or not.
+         */
+        filter?: (message: ResultMessage) => boolean;
+        /**
+         * If true, not pass any messages into other plugins, or the whatever runner you use, for logging.
+         * @default false
+         */
+        clearAllMessages?: boolean;
+        /**
+         * If true, after the plugin logs your messages it will throw an error if it found any warnings.
+         * @default false
+         */
+        throwError?: boolean;
+        /**
+         * By default, messages without line/column positions will be grouped at the beginning of the output.
+         * To put them at the end, instead, use "last". To not bother sorting these, use "any".
+         * @default 'first'
+         */
+        positionless?: 'first' | 'last' | 'any';
+    }
+
+    /**
+     * Default plugin options
+     */
+    interface DefaultOptions {
+        /**
+         * If false, messages will not be sorted by line/column position.
+         * @default true
+         */
+        sortByPosition?: boolean;
+        /**
+         * If true, no exclamatory triangle icons will be printed next to warnings.
+         * @default false
+         */
+        noIcon?: boolean;
+        /**
+         * If true, plugin names will not be printed in brackets after messages.
+         * @default false
+         */
+        noPlugin?: boolean;
+    }
+
+    type PostCSSReporter = Plugin<Options>;
+}
+
+declare const postcssReporter: postcssReporter.PostCSSReporter;
+
+export = postcssReporter;

--- a/types/postcss-reporter/lib/formatter.d.ts
+++ b/types/postcss-reporter/lib/formatter.d.ts
@@ -1,0 +1,5 @@
+import { ResultMessage } from 'postcss';
+import { DefaultOptions } from '../index';
+
+declare function formatter(options?: DefaultOptions): (input?: { messages: ResultMessage[]; source: string }) => string;
+export = formatter;

--- a/types/postcss-reporter/package.json
+++ b/types/postcss-reporter/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^7.0.27"
+    }
+}

--- a/types/postcss-reporter/postcss-reporter-tests.ts
+++ b/types/postcss-reporter/postcss-reporter-tests.ts
@@ -1,0 +1,46 @@
+/// <reference types="node" />
+
+import reporter = require('postcss-reporter');
+import formatter = require('postcss-reporter/lib/formatter');
+import { ResultMessage } from 'postcss';
+reporter({
+    formatter: input => {
+        return `${input.source} produced ${input.messages.length} messages`;
+    },
+});
+
+const basicMessages = [
+    {
+        type: 'warning',
+        plugin: 'foo',
+        text: 'foo warning',
+    },
+    {
+        type: 'warning',
+        plugin: 'bar',
+        text: 'bar warning',
+    },
+    {
+        type: 'warning',
+        plugin: 'baz',
+        text: 'baz warning',
+    },
+    {
+        type: 'error',
+        plugin: 'baz',
+        text: 'baz error',
+    },
+];
+
+const myFormatter = formatter({
+    noIcon: true,
+    noPlugin: true,
+});
+// Defaults
+myFormatter();
+
+const warningLog = myFormatter({
+    messages: basicMessages,
+    source: 'someSource',
+});
+console.log(warningLog);

--- a/types/postcss-reporter/tsconfig.json
+++ b/types/postcss-reporter/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "postcss-reporter-tests.ts"
+    ]
+}

--- a/types/postcss-reporter/tslint.json
+++ b/types/postcss-reporter/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- type definition for plugin and for the formatter
- tests

https://github.com/postcss/postcss-reporter#readme

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.