### PR TITLE
[codemirror] Add lacked arguments of runMode

### DIFF
--- a/types/codemirror/addon/runmode/runmode.d.ts
+++ b/types/codemirror/addon/runmode/runmode.d.ts
@@ -12,13 +12,13 @@ declare module "codemirror" {
     /**
      * Runs a CodeMirror mode over text without opening an editor instance.
      *
-     * @param text The document to run through the highlighter.
-     * @param mode The mode to use (must be loaded as normal).
+     * @param text   The document to run through the highlighter.
+     * @param mode   The mode to use (must be loaded as normal).
      * @param output If this is a function, it will be called for each token with
-     *               two arguments, the token's text and the token's style class
-     *               (may be null for unstyled tokens). If it is a DOM node, the
-     *               tokens will be converted to span elements as in an editor,
+     *               five arguments, the token's text, the token's style class (may be null for unstyled tokens),
+     *               the number of row of the token, the column position of token and the state of mode.
+     *               If it is a DOM node, the tokens will be converted to span elements as in an editor,
      *               and inserted into the node (through innerHTML).
      */
-    function runMode(text: string, modespec: any, callback: (HTMLElement | ((text: string, style: string | null) => void)), options? : { tabSize?: number; state?: any; }): void;
+    function runMode(text: string, mode: any, callback: (HTMLElement | ((text: string, style?: string | null, row?: number, column?: number, state?: any) => void)), options? : { tabSize?: number; state?: any; }): void;
 }

--- a/types/codemirror/test/addon/runmode/runmode.ts
+++ b/types/codemirror/test/addon/runmode/runmode.ts
@@ -4,3 +4,4 @@ import "codemirror/addon/runmode/runmode";
 const query = "SELECT * FROM Table";
 
 CodeMirror.runMode(query, "text/x-sql", document.body);
+CodeMirror.runMode(query, "text/x-sql", (text, style, row, column, state) => {});


### PR DESCRIPTION
Add lacked 3 of 5 arguments of callback function of [runMode](https://codemirror.net/doc/manual.html#addon_runmode)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/codemirror/CodeMirror/blob/master/addon/runmode/runmode.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
