### PR TITLE
Update react-tagsinput Type Mappings to use Generics instead of <any>…

### DIFF
--- a/types/react-tagsinput/index.d.ts
+++ b/types/react-tagsinput/index.d.ts
@@ -10,7 +10,7 @@ import * as React from "react";
 export as namespace ReactTagsInput;
 export = TagsInput;
 
-declare class TagsInput<Tag> extends React.Component<TagsInput.ReactTagsInputProps<Tag>> {
+declare class TagsInput<Tag = any> extends React.Component<TagsInput.ReactTagsInputProps<Tag>> {
     accept(): any;
     addTag(tag: Tag): any;
     blur(): void;
@@ -20,10 +20,10 @@ declare class TagsInput<Tag> extends React.Component<TagsInput.ReactTagsInputPro
 
 declare namespace TagsInput {
     interface InputProps {
-      readonly [prop: string]: any;
+        readonly [prop: string]: any;
     }
 
-    interface RenderInputProps<Tag> extends InputProps {
+    interface RenderInputProps<Tag = any> extends InputProps {
         readonly addTag: (tag: Tag) => void;
         readonly onChange: (e: React.ChangeEvent<{ readonly value: string }>) => void;
         readonly ref: (r: any) => void; // parameter is either a DOM element or a mounted React component
@@ -34,7 +34,7 @@ declare namespace TagsInput {
         readonly [prop: string]: any;
     }
 
-    interface RenderTagProps<Tag> extends TagProps {
+    interface RenderTagProps<Tag = any> extends TagProps {
         readonly disabled: boolean;
         readonly getTagDisplayValue: (tag: Tag) => string;
         readonly onRemove: (tagIndex: number) => void;
@@ -43,7 +43,7 @@ declare namespace TagsInput {
 
     type RenderLayout = (tagElements: React.ReactElement[], inputElement: React.ReactElement) => React.ReactChild;
 
-    interface ReactTagsInputProps<Tag> extends React.Props<TagsInput<Tag>> {
+    interface ReactTagsInputProps<Tag = any> extends React.Props<TagsInput<Tag>> {
         value: Tag[];
         onChange: (tags: Tag[], changed: Tag[], changedIndexes: number[]) => void;
         onChangeInput?: (value: string) => void;
@@ -63,7 +63,7 @@ declare namespace TagsInput {
         focusedClassName?: string;
         tagProps?: TagProps;
         inputProps?: InputProps;
-        tagDisplayProp?: string | null;
+        tagDisplayProp?: keyof Tag | string | null;
         renderTag?: (props: RenderTagProps<Tag>) => React.ReactNode;
         renderInput?: (props: RenderInputProps<Tag>) => React.ReactNode;
         renderLayout?: RenderLayout;

--- a/types/react-tagsinput/index.d.ts
+++ b/types/react-tagsinput/index.d.ts
@@ -10,9 +10,7 @@ import * as React from "react";
 export as namespace ReactTagsInput;
 export = TagsInput;
 
-type Tag = any;
-
-declare class TagsInput extends React.Component<TagsInput.ReactTagsInputProps> {
+declare class TagsInput<Tag> extends React.Component<TagsInput.ReactTagsInputProps<Tag>> {
     accept(): any;
     addTag(tag: Tag): any;
     blur(): void;
@@ -25,7 +23,7 @@ declare namespace TagsInput {
       readonly [prop: string]: any;
     }
 
-    interface RenderInputProps extends InputProps {
+    interface RenderInputProps<Tag> extends InputProps {
         readonly addTag: (tag: Tag) => void;
         readonly onChange: (e: React.ChangeEvent<{ readonly value: string }>) => void;
         readonly ref: (r: any) => void; // parameter is either a DOM element or a mounted React component
@@ -36,7 +34,7 @@ declare namespace TagsInput {
         readonly [prop: string]: any;
     }
 
-    interface RenderTagProps extends TagProps {
+    interface RenderTagProps<Tag> extends TagProps {
         readonly disabled: boolean;
         readonly getTagDisplayValue: (tag: Tag) => string;
         readonly onRemove: (tagIndex: number) => void;
@@ -45,7 +43,7 @@ declare namespace TagsInput {
 
     type RenderLayout = (tagElements: React.ReactElement[], inputElement: React.ReactElement) => React.ReactChild;
 
-    interface ReactTagsInputProps extends React.Props<TagsInput> {
+    interface ReactTagsInputProps<Tag> extends React.Props<TagsInput<Tag>> {
         value: Tag[];
         onChange: (tags: Tag[], changed: Tag[], changedIndexes: number[]) => void;
         onChangeInput?: (value: string) => void;
@@ -66,8 +64,8 @@ declare namespace TagsInput {
         tagProps?: TagProps;
         inputProps?: InputProps;
         tagDisplayProp?: string | null;
-        renderTag?: (props: RenderTagProps) => React.ReactNode;
-        renderInput?: (props: RenderInputProps) => React.ReactNode;
+        renderTag?: (props: RenderTagProps<Tag>) => React.ReactNode;
+        renderInput?: (props: RenderInputProps<Tag>) => React.ReactNode;
         renderLayout?: RenderLayout;
         preventSubmit?: boolean;
     }


### PR DESCRIPTION
… for tag types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/olahol/react-tagsinput>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
