### PR TITLE
Add @sinonjs/fake-timers redirect to @testing-library/cypress

### DIFF
--- a/types/testing-library__cypress/index.d.ts
+++ b/types/testing-library__cypress/index.d.ts
@@ -8,7 +8,7 @@
 //                 Airat Aminev <https://github.com/airato>
 //                 Simon Jespersen <https://github.com/simjes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 import {
     configure,

--- a/types/testing-library__cypress/tsconfig.json
+++ b/types/testing-library__cypress/tsconfig.json
@@ -22,6 +22,9 @@
             ],
             "@testing-library/dom": [
                 "testing-library__dom"
+            ],
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
             ]
         }
     },

--- a/types/testing-library__dom/index.d.ts
+++ b/types/testing-library__dom/index.d.ts
@@ -8,7 +8,7 @@
 //                 Justin Hall <https://github.com/wKovacs64>
 //                 Wesley Tsai <https://github.com/wezleytsai>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 import { getQueriesForElement } from './get-queries-for-element';
 import * as queries from './queries';

--- a/types/testing-library__react/index.d.ts
+++ b/types/testing-library__react/index.d.ts
@@ -8,7 +8,7 @@
 //                 Daniel Afonso <https://github.com/danieljcafonso>
 //                 Tim Swalling <https://github.com/timswalling>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 import { OptionsReceived as PrettyFormatOptions } from 'pretty-format';
 import { queries, Queries, BoundFunction } from '@testing-library/dom';

--- a/types/testing-library__vue/index.d.ts
+++ b/types/testing-library__vue/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/testing-library/vue-testing-library
 // Definitions by: Tim Yates <https://github.com/cimbul>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 import { ThisTypedMountOptions, VueClass } from '@vue/test-utils';
 import Vue from 'vue';
 import { Store, StoreOptions } from 'vuex';


### PR DESCRIPTION
@testing-library/cypress depends indirectly on @sinonjs/fake-timers (cypress -> sinon -> @sinonjs/fake-timers). However, it doesn't have a
redirect @sinonjs/fake-timers -> sinonjs__fake-timers. This causes lookup to fail.

I'm not sure what caused this problem. I think it was a change in cypress, which recently shipped a new version, but I'm not sure.