### PR TITLE
LZString.decompress* returns null for invalid inputs

### DIFF
--- a/types/lz-string/index.d.ts
+++ b/types/lz-string/index.d.ts
@@ -26,7 +26,7 @@ declare namespace LZString {
          *
          * @param compressed A string obtained from a call to compress().
          */
-        decompress(compressed: string): string;
+        decompress(compressed: string): null | string;
 
         /**
          * Compresses input string producing an instance of a "valid" UTF-16 string,
@@ -41,7 +41,7 @@ declare namespace LZString {
          *
          * @param compressed A string obtained from a call to compressToUTF16().
          */
-        decompressFromUTF16(compressed: string): string;
+        decompressFromUTF16(compressed: string): null | string;
 
         /**
          * Compresses input string producing an instance of a ASCII UTF-16 string,
@@ -58,7 +58,7 @@ declare namespace LZString {
          *
          * @param compressed A string obtained from a call to compressToBase64().
          */
-        decompressFromBase64(compressed: string): string;
+        decompressFromBase64(compressed: string): null | string;
 
         /**
          * produces ASCII strings representing the original string encoded in Base64 with a few
@@ -74,7 +74,7 @@ declare namespace LZString {
          *
          * @param compressed A string obtained from a call to compressToEncodedURIComponent().
          */
-        decompressFromEncodedURIComponent(compressed: string): string;
+        decompressFromEncodedURIComponent(compressed: string): null | string;
 
         /**
          * produces an uint8Array
@@ -88,6 +88,6 @@ declare namespace LZString {
          *
          * @param compressed A string obtained from a call to compressToUint8Array().
          */
-        decompressFromUint8Array(compressed: Uint8Array): string;
+        decompressFromUint8Array(compressed: Uint8Array): null | string;
     }
 }

--- a/types/lz-string/lz-string-tests.ts
+++ b/types/lz-string/lz-string-tests.ts
@@ -1,6 +1,6 @@
 const input = "Someting to compress";
 let encoded: string;
-let decoded: string;
+let decoded: null | string;
 let encodedU8: Uint8Array;
 
 encoded = LZString.compress(input);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pieroxy/lz-string/blob/master/libs/lz-string.js#L54 and other places with `return null`
- [x] (no) If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. 
- [x] (no) If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.