### PR TITLE
Add jest-cucumber-fusion

### DIFF
--- a/types/jest-cucumber-fusion/index.d.ts
+++ b/types/jest-cucumber-fusion/index.d.ts
@@ -3,18 +3,19 @@
 // Definitions by: Pelle Johnsen <https://github.com/pjoe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { loadFeature } from 'jest-cucumber';
+declare module 'jest-cucumber-fusion' {
+    import { loadFeature } from 'jest-cucumber';
 
-type CallBack = (...args: ReadonlyArray<string>) => void | Promise<void>;
+    type CallBack = (...args: ReadonlyArray<string>) => void | Promise<void>;
 
-export function Given(name: string | RegExp, callback: CallBack): void;
-export function When(name: string | RegExp, callback: CallBack): void;
-export function Then(name: string | RegExp, callback: CallBack): void;
-export function And(name: string | RegExp, callback: CallBack): void;
-export function But(name: string | RegExp, callback: CallBack): void;
+    export function Given(name: string | RegExp, callback: CallBack): void;
+    export function When(name: string | RegExp, callback: CallBack): void;
+    export function Then(name: string | RegExp, callback: CallBack): void;
+    export function And(name: string | RegExp, callback: CallBack): void;
+    export function But(name: string | RegExp, callback: CallBack): void;
 
-export function Before(callback: () => void | Promise<void>): void;
-export function After(callback: () => void | Promise<void>): void;
+    export function Before(callback: () => void | Promise<void>): void;
+    export function After(callback: () => void | Promise<void>): void;
 
-export function Fusion(feature: string, options?: Parameters<typeof loadFeature>[1]): void;
-
+    export function Fusion(feature: string, options?: Parameters<typeof loadFeature>[1]): void;
+}

--- a/types/jest-cucumber-fusion/index.d.ts
+++ b/types/jest-cucumber-fusion/index.d.ts
@@ -2,20 +2,19 @@
 // Project: https://github.com/b-yond-infinite-network/jest-cucumber-fusion#readme
 // Definitions by: Pelle Johnsen <https://github.com/pjoe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.4
 
-declare module 'jest-cucumber-fusion' {
-    import { loadFeature } from 'jest-cucumber';
+import { loadFeature } from 'jest-cucumber';
 
-    type CallBack = (...args: ReadonlyArray<string | Record<string, string>[]>) => void | Promise<void>;
+export type CallBack = (...args: ReadonlyArray<string | Array<Record<string, string>>>) => void | Promise<void>;
 
-    export function Given(name: string | RegExp, callback: CallBack): void;
-    export function When(name: string | RegExp, callback: CallBack): void;
-    export function Then(name: string | RegExp, callback: CallBack): void;
-    export function And(name: string | RegExp, callback: CallBack): void;
-    export function But(name: string | RegExp, callback: CallBack): void;
+export function Given(name: string | RegExp, callback: CallBack): void;
+export function When(name: string | RegExp, callback: CallBack): void;
+export function Then(name: string | RegExp, callback: CallBack): void;
+export function And(name: string | RegExp, callback: CallBack): void;
+export function But(name: string | RegExp, callback: CallBack): void;
 
-    export function Before(callback: () => void | Promise<void>): void;
-    export function After(callback: () => void | Promise<void>): void;
+export function Before(callback: () => void | Promise<void>): void;
+export function After(callback: () => void | Promise<void>): void;
 
-    export function Fusion(feature: string, options?: Parameters<typeof loadFeature>[1]): void;
-}
+export function Fusion(feature: string, options?: Parameters<typeof loadFeature>[1]): void;

--- a/types/jest-cucumber-fusion/index.d.ts
+++ b/types/jest-cucumber-fusion/index.d.ts
@@ -6,7 +6,7 @@
 declare module 'jest-cucumber-fusion' {
     import { loadFeature } from 'jest-cucumber';
 
-    type CallBack = (...args: ReadonlyArray<string>) => void | Promise<void>;
+    type CallBack = (...args: ReadonlyArray<string | Record<string, string>[]>) => void | Promise<void>;
 
     export function Given(name: string | RegExp, callback: CallBack): void;
     export function When(name: string | RegExp, callback: CallBack): void;

--- a/types/jest-cucumber-fusion/index.d.ts
+++ b/types/jest-cucumber-fusion/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for jest-cucumber-fusion 0.6
+// Project: https://github.com/b-yond-infinite-network/jest-cucumber-fusion#readme
+// Definitions by: Pelle Johnsen <https://github.com/pjoe>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { loadFeature } from 'jest-cucumber';
+
+type CallBack = (...args: ReadonlyArray<string>) => void | Promise<void>;
+
+export function Given(name: string | RegExp, callback: CallBack): void;
+export function When(name: string | RegExp, callback: CallBack): void;
+export function Then(name: string | RegExp, callback: CallBack): void;
+export function And(name: string | RegExp, callback: CallBack): void;
+export function But(name: string | RegExp, callback: CallBack): void;
+
+export function Before(callback: () => void | Promise<void>): void;
+export function After(callback: () => void | Promise<void>): void;
+
+export function Fusion(feature: string, options?: Parameters<typeof loadFeature>[1]): void;
+

--- a/types/jest-cucumber-fusion/jest-cucumber-fusion-tests.ts
+++ b/types/jest-cucumber-fusion/jest-cucumber-fusion-tests.ts
@@ -1,7 +1,8 @@
 import * as jcf from 'jest-cucumber-fusion';
 
-function cb(...args: string[]): void {}
-async function cbAsync(...args: string[]): Promise<void> {}
+type CbArgs = ReadonlyArray<string | Array<Record<string, string>>>;
+function cb(...args: CbArgs): void {}
+async function cbAsync(...args: CbArgs): Promise<void> {}
 
 jcf.Given('', cb); // $ExpectType void
 jcf.Given('', cbAsync); // $ExpectType void
@@ -25,7 +26,7 @@ jcf.Before(() => {}); // $ExpectType void
 jcf.Before(async () => {}); // $ExpectType void
 
 jcf.Fusion(''); // $ExpectType void
-jcf.Fusion('', {errors: true}); // $ExpectType void
-jcf.Fusion('', {loadRelativePath: true}); // $ExpectType void
-jcf.Fusion('', {scenarioNameTemplate: (vars) => vars.featureTitle}); // $ExpectType void
-jcf.Fusion('', {tagFilter: ""}); // $ExpectType void
+jcf.Fusion('', { errors: true }); // $ExpectType void
+jcf.Fusion('', { loadRelativePath: true }); // $ExpectType void
+jcf.Fusion('', { scenarioNameTemplate: vars => vars.featureTitle }); // $ExpectType void
+jcf.Fusion('', { tagFilter: '' }); // $ExpectType void

--- a/types/jest-cucumber-fusion/jest-cucumber-fusion-tests.ts
+++ b/types/jest-cucumber-fusion/jest-cucumber-fusion-tests.ts
@@ -1,0 +1,31 @@
+import * as jcf from 'jest-cucumber-fusion';
+
+function cb(...args: string[]): void {}
+async function cbAsync(...args: string[]): Promise<void> {}
+
+jcf.Given('', cb); // $ExpectType void
+jcf.Given('', cbAsync); // $ExpectType void
+
+jcf.When('', cb); // $ExpectType void
+jcf.When('', cbAsync); // $ExpectType void
+
+jcf.Then('', cb); // $ExpectType void
+jcf.Then('', cbAsync); // $ExpectType void
+
+jcf.And('', cb); // $ExpectType void
+jcf.And('', cbAsync); // $ExpectType void
+
+jcf.But('', cb); // $ExpectType void
+jcf.But('', cbAsync); // $ExpectType void
+
+jcf.After(() => {}); // $ExpectType void
+jcf.After(async () => {}); // $ExpectType void
+
+jcf.Before(() => {}); // $ExpectType void
+jcf.Before(async () => {}); // $ExpectType void
+
+jcf.Fusion(''); // $ExpectType void
+jcf.Fusion('', {errors: true}); // $ExpectType void
+jcf.Fusion('', {loadRelativePath: true}); // $ExpectType void
+jcf.Fusion('', {scenarioNameTemplate: (vars) => vars.featureTitle}); // $ExpectType void
+jcf.Fusion('', {tagFilter: ""}); // $ExpectType void

--- a/types/jest-cucumber-fusion/package.json
+++ b/types/jest-cucumber-fusion/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "jest-cucumber": "^2.0.11"
+    }
+}

--- a/types/jest-cucumber-fusion/tsconfig.json
+++ b/types/jest-cucumber-fusion/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "target": "es6",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jest-cucumber-fusion-tests.ts"
+    ]
+}

--- a/types/jest-cucumber-fusion/tslint.json
+++ b/types/jest-cucumber-fusion/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
  **NOTE:** can't run `npm test`, pending on whitelist of `jest-cucumber`: https://github.com/microsoft/types-publisher/pull/760
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
  **NOTE:** getting errors from external import `jest-cucumber`:
  ```
  Error: Errors in typescript@2.8 for external dependencies:
  node_modules/jest-cucumber/dist/src/configuration.d.ts(5,24): error TS2304: Cannot find name 
  'import'.
  ```
  Not really sure how to deal with this

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
