### PR TITLE
Add types for start-server-webpack-plugin

### DIFF
--- a/types/start-server-webpack-plugin/index.d.ts
+++ b/types/start-server-webpack-plugin/index.d.ts
@@ -1,0 +1,53 @@
+// Type definitions for start-server-webpack-plugin 2.2
+// Project: https://github.com/ericclemmons/start-server-webpack-plugin
+// Definitions by: AGenson <https://github.com/AGenson>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Typescript Version: 3.8
+
+import { Plugin, Compiler } from 'webpack'
+
+export = StartServerWebpackPlugin;
+
+declare class StartServerWebpackPlugin extends Plugin {
+    /**
+     * @param name - Name of the server to start (built asset from webpack).
+     */
+    constructor(name: string);
+
+    /**
+     * @param options - Plugin options (StartServerWebpackPlugin.Options)
+     */
+    constructor(options?: StartServerWebpackPlugin.Options);
+
+    apply(compiler: Compiler): void;
+}
+
+declare namespace StartServerWebpackPlugin {
+    interface Options {
+        /**
+         * Name of the server to start (built asset from webpack).
+         * If not provided, the plugin will tell you the available names.
+         */
+        name?: string;
+        /**
+         * Arguments for node.
+         * Default: `[]`.
+         */
+        nodeArgs?: string[];
+        /**
+         * Arguments for the script.
+         * Default: `[]`.
+         */
+        args?: string[];
+        /**
+         * Signal to send for HMR.
+         * Default: 'false'.
+         */
+        signal?: boolean;
+        /**
+         * Allow typing 'rs' to restart the server.
+         * Default: 'true' if in 'development' mode, 'false' otherwise.
+         */
+        keyboard?: boolean;
+    }
+}

--- a/types/start-server-webpack-plugin/index.d.ts
+++ b/types/start-server-webpack-plugin/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/ericclemmons/start-server-webpack-plugin
 // Definitions by: AGenson <https://github.com/AGenson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Typescript Version: 3.8
 
 import { Plugin, Compiler } from 'webpack';
 

--- a/types/start-server-webpack-plugin/index.d.ts
+++ b/types/start-server-webpack-plugin/index.d.ts
@@ -12,7 +12,7 @@ declare class StartServerWebpackPlugin extends Plugin {
     /**
      * @param name - Name of the server to start (built asset from webpack).
      */
-    constructor(name: string);
+    constructor(name?: string);
 
     /**
      * @param options - Plugin options (StartServerWebpackPlugin.Options)

--- a/types/start-server-webpack-plugin/index.d.ts
+++ b/types/start-server-webpack-plugin/index.d.ts
@@ -8,15 +8,7 @@ import { Plugin, Compiler } from 'webpack';
 export = StartServerWebpackPlugin;
 
 declare class StartServerWebpackPlugin extends Plugin {
-    /**
-     * @param name - Name of the server to start (built asset from webpack).
-     */
-    constructor(name?: string);
-
-    /**
-     * @param options - Plugin options (StartServerWebpackPlugin.Options)
-     */
-    constructor(options?: StartServerWebpackPlugin.Options);
+    constructor(options?: string | StartServerWebpackPlugin.Options);
 }
 
 declare namespace StartServerWebpackPlugin {

--- a/types/start-server-webpack-plugin/index.d.ts
+++ b/types/start-server-webpack-plugin/index.d.ts
@@ -43,7 +43,7 @@ declare namespace StartServerWebpackPlugin {
          * Signal to send for HMR.
          * Default: 'false'.
          */
-        signal?: boolean;
+        signal?: false | true | 'SIGUSR2';
         /**
          * Allow typing 'rs' to restart the server.
          * Default: 'true' if in 'development' mode, 'false' otherwise.

--- a/types/start-server-webpack-plugin/index.d.ts
+++ b/types/start-server-webpack-plugin/index.d.ts
@@ -18,8 +18,6 @@ declare class StartServerWebpackPlugin extends Plugin {
      * @param options - Plugin options (StartServerWebpackPlugin.Options)
      */
     constructor(options?: StartServerWebpackPlugin.Options);
-
-    apply(compiler: Compiler): void;
 }
 
 declare namespace StartServerWebpackPlugin {

--- a/types/start-server-webpack-plugin/index.d.ts
+++ b/types/start-server-webpack-plugin/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Typescript Version: 3.8
 
-import { Plugin, Compiler } from 'webpack'
+import { Plugin, Compiler } from 'webpack';
 
 export = StartServerWebpackPlugin;
 

--- a/types/start-server-webpack-plugin/start-server-webpack-plugin-tests.ts
+++ b/types/start-server-webpack-plugin/start-server-webpack-plugin-tests.ts
@@ -1,11 +1,11 @@
-import { Configuration } from 'webpack'
-import StartServerWebpackPlugin = require('start-server-webpack-plugin')
+import { Configuration } from 'webpack';
+import StartServerWebpackPlugin = require('start-server-webpack-plugin');
 
 const c1: Configuration = {
     plugins: [
         new StartServerWebpackPlugin('main.js')
     ]
-}
+};
 
 const c2: Configuration = {
     plugins: [
@@ -17,4 +17,4 @@ const c2: Configuration = {
             keyboard: false
         })
     ]
-}
+};

--- a/types/start-server-webpack-plugin/start-server-webpack-plugin-tests.ts
+++ b/types/start-server-webpack-plugin/start-server-webpack-plugin-tests.ts
@@ -1,0 +1,20 @@
+import { Configuration } from 'webpack'
+import StartServerWebpackPlugin = require('start-server-webpack-plugin')
+
+const c1: Configuration = {
+    plugins: [
+        new StartServerWebpackPlugin('main.js')
+    ]
+}
+
+const c2: Configuration = {
+    plugins: [
+        new StartServerWebpackPlugin({
+            name: 'main.js',
+            nodeArgs: [],
+            args: [],
+            signal: false,
+            keyboard: false
+        })
+    ]
+}

--- a/types/start-server-webpack-plugin/tsconfig.json
+++ b/types/start-server-webpack-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "start-server-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/start-server-webpack-plugin/tslint.json
+++ b/types/start-server-webpack-plugin/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "semicolon": false,
+        "no-padding": false
+    }
+}

--- a/types/start-server-webpack-plugin/tslint.json
+++ b/types/start-server-webpack-plugin/tslint.json
@@ -1,7 +1,1 @@
-{
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "semicolon": false,
-        "no-padding": false
-    }
-}
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
