### PR TITLE
Updated jest pinned dependencies

### DIFF
--- a/types/expect-puppeteer/index.d.ts
+++ b/types/expect-puppeteer/index.d.ts
@@ -4,7 +4,7 @@
 //                 Tanguy Krotoff <https://github.com/tkrotoff>
 //                 Jason Mong <https://github.com/jfm710>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 /// <reference types="jest" />
 

--- a/types/frisby/index.d.ts
+++ b/types/frisby/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Christopher E. Woodland <https://github.com/cwoodland>
 //                 Johnny Li <https://github.com/johnny4753>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 /// <reference types='jest'/>
 

--- a/types/jest-axe/index.d.ts
+++ b/types/jest-axe/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Josh Goldberg <https://github.com/JoshuaKGoldberg>
 //                 erbridge <https://github.com/erbridge>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 /// <reference types="jest" />
 

--- a/types/jest-image-snapshot/index.d.ts
+++ b/types/jest-image-snapshot/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 //                 erbridge <https://github.com/erbridge>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 /// <reference types="jest" />
 

--- a/types/jest-in-case/index.d.ts
+++ b/types/jest-in-case/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/thinkmill/jest-in-case#readme
 // Definitions by: Geovani de Souza <https://github.com/geovanisouza92>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 /// <reference types="jest" />
 /// <reference types="node" />

--- a/types/jest-json-schema/index.d.ts
+++ b/types/jest-json-schema/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Igor Korolev <https://github.com/deadNightTiger>
 //                 Matt Scheurich <https://github.com/lvl99>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 /// <reference types="jest" />
 import * as ajv from 'ajv';

--- a/types/jest-matcher-one-of/index.d.ts
+++ b/types/jest-matcher-one-of/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/d4nyll/jest-matcher-one-of#readme
 // Definitions by: Joe Mitchard <https://github.com/joemitchard>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 /// <reference types="jest" />
 declare namespace jest {

--- a/types/jest-plugin-context/index.d.ts
+++ b/types/jest-plugin-context/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/negativetwelve/jest-plugins/tree/master/packages/jest-plugin-context, https://github.com/negativetwelve/jest-plugins
 // Definitions by: Jonas Heinrich <https://github.com/jonasheinrich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 /// <reference types="jest" />
 

--- a/types/jest-when/index.d.ts
+++ b/types/jest-when/index.d.ts
@@ -5,7 +5,7 @@
 //                 Gregor Stamać <https://github.com/gstamac>
 //                 Valentin Stern <https://github.com/sehsyha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 /// <reference types="jest" />
 

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 25.1
+// Type definitions for Jest 25.2
 // Project: https://jestjs.io/
 // Definitions by: Asana (https://asana.com)
 //                 Ivo Stratev <https://github.com/NoHomey>

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -29,7 +29,7 @@
 //                 Pawel Fajfer <https://github.com/pawfa>
 //                 Regev Brody <https://github.com/regevbr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 declare var beforeAll: jest.Lifecycle;
 declare var beforeEach: jest.Lifecycle;

--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "jest-diff": "25.1.0",
-        "pretty-format": "25.1.0"
+        "jest-diff": "^25.2.7",
+        "pretty-format": "^25.2.7"
     }
 }

--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "jest-diff": "^25.2.7",
-        "pretty-format": "^25.2.7"
+        "jest-diff": "^25.2.1",
+        "pretty-format": "^25.2.1"
     }
 }

--- a/types/testing-library__jest-dom/index.d.ts
+++ b/types/testing-library__jest-dom/index.d.ts
@@ -4,7 +4,7 @@
 //                 John Gozde <https://github.com/jgoz>
 //                 Seth Macpherson <https://github.com/smacpherson64>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 /// <reference types="jest" />
 

--- a/types/wordpress__jest-console/index.d.ts
+++ b/types/wordpress__jest-console/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/wordpress/gutenberg/tree/master/packages/jest-console/readme.md
 // Definitions by: Damien Sorel <https://github.com/mistic100>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 3.1
 
 /// <reference types="jest" />
 


### PR DESCRIPTION
`jest-diff` and `pretty-format` were previously pinned in #43531 to work around backwards compatibility issues with the typescript definitions. Facebook added tooling to allow down-leveling their type definition in facebook/jest@d4057ce, which landed in 25.2.1, so bump the semver dependency to this.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
