### PR TITLE
Add types for react-native-calendar-picker

### DIFF
--- a/types/react-native-calendar-picker/index.d.ts
+++ b/types/react-native-calendar-picker/index.d.ts
@@ -1,0 +1,95 @@
+// Type definitions for react-native-calendar-picker 6.0
+// Project: https://github.com/stephy/CalendarPicker
+// Definitions by: Tobias Hann <https://github.com/automatensalat>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import * as React from 'react';
+import { StyleProp, TextStyle, ViewStyle } from 'react-native';
+import { Moment, MomentInput } from 'moment';
+
+export default class CalendarPicker extends React.Component<CalendarPickerProps> {
+    handleOnPressDay(day: number): void;
+    handleOnPressNext(): void;
+    handleOnPressPrevious(): void;
+    resetSelections(): void;
+}
+
+export interface CalendarPickerProps {
+    weekdays?: string[];
+    months?: string[];
+    startFromMonday?: boolean;
+    allowRangeSelection?: boolean;
+    previousTitle?: string;
+    nextTitle?: string;
+    selectedDayColor?: string;
+    selectedDayStyle?: StyleProp<ViewStyle>;
+    selectedDayTextColor?: string;
+    selectedRangeStartStyle?: StyleProp<ViewStyle>;
+    selectedRangeEndStyle?: StyleProp<ViewStyle>;
+    selectedRangeStyle?: StyleProp<ViewStyle>;
+    disabledDates?: Date[] | DisabledDatesFunc;
+    disabledDatesTextStyle?: StyleProp<TextStyle>;
+    selectedStartDate?: Date;
+    selectedEndDate?: Date;
+    minRangeDuration?: number | MinDurationArrayItem[];
+    maxRangeDuration?: number | MaxDurationArrayItem[];
+    todayBackgroundColor?: string;
+    todayTextStyle?: StyleProp<TextStyle>;
+    textStyle?: StyleProp<TextStyle>;
+    customDatesStyles?: CustomDateStyle[];
+    scaleFactor?: number;
+    minDate?: Date;
+    maxDate?: Date;
+    initialDate?: Date;
+    width?: number;
+    height?: number;
+    swipeConfig?: SwipeConfig;
+    enableSwipe?: boolean;
+    enableDateChange?: boolean;
+    restrictMonthNavigation?: boolean;
+    onDateChange?: DateChangedCallback;
+    onMonthChange?: DateChangedCallback;
+    onSwipe?: SwipeCallback;
+    dayShape?: 'circle' | 'square';
+    headingLevel?: number;
+    previousTitleStyle?: StyleProp<TextStyle>;
+    nextTitleStyle?: StyleProp<TextStyle>;
+    dayLabelsWrapper?: StyleProp<ViewStyle>;
+    dayOfWeekStyles?: DayOfWeekStyle;
+}
+
+export type DayOfWeekStyle = {
+    [key in '0' | '1' | '2' | '3' | '4' | '5' | '6']?: TextStyle;
+};
+
+export type DisabledDatesFunc = (date: Moment) => boolean;
+
+export type MomentParsable = MomentInput;
+
+export interface MinDurationArrayItem {
+    date: MomentParsable;
+    minDuration: number;
+}
+
+export interface MaxDurationArrayItem {
+    date: MomentParsable;
+    maxDuration: number;
+}
+
+export interface CustomDateStyle {
+    date: MomentParsable;
+    containerStyle?: ViewStyle;
+    style?: ViewStyle;
+    textStyle?: TextStyle;
+}
+
+export type DateChangedCallback = (date: Moment) => void;
+
+export interface SwipeConfig {
+    velocityThreshold?: number;
+    directionalOffsetThreshold?: number;
+}
+export type SwipeDirection = 'SWIPE_LEFT' | 'SWIPE_RIGHT' | 'SWIPE_UP' | 'SWIPE_DOWN';
+
+export type SwipeCallback = (swipeDirection: SwipeDirection) => void;

--- a/types/react-native-calendar-picker/package.json
+++ b/types/react-native-calendar-picker/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "moment": ">=2.0.0"
+    }
+}

--- a/types/react-native-calendar-picker/react-native-calendar-picker-tests.tsx
+++ b/types/react-native-calendar-picker/react-native-calendar-picker-tests.tsx
@@ -1,0 +1,156 @@
+import * as React from 'react';
+
+import CalendarPicker, {
+    DateChangedCallback,
+    SwipeCallback,
+    CustomDateStyle,
+    DisabledDatesFunc,
+} from 'react-native-calendar-picker';
+
+const TestSimpleProps = () => (
+    <CalendarPicker
+        weekdays={['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So']}
+        months={[
+            'Janeiro',
+            'Fevereiro',
+            'Março',
+            'Abril',
+            'Maio',
+            'Junho',
+            'Julho',
+            'Agosto',
+            'Setembro',
+            'Outubro',
+            'Novembro',
+            'Dezembro',
+        ]}
+        startFromMonday
+        allowRangeSelection
+        previousTitle="string"
+        nextTitle="string"
+        selectedDayColor="string"
+        selectedDayStyle={{ flex: 1 }}
+        selectedDayTextColor="string"
+        selectedRangeStartStyle={{ flex: 1 }}
+        selectedRangeEndStyle={{ flex: 1 }}
+        selectedRangeStyle={{ flex: 1 }}
+        disabledDates={[new Date(), new Date()]}
+        disabledDatesTextStyle={{ fontSize: 10 }}
+        selectedStartDate={new Date()}
+        selectedEndDate={new Date()}
+        minRangeDuration={1}
+        maxRangeDuration={2}
+        todayBackgroundColor="string"
+        todayTextStyle={{ fontSize: 10 }}
+        textStyle={{ fontSize: 10 }}
+        scaleFactor={3}
+        minDate={new Date()}
+        maxDate={new Date()}
+        initialDate={new Date()}
+        width={3}
+        height={3}
+        enableSwipe
+        enableDateChange
+        restrictMonthNavigation
+        dayShape="circle"
+        headingLevel={3}
+        previousTitleStyle={{ fontSize: 10 }}
+        nextTitleStyle={{ fontSize: 10 }}
+        dayLabelsWrapper={{ flex: 1 }}
+    />
+);
+
+const TestRangeDurations = () => {
+    return (
+        <CalendarPicker
+            minRangeDuration={[
+                { date: new Date(), minDuration: 4 },
+                { date: new Date(), minDuration: 3 },
+            ]}
+            maxRangeDuration={[
+                { date: new Date(), maxDuration: 4 },
+                { date: new Date(), maxDuration: 3 },
+            ]}
+        />
+    );
+};
+
+const TestDisabledDates = () => {
+    const isDateDisabled: DisabledDatesFunc = date => date.day() % 2 === 1;
+    return <CalendarPicker disabledDates={isDateDisabled} />;
+};
+
+const TestCustomDateStyle = () => {
+    const onDateChange: DateChangedCallback = date => console.log(date.day());
+
+    const customStyles: CustomDateStyle[] = [
+        {
+            date: new Date(),
+            containerStyle: { flex: 1 },
+            style: { flex: 1 },
+            textStyle: { fontSize: 10 },
+        },
+        {
+            date: '2020-10-10',
+            style: { flex: 1 },
+        },
+    ];
+
+    return <CalendarPicker customDatesStyles={customStyles} />;
+};
+
+const TestCallbacks = () => {
+    const onDateChange: DateChangedCallback = date => console.log(date.day());
+
+    return <CalendarPicker onDateChange={onDateChange} onMonthChange={onDateChange} />;
+};
+
+const TestRef = () => {
+    const ref = React.useRef<CalendarPicker>();
+    ref.current!.handleOnPressNext();
+    ref.current!.handleOnPressPrevious();
+    ref.current!.handleOnPressDay(3);
+    ref.current!.resetSelections();
+};
+
+const TestDayOfWeekStyles = () => {
+    return (
+        <CalendarPicker
+            allowRangeSelection
+            previousTitle="<"
+            previousTitleStyle={{ color: '#fff' }}
+            nextTitle=">"
+            nextTitleStyle={{ color: '#f00' }}
+            dayLabelsWrapper={{
+                borderBottomWidth: 0,
+                borderTopWidth: 0,
+            }}
+            dayOfWeekStyles={{
+                0: {
+                    color: '#00f',
+                    fontSize: 22,
+                    fontWeight: 'bold',
+                    backgroundColor: '#ff0',
+                },
+                5: {
+                    color: '#000',
+                    fontSize: 22,
+                },
+            }}
+        />
+    );
+};
+
+const TestSwipe = () => {
+    const onSwipe: SwipeCallback = direction => {
+        const b: boolean = direction === 'invalid'; // $ExpectError
+        if (direction === 'SWIPE_RIGHT') console.log('swiped right');
+    };
+    return (
+        <CalendarPicker
+            swipeConfig={{ directionalOffsetThreshold: 3, velocityThreshold: 4 }}
+            enableSwipe
+            onSwipe={onSwipe}
+        />
+    );
+};

--- a/types/react-native-calendar-picker/tsconfig.json
+++ b/types/react-native-calendar-picker/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react-native"
+    },
+    "files": [
+        "index.d.ts",
+        "react-native-calendar-picker-tests.tsx"
+    ]
+}

--- a/types/react-native-calendar-picker/tslint.json
+++ b/types/react-native-calendar-picker/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
