### PR TITLE
feat: added colormap definitions

### DIFF
--- a/types/colormap/colormap-tests.ts
+++ b/types/colormap/colormap-tests.ts
@@ -1,0 +1,8 @@
+import * as colormap from 'colormap';
+
+colormap(); // $ExpectType string[]
+colormap({}); // $ExpectType string[]
+colormap({ format: 'hex' }); // $ExpectType string[]
+colormap({ format: 'rgbaString' }); // $ExpectType string[]
+colormap({ format: 'rba' }); // $ExpectType [number, number, number, number]
+colormap({ format: 'float' }); // $ExpectType [number, number, number, number]

--- a/types/colormap/index.d.ts
+++ b/types/colormap/index.d.ts
@@ -1,0 +1,79 @@
+// Type definitions for colormap 2.3
+// Project: https://github.com/bpostlethwaite/colormap#readme
+// Definitions by: Will Worrall <https://github.com/wworrall>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = Colormap;
+
+declare function Colormap<U extends Colormap.Spec | undefined>(
+    spec?: U,
+): U extends { format?: 'hex' | 'rgbaString' } | undefined
+    ? string[]
+    : U extends { format: 'rba' | 'float' }
+    ? [number, number, number, number]
+    : never;
+
+declare namespace Colormap {
+    interface Spec {
+        colormap?: ColormapName;
+        nshades?: number;
+        format?: ColormapFormat;
+        alpha?: number | [number, number];
+    }
+
+    type ColormapFormat = 'hex' | 'rgbaString' | 'rba' | 'float';
+
+    type ColormapName =
+        | 'jet'
+        | 'hsv'
+        | 'hot'
+        | 'cool'
+        | 'spring'
+        | 'summer'
+        | 'autumn'
+        | 'winter'
+        | 'bone'
+        | 'copper'
+        | 'greys'
+        | 'YlGnBu'
+        | 'greens'
+        | 'YlOrRd'
+        | 'bluered'
+        | 'RdBu'
+        | 'picnic'
+        | 'rainbow'
+        | 'portland'
+        | 'blackbody'
+        | 'earth'
+        | 'electric'
+        | 'viridis'
+        | 'inferno'
+        | 'magma'
+        | 'plasma'
+        | 'warm'
+        | 'cool'
+        | 'rainbow-soft'
+        | 'bathymetry'
+        | 'cdom'
+        | 'chlorophyll'
+        | 'density'
+        | 'freesurface-blue'
+        | 'freesurface-red'
+        | 'oxygen'
+        | 'par'
+        | 'phase'
+        | 'salinity'
+        | 'temperature'
+        | 'turbidity'
+        | 'velocity-blue'
+        | 'velocity-green'
+        | 'cubehelix'
+        | 'jet with transparency'
+        | 'hsv with transparency'
+        | 'hot with transparency'
+        | 'cool with transparency'
+        | 'spring with transparency'
+        | 'summer with transparency';
+
+    type Colors = string[] | [number, number, number, number];
+}

--- a/types/colormap/tsconfig.json
+++ b/types/colormap/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "colormap-tests.ts"
+    ]
+}

--- a/types/colormap/tslint.json
+++ b/types/colormap/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.