### PR TITLE
socketcluster-client "invoke" method data type fix to "any"

### DIFF
--- a/types/socketcluster-client/lib/clientsocket.d.ts
+++ b/types/socketcluster-client/lib/clientsocket.d.ts
@@ -144,7 +144,7 @@ declare class AGClientSocket extends AsyncStreamEmitter<any> implements AGChanne
     isSubscribed(channelName: string, includePending?: boolean): boolean;
 
     transmitPublish(channelName: string, data: any): Promise<void>;
-    invokePublish<T>(channelName: string, data: T): Promise<{ channel: string; data: T }>;
+    invokePublish(channelName: string, data: any): Promise<{ channel: string; data: any }>;
 
     /* AGChannel.Client end */
 
@@ -175,7 +175,7 @@ declare class AGClientSocket extends AsyncStreamEmitter<any> implements AGChanne
     send(data: any): void;
 
     transmit(event: string, data: any, options?: { ackTimeout?: number }): Promise<void>;
-    invoke<T>(event: string, data: T, options?: { ackTimeout?: number }): Promise<T>;
+    invoke(event: string, data: any, options?: { ackTimeout?: number }): Promise<any>;
 
     startBatch(): void;
     flushBatch(): void;

--- a/types/socketcluster-client/socketcluster-client-tests.ts
+++ b/types/socketcluster-client/socketcluster-client-tests.ts
@@ -10,7 +10,7 @@ const socket = create({
 socket.transmit('foo', 123);
 
 (async () => {
-    // $ExpectType number
+    // $ExpectType any
     await socket.invoke('myProc', 123);
 })();
 
@@ -51,7 +51,7 @@ socket.transmitPublish('myChannel', 'This is a message');
         // $ExpectType string
         response.channel;
 
-        // $ExpectType string
+        // $ExpectType any
         response.data;
     } catch (error) {}
 })();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://socketcluster.io/docs/basic-usage/

The "invoke" example in documentation shows that the server response data from an invoke method can be of any type and not necessarily same type as request data.

Maintainer is @DanielRose and may be helpful in feedback on this request! Thanks