### PR TITLE
Add can-autoplay types

### DIFF
--- a/types/can-autoplay/can-autoplay-tests.ts
+++ b/types/can-autoplay/can-autoplay-tests.ts
@@ -1,0 +1,21 @@
+import canAutoPlay = require('can-autoplay');
+
+canAutoPlay
+    .video({ timeout: 100, muted: true })
+    .then(({ result, error }) => {
+        if (result) {
+            // Can autoplay
+        } else {
+            // Can not autoplay
+        }
+    });
+
+canAutoPlay
+    .video()
+    .then(({ result, error }) => {
+        if (result) {
+            // Can autoplay
+        } else {
+            // Can not autoplay
+        }
+    });

--- a/types/can-autoplay/index.d.ts
+++ b/types/can-autoplay/index.d.ts
@@ -3,22 +3,16 @@
 // Definitions by: Viacheslav Borodulin <https://github.com/vborodulin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface Options {
+export interface Options {
     inline?: boolean;
     muted?: boolean;
     timeout?: number;
 }
 
-interface CheckResponse {
+export interface CheckResponse {
     result: boolean;
     error: Error;
 }
 
-type CheckMethod = (options?: Options) => Promise<CheckResponse>;
-
-declare const canAutoPlay: {
-    audio: CheckMethod;
-    video: CheckMethod;
-};
-
-export = canAutoPlay;
+export function audio(options?: Options): Promise<CheckResponse>;
+export function video(options?: Options): Promise<CheckResponse>;

--- a/types/can-autoplay/index.d.ts
+++ b/types/can-autoplay/index.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for can-autoplay 3.0
+// Project: https://github.com/video-dev/can-autoplay
+// Definitions by: Viacheslav Borodulin <https://github.com/vborodulin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface Options {
+    inline?: boolean;
+    muted?: boolean;
+    timeout?: number;
+}
+
+interface CheckResponse {
+    result: boolean;
+    error: Error;
+}
+
+type CheckMethod = (options?: Options) => Promise<CheckResponse>;
+
+declare const canAutoPlay: {
+    audio: CheckMethod;
+    video: CheckMethod;
+};
+
+export = canAutoPlay;

--- a/types/can-autoplay/tsconfig.json
+++ b/types/can-autoplay/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/can-autoplay/tsconfig.json
+++ b/types/can-autoplay/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "can-autoplay-tests.ts"
+    ]
+}

--- a/types/can-autoplay/tslint.json
+++ b/types/can-autoplay/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.