### PR TITLE
Updated to Joigoose v4.0.8+

### DIFF
--- a/types/joigoose/index.d.ts
+++ b/types/joigoose/index.d.ts
@@ -1,11 +1,12 @@
-// Type definitions for joigoose 2.0
+// Type definitions for joigoose 5.0
 // Project: https://github.com/yoitsro/joigoose
 // Definitions by: Karoline <https://github.com/boothwhack>
+//                 Luke <https://github.com/lukecarr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
 import * as Mongoose from "mongoose";
-import * as Joi from "joi";
+import * as Joi from "hapi__joi";
 
 declare namespace Joigoose {
     interface Joigoose {

--- a/types/joigoose/joigoose-tests.ts
+++ b/types/joigoose/joigoose-tests.ts
@@ -1,6 +1,6 @@
 import Joigoose = require("joigoose");
 import * as Mongoose from "mongoose";
-import * as Joi from "joi";
+import * as Joi from "hapi__joi";
 
 let joigoose = Joigoose(Mongoose);
 const options: Joi.ValidationOptions = {abortEarly: true};


### PR DESCRIPTION
Since Joigoose v4.0.8 (current types are for v2), they have moved to the namespaced Joi library as a dependency (`@hapi/joi` over `joi`). The author decided to increment the patch version when implementing such a change 🤷‍♂ so I've had to pick the next suitable release after `4.0.8` for the header version (`5.0`) as it wouldn't accept a version with a patch number.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present)

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Commit changing from joi to @hapi/joi](https://github.com/yoitsro/joigoose/commit/7cfe450e7a8209ad7649d609baa566065e124d62)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
