### PR TITLE
Update selectors.d.ts

### DIFF
--- a/types/redux-form/v7/lib/selectors.d.ts
+++ b/types/redux-form/v7/lib/selectors.d.ts
@@ -1,6 +1,8 @@
 import { FormErrors, GetFormState } from "../index";
 
-export type DataSelector<FormData = {}, State = {}> = (formName: string, getFormState?: GetFormState) => (state: State) => FormData;
+export type Dictionary = { [key: string]: any };
+
+export type DataSelector<FormData = Dictionary, State = Dictionary> = (formName: string, getFormState?: GetFormState) => (state: State) => FormData;
 export type ErrorSelector<FormData = {}, State = {}, ErrorType = string> = (formName: string, getFormState?: GetFormState) => (state: State) => FormErrors<FormData, ErrorType>;
 export type BooleanSelector<State = {}> = (formName: string, getFormState?: GetFormState) => (state: State) => boolean;
 export type NamesSelector<State = {}> = (getFormState?: GetFormState) => (state: State) => string[];

--- a/types/redux-form/v7/lib/selectors.d.ts
+++ b/types/redux-form/v7/lib/selectors.d.ts
@@ -1,6 +1,6 @@
 import { FormErrors, GetFormState } from "../index";
 
-export type Dictionary = { [key: string]: any };
+export interface Dictionary = { [key: string]: any };
 
 export type DataSelector<FormData = Dictionary, State = Dictionary> = (formName: string, getFormState?: GetFormState) => (state: State) => FormData;
 export type ErrorSelector<FormData = {}, State = {}, ErrorType = string> = (formName: string, getFormState?: GetFormState) => (state: State) => FormErrors<FormData, ErrorType>;


### PR DESCRIPTION
When using the `getFormValues` function, my compilar shows an error because whatever values I extract from the result, the compiler says it is not a key of `{}`.

This way we at least can assume, by default, that it is a key value map

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
