### PR TITLE
reach__router: Correct type for `ref` in `Link<TState>`.

### DIFF
--- a/types/reach__router/index.d.ts
+++ b/types/reach__router/index.d.ts
@@ -69,7 +69,14 @@ export interface LinkGetProps {
     location: WindowLocation;
 }
 
-export class Link<TState> extends React.Component<LinkProps<TState>> {}
+export function Link<TState>(
+    // TODO: Define this as ...params: Parameters<Link<TState>> when only TypeScript >= 3.1 support is needed.
+    props: React.PropsWithoutRef<LinkProps<TState>> & React.RefAttributes<HTMLAnchorElement>,
+): ReturnType<Link<TState>>;
+export interface Link<TState>
+    extends React.ForwardRefExoticComponent<
+        React.PropsWithoutRef<LinkProps<TState>> & React.RefAttributes<HTMLAnchorElement>
+    > {}
 
 export interface RedirectProps<TState> {
     from?: string;

--- a/types/reach__router/reach__router-tests.tsx
+++ b/types/reach__router/reach__router-tests.tsx
@@ -59,6 +59,17 @@ const handleRef = (el: HTMLAnchorElement) => {
 };
 
 render(<Link innerRef={handleRef} to="./foo"></Link>, document.getElementById('app-root'));
+render(<Link ref={handleRef} to="./foo"></Link>, document.getElementById('app-root'));
 
 const refObject: React.RefObject<HTMLAnchorElement> = { current: null };
 render(<Link innerRef={refObject} to="./foo"></Link>, document.getElementById('app-root'));
+render(<Link ref={refObject} to="./foo"></Link>, document.getElementById('app-root'));
+
+// Link can be used as a generic.
+// TODO: When TS >= 3.1 is supported, use more modern syntax:
+//     <Link<number> state={5} to="./foo"></Link>
+React.createElement(Link as Link<number>, {
+    state: 5 /* Cast is a test-only fix for TS 3.1. Remove when TS >= 3.2 is supported. */ as number | undefined,
+    to: './foo',
+    ref: refObject /* Cast is a test-only fix for TS 3.1. Remove when TS >= 3.2 is supported. */ as React.Ref<HTMLAnchorElement> | undefined
+});


### PR DESCRIPTION
Link.props.ref is actually a React.Ref<HTMLAnchorElement>. Link is
defined in terms of react's forwardRef() function, which returns a
ForwardRefExoticComponent. @reach/router actually forwards an
HTMLAnchorElement.

Without this fix, Link is a component, and "ref" is assumed to be a
React.Ref<Link>. But Link actually forwards "ref" to an <a> element
it returns.

See:

1. https://reach.tech/router/api/Link (ephasis below is mine):

    > ## innerRef: func
    > Calls up with its inner ref for apps on React <16.4.
    > **If using React >=16.4, use ref instead.**
    >
    > ```
    > <Link to="./" innerRef={node => /* ... */} />
    > ``

2. https://github.com/reach/router/blob/master/src/index.js#L392-L393

    Link is the result of forwardRef rather than an actual React class.

    This implies a few things:

    1. it is a function (see the return type of `React.forwardRef` rrather than a class)
    2. its "ref" property is to an inner elememnt, rather than what it is for React.Component, which is a Ref to the element itself.

    You can see in the code that this is indeed a ref to an `<a>` element.

**This introduces a potential incompatibility where users can't use "new Link" anymore. But that reflects reality (Link is callable and was never newable).**

Since Link was previously exported as a class, we need to continue to support it being used as both a type and a value. Since Link was exported as a generic, we need to continue to support that. As a result:

1. Link is exported as a function that happens to implement the type corresponding to the result of `forwardRef<HTMLAnchorElement, LinkProps<TState>>`.

2. Link is still exported as a type (interface) which is the same as that of the return value of `forwardRef<...>`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://reach.tech/router/api/Link> + code
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **No**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. **No**
