### PR TITLE
fix(chai-dom): add missing visible assertion

### DIFF
--- a/types/chai-dom/chai-dom-tests.ts
+++ b/types/chai-dom/chai-dom-tests.ts
@@ -5,7 +5,6 @@ chai.use(chaiDom);
 var expect = chai.expect;
 
 function test() {
-
     var testElement = '<div></div>';
     expect(testElement).to.have.attribute('foo', 'bar');
     expect(testElement).to.have.attr('foo').match(/bar/);
@@ -22,5 +21,5 @@ function test() {
     expect(testElement).to.match('foo');
     expect(testElement).to.contain('foo');
     expect(testElement).to.contain(document.body);
-
+    expect(testElement).to.be.visible;
 }

--- a/types/chai-dom/index.d.ts
+++ b/types/chai-dom/index.d.ts
@@ -7,9 +7,7 @@
 /// <reference types="chai" />
 
 declare namespace Chai {
-
     interface Assertion {
-
         attr(name: string, value?: string): Assertion;
 
         attribute(name: string, value?: string): Assertion;
@@ -20,7 +18,7 @@ declare namespace Chai {
 
         html(html: string): Assertion;
 
-        text(text: string|string[]): Assertion;
+        text(text: string | string[]): Assertion;
 
         value(text: string): Assertion;
 
@@ -30,7 +28,7 @@ declare namespace Chai {
         // same type or a more general type, so don't need to be re-declared even though
         // the implementation is different
 
-        descendant(element: string|HTMLElement): Assertion;
+        descendant(element: string | HTMLElement): Assertion;
 
         descendants(selector: string): Assertion;
 
@@ -38,25 +36,21 @@ declare namespace Chai {
 
         trimmed: Assertion;
 
+        visible: Assertion;
     }
 
     interface Include {
+        text(text: string | string[]): Assertion;
 
-        text(text: string|string[]): Assertion;
-
-        html(text: string|string[]): Assertion;
-
+        html(text: string | string[]): Assertion;
     }
 
     interface Match {
-
         (selector: string): Assertion;
-
     }
-
 }
 
-declare module "chai-dom" {
+declare module 'chai-dom' {
     const chaiDom: Chai.ChaiPlugin;
     export = chaiDom;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/chai-dom#visible
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.