### PR TITLE
Update node-gettext typings to v3.0.0

### DIFF
--- a/types/node-gettext/index.d.ts
+++ b/types/node-gettext/index.d.ts
@@ -1,11 +1,11 @@
-// Type definitions for node-gettext 2.0
+// Type definitions for node-gettext 3.0
 // Project: http://github.com/alexanderwallin/node-gettext
 // Definitions by: Sameer K.C. <https://github.com/sameercaresu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 export = GetText;
 declare class GetText {
-    constructor(options?: { debug: boolean; });
+    constructor(options?: { debug?: boolean; sourceLocale?: string });
     addTranslations(locale: string, domain: string, translations: object): void;
     dgettext(domain: string, msgid: string): string;
     dngettext(domain: string, msgid: string, msgidPlural: string, count: number): string;
@@ -16,8 +16,8 @@ declare class GetText {
     gettext(msgid: string): string;
     ngettext(msgid: string, msgidPlural: string, count: number): string;
     npgettext(msgctxt: string, msgid: string, msgidPlural: string, count: number): string;
-    off(eventName: 'error', callback: (error: string) => void): void;
-    on(eventName: 'error', callback: (error: string) => void): void;
+    off(eventName: 'error', callback: (error: any) => void): void;
+    on(eventName: 'error', callback: (error: any) => void): void;
     pgettext(msgctxt: string, msgid: string): string;
     setLocale(locale: string): void;
     setTextDomain(domain: string): void;

--- a/types/node-gettext/node-gettext-tests.ts
+++ b/types/node-gettext/node-gettext-tests.ts
@@ -4,7 +4,7 @@ import Gettext from 'node-gettext';
 // import Gettext = require('node-getttext');
 
 const translations = {};
-const gt = new Gettext({ debug: true });
+const gt = new Gettext({ debug: true, sourceLocale: 'en' });
 const msgid = 'Get translation';
 const msgidPlural = 'Get translations';
 const domain = 'domain';
@@ -26,7 +26,7 @@ gt.npgettext(msgctxt, msgid, msgidPlural, count);
 gt.pgettext(msgctxt, msgid);
 Gettext.getLanguageCode('en-US');
 gt.warn('warning');
-const errorListener = (error: string) => {
+const errorListener = (error: any) => {
     // do something;
 };
 gt.on('error', errorListener);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/alexanderwallin/node-gettext/compare/v2.0.0...v3.0.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Consideration: the lib now always emits `Error`s, but the emit function is accessible to the outside and thus any other type could be passed. Therefore widening the type to `any`. This reverts https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33413 more or less.

@sameercaresu @pronebird