### PR TITLE
Fix: ref type in Animated Component

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8676,10 +8676,16 @@ export namespace Animated {
     //     : AnimatedComponent<T extends React.ComponentClass<ComponentProps<T>> ? InstanceType<T> : T>;
 
     export function createAnimatedComponent<
-        T extends React.ComponentType<any> | React.Component<any>
+        T extends React.ComponentType<any> | React.Component<any> | React.ForwardRefExoticComponent<any>
     >(
         component: T,
-    ): AnimatedComponent<T extends React.ComponentClass<any> ? InstanceType<T> : T>;
+    ): AnimatedComponent<
+        // TODO: This seems equivalent to React.ElementRef<T> no?
+        T extends React.ForwardRefExoticComponent<infer FP>
+            ? FP extends React.RefAttributes<infer FC>
+                ? FC
+                : never
+            : T extends React.ComponentClass<any> ? InstanceType<T> : T>;
 
     // export type AnimatedComponent<T extends React.Component<any> | React.ComponentType<P>, P = {}> = React.ComponentType<P>;
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8638,7 +8638,46 @@ export namespace Animated {
 
     export type AnimatedProps<T> = { [K in keyof Pick<T, Exclude<keyof T, 'ref'>>]: WithAnimatedValue<T[K]> };
 
-    export interface AnimatedComponent<T extends React.ComponentType<any> | React.Component<any>> extends React.ForwardRefExoticComponent<React.PropsWithoutRef<AnimatedProps<ComponentProps<T>>> & React.RefAttributes<T>> {
+    // type AnimatedRef<T> =
+
+    // export type AnimatedComponent<
+    //     T extends React.ComponentType<any> | React.Component<any> | React.ForwardRefExoticComponent<any>
+    // > = React.ForwardRefExoticComponent<
+    //     AnimatedProps<React.PropsWithoutRef<ComponentProps<T>>> &
+    //         React.RefAttributes<
+    //             T extends React.ForwardRefExoticComponent<React.RefAttributes<infer FT>>
+    //                 ? FT
+    //                 : T extends React.ComponentClass<any>
+    //                 ? InstanceType<T>
+    //                 : T
+    //         >
+    // >;
+
+    // export type AnimatedComponent<
+    //     T extends React.ComponentType<any> | React.Component<any> | React.ForwardRefExoticComponent<any>
+    // > = T extends React.ForwardRefExoticComponent<React.RefAttributes<infer FT>>
+    //     ? React.ForwardRefExoticComponent<
+    //           AnimatedProps<React.PropsWithoutRef<ComponentProps<FT>>> &
+    //               React.RefAttributes<FT extends React.ComponentClass<any> ? InstanceType<FT> : FT>
+    //       >
+    //     : React.ForwardRefExoticComponent<
+    //           AnimatedProps<React.PropsWithoutRef<ComponentProps<T>>> &
+    //               React.RefAttributes<T extends React.ComponentClass<any> ? InstanceType<T> : T>
+    //       >;
+
+    export interface AnimatedComponent<
+        T extends React.ComponentType<any> | React.Component<any> | React.ForwardRefExoticComponent<any>
+    >
+        extends React.ForwardRefExoticComponent<
+            AnimatedProps<React.PropsWithoutRef<ComponentProps<T>>> &
+                React.RefAttributes<
+                    T extends React.ForwardRefExoticComponent<React.RefAttributes<infer FT>>
+                        ? FT
+                        : T extends React.ComponentClass<any>
+                        ? InstanceType<T>
+                        : T
+                >
+        > {
         /**
          * @deprecated Use the `ref` prop instead.
          */
@@ -8677,15 +8716,8 @@ export namespace Animated {
 
     export function createAnimatedComponent<
         T extends React.ComponentType<any> | React.Component<any> | React.ForwardRefExoticComponent<any>
-    >(
-        component: T,
-    ): AnimatedComponent<
-        // TODO: This seems equivalent to React.ElementRef<T> no?
-        T extends React.ForwardRefExoticComponent<infer FP>
-            ? FP extends React.RefAttributes<infer FC>
-                ? FC
-                : never
-            : T extends React.ComponentClass<any> ? InstanceType<T> : T>;
+        // >(component: T): AnimatedComponent<T extends React.ComponentClass<any> ? InstanceType<T> : T>;
+    >(component: T): AnimatedComponent<T>;
 
     // export type AnimatedComponent<T extends React.Component<any> | React.ComponentType<P>, P = {}> = React.ComponentType<P>;
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8638,49 +8638,52 @@ export namespace Animated {
 
     export type AnimatedProps<T> = { [K in keyof Pick<T, Exclude<keyof T, 'ref'>>]: WithAnimatedValue<T[K]> };
 
-    export interface AnimatedComponent<
-        T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>
-    >
-        extends React.FC<
-            AnimatedProps<ComponentProps<T>> & {
-                ref?: React.Ref<AnimatedComponent<T>>;
-            }
-        > {
+    export interface AnimatedComponent<T extends React.ComponentType<any> | React.Component<any>> extends React.ForwardRefExoticComponent<React.PropsWithoutRef<AnimatedProps<ComponentProps<T>>> & React.RefAttributes<T>> {
         /**
          * @deprecated Use the `ref` prop instead.
          */
         getNode: () => T;
     }
 
-    export interface AnimatedForwardRefComponent<
-        T extends React.ForwardRefExoticComponent<ComponentProps<T> & React.RefAttributes<P>>,
-        P extends React.ComponentType<ComponentProps<P>> | React.Component<ComponentProps<P>>
-    >
-        extends React.FC<
-            AnimatedProps<ComponentProps<T>> & {
-                ref?: React.Ref<
-                    AnimatedComponent<P extends React.ComponentClass<ComponentProps<P>> ? InstanceType<P> : P>
-                >;
-            }
-        > {
-        /**
-         * @deprecated Use the `ref` prop instead.
-         */
-        getNode: () => P;
-    }
+    // export interface AnimatedForwardRefComponent<
+    //     T extends React.ForwardRefExoticComponent<ComponentProps<T> & React.RefAttributes<P>>,
+    //     P extends React.ComponentType<ComponentProps<P>> | React.Component<ComponentProps<P>>
+    // >
+    //     extends React.FC<
+    //         AnimatedProps<ComponentProps<T>> & {
+    //             ref?: React.Ref<
+    //                 P extends React.ComponentClass<ComponentProps<P>> ? InstanceType<P> : P
+    //             >;
+    //         }
+    //     > {
+    //     /**
+    //      * @deprecated Use the `ref` prop instead.
+    //      */
+    //     getNode: () => P;
+    // }
 
     /**
      * Make any React component Animatable.  Used to create `Animated.View`, etc.
      */
+    // export function createAnimatedComponent<
+    //     T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>
+    // >(
+    //     component: T,
+    // ): T extends React.ForwardRefExoticComponent<ComponentProps<T> & React.RefAttributes<infer P>>
+    //     ? P extends React.ComponentType<ComponentProps<P>> | React.Component<ComponentProps<P>>
+    //         ? AnimatedForwardRefComponent<T, P>
+    //         : never
+    //     : AnimatedComponent<T extends React.ComponentClass<ComponentProps<T>> ? InstanceType<T> : T>;
+
     export function createAnimatedComponent<
-        T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>
+        T extends React.ComponentType<any> | React.Component<any>
     >(
         component: T,
-    ): T extends React.ForwardRefExoticComponent<ComponentProps<T> & React.RefAttributes<infer P>>
-        ? P extends React.ComponentType<ComponentProps<P>> | React.Component<ComponentProps<P>>
-            ? AnimatedForwardRefComponent<T, P>
-            : never
-        : AnimatedComponent<T extends React.ComponentClass<ComponentProps<T>> ? InstanceType<T> : T>;
+    ): AnimatedComponent<T extends React.ComponentClass<any> ? InstanceType<T> : T>;
+
+    // export type AnimatedComponent<T extends React.Component<any> | React.ComponentType<P>, P = {}> = React.ComponentType<P>;
+
+    // export function createAnimatedComponent<T extends React.Component<any> | React.ComponentType<any>>(component: T): AnimatedComponent<T>
 
     /**
      * Animated variants of the basic native views. Accepts Animated.Value for

--- a/types/react-native/test/animated.tsx
+++ b/types/react-native/test/animated.tsx
@@ -29,26 +29,26 @@ function TestAnimatedAPI() {
     const v2 = new Animated.Value(0);
 
     // Ref
-    const AnimatedViewRef = React.useRef<typeof Animated.View>(null);
+    const AnimatedViewRef = React.useRef<View>(null);
 
     AnimatedViewRef.current &&
-        AnimatedViewRef.current.getNode().measure(() => {
+        AnimatedViewRef.current.measure(() => {
             return;
         });
 
     const AnimatedComp = Animated.createAnimatedComponent(Comp);
 
-    const AnimatedCompRef = React.useRef<typeof AnimatedComp>(null);
+    const AnimatedCompRef = React.useRef<React.ElementRef<typeof AnimatedComp>>(null);
 
-    AnimatedCompRef.current && AnimatedCompRef.current.getNode().f1();
+    AnimatedCompRef.current && AnimatedCompRef.current.f1();
 
     const AnimatedForwardComp = Animated.createAnimatedComponent(ForwardComp);
 
-    const AnimatedForwardCompRef = React.useRef<Animated.AnimatedComponent<View>>(null);
+    const AnimatedForwardCompRef = React.useRef<React.ElementRef<typeof AnimatedForwardComp>>(null);
     const ForwardCompRef = React.useRef<View>(null);
 
     AnimatedForwardCompRef.current &&
-        AnimatedForwardCompRef.current.getNode().measure(() => {
+        AnimatedForwardCompRef.current.measure(() => {
             return;
         });
 

--- a/types/react-native/test/animated.tsx
+++ b/types/react-native/test/animated.tsx
@@ -2,10 +2,55 @@ import * as React from 'react';
 
 import { Animated, View, NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
 
+interface CompProps {
+    width: number;
+}
+
+class Comp extends React.Component<CompProps> {
+    f1: () => boolean = () => true;
+
+    render() {
+        const { width } = this.props;
+        return <View style={{ width }} />;
+    }
+}
+
+const ForwardComp = React.forwardRef<View, CompProps>(({ width }, ref) => {
+    function f1(): boolean {
+        return true;
+    }
+
+    return <View ref={ref} style={{ width }} />;
+});
+
 function TestAnimatedAPI() {
     // Value
     const v1 = new Animated.Value(0);
     const v2 = new Animated.Value(0);
+
+    // Ref
+    const AnimatedViewRef = React.useRef<typeof Animated.View>(null);
+
+    AnimatedViewRef.current &&
+        AnimatedViewRef.current.getNode().measure(() => {
+            return;
+        });
+
+    const AnimatedComp = Animated.createAnimatedComponent(Comp);
+
+    const AnimatedCompRef = React.useRef<typeof AnimatedComp>(null);
+
+    AnimatedCompRef.current && AnimatedCompRef.current.getNode().f1();
+
+    const AnimatedForwardComp = Animated.createAnimatedComponent(ForwardComp);
+
+    const AnimatedForwardCompRef = React.useRef<Animated.AnimatedComponent<View>>(null);
+    const ForwardCompRef = React.useRef<View>(null);
+
+    AnimatedForwardCompRef.current &&
+        AnimatedForwardCompRef.current.getNode().measure(() => {
+            return;
+        });
 
     v1.setValue(0.1);
 
@@ -18,28 +63,23 @@ function TestAnimatedAPI() {
         outputRange: [0, 200],
     });
 
-    Animated.timing(v2, {
-        toValue: v1.interpolate({ inputRange: [0, 1], outputRange: [0, 200] }),
-        useNativeDriver: false,
-    });
-
     // ValueXY
     const position = new Animated.ValueXY({ x: 0, y: 0 });
 
     // Animation functions
     const spring1 = Animated.spring(v1, {
+        useNativeDriver: false,
         toValue: 0.5,
         tension: 10,
         delay: 100,
-        useNativeDriver: false,
     });
 
     const springXY = Animated.spring(position, {
+        useNativeDriver: false,
         toValue: {
             x: 1,
             y: 2,
         },
-        useNativeDriver: false,
     });
 
     spring1.start();
@@ -47,8 +87,8 @@ function TestAnimatedAPI() {
 
     Animated.parallel(
         [
-            Animated.spring(v1, { toValue: 1, useNativeDriver: false }),
-            Animated.spring(v2, { toValue: 1, useNativeDriver: false }),
+            Animated.spring(v1, { useNativeDriver: false, toValue: 1 }),
+            Animated.spring(v2, { useNativeDriver: false, toValue: 1 }),
         ],
         {
             stopTogether: true,
@@ -56,16 +96,16 @@ function TestAnimatedAPI() {
     );
 
     Animated.decay(v1, {
-        velocity: 2,
         useNativeDriver: false,
+        velocity: 2,
     });
 
     Animated.timing(v1, {
+        useNativeDriver: false,
         toValue: 1,
         duration: 100,
         delay: 100,
         easing: v => v,
-        useNativeDriver: false,
     });
 
     Animated.add(v1, v2);
@@ -91,6 +131,7 @@ function TestAnimatedAPI() {
     return (
         <View>
             <Animated.View
+                ref={AnimatedViewRef}
                 style={[
                     position.getLayout(),
                     {
@@ -98,7 +139,9 @@ function TestAnimatedAPI() {
                     },
                 ]}
             />
-
+            <AnimatedComp ref={AnimatedCompRef} width={v1} />
+            <ForwardComp ref={ForwardCompRef} width={1} />
+            <AnimatedForwardComp ref={AnimatedForwardCompRef} width={10} />
             <Animated.Image style={position.getTranslateTransform()} source={{ uri: 'https://picsum.photos/200' }} />
         </View>
     );

--- a/types/react-native/test/animated.tsx
+++ b/types/react-native/test/animated.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Animated, View, NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
+import { Animated, View, NativeSyntheticEvent, NativeScrollEvent, ComponentProps } from 'react-native';
 
 interface CompProps {
     width: number;
@@ -23,6 +23,8 @@ const ForwardComp = React.forwardRef<View, CompProps>(({ width }, ref) => {
     return <View ref={ref} style={{ width }} />;
 });
 
+type X = React.PropsWithoutRef<ComponentProps<typeof ForwardComp>>;
+
 function TestAnimatedAPI() {
     // Value
     const v1 = new Animated.Value(0);
@@ -43,6 +45,7 @@ function TestAnimatedAPI() {
     AnimatedCompRef.current && AnimatedCompRef.current.f1();
 
     const AnimatedForwardComp = Animated.createAnimatedComponent(ForwardComp);
+    type X = Animated.AnimatedComponent<typeof ForwardComp>;
 
     const AnimatedForwardCompRef = React.useRef<React.ElementRef<typeof AnimatedForwardComp>>(null);
     const ForwardCompRef = React.useRef<View>(null);


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/42806

These are the changes from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42446 re-applied on top of current `master`.

@zusinShinpei I don’t think these changes are correct at the moment, though. What I understand from [the upstream change](https://github.com/facebook/react-native/commit/66e72bb4e00aafbcb9f450ed5db261d98f99f82a) is that the `ref` of an animated component should return the _underlying_ component, i.e. the non-animated one.

The test coverage in the upstream change is a little hard to understand, but this is what I understand it should do:

```tsx
<Animated.View ref={ref => assert(ref instanceof View)} />
```