### PR TITLE
[twilio-video] fix support for VP8 simulcast

### DIFF
--- a/types/twilio-video/index.d.ts
+++ b/types/twilio-video/index.d.ts
@@ -523,7 +523,7 @@ export interface ConnectOptions {
     networkQuality?: boolean | NetworkQualityConfiguration;
     region?: 'au1' | 'br1' | 'ie1' | 'de1' | 'jp1' | 'sg1' | 'us1' | 'us2' | 'gll';
     preferredAudioCodecs?: AudioCodec[];
-    preferredVideoCodecs?: VideoCodec[] | VideoCodecSettings[];
+    preferredVideoCodecs?: Array<VideoCodec | VideoCodecSettings | VP8CodecSettings>;
     logLevel?: LogLevel | LogLevels;
     tracks?: LocalTrack[] | MediaStreamTrack[];
     video?: boolean | CreateLocalTrackOptions;
@@ -595,7 +595,7 @@ export interface VideoCodecSettings {
     codec: VideoCodec;
 }
 export type VideoTrackPublication = LocalVideoTrackPublication | RemoteVideoTrackPublication;
-export interface VP8CodecSettings {
-    name: VideoCodec;
+export interface VP8CodecSettings extends VideoCodecSettings {
+    codec: 'VP8';
     simulcast?: boolean;
 }

--- a/types/twilio-video/twilio-video-tests.ts
+++ b/types/twilio-video/twilio-video-tests.ts
@@ -27,7 +27,8 @@ async function initRoom() {
           }
         }
       }
-    }
+    },
+    preferredVideoCodecs: ['VP9', { codec: 'H264' }, { codec: 'VP8', simulcast: true }]
   });
   await Video.connect('$TOKEN', {
     networkQuality: {


### PR DESCRIPTION
The VP8 simulcast isn't currently settable, this fixes it in line with how the twilio video library processes the preferred video codecs. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/twilio/twilio-video.js/blob/bc100301a7e29a2afb36c32cbe41e9321edfb9f1/lib/connect.js#L700
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
