### PR TITLE
[@babel/plugin-transform-runtime] Add types

### DIFF
--- a/types/babel__plugin-transform-runtime/babel__plugin-transform-runtime-tests.ts
+++ b/types/babel__plugin-transform-runtime/babel__plugin-transform-runtime-tests.ts
@@ -1,0 +1,95 @@
+/* tslint:disable:no-consecutive-blank-lines comment-format */
+
+import { Options } from '@babel/plugin-transform-runtime';
+
+
+//========//
+// COREJS //
+//========//
+
+let options: Options = {
+    corejs: 2,
+};
+
+options = {
+    corejs: 3,
+};
+
+options = {
+    corejs: {
+        version: 2,
+        proposals: true,
+    },
+};
+
+options = {
+    corejs: {
+        version: 3,
+        proposals: false,
+    },
+};
+
+
+//=========//
+// HELPERS //
+//=========//
+
+options = {
+    helpers: true,
+};
+
+options = {
+    helpers: false,
+};
+
+
+//=============//
+// REGENERATOR //
+//=============//
+
+options = {
+    regenerator: true,
+};
+
+options = {
+    regenerator: false,
+};
+
+
+//================//
+// USE ES MODULES //
+//================//
+
+options = {
+    useESModules: true,
+};
+
+options = {
+    useESModules: false,
+};
+
+
+//==================//
+// ABSOLUTE RUNTIME //
+//==================//
+
+options = {
+    absoluteRuntime: true,
+};
+
+options = {
+    absoluteRuntime: false,
+};
+
+options = {
+    absoluteRuntime: '/some/path/here',
+};
+
+
+//=========//
+// VERSION //
+//=========//
+
+options = {
+    version: '^1.2.3',
+};

--- a/types/babel__plugin-transform-runtime/index.d.ts
+++ b/types/babel__plugin-transform-runtime/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for @babel/plugin-transform-runtime 7.9
+// Project: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime, https://babeljs.io/docs/en/babel-plugin-transform-runtime
+// Definitions by: Slava Fomin II <https://github.com/slavafomin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface Options {
+    corejs?: CorejsOption;
+    helpers?: boolean;
+    regenerator?: boolean;
+    useESModules?: boolean;
+    absoluteRuntime?: (boolean | string);
+    version?: string;
+}
+
+export type CorejsOption = (
+    | CorejsVersion
+    | { version: CorejsVersion, proposals: boolean }
+    | false
+);
+
+export type CorejsVersion = (2 | 3);

--- a/types/babel__plugin-transform-runtime/tsconfig.json
+++ b/types/babel__plugin-transform-runtime/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "strict": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@babel/plugin-transform-runtime": [
+                "babel__plugin-transform-runtime"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "babel__plugin-transform-runtime-tests.ts"
+    ]
+}

--- a/types/babel__plugin-transform-runtime/tslint.json
+++ b/types/babel__plugin-transform-runtime/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
This PR adds options types supported by [@babel/plugin-transform-runtime](https://babeljs.io/docs/en/babel-plugin-transform-runtime). This should help with configuring Babel programmatically.

These definitions are based on the official plugin documentation, completely covering all public options.

---

- ✓ Use a meaningful title for the pull request. Include the name of the package modified.
- ✓ Test the change in your own code. (Compile and run.)
- ✓ Add or edit tests to reflect the change. (Run with `npm test`.)
- ✓ Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- ✓ Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- ✓ Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- ✓ The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- ✓ If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [What?] Create it with `dts-gen --dt`, not by basing it on an existing project.
- ✓ Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- ✓ `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- ✓ `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.