### PR TITLE
[analytics-node] Enforce either userId or anonymousId as identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,6 @@
             "_comment": "This will remove husky from when we started migrating to use prettier",
             "pre-commit": "npm uninstall husky"
         }
-    }
+    },
+    "dependencies": {}
 }

--- a/types/analytics-node/analytics-node-tests.ts
+++ b/types/analytics-node/analytics-node-tests.ts
@@ -60,6 +60,24 @@ function testTrack(): void {
   });
 
   analytics.track({
+    anonymousId: '019mr8mf4r',
+    event: 'Purchased an Item',
+    properties: {
+      revenue: 39.95,
+      shippingMethod: '2-day'
+    }
+  });
+
+  // $ExpectError
+  analytics.track({
+    event: 'Purchased an Item',
+    properties: {
+      revenue: 39.95,
+      shippingMethod: '2-day'
+    }
+  });
+
+  analytics.track({
     userId: '019mr8mf4r',
     event: 'Purchased an Item',
     properties: {

--- a/types/analytics-node/index.d.ts
+++ b/types/analytics-node/index.d.ts
@@ -3,11 +3,16 @@
 // Definitions by: Andrew Fong <https://github.com/fongandrew>
 //                 Thomas Thiebaud <https://github.com/thomasthiebaud>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 export = AnalyticsNode.Analytics;
 
 declare namespace AnalyticsNode {
-  interface Message {
+  type Identity =
+    | { userId: string | number }
+    | { userId?: string | number; anonymousId: string | number };
+
+  type Message = Identity & {
     type: string;
     context: {
       library: {
@@ -22,9 +27,7 @@ declare namespace AnalyticsNode {
     };
     timestamp?: Date;
     messageId?: string;
-    anonymousId?: string | number;
-    userId?: string | number;
-  }
+  };
 
   interface Data {
     batch: Message[];
@@ -49,9 +52,7 @@ declare namespace AnalyticsNode {
 
     /* The identify method lets you tie a user to their actions and record
        traits about them. */
-    identify(message: {
-      userId?: string | number;
-      anonymousId?: string | number;
+    identify(message: Identity & {
       traits?: any;
       timestamp?: Date;
       context?: any;
@@ -59,9 +60,7 @@ declare namespace AnalyticsNode {
     }, callback?: (err: Error, data: Data) => void): Analytics;
 
     /* The track method lets you record the actions your users perform. */
-    track(message: {
-      userId?: string | number;
-      anonymousId?: string | number;
+    track(message: Identity & {
       event: string;
       properties?: any;
       timestamp?: Date;
@@ -71,9 +70,7 @@ declare namespace AnalyticsNode {
 
     /* The page method lets you record page views on your website, along with
        optional extra information about the page being viewed. */
-    page(message: {
-      userId?: string | number;
-      anonymousId?: string | number;
+    page(message: Identity & {
       category?: string;
       name?: string;
       properties?: any;
@@ -83,18 +80,14 @@ declare namespace AnalyticsNode {
     }, callback?: (err: Error, data: Data) => void): Analytics;
 
     /* alias is how you associate one identity with another. */
-    alias(message: {
+    alias(message: Identity & {
       previousId: string | number;
-      userId?: string | number;
-      anonymousId?: string | number;
       integrations?: Integrations;
     }, callback?: (err: Error, data: Data) => void): Analytics;
 
     /* Group calls can be used to associate individual users with shared
        accounts or companies. */
-    group(message: {
-      userId?: string | number;
-      anonymousId?: string | number;
+    group(message: Identity & {
       groupId: string | number;
       traits?: any;
       context?: any;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://segment.com/docs/connections/sources/catalog/libraries/server/node/#identify - note all of the methods lists userId as required, if anonymous ID is not provided 
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

