### PR TITLE
[@babel/preset-env] Add types

### DIFF
--- a/types/babel__preset-env/babel__preset-env-tests.ts
+++ b/types/babel__preset-env/babel__preset-env-tests.ts
@@ -1,0 +1,277 @@
+/* tslint:disable:no-consecutive-blank-lines comment-format */
+
+import { Options } from '@babel/preset-env';
+
+
+//=========//
+// TARGETS //
+//=========//
+
+let options: Options = {
+    targets: '> 0.25%, not dead',
+};
+
+options = {
+    targets: [
+        '> 0.25%',
+        'not dead',
+    ],
+};
+
+options = {
+    targets: {
+        OperaMini: '80',
+        Edge: '22',
+        ie: '11',
+    },
+};
+
+options = {
+    targets: {
+        esmodules: true,
+    },
+};
+
+options = {
+    targets: {
+        node: '12',
+    },
+};
+
+options = {
+    targets: {
+        node: 'current',
+    },
+};
+
+options = {
+    targets: {
+        node: true,
+    },
+};
+
+options = {
+    targets: {
+        safari: '20',
+    },
+};
+
+options = {
+    targets: {
+        safari: 'tp',
+    },
+};
+
+options = {
+    targets: {
+        browsers: '> 0.25%, not dead',
+    },
+};
+
+options = {
+    targets: {
+        browsers: [
+            '> 0.25%',
+            'not dead',
+        ],
+    },
+};
+
+
+//==========//
+// BUGFIXES //
+//==========//
+
+options = {
+    bugfixes: true,
+};
+
+options = {
+    bugfixes: false,
+};
+
+
+//======//
+// SPEC //
+//======//
+
+options = {
+    spec: true,
+};
+
+options = {
+    spec: false,
+};
+
+
+//=======//
+// LOOSE //
+//=======//
+
+options = {
+    loose: true,
+};
+
+options = {
+    loose: false,
+};
+
+
+//=========//
+// MODULES //
+//=========//
+
+options = {
+    modules: 'amd',
+};
+
+options = {
+    modules: 'cjs',
+};
+
+options = {
+    modules: 'commonjs',
+};
+
+options = {
+    modules: false,
+};
+
+
+//=======//
+// DEBUG //
+//=======//
+
+options = {
+    debug: true,
+};
+
+options = {
+    debug: false,
+};
+
+
+//=========//
+// INCLUDE //
+//=========//
+
+options = {
+    include: [],
+};
+
+options = {
+    include: ['foo', 'bar'],
+};
+
+options = {
+    include: [/foo/, /bar/],
+};
+
+
+//=========//
+// EXCLUDE //
+//=========//
+
+options = {
+    exclude: [],
+};
+
+options = {
+    exclude: ['foo', 'bar'],
+};
+
+options = {
+    exclude: [/foo/, /bar/],
+};
+
+
+//===============//
+// USE BUILT INS //
+//===============//
+
+options = {
+    useBuiltIns: 'usage',
+};
+
+options = {
+    useBuiltIns: 'entry',
+};
+
+options = {
+    useBuiltIns: false,
+};
+
+
+//========//
+// COREJS //
+//========//
+
+options = {
+    corejs: 2,
+};
+
+options = {
+    corejs: 3,
+};
+
+options = {
+    corejs: {
+        version: 2,
+        proposals: true,
+    },
+};
+
+options = {
+    corejs: {
+        version: 3,
+        proposals: false,
+    },
+};
+
+
+//======================//
+// FORCE ALL TRANSFORMS //
+//======================//
+
+options = {
+    forceAllTransforms: true,
+};
+
+options = {
+    forceAllTransforms: false,
+};
+
+
+//======================//
+// FORCE ALL TRANSFORMS //
+//======================//
+
+options = {
+    configPath: '/etc/babel-config.json',
+};
+
+
+//============================//
+// IGNORE BROWSERSLIST CONFIG //
+//============================//
+
+options = {
+    ignoreBrowserslistConfig: true,
+};
+
+options = {
+    ignoreBrowserslistConfig: false,
+};
+
+
+//===================//
+// SHIPPED PROPOSALS //
+//===================//
+
+options = {
+    shippedProposals: true,
+};
+
+options = {
+    shippedProposals: false,
+};

--- a/types/babel__preset-env/index.d.ts
+++ b/types/babel__preset-env/index.d.ts
@@ -1,0 +1,94 @@
+// Type definitions for @babel/preset-env 7.9
+// Project: https://github.com/babel/babel/tree/master/packages/babel-preset-env, https://babeljs.io/docs/en/babel-preset-env
+// Definitions by: Slava Fomin II <https://github.com/slavafomin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface Options {
+    targets?: TargetsOptions;
+    bugfixes?: boolean;
+    spec?: boolean;
+    loose?: boolean;
+    modules?: ModuleOption;
+    debug?: boolean;
+    include?: PluginList;
+    exclude?: PluginList;
+    useBuiltIns?: UseBuiltInsOption;
+    corejs?: CorejsOption;
+    forceAllTransforms?: boolean;
+    configPath?: string;
+    ignoreBrowserslistConfig?: boolean;
+    shippedProposals?: boolean;
+}
+
+/**
+ * "targets" config option:
+ * https://babeljs.io/docs/en/babel-preset-env#targets
+ */
+export type TargetsOptions = (
+    | BrowserslistQuery
+    | ReadonlyArray<BrowserslistQuery>
+    | { [key in Target]?: string; }
+    | { esmodules: true }
+    | { node: (string | 'current' | true) }
+    | { safari: (string | 'tp') }
+    | { browsers: (string | ReadonlyArray<string>) }
+);
+
+export type BrowserslistQuery = string;
+
+/**
+ * List of supported Browserslist targets:
+ * Source: https://github.com/browserslist/browserslist#browsers
+ */
+export type Target = (
+    | 'Android'
+    | 'Baidu'
+    | 'BlackBerry' | 'bb'
+    | 'Chrome'
+    | 'ChromeAndroid' | 'and_chr'
+    | 'Edge'
+    | 'Electron'
+    | 'Explorer' | 'ie'
+    | 'ExplorerMobile' | 'ie_mob'
+    | 'Firefox' | 'ff'
+    | 'FirefoxAndroid' | 'and_ff'
+    | 'iOS' | 'ios_saf'
+    | 'Node'
+    | 'Opera'
+    | 'OperaMini' | 'op_mini'
+    | 'OperaMobile' | 'op_mob'
+    | 'QQAndroid' | 'and_qq'
+    | 'Safari'
+    | 'Samsung'
+    | 'UCAndroid' | 'and_uc'
+    | 'kaios'
+);
+
+/**
+ * https://babeljs.io/docs/en/babel-preset-env#modules
+ */
+export type ModuleOption = (
+    | 'amd'
+    | 'umd'
+    | 'systemjs'
+    | 'commonjs'
+    | 'cjs'
+    | 'auto'
+    | false
+);
+
+export type PluginList = ReadonlyArray<PluginListItem>;
+export type PluginListItem = (string | RegExp);
+
+export type UseBuiltInsOption = (
+    | 'usage'
+    | 'entry'
+    | false
+);
+
+export type CorejsOption = (
+    | CorejsVersion
+    | { version: CorejsVersion, proposals: boolean }
+);
+
+export type CorejsVersion = (2 | 3);

--- a/types/babel__preset-env/tsconfig.json
+++ b/types/babel__preset-env/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "strict": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@babel/preset-env": [
+                "babel__preset-env"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "babel__preset-env-tests.ts"
+    ]
+}

--- a/types/babel__preset-env/tslint.json
+++ b/types/babel__preset-env/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
This PR adds options types supported by [@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env). This should help with configuring Babel programmatically.

These definitions are based on the official preset documentation, completely covering all public options.

---

- ✓ Use a meaningful title for the pull request. Include the name of the package modified.
- ✓ Test the change in your own code. (Compile and run.)
- ✓ Add or edit tests to reflect the change. (Run with `npm test`.)
- ✓ Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- ✓ Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- ✓ Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- ✓ The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- ✓ If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [What?] Create it with `dts-gen --dt`, not by basing it on an existing project.
- ✓ Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- ✓ `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- ✓ `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.