### PR TITLE
fix(sparql-http-client): the endpointUrl is optional

### DIFF
--- a/types/sparql-http-client/Endpoint.d.ts
+++ b/types/sparql-http-client/Endpoint.d.ts
@@ -1,13 +1,24 @@
+interface CommonEndpointOptions {
+    fetch?: typeof fetch;
+    headers?: HeadersInit;
+    password?: string;
+    user?: string;
+}
+
+interface QueryEndpoint {
+    endpointUrl: string;
+}
+
+interface UpdateEndpoint {
+    updateUrl: string;
+}
+
+interface StoreEndpoint {
+    storeUrl: string;
+}
+
 declare namespace Endpoint {
-    interface EndpointOptions {
-        endpointUrl: string;
-        fetch?: typeof fetch;
-        headers?: HeadersInit;
-        password?: string;
-        storeUrl?: string;
-        updateUrl?: string;
-        user?: string;
-    }
+    type EndpointOptions = CommonEndpointOptions & (QueryEndpoint | UpdateEndpoint | StoreEndpoint);
 
     interface RequestOptions {
         headers?: HeadersInit;

--- a/types/sparql-http-client/sparql-http-client-tests.ts
+++ b/types/sparql-http-client/sparql-http-client-tests.ts
@@ -37,6 +37,12 @@ async function streamingClient() {
     const minimalOptions: StreamClient = new StreamClient({
         endpointUrl,
     });
+    const storeOnly: StreamClient = new StreamClient({
+        storeUrl: endpointUrl,
+    });
+    const updateOnly: StreamClient = new StreamClient({
+        updateUrl: endpointUrl,
+    });
     const fullOptions: StreamClient<TestQuad> = new StreamClient({
         endpointUrl,
         factory,
@@ -93,6 +99,12 @@ async function parsingClient() {
     // construct
     const minimalOptions: ParsingClient = new ParsingClient({
         endpointUrl,
+    });
+    const storeOnly: ParsingClient = new ParsingClient({
+        storeUrl: endpointUrl,
+    });
+    const updateOnly: ParsingClient = new ParsingClient({
+        updateUrl: endpointUrl,
     });
     const fullOptions: ParsingClient<TestQuad> = new ParsingClient({
         endpointUrl,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
