### PR TITLE
correct parameter name for secp256k1 API v4.0

### DIFF
--- a/types/secp256k1/index.d.ts
+++ b/types/secp256k1/index.d.ts
@@ -115,7 +115,7 @@ export function signatureImport(signature: Uint8Array): Uint8Array;
  * - Compose 32-byte scalar `s = k^-1 * (r * d + m)`. Reject nonce if `s` is zero.
  * - The signature is `(r, s)`.
  */
-export function ecdsaSign(message: Uint8Array, privateKey: Uint8Array, options?: SignOptions): {signature: Uint8Array, recovery: number};
+export function ecdsaSign(message: Uint8Array, privateKey: Uint8Array, options?: SignOptions): {signature: Uint8Array, recId: number};
 
 /**
  * Verify an ECDSA signature.
@@ -133,7 +133,7 @@ export function ecdsaVerify(signature: Uint8Array, message: Uint8Array, publicKe
 /**
  * Recover an ECDSA public key from a signature.
  */
-export function ecdsaRecover(signature: Uint8Array, recovery: number, message: Uint8Array, compressed?: boolean): Uint8Array;
+export function ecdsaRecover(signature: Uint8Array, recId: number, message: Uint8Array, compressed?: boolean): Uint8Array;
 
 /**
  * Compute an EC Diffie-Hellman secret and applied sha256 to compressed public key.

--- a/types/secp256k1/index.d.ts
+++ b/types/secp256k1/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for secp256k1 3.5
+// Type definitions for secp256k1 4.0
 // Project: https://github.com/cryptocoinjs/secp256k1-node
 // Definitions by: Anler <https://github.com/anler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cryptocoinjs/secp256k1-node/blob/v4.0.0/API.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
