### PR TITLE
big refactoring of clownface

### DIFF
--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -1,225 +1,330 @@
 import { Term, NamedNode, Dataset, Literal, DatasetCore, BlankNode, Quad_Graph } from 'rdf-js';
 import Clownface = require('clownface/lib/Clownface');
 import clownface = require('clownface');
+import Context = require('clownface/lib/Context');
 
 const node: NamedNode = <any> {};
 const blankNode: BlankNode = <any> {};
 const predicate: NamedNode = <any> {};
 const literal: Literal = <any> {};
-let term: Term = <any> {};
+const term: Term = <any> {};
 
-// .ctor
 const dataset: Dataset = <any> {};
 const graph: NamedNode = <any> {};
 
-let noContext: clownface.Clownface<Dataset> = new Clownface({ dataset });
-let cf: clownface.SingleContextClownface<Dataset, BlankNode> = noContext.blankNode();
-const typedByTerm: Clownface<DatasetCore, NamedNode> = new Clownface({ dataset, term: node });
-const typedByTerms: Clownface<DatasetCore, NamedNode | BlankNode> = new Clownface({ dataset, term: [node, blankNode] });
-noContext = new Clownface({ dataset, value: 'foo' });
-noContext = new Clownface({ dataset, value: ['foo', 'bar'] });
-noContext = new Clownface({ dataset, term: [term, term], value: ['foo', 'bar'] });
-
-// .addIn
-cf = cf.addIn(node);
-cf = cf.addIn(node, node);
-cf = cf.addIn([ node, node ], node);
-cf = cf.addIn(node, [ node, node ]);
-cf = cf.addIn([ node, node ], [ node, blankNode ], child => {
-    const values: Array<NamedNode | BlankNode> = child.terms;
-});
-cf = cf.addIn(node, child => {
-    const childNode: clownface.SingleContextClownface<Dataset, BlankNode> = child;
-});
-cf = cf.addIn(cf.node(node), cf.node(node));
-
-// .addList
-cf = cf.addList(predicate, [node, node]);
-
-// .addOut
-cf = cf.addOut(predicate, node);
-cf = cf.addOut(predicate);
-cf = cf.addOut(predicate, ['', 0]);
-cf = cf.addOut([predicate, predicate], node);
-cf = cf.addOut(predicate, [node, node]);
-cf = cf.addOut([predicate, predicate], [node, node], child => {
-    const values: string[] = child.values;
-});
-cf = cf.addOut(predicate, child => {
-    const values: string[] = child.values;
-});
-cf = cf.addOut(cf.node(predicate), cf.node(node));
-
-// .blankNode
-let blankContext: clownface.SingleContextClownface<Dataset, BlankNode>;
-blankContext = cf.blankNode();
-blankContext = cf.blankNode('label');
-const multiBlankContext: clownface.SafeClownface<Dataset, BlankNode> = cf.blankNode([ 'b1', 'b2' ]);
-
-// .deleteIn
-cf = cf.deleteIn();
-cf = cf.deleteIn(node);
-cf = cf.deleteIn([node, node]);
-
-// .deleteList
-cf = cf.deleteList(predicate);
-
-// .deleteOut
-cf = cf.deleteOut();
-cf = cf.deleteOut(node);
-cf = cf.deleteOut([node, node]);
-
-// factory
-const namedGraph: clownface.Clownface<Dataset, NamedNode> = clownface({ dataset, graph });
-const singleFromValue: clownface.SingleContextClownface = clownface({ dataset, value: 'foo' });
-
-const termContext: clownface.SingleContextClownface = clownface({
-    dataset,
-    term
-});
-
-const namedContext: clownface.SingleContextClownface<DatasetCore, NamedNode> = clownface({
-    dataset,
-    term: node,
-});
-
-const namedMutlipleTerms: clownface.SafeClownface<DatasetCore, NamedNode> = clownface({
-    dataset,
-    term: [node, node],
-});
-
-const mutlipleValues: clownface.SafeClownface = clownface({
-    dataset,
-    value: ['foo', 'bar'],
-});
-
-const maybeNamed: BlankNode | NamedNode = <any> {};
-const altContext: clownface.SingleContextClownface<DatasetCore, BlankNode | NamedNode> = clownface({
-    dataset,
-    term: maybeNamed,
-});
-
-const literalContext: clownface.SingleContextClownface<Dataset, Literal> = <any> {};
-const deriveContextFromOtherGraph: clownface.SingleContextClownface<Dataset, Literal> = clownface(literalContext);
-
-// .filter
-cf = cf.filter(() => true);
-cf = cf.filter((thus: typeof cf) => true);
-
-// .forEach
-cf.forEach(() => {});
-cf.forEach((thus: typeof cf) => {});
-
-// .has
-let has: clownface.SafeClownface<Dataset> = cf.has(predicate, 'Stuart');
-has = cf.has([predicate, predicate], 'Stuart');
-has = cf.has(predicate, [literal, literal]);
-
-// .in
-let cfIn: clownface.SafeClownface<Dataset> = cf.in();
-cfIn = cf.in(node);
-cfIn = cf.in([node, node]);
-cfIn = cf.in(cf.node(node));
-
-// .list
-const listNodes: Iterable<clownface.SingleContextClownface<Dataset>> = cf.list();
-
-// .literal
-let cfLit: clownface.SafeClownface<Dataset> = cf.literal('foo');
-cfLit = cf.literal(['foo', 'bar']);
-cfLit = cf.literal('foo', node);
-cfLit = cf.literal('foo', 'en');
-
-// .map
-const arr: BlankNode[] = cf.map((item: clownface.SingleContextClownface<Dataset, BlankNode>) => item.term);
-const nums: number[] = cf.map((item: clownface.SingleContextClownface<Dataset, BlankNode>, index: number) => index);
-
-// .namedNode
-let cfSingleNamed: clownface.SingleContextClownface<Dataset, NamedNode> = cf.namedNode(node);
-cfSingleNamed = cf.namedNode('http://example.com/');
-const cfNamedMany: clownface.SafeClownface<Dataset, NamedNode> = cf.namedNode(['http://example.com/', 'http://example.org/']);
-
-// .node
-let singleTerm: clownface.SingleContextClownface<Dataset> = cf.node(node);
-cfLit = cf.node('foo');
-cfLit = cf.node(123);
-const cfLitMany: clownface.SafeClownface<Dataset, Literal> = cf.node(['foo', 'bar']);
-singleTerm = cf.node('http://example.org/', { type: 'NamedNode' });
-const cfBlank: clownface.SingleContextClownface<Dataset, BlankNode> = cf.node(null, { type: 'BlankNode' });
-cfLit = cf.node('example', { datatype: node.value });
-cfLit = cf.node('example', { datatype: node });
-
-// .out
-let cfTerm: clownface.SafeClownface<Dataset> = cf.out();
-cfTerm = cf.out(node);
-cfTerm = cf.out([node, node]);
-cfTerm = cf.out(cf.node([node, node]));
-
-// .term
-if (cf.term) {
-    term = cf.term;
+function testCasting() {
+    const singleNode: clownface.Clownface<NamedNode> = <any> {};
+    const safeContext: clownface.SafeClownface<NamedNode> = singleNode;
+    let noContext: clownface.Clownface = singleNode;
+    noContext = safeContext;
 }
 
-// .terms
-const terms: Term[] = cf.terms;
-
-// .toArray
-const toArray: clownface.Clownface[] = cf.toArray();
-
-// .value
-if (cf.value) {
-    const valueProp: string = cf.value;
+function withoutContext() {
+    const cf: clownface.Clownface<undefined, Dataset> = <any> {};
+    const term: undefined = cf.term;
+    const terms: Term[] = cf.terms;
+    const value: undefined = cf.value;
+    const values: string[] = cf.values;
+    const _context: Array<Context<DatasetCore, Term>> = cf._context;
 }
 
-// .values
-const values: string[] = cf.values;
+function multiContext() {
+    const cf: clownface.Clownface<Array<NamedNode | BlankNode>, Dataset> = <any> {};
+    const term: NamedNode | BlankNode | undefined = cf.term;
+    const terms: Array<NamedNode | BlankNode> = cf.terms;
+    const value: string | undefined = cf.value;
+    const values: string[] = cf.values;
+    const _context: Array<Context<DatasetCore, Term>> = cf._context;
+}
 
-const safeCf: clownface.SafeClownface<Dataset> = <any> {};
+function singleContext() {
+    const cf: clownface.Clownface<Literal, Dataset> = <any> {};
+    const term: Literal = cf.term;
+    const terms: [Literal] = cf.terms;
+    const value: string = cf.value;
+    const values: [string] = cf.values;
+    const _context: Array<Context<DatasetCore, Term>> = cf._context;
 
-let singleBlank: clownface.SingleContextClownface<Dataset, BlankNode> = safeCf.blankNode();
-singleBlank = clownface({ dataset }).blankNode();
-singleBlank = safeCf.blankNode('blank');
-singleBlank = clownface({ dataset }).node(null);
+    const asMultiContext: clownface.Clownface<Literal[] | Literal, Dataset> = cf;
+}
 
-let singleNamed: clownface.SingleContextClownface<Dataset, NamedNode> = clownface({ dataset }).namedNode('urn:foo:bar');
-singleNamed = safeCf.namedNode('http://example.com/a');
-singleNamed = clownface({ dataset }).node(node);
+function testConstructor() {
+    const typedByTerm: Clownface<NamedNode, Dataset> = new Clownface({ dataset, term: node });
+    const typedByTerms: Clownface<Array<NamedNode | BlankNode>, Dataset> = new Clownface({ dataset, term: [node, blankNode] });
 
-let singleLiteral: clownface.SingleContextClownface<Dataset, Literal> = clownface({ dataset }).literal('foo');
-singleLiteral = safeCf.literal('a');
-singleLiteral = clownface({ dataset }).node('b');
+    let contructedWithValueHasTermContext: Clownface<Term, Dataset> = new Clownface({ dataset, value: 'foo' });
+    contructedWithValueHasTermContext = new Clownface({ dataset, value: ['foo', 'bar'] });
+    const anyTerms: clownface.Clownface = new Clownface({ dataset, term: [term, term], value: ['foo', 'bar'] });
+}
 
-const fromSingleArrayBLank: clownface.SingleContextClownface<Dataset, BlankNode> = safeCf.blankNode([ 'b1' ]);
-const fromSingleArrayNamed: clownface.SingleContextClownface<Dataset, NamedNode> = safeCf.namedNode([ 'http://example.com/a' ]);
-const fromSingleArrayLiteral: clownface.SingleContextClownface<Dataset, Literal> = safeCf.literal([ 'a' ]);
+function testAddIn() {
+    let cf: clownface.Clownface<BlankNode> = <any> {};
+    cf = cf.addIn(node);
+    cf = cf.addIn(node);
+    cf = cf.addIn([ node, node ], node);
+    cf = cf.addIn(node, [ node, node ]);
+    cf = cf.addIn([ node, node ], [ node, blankNode ], child => {
+        const values: Array<NamedNode | BlankNode> = child.terms;
+    });
+    cf = cf.addIn(node, child => {
+        const childNode: clownface.Clownface<BlankNode> = child;
+    });
+    cf = cf.addIn(cf.node(node), cf.node(node));
+}
 
-let multipleBlanks: clownface.SafeClownface<Dataset, BlankNode> = safeCf.blankNode([ 'b1', 'b2' ]);
-multipleBlanks = clownface({ dataset }).node([ null, null ]);
+function testAddList() {
+    let cf: clownface.Clownface<NamedNode> = <any> {};
+    cf = cf.addList(predicate, [node]);
+    cf = cf.addList(predicate, [node, node]);
+}
 
-let multipleNamed: clownface.SafeClownface<Dataset, NamedNode> = safeCf.namedNode([ 'http://example.com/a', 'http://example.com/b' ]);
-multipleNamed = clownface({ dataset }).node([ node, node ]);
+function testAddOut() {
+    let cf: clownface.Clownface<BlankNode> = <any> {};
+    cf = cf.addOut(node);
+    cf = cf.addOut(node);
+    cf = cf.addOut([ node, node ], node);
+    cf = cf.addOut(node, [ node, node ]);
+    cf = cf.addOut([ node, node ], [ node, blankNode ], child => {
+        const values: Array<NamedNode | BlankNode> = child.terms;
+    });
+    cf = cf.addOut(node, child => {
+        const childNode: clownface.Clownface<BlankNode> = child;
+    });
+    cf = cf.addOut(cf.node(node), cf.node(node));
+}
 
-let multipleLiterals: clownface.SafeClownface<Dataset, Literal> = safeCf.literal([ 'a', 'b' ]);
-multipleLiterals = clownface({ dataset }).node([ 'a', 10, false ]);
+function testBlankNode() {
+    const cf: clownface.Clownface<Term[], Dataset> = <any> {};
+    let singleBlank: clownface.Clownface<BlankNode, Dataset> = cf.blankNode();
+    singleBlank = cf.blankNode('label');
+    const multiBlankContext: clownface.Clownface<BlankNode[], Dataset> = cf.blankNode([ 'b1', 'b2' ]);
+}
 
-const multipleMixedTerms: clownface.SafeClownface<Dataset> = clownface({ dataset }).node([ 'a', node, null ]);
+function testDeleteIn() {
+    let cf: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    cf = cf.deleteIn();
+    cf = cf.deleteIn(node);
+    cf = cf.deleteIn([node, node]);
+}
 
-// .context
-const ctxTerm: Literal = fromSingleArrayLiteral._context[0].term;
-const ctxGraph: Quad_Graph | undefined = fromSingleArrayLiteral._context[0].graph;
-const ctxDataset: Dataset = fromSingleArrayLiteral._context[0].dataset;
+function testDeleteList() {
+    let cf: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    cf = cf.deleteList(predicate);
+}
 
-// addIn/addOut on SingleContextClownface keeps its type
-const addOutSingle: clownface.SingleContextClownface<Dataset, NamedNode> = singleNamed.addOut(predicate, 'foo');
-const addOutSingleObjectArray: clownface.SingleContextClownface<Dataset, NamedNode> = singleNamed.addOut(predicate, ['foo', 'bar']);
-const addOutSinglePredicateArray: clownface.SingleContextClownface<Dataset, NamedNode> = singleNamed.addOut([predicate, predicate]);
-const addOutSingleNoObject: clownface.SingleContextClownface<Dataset, NamedNode> = singleNamed.addOut(predicate);
-const addOutSingleWithCallback: clownface.SingleContextClownface<Dataset, NamedNode> = singleNamed.addOut(predicate, () => {});
-const addOutSingleWithObjectAndCallback: clownface.SingleContextClownface<Dataset, NamedNode> = singleNamed.addOut(predicate, 'foo', () => {});
+function testDeleteOut() {
+    let cf: clownface.Clownface<BlankNode, Dataset> = <any> {};
+    cf = cf.deleteOut();
+    cf = cf.deleteOut(node);
+    cf = cf.deleteOut([node, node]);
+}
 
-const addInSingle: clownface.SingleContextClownface<Dataset, NamedNode> = singleNamed.addIn(predicate, 'foo');
-const addInSingleObjectArray: clownface.SingleContextClownface<Dataset, NamedNode> = singleNamed.addIn(predicate, ['foo', 'bar']);
-const addInSinglePredicateArray: clownface.SingleContextClownface<Dataset, NamedNode> = singleNamed.addIn([predicate, predicate]);
-const addInSingleNoObject: clownface.SingleContextClownface<Dataset, NamedNode> = singleNamed.addIn(predicate);
-const addInSingleWithCallback: clownface.SingleContextClownface<Dataset, NamedNode> = singleNamed.addIn(predicate, () => {});
-const addInSingleWithObjectAndCallback: clownface.SingleContextClownface<Dataset, NamedNode> = singleNamed.addIn(predicate, 'foo', () => {});
+function testFactory() {
+    const defaultContext: clownface.Clownface<Term | Term[] | undefined, Dataset> = clownface({ dataset });
+
+    const namedGraph: clownface.Clownface<NamedNode, Dataset> = clownface({ dataset, graph, term: node });
+    const singleFromValue: clownface.Clownface<Literal, Dataset> = clownface({ dataset, value: 'foo' });
+
+    const termContext: clownface.Clownface<Term, Dataset> = clownface({
+        dataset,
+        term
+    });
+
+    const namedContext: clownface.Clownface<NamedNode, Dataset> = clownface({
+        dataset,
+        term: node,
+    });
+
+    const namedMutlipleTerms: clownface.Clownface<NamedNode[], Dataset> = clownface({
+        dataset,
+        term: [node, node],
+    });
+
+    const mutlipleValues: clownface.Clownface<Literal[], Dataset> = clownface({
+        dataset,
+        value: ['foo', 'bar'],
+    });
+
+    const maybeNamed: BlankNode | NamedNode = <any> {};
+    const altContext: clownface.Clownface<BlankNode | NamedNode, Dataset> = clownface({
+        dataset,
+        term: maybeNamed,
+    });
+
+    const literalContext: clownface.Clownface<Literal, Dataset> = <any> {};
+    const deriveContextFromOtherGraph: clownface.Clownface<Literal, Dataset> = clownface(literalContext);
+
+    const namedNodeContext: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    const deriveContextFromOtherNamedNodeContext: clownface.Clownface<NamedNode, Dataset> = clownface(namedNodeContext);
+}
+
+function testFilter() {
+    let mutliple: clownface.Clownface<NamedNode[], Dataset> = <any> {};
+    mutliple = mutliple.filter(quad => {
+        const copy: clownface.Clownface<NamedNode, Dataset> = quad;
+        return true;
+    });
+
+    let single: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    single = single.filter(quad => {
+        const copy: clownface.Clownface<NamedNode, Dataset> = quad;
+        return true;
+    });
+
+    let noContext: clownface.Clownface<undefined, Dataset> = <any> {};
+    noContext = noContext.filter(quad => {
+        const copy: never = quad;
+        return true;
+    });
+}
+
+function testForEach() {
+    const mutliple: clownface.Clownface<NamedNode[], Dataset> = <any> {};
+    mutliple.forEach(quad => {
+        const copy: clownface.Clownface<NamedNode, Dataset> = quad;
+        return true;
+    });
+
+    const single: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    single.forEach(quad => {
+        const copy: clownface.Clownface<NamedNode, Dataset> = quad;
+        return true;
+    });
+
+    const noContext: clownface.Clownface<undefined, Dataset> = <any> {};
+    noContext.forEach(quad => {
+        const copy: never = quad;
+        return true;
+    });
+}
+
+function testHas() {
+    const cf: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    let has: clownface.Clownface<Term[], Dataset> = cf.has(predicate, 'Stuart');
+    has = cf.has([predicate, predicate], 'Stuart');
+    has = cf.has(predicate, [literal, literal]);
+}
+
+function testIn() {
+    const cf: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    let cfIn: clownface.Clownface<Term[], Dataset> = cf.in();
+    cfIn = cf.in(node);
+    cfIn = cf.in([node, node]);
+    cfIn = cf.in(cf.node(node));
+    cfIn = cf.in(cf.node([node, node]));
+}
+
+function testList() {
+    const cf: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    const listNodes: Iterable<clownface.Clownface<NamedNode, Dataset>> = cf.list();
+}
+
+function testLiteral() {
+    const cf: clownface.Clownface<undefined, Dataset> = <any> {};
+    let cfOneLit: clownface.Clownface<Literal, Dataset> = cf.literal('foo');
+    const cfLiterasl: clownface.Clownface<Literal[], Dataset> = cf.literal(['foo', 'bar']);
+    cfOneLit = cf.literal('foo', node);
+    cfOneLit = cf.literal('foo', 'en');
+}
+
+function testMap() {
+    const singleContext: clownface.Clownface<BlankNode, Dataset> = <any> {};
+    const multiContext: clownface.Clownface<BlankNode, Dataset> = <any> {};
+    let terms: BlankNode[] = singleContext.map((item) => item.term);
+    terms = multiContext.map((item) => item.term);
+
+    let nums: number[] = singleContext.map((_, index) => index);
+    nums = multiContext.map((_, index) => index);
+}
+
+function testNamedNode() {
+    const cf: clownface.Clownface<undefined, Dataset> = <any> {};
+    let cfSingleNamed: clownface.Clownface<NamedNode, Dataset> = cf.namedNode(node);
+    cfSingleNamed = cf.namedNode('http://example.com/');
+    const cfNamedMany: clownface.Clownface<NamedNode[], Dataset> = cf.namedNode(['http://example.com/', 'http://example.org/']);
+}
+
+function testNode() {
+    const cf: clownface.Clownface<undefined, Dataset> = <any> {};
+    let singleTerm: clownface.Clownface<Term, Dataset> = cf.node(node);
+    let cfLit: clownface.Clownface<Literal, Dataset> = cf.node('foo');
+    cfLit = cf.node(123);
+    const cfLitMany: clownface.Clownface<Literal[], Dataset> = cf.node(['foo', 'bar']);
+    singleTerm = cf.node('http://example.org/', { type: 'NamedNode' });
+    const cfBlank: clownface.Clownface<BlankNode, Dataset> = cf.node(null, { type: 'BlankNode' });
+    cfLit = cf.node('example', { datatype: node.value });
+    cfLit = cf.node('example', { datatype: node });
+}
+
+function testOut() {
+    const cf: clownface.Clownface<undefined, Dataset> = <any> {};
+    let cfTerm: clownface.Clownface<Term[], Dataset> = cf.out();
+    cfTerm = cf.out(node);
+    cfTerm = cf.out([node, node]);
+    cfTerm = cf.out(cf.node([node, node]));
+}
+
+function testToArray() {
+    const single: clownface.Clownface<Literal, Dataset> = <any> {};
+    const singleToArray: Array<clownface.Clownface<Literal, Dataset>> = single.toArray();
+
+    const mutliple: clownface.Clownface<Literal[], Dataset> = <any> {};
+    const mutlipleToArray: Array<clownface.Clownface<Literal, Dataset>> = mutliple.toArray();
+}
+
+function testMultipleContext() {
+    const safeCf: clownface.Clownface<Term[], Dataset> = <any> {};
+
+    let singleBlank: clownface.Clownface<BlankNode, Dataset> = safeCf.blankNode();
+    singleBlank = clownface({ dataset }).blankNode();
+    singleBlank = safeCf.blankNode('blank');
+    singleBlank = clownface({ dataset }).node(null);
+
+    let singleNamed: clownface.Clownface<NamedNode, Dataset> = clownface({ dataset }).namedNode('urn:foo:bar');
+    singleNamed = safeCf.namedNode('http://example.com/a');
+    singleNamed = clownface({ dataset }).node(node);
+
+    let singleLiteral: clownface.Clownface<Literal, Dataset> = clownface({ dataset }).literal('foo');
+    singleLiteral = safeCf.literal('a');
+    singleLiteral = clownface({ dataset }).node('b');
+
+    const fromSingleArrayBLank: clownface.Clownface<BlankNode, Dataset> = safeCf.blankNode([ 'b1' ]);
+    const fromSingleArrayNamed: clownface.Clownface<NamedNode, Dataset> = safeCf.namedNode([ 'http://example.com/a' ]);
+    const fromSingleArrayLiteral: clownface.Clownface<Literal, Dataset> = safeCf.literal([ 'a' ]);
+
+    let multipleBlanks: clownface.Clownface<BlankNode[], Dataset> = safeCf.blankNode([ 'b1', 'b2' ]);
+    multipleBlanks = clownface({ dataset }).node([ null, null ]);
+
+    let multipleNamed: clownface.Clownface<NamedNode[], Dataset> = safeCf.namedNode([ 'http://example.com/a', 'http://example.com/b' ]);
+    multipleNamed = clownface({ dataset }).node([ node, node ]);
+
+    let multipleLiterals: clownface.Clownface<Literal[], Dataset> = safeCf.literal([ 'a', 'b' ]);
+    multipleLiterals = clownface({ dataset }).node([ 'a', 10, false ]);
+
+    const multipleMixedTerms: clownface.Clownface<Term[], Dataset> = clownface({ dataset }).node([ 'a', node, null ]);
+}
+
+function testContext() {
+    const fromSingleArrayLiteral: clownface.Clownface<Literal, Dataset> = <any> {};
+    const ctxTerm: Term = fromSingleArrayLiteral._context[0].term;
+    const ctxGraph: Quad_Graph | undefined = fromSingleArrayLiteral._context[0].graph;
+    const ctxDataset: Dataset = fromSingleArrayLiteral._context[0].dataset;
+}
+
+function addInAddOutRetainsType() {
+    const singleNamed: clownface.Clownface<NamedNode, Dataset> = <any> {};
+
+    const addOutSingle: clownface.Clownface<NamedNode, Dataset> = singleNamed.addOut(predicate, 'foo');
+    const addOutSingleObjectArray: clownface.Clownface<NamedNode, Dataset> = singleNamed.addOut(predicate, ['foo', 'bar']);
+    const addOutSinglePredicateArray: clownface.Clownface<NamedNode, Dataset> = singleNamed.addOut([predicate, predicate]);
+    const addOutSingleNoObject: clownface.Clownface<NamedNode, Dataset> = singleNamed.addOut(predicate);
+    const addOutSingleWithCallback: clownface.Clownface<NamedNode, Dataset> = singleNamed.addOut(predicate, () => {});
+    const addOutSingleWithObjectAndCallback: clownface.Clownface<NamedNode, Dataset> = singleNamed.addOut(predicate, 'foo', () => {});
+
+    const addInSingle: clownface.Clownface<NamedNode, Dataset> = singleNamed.addIn(predicate, 'foo');
+    const addInSingleObjectArray: clownface.Clownface<NamedNode, Dataset> = singleNamed.addIn(predicate, ['foo', 'bar']);
+    const addInSinglePredicateArray: clownface.Clownface<NamedNode, Dataset> = singleNamed.addIn([predicate, predicate]);
+    const addInSingleNoObject: clownface.Clownface<NamedNode, Dataset> = singleNamed.addIn(predicate);
+    const addInSingleWithCallback: clownface.Clownface<NamedNode, Dataset> = singleNamed.addIn(predicate, () => {});
+    const addInSingleWithObjectAndCallback: clownface.Clownface<NamedNode, Dataset> = singleNamed.addIn(predicate, 'foo', () => {});
+}

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -2,21 +2,21 @@
 // Project: https://github.com/rdf-ext/clownface
 // Definitions by: tpluscode <https://github.com/tpluscode>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.2
 
 import { Term, DatasetCore, Quad_Graph, NamedNode, BlankNode, Literal } from 'rdf-js';
 import { Context } from './lib/Context';
 
 declare namespace clownface {
-    type TermOrClownface = Clownface | Term;
-    type TermOrLiteral = TermOrClownface | string | number | boolean;
+    type TermOrClownface<X extends Term = Term> = Clownface | X;
+    type TermOrLiteral<X extends Term = Term> = TermOrClownface<X> | string | number | boolean;
 
     type AddCallback<D extends DatasetCore, X extends Term> = (added: SingleContextClownface<D, X>) => void;
     type SingleOrArray<T> = T | T[];
     type SingleOrOneElementArray<T> = T | [T];
 
-    type SingleOrArrayOfTerms = SingleOrArray<TermOrClownface>;
-    type SingleOrArrayOfTermsOrLiterals = SingleOrArray<TermOrLiteral>;
+    type SingleOrArrayOfTerms<X extends Term> = SingleOrArray<TermOrClownface<X>>;
+    type SingleOrArrayOfTermsOrLiterals<X extends Term> = SingleOrArray<TermOrLiteral<X>>;
 
     interface NodeOptions {
         type?: 'BlankNode' | 'Literal' | 'NamedNode';
@@ -77,28 +77,22 @@ declare namespace clownface {
         namedNode(value: SingleOrOneElementArray<string | NamedNode>): SingleContextClownface<D, NamedNode>;
         namedNode(values: Array<string | NamedNode>): SafeClownface<D, NamedNode>;
 
-        // tslint:disable:no-unnecessary-generics
-        in<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-        out<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
+        in(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D>;
+        out(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D>;
 
-        has<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTermsOrLiterals): SafeClownface<D, X>;
+        has<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>): SafeClownface<D, X>;
 
-        addIn<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, objectOrCallback?: SingleOrOneElementArray<TermOrLiteral> | AddCallback<D, X>): SingleContextClownface<D, X>;
-        addIn<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, object: SingleOrOneElementArray<TermOrLiteral>, callback: AddCallback<D, X>): SingleContextClownface<D, X>;
-        addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
-        addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
+        addIn(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): SafeClownface<D, T>;
+        addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SafeClownface<D, T>;
 
-        addOut<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, objectOrCallback?: SingleOrOneElementArray<TermOrLiteral> | AddCallback<D, X>): SingleContextClownface<D, X>;
-        addOut<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, object: SingleOrOneElementArray<TermOrLiteral>, callback: AddCallback<D, X>): SingleContextClownface<D, X>;
-        addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
-        addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
+        addOut(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): SafeClownface<D, T>;
+        addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SafeClownface<D, T>;
 
-        addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTermsOrLiterals, callback?: AddCallback<D, X>): SafeClownface<D, X>;
+        addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SafeClownface<D, T>;
 
-        deleteIn<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-        deleteOut<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-        deleteList<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
-        // tslint:enable:no-unnecessary-generics
+        deleteIn(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
+        deleteOut(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
+        deleteList(predicates: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
     }
 
     interface SafeClownface<D extends DatasetCore = DatasetCore, T extends Term = Term> extends Clownface<D, T> {
@@ -114,6 +108,20 @@ declare namespace clownface {
         readonly value: string;
         readonly values: [string];
         readonly _context: [Context<D, T>];
+
+        filter(cb: (quad: SingleContextClownface<D, T>) => boolean): SingleContextClownface<D, T>;
+
+        addIn(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): SingleContextClownface<D, T>;
+        addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SingleContextClownface<D, T>;
+
+        addOut(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): SingleContextClownface<D, T>;
+        addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SingleContextClownface<D, T>;
+
+        addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SingleContextClownface<D, T>;
+
+        deleteIn(predicates?: SingleOrArrayOfTerms<Term>): SingleContextClownface<D, T>;
+        deleteOut(predicates?: SingleOrArrayOfTerms<Term>): SingleContextClownface<D, T>;
+        deleteList(predicates: SingleOrArrayOfTerms<Term>): SingleContextClownface<D, T>;
     }
 }
 

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/rdf-ext/clownface
 // Definitions by: tpluscode <https://github.com/tpluscode>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.2
+// TypeScript Version: 3.4
 
 import { Term, DatasetCore, Quad_Graph, NamedNode, BlankNode, Literal } from 'rdf-js';
 import { Context } from './lib/Context';
@@ -12,8 +12,8 @@ declare namespace clownface {
     type TermOrLiteral<X extends Term = Term> = TermOrClownface<X> | string | number | boolean;
 
     type AddCallback<D extends DatasetCore, X extends Term> = (added: SingleContextClownface<D, X>) => void;
-    type SingleOrArray<T> = T | T[];
-    type SingleOrOneElementArray<T> = T | [T];
+    type SingleOrArray<T> = T | readonly T[];
+    type SingleOrOneElementArray<T> = T | readonly [T];
 
     type SingleOrArrayOfTerms<X extends Term> = SingleOrArray<TermOrClownface<X>>;
     type SingleOrArrayOfTermsOrLiterals<X extends Term> = SingleOrArray<TermOrLiteral<X>>;

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -8,133 +8,98 @@ import { Term, DatasetCore, Quad_Graph, NamedNode, BlankNode, Literal } from 'rd
 import { Context } from './lib/Context';
 
 declare namespace clownface {
-    type TermOrClownface<X extends Term = Term> = Clownface | X;
-    type TermOrLiteral<X extends Term = Term> = TermOrClownface<X> | string | number | boolean;
+  type AnyContext = Term | Term[] | undefined;
 
-    type AddCallback<D extends DatasetCore, X extends Term> = (added: SingleContextClownface<D, X>) => void;
-    type SingleOrArray<T> = T | readonly T[];
-    type SingleOrOneElementArray<T> = T | readonly [T];
+  type TermOrClownface<X extends Term = Term> = Clownface<X> | X;
+  type TermOrLiteral<X extends Term = Term> = TermOrClownface<X> | string | number | boolean;
 
-    type SingleOrArrayOfTerms<X extends Term> = SingleOrArray<TermOrClownface<X>>;
-    type SingleOrArrayOfTermsOrLiterals<X extends Term> = SingleOrArray<TermOrLiteral<X>>;
+  type AddCallback<D extends DatasetCore, X extends Term> = (added: Clownface<X, D>) => void;
+  type SingleOrArray<T> = T | readonly T[];
+  type SingleOrOneElementArray<T> = T | readonly [T];
 
-    interface NodeOptions {
-        type?: 'BlankNode' | 'Literal' | 'NamedNode';
-        datatype?: Term | { toString(): string };
-        language?: string;
-    }
+  type SingleOrArrayOfTerms<X extends Term> = SingleOrArray<X> | Clownface<X | X[]>;
+  type SingleOrArrayOfTermsOrLiterals<X extends Term> = SingleOrArray<TermOrLiteral<X>>;
 
-    type ClownfaceInit<D extends DatasetCore = DatasetCore, T extends Term = Term>
-        = Partial<Pick<Clownface<D, T>, 'dataset' | '_context'> & { graph: Quad_Graph }>;
+  interface NodeOptions {
+    type?: 'BlankNode' | 'Literal' | 'NamedNode';
+    datatype?: Term | { toString(): string };
+    language?: string;
+  }
 
-    interface WithSingleValue {
-        value: string;
-    }
+  type ClownfaceInit<D extends DatasetCore = DatasetCore>
+    = Partial<Pick<Clownface<AnyContext, D>, 'dataset' | '_context'> & { graph: Quad_Graph }>;
 
-    interface WithValues {
-        value: string[];
-    }
+  type Iteratee<T extends AnyContext = undefined, D extends DatasetCore = DatasetCore> =
+    T extends undefined
+      ? never
+      : T extends any[]
+      ? Clownface<T[0], D>
+      : Clownface<T, D>;
 
-    interface WithSingleTerm<T extends Term = Term> {
-        term: T;
-    }
+  interface Clownface<T extends AnyContext = AnyContext, D extends DatasetCore = DatasetCore> {
+    readonly term: T extends undefined ? undefined : T extends any[] ? undefined : T;
+    readonly terms: T extends undefined ? Term[] : T extends any[] ? T : [T];
+    readonly value: T extends undefined ? undefined : T extends any[] ? undefined : string;
+    readonly values: T extends undefined ? string[] : T extends any[] ? string[] : [string];
+    readonly dataset: D;
+    readonly datasets: D[];
+    readonly _context: Array<Context<D, Term>>;
+    list(): Iterable<Iteratee<T, D>>;
+    toArray(): Array<Clownface<T extends undefined ? never : T extends any[] ? T[0] : T, D>>;
+    filter(cb: (quad: Iteratee<T, D>) => boolean): Clownface<T, D>;
+    forEach(cb: (quad: Iteratee<T, D>) => void): void;
+    map<X>(cb: (quad: Iteratee<T, D>, index: number) => X): X[];
 
-    interface WithTerms<T extends Term = Term> {
-        term: T[];
-    }
+    node(value: SingleOrOneElementArray<boolean | string | number>, options?: NodeOptions): Clownface<Literal, D>;
+    node(values: Array<boolean | string | number>, options?: NodeOptions): Clownface<Literal[], D>;
 
-    interface Clownface<D extends DatasetCore = DatasetCore, T extends Term = Term> {
-        readonly term: T | undefined;
-        readonly terms: T[];
-        readonly value: string | undefined;
-        readonly values: string[];
-        readonly dataset: D;
-        readonly datasets: D[];
-        readonly _context: Array<Context<D, T>>;
-        list(): Iterable<SingleContextClownface<D>>;
-        toArray(): Array<Clownface<D, T>>;
-        filter(cb: (quad: Clownface<D, T>) => boolean): Clownface<D, T>;
-        forEach(cb: (quad: Clownface<D, T>) => void): void;
-        map<X>(cb: (quad: Clownface<D, T>, index: number) => X): X[];
+    node<X extends Term>(value: SingleOrOneElementArray<X>, options?: NodeOptions): Clownface<X, D>;
+    node<X extends Term[]>(values: X, options?: NodeOptions): Clownface<X, D>;
 
-        node(value: SingleOrOneElementArray<boolean | string | number>, options?: NodeOptions): SingleContextClownface<D, Literal>;
-        node(values: Array<boolean | string | number>, options?: NodeOptions): SafeClownface<D, Literal>;
+    node(value: null, options?: NodeOptions): Clownface<BlankNode, D>;
+    node(values: null[], options?: NodeOptions): Clownface<BlankNode[], D>;
 
-        node<X extends Term>(value: SingleOrOneElementArray<X>, options?: NodeOptions): SingleContextClownface<D, X>;
-        node<X extends Term>(values: X[], options?: NodeOptions): SafeClownface<D, X>;
+    node(values: Array<boolean | string | number | Term | null>, options?: NodeOptions): Clownface<Term[], D>;
 
-        node(value: null, options?: NodeOptions): SingleContextClownface<D, BlankNode>;
-        node(values: null[], options?: NodeOptions): SafeClownface<D, BlankNode>;
+    blankNode(value?: SingleOrOneElementArray<string>): Clownface<BlankNode, D>;
+    blankNode(values: string[]): Clownface<BlankNode[], D>;
 
-        node(values: SingleOrArray<boolean | string | number | Term | null>, options?: NodeOptions): SafeClownface<D>;
+    literal(value: SingleOrOneElementArray<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): Clownface<Literal, D>;
+    literal(values: Array<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): Clownface<Literal[], D>;
 
-        blankNode(value?: SingleOrOneElementArray<string>): SingleContextClownface<D, BlankNode>;
-        blankNode(values: string[]): SafeClownface<D, BlankNode>;
+    namedNode(value: SingleOrOneElementArray<string | NamedNode>): Clownface<NamedNode, D>;
+    namedNode(values: Array<string | NamedNode>): Clownface<NamedNode[], D>;
 
-        literal(value: SingleOrOneElementArray<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): SingleContextClownface<D, Literal>;
-        literal(values: Array<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): SafeClownface<D, Literal>;
+    in(predicates?: SingleOrArrayOfTerms<Term>): Clownface<T extends undefined ? never : Term[], D>;
+    out(predicates?: SingleOrArrayOfTerms<Term>): Clownface<T extends undefined ? never : Term[], D>;
 
-        namedNode(value: SingleOrOneElementArray<string | NamedNode>): SingleContextClownface<D, NamedNode>;
-        namedNode(values: Array<string | NamedNode>): SafeClownface<D, NamedNode>;
+    has<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>): Clownface<X[], D>;
 
-        in(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D>;
-        out(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D>;
+    addIn(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): Clownface<T, D>;
+    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): Clownface<T, D>;
 
-        has<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>): SafeClownface<D, X>;
+    addOut(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): Clownface<T, D>;
+    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): Clownface<T, D>;
 
-        addIn(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): SafeClownface<D, T>;
-        addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SafeClownface<D, T>;
+    addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): Clownface<T, D>;
 
-        addOut(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): SafeClownface<D, T>;
-        addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SafeClownface<D, T>;
+    deleteIn(predicates?: SingleOrArrayOfTerms<Term>): Clownface<T, D>;
+    deleteOut(predicates?: SingleOrArrayOfTerms<Term>): Clownface<T, D>;
+    deleteList(predicates: SingleOrArrayOfTerms<Term>): Clownface<T, D>;
+  }
 
-        addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SafeClownface<D, T>;
+  type SafeClownface<T extends Term = Term, D extends DatasetCore = DatasetCore> = Clownface<T | T[], D>;
+  type SingleContextClownface<T extends Term = Term, D extends DatasetCore = DatasetCore> = Clownface<T, D>;
 
-        deleteIn(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
-        deleteOut(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
-        deleteList(predicates: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
-    }
-
-    interface SafeClownface<D extends DatasetCore = DatasetCore, T extends Term = Term> extends Clownface<D, T> {
-        filter(cb: (quad: SingleContextClownface<D, T>) => boolean): SafeClownface<D, T>;
-        forEach(cb: (quad: SingleContextClownface<D, T>) => void): void;
-        map<X>(cb: (quad: SingleContextClownface<D, T>, index: number) => X): X[];
-        toArray(): Array<SingleContextClownface<D, T>>;
-    }
-
-    interface SingleContextClownface<D extends DatasetCore = DatasetCore, T extends Term = Term> extends SafeClownface<D, T> {
-        readonly term: T;
-        readonly terms: [T];
-        readonly value: string;
-        readonly values: [string];
-        readonly _context: [Context<D, T>];
-
-        filter(cb: (quad: SingleContextClownface<D, T>) => boolean): SingleContextClownface<D, T>;
-
-        addIn(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): SingleContextClownface<D, T>;
-        addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SingleContextClownface<D, T>;
-
-        addOut(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): SingleContextClownface<D, T>;
-        addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SingleContextClownface<D, T>;
-
-        addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): SingleContextClownface<D, T>;
-
-        deleteIn(predicates?: SingleOrArrayOfTerms<Term>): SingleContextClownface<D, T>;
-        deleteOut(predicates?: SingleOrArrayOfTerms<Term>): SingleContextClownface<D, T>;
-        deleteList(predicates: SingleOrArrayOfTerms<Term>): SingleContextClownface<D, T>;
-    }
+  type ClownfaceInitWithTerms<T extends Term | Term[], D extends DatasetCore> = ClownfaceInit<D> & { term: T };
+  type ClownfaceInitWithValue<D extends DatasetCore> = ClownfaceInit<D> & { value: string };
+  type ClownfaceInitWithValues<D extends DatasetCore> = ClownfaceInit<D> & { value: string[] };
 }
 
-type ClownfaceInitWithNodes<D extends DatasetCore, T extends Term> =
-    clownface.ClownfaceInit<D> & clownface.WithTerms<T> |
-    clownface.ClownfaceInit<D> & clownface.WithValues;
-
-type ClownfaceInitWithSingleNode<D extends DatasetCore, T extends Term> =
-    clownface.ClownfaceInit<D> & clownface.WithSingleTerm<T> |
-    clownface.ClownfaceInit<D> & clownface.WithSingleValue;
-
-declare function clownface<D extends DatasetCore, T extends Term = Term>(options: ClownfaceInitWithNodes<D, T>): clownface.SafeClownface<D, T>;
-declare function clownface<D extends DatasetCore, T extends Term = Term>(options: ClownfaceInitWithSingleNode<D, T>): clownface.SingleContextClownface<D, T>;
-declare function clownface<D extends DatasetCore, T extends Term = Term>(options: clownface.ClownfaceInit<D, T>): clownface.Clownface<D, T>;
+declare function clownface<D extends DatasetCore, T extends clownface.AnyContext>(other: clownface.Clownface<T, D>): clownface.Clownface<T, D>;
+declare function clownface<D extends DatasetCore>(options: clownface.ClownfaceInitWithValue<D>): clownface.Clownface<Literal, D>;
+declare function clownface<D extends DatasetCore>(options: clownface.ClownfaceInitWithValues<D>): clownface.Clownface<Literal[], D>;
+declare function clownface<D extends DatasetCore, T extends Term | Term[]>(options: clownface.ClownfaceInitWithTerms<T, D>): clownface.Clownface<T, D>;
+declare function clownface<D extends DatasetCore>(options: clownface.ClownfaceInit<D>): clownface.Clownface<clownface.AnyContext, D>;
 
 export = clownface;

--- a/types/clownface/lib/Clownface.d.ts
+++ b/types/clownface/lib/Clownface.d.ts
@@ -52,28 +52,22 @@ declare class Clownface<D extends DatasetCore = DatasetCore, T extends Term = Te
     namedNode(value: SingleOrOneElementArray<string | NamedNode>): SingleContextClownface<D, NamedNode>;
     namedNode(values: Array<string | NamedNode>): SafeClownface<D, NamedNode>;
 
-    // tslint:disable:no-unnecessary-generics
-    in<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-    out<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
+    in(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D>;
+    out(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D>;
 
-    has<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTermsOrLiterals): SafeClownface<D, X>;
+    has<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>): SafeClownface<D, X>;
 
-    addIn<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, objectOrCallback?: SingleOrOneElementArray<TermOrLiteral> | AddCallback<D, X>): SingleContextClownface<D, X>;
-    addIn<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, object: SingleOrOneElementArray<TermOrLiteral>, callback: AddCallback<D, X>): SingleContextClownface<D, X>;
-    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
-    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
+    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals<X> | AddCallback<D, X>): SafeClownface<D, T>;
+    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback: AddCallback<D, X>): SafeClownface<D, T>;
 
-    addOut<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, objectOrCallback?: SingleOrOneElementArray<TermOrLiteral> | AddCallback<D, X>): SingleContextClownface<D, X>;
-    addOut<X extends Term = Term>(predicate: SingleOrOneElementArray<Term>, object: SingleOrOneElementArray<TermOrLiteral>, callback: AddCallback<D, X>): SingleContextClownface<D, X>;
-    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals | AddCallback<D, X>): SafeClownface<D, X>;
-    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects: SingleOrArrayOfTermsOrLiterals, callback: AddCallback<D, X>): SafeClownface<D, X>;
+    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals<X> | AddCallback<D, X>): SafeClownface<D, T>;
+    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback: AddCallback<D, X>): SafeClownface<D, T>;
 
-    addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms, objects?: SingleOrArrayOfTerms, callback?: AddCallback<D, X>): SafeClownface<D, X>;
+    addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTerms<X>, callback?: AddCallback<D, X>): SafeClownface<D, T>;
 
-    deleteIn<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-    deleteOut<X extends Term = Term>(predicates?: SingleOrArrayOfTerms): SafeClownface<D, X>;
-    deleteList<X extends Term = Term>(predicates: SingleOrArrayOfTerms): SafeClownface<D, X>;
-    // tslint:enable:no-unnecessary-generics
+    deleteIn(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
+    deleteOut(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
+    deleteList(predicates: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
 }
 
 export = Clownface;

--- a/types/clownface/lib/Clownface.d.ts
+++ b/types/clownface/lib/Clownface.d.ts
@@ -1,73 +1,72 @@
-import { BlankNode, DatasetCore, Literal, NamedNode, Quad_Graph, Term, Variable, DefaultGraph } from 'rdf-js';
+import { BlankNode, DatasetCore, Literal, NamedNode, Quad_Graph, Term, Variable, DefaultGraph, Quad } from 'rdf-js';
 import {
     Clownface as ClownfaceContract,
     ClownfaceInit,
     AddCallback,
     NodeOptions,
-    SafeClownface,
-    SingleOrArray,
     SingleOrArrayOfTerms,
     SingleOrArrayOfTermsOrLiterals,
-    WithValues,
-    WithSingleValue,
-    WithTerms,
-    WithSingleTerm,
-    SingleContextClownface,
+    ClownfaceInitWithTerms,
+    ClownfaceInitWithValue,
+    ClownfaceInitWithValues,
     SingleOrOneElementArray,
-    TermOrLiteral
+    Iteratee,
+    AnyContext
 } from '..';
 import { Context } from './Context';
 
-declare class Clownface<D extends DatasetCore = DatasetCore, T extends Term = Term> implements ClownfaceContract<D, T> {
-    constructor(options: ClownfaceInit & Partial<WithSingleTerm<T> | WithTerms<T>> & Partial<WithSingleValue | WithValues>);
-    readonly term: T | undefined;
-    readonly terms: T[];
-    readonly value: string | undefined;
-    readonly values: string[];
+declare class Clownface<T extends AnyContext = AnyContext, D extends DatasetCore = DatasetCore> implements ClownfaceContract<T, D> {
+    constructor(options: ClownfaceInit<D> | ClownfaceInitWithTerms<Term | Term[], D> | ClownfaceInitWithValue<D> | ClownfaceInitWithValues<D>);
+
+    readonly term: T extends undefined ? undefined : T extends any[] ? undefined : T;
+    readonly terms: T extends undefined ? Term[] : T extends any[] ? T : [T];
+    readonly value: T extends undefined ? undefined : T extends any[] ? undefined : string;
+    readonly values: T extends undefined ? string[] : T extends any[] ? string[] : [string];
     readonly dataset: D;
     readonly datasets: D[];
-    readonly _context: Array<Context<D, T>>;
-    list(): Iterable<SingleContextClownface<D>>;
-    toArray(): Array<Clownface<D, T>>;
-    filter(cb: (quad: Clownface<D, T>) => boolean): Clownface<D, T>;
-    forEach(cb: (quad: Clownface<D, T>) => void): void;
-    map<X>(cb: (quad: Clownface<D, T>, index: number) => X): X[];
+    readonly _context: Array<Context<D, Term>>;
+    list(): Iterable<Iteratee<T, D>>;
+    toArray(): Array<Clownface<T extends undefined ? never : T extends any[] ? T[0] : T, D>>;
+    filter(cb: (quad: Iteratee<T, D>) => boolean): Clownface<T, D>;
+    forEach(cb: (quad: Iteratee<T, D>) => void): void;
+    map<X>(cb: (quad: Iteratee<T, D>, index: number) => X): X[];
 
-    node(value: SingleOrOneElementArray<string | number | boolean>, options?: NodeOptions): SingleContextClownface<D, Literal>;
-    node(values: Array<string | number | boolean>, options?: NodeOptions): SafeClownface<D, Literal>;
-    node<X extends Term>(value: SingleOrOneElementArray<X>, options?: NodeOptions): SingleContextClownface<D, X>;
-    node<X extends Term>(values: X[], options?: NodeOptions): SafeClownface<D, X>;
-    node(value: null, options?: NodeOptions): SingleContextClownface<D, BlankNode>;
-    node(values: null[], options?: NodeOptions): SafeClownface<D, BlankNode>;
-    node(values: SingleOrArray<string | number | boolean | NamedNode | BlankNode | Literal | Variable | DefaultGraph | null>, options?: NodeOptions): SafeClownface<D>;
+    node(value: SingleOrOneElementArray<boolean | string | number>, options?: NodeOptions): Clownface<Literal, D>;
+    node(values: Array<boolean | string | number>, options?: NodeOptions): Clownface<Literal[], D>;
 
-    blankNode(value?: string | [string]): SingleContextClownface<D, BlankNode>;
-    blankNode(values: string[]): SafeClownface<D, BlankNode>;
+    node<X extends Term>(value: SingleOrOneElementArray<X>, options?: NodeOptions): Clownface<X, D>;
+    node<X extends Term[]>(values: X, options?: NodeOptions): Clownface<X, D>;
 
-    literal(
-        value: SingleOrOneElementArray<string | number | boolean | NamedNode | BlankNode | Literal | Variable | DefaultGraph | null>,
-        languageOrDatatype?: string | NamedNode): SingleContextClownface<D, Literal>;
-    literal(values: Array<string | number | boolean | NamedNode | BlankNode | Literal | Variable | DefaultGraph | null>, languageOrDatatype?: string | NamedNode): SafeClownface<D, Literal>;
+    node(value: null, options?: NodeOptions): Clownface<BlankNode, D>;
+    node(values: null[], options?: NodeOptions): Clownface<BlankNode[], D>;
 
-    namedNode(value: SingleOrOneElementArray<string | NamedNode>): SingleContextClownface<D, NamedNode>;
-    namedNode(values: Array<string | NamedNode>): SafeClownface<D, NamedNode>;
+    node(values: Array<boolean | string | number | Term | null>, options?: NodeOptions): Clownface<Term[], D>;
 
-    in(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D>;
-    out(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D>;
+    blankNode(value?: SingleOrOneElementArray<string>): Clownface<BlankNode, D>;
+    blankNode(values: string[]): Clownface<BlankNode[], D>;
 
-    has<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>): SafeClownface<D, X>;
+    literal(value: SingleOrOneElementArray<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): Clownface<Literal, D>;
+    literal(values: Array<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): Clownface<Literal[], D>;
 
-    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals<X> | AddCallback<D, X>): SafeClownface<D, T>;
-    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback: AddCallback<D, X>): SafeClownface<D, T>;
+    namedNode(value: SingleOrOneElementArray<string | NamedNode>): Clownface<NamedNode, D>;
+    namedNode(values: Array<string | NamedNode>): Clownface<NamedNode[], D>;
 
-    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objectsOrCallback?: SingleOrArrayOfTermsOrLiterals<X> | AddCallback<D, X>): SafeClownface<D, T>;
-    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback: AddCallback<D, X>): SafeClownface<D, T>;
+    in(predicates?: SingleOrArrayOfTerms<Term>): Clownface<T extends undefined ? never : Term[], D>;
+    out(predicates?: SingleOrArrayOfTerms<Term>): Clownface<T extends undefined ? never : Term[], D>;
 
-    addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTerms<X>, callback?: AddCallback<D, X>): SafeClownface<D, T>;
+    has<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>): Clownface<X[], D>;
 
-    deleteIn(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
-    deleteOut(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
-    deleteList(predicates: SingleOrArrayOfTerms<Term>): SafeClownface<D, T>;
+    addIn(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): Clownface<T, D>;
+    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): Clownface<T, D>;
+
+    addOut(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): Clownface<T, D>;
+    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): Clownface<T, D>;
+
+    addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): Clownface<T, D>;
+
+    deleteIn(predicates?: SingleOrArrayOfTerms<Term>): Clownface<T, D>;
+    deleteOut(predicates?: SingleOrArrayOfTerms<Term>): Clownface<T, D>;
+    deleteList(predicates: SingleOrArrayOfTerms<Term>): Clownface<T, D>;
 }
 
 export = Clownface;


### PR DESCRIPTION
This is a big change of how the types are structured.

Most notable the sub-interfaces are removed do that only one remains. They are replaced with type aliases and what the inheritance/overloading achieved is not done by type conditional types.

Importantly, the core interface changed its generic args order

```diff
-Clownface<DatasetCore, Term>
+Clownface<Term, DatasetCore>
```

This way it's less verbose to declare variables narrowed down to a specific node type without having to call out the default value of `DatasetCore` which would be less commonly changed.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.