### PR TITLE
@types/node: Add inherited stream events to fs.ReadStream and fs.WriteStream

### DIFF
--- a/types/klaw/index.d.ts
+++ b/types/klaw/index.d.ts
@@ -30,7 +30,7 @@ declare module "klaw" {
             preserveSymlinks?: boolean
         }
 
-        type Event = "close" | "data" | "end" | "readable" | "error"
+        type Event = "close" | "data" | "end" | "error" | "pause" | "readable" | "resume"
 
         interface Walker extends Readable {
             on(event: Event, listener: Function): this

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -134,62 +134,131 @@ declare module "fs" {
         close(): void;
         bytesRead: number;
         path: string | Buffer;
+        pending: boolean;
 
         /**
          * events.EventEmitter
          *   1. open
          *   2. close
+         *   3. ready
          */
-        addListener(event: string, listener: (...args: any[]) => void): this;
-        addListener(event: "open", listener: (fd: number) => void): this;
         addListener(event: "close", listener: () => void): this;
+        addListener(event: "data", listener: (chunk: Buffer | string) => void): this;
+        addListener(event: "end", listener: () => void): this;
+        addListener(event: "error", listener: (err: Error) => void): this;
+        addListener(event: "open", listener: (fd: number) => void): this;
+        addListener(event: "pause", listener: () => void): this;
+        addListener(event: "readable", listener: () => void): this;
+        addListener(event: "ready", listener: () => void): this;
+        addListener(event: "resume", listener: () => void): this;
+        addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        on(event: string, listener: (...args: any[]) => void): this;
-        on(event: "open", listener: (fd: number) => void): this;
         on(event: "close", listener: () => void): this;
+        on(event: "data", listener: (chunk: Buffer | string) => void): this;
+        on(event: "end", listener: () => void): this;
+        on(event: "error", listener: (err: Error) => void): this;
+        on(event: "open", listener: (fd: number) => void): this;
+        on(event: "pause", listener: () => void): this;
+        on(event: "readable", listener: () => void): this;
+        on(event: "ready", listener: () => void): this;
+        on(event: "resume", listener: () => void): this;
+        on(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        once(event: string, listener: (...args: any[]) => void): this;
-        once(event: "open", listener: (fd: number) => void): this;
         once(event: "close", listener: () => void): this;
+        once(event: "data", listener: (chunk: Buffer | string) => void): this;
+        once(event: "end", listener: () => void): this;
+        once(event: "error", listener: (err: Error) => void): this;
+        once(event: "open", listener: (fd: number) => void): this;
+        once(event: "pause", listener: () => void): this;
+        once(event: "readable", listener: () => void): this;
+        once(event: "ready", listener: () => void): this;
+        once(event: "resume", listener: () => void): this;
+        once(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        prependListener(event: string, listener: (...args: any[]) => void): this;
-        prependListener(event: "open", listener: (fd: number) => void): this;
         prependListener(event: "close", listener: () => void): this;
+        prependListener(event: "data", listener: (chunk: Buffer | string) => void): this;
+        prependListener(event: "end", listener: () => void): this;
+        prependListener(event: "error", listener: (err: Error) => void): this;
+        prependListener(event: "open", listener: (fd: number) => void): this;
+        prependListener(event: "pause", listener: () => void): this;
+        prependListener(event: "readable", listener: () => void): this;
+        prependListener(event: "ready", listener: () => void): this;
+        prependListener(event: "resume", listener: () => void): this;
+        prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        prependOnceListener(event: string, listener: (...args: any[]) => void): this;
-        prependOnceListener(event: "open", listener: (fd: number) => void): this;
         prependOnceListener(event: "close", listener: () => void): this;
+        prependOnceListener(event: "data", listener: (chunk: Buffer | string) => void): this;
+        prependOnceListener(event: "end", listener: () => void): this;
+        prependOnceListener(event: "error", listener: (err: Error) => void): this;
+        prependOnceListener(event: "open", listener: (fd: number) => void): this;
+        prependOnceListener(event: "pause", listener: () => void): this;
+        prependOnceListener(event: "readable", listener: () => void): this;
+        prependOnceListener(event: "ready", listener: () => void): this;
+        prependOnceListener(event: "resume", listener: () => void): this;
+        prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 
     class WriteStream extends stream.Writable {
         close(): void;
         bytesWritten: number;
         path: string | Buffer;
+        pending: boolean;
 
         /**
          * events.EventEmitter
          *   1. open
          *   2. close
+         *   3. ready
          */
-        addListener(event: string, listener: (...args: any[]) => void): this;
-        addListener(event: "open", listener: (fd: number) => void): this;
         addListener(event: "close", listener: () => void): this;
+        addListener(event: "drain", listener: () => void): this;
+        addListener(event: "error", listener: (err: Error) => void): this;
+        addListener(event: "finish", listener: () => void): this;
+        addListener(event: "open", listener: (fd: number) => void): this;
+        addListener(event: "pipe", listener: (src: stream.Readable) => void): this;
+        addListener(event: "ready", listener: () => void): this;
+        addListener(event: "unpipe", listener: (src: stream.Readable) => void): this;
+        addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        on(event: string, listener: (...args: any[]) => void): this;
-        on(event: "open", listener: (fd: number) => void): this;
         on(event: "close", listener: () => void): this;
+        on(event: "drain", listener: () => void): this;
+        on(event: "error", listener: (err: Error) => void): this;
+        on(event: "finish", listener: () => void): this;
+        on(event: "open", listener: (fd: number) => void): this;
+        on(event: "pipe", listener: (src: stream.Readable) => void): this;
+        on(event: "ready", listener: () => void): this;
+        on(event: "unpipe", listener: (src: stream.Readable) => void): this;
+        on(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        once(event: string, listener: (...args: any[]) => void): this;
-        once(event: "open", listener: (fd: number) => void): this;
         once(event: "close", listener: () => void): this;
+        once(event: "drain", listener: () => void): this;
+        once(event: "error", listener: (err: Error) => void): this;
+        once(event: "finish", listener: () => void): this;
+        once(event: "open", listener: (fd: number) => void): this;
+        once(event: "pipe", listener: (src: stream.Readable) => void): this;
+        once(event: "ready", listener: () => void): this;
+        once(event: "unpipe", listener: (src: stream.Readable) => void): this;
+        once(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        prependListener(event: string, listener: (...args: any[]) => void): this;
-        prependListener(event: "open", listener: (fd: number) => void): this;
         prependListener(event: "close", listener: () => void): this;
+        prependListener(event: "drain", listener: () => void): this;
+        prependListener(event: "error", listener: (err: Error) => void): this;
+        prependListener(event: "finish", listener: () => void): this;
+        prependListener(event: "open", listener: (fd: number) => void): this;
+        prependListener(event: "pipe", listener: (src: stream.Readable) => void): this;
+        prependListener(event: "ready", listener: () => void): this;
+        prependListener(event: "unpipe", listener: (src: stream.Readable) => void): this;
+        prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        prependOnceListener(event: string, listener: (...args: any[]) => void): this;
-        prependOnceListener(event: "open", listener: (fd: number) => void): this;
         prependOnceListener(event: "close", listener: () => void): this;
+        prependOnceListener(event: "drain", listener: () => void): this;
+        prependOnceListener(event: "error", listener: (err: Error) => void): this;
+        prependOnceListener(event: "finish", listener: () => void): this;
+        prependOnceListener(event: "open", listener: (fd: number) => void): this;
+        prependOnceListener(event: "pipe", listener: (src: stream.Readable) => void): this;
+        prependOnceListener(event: "ready", listener: () => void): this;
+        prependOnceListener(event: "unpipe", listener: (src: stream.Readable) => void): this;
+        prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 
     /**

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -50,56 +50,72 @@ declare module "stream" {
              * 1. close
              * 2. data
              * 3. end
-             * 4. readable
-             * 5. error
+             * 4. error
+             * 5. pause
+             * 6. readable
+             * 7. resume
              */
             addListener(event: "close", listener: () => void): this;
             addListener(event: "data", listener: (chunk: any) => void): this;
             addListener(event: "end", listener: () => void): this;
-            addListener(event: "readable", listener: () => void): this;
             addListener(event: "error", listener: (err: Error) => void): this;
+            addListener(event: "pause", listener: () => void): this;
+            addListener(event: "readable", listener: () => void): this;
+            addListener(event: "resume", listener: () => void): this;
             addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
             emit(event: "close"): boolean;
             emit(event: "data", chunk: any): boolean;
             emit(event: "end"): boolean;
-            emit(event: "readable"): boolean;
             emit(event: "error", err: Error): boolean;
+            emit(event: "pause"): boolean;
+            emit(event: "readable"): boolean;
+            emit(event: "resume"): boolean;
             emit(event: string | symbol, ...args: any[]): boolean;
 
             on(event: "close", listener: () => void): this;
             on(event: "data", listener: (chunk: any) => void): this;
             on(event: "end", listener: () => void): this;
-            on(event: "readable", listener: () => void): this;
             on(event: "error", listener: (err: Error) => void): this;
+            on(event: "pause", listener: () => void): this;
+            on(event: "readable", listener: () => void): this;
+            on(event: "resume", listener: () => void): this;
             on(event: string | symbol, listener: (...args: any[]) => void): this;
 
             once(event: "close", listener: () => void): this;
             once(event: "data", listener: (chunk: any) => void): this;
             once(event: "end", listener: () => void): this;
-            once(event: "readable", listener: () => void): this;
             once(event: "error", listener: (err: Error) => void): this;
+            once(event: "pause", listener: () => void): this;
+            once(event: "readable", listener: () => void): this;
+            once(event: "resume", listener: () => void): this;
             once(event: string | symbol, listener: (...args: any[]) => void): this;
 
             prependListener(event: "close", listener: () => void): this;
             prependListener(event: "data", listener: (chunk: any) => void): this;
             prependListener(event: "end", listener: () => void): this;
-            prependListener(event: "readable", listener: () => void): this;
             prependListener(event: "error", listener: (err: Error) => void): this;
+            prependListener(event: "pause", listener: () => void): this;
+            prependListener(event: "readable", listener: () => void): this;
+            prependListener(event: "resume", listener: () => void): this;
             prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
             prependOnceListener(event: "close", listener: () => void): this;
             prependOnceListener(event: "data", listener: (chunk: any) => void): this;
             prependOnceListener(event: "end", listener: () => void): this;
-            prependOnceListener(event: "readable", listener: () => void): this;
             prependOnceListener(event: "error", listener: (err: Error) => void): this;
+            prependOnceListener(event: "pause", listener: () => void): this;
+            prependOnceListener(event: "readable", listener: () => void): this;
+            prependOnceListener(event: "resume", listener: () => void): this;
             prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
             removeListener(event: "close", listener: () => void): this;
             removeListener(event: "data", listener: (chunk: any) => void): this;
             removeListener(event: "end", listener: () => void): this;
-            removeListener(event: "readable", listener: () => void): this;
             removeListener(event: "error", listener: (err: Error) => void): this;
+            removeListener(event: "pause", listener: () => void): this;
+            removeListener(event: "readable", listener: () => void): this;
+            removeListener(event: "resume", listener: () => void): this;
             removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
             [Symbol.asyncIterator](): AsyncIterableIterator<any>;


### PR DESCRIPTION
I was surprised the other day when I tried to call `.on('...')` on a stream obtained from `fs.createWriteStream()` and it didn't suggest `'finish'` as a possible event name. 
This PR will allow for type-checking and autocompletion of events inherited by `fs.ReadStream` and `fs.WriteStream` from `stream.Readable` and `stream.Writable`, respectively.

Also added:
- `'ready'` event (from Node 9.x) and `pending` field (from Node 11.x) to both `fs` streams
- `'pause'` and `'resume'` events on `stream.Readable` (from Node 0.x)

There are some other stream subclasses which are missing a few of these events, but didn't seem worth changing:
- `Http2Stream` and subclasses
- `Http2ServerRequest`
- `Socket`

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/fs.html#fs_class_fs_readstream, https://nodejs.org/api/fs.html#fs_class_fs_writestream, https://nodejs.org/api/stream.html#stream_event_pause, https://nodejs.org/api/stream.html#stream_event_resume
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.