### PR TITLE
[screeps] Updated types for 2020-03-24 game update

### DIFF
--- a/types/screeps/screeps-tests.ts
+++ b/types/screeps/screeps-tests.ts
@@ -337,10 +337,11 @@ function resources(o: GenericStore): ResourceConstant[] {
     Game.map.getTerrainAt(new RoomPosition(25, 20, "W10N10"));
 }
 
-// Game.map.isRoomAvailable(roomName)
+// Game.map.getRoomStatus(roomName)
 
 {
-    if (Game.map.isRoomAvailable(room.name)) {
+    const roomStatus = Game.map.getRoomStatus(room.name);
+    if (roomStatus.status === "normal") {
         creep.moveTo(room.getPositionAt(25, 25)!);
     }
 }
@@ -658,19 +659,36 @@ function resources(o: GenericStore): ResourceConstant[] {
     const e1: number = extension.store.getUsedCapacity(RESOURCE_ENERGY);
     const e2: number = extension.store[RESOURCE_ENERGY];
 
-    const g1: 0 = extension.store.getUsedCapacity(RESOURCE_GHODIUM);
-    const g2: 0 = extension.store.getUsedCapacity(RESOURCE_GHODIUM);
+    // Invalid resource type for extension
+    const eg1: null = extension.store.getUsedCapacity(RESOURCE_GHODIUM);
+    const eg2: null = extension.store.getFreeCapacity(RESOURCE_GHODIUM);
+    const eg3: null = extension.store.getCapacity(RESOURCE_GHODIUM);
+    const eg4: 0 = extension.store.G;
 
     const storage = new StructureStorage("" as Id<StructureStorage>);
 
-    const g3: number = storage.store.getUsedCapacity(RESOURCE_GHODIUM);
+    const sg1: number = storage.store.getUsedCapacity(RESOURCE_GHODIUM);
+    const sg2: number = storage.store.getFreeCapacity(RESOURCE_GHODIUM);
+    const sg3: number = storage.store.getCapacity(RESOURCE_GHODIUM);
 }
 
 // Advanced Structure types
 {
-    const owned = Game.getObjectById<AnyOwnedStructure>("blah");
-    const owner = owned!.owner.username;
-    owned!.notifyWhenAttacked(false);
+    const owned = Game.getObjectById<AnyOwnedStructure>("blah")!;
+    const owner = owned.owner && owned.owner.username;
+    owned.notifyWhenAttacked(false);
+
+    const structs = room.find(FIND_MY_STRUCTURES);
+    structs.forEach(struct => {
+        switch (struct.structureType) {
+            case STRUCTURE_CONTROLLER:
+                const usernameOptional: string | undefined = struct.owner && struct.owner.username;
+                break;
+            default:
+                const usernameRequired: string = struct.owner.username;
+                break;
+        }
+    });
 
     const unowned = Game.getObjectById<AnyStructure>("blah2")!;
     const hp = unowned.hits / unowned.hitsMax;
@@ -775,6 +793,8 @@ function resources(o: GenericStore): ResourceConstant[] {
         if (lab1.mineralAmount >= LAB_REACTION_AMOUNT && lab2.mineralAmount >= LAB_REACTION_AMOUNT && lab0.mineralType === null) {
             lab0.runReaction(lab1, lab2);
         }
+        // nevermind, reverse that
+        lab0.reverseReaction(lab1, lab2);
     }
 }
 
@@ -820,4 +840,17 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     const enemyTerrain = new Room.Terrain("W2N5");
+}
+
+// Creep.body
+function atackPower(creep: Creep) {
+    return creep.body
+        .map(part => {
+            if (part.type === ATTACK) {
+                const multiplier = part.boost ? BOOSTS[part.type][part.boost].attack : 1;
+                return multiplier * ATTACK_POWER;
+            }
+            return 0;
+        })
+        .reduce((a, b) => a + b);
 }


### PR DESCRIPTION
This PR publishes v3.1 of the community managed types from typed-screeps for the Screeps game. Includes fixes and updates from latest game release.

- Fixed `StructureSpawn.renewCreep()` documentation
- Added missing `PWR_OPERATE_FACTORY` constant
- Changed `BodyPartConstant` to allow inferred Boost type from part type
- Added `ConcreteStructure<T>` type
- Change `owner` to allow undefined on `StructureController`
- Various updates from [2020-03-24 game update](https://screeps.com/forum/topic/2936/changelog-2020-03-24)
  - Added `Game.map.getRoomStauts(roomName)`
  - Added `RoomStatus` type, a discriminated union on `status` of `RoomStatusTemporary` and `RoomStatusPermanent`.
  - Added `StructureLab.reverseReaction(lab1,lab2)`
  - Changed `room.name` to be readonly
  - Changed typing of `StoreBase.getFreeCapacity()` to return `null` for invalid resources types on limited stores.
  - Changed documentation of `store` functions
  - Deprecated `Game.map.isRoomAvailable()`, see `Game.map.getRoomStatus()`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://screeps.com/forum/topic/2936/changelog-2020-03-24
  - https://github.com/screepers/typed-screeps/releases/tag/v3.1.0
