### PR TITLE
fix(tcp-ping): Fix incorrect typings for probe method

### DIFF
--- a/types/tcp-ping/index.d.ts
+++ b/types/tcp-ping/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for tcp-ping 0.1
+// Type definitions for tcp-ping 0.2
 // Project: https://github.com/wesolyromek/tcp-ping
 // Definitions by: JUNG YONG WOO <https://github.com/stegano>
+//                 rymate1234 <https://github.com/rymate1234>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Options {
@@ -27,4 +28,4 @@ export interface Result {
 }
 
 export function ping(options: Options, callback: (error: Error, result: Result) => void): void;
-export function probe(address: string, port: number, callback: (error: Error, result: Result) => void): void;
+export function probe(address: string, port: number, callback: (error: Error, result: boolean) => void): void;

--- a/types/tcp-ping/index.d.ts
+++ b/types/tcp-ping/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for tcp-ping 0.2
+// Type definitions for tcp-ping 0.1
 // Project: https://github.com/wesolyromek/tcp-ping
 // Definitions by: JUNG YONG WOO <https://github.com/stegano>
 //                 rymate1234 <https://github.com/rymate1234>

--- a/types/tcp-ping/tcp-ping-tests.ts
+++ b/types/tcp-ping/tcp-ping-tests.ts
@@ -15,7 +15,10 @@ tp.ping();
 tp.ping({});
 
 // $ExpectType void
-tp.probe("localhost", 8080, () => {});
+tp.probe("localhost", 8080, (err, result) => {
+    // $ExpectType boolean
+    result;
+});
 
 // $ExpectError
 tp.probe("localhost", 8080);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
     - As per the source code for tcp-ping, the callback result of probe should return a `boolean` not a `Result` object: https://github.com/apaszke/tcp-ping/blob/master/ping.js#L92 
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


