### PR TITLE
[@types/intercom-client] Update response definitions for User API's find method

### DIFF
--- a/types/intercom-client/index.d.ts
+++ b/types/intercom-client/index.d.ts
@@ -4,6 +4,7 @@
 //                 Josef Hornych <https://github.com/peping>
 //                 Mikhail Monchak <https://github.com/mikhail-monchak>
 //                 Chris Doe <https://github.com/cdoe>
+//                 Malith Wijenayake <https://github.com/malithrw>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 /// <reference types="node" />
@@ -56,8 +57,8 @@ export class Users {
     update(user: UserIdentifier & Partial<CreateUpdateUser>): Promise<ApiResponse<User>>;
     update(user: UserIdentifier & Partial<CreateUpdateUser>, cb: callback<ApiResponse<User>>): void;
 
-    find(identifier: UserIdentifier): Promise<ApiResponse<UserList>>;
-    find(identifier: UserIdentifier, cb: callback<ApiResponse<UserList>>): void;
+    find(identifier: UserIdentifier): Promise<ApiResponse<User>>;
+    find(identifier: UserIdentifier, cb: callback<ApiResponse<User>>): void;
 
     list(): Promise<ApiResponse<UserList>>;
     list(cb: callback<ApiResponse<UserList>>): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.intercom.com/intercom-api-reference/v1.4/reference#view-a-user
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

More details on the change:

1. In `intercom-node` package the `.find()` method calls to `/user` endpoint in Intercom API: https://github.com/intercom/intercom-node/blob/master/lib/user.js#L25
2. `/user` endpoint returns a user object in the response: https://developers.intercom.com/intercom-api-reference/v1.4/reference#view-a-user
