### PR TITLE
Adds pdf-fill-form's module and types

### DIFF
--- a/types/pdf-fill-form/index.d.ts
+++ b/types/pdf-fill-form/index.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for pdf-fill-form 5.0
+// Project: https://github.com/tpisto/pdf-fill-form#readme
+// Definitions by: Grégoire Lodi <https://github.com/lodi-g>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node" />
+
+export interface WritableFields {
+    [key: string]: string;
+}
+
+export type ReadableFields = Array<{
+    name: string;
+    page: number;
+    value: string;
+    id: number;
+    type: string;
+}>;
+
+export interface PdfOptions {
+    save?: string;
+    cores?: number;
+    scale?: number;
+    antialias?: boolean;
+}
+
+export interface ImgPdfOptions extends PdfOptions {
+    startPage?: number;
+    endPage?: number;
+}
+
+export type Options = PdfOptions | ImgPdfOptions;
+
+export type WriteAsyncCallback = (err: Error, result: Buffer) => void;
+
+export function read(sourceFile: string): Promise<ReadableFields>;
+export function readSync(sourceFile: string): ReadableFields;
+export function readBuffer(sourceBuffer: Buffer): Promise<ReadableFields>;
+export function readBufferSync(sourceBuffer: Buffer): ReadableFields;
+
+export function write(sourceFile: string, fields: WritableFields, options?: Options): Promise<Buffer>;
+export function writeBuffer(sourceBuffer: Buffer, fields: WritableFields, options?: Options): Promise<Buffer>;
+export function writeBufferSync(sourceBuffer: Buffer, fields: WritableFields, options?: Options): Buffer;
+
+// Options are not optional here because the callback MUST be defined to avoid a crash
+export function writeAsync(
+    sourceFile: string,
+    fields: WritableFields,
+    options: Options,
+    callback: WriteAsyncCallback,
+): void;

--- a/types/pdf-fill-form/pdf-fill-form-tests.ts
+++ b/types/pdf-fill-form/pdf-fill-form-tests.ts
@@ -1,0 +1,24 @@
+import { write, writeBuffer, read, readBuffer, writeAsync, ReadableFields } from 'pdf-fill-form';
+import { readFileSync } from 'fs';
+
+const buffer = readFileSync('test.pdf');
+
+async function main() {
+    // Workaround because TS 3.9 resolves to ReadableFields and TS 3.6 to the object
+    // $ExpectType ReadableFields || { name: string; page: number; value: string; id: number; type: string; }[]
+    await read('./test.pdf');
+
+    // $ExpectType ReadableFields || { name: string; page: number; value: string; id: number; type: string; }[]
+    await readBuffer(buffer);
+
+    // $ExpectType Buffer
+    await write('test.pdf', { field: 'test' }, { save: 'pdf' });
+
+    // $ExpectType Buffer
+    await writeBuffer(buffer, { otherField: '123' }, { save: 'imgpdf', antialias: true });
+
+    // $ExpectError
+    await writeBuffer(buffer, { field: 123 });
+}
+
+main();

--- a/types/pdf-fill-form/tsconfig.json
+++ b/types/pdf-fill-form/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "pdf-fill-form-tests.ts"]
+}

--- a/types/pdf-fill-form/tslint.json
+++ b/types/pdf-fill-form/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
