### PR TITLE
[@types/rebass]: Add font style props to Text and Heading components

### DIFF
--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -91,6 +91,7 @@ interface TextKnownProps
     extends BoxKnownProps,
         StyledSystem.FontFamilyProps,
         StyledSystem.FontWeightProps,
+        StyledSystem.FontStyleProps,
         StyledSystem.TextAlignProps,
         StyledSystem.LineHeightProps,
         StyledSystem.LetterSpacingProps {}

--- a/types/rebass/rebass-tests.tsx
+++ b/types/rebass/rebass-tests.tsx
@@ -35,7 +35,7 @@ export default () => (
             <Heading fontSize={5} fontWeight="bold">
                 Hi, I'm a heading.
             </Heading>
-            <Text as="p" fontSize={3} lineHeight="1em" letterSpacing="1rem">
+            <Text as="p" fontSize={3} lineHeight="1em" letterSpacing="1rem" fontStyle="italic">
                 Hi, I'm text.
             </Text>
             <Card


### PR DESCRIPTION
Both the rebass `Text` and `Heading` components support the `fontStyle` CSS property, defined by styled-system. The TS types are missing this prop. 

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://rebassjs.org/props/#typography
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.