### PR TITLE
mongodb: Refactor the types for ChangeStreams

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -937,8 +937,10 @@ type EnhancedOmit<T, K> =
     Omit<T, K>;
 
 type ExtractIdType<TSchema> =
-    TSchema extends { _id: any } // user has defined a type for _id
-    ? TSchema['_id'] : ObjectId;
+    TSchema extends { _id: infer U } // user has defined a type for _id
+    ? {} extends U ? Exclude<U, {}> :
+    unknown extends U ? ObjectId : U
+     : ObjectId; // user has not defined _id on schema
 
 // this makes _id optional
 type OptionalId<TSchema extends { _id?: any }> =

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -937,10 +937,8 @@ type EnhancedOmit<T, K> =
     Omit<T, K>;
 
 type ExtractIdType<TSchema> =
-    TSchema extends { _id: infer U } // user has defined a type for _id
-    ? {} extends U ? Exclude<U, {}> :
-      unknown extends U ? ObjectId : U
-    : ObjectId; // user has not defined _id on schema
+    TSchema extends { _id: any } // user has defined a type for _id
+    ? TSchema['_id'] : ObjectId;
 
 // this makes _id optional
 type OptionalId<TSchema extends { _id?: any }> =

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2471,13 +2471,13 @@ export interface ChangeEventUpdate<TSchema extends { [key: string]: any } = Defa
     };
     fullDocument?: TSchema;
     documentKey: {
-        _id: TSchema extends {_id: any} ? TSchema['_id'] : any;
+        _id: ExtractIdType<TSchema>;
     };
 }
 export interface ChangeEventDelete<TSchema extends { [key: string]: any } = DefaultSchema> extends ChangeEventBase<TSchema> {
     operationType: 'delete';
     documentKey: {
-        _id: TSchema extends {_id: any} ? TSchema['_id'] : any;
+        _id: ExtractIdType<TSchema>;
     };
 }
 export interface ChangeEventRename<TSchema extends { [key: string]: any } = DefaultSchema> extends ChangeEventBase<TSchema> {

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2350,7 +2350,12 @@ export interface GridFSBucketWriteStreamOptions extends WriteConcern {
     disableMD5?: boolean;
 }
 
-type Arguments<T> = [T] extends [(...args: infer U) => any]
+/**
+ * This is similar to Parameters but will work with a type which is
+ * a function or with a tuple specifying arguments, which are both
+ * common ways to define eventemitter events
+ */
+type EventArguments<T> = [T] extends [(...args: infer U) => any]
   ? U
   : [T] extends [undefined] ? [] : [T];
 
@@ -2383,7 +2388,7 @@ declare class TypedEventEmitter<Events> {
     removeAllListeners<E extends keyof Events> (event?: E): this;
     removeListener<E extends keyof Events> (event: E, listener: Events[E]): this;
 
-    emit<E extends keyof Events> (event: E, ...args: Arguments<Events[E]>): boolean;
+    emit<E extends keyof Events> (event: E, ...args: EventArguments<Events[E]>): boolean;
     eventNames (): Array<keyof Events>;
     listeners<E extends keyof Events> (event: E): Function[];
     listenerCount<E extends keyof Events> (event: E): number;

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1216,10 +1216,10 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
         callback: MongoCallback<UpdateWriteOpResult>,
     ): void;
     /** http://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#watch */
-    watch<TSchema extends object = {_id: ObjectId}>(
+    watch<T = TSchema>(
         pipeline?: object[],
         options?: ChangeStreamOptions & { session?: ClientSession },
-    ): ChangeStream<TSchema>;
+    ): ChangeStream<T>;
 }
 
 /** Update Query */
@@ -2392,7 +2392,7 @@ declare class TypedEventEmitter<Events> {
     setMaxListeners (maxListeners: number): this;
 }
 
-interface ChangeStreamEvents<TSchema extends object> {
+interface ChangeStreamEvents<TSchema extends { [key: string]: any } = DefaultSchema> {
     change: (doc: ChangeEvent<TSchema>) => void;
     close: () => void;
     end: () => void;
@@ -2401,7 +2401,7 @@ interface ChangeStreamEvents<TSchema extends object> {
 }
 
 /** http://mongodb.github.io/node-mongodb-native/3.3/api/ChangeStream.html */
-export class ChangeStream<TSchema extends object = any> extends TypedEventEmitter<ChangeStreamEvents<TSchema>> {
+export class ChangeStream<TSchema extends { [key: string]: any } = DefaultSchema> extends TypedEventEmitter<ChangeStreamEvents<TSchema>> {
     resumeToken: ResumeToken;
 
     constructor(parent: MongoClient | Db | Collection, pipeline: object[], options?: ChangeStreamOptions);
@@ -2428,7 +2428,7 @@ export class ChangeStream<TSchema extends object = any> extends TypedEventEmitte
 export class ResumeToken {}
 
 export type ChangeEventTypes = 'insert' | 'delete' | 'replace' | 'update' | 'drop' | 'rename' | 'dropDatabase' | 'invalidate';
-export interface ChangeEventBase<TSchema extends object = {_id: ObjectId}> {
+export interface ChangeEventBase<TSchema extends { [key: string]: any } = DefaultSchema> {
     _id: ResumeToken;
     /**
      * We leave this off the base type so that we can differentiate
@@ -2446,7 +2446,7 @@ export interface ChangeEventBase<TSchema extends object = {_id: ObjectId}> {
         "uid": any;
     };
 }
-export interface ChangeEventCR<TSchema extends object = {_id: ObjectId}> extends ChangeEventBase<TSchema> {
+export interface ChangeEventCR<TSchema extends { [key: string]: any } = DefaultSchema> extends ChangeEventBase<TSchema> {
     operationType: 'insert' | 'replace';
     fullDocument?: TSchema;
     documentKey: {
@@ -2454,7 +2454,7 @@ export interface ChangeEventCR<TSchema extends object = {_id: ObjectId}> extends
     };
 }
 type FieldUpdates<TSchema> = Partial<TSchema> & {[key: string]: any};
-export interface ChangeEventUpdate<TSchema extends object = {_id: ObjectId}> extends ChangeEventBase<TSchema> {
+export interface ChangeEventUpdate<TSchema extends { [key: string]: any } = DefaultSchema> extends ChangeEventBase<TSchema> {
     operationType: 'update';
     updateDescription: {
         /**
@@ -2469,13 +2469,13 @@ export interface ChangeEventUpdate<TSchema extends object = {_id: ObjectId}> ext
         _id: TSchema extends {_id: any} ? TSchema['_id'] : any;
     };
 }
-export interface ChangeEventDelete<TSchema extends object = {_id: ObjectId}> extends ChangeEventBase<TSchema> {
+export interface ChangeEventDelete<TSchema extends { [key: string]: any } = DefaultSchema> extends ChangeEventBase<TSchema> {
     operationType: 'delete';
     documentKey: {
         _id: TSchema extends {_id: any} ? TSchema['_id'] : any;
     };
 }
-export interface ChangeEventRename<TSchema extends object = {_id: ObjectId}> extends ChangeEventBase<TSchema> {
+export interface ChangeEventRename<TSchema extends { [key: string]: any } = DefaultSchema> extends ChangeEventBase<TSchema> {
     operationType: 'rename';
     to: {
         db: string;
@@ -2483,11 +2483,11 @@ export interface ChangeEventRename<TSchema extends object = {_id: ObjectId}> ext
     };
 }
 
-export interface ChangeEventOther<TSchema extends object = {_id: ObjectId}> extends ChangeEventBase<TSchema> {
+export interface ChangeEventOther<TSchema extends { [key: string]: any } = DefaultSchema> extends ChangeEventBase<TSchema> {
     operationType: 'drop' | 'dropDatabase';
 }
 
-export interface ChangeEventInvalidate<TSchema extends object = {_id: ObjectId}> {
+export interface ChangeEventInvalidate<TSchema extends { [key: string]: any } = DefaultSchema> {
     _id: ResumeToken;
     operationType: 'invalidate';
     clusterTime: Timestamp;

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2457,7 +2457,7 @@ export interface ChangeEventCR<TSchema extends { [key: string]: any } = DefaultS
     operationType: 'insert' | 'replace';
     fullDocument?: TSchema;
     documentKey: {
-        _id: TSchema extends {_id: any} ? TSchema['_id'] : any;
+        _id: ExtractIdType<TSchema>;
     };
 }
 type FieldUpdates<TSchema> = Partial<TSchema> & {[key: string]: any};

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2455,10 +2455,15 @@ export interface ChangeEventCR<TSchema extends object = {_id: ObjectId}> extends
         _id: TSchema extends {_id: any} ? TSchema['_id'] : any;
     };
 }
+type FieldUpdates<TSchema> = Partial<TSchema> & {[key: string]: any};
 export interface ChangeEventUpdate<TSchema extends object = {_id: ObjectId}> extends ChangeEventBase<TSchema> {
     operationType: 'update';
     updateDescription: {
-        updatedFields: Partial<TSchema>;
+        /**
+         * This is an object with all changed fields; if they are nested,
+         * the keys will be paths, e.g. 'question.answer.0.text': 'new text'
+         */
+        updatedFields: FieldUpdates<TSchema>;
         removedFields: Array<keyof TSchema | string>;
     };
     fullDocument?: TSchema;


### PR DESCRIPTION

The types for ChangeStreams were incorrect, since ChangeStream extends EventEmitter and it had it extending Readable. While I was at it I added the specific types of all of the different ChangeEvents which can come and added those, so you can differentiate based on the operation it is reporting and have accurate types.

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
