### PR TITLE
[redux-form] Fix selectors types

### DIFF
--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -13,6 +13,7 @@
 //                 Ethan Setnik <https://github.com/esetnik>
 //                 Kota Marusue <https://github.com/mrsekut>
 //                 Adam Bouqdib <https://github.com/abemedia>
+//                 Bartosz Kopciuch <https://github.com/ideffix>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 import {

--- a/types/redux-form/lib/selectors.d.ts
+++ b/types/redux-form/lib/selectors.d.ts
@@ -1,10 +1,10 @@
 import { FormErrors, GetFormState } from "../index";
 
-export type DataSelector<FormData = {}, State = {}> = (formName: string, getFormState?: GetFormState) => (state: State) => FormData;
-export type ErrorSelector<FormData = {}, State = {}, ErrorType = string> = (formName: string, getFormState?: GetFormState) => (state: State) => FormErrors<FormData, ErrorType>;
-export type BooleanSelector<State = {}> = (formName: string, getFormState?: GetFormState) => (state: State) => boolean;
-export type NamesSelector<State = {}> = (getFormState?: GetFormState) => (state: State) => string[];
-export type FormOrFieldsBooleanSelector<State = {}> = (formName: string, getFormState?: GetFormState) => (state: State, ...fields: string[]) => boolean;
+export type DataSelector = <FormData = {}, State = {}>(formName: string, getFormState?: GetFormState) => (state: State) => FormData;
+export type ErrorSelector = <FormData = {}, State = {}, ErrorType = string>(formName: string, getFormState?: GetFormState) => (state: State) => FormErrors<FormData, ErrorType>;
+export type BooleanSelector = <State = {}>(formName: string, getFormState?: GetFormState) => (state: State) => boolean;
+export type NamesSelector = <State = {}>(getFormState?: GetFormState) => (state: State) => string[];
+export type FormOrFieldsBooleanSelector = <State = {}>(formName: string, getFormState?: GetFormState) => (state: State, ...fields: string[]) => boolean;
 
 export const getFormValues: DataSelector;
 export const getFormInitialValues: DataSelector;

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Action, Dispatch } from "redux";
+import { Dispatch } from "redux";
 import {
     reduxForm,
     InjectedFormProps,
@@ -8,7 +8,6 @@ import {
     GenericForm,
     FormSection,
     formValues,
-    formValueSelector,
     Field,
     GenericField,
     WrappedFieldProps,
@@ -23,15 +22,12 @@ import {
     FormAction,
     actionTypes,
     submit,
-    SubmissionError,
-    FieldArrayFieldsProps
+    SubmissionError
 } from "redux-form";
 
 import {
     Field as ImmutableField,
-    reduxForm as immutableReduxForm,
-    startSubmit as immutableStartSubmit,
-    stopSubmit as immutableStopSubmit
+    reduxForm as immutableReduxForm
 } from "redux-form/immutable";
 
 import LibField, {
@@ -39,7 +35,6 @@ import LibField, {
 } from "redux-form/lib/Field";
 import libReducer from "redux-form/lib/reducer";
 import LibFormSection from "redux-form/lib/FormSection";
-import libFormValueSelector from "redux-form/lib/formValueSelector";
 import libReduxForm from "redux-form/lib/reduxForm";
 import libActions from "redux-form/lib/actions";
 import LibSubmissionError from "redux-form/lib/SubmissionError";

--- a/types/redux-form/tslint.json
+++ b/types/redux-form/tslint.json
@@ -2,6 +2,7 @@
     "extends": "dtslint/dt.json",
     "rules": {
         "no-object-literal-type-assertion": false,
-        "strict-export-declare-modifiers": false
+        "strict-export-declare-modifiers": false,
+        "no-unnecessary-generics": false
     }
 }


### PR DESCRIPTION
Hello!

I create this PR because I think that types for selectors are invalid. Example:

I want to use **getFormValues** selector. I also want to have result in given type. What I tried to do was:
`const valuesSelector = (state: RootState) => getFormValues<MyForm, RootState>('myForm')(state);`

but I ended up with an error: **Expected 0 type arguments, but got 2.  TS2558**

I think that someone wants to do this function as generic, but instead it was defined as a generic type alias with default values.

With my change all works as expected.

Im not sure about that but Ive also added a change in tslint **no-unnecessary-generics: false**. Ive added that because after my change linter shown this error.