### PR TITLE
fix(clownface): multiple context term may be defined

### DIFF
--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -30,9 +30,17 @@ function withoutContext() {
 
 function multiContext() {
     const cf: clownface.Clownface<Array<NamedNode | BlankNode>, Dataset> = <any> {};
-    const term: NamedNode | BlankNode | undefined = cf.term;
+    if (cf.term) {
+        const definedTerm: NamedNode | BlankNode = cf.term;
+    } else {
+        const undefinedTerm: undefined = cf.term;
+    }
     const terms: Array<NamedNode | BlankNode> = cf.terms;
-    const value: string | undefined = cf.value;
+    if (cf.value) {
+        const definedValue: string = cf.value;
+    } else {
+        const undefinedValue = cf.value;
+    }
     const values: string[] = cf.values;
     const _context: Array<Context<DatasetCore, Term>> = cf._context;
 }

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -37,9 +37,9 @@ declare namespace clownface {
       : Clownface<T, D>;
 
   interface Clownface<T extends AnyContext = AnyContext, D extends DatasetCore = DatasetCore> {
-    readonly term: T extends undefined ? undefined : T extends any[] ? undefined : T;
+    readonly term: T extends undefined ? undefined : T extends any[] ? undefined | T[0] : T;
     readonly terms: T extends undefined ? Term[] : T extends any[] ? T : [T];
-    readonly value: T extends undefined ? undefined : T extends any[] ? undefined : string;
+    readonly value: T extends undefined ? undefined : T extends any[] ? undefined | string[0] : string;
     readonly values: T extends undefined ? string[] : T extends any[] ? string[] : [string];
     readonly dataset: D;
     readonly datasets: D[];


### PR DESCRIPTION
re libero/article-store#306

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <[more like it was before 0.12.9](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/174534f0fced6efbf17fb1908ae3f2f2e6b8ddfa/types/clownface/index.d.ts#L47)>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.