### PR TITLE
[webpack-hot-middleware] Separating client and middleware options into 2 separate types

### DIFF
--- a/types/webpack-hot-middleware/index.d.ts
+++ b/types/webpack-hot-middleware/index.d.ts
@@ -4,6 +4,7 @@
 //               Ron Martinez <https://github.com/icylace>
 //               Chris Abrams <https://github.com/chrisabrams>
 //               Ilya Zelenko <https://github.com/iliyaZelenko>
+//               Rodrigo Saboya <https://github.com/saboya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -14,11 +15,11 @@ export = WebpackHotMiddleware;
 
 declare function WebpackHotMiddleware(
 	compiler: webpack.ICompiler,
-	options?: WebpackHotMiddleware.Options
+	options?: WebpackHotMiddleware.MiddlewareOptions
 ): NextHandleFunction & WebpackHotMiddleware.EventStream;
 
 declare namespace WebpackHotMiddleware {
-	interface Options {
+	interface ClientOptions {
 		reload?: boolean;
 		name?: string;
 		timeout?: number;
@@ -34,6 +35,8 @@ declare namespace WebpackHotMiddleware {
 			[key: string]: any
 		};
 		overlayWarnings?: boolean;
+	}
+	interface MiddlewareOptions {
 		log?: false | Logger;
 		path?: string;
 		heartbeat?: number;
@@ -43,5 +46,6 @@ declare namespace WebpackHotMiddleware {
 
 	interface EventStream {
 		publish(payload: any): void;
+		close(): void;
 	}
 }

--- a/types/webpack-hot-middleware/webpack-hot-middleware-tests.ts
+++ b/types/webpack-hot-middleware/webpack-hot-middleware-tests.ts
@@ -9,9 +9,26 @@ let webpackHotMiddlewareInstance = webpackHotMiddleware(compiler);
 webpackHotMiddlewareInstance = webpackHotMiddleware(compiler, {
 	log: console.log.bind(console),
 	path: '/__what',
-	heartbeat: 2000,
-	reload: false,
+	heartbeat: 2000
 });
+
+const clientOpts: webpackHotMiddleware.ClientOptions = {
+	reload: true,
+	name: '__webpack_hmr_custom_bundle_name',
+	timeout: 1000,
+	overlay: false,
+	noInfo: true,
+	quiet: true,
+	dynamicPublicPath: false,
+	autoConnect: true,
+	ansiColors: {
+		red: '00FF00'
+	},
+	overlayStyles: {
+		color: '#FF0000'
+	},
+	overlayWarnings: false
+};
 
 const app = express();
 app.use(webpackHotMiddlewareInstance);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack-contrib/webpack-hot-middleware#config
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
