### PR TITLE
akamai-edgeworkers: Update type definitions to include new API (routing, setvariable)

### DIFF
--- a/types/akamai-edgeworkers/README.md
+++ b/types/akamai-edgeworkers/README.md
@@ -29,10 +29,10 @@ with the following stubs:
 ```typescript
 /// <reference types="akamai-edgeworkers"/>
 
-export function onClientRequest(request : EW.MutableRequest & EW.HasRespondWith){}
-export function onOriginRequest(request : EW.MutableRequest) {}
-export function onOriginResponse(request : EW.ImmutableRequest & EW.HasRespondWith, response : EW.Response) {}
-export function onClientResponse(request : EW.ImmutableRequest, response : EW.Response) {} 
+export function onClientRequest(request: EW.IngressClientRequest) {}
+export function onOriginRequest(request: EW.IngressOriginRequest) {}
+export function onOriginResponse(request: EW.EgressOriginRequest, response: EW.EgressOriginResponse) {}
+export function onClientResponse(request: EW.EgressClientRequest, response: EW.EgressClientResponse) {}
 ```
 
 The triple-slashed first line references this package and pulls `EW` into your 

--- a/types/akamai-edgeworkers/index.d.ts
+++ b/types/akamai-edgeworkers/index.d.ts
@@ -30,9 +30,17 @@ declare namespace EW {
 
     interface ReadsVariables {
         /**
-         * Get's the value of a request variable
+         * Gets the value of a metadata variable
          */
         getVariable(name: string): string | undefined;
+    }
+
+    interface MutatesVariables {
+        /**
+         * Sets the value of a metadata variable, throwing an error if the
+         * variable name does not start with 'PMUSER_'
+         */
+        setVariable(name: string, value: string): void;
     }
 
     interface HasRespondWith {
@@ -66,6 +74,72 @@ declare namespace EW {
          * The HTTP status of a response sent to the client.
          */
         status: number;
+    }
+
+    interface HasRoute {
+        /**
+         * If called, indicates that the request should be routed to a pre-specified origin
+         * server,or have the path or query string modified.
+         *
+         * @param destination Object holding properties that will control route
+         */
+        route(destination: Destination): void;
+    }
+
+    interface CacheKey {
+        /**
+         * Specifies that the entire query string should be excluded from the cache key. By
+         * default, the entire query string is part of the cache key.
+         */
+        excludeQueryString(): void;
+
+        /**
+         * Specifies that the entire query string should be included from the cache key. This is
+         * done by default, however it is provided as an API to be reverted to the default.
+         */
+        includeQueryString(): void;
+
+        /**
+         * Specifies that the named query argument is included in the cache key. Can be called
+         * multiple times to include multiple query arguments. Calling this function will result
+         * in all query arguments not explicitly included to be excluded from the cache key. By
+         * default, the entire query string is part of the cache key. This would override previous
+         * calls to "excludeQueryString()" or "includeQueryString()".
+         *
+         * @param name The name of the query arg to include in the cache key
+         */
+        includeQueryArgument(name: string): void;
+
+        /**
+         * Specifies that the named cookie is included in the cache key. Can be called multiple
+         * times to include multiple cookies.
+         *
+         * @param name The name of the cookie to include in the cid
+         */
+        includeCookie(name: string): void;
+
+        /**
+         * Specifies that the named HTTP request header is included in the cache key. Can be
+         * called multiple times to include multiple headers.
+         *
+         * @param name The name of the header to include in the cid
+         */
+        includeHeader(name: string): void;
+
+        /**
+         * Specifies that the named variable is included in the cache key. Can be called multiple
+         * times to include multiple variable.
+         *
+         * @param name The name of the variable to include in the cid
+         */
+        includeVariable(name: string): void;
+    }
+
+    interface HasCacheKey {
+        /**
+         * An object for manipulating this requests cache key. Only present during `onClientRequest()`.
+         */
+        readonly cacheKey: CacheKey;
     }
 
     interface Request {
@@ -121,13 +195,49 @@ declare namespace EW {
         readonly cpCode: number;
     }
 
+    // Legacy interfaces for backwards compatability
     interface MutableRequest extends MutatesHeaders, ReadsHeaders, ReadsVariables, Request {
     }
-
     interface ImmutableRequest extends ReadsHeaders, ReadsVariables, Request {
     }
-
     interface Response extends HasStatus, MutatesHeaders, ReadsHeaders {
+    }
+
+    // onClientRequest
+    interface IngressClientRequest extends MutatesHeaders, ReadsHeaders, ReadsVariables, Request, HasRespondWith, HasRoute, HasCacheKey, MutatesVariables {
+    }
+
+    // onOriginRequest
+    interface IngressOriginRequest extends MutatesHeaders, ReadsHeaders, ReadsVariables, Request, MutatesVariables {
+    }
+
+    // onOriginResponse
+    interface EgressOriginRequest extends ReadsHeaders, ReadsVariables, Request, HasRespondWith, MutatesVariables {
+    }
+    interface EgressOriginResponse extends MutatesHeaders, ReadsHeaders, HasStatus {
+    }
+
+    // onClientResponse
+    interface EgressClientRequest extends ReadsHeaders, ReadsVariables, Request, MutatesVariables {
+    }
+    interface EgressClientResponse extends MutatesHeaders, ReadsHeaders, HasStatus {
+    }
+
+    interface Destination {
+        /**
+         * The identifier of the pre-configured origin to send the outgoing request to.
+         */
+        origin?: string;
+
+        /**
+         * The new path to use in the outgoing request.
+         */
+        path?: string;
+
+        /**
+         * The new query string to use in the outgoing request.
+         */
+        query?: string;
     }
 
     /**

--- a/types/akamai-edgeworkers/test/akamai-edgeworkers-global.test.ts
+++ b/types/akamai-edgeworkers/test/akamai-edgeworkers-global.test.ts
@@ -1,4 +1,4 @@
-export function onClientRequest(request: EW.MutableRequest & EW.HasRespondWith) {
+export function onClientRequest(request: EW.IngressClientRequest) {
     // Exercise EW.ClientRequest.setHeader()
     request.setHeader("from-set-header-1", ["value-1", "trailer-1"]);
 
@@ -20,7 +20,7 @@ export function onClientRequest(request: EW.MutableRequest & EW.HasRespondWith) 
     }
 }
 
-export function onOriginRequest(request: EW.MutableRequest) {
+export function onOriginRequest(request: EW.IngressOriginRequest) {
     // getHeader
     const h = request.getHeader("onOriginRequest-getHeader");
     if (h == null) {
@@ -43,7 +43,7 @@ export function onOriginRequest(request: EW.MutableRequest) {
     request.setHeader("variable", v);
 }
 
-export function onOriginResponse(request: EW.ImmutableRequest & EW.HasRespondWith, response: EW.Response) {
+export function onOriginResponse(request: EW.EgressOriginRequest, response: EW.EgressOriginResponse) {
     if (response.getHeader("should-respondWith")) {
         request.respondWith(444, {}, "wanted a respond with");
         return;
@@ -82,7 +82,7 @@ export function onOriginResponse(request: EW.ImmutableRequest & EW.HasRespondWit
     response.status = 189;
 }
 
-export function onClientResponse(request: EW.ImmutableRequest, response: EW.Response) {
+export function onClientResponse(request: EW.EgressClientRequest, response: EW.EgressClientResponse) {
     if (request.getHeader("should-status")) {
         response.status = 234;
         return;

--- a/types/akamai-edgeworkers/test/cookies-tests.ts
+++ b/types/akamai-edgeworkers/test/cookies-tests.ts
@@ -1,6 +1,6 @@
 import { Cookies, SetCookie } from 'cookies';
 
-function onClientRequest(request: EW.MutableRequest & EW.HasRespondWith) {
+function onClientRequest(request: EW.IngressClientRequest) {
     // Verify parse constructor
     const c = new Cookies(request.getHeader('cookies') || undefined);
 
@@ -31,7 +31,7 @@ function onClientRequest(request: EW.MutableRequest & EW.HasRespondWith) {
     c.delete('name');
 }
 
-function onClientRequest2(request: EW.MutableRequest & EW.HasRespondWith) {
+function onClientRequest2(request: EW.IngressClientRequest) {
     // The values passed to SetCookie can be ignored - they're just to verify the compiler.
     const c = new SetCookie({
         name: "n",

--- a/types/akamai-edgeworkers/test/set_variable.ts
+++ b/types/akamai-edgeworkers/test/set_variable.ts
@@ -1,0 +1,15 @@
+export function onClientRequest(request: EW.IngressClientRequest) {
+    request.setVariable('PMUSER_client_request', 'foobar');
+}
+
+export function onOriginRequest(request: EW.IngressOriginRequest) {
+    request.setVariable('PMUSER_origin_request', 'foobar');
+}
+
+export function onOriginResponse(request: EW.EgressOriginRequest, response: EW.EgressOriginResponse) {
+    request.setVariable('PMUSER_origin_response', 'foobar');
+}
+
+export function onClientResponse(request: EW.EgressClientRequest, response: EW.EgressClientResponse) {
+    request.setVariable('PMUSER_client_response', 'foobar');
+}

--- a/types/akamai-edgeworkers/test/url-search-params-tests.ts
+++ b/types/akamai-edgeworkers/test/url-search-params-tests.ts
@@ -1,6 +1,6 @@
 import URLSearchParams from 'url-search-params';
 
-export function onClientRequest(request: EW.MutableRequest & EW.HasRespondWith) {
+export function onClientRequest(request: EW.IngressClientRequest) {
     const params = new URLSearchParams(request.query);
 
     params.append("from-script", "from-value");

--- a/types/akamai-edgeworkers/tsconfig.json
+++ b/types/akamai-edgeworkers/tsconfig.json
@@ -21,6 +21,7 @@
         "index.d.ts",
 	"test/akamai-edgeworkers-global.test.ts",
 	"test/cookies-tests.ts",
+	"test/set_variable.ts", 
 	"test/url-search-params-tests.ts"
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://learn.akamai.com/en-us/webhelp/edgeworkers/edgeworkers-user-guide/GUID-14077BCA-0D9F-422C-8273-2F3E37339D5B.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.