### PR TITLE
react-textarea-autocomplete: Allow all textarea attributes

### DIFF
--- a/types/webscopeio__react-textarea-autocomplete/index.d.ts
+++ b/types/webscopeio__react-textarea-autocomplete/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webscopeio__react-textarea-autocomplete 2.3
+// Type definitions for webscopeio__react-textarea-autocomplete 4.6
 // Project: https://github.com/webscopeio/react-textarea-autocomplete
 // Definitions by: Michal Zochowski <https://github.com/michauzo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -68,9 +68,7 @@ export interface TriggerType<TItem> {
     [key: string]: SettingType<TItem>;
 }
 
-type PickedAttributes = "onChange" | "onSelect" | "onBlur" | "value";
-
-export interface TextareaProps<TItem> extends Pick<React.InputHTMLAttributes<HTMLTextAreaElement>, PickedAttributes> {
+export interface TextareaProps<TItem> extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
     /**
      * Define triggers and their corresponding behavior.
      */

--- a/types/webscopeio__react-textarea-autocomplete/webscopeio__react-textarea-autocomplete-tests.tsx
+++ b/types/webscopeio__react-textarea-autocomplete/webscopeio__react-textarea-autocomplete-tests.tsx
@@ -22,6 +22,7 @@ class Autocomplete extends React.Component {
 
     render() {
         return <ReactTextareaAutocomplete<string>
+            rows={8}
             className="my-textarea"
             loadingComponent={Loading}
             style={{


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - All props except some internals marked unsafe are always passed down to the textarea. https://github.com/webscopeio/react-textarea-autocomplete/blob/0240a8e39ff94c69d75f599ffe9f8e2dd915e1e4/src/Textarea.jsx#L1051-L1052
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
