### PR TITLE
adm-zip: add overload of toBuffer

### DIFF
--- a/types/adm-zip/adm-zip-tests.ts
+++ b/types/adm-zip/adm-zip-tests.ts
@@ -13,19 +13,11 @@ zipEntries.forEach(zipEntry => {
 // outputs the content of some_folder/my_file.txt
 console.log(zip.readAsText('some_folder/my_file.txt'));
 // extracts the specified file to the specified location
-zip.extractEntryTo(
-    /*entry name*/ 'some_folder/my_file.txt',
-    /*target path*/ '/home/me/tempfolder',
-    /*overwrite*/ true
-);
+zip.extractEntryTo(/*entry name*/ 'some_folder/my_file.txt', /*target path*/ '/home/me/tempfolder', /*overwrite*/ true);
 // extracts everything
 zip.extractAllTo(/*target path*/ '/home/me/zipcontent/', /*overwrite*/ true);
 // extracts everything and calls callback -> async extracction
-zip.extractAllToAsync(
-    /*target path*/ '/home/me/zipcontent/',
-    /*overwrite*/ true,
-    (error: Error) => {}
-);
+zip.extractAllToAsync(/*target path*/ '/home/me/zipcontent/', /*overwrite*/ true, (error: Error) => {});
 
 // creating archives
 new AdmZip();
@@ -36,6 +28,13 @@ zip.addFile('test.txt', new Buffer('inner content of the file'), 'entry comment 
 zip.addLocalFile('/home/me/some_picture.png');
 // get everything as a buffer
 const willSendthis = zip.toBuffer();
+
+zip.toBuffer(
+    buffer => console.log(buffer.length),
+    () => {},
+    name => console.log(name),
+    name => console.log(name),
+);
 // or write everything to disk
 zip.writeZip(/*target file name*/ '/home/me/files.zip');
 

--- a/types/adm-zip/index.d.ts
+++ b/types/adm-zip/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: John Vilk <https://github.com/jvilk>
 //                 Abner Oliveira <https://github.com/abner>
 //                 BendingBender <https://github.com/BendingBender>
+//                 Matthew Sainsbury <https://github.com/mattsains>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -23,10 +24,7 @@ declare class AdmZip {
      * @param entry The full path of the entry or a `IZipEntry` object.
      * @param callback Called with a `Buffer` or `null` in case of error.
      */
-    readFileAsync(
-        entry: string | AdmZip.IZipEntry,
-        callback: (data: Buffer | null, err: string) => any
-    ): void;
+    readFileAsync(entry: string | AdmZip.IZipEntry, callback: (data: Buffer | null, err: string) => any): void;
     /**
      * Extracts the given entry from the archive and returns the content as
      * plain text in the given encoding.
@@ -40,11 +38,7 @@ declare class AdmZip {
      * @param callback Called with the resulting string.
      * @param encoding If no encoding is specified `"utf8"` is used.
      */
-    readAsTextAsync(
-        fileName: string | AdmZip.IZipEntry,
-        callback: (data: string) => any,
-        encoding?: string
-    ): void;
+    readAsTextAsync(fileName: string | AdmZip.IZipEntry, callback: (data: string) => any, encoding?: string): void;
     /**
      * Remove the entry from the file or the entry and all its nested directories
      * and files if the given entry is a directory.
@@ -97,11 +91,7 @@ declare class AdmZip {
      * @param zipPath Path to a folder in the archive. Default: `""`.
      * @param filter RegExp or Function if files match will be included.
      */
-    addLocalFolder(
-        localPath: string,
-        zipPath?: string,
-        filter?: RegExp | ((filename: string) => boolean)
-    ): void;
+    addLocalFolder(localPath: string, zipPath?: string, filter?: RegExp | ((filename: string) => boolean)): void;
     /**
      * Allows you to create a entry (file or directory) in the zip file.
      * If you want to create a directory the `entryName` must end in `"/"` and a `null`
@@ -140,7 +130,7 @@ declare class AdmZip {
         entryPath: string | AdmZip.IZipEntry,
         targetPath: string,
         maintainEntryPath?: boolean,
-        overwrite?: boolean
+        overwrite?: boolean,
     ): boolean;
     /**
      * Extracts the entire archive to the given location.
@@ -156,11 +146,7 @@ declare class AdmZip {
      *   will be overwriten if this is `true`. Default: `false`.
      * @param callback The callback function will be called after extraction.
      */
-    extractAllToAsync(
-        targetPath: string,
-        overwrite?: boolean,
-        callback?: (error: Error) => void
-    ): void;
+    extractAllToAsync(targetPath: string, overwrite?: boolean, callback?: (error: Error) => void): void;
     /**
      * Writes the newly created zip file to disk at the specified location or
      * if a zip was opened and no `targetFileName` is provided, it will
@@ -171,6 +157,19 @@ declare class AdmZip {
      * Returns the content of the entire zip file.
      */
     toBuffer(): Buffer;
+    /**
+     * Asynchronously returns the content of the entire zip file.
+     * @param onSuccess called with the content of the zip file, once it has been generated.
+     * @param onFail unused.
+     * @param onItemStart called before an entry is compressed.
+     * @param onItemEnd called after an entry is compressed.
+     */
+    toBuffer(
+        onSuccess: (buffer: Buffer) => void,
+        onFail?: (...args: any[]) => void,
+        onItemStart?: (name: string) => void,
+        onItemEnd?: (name: string) => void,
+    ): void;
 }
 
 declare namespace AdmZip {


### PR DESCRIPTION
Notes:

* I read through https://github.com/cthackers/adm-zip/blob/master/zipFile.js#L315 to guess the types passed to the callbacks. The error callback appears to be unused, so I set the type to `(...any) => void`

* I ran prettier as required by the pull request guide, that changed a few lines that I didn't modify. I can re-cut this PR without them if that's preferred, but probably this is a good change so that you don't have to fight prettier in the future.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cthackers/adm-zip/blob/master/adm-zip.js#L630
and I derived the types from here:  https://github.com/cthackers/adm-zip/blob/master/zipFile.js#L315
- [?] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.