### PR TITLE
[bookshelf] Update knex dependency

### DIFF
--- a/types/bookshelf/bookshelf-tests.ts
+++ b/types/bookshelf/bookshelf-tests.ts
@@ -972,7 +972,7 @@ let tabs = new TabSet([tab1, tab2, tab3]);
 
 /* Collection.extend(), see http://bookshelfjs.org/#Collection-static-extend */
 
-/* Collection.forge(), see http://bookshelfjs.org/#Collection-static-forge */
+/* Collection.forge(), see https://bookshelfjs.org/api.html#Collection-static-forge */
 
 class Accounts extends bookshelf.Collection<Account> {
 	get model() {
@@ -985,7 +985,7 @@ var accounts = Accounts.forge<Accounts>([
 	{name: 'Person2'}
 ]);
 
-Promise.all(accounts.invoke('save')).then(() => {
+Promise.all(accounts.invokeMap('save')).then(() => {
 	// collection models should now be saved...
 });
 
@@ -1219,63 +1219,26 @@ ships.trigger('fetched');
 	}
 }
 
-/* Lodash methods, see http://bookshelfjs.org/#Collection-subsection-lodash-methods */
+/* Lodash methods, see https://bookshelfjs.org/api.html#Collection-subsection-lodash-methods */
 
-/* all(), see http://lodash.com/docs/#all */
-
-/* any(), see http://lodash.com/docs/#any */
-
-/* chain(), see http://lodash.com/docs/#chain */
-
-/* collect(), see http://lodash.com/docs/#collect */
-
-/* contains(), see http://lodash.com/docs/#contains */
-
-/* countBy(), see http://lodash.com/docs/#countBy */
-
-/* detect(), see http://lodash.com/docs/#detect */
-
-/* difference(), see http://lodash.com/docs/#difference */
-
-/* drop(), see http://lodash.com/docs/#drop */
-
-/* each(), see http://lodash.com/docs/#each */
-
-/* every(), see http://lodash.com/docs/#every */
-
-/* filter(), see http://lodash.com/docs/#filter */
-
-/* find(), see http://lodash.com/docs/#find */
-
-/* first(), see http://lodash.com/docs/#first */
-
-/* foldl(), see http://lodash.com/docs/#foldl */
-
-/* foldr(), see http://lodash.com/docs/#foldr */
-
-/* forEach(), see http://lodash.com/docs/#forEach */
-
-/* groupBy(), see http://lodash.com/docs/#groupBy */
-
-/* head(), see http://lodash.com/docs/#head */
-
-/* include(), see http://lodash.com/docs/#include */
-
-/* indexOf(), see http://lodash.com/docs/#indexOf */
-
-/* initial(), see http://lodash.com/docs/#initial */
-
-/* inject(), see http://lodash.com/docs/#inject */
-
-/* invoke(), see http://lodash.com/docs/#invoke */
-
-/* isEmpty(), see http://lodash.com/docs/#isEmpty */
-
-/* last(), see http://lodash.com/docs/#last */
-
-/* lastIndexOf(), see http://lodash.com/docs/#lastIndexOf */
-
-/* map(), see http://lodash.com/docs/#map */
+/*
+- countBy()
+- every()
+- filter()
+- find()
+- forEach()
+- groupBy()
+- includes()
+- invokeMap()
+- isEmpty()
+- map()
+- reduce()
+- reduceRight()
+- reject()
+- some()
+- sortBy()
+- toArray()
+*/
 
 // TODO No example provided on Bookshelf website
 

--- a/types/bookshelf/bookshelf-tests.ts
+++ b/types/bookshelf/bookshelf-tests.ts
@@ -701,17 +701,15 @@ qb.where({id: 1}).select().then(resp => {
 
 /* model.refresh(), see http://bookshelfjs.org/#Model-instance-refresh */
 
-/* model.related(), see http://bookshelfjs.org/#Model-instance-related */
+/* model.related(), see https://bookshelfjs.org/api.html#Model-instance-related */
 class Trip extends bookshelf.Model<Trip> {}
 class Trips extends bookshelf.Collection<Trip> {}
 new Photo({id: 1}).fetch({
 	withRelated: ['account']
 }).then(photo => {
-	if (photo) {
-		var account = <Account> photo.related('account');
-		if (account.id) {
-			return (<Trips> account.related('trips')).fetch();
-		}
+	var account = photo.related('account') as Account;
+	if (account.id) {
+		return (account.related('trips') as Trips).fetch();
 	}
 });
 

--- a/types/bookshelf/bookshelf-tests.ts
+++ b/types/bookshelf/bookshelf-tests.ts
@@ -977,7 +977,9 @@ let tabs = new TabSet([tab1, tab2, tab3]);
 /* Collection.forge(), see http://bookshelfjs.org/#Collection-static-forge */
 
 class Accounts extends bookshelf.Collection<Account> {
-	model: Account
+	get model() {
+		return Account
+	}
 }
 
 var accounts = Accounts.forge<Accounts>([

--- a/types/bookshelf/index.d.ts
+++ b/types/bookshelf/index.d.ts
@@ -214,32 +214,12 @@ declare namespace Bookshelf {
         where(match: { [key: string]: any }, firstOnly: boolean): T | Collection<T>;
 
         // lodash methods
-        all(
-            predicate?: Lodash.ListIterator<T, boolean> | Lodash.DictionaryIterator<T, boolean> | string,
-            thisArg?: any,
-        ): boolean;
-        all<R extends {}>(predicate?: R): boolean;
-        any(
-            predicate?: Lodash.ListIterator<T, boolean> | Lodash.DictionaryIterator<T, boolean> | string,
-            thisArg?: any,
-        ): boolean;
-        any<R extends {}>(predicate?: R): boolean;
-        collect(
-            predicate?: Lodash.ListIterator<T, boolean> | Lodash.DictionaryIterator<T, boolean> | string,
-            thisArg?: any,
-        ): T[];
-        collect<R extends {}>(predicate?: R): T[];
-        contains(value: any, fromIndex?: number): boolean;
+        includes(value: any, fromIndex?: number): boolean;
         countBy(
             predicate?: Lodash.ListIterator<T, boolean> | Lodash.DictionaryIterator<T, boolean> | string,
             thisArg?: any,
         ): Lodash.Dictionary<number>;
         countBy<R extends {}>(predicate?: R): Lodash.Dictionary<number>;
-        detect(
-            predicate?: Lodash.ListIterator<T, boolean> | Lodash.DictionaryIterator<T, boolean> | string,
-            thisArg?: any,
-        ): T;
-        detect<R extends {}>(predicate?: R): T;
         every(
             predicate?: Lodash.ListIterator<T, boolean> | Lodash.DictionaryIterator<T, boolean> | string,
             thisArg?: any,
@@ -256,8 +236,6 @@ declare namespace Bookshelf {
         ): T;
         find<R extends {}>(predicate?: R): T;
         first(): T;
-        foldl<R>(callback?: Lodash.MemoIterator<T, R>, accumulator?: R, thisArg?: any): R;
-        foldr<R>(callback?: Lodash.MemoIterator<T, R>, accumulator?: R, thisArg?: any): R;
         forEach(callback?: Lodash.ListIterator<T, void>, thisArg?: any): Lodash.List<T>;
         forEach(callback?: Lodash.DictionaryIterator<T, void>, thisArg?: any): Lodash.Dictionary<T>;
         forEach(callback?: Lodash.ObjectIterator<T, void>, thisArg?: any): T;
@@ -266,9 +244,7 @@ declare namespace Bookshelf {
             thisArg?: any,
         ): Lodash.Dictionary<T[]>;
         groupBy<R extends {}>(predicate?: R): Lodash.Dictionary<T[]>;
-        include(value: any, fromIndex?: number): boolean;
-        inject<R>(callback?: Lodash.MemoIterator<T, R>, accumulator?: R, thisArg?: any): R;
-        invoke(methodName: string | Function, ...args: any[]): any;
+        invokeMap(methodName: string | Function, ...args: any[]): any;
         isEmpty(): boolean;
         keys(): string[];
         last(): T;
@@ -286,12 +262,7 @@ declare namespace Bookshelf {
             thisArg?: any,
         ): T[];
         reject<R extends {}>(predicate?: R): T[];
-        rest(): T[];
-        select(
-            predicate?: Lodash.ListIterator<T, boolean> | Lodash.DictionaryIterator<T, boolean> | string,
-            thisArg?: any,
-        ): T[];
-        select<R extends {}>(predicate?: R): T[];
+        tail(): T[];
         some(
             predicate?: Lodash.ListIterator<T, boolean> | Lodash.DictionaryIterator<T, boolean> | string,
             thisArg?: any,

--- a/types/bookshelf/index.d.ts
+++ b/types/bookshelf/index.d.ts
@@ -4,7 +4,7 @@
 //                 Vesa Poikajärvi <https://github.com/vesse>
 //                 Ian Serpa <http://github.com/ianldgs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.4
+// Minimum TypeScript Version: 3.6
 
 import Knex = require('knex');
 import knex = require('knex');

--- a/types/bookshelf/index.d.ts
+++ b/types/bookshelf/index.d.ts
@@ -4,7 +4,7 @@
 //                 Vesa Poikajärvi <https://github.com/vesse>
 //                 Ian Serpa <http://github.com/ianldgs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.2
+// TypeScript Version: 3.4
 
 import Knex = require('knex');
 import knex = require('knex');

--- a/types/bookshelf/index.d.ts
+++ b/types/bookshelf/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for bookshelfjs v1.0.1
+// Type definitions for bookshelfjs v1.1.1
 // Project: http://bookshelfjs.org/
 // Definitions by: Andrew Schurman <https://github.com/arcticwaters>
 //                 Vesa Poikajärvi <https://github.com/vesse>

--- a/types/bookshelf/package.json
+++ b/types/bookshelf/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "knex": "^0.17.0"
+        "knex": "^0.20.13"
     }
 }

--- a/types/bookshelf/tsconfig.json
+++ b/types/bookshelf/tsconfig.json
@@ -5,10 +5,7 @@
         "lib": [
             "es6"
         ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": false,
-        "strictFunctionTypes": true,
+        "strict": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Update `knex` dependency from ^0.17.0 to latest version (^0.20.13) to match Bookshelf latest version (v1.1.1)

See https://github.com/bookshelf/bookshelf/blob/1.1.1/package.json#L65

This allows users to use latest Bookshelf and Knex together.

Also contains an update about https://github.com/bookshelf/bookshelf/blob/1.1.1/CHANGELOG.md#breaking-changes-4

<br>
<br>
<br>

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bookshelf/bookshelf/blob/1.1.1/package.json#L65 + https://github.com/bookshelf/bookshelf/blob/1.1.1/CHANGELOG.md#breaking-changes-4
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
