### PR TITLE
[@types/ldapjs] Callback error arguments can be null

### DIFF
--- a/types/ldapjs/index.d.ts
+++ b/types/ldapjs/index.d.ts
@@ -18,15 +18,15 @@ export interface ErrorCallback {
 }
 
 export interface CompareCallback {
-	(error: Error, matched?: boolean): void;
+	(error: Error | null, matched?: boolean): void;
 }
 
 export interface ExopCallback {
-	(error: Error, value: string, result?: any): void;
+	(error: Error | null, value: string, result?: any): void;
 }
 
 export interface CallBack {
-	(error: Error, result?: any): void;
+	(error: Error | null, result?: any): void;
 }
 
 export interface ClientOptions {


### PR DESCRIPTION
The error argument in callbacks can be null. Without the explicit `Error | null` union, consumers of these types cannot use Typescript's strict null checks.

---

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ldapjs/node-ldapjs/blob/ad451edc18d7768c3ddee1a1dd472d2bbafdae5e/lib/client/client.js#L1395
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

@cvillemure, @peterkooijmans, @pmoleri, @mscottnelson