### PR TITLE
[express-serve-static-core] enable literal union for accept languages

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -58,3 +58,53 @@ app.post<never, { foo: string }, { bar: number }>('/', (req, res) => {
     res.json({ baz: "fail" }); // $ExpectError
     req.body.baz; // $ExpectError
 });
+
+app.get('/', (req, res) => {
+    const supportedLanguages = 'en' as string;
+    const accepted = req.acceptsLanguages(supportedLanguages);
+    if (accepted !== false) {
+        accepted; // $ExpectType string
+    }
+});
+
+app.get('/', (req, res) => {
+    const supportedLanguages = 'en' as const;
+    const accepted = req.acceptsLanguages(supportedLanguages);
+    if (accepted !== false) {
+        accepted; // $ExpectType "en"
+    }
+});
+
+app.get('/', (req, res) => {
+    const supportedLanguages = ['en', 'fi', 'sv'];
+    const accepted = req.acceptsLanguages(supportedLanguages);
+    if (accepted !== false) {
+        accepted; // $ExpectType string
+    }
+});
+
+app.get('/', (req, res) => {
+    const supportedLanguages = ['en', 'fi', 'sv'] as const;
+    const accepted = req.acceptsLanguages(supportedLanguages);
+    if (accepted !== false) {
+        accepted; // $ExpectType "en" | "fi" | "sv"
+    }
+});
+
+app.get('/', (req, res) => {
+    const supportedLanguages1 = 'en' as string;
+    const supportedLanguages2 = 'fi' as string;
+    const accepted = req.acceptsLanguages(supportedLanguages1, supportedLanguages2);
+    if (accepted !== false) {
+        accepted; // $ExpectType string
+    }
+});
+
+app.get('/', (req, res) => {
+    const supportedLanguages1 = 'en' as const;
+    const supportedLanguages2 = 'fi' as const;
+    const accepted = req.acceptsLanguages(supportedLanguages1, supportedLanguages2);
+    if (accepted !== false) {
+        accepted; // $ExpectType "en" | "fi"
+    }
+});

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -309,9 +309,9 @@ export interface Request<P extends Params = ParamsDictionary, ResBody = any, Req
      * For more information, or if you have issues or concerns, see accepts.
      */
     acceptsLanguages(): string[];
-    acceptsLanguages(lang: string): string | false;
-    acceptsLanguages(lang: string[]): string | false;
-    acceptsLanguages(...lang: string[]): string | false;
+    acceptsLanguages<T extends string>(lang: T): T | false;
+    acceptsLanguages<T extends string>(lang: ReadonlyArray<T>): T | false;
+    acceptsLanguages<T extends string>(...lang: T[]): T | false;
 
     /**
      * Parse Range header field, capping to the given `size`.


### PR DESCRIPTION
I want to receive back the selected locale as the same type as the elements of my input array are.
For example:

```ts
type SupportedLanguages = 'en' | 'fi' | 'sv'
const supportedLanguages: readonly SupportedLanguages[] = ['en', 'fi', 'sv']

app.get('/', (req, res) => {
  const acceptedLanguage = req.supports(supportedLanguages)
  // expecting 'en' | 'fi' | 'sv' | false
})
```

This change enables this, while being transparent to anyone using a basic string array.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.