### PR TITLE
Fix react-rte tests

### DIFF
--- a/types/react-rte/react-rte-tests.tsx
+++ b/types/react-rte/react-rte-tests.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import RichTextEditor, { EditorValue } from "react-rte";
 
 interface Props {
-    onChange: (val: string) => void;
+    onChange?: (val: string) => void;
 }
 
 class MyStatefulEditor extends React.Component<Props, any> {


### PR DESCRIPTION
They check whether a method is defined on props, but the props type doesn't make the method optional. Typescript now catches this error, so I made the method optional.