### PR TITLE
chore: Broaden graphql range for graphql-relay

### DIFF
--- a/types/graphql-relay/index.d.ts
+++ b/types/graphql-relay/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for graphql-relay 0.4
+// Type definitions for graphql-relay 0.6
 // Project: https://github.com/graphql/graphql-relay-js
 // Definitions by: Arvitaly <https://github.com/arvitaly>, nitintutlani <https://github.com/nitintutlani>, Grelinfo <https://github.com/Grelinfo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/graphql-relay/package.json
+++ b/types/graphql-relay/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "^14.5.3"
+    "graphql": "^14.5.3 || ^15.0.0"
   }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
  - asterisk: i ran `tsc` – the existing types were already broken under tslint

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/graphql/graphql-relay-js/pull/242 – `graphql` v15.0.0 is now out, and `graphql-relay` works out-of-the-box with it, but the dependency here resolves to the wrong version of `graphql`, and leads to type errors for consumers that upgrade to graphql v15.0.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

I'm not totally sure how to handle the versioning here. These types are compatible with both versions of `graphql`, but the version has to match what the rest of the code uses. I think a peer dependency to match the actual code is best here.