### PR TITLE
[@types/pino] Updated types to match pino@6.0.0

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -221,9 +221,15 @@ declare namespace P {
          */
         level?: LevelWithSilent | string;
         /**
-         * Outputs the level as a string instead of integer. Default: `false`.
+         * (DEPRECATED, use `formatters.level`) Outputs the level as a string instead of integer. Default: `false`.
          */
         useLevelLabels?: boolean;
+        /**
+         * Changes the shape of the log level: Default shape: { level: number }
+         */
+        formatters: {
+            [key: string]: (level: string, value: number) => Record<string, string>;
+        };
         /**
          * Changes the property `level` to any string value you pass in. Default: 'level'
          */

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -227,7 +227,7 @@ declare namespace P {
         /**
          * Changes the shape of the log level: Default shape: { level: number }
          */
-        formatters: {
+        formatters?: {
             [key: string]: (level: string, value: number) => Record<string, string>;
         };
         /**


### PR DESCRIPTION
Changes:
- Deprecated `useLevelLabels`
- Added `formatters` definitions
- Fixed 
```
Warning: useLevelLabels is deprecated, use the formatters.level option instead
```
