### PR TITLE
Series Gauge missing field data

### DIFF
--- a/types/echarts/options/series/gauge.d.ts
+++ b/types/echarts/options/series/gauge.d.ts
@@ -88,6 +88,26 @@ declare namespace echarts {
              */
             clockwise?: boolean;
 
+
+            /** 
+             * Data array of series, which can be a single data value.
+             * 
+             * [see doc](https://echarts.apache.org/en/option.html#series-gauge.data)
+             * 
+             * Or, if need extra dimensions for components like [visualMap](https://echarts.apache.org/en/option.html#visualMap) 
+             * to map to graphic attributes like color, it can also be in the form of array.
+             * 
+             * In this case, we can assigin the second value in each arrary item to [visualMap](https://echarts.apache.org/en/option.html#visualMap) component.
+             * More likely, we need to assign name to each data item, in which case each item should be an object:
+             * 
+             * 
+             * @see https://echarts.apache.org/en/option.html#series-gauge.data
+             */
+            data?: (
+                (void | string | number | SeriesGauge.DataObject)[]
+                | (void | string | number | SeriesGauge.DataObject)[][]
+            );
+
             /**
              * The minimum data value which map to
              * [minAngle](https://echarts.apache.org/en/option.html#series-gauge.minAngle)
@@ -14299,6 +14319,26 @@ declare namespace echarts {
                  */
                 extraCssText?: string;
             };
+        }
+
+        namespace SeriesGauge {
+            interface DataObject {
+                /**
+                 * The name of data item.
+                 *
+                 *
+                 * @see https://echarts.apache.org/en/option.html#series-gauge.data.name
+                 */
+                name?: string;
+
+                /**
+                 * The value of a single data item.
+                 *
+                 *
+                 * @see https://echarts.apache.org/en/option.html#series-gauge.data.value
+                 */
+                value?: number;
+            }
         }
     }
 }

--- a/types/echarts/options/series/gauge.d.ts
+++ b/types/echarts/options/series/gauge.d.ts
@@ -88,19 +88,18 @@ declare namespace echarts {
              */
             clockwise?: boolean;
 
-
-            /** 
+            /**
              * Data array of series, which can be a single data value.
-             * 
+             *
              * [see doc](https://echarts.apache.org/en/option.html#series-gauge.data)
-             * 
-             * Or, if need extra dimensions for components like [visualMap](https://echarts.apache.org/en/option.html#visualMap) 
+             *
+             * Or, if need extra dimensions for components like [visualMap](https://echarts.apache.org/en/option.html#visualMap)
              * to map to graphic attributes like color, it can also be in the form of array.
-             * 
+             *
              * In this case, we can assigin the second value in each arrary item to [visualMap](https://echarts.apache.org/en/option.html#visualMap) component.
              * More likely, we need to assign name to each data item, in which case each item should be an object:
-             * 
-             * 
+             *
+             *
              * @see https://echarts.apache.org/en/option.html#series-gauge.data
              */
             data?: (


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [series-gauge.data](https://echarts.apache.org/en/option.html#series-gauge.data)


If removing a declaration:



The PR follows the issue I have opened in the echarts repo:

[issue-echarts-series-gauge](https://github.com/apache/incubator-echarts/issues/12282)

I don't add the label and itemStyle part to the DataObject because they are not covered in the documentation. (They are present instead in the example)
