### PR TITLE
[types/@passport]: fix property 'x' does not exist on type 'User'

### DIFF
--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -16,8 +16,9 @@ declare global {
     namespace Express {
         // tslint:disable-next-line:no-empty-interface
         interface AuthInfo {}
-        // tslint:disable-next-line:no-empty-interface
-        interface User {}
+        interface User {
+            [key: string]: any;
+        }
 
         interface Request {
             authInfo?: AuthInfo;

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -17,7 +17,9 @@ declare global {
         // tslint:disable-next-line:no-empty-interface
         interface AuthInfo {}
         interface User {
-            [key: string]: any;
+            profile?: Profile;
+            accessToken?: string;
+            refreshToken?: string; 
         }
 
         interface Request {

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -16,10 +16,29 @@ declare global {
     namespace Express {
         // tslint:disable-next-line:no-empty-interface
         interface AuthInfo {}
-        interface User {
+
+        interface Profile {
+          provider: string;
+          id: string;
+          displayName: string;
+          username?: string;
+          name?: {
+            familyName: string;
+            givenName: string;
+            middleName?: string;
+          };
+          emails?: Array<{
+            value: string;
+            type?: string;
+          }>;
+          photos?: Array<{
+            value: string;
+          }>;
+        }
+        interface User extends Profile {
             profile?: Profile;
             accessToken?: string;
-            refreshToken?: string; 
+            refreshToken?: string;
         }
 
         interface Request {
@@ -141,25 +160,6 @@ declare namespace passport {
     type StrategyCreated<T, O = T & StrategyCreatedStatic> = {
         [P in keyof O]: O[P];
     };
-
-    interface Profile {
-        provider: string;
-        id: string;
-        displayName: string;
-        username?: string;
-        name?: {
-            familyName: string;
-            givenName: string;
-            middleName?: string;
-        };
-        emails?: Array<{
-            value: string;
-            type?: string;
-        }>;
-        photos?: Array<{
-            value: string;
-        }>;
-    }
 
     interface Framework<InitializeRet = any, AuthenticateRet = any, AuthorizeRet = AuthenticateRet> {
         initialize(passport: Authenticator<InitializeRet, AuthenticateRet, AuthorizeRet>, options?: any): (...args: any[]) => InitializeRet;

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -4,7 +4,7 @@
 //                 Eric Naeseth <https://github.com/enaeseth>
 //                 Igor Belagorudsky <https://github.com/theigor>
 //                 Tomek Łaziuk <https://github.com/tlaziuk>
-//                 Daniel Perez Alvarez <https://github.com/unindented>
+//                 Daniel Perez Alvarez <https://github.com/danielpa9708>
 //                 Kevin Stiehl <https://github.com/kstiehl>
 //                 Oleg Vaskevich <https://github.com/vaskevich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -17,26 +17,7 @@ declare global {
         // tslint:disable-next-line:no-empty-interface
         interface AuthInfo {}
 
-        interface Profile {
-          provider: string;
-          id: string;
-          displayName: string;
-          username?: string;
-          name?: {
-            familyName: string;
-            givenName: string;
-            middleName?: string;
-          };
-          emails?: Array<{
-            value: string;
-            type?: string;
-          }>;
-          photos?: Array<{
-            value: string;
-          }>;
-        }
-        interface User extends Profile {
-            profile?: Profile;
+        interface User {
             accessToken?: string;
             refreshToken?: string;
         }
@@ -160,6 +141,25 @@ declare namespace passport {
     type StrategyCreated<T, O = T & StrategyCreatedStatic> = {
         [P in keyof O]: O[P];
     };
+
+    interface Profile {
+        provider: string;
+        id: string;
+        displayName: string;
+        username?: string;
+        name?: {
+            familyName: string;
+            givenName: string;
+            middleName?: string;
+        };
+        emails?: Array<{
+            value: string;
+            type?: string;
+        }>;
+        photos?: Array<{
+            value: string;
+        }>;
+    }
 
     interface Framework<InitializeRet = any, AuthenticateRet = any, AuthorizeRet = AuthenticateRet> {
         initialize(passport: Authenticator<InitializeRet, AuthenticateRet, AuthorizeRet>, options?: any): (...args: any[]) => InitializeRet;


### PR DESCRIPTION
when getting properties from req.user returned after passport authentication, an error is thrown by TypeScript
**example this code:**
```
const { user: { accessToken, profile } } = req;
```
or
```
const { accessToken, profile } = req.user;
```
**will throw Error:**
```
TSError: ⨯ Unable to compile TypeScript:
file.ts:9:19 - error TS2339: Property 'accessToken' does not exist on type 'User'.
file.ts:9:32 - error TS2339: Property 'profile' does not exist on type 'User'.
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<just normal TypeScript interface>>

