### PR TITLE
secure-json-parse: add missing option

### DIFF
--- a/types/secure-json-parse/index.d.ts
+++ b/types/secure-json-parse/index.d.ts
@@ -1,12 +1,14 @@
 // Type definitions for secure-json-parse 1.0
 // Project: https://github.com/fastify/secure-json-parse#readme
 // Definitions by: Sjoerd Diepen <https://github.com/OSjoerdWie>
+//                 Mike MacCana <https://github.com/mikemaccana>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export type Reviver = (this: any, key: string, value: any) => any;
 
 export interface ParseOptions {
-	protoAction: "error" | "remove" | "ignore";
+	protoAction?: "error" | "remove" | "ignore";
+	constructorAction?: "error" | "remove";
 }
 
 export function parse(input: string, reviver?: Reviver, options?: ParseOptions): any;


### PR DESCRIPTION
Added constructorAction, which was missing from the previous type definition
See https://github.com/fastify/secure-json-parse#readme

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/fastify/secure-json-parse#readme
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.