### PR TITLE
[mongoose] add generic type for SchemaDefinition

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -751,10 +751,10 @@ declare module "mongoose" {
      * the child schema first before passing it into its parent.
      * @event init Emitted after the schema is compiled into a Model.
      */
-    constructor(definition?: SchemaDefinition, options?: SchemaOptions);
+    constructor(definition?: SchemaDefinition<T>, options?: SchemaOptions);
 
     /** Adds key path / schema type pairs to this schema. */
-    add(obj: SchemaDefinition, prefix?: string): void;
+    add(obj: SchemaDefinition<T>, prefix?: string): void;
 
     /** Return a deep copy of this schema */
     clone(): Schema;
@@ -1102,8 +1102,9 @@ declare module "mongoose" {
   /*
    * Intellisense for Schema definitions
    */
-  interface SchemaDefinition {
-    [path: string]: SchemaTypeOpts<any> | Schema | SchemaType;
+
+  type SchemaDefinition<T> = {
+    [key in keyof T]: SchemaTypeOpts<any> | Schema | SchemaType;
   }
 
   /*

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -545,7 +545,9 @@ mongoose.Schema.reserved.hasOwnProperty('');
 schema.addListener('e', cb);
 /* practical examples */
 interface Animal {
-  findSimilarTypes(cb: any): Promise<Animal>
+  findSimilarTypes?(cb: any): Promise<Animal>;
+  name: string;
+  type: string;
 }
 var animalSchema = new mongoose.Schema<Animal>({
   name: String,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
Improve interface and schema consistency and better completion
e.g
```javascript
import { Schema } from 'mongoose';

interface User {
  email: string;
  name?: string;
  birthday?: string;
  phone?: string;
}

export const UserSchema = new Schema<User>({

});
```
![Screenshot 2020-04-07 at 06 10 18](https://user-images.githubusercontent.com/6708097/78626137-87621100-7896-11ea-8be3-339a636d92cb.png)
![Screenshot 2020-04-07 at 06 09 46](https://user-images.githubusercontent.com/6708097/78626139-8a5d0180-7896-11ea-9a8d-04531b13fccb.png)

 


