### PR TITLE
Fix bent response

### DIFF
--- a/types/bent/index.d.ts
+++ b/types/bent/index.d.ts
@@ -5,6 +5,7 @@
 // TypeScript Version: 2.7
 
 /// <reference types="node" />
+/// <reference lib="dom" />
 
 import { PassThrough, Stream } from 'stream';
 

--- a/types/bent/index.d.ts
+++ b/types/bent/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mikeal/bent#readme
 // Definitions by: Ovyerus <https://github.com/Ovyerus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.7
+// TypeScript Version: 3.0
 
 /// <reference types="node" />
 /// <reference lib="dom" />


### PR DESCRIPTION
For some reason including dom in the lib doesn't appear to work, and tsc throws an error if the user doesn't include `dom` in their own project.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Fixes #43456.