### PR TITLE
New package for Web Locks API definitions

### DIFF
--- a/types/web-locks-api/index.d.ts
+++ b/types/web-locks-api/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for non-npm package web-locks-api-browser 0.0
+// Project: https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API
+// Definitions by: Joël Charles <https://github.com/magne4000>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface Lock {
+  readonly mode: 'exclusive' | 'shared';
+  readonly name: string;
+}
+
+interface LockManagerSnapshot {
+  held: Lock[];
+  pending: Lock[];
+}
+
+interface LockManagerRequestOptions {
+  mode?: 'exclusive' | 'shared';
+  ifAvailable?: boolean;
+  steal?: boolean;
+  signal?: AbortSignal;
+}
+
+interface LockManager {
+  request(name: string, callback: (lock: Lock) => Promise<any>): Promise<undefined>;
+  request<T extends LockManagerRequestOptions>(
+    name: string,
+    options: T,
+    callback: (lock: T['ifAvailable'] extends true ? Lock | null : Lock) => Promise<any>,
+  ): Promise<undefined>;
+  query(): Promise<LockManagerSnapshot>;
+}
+
+interface Navigator {
+  locks: LockManager;
+}

--- a/types/web-locks-api/tsconfig.json
+++ b/types/web-locks-api/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "web-locks-api-tests.ts"
+    ]
+}

--- a/types/web-locks-api/tslint.json
+++ b/types/web-locks-api/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/web-locks-api/web-locks-api-tests.ts
+++ b/types/web-locks-api/web-locks-api-tests.ts
@@ -1,0 +1,10 @@
+navigator.locks.query().then((query: LockManagerSnapshot) => query);
+
+navigator.locks.request('test', async (lock: Lock) => {
+    return lock;
+});
+
+navigator.locks.request('test', { ifAvailable: true, mode: 'exclusive', steal: false },
+    async (lock: Lock | null) => {
+        return lock;
+    });


### PR DESCRIPTION
Based on https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.