### PR TITLE
fix: nullable value for node-pdftk output method

### DIFF
--- a/types/node-pdftk/index.d.ts
+++ b/types/node-pdftk/index.d.ts
@@ -54,7 +54,7 @@ export class PDFTK {
      * Run the command.
      */
     output(writeFile: string, outputDest: string, needsOutput?: boolean): Promise<string>;
-    output(writeFile: string): Promise<Buffer>;
+    output(writeFile?: string): Promise<Buffer>;
     /**
      * Assembles ("concatenate") pages from input PDFs to create a new PDF.
      * @see {@link https://www.pdflabs.com/docs/pdftk-man-page/#dest-op-cat}

--- a/types/node-pdftk/node-pdftk-tests.ts
+++ b/types/node-pdftk/node-pdftk-tests.ts
@@ -13,5 +13,7 @@ pdftk.allow(['FillIn']).attachFiles(['./file1.pdf', './file2.pdf']); // $ExpectT
 
 pdftk.allow(['FillIn']).compress().output('./fileoutput.pdf'); // $ExpectType Promise<Buffer>
 pdftk.allow(['FillIn']).compress().output('./fileoutput.pdf', './destination/folder'); // $ExpectType Promise<string>
+pdftk.allow(['FillIn']).compress().output(); // $ExpectType Promise<Buffer>
+
 PDFTK.input('file').flatten().ignoreWarnings().inputPw('password').burst('page_%02d.pdf'); // $ExpectType Promise<string>
 PDFTK.input('file').flatten().ignoreWarnings().inputPw('password').burst(); // $ExpectType Promise<Buffer>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jjwilly16/node-pdftk#readme
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~

