### PR TITLE
datatables.net : The API constructor now accepts a parameter of type SettingsLegacy (https://datatables.net/reference/type/DataTables.Settings)

### DIFF
--- a/types/datatables.net/datatables.net-tests.ts
+++ b/types/datatables.net/datatables.net-tests.ts
@@ -185,7 +185,9 @@ const footerCallbackFunc: DataTables.FunctionFooterCallback = (tfoot, data, star
 const formatNumberFunc: DataTables.FunctionFormatNumber = (toForm) => { };
 const headerCallbackFunc: DataTables.FunctionHeaderCallback = (thead, data, start, end, display) => { };
 const infoCallbackFunc: DataTables.FunctionInfoCallback = (settings, start, end, total, pre) => { };
-const initCallbackFunc: DataTables.FunctionInitComplete = (settings, json) => { };
+const initCallbackFunc: DataTables.FunctionInitComplete = (settings, json) => {
+    const api = new $.fn.dataTable.Api(settings);
+};
 const preDrawFunc: DataTables.FunctionPreDrawCallback = (settings) => { };
 const rowCallbackFunc: DataTables.FunctionRowCallback = (row, data, index) => { };
 const stateLoadCallbackFunc: DataTables.FunctionStateLoadCallback = (settings) => { };

--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -1137,7 +1137,7 @@ declare namespace DataTables {
          *
          * @param table Selector string for table
          */
-        Api: new (selector: string | Node | Node[] | JQuery) => Api;
+        Api: new (selector: string | Node | Node[] | JQuery | SettingsLegacy) => Api;
 
         /**
          * Default Settings


### PR DESCRIPTION
Hi,

The API constructor now accepts a parameter of type `SettingsLegacy`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://datatables.net/reference/type/DataTables.Settings
