### PR TITLE
[i18n-js] Add types for getFullScope

### DIFF
--- a/types/i18n-js/i18n-js-tests.ts
+++ b/types/i18n-js/i18n-js-tests.ts
@@ -3,79 +3,86 @@
  * Created by using code examples from https://github.com/fnando/i18n-js
  */
 
-import I18n = require("i18n-js");
+import I18n = require('i18n-js');
 
-I18n.defaultLocale = "pt-BR";
-I18n.locale = "pt-BR";
-I18n.currentLocale() === "pt-BR";
+I18n.defaultLocale = 'pt-BR';
+I18n.locale = 'pt-BR';
+I18n.currentLocale() === 'pt-BR';
 
-I18n.t("some.scoped.translation");
-I18n.t("some.scoped.translation", { locale: "fr" });
-I18n.t("hello", { name: "John Doe" });
-I18n.t("some.missing.scope", { defaultValue: "A default message" });
-I18n.t("noun", { defaultValue: "I'm a {{noun}}", noun: "Mac" });
-I18n.t("some.missing.scope", { defaults: [{ scope: "some.existing.scope" }] });
-I18n.t("some.missing.scope", { defaults: [{ message: "Some message" }] });
+I18n.t('some.scoped.translation');
+I18n.t('some.scoped.translation', { locale: 'fr' });
+I18n.t('hello', { name: 'John Doe' });
+I18n.t('some.missing.scope', { defaultValue: 'A default message' });
+I18n.t('noun', { defaultValue: "I'm a {{noun}}", noun: 'Mac' });
+I18n.t('some.missing.scope', { defaults: [{ scope: 'some.existing.scope' }] });
+I18n.t('some.missing.scope', { defaults: [{ message: 'Some message' }] });
 
 I18n.fallbacks = true;
-I18n.locales.no = ["nb", "en"];
-I18n.locales.no = "nb";
-I18n.locales.no = locale => ["nb"];
+I18n.locales.no = ['nb', 'en'];
+I18n.locales.no = 'nb';
+I18n.locales.no = locale => ['nb'];
 
-I18n.missingBehaviour = "guess";
-I18n.missingTranslationPrefix = "EE: ";
-I18n.missingTranslation = (scope, options) => "foobar";
+I18n.getFullScope('en');
+I18n.getFullScope('en', {});
+I18n.getFullScope(['en', 'es'], {});
+I18n.missingBehaviour = 'guess';
+I18n.missingTranslationPrefix = 'EE: ';
+I18n.missingTranslation = (scope, options) => 'foobar';
 I18n.missingTranslation = (scope, options) => null;
 I18n.missingTranslation = (scope, options) => undefined;
 
-I18n.t("inbox.counting", { count: 10 });
-I18n.pluralization["ru"] = count => {
-    const key = count % 10 === 1 && count % 100 !== 11 ? "one"
-        : [2, 3, 4].indexOf(count % 10) >= 0 && [12, 13, 14].indexOf(count % 100) < 0 ? "few"
-            : count % 10 === 0 || [5, 6, 7, 8, 9].indexOf(count % 10) >= 0 || [11, 12, 13, 14].indexOf(count % 100) >= 0 ? "many"
-                : "other";
+I18n.t('inbox.counting', { count: 10 });
+I18n.pluralization['ru'] = count => {
+    const key =
+        count % 10 === 1 && count % 100 !== 11
+            ? 'one'
+            : [2, 3, 4].indexOf(count % 10) >= 0 && [12, 13, 14].indexOf(count % 100) < 0
+            ? 'few'
+            : count % 10 === 0 || [5, 6, 7, 8, 9].indexOf(count % 10) >= 0 || [11, 12, 13, 14].indexOf(count % 100) >= 0
+            ? 'many'
+            : 'other';
     return [key];
 };
 
-const options = { scope: "activerecord.attributes.user" };
-I18n.t("name", options);
-I18n.t(["greetings", "hello"]);
+const options = { scope: 'activerecord.attributes.user' };
+I18n.t('name', options);
+I18n.t(['greetings', 'hello']);
 
-I18n.l("currency", 1990.99);
-I18n.l("number", 1990.99);
-I18n.l("percentage", 123.45);
+I18n.l('currency', 1990.99);
+I18n.l('number', 1990.99);
+I18n.l('percentage', 123.45);
 
 I18n.toNumber(1000);
 I18n.toCurrency(1000);
 I18n.toPercentage(100);
 
 I18n.toNumber(1000, { precision: 0 });
-I18n.toNumber(1000, { delimiter: ".", separator: "," });
-I18n.toNumber(1000, { delimiter: ".", precision: 0 });
+I18n.toNumber(1000, { delimiter: '.', separator: ',' });
+I18n.toNumber(1000, { delimiter: '.', precision: 0 });
 
 I18n.toCurrency(1000, { precision: 0 });
 
 I18n.toHumanSize(1234);
 
-I18n.l("date.formats.short", "2009-09-18");
-I18n.l("time.formats.short", "2009-09-18 23:12:43");
-I18n.l("time.formats.short", "2009-11-09T18:10:34");
-I18n.l("time.formats.short", "2009-11-09T18:10:34Z");
-I18n.l("date.formats.short", 1251862029000);
-I18n.l("date.formats.short", "09/18/2009");
-I18n.l("date.formats.short", (new Date()));
+I18n.l('date.formats.short', '2009-09-18');
+I18n.l('time.formats.short', '2009-09-18 23:12:43');
+I18n.l('time.formats.short', '2009-11-09T18:10:34');
+I18n.l('time.formats.short', '2009-11-09T18:10:34Z');
+I18n.l('date.formats.short', 1251862029000);
+I18n.l('date.formats.short', '09/18/2009');
+I18n.l('date.formats.short', new Date());
 
-I18n.l("date.formats.ordinal_day", "2009-09-18", { day: "18th" });
+I18n.l('date.formats.ordinal_day', '2009-09-18', { day: '18th' });
 
-I18n.strftime(new Date(), "%d/%m/%Y");
+I18n.strftime(new Date(), '%d/%m/%Y');
 
 const point_in_number = 1000;
-I18n.t("point", { count: point_in_number, formatted_number: I18n.toNumber(point_in_number) });
+I18n.t('point', { count: point_in_number, formatted_number: I18n.toNumber(point_in_number) });
 
 I18n.translations = {};
-I18n.translations["en"] = {
-  message: "Some special message for you"
+I18n.translations['en'] = {
+    message: 'Some special message for you',
 };
-I18n.translations["pt-BR"] = {
-  message: "Uma mensagem especial para você"
+I18n.translations['pt-BR'] = {
+    message: 'Uma mensagem especial para você',
 };

--- a/types/i18n-js/i18n-js-tests.ts
+++ b/types/i18n-js/i18n-js-tests.ts
@@ -3,86 +3,86 @@
  * Created by using code examples from https://github.com/fnando/i18n-js
  */
 
-import I18n = require('i18n-js');
+import I18n = require("i18n-js");
 
-I18n.defaultLocale = 'pt-BR';
-I18n.locale = 'pt-BR';
-I18n.currentLocale() === 'pt-BR';
+I18n.defaultLocale = "pt-BR";
+I18n.locale = "pt-BR";
+I18n.currentLocale() === "pt-BR";
 
-I18n.t('some.scoped.translation');
-I18n.t('some.scoped.translation', { locale: 'fr' });
-I18n.t('hello', { name: 'John Doe' });
-I18n.t('some.missing.scope', { defaultValue: 'A default message' });
-I18n.t('noun', { defaultValue: "I'm a {{noun}}", noun: 'Mac' });
-I18n.t('some.missing.scope', { defaults: [{ scope: 'some.existing.scope' }] });
-I18n.t('some.missing.scope', { defaults: [{ message: 'Some message' }] });
+I18n.t("some.scoped.translation");
+I18n.t("some.scoped.translation", { locale: "fr" });
+I18n.t("hello", { name: "John Doe" });
+I18n.t("some.missing.scope", { defaultValue: "A default message" });
+I18n.t("noun", { defaultValue: "I'm a {{noun}}", noun: "Mac" });
+I18n.t("some.missing.scope", { defaults: [{ scope: "some.existing.scope" }] });
+I18n.t("some.missing.scope", { defaults: [{ message: "Some message" }] });
 
 I18n.fallbacks = true;
-I18n.locales.no = ['nb', 'en'];
-I18n.locales.no = 'nb';
-I18n.locales.no = locale => ['nb'];
+I18n.locales.no = ["nb", "en"];
+I18n.locales.no = "nb";
+I18n.locales.no = locale => ["nb"];
 
-I18n.getFullScope('en');
-I18n.getFullScope('en', {});
-I18n.getFullScope(['en', 'es'], {});
-I18n.missingBehaviour = 'guess';
-I18n.missingTranslationPrefix = 'EE: ';
-I18n.missingTranslation = (scope, options) => 'foobar';
+I18n.getFullScope("en");
+I18n.getFullScope("en", {});
+I18n.getFullScope(["en", "es"], {});
+I18n.missingBehaviour = "guess";
+I18n.missingTranslationPrefix = "EE: ";
+I18n.missingTranslation = (scope, options) => "foobar";
 I18n.missingTranslation = (scope, options) => null;
 I18n.missingTranslation = (scope, options) => undefined;
 
-I18n.t('inbox.counting', { count: 10 });
-I18n.pluralization['ru'] = count => {
+I18n.t("inbox.counting", { count: 10 });
+I18n.pluralization["ru"] = count => {
     const key =
         count % 10 === 1 && count % 100 !== 11
-            ? 'one'
+            ? "one"
             : [2, 3, 4].indexOf(count % 10) >= 0 && [12, 13, 14].indexOf(count % 100) < 0
-            ? 'few'
+            ? "few"
             : count % 10 === 0 || [5, 6, 7, 8, 9].indexOf(count % 10) >= 0 || [11, 12, 13, 14].indexOf(count % 100) >= 0
-            ? 'many'
-            : 'other';
+            ? "many"
+            : "other";
     return [key];
 };
 
-const options = { scope: 'activerecord.attributes.user' };
-I18n.t('name', options);
-I18n.t(['greetings', 'hello']);
+const options = { scope: "activerecord.attributes.user" };
+I18n.t("name", options);
+I18n.t(["greetings", "hello"]);
 
-I18n.l('currency', 1990.99);
-I18n.l('number', 1990.99);
-I18n.l('percentage', 123.45);
+I18n.l("currency", 1990.99);
+I18n.l("number", 1990.99);
+I18n.l("percentage", 123.45);
 
 I18n.toNumber(1000);
 I18n.toCurrency(1000);
 I18n.toPercentage(100);
 
 I18n.toNumber(1000, { precision: 0 });
-I18n.toNumber(1000, { delimiter: '.', separator: ',' });
-I18n.toNumber(1000, { delimiter: '.', precision: 0 });
+I18n.toNumber(1000, { delimiter: ".", separator: "," });
+I18n.toNumber(1000, { delimiter: ".", precision: 0 });
 
 I18n.toCurrency(1000, { precision: 0 });
 
 I18n.toHumanSize(1234);
 
-I18n.l('date.formats.short', '2009-09-18');
-I18n.l('time.formats.short', '2009-09-18 23:12:43');
-I18n.l('time.formats.short', '2009-11-09T18:10:34');
-I18n.l('time.formats.short', '2009-11-09T18:10:34Z');
-I18n.l('date.formats.short', 1251862029000);
-I18n.l('date.formats.short', '09/18/2009');
-I18n.l('date.formats.short', new Date());
+I18n.l("date.formats.short", "2009-09-18");
+I18n.l("time.formats.short", "2009-09-18 23:12:43");
+I18n.l("time.formats.short", "2009-11-09T18:10:34");
+I18n.l("time.formats.short", "2009-11-09T18:10:34Z");
+I18n.l("date.formats.short", 1251862029000);
+I18n.l("date.formats.short", "09/18/2009");
+I18n.l("date.formats.short", new Date());
 
-I18n.l('date.formats.ordinal_day', '2009-09-18', { day: '18th' });
+I18n.l("date.formats.ordinal_day", "2009-09-18", { day: "18th" });
 
-I18n.strftime(new Date(), '%d/%m/%Y');
+I18n.strftime(new Date(), "%d/%m/%Y");
 
 const point_in_number = 1000;
-I18n.t('point', { count: point_in_number, formatted_number: I18n.toNumber(point_in_number) });
+I18n.t("point", { count: point_in_number, formatted_number: I18n.toNumber(point_in_number) });
 
 I18n.translations = {};
-I18n.translations['en'] = {
-    message: 'Some special message for you',
+I18n.translations["en"] = {
+    message: "Some special message for you",
 };
-I18n.translations['pt-BR'] = {
-    message: 'Uma mensagem especial para você',
+I18n.translations["pt-BR"] = {
+    message: "Uma mensagem especial para você",
 };

--- a/types/i18n-js/index.d.ts
+++ b/types/i18n-js/index.d.ts
@@ -20,6 +20,8 @@ declare namespace I18n {
     let missingTranslationPrefix: string;
 
     // tslint:disable-next-line prefer-declare-function
+    let getFullScope: (scope: string | ReadonlyArray<string>, options?: TranslateOptions) => string;
+    // tslint:disable-next-line prefer-declare-function
     let missingTranslation: (scope: string, options?: TranslateOptions) => string | null | undefined;
     // tslint:disable-next-line prefer-declare-function
     let missingPlaceholder: (placeholder: string, message: string, options?: InterpolateOptions) => string | null | undefined;


### PR DESCRIPTION
I18n-js's [authors recommend overriding `missingTranslation()` to add
fallback behavior](https://github.com/fnando/i18n-js/issues/477#issuecomment-411509345) when a translation is missing. Doing with the full
intended translation scope that the user requires necessitates the user
of `getFullScope` which is not explicitly a private method, but has not been
typed yet.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/fnando/i18n-js/blob/master/app/assets/javascripts/i18n.js#L1051-L1068
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

