### PR TITLE
[jest] Return this from mockClear and mockReset

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1126,7 +1126,7 @@ declare namespace jest {
          * You should therefore avoid assigning mockFn.mock to other variables, temporary or not, to make sure you
          * don't access stale data.
          */
-        mockClear(): void;
+        mockClear(): this;
         /**
          * Resets all information stored in the mock, including any initial implementation and mock name given.
          *
@@ -1136,7 +1136,7 @@ declare namespace jest {
          * You should therefore avoid assigning mockFn.mock to other variables, temporary or not, to make sure you
          * don't access stale data.
          */
-        mockReset(): void;
+        mockReset(): this;
         /**
          * Does everything that `mockFn.mockReset()` does, and also restores the original (non-mocked) implementation.
          *


### PR DESCRIPTION
I am unable to run any tests, it would be helpful if there was  README that explains how to do it. I have tried running. The package.json contains none of the dependencies required to run typescript formatted jest tests. If i try run `$ ts-node jest-tests.ts` i get lots of typescript syntax errors. If i try run the tests through `ts-jest` i get the same syntax errors. I will gladly fix the errors if somebody helps me to run them.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - their internal types:<https://github.com/facebook/jest/blob/master/packages/jest-mock/src/index.ts#L105-L106>
  - their implementations: <https://github.com/facebook/jest/blob/master/packages/jest-mock/src/index.ts#L639-L648>
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header~~.
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed~~.