### PR TITLE
jsdom: ResourceLoader#fetch may return null

### DIFF
--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -62,7 +62,7 @@ declare module 'jsdom' {
 	}
 
 	class ResourceLoader {
-		fetch(url: string, options: FetchOptions): Promise<Buffer>;
+		fetch(url: string, options: FetchOptions): Promise<Buffer> | null;
 
 		constructor(obj?: ResourceLoaderConstructorOptions);
 	}

--- a/types/jsdom/jsdom-tests.ts
+++ b/types/jsdom/jsdom-tests.ts
@@ -190,6 +190,11 @@ function test_custom_resource_loader() {
 		fetch(url: string, options: FetchOptions) {
 			if (options.element) {
 				console.log(`Element ${options.element.localName} is requesting the url ${url}`);
+
+				if (options.element.localName === "iframe") {
+					console.log("Ignoring resource requested by iframe element");
+					return null;
+				}
 			}
 
 			return super.fetch(url, options);


### PR DESCRIPTION
According to the jsdom documentation, ResourceLoader#fetch may return
null to indicate that the resource was intentionally not loaded.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/jsdom
  > jsdom will call your custom resource loader's fetch() method whenever it encounters a "usable" resource, per the above section. The method takes a URL string, as well as a few options which you should pass through unmodified if calling super.fetch(). It must return a promise for a Node.js Buffer object, **or return null if the resource is intentionally not to be loaded**. In general, most cases will want to delegate to super.fetch(), as shown.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **N/A**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.