### PR TITLE
feat(express-fileupload): `uploadTimeout` added

### DIFF
--- a/types/express-fileupload/express-fileupload-tests.ts
+++ b/types/express-fileupload/express-fileupload-tests.ts
@@ -6,8 +6,6 @@ type UploadedFile = fileUpload.UploadedFile;
 
 const app: express.Express = express();
 
-app.use(fileUpload({ debug: true }));
-
 function isUploadedFile(file: UploadedFile | UploadedFile[]): file is UploadedFile {
     return typeof file === 'object' && (file as UploadedFile).name !== undefined;
 }
@@ -34,6 +32,7 @@ const uploadHandler: RequestHandler = (req: Request, res: Response, next: NextFu
 };
 
 app.post('/upload', uploadHandler);
+app.use(fileUpload({ debug: true }));
 app.use(fileUpload({ safeFileNames: /\\/g }));
 app.use(fileUpload({ safeFileNames: true }));
 app.use(fileUpload({ safeFileNames: true, preserveExtension: true }));
@@ -54,4 +53,5 @@ app.use(
     }),
 );
 app.use(fileUpload({ useTempFiles: true, tempFileDir: 'temp2/' }));
-app.use(fileUpload({ parseNested: true }));
+app.use(fileUpload({ limitHandler: true }));
+app.use(fileUpload({ uploadTimeout: 6000 }));

--- a/types/express-fileupload/index.d.ts
+++ b/types/express-fileupload/index.d.ts
@@ -51,7 +51,10 @@ declare namespace fileUpload {
     interface Options {
         /** Automatically creates the directory path specified in `.mv(filePathName)` */
         createParentPath?: boolean;
-        /** Applies uri decoding to file names if set true. */
+        /**
+         * Applies uri decoding to file names if set true.
+         * @default false
+         */
         uriDecodeFileNames?: boolean;
         /**
          * Strips characters from the upload's filename.
@@ -69,6 +72,7 @@ declare namespace fileUpload {
         /**
          * Returns a HTTP 413 when the file is bigger than the size limit if `true`.
          * Otherwise, it will add a `truncated = true` to the resulting file structure.
+         * @default false
          */
         abortOnLimit?: boolean;
         /**
@@ -103,8 +107,14 @@ declare namespace fileUpload {
         /**
          * Turn on/off upload process logging.
          * Can be useful for troubleshooting.
+         * @default false
          */
         debug?: boolean;
+
+        /**
+         * @default 60000
+         */
+        uploadTimeout?: number;
         [property: string]: any;
     }
 }


### PR DESCRIPTION
- missing from recent updates `uploadTimeout`:
https://github.com/richardgirges/express-fileupload/releases/tag/1.1.6
- minor JSDoc defaults changes for `uriDecodeFileNames` and
`abortOnLimit`

https://github.com/richardgirges/express-fileupload/releases/tag/1.1.6

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.