### PR TITLE
(DRAFT) contract-proxy-kit: Add cpkProvider-based config

### DIFF
--- a/types/contract-proxy-kit/contract-proxy-kit-tests.ts
+++ b/types/contract-proxy-kit/contract-proxy-kit-tests.ts
@@ -53,6 +53,10 @@ CPK.create({
     signer: ethers.Wallet.createRandom(),
     networks: { 4447: networkConfigEntry },
 });
+// $ExpectType Promise<CPK>
+CPK.create({
+    cpkProvider: { foo: 'bar' }
+});
 
 CPK.create({ web3 }).then(async cpk => {
     // $ExpectType CPK

--- a/types/contract-proxy-kit/index.d.ts
+++ b/types/contract-proxy-kit/index.d.ts
@@ -32,7 +32,11 @@ declare namespace CPK {
         signer: ethers.Signer;
     }
 
-    type CPKConfig = Web3SpecificConfig | EthersSpecificConfig;
+    interface CPKSpecificConfig extends CommonConfig {
+        cpkProvider: object;
+    }
+
+    type CPKConfig = Web3SpecificConfig | EthersSpecificConfig | CPKSpecificConfig;
 
     interface Transaction {
         operation: number | string | object;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
