### PR TITLE
fix(moo): Add missing Lexer methods

### DIFF
--- a/types/moo/index.d.ts
+++ b/types/moo/index.d.ts
@@ -96,6 +96,19 @@ export interface Lexer {
      * to reset() to explicitly control the internal state of the lexer.
      */
     save(): LexerState;
+    /**
+     * Transitions to the provided state and pushes the state onto the state
+     * stack.
+     */
+    pushState(state: string): void;
+    /**
+     * Returns back to the previous state in the stack.
+     */
+    popState(): void;
+    /**
+     * Transitiosn to the provided state. Does not push onto the state stack.
+     */
+    setState(state: string): void;
 
     [Symbol.iterator](): Iterator<Token>;
 }

--- a/types/moo/moo-tests.ts
+++ b/types/moo/moo-tests.ts
@@ -55,6 +55,11 @@ lexer = moo.states({
     },
 });
 
+lexer.pushState('lit');
+lexer.popState();
+lexer.setState('lit');
+lexer.popState();
+
 moo.compile({
     myError: moo.error
 });


### PR DESCRIPTION
Some state transition methods were missing from the `Lexer` interface. There are cases where you may want to use these (for example: https://github.com/no-context/moo/issues/115)

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/no-context/moo/blob/56ccbdd41b493332bc2cd7a4097a5802594cdb9c/moo.js#L406-L423
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.