### PR TITLE
Add type definitions for git-diff-parser module

### DIFF
--- a/types/git-diff-parser/git-diff-parser-tests.ts
+++ b/types/git-diff-parser/git-diff-parser-tests.ts
@@ -1,0 +1,19 @@
+import parser = require("git-diff-parser");
+
+const input = `commit cd4a4e2db47f9642cf322fe109b5bfb3f6eb23c7 (HEAD -> master, origin/master, origin/HEAD)
+Author: John Doe <johndoe@google.com>
+Date:   Thu Apr 1 23:59:59 2020 -0100
+
+    Just a typical commit message
+
+diff --git a/types/pkg/index.d.ts b/types/pkg/index.d.ts
+index 60bb057b92..5c25c419d1 100644
+--- a/types/pkg/index.d.ts
++++ b/types/pkg/index.d.ts
+@@ -3,3 +3,3 @@ declare namespace A {
+          */
+-        aaa
++        bbb
+         /**`;
+
+parser(input); // $ExpectType Result

--- a/types/git-diff-parser/index.d.ts
+++ b/types/git-diff-parser/index.d.ts
@@ -1,0 +1,67 @@
+// Type definitions for git-diff-parser 1.0
+// Project: https://github.com/spookd/git-diff-parser
+// Definitions by: Alexey Yaroshevich <https://github.com/qfox>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types='node' />
+
+declare function GitDiffParser(input: string | Buffer): GitDiffParser.Result;
+declare namespace GitDiffParser {
+    /** Represents prefix in `git diff` output: '+', '-', or space */
+    type LineType = 'deleted' | 'added' | 'normal';
+
+    interface Line {
+        type: LineType;
+
+        /** Has line break. Always false for added failes */
+        break: boolean;
+
+        /** Content of removed or added string */
+        text: string;
+
+        /** The main line number */
+        ln1: number;
+
+        /** New line number (for type normal) */
+        ln2?: number;
+    }
+
+    interface File {
+        deleted: boolean;
+        added: boolean;
+        renamed: boolean;
+        binary: boolean;
+        lines: Line[];
+        index?: string[];
+        oldName?: string;
+        name: string;
+    }
+
+    interface Commit {
+        files: File[];
+    }
+
+    interface DetailedCommit extends Commit {
+        message?: string;
+        sha?: string;
+        date?: Date;
+        author?: string;
+        email?: string;
+    }
+
+    interface Result {
+        detailed: boolean;
+        commits: Commit[];
+    }
+
+    interface DryResult extends Result {
+        detailed: false;
+    }
+
+    interface DetailedResult extends Result {
+        detailed: true;
+        commits: DetailedCommit[];
+    }
+}
+
+export = GitDiffParser;

--- a/types/git-diff-parser/tsconfig.json
+++ b/types/git-diff-parser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "git-diff-parser-tests.ts"
+    ]
+}

--- a/types/git-diff-parser/tslint.json
+++ b/types/git-diff-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
