### PR TITLE
[aws-lambda]: Fix definition of APIGatewayRequestAuthorizerEvent

### DIFF
--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -201,7 +201,6 @@ const authorizer: APIGatewayAuthorizerHandler = async (event, context, callback)
         str = event.resource; // $ExpectError
     } else {
         event.type; // $ExpectType "REQUEST"
-        str = event.methodArn; // $ExpectError
         str = event.resource;
     }
 
@@ -221,7 +220,6 @@ const authorizerWithCustomContext: APIGatewayAuthorizerWithContextHandler<Custom
         str = event.resource; // $ExpectError
     } else {
         event.type; // $ExpectType "REQUEST"
-        str = event.methodArn; // $ExpectError
         str = event.resource;
     }
 
@@ -273,7 +271,7 @@ const requestAuthorizer: APIGatewayRequestAuthorizerHandler = async (event, cont
     event.type; // $ExpectType "REQUEST"
 
     str = event.type;
-    str = event.methodArn; // $ExpectError
+    str = event.methodArn;
     str = event.authorizationToken; // $ExpectError
     str = event.resource;
     str = event.path;
@@ -291,8 +289,10 @@ const requestAuthorizer: APIGatewayRequestAuthorizerHandler = async (event, cont
     if (event.stageVariables !== null)
         str = event.stageVariables[str];
     const requestContext: APIGatewayEventRequestContext = event.requestContext;
-    str = event.domainName;
-    str = event.apiId;
+    if (requestContext.domainName != null) {
+        str = requestContext.domainName;
+    }
+    str = requestContext.apiId;
 
     const result = createAuthorizerResult();
 
@@ -305,7 +305,7 @@ const requestAuthorizerWithCustomContext: APIGatewayRequestAuthorizerWithContext
     event.type; // $ExpectType "REQUEST"
 
     str = event.type;
-    str = event.methodArn; // $ExpectError
+    str = event.methodArn;
     str = event.authorizationToken; // $ExpectError
 
     const result = createAuthorizerResultWithCustomContext();

--- a/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
@@ -34,8 +34,11 @@ export interface APIGatewayTokenAuthorizerEvent {
 // Note, when invoked by the tester in the AWS web console, the map values can be null,
 // but they will be empty objects in the real object.
 // Worse, it will include "body" and "isBase64Encoded" properties, unlike the real call!
+// See https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-input.html for the
+// formal definition.
 export interface APIGatewayRequestAuthorizerEvent {
     type: "REQUEST";
+    methodArn: string;
     resource: string;
     path: string;
     httpMethod: string;
@@ -46,8 +49,6 @@ export interface APIGatewayRequestAuthorizerEvent {
     multiValueQueryStringParameters: { [name: string]: string[] } | null;
     stageVariables: { [name: string]: string } | null;
     requestContext: APIGatewayEventRequestContextWithAuthorizer<undefined>;
-    domainName: string;
-    apiId: string;
 }
 
 export interface APIGatewayAuthorizerResult {


### PR DESCRIPTION
According to the AWS docs, the APIGatewayRequestAuthorizerEvent does include `methodArn` and does not include `apiId` and `domainName`. See also the link provided below. This pull request updates the type to match the definition in the AWS docs.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [AWS docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-input.html)
