### PR TITLE
Fix the type of lines of lyric-parser

### DIFF
--- a/types/lyric-parser/index.d.ts
+++ b/types/lyric-parser/index.d.ts
@@ -8,7 +8,7 @@ export default class Lyric {
 
     lrc: string;
     tags: { album: string; artist: string; by: string; offset: string; title: string };
-    lines: Array<{ lineNum: number; txt: string }>;
+    lines: Array<{ time: number; txt: string }>;
     handler: (params: { lineNum: number; txt: string }) => void;
     state: number;
     curLine: number;

--- a/types/lyric-parser/index.d.ts
+++ b/types/lyric-parser/index.d.ts
@@ -8,7 +8,7 @@ export default class Lyric {
 
     lrc: string;
     tags: { album: string; artist: string; by: string; offset: string; title: string };
-    lines: { lineNum: number; txt: string }[];
+    lines: Array<{ lineNum: number; txt: string }>;
     handler: (params: { lineNum: number; txt: string }) => void;
     state: number;
     curLine: number;

--- a/types/lyric-parser/index.d.ts
+++ b/types/lyric-parser/index.d.ts
@@ -8,7 +8,7 @@ export default class Lyric {
 
     lrc: string;
     tags: { album: string; artist: string; by: string; offset: string; title: string };
-    lines: string[];
+    lines: { lineNum: number; txt: string }[];
     handler: (params: { lineNum: number; txt: string }) => void;
     state: number;
     curLine: number;


### PR DESCRIPTION
The inner type should be { lineNum: number; txt: string }[] instead of js.Array[String]

Please fill in this template.
- tested locally with the type.

If changing an existing definition:
- https://github.com/ustbhuangyi/lyric-parser/blob/master/src/index.js#L51-L54

