### PR TITLE
express-http-proxy: proxyReqPathResolver can also return Promise<string>

### DIFF
--- a/types/express-http-proxy/express-http-proxy-tests.ts
+++ b/types/express-http-proxy/express-http-proxy-tests.ts
@@ -12,6 +12,10 @@ proxy("www.google.com", {
 });
 
 proxy("www.google.com", {
+    proxyReqPathResolver: async req => req.url
+});
+
+proxy("www.google.com", {
     limit: "10mb"
 });
 

--- a/types/express-http-proxy/index.d.ts
+++ b/types/express-http-proxy/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for express-http-proxy 1.5
+// Type definitions for express-http-proxy 1.6
 // Project: https://github.com/villadora/express-http-proxy#readme
 // Definitions by:  ulrichb <https://github.com/ulrichb>
 //                  Daniel Schopf <https://github.com/Danscho>

--- a/types/express-http-proxy/index.d.ts
+++ b/types/express-http-proxy/index.d.ts
@@ -25,7 +25,7 @@ declare namespace proxy {
             res: Response,
             next: NextFunction
         ) => any;
-        proxyReqPathResolver?: (req: Request) => string;
+        proxyReqPathResolver?: (req: Request) => string | Promise<string>;
         proxyReqOptDecorator?: (
             proxyReqOpts: RequestOptions,
             srcReq: Request


### PR DESCRIPTION
express-http-proxy: the proxyReqPathResolver can return a *promise* to a string, too.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/villadora/express-http-proxy#proxyreqpathresolver-supports-promises
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

