### PR TITLE
feat(eslint): update types to 6.8

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -349,6 +349,31 @@ rule = {
             }
         });
 
+        context.report({
+            message: 'foo',
+            node: AST,
+            suggest: [
+                {
+                    desc: 'foo',
+                    fix: ruleFixer => {
+                        return [
+                            ruleFixer.insertTextAfter(AST, 'foo'),
+                            ruleFixer.insertTextAfter(TOKEN, 'foo')
+                        ];
+                    },
+                },
+                {
+                    messageId: 'foo',
+                    fix: ruleFixer => {
+                        return [
+                            ruleFixer.insertTextAfter(AST, 'foo'),
+                            ruleFixer.insertTextAfter(TOKEN, 'foo')
+                        ];
+                    },
+                },
+            ],
+        });
+
         return {
             onCodePathStart(codePath, node) {},
             onCodePathEnd(codePath, node) {},
@@ -430,6 +455,9 @@ for (const msg of lintingResult) {
 
     msg.fatal = true;
 
+    msg.message = 'foo';
+    msg.messageId = 'foo';
+
     msg.line = 0;
     msg.endLine = 0;
     msg.column = 0;
@@ -440,6 +468,15 @@ for (const msg of lintingResult) {
     if (msg.fix) {
         msg.fix.text = 'foo';
         msg.fix.range = [0, 0];
+    }
+
+    if (msg.suggestions) {
+        for (const suggestion of msg.suggestions) {
+            suggestion.desc = 'foo';
+            suggestion.messageId = 'foo';
+            suggestion.fix.text = 'foo';
+            suggestion.fix.range = [0, 0];
+        }
     }
 }
 
@@ -596,11 +633,25 @@ ruleTester.run('my-rule', rule, {
 
     invalid: [
         { code: 'foo', errors: 1 },
+        { code: 'foo', errors: 1, output: 'foo' },
         { code: 'foo', errors: ['foo'] },
         { code: 'foo', errors: [{ message: 'foo' }] },
         { code: 'foo', errors: [{ message: 'foo', type: 'foo' }] },
         { code: 'foo', errors: [{ message: 'foo', data: { foo: true } }] },
         { code: 'foo', errors: [{ message: 'foo', line: 0 }] },
+        { code: 'foo', errors: [{
+            message: 'foo',
+            suggestions: [
+                {
+                    desc: 'foo',
+                    output: 'foo',
+                },
+                {
+                    messageId: 'foo',
+                    output: 'foo',
+                },
+            ],
+        }] },
     ]
 });
 

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for eslint 6.1
+// Type definitions for eslint 6.8
 // Project: https://eslint.org
 // Definitions by: Pierre-Marie Dartus <https://github.com/pmdartus>
 //                 Jed Fox <https://github.com/j-f1>
@@ -319,16 +319,24 @@ export namespace Rule {
         report(descriptor: ReportDescriptor): void;
     }
 
+    interface ReportDescriptorOptionsBase {
+        data?: { [key: string]: string };
+
+        fix?: null | ((fixer: RuleFixer) => null | Fix | IterableIterator<Fix> | Fix[]);
+    }
+
+    type SuggestionDescriptorMessage = { desc: string } | { messageId: string };
+    type SuggestionReportDescriptor = SuggestionDescriptorMessage & ReportDescriptorOptionsBase;
+
+    interface ReportDescriptorOptions extends ReportDescriptorOptionsBase {
+        suggest?: SuggestionReportDescriptor[] | null;
+    }
+
     type ReportDescriptor = ReportDescriptorMessage & ReportDescriptorLocation & ReportDescriptorOptions;
     type ReportDescriptorMessage = { message: string } | { messageId: string };
     type ReportDescriptorLocation =
         | { node: ESTree.Node }
         | { loc: AST.SourceLocation | { line: number; column: number } };
-    interface ReportDescriptorOptions {
-        data?: { [key: string]: string };
-
-        fix?(fixer: RuleFixer): null | Fix | IterableIterator<Fix> | Fix[];
-    }
 
     interface RuleFixer {
         insertTextAfter(nodeOrToken: ESTree.Node | AST.Token, text: string): Fix;
@@ -378,33 +386,45 @@ export class Linter {
 
 export namespace Linter {
     type Severity = 0 | 1 | 2;
-    type RuleLevel = Severity | 'off' | 'warn' | 'error';
 
+    type RuleLevel = Severity | 'off' | 'warn' | 'error';
     interface RuleLevelAndOptions extends Array<any> {
         0: RuleLevel;
     }
+
+    type RuleEntry = RuleLevel | RuleLevelAndOptions;
+
+    interface RulesRecord {
+        [rule: string]: RuleEntry;
+    }
+
     interface HasRules {
-        rules?: {
-            [name: string]: RuleLevel | RuleLevelAndOptions;
-        };
+        rules?: Partial<RulesRecord>;
     }
 
-    interface RuleOverride extends HasRules {
+    interface BaseConfig extends HasRules {
+        $schema?: string;
+        env?: { [name: string]: boolean };
         extends?: string | string[];
-        excludedFiles?: string[];
-        files?: string[];
-    }
-
-    interface Config extends HasRules {
+        globals?: { [name: string]: boolean };
+        noInlineConfig?: boolean;
+        overrides?: ConfigOverride[];
         parser?: string;
         parserOptions?: ParserOptions;
-        settings?: { [name: string]: any };
-        env?: { [name: string]: boolean };
-        globals?: { [name: string]: boolean };
-        extends?: string | string[];
-        overrides?: RuleOverride[];
-        processor?: string;
         plugins?: string[];
+        processor?: string;
+        reportUnusedDisableDirectives?: boolean;
+        settings?: { [name: string]: any };
+    }
+
+    interface ConfigOverride extends BaseConfig {
+        excludedFiles?: string | string[];
+        files: string | string[];
+    }
+
+    // https://github.com/eslint/eslint/blob/v6.8.0/conf/config-schema.js
+    interface Config extends BaseConfig {
+        ignorePatterns?: string | string[];
         root?: boolean;
     }
 
@@ -429,6 +449,12 @@ export namespace Linter {
         reportUnusedDisableDirectives?: boolean;
     }
 
+    interface LintSuggestion {
+        desc: string;
+        fix: Rule.Fix;
+        messageId?: string;
+    }
+
     interface LintMessage {
         column: number;
         line: number;
@@ -436,11 +462,13 @@ export namespace Linter {
         endLine?: number;
         ruleId: string | null;
         message: string;
+        messageId?: string;
         nodeType: string;
         fatal?: true;
         severity: Severity;
         fix?: Rule.Fix;
         source: string | null;
+        suggestions?: LintSuggestion[];
     }
 
     interface FixOptions extends LintOptions {
@@ -592,6 +620,13 @@ export namespace RuleTester {
         globals?: { [name: string]: boolean };
     }
 
+    interface SuggestionOutput {
+        messageId?: string;
+        desc?: string;
+        data?: Record<string, any>;
+        output: string;
+    }
+
     interface InvalidTestCase extends ValidTestCase {
         errors: number | Array<TestCaseError | string>;
         output?: string | null;
@@ -606,6 +641,7 @@ export namespace RuleTester {
         column?: number;
         endLine?: number;
         endColumn?: number;
+        suggestions?: SuggestionOutput[];
     }
 }
 

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -4,6 +4,7 @@
 //                 Jed Fox <https://github.com/j-f1>
 //                 Saad Quadri <https://github.com/saadq>
 //                 Jason Kwok <https://github.com/JasonHK>
+//                 Brad Zacher <https://github.com/bradzacher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/eslint/ts3.1/eslint-tests.ts
+++ b/types/eslint/ts3.1/eslint-tests.ts
@@ -349,6 +349,31 @@ rule = {
             }
         });
 
+        context.report({
+            message: 'foo',
+            node: AST,
+            suggest: [
+                {
+                    desc: 'foo',
+                    fix: ruleFixer => {
+                        return [
+                            ruleFixer.insertTextAfter(AST, 'foo'),
+                            ruleFixer.insertTextAfter(TOKEN, 'foo')
+                        ];
+                    },
+                },
+                {
+                    messageId: 'foo',
+                    fix: ruleFixer => {
+                        return [
+                            ruleFixer.insertTextAfter(AST, 'foo'),
+                            ruleFixer.insertTextAfter(TOKEN, 'foo')
+                        ];
+                    },
+                },
+            ],
+        });
+
         return {
             onCodePathStart(codePath, node) {},
             onCodePathEnd(codePath, node) {},
@@ -430,6 +455,9 @@ for (const msg of lintingResult) {
 
     msg.fatal = true;
 
+    msg.message = 'foo';
+    msg.messageId = 'foo';
+
     msg.line = 0;
     msg.endLine = 0;
     msg.column = 0;
@@ -440,6 +468,15 @@ for (const msg of lintingResult) {
     if (msg.fix) {
         msg.fix.text = 'foo';
         msg.fix.range = [0, 0];
+    }
+
+    if (msg.suggestions) {
+        for (const suggestion of msg.suggestions) {
+            suggestion.desc = 'foo';
+            suggestion.messageId = 'foo';
+            suggestion.fix.text = 'foo';
+            suggestion.fix.range = [0, 0];
+        }
     }
 }
 
@@ -596,11 +633,25 @@ ruleTester.run('my-rule', rule, {
 
     invalid: [
         { code: 'foo', errors: 1 },
+        { code: 'foo', errors: 1, output: 'foo' },
         { code: 'foo', errors: ['foo'] },
         { code: 'foo', errors: [{ message: 'foo' }] },
         { code: 'foo', errors: [{ message: 'foo', type: 'foo' }] },
         { code: 'foo', errors: [{ message: 'foo', data: { foo: true } }] },
         { code: 'foo', errors: [{ message: 'foo', line: 0 }] },
+        { code: 'foo', errors: [{
+            message: 'foo',
+            suggestions: [
+                {
+                    desc: 'foo',
+                    output: 'foo',
+                },
+                {
+                    messageId: 'foo',
+                    output: 'foo',
+                },
+            ],
+        }] },
     ]
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Add or edit tests to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - https://github.com/eslint/eslint/blob/v6.8.0/conf/config-schema.js
    - https://github.com/eslint/eslint/blob/78c8cda5a5d82f5f8548c4528a6438d29756bb71/docs/developer-guide/working-with-rules.md#providing-suggestions
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

Changes include:
- a few new config options
- correct of the config overrides
- support for 6.7's suggestions API