### PR TITLE
rsocket-flowable - adds Single.never()

### DIFF
--- a/types/rsocket-flowable/Single.d.ts
+++ b/types/rsocket-flowable/Single.d.ts
@@ -47,6 +47,7 @@ export interface IFutureSubject<T> {
 export default class Single<T> {
     static of<U>(value: U): Single<U>;
     static error(error: Error): Single<never>;
+    static never(): Single<never>;
     constructor(source: Source<T>);
     subscribe(partialSubscriber?: Partial<IFutureSubscriber<T>>): void;
     flatMap<R>(fn: (data: T) => Single<R>): Single<R>;


### PR DESCRIPTION
This PR updates the `rsocket-flowable` types to include the recently added `Single.never()` method: https://github.com/rsocket/rsocket-js/commit/91323ce3c732ba1dbcf8b7f9edadc0d0e0c7d1e0

That change hasn't landed in an rsocket-flowable release yet, but assuming it is included in the next release, that should be rsocket-flowable@0.0.15.

Since rsocket doesn't seem to follow semver so far - all releases are 0.0 - I'm not sure what the right solution is for this PR.  The `Single.never()` method does not exist in current rsocket releases.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rsocket/rsocket-js/pull/80
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header
   => see above, rsocket looks like it's always 0.0.
