### PR TITLE
feat: Add `html‑encoding‑sniffer`

### DIFF
--- a/types/html-encoding-sniffer/html-encoding-sniffer-tests.ts
+++ b/types/html-encoding-sniffer/html-encoding-sniffer-tests.ts
@@ -1,0 +1,32 @@
+import sniffHTMLEncoding = require('html-encoding-sniffer');
+import whatwgEncoding = require('whatwg-encoding');
+import MIMEType = require('whatwg-mimetype');
+
+// https://github.com/jsdom/jsdom/blob/59fa79518da02dc2f098e989cfae3bdb24449f66/lib/api.js#L290-L310
+function normalizeHTML(
+	html: string | ArrayBufferView | ArrayBuffer | Buffer = '',
+	mimeType: MIMEType,
+): {
+	html: string;
+	encoding: string;
+} {
+	let encoding = 'UTF-8';
+
+	if (ArrayBuffer.isView(html)) {
+		html = Buffer.from(html.buffer, html.byteOffset, html.byteLength);
+	} else if (html instanceof ArrayBuffer) {
+		html = Buffer.from(html);
+	}
+
+	if (Buffer.isBuffer(html)) {
+		encoding = sniffHTMLEncoding(html, {
+			defaultEncoding: mimeType.isXML() ? 'UTF-8' : 'windows-1252',
+			transportLayerEncodingLabel: mimeType.parameters.get('charset'),
+		});
+		html = whatwgEncoding.decode(html, encoding);
+	} else {
+		html = String(html);
+	}
+
+	return { html, encoding };
+}

--- a/types/html-encoding-sniffer/index.d.ts
+++ b/types/html-encoding-sniffer/index.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for html-encoding-sniffer 2.0
+// Project: https://github.com/jsdom/html-encoding-sniffer#readme
+// Definitions by: ExE Boss <https://github.com/ExE-Boss>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node"/>
+
+/**
+ * @param buffer The NodeJS buffer containing the (X)HTML source text.
+ *
+ * @return The canonical [encoding name](https://encoding.spec.whatwg.org/#names-and-labels)
+ *         for use with the `whatwg-encoding` or similar package.
+ */
+declare function sniffHTMLEncoding(buffer: Buffer, options?: sniffHTMLEncoding.Options): string;
+
+declare namespace sniffHTMLEncoding {
+	interface Options {
+		/**
+		 * An encoding label that is obtained from the "transport layer"
+		 * (probably an HTTP `Content-Type` header), which overrides
+		 * everything but a BOM.
+		 */
+		transportLayerEncodingLabel?: string;
+
+		/**
+		 * The ultimate fallback encoding used if no valid encoding is supplied
+		 * by the transport layer, and no encoding is sniffed from the bytes.
+		 *
+		 * @default
+		 * ```js
+		 * 'windows-1252'
+		 * ```
+		 *
+		 * Which is recommended by the algorithm's table of suggested
+		 * defaults for "All other locales" (including the `en` locale).
+		 */
+		defaultEncoding?: string;
+	}
+}
+
+export = sniffHTMLEncoding;

--- a/types/html-encoding-sniffer/tsconfig.json
+++ b/types/html-encoding-sniffer/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": ["ES2015"],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": ["../"],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"html-encoding-sniffer-tests.ts",
+		"index.d.ts"
+	]
+}

--- a/types/html-encoding-sniffer/tslint.json
+++ b/types/html-encoding-sniffer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
