### PR TITLE
Ember Data Adapter: export default AdapterError

### DIFF
--- a/types/ember-data__adapter/error.d.ts
+++ b/types/ember-data__adapter/error.d.ts
@@ -1,6 +1,7 @@
 import DS from 'ember-data';
 
-export import AdapterError = DS.AdapterError;
+export default DS.AdapterError;
+
 export import InvalidError = DS.InvalidError;
 export import UnauthorizedError = DS.UnauthorizedError;
 export import ForbiddenError = DS.ForbiddenError;

--- a/types/ember-data__adapter/test/error.ts
+++ b/types/ember-data__adapter/test/error.ts
@@ -22,5 +22,9 @@ class MyInvalid extends InvalidError {
     }
 }
 
+const invalid = new MyInvalid();
+
+const isInvalid = invalid instanceof AdapterError; // $ExpectType<boolean>
+
 errorsHashToArray({}); // $ExpectType<any[]>
 errorsArrayToHash([]); // $ExpectType<{}>


### PR DESCRIPTION
The current types use a named export

```ts
import { AdapterError } from '@ember-data/adapter/error';
```

compared to what is documented

```ts
import AdapterError from '@ember-data/adapter/error';
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/emberjs/data/blob/279e55c1f656a2018e72e280ed7cce8a8bb45d66/packages/adapter/addon/error.js#L98>