### PR TITLE
[validator] export validator function argument types from lib/* files

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -600,24 +600,28 @@ declare namespace validator {
      */
     function isInt(str: string, options?: IsIntOptions): boolean;
 
+    type IPVersion = '4' | '6' | 4 | 6;
+
     /**
      * Check if the string is an IP (version 4 or 6).
      *
      * @param [version] - IP Version
      */
-    function isIP(str: string, version?: '4' | '6'): boolean;
+    function isIP(str: string, version?: IPVersion): boolean;
 
     /**
      * Check if the string is an IP Range (version 4 only).
      */
     function isIPRange(str: string): boolean;
 
+    type ISBNVersion = '10' | '13' | 10 | 13;
+
     /**
      * Check if the string is an ISBN (version 10 or 13).
      *
      * @param [version] - ISBN Version
      */
-    function isISBN(str: string, version?: '10' | '13'): boolean;
+    function isISBN(str: string, version?: ISBNVersion): boolean;
 
     /**
      * Check if the string is an [ISIN](https://en.wikipedia.org/wiki/International_Securities_Identification_Number) (stock/security identifier).
@@ -1031,12 +1035,13 @@ declare namespace validator {
      */
     function isUppercase(str: string): boolean;
 
+    type UUIDVersion = 3 | 4 | 5 | '3' | '4' | '5' | 'all';
     /**
      * Check if the string is a UUID (version 3, 4 or 5).
      *
      * @param [version="all"] - UUID version
      */
-    function isUUID(str: string, version?: 3 | 4 | 5 | '3' | '4' | '5' | 'all'): boolean;
+    function isUUID(str: string, version?: UUIDVersion): boolean;
 
     /**
      * Check if the string contains a mixture of full and half-width chars.

--- a/types/validator/lib/isAlpha.d.ts
+++ b/types/validator/lib/isAlpha.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type AlphaLocale = validator.AlphaLocale;
 export default validator.isAlpha;

--- a/types/validator/lib/isAlphanumeric.d.ts
+++ b/types/validator/lib/isAlphanumeric.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type AlphanumericLocale = validator.AlphanumericLocale;
 export default validator.isAlphanumeric;

--- a/types/validator/lib/isByteLength.d.ts
+++ b/types/validator/lib/isByteLength.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type IsByteLengthOptions = validator.IsByteLengthOptions;
 export default validator.isByteLength;

--- a/types/validator/lib/isCurrency.d.ts
+++ b/types/validator/lib/isCurrency.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type IsCurrencyOptions = validator.IsCurrencyOptions;
 export default validator.isCurrency;

--- a/types/validator/lib/isDecimal.d.ts
+++ b/types/validator/lib/isDecimal.d.ts
@@ -1,2 +1,4 @@
 import validator from '../';
+export type IsDecimalOptions = validator.IsDecimalOptions;
+export type DecimalLocale = validator.DecimalLocale;
 export default validator.isDecimal;

--- a/types/validator/lib/isEmail.d.ts
+++ b/types/validator/lib/isEmail.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type IsEmailOptions = validator.IsEmailOptions;
 export default validator.isEmail;

--- a/types/validator/lib/isEmpty.d.ts
+++ b/types/validator/lib/isEmpty.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type IsEmptyOptions = validator.IsEmptyOptions;
 export default validator.isEmpty;

--- a/types/validator/lib/isFQDN.d.ts
+++ b/types/validator/lib/isFQDN.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type IsFQDNOptions = validator.IsFQDNOptions;
 export default validator.isFQDN;

--- a/types/validator/lib/isFloat.d.ts
+++ b/types/validator/lib/isFloat.d.ts
@@ -1,2 +1,4 @@
 import validator from '../';
+export type FloatLocale = validator.FloatLocale;
+export type IsFloatOptions = validator.IsFloatOptions;
 export default validator.isFloat;

--- a/types/validator/lib/isHash.d.ts
+++ b/types/validator/lib/isHash.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type HashAlgorithm = validator.HashAlgorithm;
 export default validator.isHash;

--- a/types/validator/lib/isIP.d.ts
+++ b/types/validator/lib/isIP.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type IPVersion = validator.IPVersion;
 export default validator.isIP;

--- a/types/validator/lib/isISBN.d.ts
+++ b/types/validator/lib/isISBN.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type ISBNVersion = validator.ISBNVersion;
 export default validator.isISBN;

--- a/types/validator/lib/isISO8601.d.ts
+++ b/types/validator/lib/isISO8601.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type IsISO8601Options = validator.IsISO8601Options;
 export default validator.isISO8601;

--- a/types/validator/lib/isISSN.d.ts
+++ b/types/validator/lib/isISSN.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type IsISSNOptions = validator.IsISSNOptions;
 export default validator.isISSN;

--- a/types/validator/lib/isIdentityCard.d.ts
+++ b/types/validator/lib/isIdentityCard.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type IdentityCardLocale = validator.IdentityCardLocale;
 export default validator.isIdentityCard;

--- a/types/validator/lib/isInt.d.ts
+++ b/types/validator/lib/isInt.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type IsIntOptions = validator.IsIntOptions;
 export default validator.isInt;

--- a/types/validator/lib/isLength.d.ts
+++ b/types/validator/lib/isLength.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type IsLengthOptions = validator.IsLengthOptions;
 export default validator.isLength;

--- a/types/validator/lib/isMACAddress.d.ts
+++ b/types/validator/lib/isMACAddress.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type IsMACAddressOptions = validator.IsMACAddressOptions;
 export default validator.isMACAddress;

--- a/types/validator/lib/isMobilePhone.d.ts
+++ b/types/validator/lib/isMobilePhone.d.ts
@@ -1,2 +1,4 @@
 import validator from '../';
+export type MobilePhoneLocale = validator.MobilePhoneLocale;
+export type IsMobilePhoneOptions = validator.IsMobilePhoneOptions;
 export default validator.isMobilePhone;

--- a/types/validator/lib/isNumeric.d.ts
+++ b/types/validator/lib/isNumeric.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type IsNumericOptions = validator.IsNumericOptions;
 export default validator.isNumeric;

--- a/types/validator/lib/isPostalCode.d.ts
+++ b/types/validator/lib/isPostalCode.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type PostalCodeLocale = validator.PostalCodeLocale;
 export default validator.isPostalCode;

--- a/types/validator/lib/isURL.d.ts
+++ b/types/validator/lib/isURL.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type IsURLOptions = validator.IsURLOptions;
 export default validator.isURL;

--- a/types/validator/lib/isUUID.d.ts
+++ b/types/validator/lib/isUUID.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type UUIDVersion = validator.UUIDVersion;
 export default validator.isUUID;

--- a/types/validator/lib/normalizeEmail.d.ts
+++ b/types/validator/lib/normalizeEmail.d.ts
@@ -1,2 +1,3 @@
 import validator from '../';
+export type NormalizeEmailOptions = validator.NormalizeEmailOptions;
 export default validator.normalizeEmail;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

**We would like to import types of validator fnc argumens from subfiles. The main reason is we want to import only subset of library not a whole validator namespace with all code. Example:**
```ts
import isEmail from 'validator/lib/isEmail';
import { IsEmailOptions } from 'validator/lib/isEmail';

export function myCustomFnc(emailValidationOptions: IsEmailOptions) {
	return isEmail(emailValidationOptions)
}
```
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
