### PR TITLE
create new definitions for chai-html

### DIFF
--- a/types/chai-html/chai-html-tests.ts
+++ b/types/chai-html/chai-html-tests.ts
@@ -1,0 +1,11 @@
+// tests taken from https://www.npmjs.com/package/chai-html
+
+import { use, expect } from 'chai';
+import * as chaiHtml from 'chai-html';
+
+use(chaiHtml);
+
+expect('<div><img /></div>').html.to.equal('<div><img></div>');
+expect('<h1>Hello World!</h1>').html.to.not.equal('<h1>Hallo Welt!</h1>');
+
+expect('<div><!--Comment--></div>').html.ignoringComments.to.equal('<div></div>');

--- a/types/chai-html/index.d.ts
+++ b/types/chai-html/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for chai-html 1.3
+// Project: https://github.com/i-like-robots/chai-html
+// Definitions by: Alex <https://github.com/adjerbetian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+/// <reference types="chai" />
+
+declare global {
+    namespace Chai {
+        interface Assertion {
+            html: ChaiHtml.HtmlAssertion;
+        }
+    }
+}
+
+declare namespace ChaiHtml {
+    interface HtmlAssertion extends Chai.Assertion {
+        ignoringComments: Chai.Assertion;
+    }
+}
+
+declare const chaiHtml: Chai.ChaiPlugin;
+declare namespace chaiHtml {}
+export = chaiHtml;

--- a/types/chai-html/tsconfig.json
+++ b/types/chai-html/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "chai-html-tests.ts"
+    ]
+}

--- a/types/chai-html/tslint.json
+++ b/types/chai-html/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
