### PR TITLE
Allow RefObject<T> in reach__router's innerRef.

### DIFF
--- a/types/reach__router/index.d.ts
+++ b/types/reach__router/index.d.ts
@@ -59,7 +59,7 @@ export interface LinkProps<TState> extends AnchorProps {
     getProps?: (props: LinkGetProps) => {};
     state?: TState;
     /** @deprecated If using React >= 16.4, use ref instead. */
-    innerRef?: React.RefCallback<HTMLAnchorElement>;
+    innerRef?: React.Ref<HTMLAnchorElement>;
 }
 
 export interface LinkGetProps {

--- a/types/reach__router/reach__router-tests.tsx
+++ b/types/reach__router/reach__router-tests.tsx
@@ -59,3 +59,6 @@ const handleRef = (el: HTMLAnchorElement) => {
 };
 
 render(<Link innerRef={handleRef} to="./foo"></Link>, document.getElementById('app-root'));
+
+const refObject: React.RefObject<HTMLAnchorElement> = { current: null };
+render(<Link innerRef={refObject} to="./foo"></Link>, document.getElementById('app-root'));


### PR DESCRIPTION
While https://reach.tech/router/api/Link describes innerRef as a func,
it is actually passed to React's HTMLAnchorElement's "ref" prop as such:

`<a ref={ref || innerRef} ...`

See: https://github.com/reach/router/blob/master/src/index.js#L392-L405

HTMLAnchorElement's "ref" is defined as Ref<HTMLAnchorElement>.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/reach/router/blob/master/src/index.js#L392-L405>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **No**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. **No**
