### PR TITLE
update(autoprefixer): add `browsers` and `prefixes` modules

### DIFF
--- a/types/autoprefixer/autoprefixer-tests.ts
+++ b/types/autoprefixer/autoprefixer-tests.ts
@@ -1,4 +1,6 @@
 import autoprefixer = require('autoprefixer');
+import Browsers = require('autoprefixer/lib/browsers');
+import Prefixes = require('autoprefixer/lib/prefixes');
 import { Transformer } from 'postcss';
 
 // No options
@@ -36,3 +38,31 @@ const ap3: Transformer = autoprefixer({
         ssr: ['node 12'],
     },
 });
+
+const prefixes = new Prefixes(autoprefixer.data.prefixes, new Browsers(autoprefixer.data.browsers, []));
+const autoprefixerApiTest = {
+    atRuleName(identifier: string) {
+        return Boolean(prefixes.remove[`@${identifier.toLowerCase()}`]);
+    },
+    selector(identifier: string) {
+        return prefixes.remove.selectors.some((selectorObj: { prefixed: string }) => {
+            return identifier.toLowerCase() === selectorObj.prefixed;
+        });
+    },
+    mediaFeatureName(identifier: string) {
+        return identifier.toLowerCase().includes('device-pixel-ratio');
+    },
+    property(identifier: string) {
+        return Boolean(autoprefixer.data.prefixes[prefixes.unprefixed(identifier.toLowerCase())]);
+    },
+    propertyValue(prop: string, value: string) {
+        const possiblePrefixableValues =
+            (prefixes.remove[prop.toLowerCase()] && prefixes.remove[prop.toLowerCase()].values) || false;
+        return (
+            possiblePrefixableValues &&
+            possiblePrefixableValues.some((valueObj: { prefixed: string }) => {
+                return value.toLowerCase() === valueObj.prefixed;
+            })
+        );
+    },
+};

--- a/types/autoprefixer/lib/browsers.d.ts
+++ b/types/autoprefixer/lib/browsers.d.ts
@@ -1,0 +1,25 @@
+import browserslist = require('browserslist');
+
+type Queries = string | ReadonlyArray<string>;
+
+interface Browsers {
+    parse(queries: Queries): string[];
+    prefix(browser: string): string;
+    isSelected(browser: string): boolean;
+}
+
+declare class BrowsersImpl implements Browsers {
+    constructor(data: { [k: string]: any }, options?: any, browserslistOpts?: browserslist.Options);
+
+    isSelected(browser: string): boolean;
+
+    parse(queries: string | ReadonlyArray<string>): string[];
+
+    prefix(browser: string): string;
+
+    prefixes(): string[];
+
+    withPrefix(value: string): boolean;
+}
+
+export = BrowsersImpl;

--- a/types/autoprefixer/lib/prefixes.d.ts
+++ b/types/autoprefixer/lib/prefixes.d.ts
@@ -1,0 +1,17 @@
+import Browsers = require('./browsers');
+
+interface Prefixes {
+    remove: { [k: string]: any };
+
+    unprefixed(value: string): string;
+}
+
+declare class PrefixesImpl implements Prefixes {
+    constructor(data: string[], browsers: Browsers, options?: any);
+
+    remove: { [p: string]: any };
+
+    unprefixed(value: string): string;
+}
+
+export = PrefixesImpl;


### PR DESCRIPTION
As already used in the stylelint project:
https://github.com/stylelint/stylelint/blob/master/types/autoprefixer/index.d.ts

- add `lib/browsers` and `lib/prefixes`
- update tests

https://github.com/postcss/autoprefixer/blob/master/lib/browsers.js
https://github.com/postcss/autoprefixer/blob/master/lib/prefixes.js

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/postcss/autoprefixer/blob/master/lib/browsers.js
https://github.com/postcss/autoprefixer/blob/master/lib/prefixes.js