### PR TITLE
refactor: use interface merging to simplify class declarations

### DIFF
--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -62,7 +62,9 @@ function testConstructor() {
 
     let contructedWithValueHasTermContext: Clownface<Term, Dataset> = new Clownface({ dataset, value: 'foo' });
     contructedWithValueHasTermContext = new Clownface({ dataset, value: ['foo', 'bar'] });
-    const anyTerms: clownface.Clownface = new Clownface({ dataset, term: [term, term], value: ['foo', 'bar'] });
+    const anyTerms: clownface.SafeClownface = new Clownface({ dataset, term: [term, term], value: ['foo', 'bar'] });
+
+    const constructedWithSingleTerm: clownface.SingleContextClownface<NamedNode> = new Clownface({ dataset, term: node });
 }
 
 function testAddIn() {

--- a/types/clownface/lib/Clownface.d.ts
+++ b/types/clownface/lib/Clownface.d.ts
@@ -1,73 +1,18 @@
-import { BlankNode, DatasetCore, Literal, NamedNode, Term } from 'rdf-js';
+import { DatasetCore, Term } from 'rdf-js';
 import {
-    Clownface as ClownfaceContract,
+    Clownface,
     ClownfaceInit,
-    AddCallback,
-    NodeOptions,
-    SingleOrArrayOfTerms,
-    SingleOrArrayOfTermsOrLiterals,
     ClownfaceInitWithTerms,
     ClownfaceInitWithValue,
     ClownfaceInitWithValues,
-    SingleOrOneElementArray,
-    Iteratee,
     AnyContext,
-    SafeClownface
 } from '..';
-import { Context } from './Context';
 
-declare class Clownface<T extends AnyContext = AnyContext, D extends DatasetCore = DatasetCore> implements ClownfaceContract<T, D> {
-    constructor(options: ClownfaceInit<D> | ClownfaceInitWithTerms<Term | Term[], D> | ClownfaceInitWithValue<D> | ClownfaceInitWithValues<D>);
+interface ClownfaceImpl<T extends AnyContext = AnyContext, D extends DatasetCore = DatasetCore> extends Clownface<T, D> {}
 
-    readonly term: T extends undefined ? undefined : T extends any[] ? undefined | T[0] : T;
-    readonly terms: T extends undefined ? Term[] : T extends any[] ? T : [T];
-    readonly value: T extends undefined ? undefined : T extends any[] ? undefined | string[0] : string;
-    readonly values: T extends undefined ? string[] : T extends any[] ? string[] : [string];
-    readonly dataset: D;
-    readonly datasets: D[];
-    readonly _context: Array<Context<D, Term>>;
-    list(): Iterable<Iteratee<T, D>>;
-    toArray(): Array<Clownface<T extends undefined ? never : T extends any[] ? T[0] : T, D>>;
-    filter(cb: (quad: Iteratee<T, D>) => boolean): Clownface<T, D>;
-    forEach(cb: (quad: Iteratee<T, D>) => void): void;
-    map<X>(cb: (quad: Iteratee<T, D>, index: number) => X): X[];
-
-    node(value: SingleOrOneElementArray<boolean | string | number>, options?: NodeOptions): Clownface<Literal, D>;
-    node(values: Array<boolean | string | number>, options?: NodeOptions): Clownface<Literal[], D>;
-
-    node<X extends Term>(value: SingleOrOneElementArray<X>, options?: NodeOptions): Clownface<X, D>;
-    node<X extends Term[]>(values: X, options?: NodeOptions): Clownface<X, D>;
-
-    node(value: null, options?: NodeOptions): Clownface<BlankNode, D>;
-    node(values: null[], options?: NodeOptions): Clownface<BlankNode[], D>;
-
-    node(values: Array<boolean | string | number | Term | null>, options?: NodeOptions): Clownface<Term[], D>;
-
-    blankNode(value?: SingleOrOneElementArray<string>): Clownface<BlankNode, D>;
-    blankNode(values: string[]): Clownface<BlankNode[], D>;
-
-    literal(value: SingleOrOneElementArray<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): Clownface<Literal, D>;
-    literal(values: Array<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): Clownface<Literal[], D>;
-
-    namedNode(value: SingleOrOneElementArray<string | NamedNode>): Clownface<NamedNode, D>;
-    namedNode(values: Array<string | NamedNode>): Clownface<NamedNode[], D>;
-
-    in(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<T extends undefined ? never : NamedNode | BlankNode, D>;
-    out(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<T extends undefined ? never : Term, D>;
-
-    has(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<Term>): Clownface<Array<NamedNode | BlankNode>, D>;
-
-    addIn(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): Clownface<T, D>;
-    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): Clownface<T, D>;
-
-    addOut(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): Clownface<T, D>;
-    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): Clownface<T, D>;
-
-    addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): Clownface<T, D>;
-
-    deleteIn(predicates?: SingleOrArrayOfTerms<Term>): Clownface<T, D>;
-    deleteOut(predicates?: SingleOrArrayOfTerms<Term>): Clownface<T, D>;
-    deleteList(predicates: SingleOrArrayOfTerms<Term>): Clownface<T, D>;
+// tslint:disable-next-line no-unnecessary-class
+declare class ClownfaceImpl<T extends AnyContext = AnyContext, D extends DatasetCore = DatasetCore> {
+    constructor(options: ClownfaceInit<D> | ClownfaceInitWithTerms<T extends undefined ? Term | Term[] : T, D> | ClownfaceInitWithValue<D> | ClownfaceInitWithValues<D>);
 }
 
-export = Clownface;
+export = ClownfaceImpl;

--- a/types/clownface/lib/Context.d.ts
+++ b/types/clownface/lib/Context.d.ts
@@ -8,11 +8,11 @@ declare namespace Context {
     }
 }
 
-declare class Context<D extends DatasetCore, T extends Term> implements Context.Context<D, T> {
+interface Context<D extends DatasetCore, T extends Term> extends Context.Context<D, T> {}
+
+// tslint:disable-next-line no-unnecessary-class
+declare class Context<D extends DatasetCore, T extends Term> {
     constructor(dataset: D, graph: Quad_Graph | undefined, value: any);
-    dataset: D;
-    graph?: Quad_Graph;
-    term: T;
 }
 
 export = Context;

--- a/types/rdf-ext/lib/DataFactory.d.ts
+++ b/types/rdf-ext/lib/DataFactory.d.ts
@@ -1,4 +1,4 @@
-import { DataFactory, Sink, NamedNode, BaseQuad, Quad, Stream, Quad_Subject, Quad_Predicate, Quad_Object, Quad_Graph } from 'rdf-js';
+import { DataFactory, NamedNode, Quad, Quad_Subject, Quad_Predicate, Quad_Object, Quad_Graph } from 'rdf-js';
 import BlankNodeExt = require("./BlankNode");
 import LiteralExt = require("./Literal");
 import NamedNodeExt = require("./NamedNode");
@@ -12,7 +12,10 @@ import { PropType } from './_PropType';
 type PrefixesRecord = Record<string, NamedNode | string>;
 type Prefixes = PrefixMap | PrefixesRecord;
 
-declare class DataFactoryExt implements DataFactory<QuadExt> {
+interface DataFactoryExt extends DataFactory<QuadExt, Quad> {}
+
+// tslint:disable-next-line no-unnecessary-class
+declare class DataFactoryExt  {
   static defaults: {
     defaultGraph: DefaultGraphExt;
     NamedNode: NamedNodeExt;
@@ -34,14 +37,6 @@ declare class DataFactoryExt implements DataFactory<QuadExt> {
   static graph(quads?: any): Dataset;
   static prefixMap(prefixes: Prefixes): PrefixMap;
   static dataset(quads?: Quad[], graph?: PropType<QuadExt, 'graph'>): Dataset;
-
-  blankNode(value?: string): BlankNodeExt;
-  defaultGraph(): DefaultGraphExt;
-  literal(value: string, languageOrDatatype?: string | NamedNode): LiteralExt;
-  namedNode(value: string): NamedNode;
-  quad(subject: Quad_Subject, predicate: Quad_Predicate, object: Quad_Object, graph?: Quad_Graph): QuadExt;
-  triple(subject: Quad_Subject, predicate: Quad_Predicate, object: Quad_Object): QuadExt;
-  variable(value: string): VariableExt;
 }
 
 export = DataFactoryExt;

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -246,7 +246,7 @@ export interface Triple extends Quad {}
 /**
  * A factory for instantiating RDF terms, triples and quads.
  */
-export interface DataFactory<Q extends BaseQuad = Quad> {
+export interface DataFactory<OutQuad extends BaseQuad = Quad, InQuad extends BaseQuad = OutQuad> {
     /**
      * @param value The IRI for the named node.
      * @return A new instance of NamedNode.
@@ -297,7 +297,7 @@ export interface DataFactory<Q extends BaseQuad = Quad> {
      * @see Triple
      * @see DefaultGraph
      */
-    triple(subject: Q['subject'], predicate: Q['predicate'], object: Q['object']): Q;
+    triple(subject: InQuad['subject'], predicate: InQuad['predicate'], object: InQuad['object']): InQuad;
 
     /**
      * @param subject   The quad subject term.
@@ -307,7 +307,7 @@ export interface DataFactory<Q extends BaseQuad = Quad> {
      * @return A new instance of Quad.
      * @see Quad
      */
-    quad(subject: Q['subject'], predicate: Q['predicate'], object: Q['object'], graph?: Q['graph']): Q;
+    quad(subject: InQuad['subject'], predicate: InQuad['predicate'], object: InQuad['object'], graph?: InQuad['graph']): OutQuad;
 }
 
 /* Stream Interfaces */

--- a/types/rdfjs__dataset/DatasetCore.d.ts
+++ b/types/rdfjs__dataset/DatasetCore.d.ts
@@ -1,13 +1,11 @@
 import * as RDF from 'rdf-js';
 
-declare class DatasetCore implements RDF.DatasetCore {
+// tslint:disable-next-line no-empty-interface
+interface DatasetCore extends RDF.DatasetCore {}
+
+// tslint:disable-next-line no-unnecessary-class
+declare class DatasetCore {
     constructor(quads: RDF.Quad[]);
-    size: number;
-    add(quad: RDF.Quad): this;
-    delete(quad: RDF.Quad): this;
-    has(quad: RDF.Quad): boolean;
-    match(subject?: RDF.Term | null, predicate?: RDF.Term | null, object?: RDF.Term | null, graph?: RDF.Term | null): this;
-    [Symbol.iterator](): Iterator<RDF.Quad>;
 }
 
 export = DatasetCore;

--- a/types/sparql-http-client/BaseClient.d.ts
+++ b/types/sparql-http-client/BaseClient.d.ts
@@ -1,10 +1,11 @@
 import { BaseQuad, Quad } from 'rdf-js';
-import { Client, ClientOptions, Query, Store } from '.';
+import * as SparqlHttp from '.';
 
-declare class BaseClient<TQuery extends Query, Q extends BaseQuad = Quad, TStore extends Store<Q> = never> implements Client<TQuery, Q, TStore> {
-    constructor(options: ClientOptions<TQuery, Q, TStore>);
-    query: TQuery;
-    store: TStore;
+interface BaseClient<TQuery extends SparqlHttp.Query, Q extends BaseQuad, TStore extends SparqlHttp.Store<Q>> extends SparqlHttp.Client<TQuery, Q, TStore> {}
+
+// tslint:disable-next-line no-unnecessary-class
+declare class BaseClient<TQuery extends SparqlHttp.Query, Q extends BaseQuad = Quad, TStore extends SparqlHttp.Store<Q> = never> {
+    constructor(options: SparqlHttp.ClientOptions<TQuery, Q, TStore>);
 }
 
 export = BaseClient;

--- a/types/sparql-http-client/Endpoint.d.ts
+++ b/types/sparql-http-client/Endpoint.d.ts
@@ -30,19 +30,12 @@ declare namespace Endpoint {
     }
 }
 
-declare class Endpoint implements Endpoint.Endpoint {
+// tslint:disable-next-line no-empty-interface
+interface Endpoint extends Endpoint.Endpoint {}
+
+// tslint:disable-next-line no-unnecessary-class
+declare class Endpoint {
     constructor(options: Endpoint.EndpointOptions);
-    endpointUrl: string;
-    fetch: typeof fetch;
-    headers: HeadersInit;
-    password?: string;
-    storeUrl?: string;
-    updateUrl?: string;
-    user?: string;
-    get(query: string, options?: Endpoint.RequestOptions): Promise<Response>;
-    postDirect(query: string, options?: Endpoint.RequestOptions): Promise<Response>;
-    postUrlencoded(query: string, options?: Endpoint.RequestOptions): Promise<Response>;
-    mergeHeaders(args?: HeadersInit): Headers;
 }
 
 export = Endpoint;

--- a/types/sparql-http-client/ParsingQuery.d.ts
+++ b/types/sparql-http-client/ParsingQuery.d.ts
@@ -1,19 +1,16 @@
 import { Quad, BaseQuad } from 'rdf-js';
-import { QueryOptions, Query, QueryInit } from '.';
-import { Endpoint } from './Endpoint';
+import { Query, QueryInit } from '.';
 import { ResultRow } from './ResultParser';
 
 declare namespace ParsingQuery {
     type ParsingQuery<Q extends BaseQuad = Quad> = Query<boolean, Q[], ResultRow[], void>;
 }
 
-declare class ParsingQuery<Q extends BaseQuad = Quad> implements ParsingQuery.ParsingQuery<Q> {
+interface ParsingQuery<Q extends BaseQuad = Quad> extends ParsingQuery.ParsingQuery<Q> {}
+
+// tslint:disable-next-line no-unnecessary-class
+declare class ParsingQuery<Q extends BaseQuad = Quad> {
     constructor(options: QueryInit);
-    endpoint: Endpoint;
-    ask(query: string, options?: QueryOptions): Promise<boolean>;
-    construct(query: string, options?: QueryOptions): Promise<Q[]>;
-    select(query: string, options?: QueryOptions): Promise<ResultRow[]>;
-    update(query: string, options?: QueryOptions): Promise<void>;
 }
 
 export = ParsingQuery;

--- a/types/sparql-http-client/RawQuery.d.ts
+++ b/types/sparql-http-client/RawQuery.d.ts
@@ -1,17 +1,15 @@
-import { Endpoint } from './Endpoint';
-import { QueryOptions, QueryInit, Query } from '.';
+import { QueryInit, Query } from '.';
 
 declare namespace RawQuery {
     type RawQuery = Query<Response, Response, Response, Response>;
 }
 
+// tslint:disable-next-line no-empty-interface
+interface RawQuery extends RawQuery.RawQuery {}
+
+// tslint:disable-next-line no-unnecessary-class
 declare class RawQuery {
     constructor(options: QueryInit);
-    endpoint: Endpoint;
-    ask(query: string, options?: QueryOptions): Promise<Response>;
-    construct(query: string, options?: QueryOptions): Promise<Response>;
-    select(query: string, options?: QueryOptions): Promise<Response>;
-    update(query: string, options?: QueryOptions): Promise<Response>;
 }
 
 export = RawQuery;

--- a/types/sparql-http-client/ResultParser.d.ts
+++ b/types/sparql-http-client/ResultParser.d.ts
@@ -9,7 +9,7 @@ declare namespace ResultParser {
     }
 }
 
-declare class ResultParser<Q extends BaseQuad = Quad>  extends Duplex {
+declare class ResultParser<Q extends BaseQuad = Quad> extends Duplex {
     constructor(options?: ResultParser.ResultParserInit<Q>)
 }
 

--- a/types/sparql-http-client/StreamQuery.d.ts
+++ b/types/sparql-http-client/StreamQuery.d.ts
@@ -1,6 +1,5 @@
 import { DataFactory, BaseQuad, Quad, Stream } from 'rdf-js';
-import { QueryOptions, Query, QueryInit } from '.';
-import { Endpoint } from './Endpoint';
+import { Query, QueryInit } from '.';
 import { Readable } from 'stream';
 
 declare namespace StreamQuery {
@@ -11,13 +10,11 @@ declare namespace StreamQuery {
     type StreamQuery<Q extends BaseQuad = Quad> = Query<boolean, Stream<Q>, Readable, void>;
 }
 
-declare class StreamQuery<Q extends BaseQuad = Quad> implements StreamQuery.StreamQuery<Q> {
+interface StreamQuery<Q extends BaseQuad = Quad> extends StreamQuery.StreamQuery<Q> {}
+
+// tslint:disable-next-line no-unnecessary-class
+declare class StreamQuery<Q extends BaseQuad = Quad> {
     constructor(options: StreamQuery.StreamQueryInit<Q>);
-    endpoint: Endpoint;
-    ask(query: string, options?: QueryOptions): Promise<boolean>;
-    construct(query: string, options?: QueryOptions): Promise<Stream<Q>>;
-    select(query: string, options?: QueryOptions): Promise<Readable>;
-    update(query: string, options?: QueryOptions): Promise<void>;
 }
 
 export = StreamQuery;

--- a/types/sparql-http-client/StreamStore.d.ts
+++ b/types/sparql-http-client/StreamStore.d.ts
@@ -1,5 +1,5 @@
 import { Store } from "./";
-import { BaseQuad, Quad, DataFactory, Stream } from "rdf-js";
+import { BaseQuad, Quad, DataFactory } from "rdf-js";
 import Endpoint = require("./Endpoint");
 
 declare namespace StreamStore {
@@ -9,12 +9,11 @@ declare namespace StreamStore {
     }
 }
 
-declare class StreamStore<Q extends BaseQuad = Quad> implements Store<Q> {
+interface StreamStore<Q extends BaseQuad = Quad> extends Store<Q> {}
+
+// tslint:disable-next-line no-unnecessary-class
+declare class StreamStore<Q extends BaseQuad = Quad> {
     constructor(options: StreamStore.StreamStoreInit<Q>)
-    endpoint: Endpoint;
-    get(graph: Quad['graph']): Promise<Stream<Q>>;
-    post(stream: Stream): Promise<void>;
-    put(stream: Stream): Promise<void>;
 }
 
 export = StreamStore;


### PR DESCRIPTION
This takes advantage of [interface merging](https://stackoverflow.com/a/60047014/1103498) to get rid of all declared class' members inherited from the interfaces, leaving only static members and constructors.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
