### PR TITLE
OpenPGP: Make TS 3.2 definitions be valid Typescript

### DIFF
--- a/types/openpgp/index.d.ts
+++ b/types/openpgp/index.d.ts
@@ -9,10 +9,10 @@
 //                 Ryo Ota <https://github.com/nwtgck>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
-import BN = require("bn.js");
-import stream = require("stream")
+import BN = require('bn.js');
+import stream = require('stream');
 
-export { }
+export {};
 
 // Declare to fix type issue
 type NodeStream = stream;
@@ -58,7 +58,12 @@ export namespace cleartext {
          * @param userIds (optional) user IDs to sign with, e.g. [ { name:'Steve Sender', email:'steve@openpgp.org' }]
          * @returns new detached signature of message content
          */
-        signDetached(privateKeys: any[], signature: signature.Signature, date: Date, userIds: any[]): Promise<signature.Signature>;
+        signDetached(
+            privateKeys: any[],
+            signature: signature.Signature,
+            date: Date,
+            userIds: any[],
+        ): Promise<signature.Signature>;
 
         /**
          * Verify signatures of cleartext signed message
@@ -66,7 +71,7 @@ export namespace cleartext {
          * @param date (optional) Verify the signature against the given date, i.e. check signature creation time < date < expiration time
          * @returns list of signer's keyid and validity of signature
          */
-        verify(keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid, valid: boolean }>>;
+        verify(keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
         /**
          * Verify signatures of cleartext signed message
@@ -74,7 +79,7 @@ export namespace cleartext {
          * @param date (optional) Verify the signature against the given date, i.e. check signature creation time < date < expiration time
          * @returns list of signer's keyid and validity of signature
          */
-        verifyDetached(keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid, valid: boolean }>>;
+        verifyDetached(keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
         /**
          * Get cleartext
@@ -238,8 +243,6 @@ export class LocalStorage {
     write(): void;
 }
 
-
-
 /**
  * @see module:crypto/crypto
  * @see module:crypto/signature
@@ -250,8 +253,8 @@ export class LocalStorage {
  */
 export namespace crypto {
     /**
- * @see module:crypto/public_key/elliptic/ecdh
- */
+     * @see module:crypto/public_key/elliptic/ecdh
+     */
     namespace aes_kw {
         /**
          * AES key wrap
@@ -272,8 +275,8 @@ export namespace crypto {
     }
 
     namespace cfb {
-        function encrypt(algo: any, key: any, plaintext: any, iv: any): any
-        function decrypt(algo: any, key: any, ciphertext: any, iv: any): Promise<any>
+        function encrypt(algo: any, key: any, plaintext: any, iv: any): any;
+        function decrypt(algo: any, key: any, ciphertext: any, iv: any): Promise<any>;
     }
 
     namespace cipher {
@@ -378,7 +381,12 @@ export namespace crypto {
          * @param fingerprint Recipient fingerprint
          * @returns encrypted session key parameters
          */
-        function publicKeyEncrypt(algo: enums.publicKey, pub_params: Array<type.mpi.MPI | type.oid.OID | type.kdf_params.KDFParams>, data: type.mpi.MPI, fingerprint: string): any[];
+        function publicKeyEncrypt(
+            algo: enums.publicKey,
+            pub_params: Array<type.mpi.MPI | type.oid.OID | type.kdf_params.KDFParams>,
+            data: type.mpi.MPI,
+            fingerprint: string,
+        ): any[];
 
         /**
          * Decrypts data using specified algorithm and private key parameters.
@@ -389,7 +397,12 @@ export namespace crypto {
          * @param fingerprint Recipient fingerprint
          * @returns An MPI containing the decrypted data
          */
-        function publicKeyDecrypt(algo: enums.publicKey, key_params: Array<type.mpi.MPI | type.oid.OID | type.kdf_params.KDFParams>, data_params: Array<type.mpi.MPI | type.oid.OID | type.kdf_params.KDFParams>, fingerprint: string): type.mpi.MPI;
+        function publicKeyDecrypt(
+            algo: enums.publicKey,
+            key_params: Array<type.mpi.MPI | type.oid.OID | type.kdf_params.KDFParams>,
+            data_params: Array<type.mpi.MPI | type.oid.OID | type.kdf_params.KDFParams>,
+            fingerprint: string,
+        ): type.mpi.MPI;
 
         /**
          * Returns the types comprising the private key of an algorithm
@@ -577,10 +590,10 @@ export namespace crypto {
     }
 
     /**
-    * @see module:crypto/public_key/rsa
-    * @see module:crypto/public_key/elliptic/ecdh
-    * @see module:packet.PublicKeyEncryptedSessionKey
-    */
+     * @see module:crypto/public_key/rsa
+     * @see module:crypto/public_key/elliptic/ecdh
+     * @see module:packet.PublicKeyEncryptedSessionKey
+     */
     namespace pkcs1 {
         namespace eme {
             /**
@@ -672,15 +685,14 @@ export namespace crypto {
         }
 
         /**
-        * @see module:crypto/public_key/elliptic/curve
-        * @see module:crypto/public_key/elliptic/ecdh
-        * @see module:crypto/public_key/elliptic/ecdsa
-        * @see module:crypto/public_key/elliptic/eddsa
-        */
+         * @see module:crypto/public_key/elliptic/curve
+         * @see module:crypto/public_key/elliptic/ecdh
+         * @see module:crypto/public_key/elliptic/ecdsa
+         * @see module:crypto/public_key/elliptic/eddsa
+         */
         namespace elliptic {
             namespace curve {
-                class Curve {
-                }
+                class Curve {}
             }
 
             namespace ecdh {
@@ -690,7 +702,7 @@ export namespace crypto {
                  * @param Q Recipient public key
                  * @returns Returns public part of ephemeral key and generated ephemeral secret
                  */
-                function genPublicEphemeralKey(curve: curve.Curve, Q: Uint8Array): Promise<{ V: Uint8Array, S: BN }>;
+                function genPublicEphemeralKey(curve: curve.Curve, Q: Uint8Array): Promise<{ V: Uint8Array; S: BN }>;
 
                 /**
                  * Encrypt and wrap a session key
@@ -702,7 +714,14 @@ export namespace crypto {
                  * @param fingerprint Recipient fingerprint
                  * @returns Returns public part of ephemeral key and encoded session key
                  */
-                function encrypt(oid: type.oid.OID, cipher_algo: enums.symmetric, hash_algo: enums.hash, m: type.mpi.MPI, Q: Uint8Array, fingerprint: string): Promise<{ V: BN, C: BN }>;
+                function encrypt(
+                    oid: type.oid.OID,
+                    cipher_algo: enums.symmetric,
+                    hash_algo: enums.hash,
+                    m: type.mpi.MPI,
+                    Q: Uint8Array,
+                    fingerprint: string,
+                ): Promise<{ V: BN; C: BN }>;
 
                 /**
                  * Generate ECDHE secret from private key and public part of ephemeral key
@@ -724,7 +743,15 @@ export namespace crypto {
                  * @param fingerprint Recipient fingerprint
                  * @returns Value derived from session
                  */
-                function decrypt(oid: type.oid.OID, cipher_algo: enums.symmetric, hash_algo: enums.hash, V: Uint8Array, C: Uint8Array, d: Uint8Array, fingerprint: string): Promise<BN>;
+                function decrypt(
+                    oid: type.oid.OID,
+                    cipher_algo: enums.symmetric,
+                    hash_algo: enums.hash,
+                    V: Uint8Array,
+                    C: Uint8Array,
+                    d: Uint8Array,
+                    fingerprint: string,
+                ): Promise<BN>;
             }
 
             namespace ecdsa {
@@ -737,7 +764,13 @@ export namespace crypto {
                  * @param hashed The hashed message
                  * @returns Signature of the message
                  */
-                function sign(oid: type.oid.OID, hash_algo: enums.hash, m: Uint8Array, d: Uint8Array, hashed: Uint8Array): object;
+                function sign(
+                    oid: type.oid.OID,
+                    hash_algo: enums.hash,
+                    m: Uint8Array,
+                    d: Uint8Array,
+                    hashed: Uint8Array,
+                ): object;
 
                 /**
                  * Verifies if a signature is valid for a message
@@ -749,7 +782,14 @@ export namespace crypto {
                  * @param hashed The hashed message
                  * @returns
                  */
-                function verify(oid: type.oid.OID, hash_algo: enums.hash, signature: object, m: Uint8Array, Q: Uint8Array, hashed: Uint8Array): boolean;
+                function verify(
+                    oid: type.oid.OID,
+                    hash_algo: enums.hash,
+                    signature: object,
+                    m: Uint8Array,
+                    Q: Uint8Array,
+                    hashed: Uint8Array,
+                ): boolean;
             }
 
             namespace eddsa {
@@ -762,7 +802,13 @@ export namespace crypto {
                  * @param hashed The hashed message
                  * @returns Signature of the message
                  */
-                function sign(oid: type.oid.OID, hash_algo: enums.hash, m: Uint8Array, d: Uint8Array, hashed: Uint8Array): object;
+                function sign(
+                    oid: type.oid.OID,
+                    hash_algo: enums.hash,
+                    m: Uint8Array,
+                    d: Uint8Array,
+                    hashed: Uint8Array,
+                ): object;
 
                 /**
                  * Verifies if a signature is valid for a message
@@ -774,12 +820,18 @@ export namespace crypto {
                  * @param hashed The hashed message
                  * @returns
                  */
-                function verify(oid: type.oid.OID, hash_algo: enums.hash, signature: object, m: Uint8Array, Q: Uint8Array, hashed: Uint8Array): boolean;
+                function verify(
+                    oid: type.oid.OID,
+                    hash_algo: enums.hash,
+                    signature: object,
+                    m: Uint8Array,
+                    Q: Uint8Array,
+                    hashed: Uint8Array,
+                ): boolean;
             }
 
             namespace key {
-                class KeyPair {
-                }
+                class KeyPair {}
             }
         }
 
@@ -914,7 +966,14 @@ export namespace crypto {
          * @param hashed The hashed data
          * @returns True if signature is valid
          */
-        function verify(algo: enums.publicKey, hash_algo: enums.hash, msg_MPIs: type.mpi.MPI[], pub_MPIs: type.mpi.MPI[], data: Uint8Array, hashed: Uint8Array): boolean;
+        function verify(
+            algo: enums.publicKey,
+            hash_algo: enums.hash,
+            msg_MPIs: type.mpi.MPI[],
+            pub_MPIs: type.mpi.MPI[],
+            data: Uint8Array,
+            hashed: Uint8Array,
+        ): boolean;
 
         /**
          * Creates a signature on data using specified algorithms and private key parameters.
@@ -928,7 +987,13 @@ export namespace crypto {
          * @param hashed The hashed data
          * @returns Signature
          */
-        function sign(algo: enums.publicKey, hash_algo: enums.hash, key_params: type.mpi.MPI[], data: Uint8Array, hashed: Uint8Array): Uint8Array;
+        function sign(
+            algo: enums.publicKey,
+            hash_algo: enums.hash,
+            key_params: type.mpi.MPI[],
+            data: Uint8Array,
+            hashed: Uint8Array,
+        ): Uint8Array;
     }
 }
 
@@ -1015,7 +1080,13 @@ export namespace encoding {
          * @param customComment (optional) additional comment to add to the armored string
          * @returns Armored text
          */
-        function armor(messagetype: Integer, body: any, partindex: Integer, parttotal: Integer, customComment?: string): string | ReadableStream<String>;
+        function armor(
+            messagetype: Integer,
+            body: any,
+            partindex: Integer,
+            parttotal: Integer,
+            customComment?: string,
+        ): string | ReadableStream<String>;
     }
 
     namespace base64 {
@@ -1037,14 +1108,21 @@ export namespace encoding {
     }
 }
 
-
-
 export namespace enums {
     /**
      * Maps curve names under various standards to one
      * @see
-    */
-    type curve = "p256" | "p384" | "p251" | "secp256k1" | "ed25519" | "curve25519" | "brainpoolP256r1" | "brainpoolP384r1" | "brainpoolP512r1";
+     */
+    type curve =
+        | 'p256'
+        | 'p384'
+        | 'p251'
+        | 'secp256k1'
+        | 'ed25519'
+        | 'curve25519'
+        | 'brainpoolP256r1'
+        | 'brainpoolP384r1'
+        | 'brainpoolP512r1';
 
     /**
      * A string to key specifier type
@@ -1112,7 +1190,7 @@ export namespace enums {
          * Not implemented!
          */
         idea = 1,
-        "3des" = 2,
+        '3des' = 2,
         tripledes = 2,
         cast5 = 3,
         blowfish = 4,
@@ -1156,10 +1234,10 @@ export namespace enums {
      * {@link https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest|Parameters, algo}
      */
     enum webHash {
-        "SHA-1" = 2,
-        "SHA-256" = 8,
-        "SHA-384" = 9,
-        "SHA-512" = 10,
+        'SHA-1' = 2,
+        'SHA-256' = 8,
+        'SHA-384' = 9,
+        'SHA-512' = 10,
     }
 
     /**
@@ -1656,7 +1734,10 @@ export namespace key {
          * @param keyId
          * @returns
          */
-        encrypt(passphrases: string | any[], keyId?: type.keyid.Keyid): Promise<Array<packet.SecretKey | packet.SecretSubkey>>;
+        encrypt(
+            passphrases: string | any[],
+            keyId?: type.keyid.Keyid,
+        ): Promise<Array<packet.SecretKey | packet.SecretSubkey>>;
 
         /**
          * Decrypts all secret key and subkey packets matching keyId
@@ -1674,7 +1755,11 @@ export namespace key {
          * @param date Use the given date instead of the current time
          * @returns True if the certificate is revoked
          */
-        isRevoked(signature: packet.Signature, key?: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey, date?: Date): Promise<Boolean>;
+        isRevoked(
+            signature: packet.Signature,
+            key?: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey,
+            date?: Date,
+        ): Promise<Boolean>;
 
         /**
          * Verify primary key. Checks for revocation signatures, expiration time
@@ -1695,7 +1780,11 @@ export namespace key {
          * @param userId, optional user ID
          * @returns
          */
-        getExpirationTime(capabilities?: any, keyId?: type.keyid.Keyid, userId?: object): Promise<Date | Infinity | null>;
+        getExpirationTime(
+            capabilities?: any,
+            keyId?: type.keyid.Keyid,
+            userId?: object,
+        ): Promise<Date | Infinity | null>;
 
         /**
          * Returns primary user and most significant (latest valid) self signature
@@ -1705,7 +1794,7 @@ export namespace key {
          * @param userId (optional) user ID to get instead of the primary user, if it exists
          * @returns The primary user and the self signature
          */
-        getPrimaryUser(date?: Date, userId?: object): Promise<{ user: User, selfCertification: packet.Signature }>;
+        getPrimaryUser(date?: Date, userId?: object): Promise<{ user: User; selfCertification: packet.Signature }>;
 
         /**
          * Update key with new components from specified key with same key ID:
@@ -1769,7 +1858,11 @@ export namespace key {
          * @param userId (optional) user ID to get instead of the primary user, if it exists
          * @returns List of signer's keyid and validity of signature
          */
-        verifyPrimaryUser(keys: any[], date: Date, userId: object): Promise<Array<{ keyid: type.keyid.Keyid, valid: boolean }>>;
+        verifyPrimaryUser(
+            keys: any[],
+            date: Date,
+            userId: object,
+        ): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
         /**
          * Verifies all users of key
@@ -1778,7 +1871,7 @@ export namespace key {
          * @param keys array of keys to verify certificate signatures
          * @returns list of userid, signer's keyid and validity of signature
          */
-        verifyAllUsers(keys: any[]): Promise<Array<{ userid: string, keyid: type.keyid.Keyid, valid: boolean }>>;
+        verifyAllUsers(keys: any[]): Promise<Array<{ userid: string; keyid: type.keyid.Keyid; valid: boolean }>>;
 
         /**
          * Calculates the key id of the key
@@ -1855,7 +1948,12 @@ export namespace key {
          * @param date Use the given date instead of the current time
          * @returns True if the certificate is revoked
          */
-        isRevoked(primaryKey: packet.SecretKey | packet.PublicKey, certificate: packet.Signature, key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey, date: Date): Promise<Boolean>;
+        isRevoked(
+            primaryKey: packet.SecretKey | packet.PublicKey,
+            certificate: packet.Signature,
+            key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey,
+            date: Date,
+        ): Promise<Boolean>;
 
         /**
          * Verifies the user certificate
@@ -1865,7 +1963,12 @@ export namespace key {
          * @param date Use the given date instead of the current time
          * @returns status of the certificate
          */
-        verifyCertificate(primaryKey: packet.SecretKey | packet.PublicKey, certificate: packet.Signature, keys: any[], date: Date): Promise<enums.keyStatus>;
+        verifyCertificate(
+            primaryKey: packet.SecretKey | packet.PublicKey,
+            certificate: packet.Signature,
+            keys: any[],
+            date: Date,
+        ): Promise<enums.keyStatus>;
 
         /**
          * Verifies all user certificates
@@ -1874,7 +1977,11 @@ export namespace key {
          * @param date Use the given date instead of the current time
          * @returns List of signer's keyid and validity of signature
          */
-        verifyAllCertifications(primaryKey: packet.SecretKey | packet.PublicKey, keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid, valid: boolean }>>;
+        verifyAllCertifications(
+            primaryKey: packet.SecretKey | packet.PublicKey,
+            keys: any[],
+            date: Date,
+        ): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
         /**
          * Verify User. Checks for existence of self signatures, revocation signatures
@@ -1903,7 +2010,13 @@ export namespace key {
      * @param userId (optional) user ID
      * @returns signature packet
      */
-    function createSignaturePacket(dataToSign: object, signingKeyPacket: packet.SecretKey | packet.SecretSubkey, signatureProperties: object, date: Date, userId: object): packet.Signature;
+    function createSignaturePacket(
+        dataToSign: object,
+        signingKeyPacket: packet.SecretKey | packet.SecretSubkey,
+        signatureProperties: object,
+        date: Date,
+        userId: object,
+    ): packet.Signature;
 
     /**
      * Class that represents a subkey packet and the relevant signatures.
@@ -1925,7 +2038,12 @@ export namespace key {
          * @param date Use the given date instead of the current time
          * @returns True if the binding signature is revoked
          */
-        isRevoked(primaryKey: packet.SecretKey | packet.PublicKey, signature: packet.Signature, key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey, date: Date): Promise<Boolean>;
+        isRevoked(
+            primaryKey: packet.SecretKey | packet.PublicKey,
+            signature: packet.Signature,
+            key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey,
+            date: Date,
+        ): Promise<Boolean>;
 
         /**
          * Verify subkey. Checks for revocation signatures, expiration time
@@ -1962,7 +2080,11 @@ export namespace key {
          * @param date optional, override the creationtime of the revocation signature
          * @returns new subkey with revocation signature
          */
-        revoke(primaryKey: packet.SecretKey, reasonForRevocation: revoke_reasonForRevocation, date: Date): Promise<SubKey>;
+        revoke(
+            primaryKey: packet.SecretKey,
+            reasonForRevocation: revoke_reasonForRevocation,
+            date: Date,
+        ): Promise<SubKey>;
 
         /**
          * Calculates the key id of the key
@@ -2006,9 +2128,12 @@ export namespace key {
      * @param data to be parsed
      * @returns result object with key and error arrays
      */
-    function read(data: Uint8Array): Promise<{ keys: Array<Key>, err: Array<Error> | null }>;
+    function read(data: Uint8Array): Promise<{ keys: Array<Key>; err: Array<Error> | null }>;
 
-    interface KeyResult { keys: Array<Key>, err: Array<Error> | null }
+    interface KeyResult {
+        keys: Array<Key>;
+        err: Array<Error> | null;
+    }
 
     /**
      * Reads an OpenPGP armored text and returns one or multiple key objects
@@ -2059,7 +2184,14 @@ export namespace key {
      * @param date Use the given date instead of the current time
      * @returns True if the signature revokes the data
      */
-    function isDataRevoked(primaryKey: packet.SecretKey | packet.PublicKey, dataToVerify: object, revocations: any[], signature: packet.Signature, key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey, date: Date): Promise<Boolean>;
+    function isDataRevoked(
+        primaryKey: packet.SecretKey | packet.PublicKey,
+        dataToVerify: object,
+        revocations: any[],
+        signature: packet.Signature,
+        key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey,
+        date: Date,
+    ): Promise<Boolean>;
 
     /**
      * Check if signature has revocation key sub packet (not supported by OpenPGP.js)
@@ -2077,7 +2209,12 @@ export namespace key {
      * @param userId (optional) user ID
      * @returns
      */
-    function getPreferredHashAlgo(key: Key, keyPacket: packet.SecretKey | packet.SecretSubkey, date: Date, userId: object): Promise<String>;
+    function getPreferredHashAlgo(
+        key: Key,
+        keyPacket: packet.SecretKey | packet.SecretSubkey,
+        date: Date,
+        userId: object,
+    ): Promise<String>;
 
     /**
      * Returns the preferred symmetric/aead algorithm for a set of keys
@@ -2138,7 +2275,12 @@ export class User {
      * @param date Use the given date instead of the current time
      * @returns True if the certificate is revoked
      */
-    isRevoked(primaryKey: packet.SecretKey | packet.PublicKey, certificate: packet.Signature, key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey, date: Date): Promise<Boolean>;
+    isRevoked(
+        primaryKey: packet.SecretKey | packet.PublicKey,
+        certificate: packet.Signature,
+        key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey,
+        date: Date,
+    ): Promise<Boolean>;
 
     /**
      * Verifies the user certificate
@@ -2148,7 +2290,12 @@ export class User {
      * @param date Use the given date instead of the current time
      * @returns status of the certificate
      */
-    verifyCertificate(primaryKey: packet.SecretKey | packet.PublicKey, certificate: packet.Signature, keys: any[], date: Date): Promise<enums.keyStatus>;
+    verifyCertificate(
+        primaryKey: packet.SecretKey | packet.PublicKey,
+        certificate: packet.Signature,
+        keys: any[],
+        date: Date,
+    ): Promise<enums.keyStatus>;
 
     /**
      * Verifies all user certificates
@@ -2157,7 +2304,11 @@ export class User {
      * @param date Use the given date instead of the current time
      * @returns List of signer's keyid and validity of signature
      */
-    verifyAllCertifications(primaryKey: packet.SecretKey | packet.PublicKey, keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid, valid: boolean }>>;
+    verifyAllCertifications(
+        primaryKey: packet.SecretKey | packet.PublicKey,
+        keys: any[],
+        date: Date,
+    ): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
     /**
      * Verify User. Checks for existence of self signatures, revocation signatures
@@ -2197,7 +2348,12 @@ export class SubKey {
      * @param date Use the given date instead of the current time
      * @returns True if the binding signature is revoked
      */
-    isRevoked(primaryKey: packet.SecretKey | packet.PublicKey, signature: packet.Signature, key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey, date: Date): Promise<Boolean>;
+    isRevoked(
+        primaryKey: packet.SecretKey | packet.PublicKey,
+        signature: packet.Signature,
+        key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey,
+        date: Date,
+    ): Promise<Boolean>;
 
     /**
      * Verify subkey. Checks for revocation signatures, expiration time
@@ -2234,7 +2390,11 @@ export class SubKey {
      * @param date optional, override the creationtime of the revocation signature
      * @returns new subkey with revocation signature
      */
-    revoke(primaryKey: packet.SecretKey, reasonForRevocation: revoke_reasonForRevocation, date: Date): Promise<key.SubKey>;
+    revoke(
+        primaryKey: packet.SecretKey,
+        reasonForRevocation: revoke_reasonForRevocation,
+        date: Date,
+    ): Promise<key.SubKey>;
 
     /**
      * Calculates the key id of the key
@@ -2447,7 +2607,10 @@ export namespace message {
          * @param passwords (optional) passwords used to decrypt
          * @returns array of object with potential sessionKey, algorithm pairs
          */
-        decryptSessionKeys(privateKeys?: any[], passwords?: any[]): Promise<Array<{ data: Uint8Array, algorithm: string }>>;
+        decryptSessionKeys(
+            privateKeys?: any[],
+            passwords?: any[],
+        ): Promise<Array<{ data: Uint8Array; algorithm: string }>>;
 
         /**
          * Get literal data that is the body of the message
@@ -2478,7 +2641,15 @@ export namespace message {
          * @param streaming (optional) whether to process data as a stream
          * @returns new message with encrypted content
          */
-        encrypt(keys?: any[], passwords?: any[], sessionKey?: object, wildcard?: boolean, date?: Date, userIds?: any[], streaming?: boolean): Promise<Message>;
+        encrypt(
+            keys?: any[],
+            passwords?: any[],
+            sessionKey?: object,
+            wildcard?: boolean,
+            date?: Date,
+            userIds?: any[],
+            streaming?: boolean,
+        ): Promise<Message>;
 
         /**
          * Sign the message (the literal data packet of the message)
@@ -2505,7 +2676,12 @@ export namespace message {
          * @param userIds (optional) user IDs to sign with, e.g. [ { name:'Steve Sender', email:'steve@openpgp.org' }]
          * @returns new detached signature of message content
          */
-        signDetached(privateKeys: any[], signature?: signature.Signature, date?: Date, userIds?: any[]): Promise<signature.Signature>;
+        signDetached(
+            privateKeys: any[],
+            signature?: signature.Signature,
+            date?: Date,
+            userIds?: any[],
+        ): Promise<signature.Signature>;
 
         /**
          * Verify message signatures
@@ -2514,7 +2690,11 @@ export namespace message {
          * @param streaming (optional) whether to process data as a stream
          * @returns list of signer's keyid and validity of signature
          */
-        verify(keys: any[], date?: Date, streaming?: boolean): Promise<Array<({ keyid: type.keyid.Keyid, valid: boolean })>>;
+        verify(
+            keys: any[],
+            date?: Date,
+            streaming?: boolean,
+        ): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
         /**
          * Verify detached message signature
@@ -2523,7 +2703,11 @@ export namespace message {
          * @param date Verify the signature against the given date, i.e. check signature creation time < date < expiration time
          * @returns list of signer's keyid and validity of signature
          */
-        verifyDetached(keys: any[], signature: signature.Signature, date?: Date): Promise<Array<({ keyid: type.keyid.Keyid, valid: boolean })>>;
+        verifyDetached(
+            keys: any[],
+            signature: signature.Signature,
+            date?: Date,
+        ): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
         /**
          * Unwrap compressed message
@@ -2556,7 +2740,16 @@ export namespace message {
      * @param userIds (optional) user IDs to encrypt for, e.g. [ { name:'Robert Receiver', email:'robert@openpgp.org' }]
      * @returns new message with encrypted content
      */
-    function encryptSessionKey(sessionKey: Uint8Array, symAlgo: string, aeadAlgo: string, publicKeys: any[], passwords: any[], wildcard: boolean, date: Date, userIds: any[]): Promise<Message>;
+    function encryptSessionKey(
+        sessionKey: Uint8Array,
+        symAlgo: string,
+        aeadAlgo: string,
+        publicKeys: any[],
+        passwords: any[],
+        wildcard: boolean,
+        date: Date,
+        userIds: any[],
+    ): Promise<Message>;
 
     /**
      * Create signature packets for the message
@@ -2567,7 +2760,13 @@ export namespace message {
      * @param userIds (optional) user IDs to sign with, e.g. [ { name:'Steve Sender', email:'steve@openpgp.org' }]
      * @returns list of signature packets
      */
-    function createSignaturePackets(literalDataPacket: packet.Literal, privateKeys: any[], signature: signature.Signature, date: Date, userIds: any[]): Promise<packet.List>;
+    function createSignaturePackets(
+        literalDataPacket: packet.Literal,
+        privateKeys: any[],
+        signature: signature.Signature,
+        date: Date,
+        userIds: any[],
+    ): Promise<packet.List>;
 
     /**
      * Create object containing signer's keyid and validity of signature
@@ -2578,7 +2777,12 @@ export namespace message {
      *        i.e. check signature creation time < date < expiration time
      * @returns list of signer's keyid and validity of signature
      */
-    function createVerificationObject(signature: packet.Signature, literalDataList: any[], keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid, valid: boolean }>>;
+    function createVerificationObject(
+        signature: packet.Signature,
+        literalDataList: any[],
+        keys: any[],
+        date: Date,
+    ): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
     /**
      * Create list of objects containing signer's keyid and validity of signature
@@ -2589,7 +2793,12 @@ export namespace message {
      *        i.e. check signature creation time < date < expiration time
      * @returns list of signer's keyid and validity of signature
      */
-    function createVerificationObjects(signatureList: any[], literalDataList: any[], keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid, valid: boolean }>>;
+    function createVerificationObjects(
+        signatureList: any[],
+        literalDataList: any[],
+        keys: any[],
+        date: Date,
+    ): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
     /**
      * reads an OpenPGP armored message and returns a message object
@@ -2624,7 +2833,12 @@ export namespace message {
      * @param {utf8 | binary | text | mime} type (optional) data packet type
      * @returns new message object
      */
-    function fromBinary(bytes: Uint8Array | ReadableStream<Uint8Array>, filename?: string, date?: Date, type?: any): Message;
+    function fromBinary(
+        bytes: Uint8Array | ReadableStream<Uint8Array>,
+        filename?: string,
+        date?: Date,
+        type?: any,
+    ): Message;
 }
 
 export interface revokeKey_reasonForRevocation {
@@ -3099,7 +3313,7 @@ export namespace packet {
          *        input at position
          * @returns Object representation
          */
-        read(input: Uint8Array, position: Integer, len: Integer): PublicKeyEncryptedSessionKey
+        read(input: Uint8Array, position: Integer, len: Integer): PublicKeyEncryptedSessionKey;
 
         /**
          * Create a string representation of a tag 1 packet
@@ -3624,7 +3838,11 @@ export namespace packet {
          * @param data data which on the signature applies
          * @returns True if message is verified, else false.
          */
-        verify(key: PublicSubkey | PublicKey | SecretSubkey | SecretKey, signatureType: enums.signature, data: string | object): Promise<Boolean>;
+        verify(
+            key: PublicSubkey | PublicKey | SecretSubkey | SecretKey,
+            signatureType: enums.signature,
+            data: string | object,
+        ): Promise<Boolean>;
 
         /**
          * Verifies signature expiration date
@@ -3691,7 +3909,12 @@ export namespace packet {
          * @param streaming Whether the top-level function will return a stream
          * @returns
          */
-        crypt(fn: any, key: Uint8Array, data: Uint8Array | ReadableStream<Uint8Array>, streaming: boolean): Uint8Array | ReadableStream<Uint8Array>;
+        crypt(
+            fn: any,
+            key: Uint8Array,
+            data: Uint8Array | ReadableStream<Uint8Array>,
+            streaming: boolean,
+        ): Uint8Array | ReadableStream<Uint8Array>;
     }
 
     class SymEncryptedIntegrityProtected {
@@ -4087,9 +4310,7 @@ export namespace packet {
     }
 }
 
-
-export namespace polyfills {
-}
+export namespace polyfills {}
 
 export namespace signature {
     /**
@@ -4282,14 +4503,14 @@ export namespace type {
     }
 
     /**
- * Implementation of the String-to-key specifier
- * {@link https://tools.ietf.org/html/rfc4880#section-3.7|RFC4880 3.7}:
- * String-to-key (S2K) specifiers are used to convert passphrase strings
- * into symmetric-key encryption/decryption keys.  They are used in two
- * places, currently: to encrypt the secret part of private keys in the
- * private keyring, and to convert passphrases to encryption keys for
- * symmetrically encrypted messages.
- */
+     * Implementation of the String-to-key specifier
+     * {@link https://tools.ietf.org/html/rfc4880#section-3.7|RFC4880 3.7}:
+     * String-to-key (S2K) specifiers are used to convert passphrase strings
+     * into symmetric-key encryption/decryption keys.  They are used in two
+     * places, currently: to encrypt the secret part of private keys in the
+     * private keyring, and to convert passphrases to encryption keys for
+     * symmetrically encrypted messages.
+     */
     namespace s2k {
         class S2K {
             constructor();
@@ -4497,7 +4718,11 @@ export namespace util {
      * @param input Stream to print
      * @param concat Function to concatenate chunks of the stream (defaults to util.concat).
      */
-    function print_entire_stream(str: string, input: ReadableStream<string> | Uint8Array | string, concat: Function): void;
+    function print_entire_stream(
+        str: string,
+        input: ReadableStream<string> | Uint8Array | string,
+        concat: Function,
+    ): void;
 
     /**
      * If S[1] == 0, then double(S) == (S[2..128] || 0);
@@ -4565,12 +4790,12 @@ export namespace util {
     /**
      * Format user id for internal use.
      */
-    function formatUserId(id: { name: string, email: string; comment: string }): string;
+    function formatUserId(id: { name: string; email: string; comment: string }): string;
 
     /**
      * Parse user id.
      */
-    function parseUserId(userId: string): { name: string, email: string; comment: string };
+    function parseUserId(userId: string): { name: string; email: string; comment: string };
 
     /**
      * Normalize line endings to \r\n
@@ -4609,17 +4834,17 @@ export namespace wkd {
          * @param options.rawBytes Returns Uint8Array instead of parsed key.
          * @returns The public key.
          */
-        lookup(): Promise<Uint8Array | { keys: Array<key.Key>, err: Array<Error> | null }>;
+        lookup(): Promise<Uint8Array | { keys: Array<key.Key>; err: Array<Error> | null }>;
     }
 }
 
 export namespace worker {
     /**
- * @see module:openpgp.initWorker
- * @see module:openpgp.getWorker
- * @see module:openpgp.destroyWorker
- * @see module:worker/worker
- */
+     * @see module:openpgp.initWorker
+     * @see module:openpgp.getWorker
+     * @see module:openpgp.destroyWorker
+     * @see module:worker/worker
+     */
     namespace async_proxy {
         class AsyncProxy {
             /**
@@ -4664,11 +4889,11 @@ export namespace worker {
     }
 
     /**
- * @see module:openpgp.initWorker
- * @see module:openpgp.getWorker
- * @see module:openpgp.destroyWorker
- * @see module:worker/async_proxy
- */
+     * @see module:openpgp.initWorker
+     * @see module:openpgp.getWorker
+     * @see module:openpgp.destroyWorker
+     * @see module:worker/async_proxy
+     */
     namespace worker {
         /**
          * Handle random buffer exhaustion by requesting more random bytes from the main window
@@ -4774,7 +4999,7 @@ export interface KeyOptions {
      * (optional) options for each subkey, default to main key options. e.g. [ {sign: true, passphrase: '123'}]
      *            sign parameter defaults to false, and indicates whether the subkey should sign rather than encrypt
      */
-    subkeys?: { sign: true, passphrase: string }[];
+    subkeys?: { sign: true; passphrase: string }[];
 }
 
 /**
@@ -4783,7 +5008,9 @@ export interface KeyOptions {
  * @returns The generated key object in the form:
  *          { key:Key, privateKeyArmored:String, publicKeyArmored:String, revocationCertificate:String }
  */
-export function generateKey(option: KeyOptions): Promise<{ key: key.Key, privateKeyArmored: string, publicKeyArmored: string, revocationCertificate: string }>;
+export function generateKey(
+    option: KeyOptions,
+): Promise<{ key: key.Key; privateKeyArmored: string; publicKeyArmored: string; revocationCertificate: string }>;
 
 /**
  * Reformats signature packets for a key and rewraps key object.
@@ -4795,7 +5022,13 @@ export function generateKey(option: KeyOptions): Promise<{ key: key.Key, private
  * @returns The generated key object in the form:
  *          { key:Key, privateKeyArmored:String, publicKeyArmored:String, revocationCertificate:String }
  */
-export function reformatKey(privateKey: key.Key, userIds: any[], passphrase?: string, keyExpirationTime?: number, revocationCertificate?: boolean): Promise<Object>;
+export function reformatKey(
+    privateKey: key.Key,
+    userIds: any[],
+    passphrase?: string,
+    keyExpirationTime?: number,
+    revocationCertificate?: boolean,
+): Promise<Object>;
 
 /**
  * Revokes a key. Requires either a private key or a revocation certificate.
@@ -4809,15 +5042,22 @@ export function reformatKey(privateKey: key.Key, userIds: any[], passphrase?: st
  *          { privateKey:Key, privateKeyArmored:String, publicKey:Key, publicKeyArmored:String }
  *          (if private key is passed) or { publicKey:Key, publicKeyArmored:String } (otherwise)
  */
-export function revokeKey(key?: key.Key, revocationCertificate?: string, reasonForRevocation?: revokeKey_reasonForRevocation): Promise<{
-    privateKey: key.Key,
-    privateKeyArmored: string,
-    publicKey: key.Key,
-    publicKeyArmored: string
-} | {
-    publicKey: key.Key,
-    publicKeyArmored: string
-}>;
+export function revokeKey(
+    key?: key.Key,
+    revocationCertificate?: string,
+    reasonForRevocation?: revokeKey_reasonForRevocation,
+): Promise<
+    | {
+          privateKey: key.Key;
+          privateKeyArmored: string;
+          publicKey: key.Key;
+          publicKeyArmored: string;
+      }
+    | {
+          publicKey: key.Key;
+          publicKeyArmored: string;
+      }
+>;
 
 /**
  * Unlock a private key with your passphrase.
@@ -4855,7 +5095,7 @@ export interface EncryptOptions {
     /**
      * (optional) session key in the form: { data:Uint8Array, algorithm:String }
      */
-    sessionKey?: { data: Uint8Array, algorithm: string };
+    sessionKey?: { data: Uint8Array; algorithm: string };
     /**
      * (optional) which compression algorithm to compress the message with, defaults to what is specified in config
      */
@@ -4895,17 +5135,17 @@ export interface EncryptOptions {
     /**
      * (optional) array of user IDs to encrypt for, one per key in `publicKeys`, e.g. [ { name:'Robert Receiver', email:'robert@openpgp.org' }]
      */
-    toUserIds?: UserID[]
+    toUserIds?: UserID[];
 }
 
 export interface EncryptResult {
-    sessionKey: { data: Uint8Array, algorithm: string, aeadAlgorithm: string };
+    sessionKey: { data: Uint8Array; algorithm: string; aeadAlgorithm: string };
 }
 
 /**
  * Encrypts message text/data with public keys, passwords or both at once. At least either public keys or passwords
  * must be specified. If private keys are specified, those will be used to sign the message.
- * @param options 
+ * @param options
  * @returns Object containing encrypted (and optionally signed) message in the form:
  *          {
  *          data: string|ReadableStream<String>|NodeStream, (if `armor` was true, the default)
@@ -4915,15 +5155,27 @@ export interface EncryptResult {
  *          sessionKey: { data, algorithm, aeadAlgorithm } (if `returnSessionKey` was true)
  *          }
  */
-export function encrypt(options: EncryptOptions & { armor?: true, detached?: false }): Promise<EncryptResult & { data: string }>
-export function encrypt(options: EncryptOptions & { armor?: true, detached: true }): Promise<EncryptResult & { data: string, signature: string }>
-export function encrypt(options: EncryptOptions & { armor: false, detached?: false }): Promise<EncryptResult & { message: message.Message }>
-export function encrypt(options: EncryptOptions & { armor: false, detached: true }): Promise<EncryptResult & { message: message.Message, signature: signature.Signature }>
-export function encrypt(options: EncryptOptions): Promise<EncryptResult & {
-    data: string | ReadableStream<String>;
-    message: message.Message;
-    signature: string | ReadableStream<String> | signature.Signature;
-}>;
+export function encrypt(
+    options: EncryptOptions & { armor?: true; detached?: false },
+): Promise<EncryptResult & { data: string }>;
+export function encrypt(
+    options: EncryptOptions & { armor?: true; detached: true },
+): Promise<EncryptResult & { data: string; signature: string }>;
+export function encrypt(
+    options: EncryptOptions & { armor: false; detached?: false },
+): Promise<EncryptResult & { message: message.Message }>;
+export function encrypt(
+    options: EncryptOptions & { armor: false; detached: true },
+): Promise<EncryptResult & { message: message.Message; signature: signature.Signature }>;
+export function encrypt(
+    options: EncryptOptions,
+): Promise<
+    EncryptResult & {
+        data: string | ReadableStream<String>;
+        message: message.Message;
+        signature: string | ReadableStream<String> | signature.Signature;
+    }
+>;
 
 export interface DecryptOptions {
     /**
@@ -4941,7 +5193,7 @@ export interface DecryptOptions {
     /**
      * (optional) session keys in the form: { data:Uint8Array, algorithm:String }
      */
-    sessionKeys?: { data: Uint8Array, algorithm: string } | { data: Uint8Array, algorithm: string }[];
+    sessionKeys?: { data: Uint8Array; algorithm: string } | { data: Uint8Array; algorithm: string }[];
     /**
      * (optional) array of public keys or single key, to verify signatures
      */
@@ -4961,17 +5213,17 @@ export interface DecryptOptions {
     /**
      * (optional) use the given date for verification instead of the current time
      */
-    date?: Date
+    date?: Date;
 }
 
 export interface DecryptResult {
-    data: string | ReadableStream<String> | NodeStream | Uint8Array | ReadableStream<Uint8Array>,
-    filename: string,
+    data: string | ReadableStream<String> | NodeStream | Uint8Array | ReadableStream<Uint8Array>;
+    filename: string;
     signatures: {
-        keyid: type.keyid.Keyid,
-        verified: Promise<Boolean>,
-        valid: boolean
-    }[]
+        keyid: type.keyid.Keyid;
+        verified: Promise<Boolean>;
+        valid: boolean;
+    }[];
 }
 
 /**
@@ -4992,8 +5244,12 @@ export interface DecryptResult {
  *          ]
  *          }
  */
-export function decrypt(options: DecryptOptions & { format: "utf8" }): Promise<DecryptResult & { data: string | ReadableStream<String> | NodeStream }>
-export function decrypt(options: DecryptOptions & { format: "binary" }): Promise<DecryptResult & { data: Uint8Array | ReadableStream<Uint8Array> | NodeStream }>
+export function decrypt(
+    options: DecryptOptions & { format: 'utf8' },
+): Promise<DecryptResult & { data: string | ReadableStream<String> | NodeStream }>;
+export function decrypt(
+    options: DecryptOptions & { format: 'binary' },
+): Promise<DecryptResult & { data: Uint8Array | ReadableStream<Uint8Array> | NodeStream }>;
 export function decrypt(options: DecryptOptions): Promise<DecryptResult>;
 
 export interface SignOptions {
@@ -5024,13 +5280,13 @@ export interface SignOptions {
     /**
      *  (optional) array of user IDs to sign with, one per key in `privateKeys`, e.g. [ { name:'Steve Sender', email:'steve@openpgp.org' }]
      */
-    fromUserIds?: UserID[]
+    fromUserIds?: UserID[];
 }
 
 export interface SignResult {
-    data: string | ReadableStream<String> | NodeStream,
-    message: message.Message,
-    signature: string | ReadableStream<String> | NodeStream | signature.Signature
+    data: string | ReadableStream<String> | NodeStream;
+    message: message.Message;
+    signature: string | ReadableStream<String> | NodeStream | signature.Signature;
 }
 
 /**
@@ -5047,10 +5303,12 @@ export interface SignResult {
  *          signature: Signature (if `armor` was false)
  *          }
  */
-export function sign(options: SignOptions & { armor?: true, detached?: false }): Promise<{ data: string }>
-export function sign(options: SignOptions & { armor: false, detached?: false }): Promise<{ message: message.Message }>
-export function sign(options: SignOptions & { armor?: true, detached: true }): Promise<{ signature: string }>
-export function sign(options: SignOptions & { armor: false, detached: true }): Promise<{ signature: signature.Signature }>
+export function sign(options: SignOptions & { armor?: true; detached?: false }): Promise<{ data: string }>;
+export function sign(options: SignOptions & { armor: false; detached?: false }): Promise<{ message: message.Message }>;
+export function sign(options: SignOptions & { armor?: true; detached: true }): Promise<{ signature: string }>;
+export function sign(
+    options: SignOptions & { armor: false; detached: true },
+): Promise<{ signature: signature.Signature }>;
 export function sign(options: SignOptions): Promise<SignResult>;
 
 export interface VerifyOptions {
@@ -5073,16 +5331,16 @@ export interface VerifyOptions {
     /**
      * (optional) use the given date for verification instead of the current time
      */
-    date?: Date
+    date?: Date;
 }
 
 export interface VerifyResult {
-    data: string | ReadableStream<String> | NodeStream | Uint8Array | ReadableStream<Uint8Array> | NodeStream,
+    data: string | ReadableStream<String> | NodeStream | Uint8Array | ReadableStream<Uint8Array> | NodeStream;
     signatures: {
-        keyid: type.keyid.Keyid,
-        verified: Promise<Boolean>,
-        valid: boolean
-    }[]
+        keyid: type.keyid.Keyid;
+        verified: Promise<Boolean>;
+        valid: boolean;
+    }[];
 }
 
 /**
@@ -5116,7 +5374,16 @@ export function verify(options: VerifyOptions): Promise<VerifyResult>;
  * @param toUserIds (optional) array of user IDs to encrypt for, one per key in `publicKeys`, e.g. [ { name:'Phil Zimmermann', email:'phil@openpgp.org' }]
  * @returns the encrypted session key packets contained in a message object
  */
-export function encryptSessionKey(data: Uint8Array, algorithm: string, aeadAlgorithm?: string, publicKeys?: key.Key | key.Key[], passwords?: string | string[], wildcard?: boolean, date?: Date, toUserIds?: any[]): Promise<message.Message>;
+export function encryptSessionKey(
+    data: Uint8Array,
+    algorithm: string,
+    aeadAlgorithm?: string,
+    publicKeys?: key.Key | key.Key[],
+    passwords?: string | string[],
+    wildcard?: boolean,
+    date?: Date,
+    toUserIds?: any[],
+): Promise<message.Message>;
 
 /**
  * Decrypt symmetric session keys with a private key or password. Either a private key or
@@ -5128,7 +5395,11 @@ export function encryptSessionKey(data: Uint8Array, algorithm: string, aeadAlgor
  *          { data:Uint8Array, algorithm:String }
  *          or 'undefined' if no key packets found
  */
-export function decryptSessionKeys(message: message.Message, privateKeys?: key.Key | key.Key[], passwords?: string | string[]): Promise<{ data: Uint8Array, algorithm: string }[] | undefined>;
+export function decryptSessionKeys(
+    message: message.Message,
+    privateKeys?: key.Key | key.Key[],
+    passwords?: string | string[],
+): Promise<{ data: Uint8Array; algorithm: string }[] | undefined>;
 
 /**
  * Input validation

--- a/types/openpgp/openpgp-tests.ts
+++ b/types/openpgp/openpgp-tests.ts
@@ -1,82 +1,97 @@
-import openpgp from "openpgp"
+import openpgp from 'openpgp';
 
 // Open PGP Sample codes
 
 const options: openpgp.KeyOptions = {
     numBits: 2048,
-    userIds: [{
-        name: 'Jon Smith',
-        email: 'jon.smith@example.org',
-    }, {
-        email: 'jon.smith@example.org',
-    }, {
-        name: 'Jon Smith',
-    }, {
-    }],
-    passphrase: 'super long and hard to guess secret'
+    userIds: [
+        {
+            name: 'Jon Smith',
+            email: 'jon.smith@example.org',
+        },
+        {
+            email: 'jon.smith@example.org',
+        },
+        {
+            name: 'Jon Smith',
+        },
+        {},
+    ],
+    passphrase: 'super long and hard to guess secret',
 };
-openpgp.generateKey(options).then((keypair) => {
-    // success
-    const privkey = keypair.privateKeyArmored;
-    const pubkey = keypair.publicKeyArmored;
-}).catch((error) => {
-    // failure
-});
+openpgp
+    .generateKey(options)
+    .then(keypair => {
+        // success
+        const privkey = keypair.privateKeyArmored;
+        const pubkey = keypair.publicKeyArmored;
+    })
+    .catch(error => {
+        // failure
+    });
 
 const spubkey = '-----BEGIN PGP PUBLIC KEY BLOCK ... END PGP PUBLIC KEY BLOCK-----';
 
-openpgp.key.readArmored(spubkey)
-    .then((publicKey) => {
+openpgp.key
+    .readArmored(spubkey)
+    .then(publicKey => {
         return {
             message: openpgp.message.fromText('Hello, World!'),
-            publicKeys: publicKey.keys
+            publicKeys: publicKey.keys,
         };
     })
     .then(openpgp.encrypt)
-    .then((pgpMessage) => {
+    .then(pgpMessage => {
         // success
     })
-    .catch((error) => {
+    .catch(error => {
         // failure
     });
 
 const sprivkey = '-----BEGIN PGP PRIVATE KEY BLOCK ... END PGP PRIVATE KEY BLOCK-----';
 const pgpMessageStr = '-----BEGIN PGP MESSAGE ... END PGP MESSAGE-----';
 
-openpgp.message.readArmored(pgpMessageStr).then((pgpMessage) => {
-    const options = {
-        message: pgpMessage
-    };
-    return openpgp.decrypt(options);
-}).then((plaintext) => {
-    // success
-}).catch((error) => {
-    // failure
-});
+openpgp.message
+    .readArmored(pgpMessageStr)
+    .then(pgpMessage => {
+        const options = {
+            message: pgpMessage,
+        };
+        return openpgp.decrypt(options);
+    })
+    .then(plaintext => {
+        // success
+    })
+    .catch(error => {
+        // failure
+    });
 
-const promises: [Promise<{ keys: openpgp.key.Key[], err: Error[] | null }>, Promise<openpgp.message.Message>] = [
+const promises: [Promise<{ keys: openpgp.key.Key[]; err: Error[] | null }>, Promise<openpgp.message.Message>] = [
     openpgp.key.readArmored(sprivkey),
-    openpgp.message.readArmored(pgpMessageStr)
+    openpgp.message.readArmored(pgpMessageStr),
 ];
 
-Promise.all(promises).then((values) => {
-    const keyObject: openpgp.key.KeyResult = values[0];
-    const pgpMessage: openpgp.message.Message = values[1];
-    const privateKey = keyObject.keys[0];
-    privateKey.decrypt('passphrase');
-    const options = {
-        privateKeys: privateKey,
-        message: pgpMessage
-    };
-    return openpgp.decrypt(options);
-}).then((plaintext) => {
-    // success
-}).catch((error) => {
-    // failure
-});
+Promise.all(promises)
+    .then(values => {
+        const keyObject: openpgp.key.KeyResult = values[0];
+        const pgpMessage: openpgp.message.Message = values[1];
+        const privateKey = keyObject.keys[0];
+        privateKey.decrypt('passphrase');
+        const options = {
+            privateKeys: privateKey,
+            message: pgpMessage,
+        };
+        return openpgp.decrypt(options);
+    })
+    .then(plaintext => {
+        // success
+    })
+    .catch(error => {
+        // failure
+    });
 
 openpgp.initWorker({
-    path: 'openpgp.worker.js'
+    path: 'openpgp.worker.js',
 });
 
 (async () => {
@@ -94,7 +109,7 @@ openpgp.initWorker({
     let armored = await openpgp.encrypt({
         message: openpgp.message.fromBinary(new Uint8Array([0x01, 0x01, 0x01])),
         armor: true,
-        privateKeys: []
+        privateKeys: [],
     });
     let data: string = armored.data;
     // let msg: openpgp.message.Message = armored.message; // without member 'message'
@@ -102,7 +117,7 @@ openpgp.initWorker({
     const plain = await openpgp.decrypt({
         message: await openpgp.message.read(encrypted),
         passwords: ['secret stuff'],
-        format: 'binary'
+        format: 'binary',
     });
 
     return plain.data;
@@ -125,12 +140,12 @@ openpgp.initWorker({
 })();
 
 (async () => {
-    const publicKey = (await openpgp.key.readArmored(spubkey));
-    const privateKey = (await openpgp.key.readArmored(sprivkey));
+    const publicKey = await openpgp.key.readArmored(spubkey);
+    const privateKey = await openpgp.key.readArmored(sprivkey);
     const signOptions: openpgp.SignOptions = {
         message: openpgp.message.fromText('hello world'),
         privateKeys: privateKey.keys,
-        detached: true
+        detached: true,
     };
 
     const signed = await openpgp.sign(signOptions);
@@ -139,33 +154,41 @@ openpgp.initWorker({
     const message = signed.message;
 
     // Test function reload
-    openpgp.sign({
-        message: null,
-        privateKeys: [],
-        detached: true
-    }).then(s => s.signature/* as string*/);
-    openpgp.sign({
-        message: null,
-        privateKeys: [],
-        detached: false,
-    }).then(s => s.data/* as string*/);
-    openpgp.sign({
-        message: null,
-        privateKeys: [],
-        armor: false,
-        detached: true
-    }).then(s => s.signature/* as openpgp.signature.Signature*/);
-    openpgp.sign({
-        message: null,
-        privateKeys: [],
-        armor: false,
-        detached: false,
-    }).then(s => s.message/* as openpgp.message.Message*/);
+    openpgp
+        .sign({
+            message: null,
+            privateKeys: [],
+            detached: true,
+        })
+        .then(s => s.signature /* as string*/);
+    openpgp
+        .sign({
+            message: null,
+            privateKeys: [],
+            detached: false,
+        })
+        .then(s => s.data /* as string*/);
+    openpgp
+        .sign({
+            message: null,
+            privateKeys: [],
+            armor: false,
+            detached: true,
+        })
+        .then(s => s.signature /* as openpgp.signature.Signature*/);
+    openpgp
+        .sign({
+            message: null,
+            privateKeys: [],
+            armor: false,
+            detached: false,
+        })
+        .then(s => s.message /* as openpgp.message.Message*/);
 
     const verifyOptions: openpgp.VerifyOptions = {
         message,
         signature,
-        publicKeys: publicKey.keys
+        publicKeys: publicKey.keys,
     };
 
     const verified = await openpgp.verify(verifyOptions);
@@ -173,11 +196,11 @@ openpgp.initWorker({
     return verified.signatures[0].valid;
 })();
 
-(async () => {
-    const publicKey = (await openpgp.key.readArmored(spubkey));
+async () => {
+    const publicKey = await openpgp.key.readArmored(spubkey);
 
-    return publicKey.keys[0].primaryKey.getFingerprint()/* as string*/
-})
+    return publicKey.keys[0].primaryKey.getFingerprint(); /* as string*/
+};
 
 // Open PGP Tests
 
@@ -186,20 +209,20 @@ const mpi: openpgp.type.mpi.MPI = null;
 const mpis: openpgp.type.mpi.MPI[] = [];
 
 openpgp.encoding.armor.armor(openpgp.enums.armor.message, {}, 0, 1);
-openpgp.encoding.armor.dearmor("");
+openpgp.encoding.armor.dearmor('');
 
-openpgp.cleartext.readArmored("");
+openpgp.cleartext.readArmored('');
 
 openpgp.crypto.crypto.generateSessionKey(openpgp.enums.symmetric.aes128);
 openpgp.crypto.crypto.getPrefixRandom(openpgp.enums.symmetric.aes128);
 // openpgp.crypto.crypto.getPrivateMpiCount(openpgp.enums.symmetric.aes128);
-openpgp.crypto.crypto.publicKeyDecrypt(openpgp.enums.publicKey.rsa_encrypt, mpis, mpis, "");
-openpgp.crypto.crypto.publicKeyEncrypt(openpgp.enums.publicKey.rsa_encrypt, mpis, mpi, "");
+openpgp.crypto.crypto.publicKeyDecrypt(openpgp.enums.publicKey.rsa_encrypt, mpis, mpis, '');
+openpgp.crypto.crypto.publicKeyEncrypt(openpgp.enums.publicKey.rsa_encrypt, mpis, mpi, '');
 
 openpgp.crypto;
 // API update with no documentation
-openpgp.crypto.cfb.decrypt("", "", "", true);
-openpgp.crypto.cfb.encrypt("", "", "", true);
+openpgp.crypto.cfb.decrypt('', '', '', true);
+openpgp.crypto.cfb.encrypt('', '', '', true);
 // Function removed from openpgp.crypto.cfb
 // openpgp.crypto.cfb.mdc({}, "", "");
 
@@ -212,28 +235,41 @@ openpgp.crypto.random.getRandomBytes(0);
 // openpgp.crypto.random.getRandomValues(openpgp.util.str_to_Uint8Array(""));
 // openpgp.crypto.random.getSecureRandom(0, 1);
 
-openpgp.crypto.signature.sign(openpgp.enums.publicKey.rsa_encrypt, openpgp.enums.hash.md5, mpis, new Uint8Array([0, 1]), new Uint8Array([0, 1]));
-openpgp.crypto.signature.verify(openpgp.enums.publicKey.rsa_encrypt, openpgp.enums.hash.md5, mpis, mpis, new Uint8Array([0, 1]), new Uint8Array([0, 1]));
+openpgp.crypto.signature.sign(
+    openpgp.enums.publicKey.rsa_encrypt,
+    openpgp.enums.hash.md5,
+    mpis,
+    new Uint8Array([0, 1]),
+    new Uint8Array([0, 1]),
+);
+openpgp.crypto.signature.verify(
+    openpgp.enums.publicKey.rsa_encrypt,
+    openpgp.enums.hash.md5,
+    mpis,
+    mpis,
+    new Uint8Array([0, 1]),
+    new Uint8Array([0, 1]),
+);
 
 openpgp.key.generate(keyoptions);
-openpgp.key.readArmored("");
+openpgp.key.readArmored('');
 
 openpgp.message.fromBinary(new Uint8Array([0x01, 0x02, 0x03]));
-openpgp.message.fromText("");
-openpgp.message.readArmored("");
+openpgp.message.fromText('');
+openpgp.message.readArmored('');
 
 openpgp.packet.fromStructuredClone({});
-openpgp.packet.newPacketFromTag("");
+openpgp.packet.newPacketFromTag('');
 
 openpgp.util.Uint8Array_to_str(new Uint8Array([1, 0]));
 openpgp.util.decode_utf8(new Uint8Array([1, 0]));
-openpgp.util.encode_utf8("");
+openpgp.util.encode_utf8('');
 openpgp.util.getWebCrypto();
-openpgp.util.hex_to_Uint8Array("");
-openpgp.util.print_debug_hexarray_dump("");
-openpgp.util.print_debug_hexstr_dump("");
-openpgp.util.print_debug("");
-openpgp.util.print_debug_hexstr_dump("");
+openpgp.util.hex_to_Uint8Array('');
+openpgp.util.print_debug_hexarray_dump('');
+openpgp.util.print_debug_hexstr_dump('');
+openpgp.util.print_debug('');
+openpgp.util.print_debug_hexstr_dump('');
 openpgp.util.shiftRight(new Uint8Array([1, 0]), 1);
-openpgp.util.str_to_Uint8Array("");
-openpgp.util.Uint8Array_to_str(openpgp.util.str_to_Uint8Array(""));
+openpgp.util.str_to_Uint8Array('');
+openpgp.util.Uint8Array_to_str(openpgp.util.str_to_Uint8Array(''));

--- a/types/openpgp/ts3.2/index.d.ts
+++ b/types/openpgp/ts3.2/index.d.ts
@@ -9,13 +9,14 @@
 //                 Ryo Ota <https://github.com/nwtgck>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import BN = require("bn.js")
-import stream = require("stream")
+import BN = require('bn.js');
+import stream = require('stream');
 
-export {}
+export {};
 type NodeStream = stream;
 type Integer = number;
 type Infinity = any;
+type ReadableStream<T> = any;
 
 export namespace cleartext {
     /**
@@ -53,7 +54,12 @@ export namespace cleartext {
          * @param userIds (optional) user IDs to sign with, e.g. [ { name:'Steve Sender', email:'steve@openpgp.org' }]
          * @returns new detached signature of message content
          */
-        signDetached(privateKeys: any[], signature: signature.Signature, date: Date, userIds: any[]): Promise<signature.Signature>;
+        signDetached(
+            privateKeys: any[],
+            signature: signature.Signature,
+            date: Date,
+            userIds: any[],
+        ): Promise<signature.Signature>;
 
         /**
          * Verify signatures of cleartext signed message
@@ -61,7 +67,7 @@ export namespace cleartext {
          * @param date (optional) Verify the signature against the given date, i.e. check signature creation time < date < expiration time
          * @returns list of signer's keyid and validity of signature
          */
-        verify(keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid, valid: boolean }>>;
+        verify(keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
         /**
          * Verify signatures of cleartext signed message
@@ -69,7 +75,7 @@ export namespace cleartext {
          * @param date (optional) Verify the signature against the given date, i.e. check signature creation time < date < expiration time
          * @returns list of signer's keyid and validity of signature
          */
-        verifyDetached(keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid, valid: boolean }>>;
+        verifyDetached(keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
         /**
          * Get cleartext
@@ -233,8 +239,6 @@ export class LocalStorage {
     write(): void;
 }
 
-
-
 /**
  * @see module:crypto/crypto
  * @see module:crypto/signature
@@ -245,8 +249,8 @@ export class LocalStorage {
  */
 export namespace crypto {
     /**
- * @see module:crypto/public_key/elliptic/ecdh
- */
+     * @see module:crypto/public_key/elliptic/ecdh
+     */
     namespace aes_kw {
         /**
          * AES key wrap
@@ -267,8 +271,8 @@ export namespace crypto {
     }
 
     namespace cfb {
-        function encrypt(algo: any, key: any, plaintext: any, iv: any): any
-        function decrypt(algo: any, key: any, ciphertext: any, iv: any): Promise<any>
+        function encrypt(algo: any, key: any, plaintext: any, iv: any): any;
+        function decrypt(algo: any, key: any, ciphertext: any, iv: any): Promise<any>;
     }
 
     namespace cipher {
@@ -373,7 +377,12 @@ export namespace crypto {
          * @param fingerprint Recipient fingerprint
          * @returns encrypted session key parameters
          */
-        function publicKeyEncrypt(algo: enums.publicKey, pub_params: Array<type.mpi.MPI | type.oid.OID | type.kdf_params.KDFParams>, data: type.mpi.MPI, fingerprint: string): any[];
+        function publicKeyEncrypt(
+            algo: enums.publicKey,
+            pub_params: Array<type.mpi.MPI | type.oid.OID | type.kdf_params.KDFParams>,
+            data: type.mpi.MPI,
+            fingerprint: string,
+        ): any[];
 
         /**
          * Decrypts data using specified algorithm and private key parameters.
@@ -384,7 +393,12 @@ export namespace crypto {
          * @param fingerprint Recipient fingerprint
          * @returns An MPI containing the decrypted data
          */
-        function publicKeyDecrypt(algo: enums.publicKey, key_params: Array<type.mpi.MPI | type.oid.OID | type.kdf_params.KDFParams>, data_params: Array<type.mpi.MPI | type.oid.OID | type.kdf_params.KDFParams>, fingerprint: string): type.mpi.MPI;
+        function publicKeyDecrypt(
+            algo: enums.publicKey,
+            key_params: Array<type.mpi.MPI | type.oid.OID | type.kdf_params.KDFParams>,
+            data_params: Array<type.mpi.MPI | type.oid.OID | type.kdf_params.KDFParams>,
+            fingerprint: string,
+        ): type.mpi.MPI;
 
         /**
          * Returns the types comprising the private key of an algorithm
@@ -572,10 +586,10 @@ export namespace crypto {
     }
 
     /**
-    * @see module:crypto/public_key/rsa
-    * @see module:crypto/public_key/elliptic/ecdh
-    * @see module:packet.PublicKeyEncryptedSessionKey
-    */
+     * @see module:crypto/public_key/rsa
+     * @see module:crypto/public_key/elliptic/ecdh
+     * @see module:packet.PublicKeyEncryptedSessionKey
+     */
     namespace pkcs1 {
         namespace eme {
             /**
@@ -667,15 +681,14 @@ export namespace crypto {
         }
 
         /**
-        * @see module:crypto/public_key/elliptic/curve
-        * @see module:crypto/public_key/elliptic/ecdh
-        * @see module:crypto/public_key/elliptic/ecdsa
-        * @see module:crypto/public_key/elliptic/eddsa
-        */
+         * @see module:crypto/public_key/elliptic/curve
+         * @see module:crypto/public_key/elliptic/ecdh
+         * @see module:crypto/public_key/elliptic/ecdsa
+         * @see module:crypto/public_key/elliptic/eddsa
+         */
         namespace elliptic {
             namespace curve {
-                class Curve {
-                }
+                class Curve {}
             }
 
             namespace ecdh {
@@ -685,7 +698,7 @@ export namespace crypto {
                  * @param Q Recipient public key
                  * @returns Returns public part of ephemeral key and generated ephemeral secret
                  */
-                function genPublicEphemeralKey(curve: curve.Curve, Q: Uint8Array): Promise<{ V: Uint8Array, S: BN }>;
+                function genPublicEphemeralKey(curve: curve.Curve, Q: Uint8Array): Promise<{ V: Uint8Array; S: BN }>;
 
                 /**
                  * Encrypt and wrap a session key
@@ -697,7 +710,14 @@ export namespace crypto {
                  * @param fingerprint Recipient fingerprint
                  * @returns Returns public part of ephemeral key and encoded session key
                  */
-                function encrypt(oid: type.oid.OID, cipher_algo: enums.symmetric, hash_algo: enums.hash, m: type.mpi.MPI, Q: Uint8Array, fingerprint: string): Promise<{ V: BN, C: BN }>;
+                function encrypt(
+                    oid: type.oid.OID,
+                    cipher_algo: enums.symmetric,
+                    hash_algo: enums.hash,
+                    m: type.mpi.MPI,
+                    Q: Uint8Array,
+                    fingerprint: string,
+                ): Promise<{ V: BN; C: BN }>;
 
                 /**
                  * Generate ECDHE secret from private key and public part of ephemeral key
@@ -719,7 +739,15 @@ export namespace crypto {
                  * @param fingerprint Recipient fingerprint
                  * @returns Value derived from session
                  */
-                function decrypt(oid: type.oid.OID, cipher_algo: enums.symmetric, hash_algo: enums.hash, V: Uint8Array, C: Uint8Array, d: Uint8Array, fingerprint: string): Promise<BN>;
+                function decrypt(
+                    oid: type.oid.OID,
+                    cipher_algo: enums.symmetric,
+                    hash_algo: enums.hash,
+                    V: Uint8Array,
+                    C: Uint8Array,
+                    d: Uint8Array,
+                    fingerprint: string,
+                ): Promise<BN>;
             }
 
             namespace ecdsa {
@@ -732,7 +760,13 @@ export namespace crypto {
                  * @param hashed The hashed message
                  * @returns Signature of the message
                  */
-                function sign(oid: type.oid.OID, hash_algo: enums.hash, m: Uint8Array, d: Uint8Array, hashed: Uint8Array): object;
+                function sign(
+                    oid: type.oid.OID,
+                    hash_algo: enums.hash,
+                    m: Uint8Array,
+                    d: Uint8Array,
+                    hashed: Uint8Array,
+                ): object;
 
                 /**
                  * Verifies if a signature is valid for a message
@@ -744,7 +778,14 @@ export namespace crypto {
                  * @param hashed The hashed message
                  * @returns
                  */
-                function verify(oid: type.oid.OID, hash_algo: enums.hash, signature: object, m: Uint8Array, Q: Uint8Array, hashed: Uint8Array): boolean;
+                function verify(
+                    oid: type.oid.OID,
+                    hash_algo: enums.hash,
+                    signature: object,
+                    m: Uint8Array,
+                    Q: Uint8Array,
+                    hashed: Uint8Array,
+                ): boolean;
             }
 
             namespace eddsa {
@@ -757,7 +798,13 @@ export namespace crypto {
                  * @param hashed The hashed message
                  * @returns Signature of the message
                  */
-                function sign(oid: type.oid.OID, hash_algo: enums.hash, m: Uint8Array, d: Uint8Array, hashed: Uint8Array): object;
+                function sign(
+                    oid: type.oid.OID,
+                    hash_algo: enums.hash,
+                    m: Uint8Array,
+                    d: Uint8Array,
+                    hashed: Uint8Array,
+                ): object;
 
                 /**
                  * Verifies if a signature is valid for a message
@@ -769,12 +816,18 @@ export namespace crypto {
                  * @param hashed The hashed message
                  * @returns
                  */
-                function verify(oid: type.oid.OID, hash_algo: enums.hash, signature: object, m: Uint8Array, Q: Uint8Array, hashed: Uint8Array): boolean;
+                function verify(
+                    oid: type.oid.OID,
+                    hash_algo: enums.hash,
+                    signature: object,
+                    m: Uint8Array,
+                    Q: Uint8Array,
+                    hashed: Uint8Array,
+                ): boolean;
             }
 
             namespace key {
-                class KeyPair {
-                }
+                class KeyPair {}
             }
         }
 
@@ -909,7 +962,14 @@ export namespace crypto {
          * @param hashed The hashed data
          * @returns True if signature is valid
          */
-        function verify(algo: enums.publicKey, hash_algo: enums.hash, msg_MPIs: type.mpi.MPI[], pub_MPIs: type.mpi.MPI[], data: Uint8Array, hashed: Uint8Array): boolean;
+        function verify(
+            algo: enums.publicKey,
+            hash_algo: enums.hash,
+            msg_MPIs: type.mpi.MPI[],
+            pub_MPIs: type.mpi.MPI[],
+            data: Uint8Array,
+            hashed: Uint8Array,
+        ): boolean;
 
         /**
          * Creates a signature on data using specified algorithms and private key parameters.
@@ -923,7 +983,13 @@ export namespace crypto {
          * @param hashed The hashed data
          * @returns Signature
          */
-        function sign(algo: enums.publicKey, hash_algo: enums.hash, key_params: type.mpi.MPI[], data: Uint8Array, hashed: Uint8Array): Uint8Array;
+        function sign(
+            algo: enums.publicKey,
+            hash_algo: enums.hash,
+            key_params: type.mpi.MPI[],
+            data: Uint8Array,
+            hashed: Uint8Array,
+        ): Uint8Array;
     }
 }
 
@@ -1010,7 +1076,13 @@ export namespace encoding {
          * @param customComment (optional) additional comment to add to the armored string
          * @returns Armored text
          */
-        function armor(messagetype: Integer, body: any, partindex: Integer, parttotal: Integer, customComment?: string): string | ReadableStream<String>;
+        function armor(
+            messagetype: Integer,
+            body: any,
+            partindex: Integer,
+            parttotal: Integer,
+            customComment?: string,
+        ): string | ReadableStream<String>;
     }
 
     namespace base64 {
@@ -1041,78 +1113,78 @@ export namespace enums {
         /**
          * NIST P-256 Curve
          */
-        p256 = "p256",
-        "P-256" = "p256",
-        secp256r1 = "p256",
-        prime256v1 = "p256",
-        "1.2.840.10045.3.1.7" = "p256",
-        "2a8648ce3d030107" = "p256",
-        "2A8648CE3D030107" = "p256",
+        p256 = 'p256',
+        'P-256' = 'p256',
+        secp256r1 = 'p256',
+        prime256v1 = 'p256',
+        '1.2.840.10045.3.1.7' = 'p256',
+        '2a8648ce3d030107' = 'p256',
+        '2A8648CE3D030107' = 'p256',
         /**
          * NIST P-384 Curve
          */
-        p384 = "p384",
-        "P-384" = "p384",
-        secp384r1 = "p384",
-        "1.3.132.0.34" = "p384",
-        "2b81040022" = "p384",
-        "2B81040022" = "p384",
+        p384 = 'p384',
+        'P-384' = 'p384',
+        secp384r1 = 'p384',
+        '1.3.132.0.34' = 'p384',
+        '2b81040022' = 'p384',
+        '2B81040022' = 'p384',
         /**
          * NIST P-521 Curve
          */
-        p521 = "p521",
-        "P-521" = "p521",
-        secp521r1 = "p521",
-        "1.3.132.0.35" = "p521",
-        "2b81040023" = "p521",
-        "2B81040023" = "p521",
+        p521 = 'p521',
+        'P-521' = 'p521',
+        secp521r1 = 'p521',
+        '1.3.132.0.35' = 'p521',
+        '2b81040023' = 'p521',
+        '2B81040023' = 'p521',
         /**
          * SECG SECP256k1 Curve
          */
-        secp256k1 = "secp256k1",
-        "1.3.132.0.10" = "secp256k1",
-        "2b8104000a" = "secp256k1",
-        "2B8104000A" = "secp256k1",
+        secp256k1 = 'secp256k1',
+        '1.3.132.0.10' = 'secp256k1',
+        '2b8104000a' = 'secp256k1',
+        '2B8104000A' = 'secp256k1',
         /**
          * Ed25519
          */
-        ED25519 = "ed25519",
-        ed25519 = "ed25519",
-        Ed25519 = "ed25519",
-        "1.3.6.1.4.1.11591.15.1" = "ed25519",
-        "2b06010401da470f01" = "ed25519",
-        "2B06010401DA470F01" = "ed25519",
+        ED25519 = 'ed25519',
+        ed25519 = 'ed25519',
+        Ed25519 = 'ed25519',
+        '1.3.6.1.4.1.11591.15.1' = 'ed25519',
+        '2b06010401da470f01' = 'ed25519',
+        '2B06010401DA470F01' = 'ed25519',
         /**
          * Curve25519
          */
-        X25519 = "curve25519",
-        cv25519 = "curve25519",
-        curve25519 = "curve25519",
-        Curve25519 = "curve25519",
-        "1.3.6.1.4.1.3029.1.5.1" = "curve25519",
-        "2b060104019755010501" = "curve25519",
-        "2B060104019755010501" = "curve25519",
+        X25519 = 'curve25519',
+        cv25519 = 'curve25519',
+        curve25519 = 'curve25519',
+        Curve25519 = 'curve25519',
+        '1.3.6.1.4.1.3029.1.5.1' = 'curve25519',
+        '2b060104019755010501' = 'curve25519',
+        '2B060104019755010501' = 'curve25519',
         /**
          * BrainpoolP256r1 Curve
          */
-        brainpoolP256r1 = "brainpoolP256r1",
-        "1.3.36.3.3.2.8.1.1.7" = "brainpoolP256r1",
-        "2b2403030208010107" = "brainpoolP256r1",
-        "2B2403030208010107" = "brainpoolP256r1",
+        brainpoolP256r1 = 'brainpoolP256r1',
+        '1.3.36.3.3.2.8.1.1.7' = 'brainpoolP256r1',
+        '2b2403030208010107' = 'brainpoolP256r1',
+        '2B2403030208010107' = 'brainpoolP256r1',
         /**
          * BrainpoolP384r1 Curve
          */
-        brainpoolP384r1 = "brainpoolP384r1",
-        "1.3.36.3.3.2.8.1.1.11" = "brainpoolP384r1",
-        "2b240303020801010b" = "brainpoolP384r1",
-        "2B240303020801010B" = "brainpoolP384r1",
+        brainpoolP384r1 = 'brainpoolP384r1',
+        '1.3.36.3.3.2.8.1.1.11' = 'brainpoolP384r1',
+        '2b240303020801010b' = 'brainpoolP384r1',
+        '2B240303020801010B' = 'brainpoolP384r1',
         /**
          * BrainpoolP512r1 Curve
          */
-        brainpoolP512r1 = "brainpoolP512r1",
-        "1.3.36.3.3.2.8.1.1.13" = "brainpoolP512r1",
-        "2b240303020801010d" = "brainpoolP512r1",
-        "2B240303020801010D" = "brainpoolP512r1",
+        brainpoolP512r1 = 'brainpoolP512r1',
+        '1.3.36.3.3.2.8.1.1.13' = 'brainpoolP512r1',
+        '2b240303020801010d' = 'brainpoolP512r1',
+        '2B240303020801010D' = 'brainpoolP512r1',
     }
 
     /**
@@ -1181,7 +1253,7 @@ export namespace enums {
          * Not implemented!
          */
         idea = 1,
-        "3des" = 2,
+        '3des' = 2,
         tripledes = 2,
         cast5 = 3,
         blowfish = 4,
@@ -1225,10 +1297,10 @@ export namespace enums {
      * {@link https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest|Parameters, algo}
      */
     enum webHash {
-        "SHA-1" = 2,
-        "SHA-256" = 8,
-        "SHA-384" = 9,
-        "SHA-512" = 10,
+        'SHA-1' = 2,
+        'SHA-256' = 8,
+        'SHA-384' = 9,
+        'SHA-512' = 10,
     }
 
     /**
@@ -1271,19 +1343,19 @@ export namespace enums {
         /**
          * Binary data 'b'
          */
-        binary = "",
+        binary = '',
         /**
          * Text data 't'
          */
-        text = "",
+        text = '',
         /**
          * Utf8 data 'u'
          */
-        utf8 = "",
+        utf8 = '',
         /**
          * MIME message body part 'm'
          */
-        mime = "",
+        mime = '',
     }
 
     /**
@@ -1725,7 +1797,10 @@ export namespace key {
          * @param keyId
          * @returns
          */
-        encrypt(passphrases: string | any[], keyId?: type.keyid.Keyid): Promise<Array<packet.SecretKey | packet.SecretSubkey>>;
+        encrypt(
+            passphrases: string | any[],
+            keyId?: type.keyid.Keyid,
+        ): Promise<Array<packet.SecretKey | packet.SecretSubkey>>;
 
         /**
          * Decrypts all secret key and subkey packets matching keyId
@@ -1743,7 +1818,11 @@ export namespace key {
          * @param date Use the given date instead of the current time
          * @returns True if the certificate is revoked
          */
-        isRevoked(signature: packet.Signature, key?: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey, date?: Date): Promise<Boolean>;
+        isRevoked(
+            signature: packet.Signature,
+            key?: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey,
+            date?: Date,
+        ): Promise<Boolean>;
 
         /**
          * Verify primary key. Checks for revocation signatures, expiration time
@@ -1764,7 +1843,11 @@ export namespace key {
          * @param userId, optional user ID
          * @returns
          */
-        getExpirationTime(capabilities?: any, keyId?: type.keyid.Keyid, userId?: object): Promise<Date | Infinity | null>;
+        getExpirationTime(
+            capabilities?: any,
+            keyId?: type.keyid.Keyid,
+            userId?: object,
+        ): Promise<Date | Infinity | null>;
 
         /**
          * Returns primary user and most significant (latest valid) self signature
@@ -1774,7 +1857,7 @@ export namespace key {
          * @param userId (optional) user ID to get instead of the primary user, if it exists
          * @returns The primary user and the self signature
          */
-        getPrimaryUser(date?: Date, userId?: object): Promise<{ user: User, selfCertification: packet.Signature }>;
+        getPrimaryUser(date?: Date, userId?: object): Promise<{ user: User; selfCertification: packet.Signature }>;
 
         /**
          * Update key with new components from specified key with same key ID:
@@ -1838,7 +1921,11 @@ export namespace key {
          * @param userId (optional) user ID to get instead of the primary user, if it exists
          * @returns List of signer's keyid and validity of signature
          */
-        verifyPrimaryUser(keys: any[], date: Date, userId: object): Promise<Array<{ keyid: type.keyid.Keyid, valid: boolean }>>;
+        verifyPrimaryUser(
+            keys: any[],
+            date: Date,
+            userId: object,
+        ): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
         /**
          * Verifies all users of key
@@ -1847,7 +1934,7 @@ export namespace key {
          * @param keys array of keys to verify certificate signatures
          * @returns list of userid, signer's keyid and validity of signature
          */
-        verifyAllUsers(keys: any[]): Promise<Array<{ userid: string, keyid: type.keyid.Keyid, valid: boolean }>>;
+        verifyAllUsers(keys: any[]): Promise<Array<{ userid: string; keyid: type.keyid.Keyid; valid: boolean }>>;
 
         /**
          * Calculates the key id of the key
@@ -1924,7 +2011,12 @@ export namespace key {
          * @param date Use the given date instead of the current time
          * @returns True if the certificate is revoked
          */
-        isRevoked(primaryKey: packet.SecretKey | packet.PublicKey, certificate: packet.Signature, key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey, date: Date): Promise<Boolean>;
+        isRevoked(
+            primaryKey: packet.SecretKey | packet.PublicKey,
+            certificate: packet.Signature,
+            key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey,
+            date: Date,
+        ): Promise<Boolean>;
 
         /**
          * Verifies the user certificate
@@ -1934,7 +2026,12 @@ export namespace key {
          * @param date Use the given date instead of the current time
          * @returns status of the certificate
          */
-        verifyCertificate(primaryKey: packet.SecretKey | packet.PublicKey, certificate: packet.Signature, keys: any[], date: Date): Promise<enums.keyStatus>;
+        verifyCertificate(
+            primaryKey: packet.SecretKey | packet.PublicKey,
+            certificate: packet.Signature,
+            keys: any[],
+            date: Date,
+        ): Promise<enums.keyStatus>;
 
         /**
          * Verifies all user certificates
@@ -1943,7 +2040,11 @@ export namespace key {
          * @param date Use the given date instead of the current time
          * @returns List of signer's keyid and validity of signature
          */
-        verifyAllCertifications(primaryKey: packet.SecretKey | packet.PublicKey, keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid, valid: boolean }>>;
+        verifyAllCertifications(
+            primaryKey: packet.SecretKey | packet.PublicKey,
+            keys: any[],
+            date: Date,
+        ): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
         /**
          * Verify User. Checks for existence of self signatures, revocation signatures
@@ -1972,7 +2073,13 @@ export namespace key {
      * @param userId (optional) user ID
      * @returns signature packet
      */
-    function createSignaturePacket(dataToSign: object, signingKeyPacket: packet.SecretKey | packet.SecretSubkey, signatureProperties: object, date: Date, userId: object): packet.Signature;
+    function createSignaturePacket(
+        dataToSign: object,
+        signingKeyPacket: packet.SecretKey | packet.SecretSubkey,
+        signatureProperties: object,
+        date: Date,
+        userId: object,
+    ): packet.Signature;
 
     /**
      * Class that represents a subkey packet and the relevant signatures.
@@ -1994,7 +2101,12 @@ export namespace key {
          * @param date Use the given date instead of the current time
          * @returns True if the binding signature is revoked
          */
-        isRevoked(primaryKey: packet.SecretKey | packet.PublicKey, signature: packet.Signature, key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey, date: Date): Promise<Boolean>;
+        isRevoked(
+            primaryKey: packet.SecretKey | packet.PublicKey,
+            signature: packet.Signature,
+            key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey,
+            date: Date,
+        ): Promise<Boolean>;
 
         /**
          * Verify subkey. Checks for revocation signatures, expiration time
@@ -2031,7 +2143,11 @@ export namespace key {
          * @param date optional, override the creationtime of the revocation signature
          * @returns new subkey with revocation signature
          */
-        revoke(primaryKey: packet.SecretKey, reasonForRevocation: revoke_reasonForRevocation, date: Date): Promise<SubKey>;
+        revoke(
+            primaryKey: packet.SecretKey,
+            reasonForRevocation: revoke_reasonForRevocation,
+            date: Date,
+        ): Promise<SubKey>;
 
         /**
          * Calculates the key id of the key
@@ -2075,9 +2191,12 @@ export namespace key {
      * @param data to be parsed
      * @returns result object with key and error arrays
      */
-    function read(data: Uint8Array): Promise<{ keys: Array<Key>, err: Array<Error> | null }>;
+    function read(data: Uint8Array): Promise<{ keys: Array<Key>; err: Array<Error> | null }>;
 
-    interface KeyResult { keys: Array<Key>, err: Array<Error> | null }
+    interface KeyResult {
+        keys: Array<Key>;
+        err: Array<Error> | null;
+    }
 
     /**
      * Reads an OpenPGP armored text and returns one or multiple key objects
@@ -2128,7 +2247,14 @@ export namespace key {
      * @param date Use the given date instead of the current time
      * @returns True if the signature revokes the data
      */
-    function isDataRevoked(primaryKey: packet.SecretKey | packet.PublicKey, dataToVerify: object, revocations: any[], signature: packet.Signature, key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey, date: Date): Promise<Boolean>;
+    function isDataRevoked(
+        primaryKey: packet.SecretKey | packet.PublicKey,
+        dataToVerify: object,
+        revocations: any[],
+        signature: packet.Signature,
+        key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey,
+        date: Date,
+    ): Promise<Boolean>;
 
     /**
      * Check if signature has revocation key sub packet (not supported by OpenPGP.js)
@@ -2146,7 +2272,12 @@ export namespace key {
      * @param userId (optional) user ID
      * @returns
      */
-    function getPreferredHashAlgo(key: Key, keyPacket: packet.SecretKey | packet.SecretSubkey, date: Date, userId: object): Promise<String>;
+    function getPreferredHashAlgo(
+        key: Key,
+        keyPacket: packet.SecretKey | packet.SecretSubkey,
+        date: Date,
+        userId: object,
+    ): Promise<String>;
 
     /**
      * Returns the preferred symmetric/aead algorithm for a set of keys
@@ -2207,7 +2338,12 @@ export class User {
      * @param date Use the given date instead of the current time
      * @returns True if the certificate is revoked
      */
-    isRevoked(primaryKey: packet.SecretKey | packet.PublicKey, certificate: packet.Signature, key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey, date: Date): Promise<Boolean>;
+    isRevoked(
+        primaryKey: packet.SecretKey | packet.PublicKey,
+        certificate: packet.Signature,
+        key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey,
+        date: Date,
+    ): Promise<Boolean>;
 
     /**
      * Verifies the user certificate
@@ -2217,7 +2353,12 @@ export class User {
      * @param date Use the given date instead of the current time
      * @returns status of the certificate
      */
-    verifyCertificate(primaryKey: packet.SecretKey | packet.PublicKey, certificate: packet.Signature, keys: any[], date: Date): Promise<enums.keyStatus>;
+    verifyCertificate(
+        primaryKey: packet.SecretKey | packet.PublicKey,
+        certificate: packet.Signature,
+        keys: any[],
+        date: Date,
+    ): Promise<enums.keyStatus>;
 
     /**
      * Verifies all user certificates
@@ -2226,7 +2367,11 @@ export class User {
      * @param date Use the given date instead of the current time
      * @returns List of signer's keyid and validity of signature
      */
-    verifyAllCertifications(primaryKey: packet.SecretKey | packet.PublicKey, keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid, valid: boolean }>>;
+    verifyAllCertifications(
+        primaryKey: packet.SecretKey | packet.PublicKey,
+        keys: any[],
+        date: Date,
+    ): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
     /**
      * Verify User. Checks for existence of self signatures, revocation signatures
@@ -2266,7 +2411,12 @@ export class SubKey {
      * @param date Use the given date instead of the current time
      * @returns True if the binding signature is revoked
      */
-    isRevoked(primaryKey: packet.SecretKey | packet.PublicKey, signature: packet.Signature, key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey, date: Date): Promise<Boolean>;
+    isRevoked(
+        primaryKey: packet.SecretKey | packet.PublicKey,
+        signature: packet.Signature,
+        key: packet.PublicSubkey | packet.SecretSubkey | packet.PublicKey | packet.SecretKey,
+        date: Date,
+    ): Promise<Boolean>;
 
     /**
      * Verify subkey. Checks for revocation signatures, expiration time
@@ -2303,7 +2453,11 @@ export class SubKey {
      * @param date optional, override the creationtime of the revocation signature
      * @returns new subkey with revocation signature
      */
-    revoke(primaryKey: packet.SecretKey, reasonForRevocation: revoke_reasonForRevocation, date: Date): Promise<key.SubKey>;
+    revoke(
+        primaryKey: packet.SecretKey,
+        reasonForRevocation: revoke_reasonForRevocation,
+        date: Date,
+    ): Promise<key.SubKey>;
 
     /**
      * Calculates the key id of the key
@@ -2516,7 +2670,10 @@ export namespace message {
          * @param passwords (optional) passwords used to decrypt
          * @returns array of object with potential sessionKey, algorithm pairs
          */
-        decryptSessionKeys(privateKeys?: any[], passwords?: any[]): Promise<Array<{ data: Uint8Array, algorithm: string }>>;
+        decryptSessionKeys(
+            privateKeys?: any[],
+            passwords?: any[],
+        ): Promise<Array<{ data: Uint8Array; algorithm: string }>>;
 
         /**
          * Get literal data that is the body of the message
@@ -2547,7 +2704,15 @@ export namespace message {
          * @param streaming (optional) whether to process data as a stream
          * @returns new message with encrypted content
          */
-        encrypt(keys?: any[], passwords?: any[], sessionKey?: object, wildcard?: boolean, date?: Date, userIds?: any[], streaming?: boolean): Promise<Message>;
+        encrypt(
+            keys?: any[],
+            passwords?: any[],
+            sessionKey?: object,
+            wildcard?: boolean,
+            date?: Date,
+            userIds?: any[],
+            streaming?: boolean,
+        ): Promise<Message>;
 
         /**
          * Sign the message (the literal data packet of the message)
@@ -2574,7 +2739,12 @@ export namespace message {
          * @param userIds (optional) user IDs to sign with, e.g. [ { name:'Steve Sender', email:'steve@openpgp.org' }]
          * @returns new detached signature of message content
          */
-        signDetached(privateKeys: any[], signature?: signature.Signature, date?: Date, userIds?: any[]): Promise<signature.Signature>;
+        signDetached(
+            privateKeys: any[],
+            signature?: signature.Signature,
+            date?: Date,
+            userIds?: any[],
+        ): Promise<signature.Signature>;
 
         /**
          * Verify message signatures
@@ -2583,7 +2753,11 @@ export namespace message {
          * @param streaming (optional) whether to process data as a stream
          * @returns list of signer's keyid and validity of signature
          */
-        verify(keys: any[], date?: Date, streaming?: boolean): Promise<Array<({ keyid: type.keyid.Keyid, valid: boolean })>>;
+        verify(
+            keys: any[],
+            date?: Date,
+            streaming?: boolean,
+        ): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
         /**
          * Verify detached message signature
@@ -2592,7 +2766,11 @@ export namespace message {
          * @param date Verify the signature against the given date, i.e. check signature creation time < date < expiration time
          * @returns list of signer's keyid and validity of signature
          */
-        verifyDetached(keys: any[], signature: signature.Signature, date?: Date): Promise<Array<({ keyid: type.keyid.Keyid, valid: boolean })>>;
+        verifyDetached(
+            keys: any[],
+            signature: signature.Signature,
+            date?: Date,
+        ): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
         /**
          * Unwrap compressed message
@@ -2625,7 +2803,16 @@ export namespace message {
      * @param userIds (optional) user IDs to encrypt for, e.g. [ { name:'Robert Receiver', email:'robert@openpgp.org' }]
      * @returns new message with encrypted content
      */
-    function encryptSessionKey(sessionKey: Uint8Array, symAlgo: string, aeadAlgo: string, publicKeys: any[], passwords: any[], wildcard: boolean, date: Date, userIds: any[]): Promise<Message>;
+    function encryptSessionKey(
+        sessionKey: Uint8Array,
+        symAlgo: string,
+        aeadAlgo: string,
+        publicKeys: any[],
+        passwords: any[],
+        wildcard: boolean,
+        date: Date,
+        userIds: any[],
+    ): Promise<Message>;
 
     /**
      * Create signature packets for the message
@@ -2636,7 +2823,13 @@ export namespace message {
      * @param userIds (optional) user IDs to sign with, e.g. [ { name:'Steve Sender', email:'steve@openpgp.org' }]
      * @returns list of signature packets
      */
-    function createSignaturePackets(literalDataPacket: packet.Literal, privateKeys: any[], signature: signature.Signature, date: Date, userIds: any[]): Promise<packet.List>;
+    function createSignaturePackets(
+        literalDataPacket: packet.Literal,
+        privateKeys: any[],
+        signature: signature.Signature,
+        date: Date,
+        userIds: any[],
+    ): Promise<packet.List>;
 
     /**
      * Create object containing signer's keyid and validity of signature
@@ -2647,7 +2840,12 @@ export namespace message {
      *        i.e. check signature creation time < date < expiration time
      * @returns list of signer's keyid and validity of signature
      */
-    function createVerificationObject(signature: packet.Signature, literalDataList: any[], keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid, valid: boolean }>>;
+    function createVerificationObject(
+        signature: packet.Signature,
+        literalDataList: any[],
+        keys: any[],
+        date: Date,
+    ): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
     /**
      * Create list of objects containing signer's keyid and validity of signature
@@ -2658,7 +2856,12 @@ export namespace message {
      *        i.e. check signature creation time < date < expiration time
      * @returns list of signer's keyid and validity of signature
      */
-    function createVerificationObjects(signatureList: any[], literalDataList: any[], keys: any[], date: Date): Promise<Array<{ keyid: type.keyid.Keyid, valid: boolean }>>;
+    function createVerificationObjects(
+        signatureList: any[],
+        literalDataList: any[],
+        keys: any[],
+        date: Date,
+    ): Promise<Array<{ keyid: type.keyid.Keyid; valid: boolean }>>;
 
     /**
      * reads an OpenPGP armored message and returns a message object
@@ -2693,7 +2896,12 @@ export namespace message {
      * @param {utf8 | binary | text | mime} type (optional) data packet type
      * @returns new message object
      */
-    function fromBinary(bytes: Uint8Array | ReadableStream<Uint8Array>, filename?: string, date?: Date, type?: any): Message;
+    function fromBinary(
+        bytes: Uint8Array | ReadableStream<Uint8Array>,
+        filename?: string,
+        date?: Date,
+        type?: any,
+    ): Message;
 }
 
 export interface revokeKey_reasonForRevocation {
@@ -3168,7 +3376,7 @@ export namespace packet {
          *        input at position
          * @returns Object representation
          */
-        read(input: Uint8Array, position: Integer, len: Integer): PublicKeyEncryptedSessionKey
+        read(input: Uint8Array, position: Integer, len: Integer): PublicKeyEncryptedSessionKey;
 
         /**
          * Create a string representation of a tag 1 packet
@@ -3693,7 +3901,11 @@ export namespace packet {
          * @param data data which on the signature applies
          * @returns True if message is verified, else false.
          */
-        verify(key: PublicSubkey | PublicKey | SecretSubkey | SecretKey, signatureType: enums.signature, data: string | object): Promise<Boolean>;
+        verify(
+            key: PublicSubkey | PublicKey | SecretSubkey | SecretKey,
+            signatureType: enums.signature,
+            data: string | object,
+        ): Promise<Boolean>;
 
         /**
          * Verifies signature expiration date
@@ -3760,7 +3972,12 @@ export namespace packet {
          * @param streaming Whether the top-level function will return a stream
          * @returns
          */
-        crypt(fn: any, key: Uint8Array, data: Uint8Array | ReadableStream<Uint8Array>, streaming: boolean): Uint8Array | ReadableStream<Uint8Array>;
+        crypt(
+            fn: any,
+            key: Uint8Array,
+            data: Uint8Array | ReadableStream<Uint8Array>,
+            streaming: boolean,
+        ): Uint8Array | ReadableStream<Uint8Array>;
     }
 
     class SymEncryptedIntegrityProtected {
@@ -4156,9 +4373,7 @@ export namespace packet {
     }
 }
 
-
-export namespace polyfills {
-}
+export namespace polyfills {}
 
 export namespace signature {
     /**
@@ -4353,14 +4568,14 @@ export namespace type {
     }
 
     /**
- * Implementation of the String-to-key specifier
- * {@link https://tools.ietf.org/html/rfc4880#section-3.7|RFC4880 3.7}:
- * String-to-key (S2K) specifiers are used to convert passphrase strings
- * into symmetric-key encryption/decryption keys.  They are used in two
- * places, currently: to encrypt the secret part of private keys in the
- * private keyring, and to convert passphrases to encryption keys for
- * symmetrically encrypted messages.
- */
+     * Implementation of the String-to-key specifier
+     * {@link https://tools.ietf.org/html/rfc4880#section-3.7|RFC4880 3.7}:
+     * String-to-key (S2K) specifiers are used to convert passphrase strings
+     * into symmetric-key encryption/decryption keys.  They are used in two
+     * places, currently: to encrypt the secret part of private keys in the
+     * private keyring, and to convert passphrases to encryption keys for
+     * symmetrically encrypted messages.
+     */
     namespace s2k {
         class S2K {
             constructor();
@@ -4494,14 +4709,14 @@ export namespace util {
      * @param str The string to convert
      * @returns A valid squence of utf8 bytes
      */
-    function encode_utf8(str: string | ReadableStream): Uint8Array | ReadableStream;
+    function encode_utf8(str: string | ReadableStream<string>): Uint8Array | ReadableStream<string>;
 
     /**
      * Convert a Uint8Array of utf8 bytes to a native javascript string
      * @param utf8 A valid squence of utf8 bytes
      * @returns A native javascript string
      */
-    function decode_utf8(utf8: Uint8Array | ReadableStream): string | ReadableStream;
+    function decode_utf8(utf8: Uint8Array | ReadableStream<string>): string | ReadableStream<string>;
 
     /**
      * Concat a list of Uint8Arrays, Strings or Streams
@@ -4568,7 +4783,11 @@ export namespace util {
      * @param input Stream to print
      * @param concat Function to concatenate chunks of the stream (defaults to util.concat).
      */
-    function print_entire_stream(str: string, input: ReadableStream | Uint8Array | string, concat: Function): void;
+    function print_entire_stream(
+        str: string,
+        input: ReadableStream<string> | Uint8Array | string,
+        concat: Function,
+    ): void;
 
     /**
      * If S[1] == 0, then double(S) == (S[2..128] || 0);
@@ -4636,12 +4855,12 @@ export namespace util {
     /**
      * Format user id for internal use.
      */
-    function formatUserId(id: { name: string, email: string; comment: string }): string;
+    function formatUserId(id: { name: string; email: string; comment: string }): string;
 
     /**
      * Parse user id.
      */
-    function parseUserId(userId: string): { name: string, email: string; comment: string };
+    function parseUserId(userId: string): { name: string; email: string; comment: string };
 
     /**
      * Normalize line endings to \r\n
@@ -4680,17 +4899,17 @@ export namespace wkd {
          * @param options.rawBytes Returns Uint8Array instead of parsed key.
          * @returns The public key.
          */
-        lookup(): Promise<Uint8Array | { keys: Array<key.Key>, err: Array<Error> | null }>;
+        lookup(): Promise<Uint8Array | { keys: Array<key.Key>; err: Array<Error> | null }>;
     }
 }
 
 export namespace worker {
     /**
- * @see module:openpgp.initWorker
- * @see module:openpgp.getWorker
- * @see module:openpgp.destroyWorker
- * @see module:worker/worker
- */
+     * @see module:openpgp.initWorker
+     * @see module:openpgp.getWorker
+     * @see module:openpgp.destroyWorker
+     * @see module:worker/worker
+     */
     namespace async_proxy {
         class AsyncProxy {
             /**
@@ -4735,11 +4954,11 @@ export namespace worker {
     }
 
     /**
- * @see module:openpgp.initWorker
- * @see module:openpgp.getWorker
- * @see module:openpgp.destroyWorker
- * @see module:worker/async_proxy
- */
+     * @see module:openpgp.initWorker
+     * @see module:openpgp.getWorker
+     * @see module:openpgp.destroyWorker
+     * @see module:worker/async_proxy
+     */
     namespace worker {
         /**
          * Handle random buffer exhaustion by requesting more random bytes from the main window
@@ -4845,7 +5064,7 @@ export interface KeyOptions {
      * (optional) options for each subkey, default to main key options. e.g. [ {sign: true, passphrase: '123'}]
      *            sign parameter defaults to false, and indicates whether the subkey should sign rather than encrypt
      */
-    subkeys?: { sign: true, passphrase: string }[];
+    subkeys?: { sign: true; passphrase: string }[];
 }
 
 /**
@@ -4854,7 +5073,9 @@ export interface KeyOptions {
  * @returns The generated key object in the form:
  *          { key:Key, privateKeyArmored:String, publicKeyArmored:String, revocationCertificate:String }
  */
-export function generateKey(option: KeyOptions): Promise<{ key: key.Key, privateKeyArmored: string, publicKeyArmored: string, revocationCertificate: string }>;
+export function generateKey(
+    option: KeyOptions,
+): Promise<{ key: key.Key; privateKeyArmored: string; publicKeyArmored: string; revocationCertificate: string }>;
 
 /**
  * Reformats signature packets for a key and rewraps key object.
@@ -4866,7 +5087,13 @@ export function generateKey(option: KeyOptions): Promise<{ key: key.Key, private
  * @returns The generated key object in the form:
  *          { key:Key, privateKeyArmored:String, publicKeyArmored:String, revocationCertificate:String }
  */
-export function reformatKey(privateKey: key.Key, userIds: any[], passphrase?: string, keyExpirationTime?: number, revocationCertificate?: boolean): Promise<Object>;
+export function reformatKey(
+    privateKey: key.Key,
+    userIds: any[],
+    passphrase?: string,
+    keyExpirationTime?: number,
+    revocationCertificate?: boolean,
+): Promise<Object>;
 
 /**
  * Revokes a key. Requires either a private key or a revocation certificate.
@@ -4880,15 +5107,22 @@ export function reformatKey(privateKey: key.Key, userIds: any[], passphrase?: st
  *          { privateKey:Key, privateKeyArmored:String, publicKey:Key, publicKeyArmored:String }
  *          (if private key is passed) or { publicKey:Key, publicKeyArmored:String } (otherwise)
  */
-export function revokeKey(key?: key.Key, revocationCertificate?: string, reasonForRevocation?: revokeKey_reasonForRevocation): Promise<{
-    privateKey: key.Key,
-    privateKeyArmored: string,
-    publicKey: key.Key,
-    publicKeyArmored: string
-} | {
-    publicKey: key.Key,
-    publicKeyArmored: string
-}>;
+export function revokeKey(
+    key?: key.Key,
+    revocationCertificate?: string,
+    reasonForRevocation?: revokeKey_reasonForRevocation,
+): Promise<
+    | {
+          privateKey: key.Key;
+          privateKeyArmored: string;
+          publicKey: key.Key;
+          publicKeyArmored: string;
+      }
+    | {
+          publicKey: key.Key;
+          publicKeyArmored: string;
+      }
+>;
 
 /**
  * Unlock a private key with your passphrase.
@@ -4926,7 +5160,7 @@ export interface EncryptOptions {
     /**
      * (optional) session key in the form: { data:Uint8Array, algorithm:String }
      */
-    sessionKey?: { data: Uint8Array, algorithm: string };
+    sessionKey?: { data: Uint8Array; algorithm: string };
     /**
      * (optional) which compression algorithm to compress the message with, defaults to what is specified in config
      */
@@ -4966,11 +5200,11 @@ export interface EncryptOptions {
     /**
      * (optional) array of user IDs to encrypt for, one per key in `publicKeys`, e.g. [ { name:'Robert Receiver', email:'robert@openpgp.org' }]
      */
-    toUserIds?: UserID[]
+    toUserIds?: UserID[];
 }
 
 export interface EncryptResult {
-    sessionKey: { data: Uint8Array, algorithm: string, aeadAlgorithm: string };
+    sessionKey: { data: Uint8Array; algorithm: string; aeadAlgorithm: string };
 }
 
 /**
@@ -4986,15 +5220,27 @@ export interface EncryptResult {
  *          sessionKey: { data, algorithm, aeadAlgorithm } (if `returnSessionKey` was true)
  *          }
  */
-export function encrypt(options: EncryptOptions & { armor?: true, detached?: false }): Promise<EncryptResult & { data: string }>
-export function encrypt(options: EncryptOptions & { armor?: true, detached: true }): Promise<EncryptResult & { data: string, signature: string }>
-export function encrypt(options: EncryptOptions & { armor: false, detached?: false }): Promise<EncryptResult & { message: message.Message }>
-export function encrypt(options: EncryptOptions & { armor: false, detached: true }): Promise<EncryptResult & { message: message.Message, signature: signature.Signature }>
-export function encrypt(options: EncryptOptions): Promise<EncryptResult & {
-    data: string | ReadableStream<String>;
-    message: message.Message;
-    signature: string | ReadableStream<String> | signature.Signature;
-}>;
+export function encrypt(
+    options: EncryptOptions & { armor?: true; detached?: false },
+): Promise<EncryptResult & { data: string }>;
+export function encrypt(
+    options: EncryptOptions & { armor?: true; detached: true },
+): Promise<EncryptResult & { data: string; signature: string }>;
+export function encrypt(
+    options: EncryptOptions & { armor: false; detached?: false },
+): Promise<EncryptResult & { message: message.Message }>;
+export function encrypt(
+    options: EncryptOptions & { armor: false; detached: true },
+): Promise<EncryptResult & { message: message.Message; signature: signature.Signature }>;
+export function encrypt(
+    options: EncryptOptions,
+): Promise<
+    EncryptResult & {
+        data: string | ReadableStream<String>;
+        message: message.Message;
+        signature: string | ReadableStream<String> | signature.Signature;
+    }
+>;
 
 export interface DecryptOptions {
     /**
@@ -5012,7 +5258,7 @@ export interface DecryptOptions {
     /**
      * (optional) session keys in the form: { data:Uint8Array, algorithm:String }
      */
-    sessionKeys?: { data: Uint8Array, algorithm: string } | { data: Uint8Array, algorithm: string }[];
+    sessionKeys?: { data: Uint8Array; algorithm: string } | { data: Uint8Array; algorithm: string }[];
     /**
      * (optional) array of public keys or single key, to verify signatures
      */
@@ -5032,17 +5278,17 @@ export interface DecryptOptions {
     /**
      * (optional) use the given date for verification instead of the current time
      */
-    date?: Date
+    date?: Date;
 }
 
 export interface DecryptResult {
-    data: string | ReadableStream<String> | NodeStream | Uint8Array | ReadableStream<Uint8Array>,
-    filename: string,
+    data: string | ReadableStream<String> | NodeStream | Uint8Array | ReadableStream<Uint8Array>;
+    filename: string;
     signatures: {
-        keyid: type.keyid.Keyid,
-        verified: Promise<Boolean>,
-        valid: boolean
-    }[]
+        keyid: type.keyid.Keyid;
+        verified: Promise<Boolean>;
+        valid: boolean;
+    }[];
 }
 
 /**
@@ -5063,8 +5309,12 @@ export interface DecryptResult {
  *          ]
  *          }
  */
-export function decrypt(options: DecryptOptions & { format: "utf8" }): Promise<DecryptResult & { data: string | ReadableStream<String> | NodeStream}>
-export function decrypt(options: DecryptOptions & { format: "binary" }): Promise<DecryptResult & { data: Uint8Array | ReadableStream<Uint8Array> | NodeStream }>
+export function decrypt(
+    options: DecryptOptions & { format: 'utf8' },
+): Promise<DecryptResult & { data: string | ReadableStream<String> | NodeStream }>;
+export function decrypt(
+    options: DecryptOptions & { format: 'binary' },
+): Promise<DecryptResult & { data: Uint8Array | ReadableStream<Uint8Array> | NodeStream }>;
 export function decrypt(options: DecryptOptions): Promise<DecryptResult>;
 
 export interface SignOptions {
@@ -5095,13 +5345,13 @@ export interface SignOptions {
     /**
      *  (optional) array of user IDs to sign with, one per key in `privateKeys`, e.g. [ { name:'Steve Sender', email:'steve@openpgp.org' }]
      */
-    fromUserIds?: UserID[]
+    fromUserIds?: UserID[];
 }
 
 export interface SignResult {
-    data: string | ReadableStream<String> | NodeStream,
-    message: message.Message,
-    signature: string | ReadableStream<String> | NodeStream | signature.Signature
+    data: string | ReadableStream<String> | NodeStream;
+    message: message.Message;
+    signature: string | ReadableStream<String> | NodeStream | signature.Signature;
 }
 
 /**
@@ -5118,10 +5368,12 @@ export interface SignResult {
  *          signature: Signature (if `armor` was false)
  *          }{
  */
-export function sign(options: SignOptions & { armor?: true, detached?: false }): Promise<{ data: string }>
-export function sign(options: SignOptions & { armor: false, detached?: false }): Promise<{ message: message.Message }>
-export function sign(options: SignOptions & { armor?: true, detached: true }): Promise<{ signature: string }>
-export function sign(options: SignOptions & { armor: false, detached: true }): Promise<{ signature: signature.Signature }>
+export function sign(options: SignOptions & { armor?: true; detached?: false }): Promise<{ data: string }>;
+export function sign(options: SignOptions & { armor: false; detached?: false }): Promise<{ message: message.Message }>;
+export function sign(options: SignOptions & { armor?: true; detached: true }): Promise<{ signature: string }>;
+export function sign(
+    options: SignOptions & { armor: false; detached: true },
+): Promise<{ signature: signature.Signature }>;
 export function sign(options: SignOptions): Promise<SignResult>;
 
 export interface VerifyOptions {
@@ -5144,16 +5396,16 @@ export interface VerifyOptions {
     /**
      * (optional) use the given date for verification instead of the current time
      */
-    date?: Date
+    date?: Date;
 }
 
 export interface VerifyResult {
-    data: string | ReadableStream<String> | NodeStream | Uint8Array | ReadableStream<Uint8Array> | NodeStream,
+    data: string | ReadableStream<String> | NodeStream | Uint8Array | ReadableStream<Uint8Array> | NodeStream;
     signatures: {
-        keyid: type.keyid.Keyid,
-        verified: Promise<Boolean>,
-        valid: boolean
-    }[]
+        keyid: type.keyid.Keyid;
+        verified: Promise<Boolean>;
+        valid: boolean;
+    }[];
 }
 
 /**
@@ -5187,7 +5439,16 @@ export function verify(options: VerifyOptions): Promise<VerifyResult>;
  * @param toUserIds (optional) array of user IDs to encrypt for, one per key in `publicKeys`, e.g. [ { name:'Phil Zimmermann', email:'phil@openpgp.org' }]
  * @returns the encrypted session key packets contained in a message object
  */
-export function encryptSessionKey(data: Uint8Array, algorithm: string, aeadAlgorithm?: string, publicKeys?: key.Key | key.Key[], passwords?: string | string[], wildcard?: boolean, date?: Date, toUserIds?: any[]): Promise<message.Message>;
+export function encryptSessionKey(
+    data: Uint8Array,
+    algorithm: string,
+    aeadAlgorithm?: string,
+    publicKeys?: key.Key | key.Key[],
+    passwords?: string | string[],
+    wildcard?: boolean,
+    date?: Date,
+    toUserIds?: any[],
+): Promise<message.Message>;
 
 /**
  * Decrypt symmetric session keys with a private key or password. Either a private key or
@@ -5199,7 +5460,11 @@ export function encryptSessionKey(data: Uint8Array, algorithm: string, aeadAlgor
  *          { data:Uint8Array, algorithm:String }
  *          or 'undefined' if no key packets found
  */
-export function decryptSessionKeys(message: message.Message, privateKeys?: key.Key | key.Key[], passwords?: string | string[]): Promise<{ data: Uint8Array, algorithm: string }[] | undefined>;
+export function decryptSessionKeys(
+    message: message.Message,
+    privateKeys?: key.Key | key.Key[],
+    passwords?: string | string[],
+): Promise<{ data: Uint8Array; algorithm: string }[] | undefined>;
 
 /**
  * Input validation
@@ -5238,7 +5503,7 @@ export function convertStreams(obj: object, streaming: 'web' | 'node' | false, k
  * @param erroringStream (optional) stream which either errors or gets closed without data
  * @returns
  */
-export function linkStreams(result: object, message: message.Message, erroringStream: ReadableStream): object;
+export function linkStreams(result: object, message: message.Message, erroringStream: ReadableStream<string>): object;
 
 /**
  * Wait until signature objects have been verified

--- a/types/openpgp/ts3.2/openpgp-tests.ts
+++ b/types/openpgp/ts3.2/openpgp-tests.ts
@@ -68,7 +68,7 @@ openpgp.message
 
 const promises: [
     Promise<{ keys: Array<openpgp.key.Key>; err: Array<Error> | null }>,
-    Promise<openpgp.message.Message>,
+    Promise<openpgp.message.Message>
 ] = [openpgp.key.readArmored(sprivkey), openpgp.message.readArmored(pgpMessageStr)];
 
 Promise.all(promises)

--- a/types/openpgp/ts3.2/openpgp-tests.ts
+++ b/types/openpgp/ts3.2/openpgp-tests.ts
@@ -1,84 +1,97 @@
-import openpgp, { encrypt } from "openpgp";
+import openpgp, { encrypt } from 'openpgp';
 
 // Open PGP Sample codes
 
 var options: openpgp.KeyOptions = {
     numBits: 2048,
-    userIds: [{
-        name: 'Jon Smith',
-        email: 'jon.smith@example.org',
-    }, {
-        email: 'jon.smith@example.org',
-    }, {
-        name: 'Jon Smith',
-    }, {
-    }],
-    passphrase: 'super long and hard to guess secret'
+    userIds: [
+        {
+            name: 'Jon Smith',
+            email: 'jon.smith@example.org',
+        },
+        {
+            email: 'jon.smith@example.org',
+        },
+        {
+            name: 'Jon Smith',
+        },
+        {},
+    ],
+    passphrase: 'super long and hard to guess secret',
 };
-openpgp.generateKey(options).then(function (keypair) {
-    // success
-    var privkey = keypair.privateKeyArmored;
-    var pubkey = keypair.publicKeyArmored;
-}).catch(function (error) {
-    // failure
-});
-
+openpgp
+    .generateKey(options)
+    .then(function(keypair) {
+        // success
+        var privkey = keypair.privateKeyArmored;
+        var pubkey = keypair.publicKeyArmored;
+    })
+    .catch(function(error) {
+        // failure
+    });
 
 var spubkey = '-----BEGIN PGP PUBLIC KEY BLOCK ... END PGP PUBLIC KEY BLOCK-----';
 
-openpgp.key.readArmored(spubkey)
-    .then(function (publicKey) {
+openpgp.key
+    .readArmored(spubkey)
+    .then(function(publicKey) {
         return {
             message: openpgp.message.fromText('Hello, World!'),
-            publicKeys: publicKey.keys
+            publicKeys: publicKey.keys,
         };
     })
     .then(openpgp.encrypt)
-    .then(function (pgpMessage) {
+    .then(function(pgpMessage) {
         // success
     })
-    .catch(function (error) {
+    .catch(function(error) {
         // failure
     });
 
 var sprivkey = '-----BEGIN PGP PRIVATE KEY BLOCK ... END PGP PRIVATE KEY BLOCK-----';
 var pgpMessageStr = '-----BEGIN PGP MESSAGE ... END PGP MESSAGE-----';
 
-openpgp.message.readArmored(pgpMessageStr).then(function (pgpMessage) {
-    const options = {
-        message: pgpMessage
-    };
-    return openpgp.decrypt(options);
-}).then(function (plaintext) {
-    // success
-}).catch(function (error) {
-    // failure
-});
+openpgp.message
+    .readArmored(pgpMessageStr)
+    .then(function(pgpMessage) {
+        const options = {
+            message: pgpMessage,
+        };
+        return openpgp.decrypt(options);
+    })
+    .then(function(plaintext) {
+        // success
+    })
+    .catch(function(error) {
+        // failure
+    });
 
-const promises: [Promise<{ keys: Array<openpgp.key.Key>, err: Array<Error> | null }>, Promise<openpgp.message.Message>] = [
-    openpgp.key.readArmored(sprivkey),
-    openpgp.message.readArmored(pgpMessageStr)
-];
+const promises: [
+    Promise<{ keys: Array<openpgp.key.Key>; err: Array<Error> | null }>,
+    Promise<openpgp.message.Message>,
+] = [openpgp.key.readArmored(sprivkey), openpgp.message.readArmored(pgpMessageStr)];
 
-
-Promise.all(promises).then(function (values) {
-    const keyObject: openpgp.key.KeyResult = values[0];
-    const pgpMessage: openpgp.message.Message = values[1];
-    const privateKey = keyObject.keys[0];
-    privateKey.decrypt('passphrase');
-    const options = {
-        privateKeys: privateKey,
-        message: pgpMessage
-    };
-    return openpgp.decrypt(options);
-}).then(function (plaintext) {
-    // success
-}).catch(function (error) {
-    // failure
-});
+Promise.all(promises)
+    .then(function(values) {
+        const keyObject: openpgp.key.KeyResult = values[0];
+        const pgpMessage: openpgp.message.Message = values[1];
+        const privateKey = keyObject.keys[0];
+        privateKey.decrypt('passphrase');
+        const options = {
+            privateKeys: privateKey,
+            message: pgpMessage,
+        };
+        return openpgp.decrypt(options);
+    })
+    .then(function(plaintext) {
+        // success
+    })
+    .catch(function(error) {
+        // failure
+    });
 
 openpgp.initWorker({
-    path: 'openpgp.worker.js'
+    path: 'openpgp.worker.js',
 });
 
 (async () => {
@@ -97,7 +110,7 @@ openpgp.initWorker({
     let armored = await openpgp.encrypt({
         message: openpgp.message.fromBinary(new Uint8Array([0x01, 0x01, 0x01])),
         armor: true,
-        privateKeys: []
+        privateKeys: [],
     });
     let data: string = armored.data;
     // let msg: openpgp.message.Message = armored.message; // without member 'message'
@@ -105,7 +118,7 @@ openpgp.initWorker({
     let plain = await openpgp.decrypt({
         message: await openpgp.message.read(encrypted),
         passwords: ['secret stuff'],
-        format: 'binary'
+        format: 'binary',
     });
 
     return plain.data;
@@ -128,39 +141,47 @@ openpgp.initWorker({
 })();
 
 (async () => {
-    const publicKey = (await openpgp.key.readArmored(spubkey))
-    const privateKey = (await openpgp.key.readArmored(sprivkey))
+    const publicKey = await openpgp.key.readArmored(spubkey);
+    const privateKey = await openpgp.key.readArmored(sprivkey);
     const signOptions: openpgp.SignOptions = {
         message: openpgp.message.fromText('hello world'),
         privateKeys: privateKey.keys,
-        detached: true
+        detached: true,
     };
 
     const signed = await openpgp.sign(signOptions);
 
     // Test function reload
-    openpgp.sign({
-        message: null,
-        privateKeys: [],
-        detached: true
-    }).then(s => s.signature/* as string*/);
-    openpgp.sign({
-        message: null,
-        privateKeys: [],
-        detached: false,
-    }).then(s => s.data/* as string*/);
-    openpgp.sign({
-        message: null,
-        privateKeys: [],
-        armor: false,
-        detached: true
-    }).then(s => s.signature/* as openpgp.signature.Signature*/);
-    openpgp.sign({
-        message: null,
-        privateKeys: [],
-        armor: false,
-        detached: false,
-    }).then(s => s.message/* as openpgp.message.Message*/);
+    openpgp
+        .sign({
+            message: null,
+            privateKeys: [],
+            detached: true,
+        })
+        .then(s => s.signature /* as string*/);
+    openpgp
+        .sign({
+            message: null,
+            privateKeys: [],
+            detached: false,
+        })
+        .then(s => s.data /* as string*/);
+    openpgp
+        .sign({
+            message: null,
+            privateKeys: [],
+            armor: false,
+            detached: true,
+        })
+        .then(s => s.signature /* as openpgp.signature.Signature*/);
+    openpgp
+        .sign({
+            message: null,
+            privateKeys: [],
+            armor: false,
+            detached: false,
+        })
+        .then(s => s.message /* as openpgp.message.Message*/);
 
     const signature = signed.signature as openpgp.signature.Signature;
     const message = signed.message;
@@ -168,7 +189,7 @@ openpgp.initWorker({
     const verifyOptions: openpgp.VerifyOptions = {
         message,
         signature,
-        publicKeys: publicKey.keys
+        publicKeys: publicKey.keys,
     };
 
     let verified = await openpgp.verify(verifyOptions);
@@ -176,34 +197,33 @@ openpgp.initWorker({
     return verified.signatures[0].valid;
 })();
 
-(async () => {
-    const publicKey = (await openpgp.key.readArmored(spubkey));
+async () => {
+    const publicKey = await openpgp.key.readArmored(spubkey);
 
-    return publicKey.keys[0].primaryKey.getFingerprint()/* as string*/
-})
+    return publicKey.keys[0].primaryKey.getFingerprint(); /* as string*/
+};
 
 // Open PGP Tests
-
 
 var keyoptions: openpgp.KeyOptions;
 var mpi: openpgp.type.mpi.MPI;
 var mpis: Array<openpgp.type.mpi.MPI>;
 
 openpgp.encoding.armor.armor(openpgp.enums.armor.message, {}, 0, 1);
-openpgp.encoding.armor.dearmor("");
+openpgp.encoding.armor.dearmor('');
 
-openpgp.cleartext.readArmored("");
+openpgp.cleartext.readArmored('');
 
 openpgp.crypto.crypto.generateSessionKey(openpgp.enums.symmetric.aes128);
 openpgp.crypto.crypto.getPrefixRandom(openpgp.enums.symmetric.aes128);
 // openpgp.crypto.crypto.getPrivateMpiCount(openpgp.enums.symmetric.aes128);
-openpgp.crypto.crypto.publicKeyDecrypt(openpgp.enums.publicKey.rsa_encrypt, mpis, mpis, "");
-openpgp.crypto.crypto.publicKeyEncrypt(openpgp.enums.publicKey.rsa_encrypt, mpis, mpi, "");
+openpgp.crypto.crypto.publicKeyDecrypt(openpgp.enums.publicKey.rsa_encrypt, mpis, mpis, '');
+openpgp.crypto.crypto.publicKeyEncrypt(openpgp.enums.publicKey.rsa_encrypt, mpis, mpi, '');
 
-openpgp.crypto
+openpgp.crypto;
 // API update with no documentation
-openpgp.crypto.cfb.decrypt("", "", "", true);
-openpgp.crypto.cfb.encrypt("", "", "", true);
+openpgp.crypto.cfb.decrypt('', '', '', true);
+openpgp.crypto.cfb.encrypt('', '', '', true);
 // Function removed from openpgp.crypto.cfb
 // openpgp.crypto.cfb.mdc({}, "", "");
 
@@ -216,28 +236,41 @@ openpgp.crypto.random.getRandomBytes(0);
 // openpgp.crypto.random.getRandomValues(openpgp.util.str_to_Uint8Array(""));
 // openpgp.crypto.random.getSecureRandom(0, 1);
 
-openpgp.crypto.signature.sign(openpgp.enums.publicKey.rsa_encrypt, openpgp.enums.hash.md5, mpis, new Uint8Array([0, 1]), new Uint8Array([0, 1]));
-openpgp.crypto.signature.verify(openpgp.enums.publicKey.rsa_encrypt, openpgp.enums.hash.md5, mpis, mpis, new Uint8Array([0, 1]), new Uint8Array([0, 1]));
+openpgp.crypto.signature.sign(
+    openpgp.enums.publicKey.rsa_encrypt,
+    openpgp.enums.hash.md5,
+    mpis,
+    new Uint8Array([0, 1]),
+    new Uint8Array([0, 1]),
+);
+openpgp.crypto.signature.verify(
+    openpgp.enums.publicKey.rsa_encrypt,
+    openpgp.enums.hash.md5,
+    mpis,
+    mpis,
+    new Uint8Array([0, 1]),
+    new Uint8Array([0, 1]),
+);
 
 openpgp.key.generate(keyoptions);
-openpgp.key.readArmored("");
+openpgp.key.readArmored('');
 
 openpgp.message.fromBinary(new Uint8Array([0x01, 0x02, 0x03]));
-openpgp.message.fromText("");
-openpgp.message.readArmored("");
+openpgp.message.fromText('');
+openpgp.message.readArmored('');
 
 openpgp.packet.fromStructuredClone({});
-openpgp.packet.newPacketFromTag("");
+openpgp.packet.newPacketFromTag('');
 
 openpgp.util.Uint8Array_to_str(new Uint8Array([1, 0]));
 openpgp.util.decode_utf8(new Uint8Array([1, 0]));
-openpgp.util.encode_utf8("");
+openpgp.util.encode_utf8('');
 openpgp.util.getWebCrypto();
-openpgp.util.hex_to_Uint8Array("");
-openpgp.util.print_debug_hexarray_dump("");
-openpgp.util.print_debug_hexstr_dump("");
-openpgp.util.print_debug("");
-openpgp.util.print_debug_hexstr_dump("");
+openpgp.util.hex_to_Uint8Array('');
+openpgp.util.print_debug_hexarray_dump('');
+openpgp.util.print_debug_hexstr_dump('');
+openpgp.util.print_debug('');
+openpgp.util.print_debug_hexstr_dump('');
 openpgp.util.shiftRight(new Uint8Array([1, 0]), 1);
-openpgp.util.str_to_Uint8Array("");
-openpgp.util.Uint8Array_to_str(openpgp.util.str_to_Uint8Array(""));
+openpgp.util.str_to_Uint8Array('');
+openpgp.util.Uint8Array_to_str(openpgp.util.str_to_Uint8Array(''));


### PR DESCRIPTION
Fixes #43154

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes :https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d08665f370115461683a37dc20c6f339e60d21b2/types/openpgp/index.d.ts#L21 (all I did was add in a type that was removed in the transition from TS2 -> 3)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
