### PR TITLE
Added requestId member on all CloudFrontEvent types

### DIFF
--- a/types/aws-lambda/common/cloudfront.d.ts
+++ b/types/aws-lambda/common/cloudfront.d.ts
@@ -60,7 +60,7 @@ export interface CloudFrontEvent {
     config: {
         readonly distributionDomainName: string;
         readonly distributionId: string;
-        readonly eventType: 'origin-request' | 'origin-response'|'viewer-request' | 'viewer-response';
+        readonly eventType: 'origin-request' | 'origin-response' | 'viewer-request' | 'viewer-response';
         readonly requestId: string;
     };
 }

--- a/types/aws-lambda/common/cloudfront.d.ts
+++ b/types/aws-lambda/common/cloudfront.d.ts
@@ -60,9 +60,9 @@ export interface CloudFrontEvent {
     config: {
         readonly distributionDomainName: string;
         readonly distributionId: string;
-    } & (
-        | { readonly eventType: 'origin-request' | 'origin-response' }
-        | { readonly eventType: 'viewer-request' | 'viewer-response'; readonly requestId: string });
+        readonly eventType: 'origin-request' | 'origin-response'|'viewer-request' | 'viewer-response';
+        readonly requestId: string;
+    };
 }
 
 /**

--- a/types/aws-lambda/test/cloudfront-tests.ts
+++ b/types/aws-lambda/test/cloudfront-tests.ts
@@ -344,7 +344,6 @@ const originRequestEvent: CloudFrontRequestEvent = {
     ]
 };
 
-
 const originResponseEvent: CloudFrontResponseEvent = {
     Records: [
         {

--- a/types/aws-lambda/test/cloudfront-tests.ts
+++ b/types/aws-lambda/test/cloudfront-tests.ts
@@ -277,3 +277,202 @@ const responseEvent: CloudFrontResponseEvent = {
         },
     ],
 };
+
+const originRequestEvent: CloudFrontRequestEvent = {
+    Records: [
+        {
+            cf: {
+                config: {
+                    distributionDomainName: "d111111abcdef8.cloudfront.net",
+                    distributionId: "EDFDVBD6EXAMPLE",
+                    eventType: "origin-request",
+                    requestId: "4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ=="
+                },
+                request: {
+                    clientIp: "203.0.113.178",
+                    headers: {
+                        "x-forwarded-for": [
+                            {
+                                key: "X-Forwarded-For",
+                                value: "203.0.113.178"
+                            }
+                        ],
+                        "user-agent": [
+                            {
+                                key: "User-Agent",
+                                value: "Amazon CloudFront"
+                            }
+                        ],
+                        via: [
+                            {
+                                key: "Via",
+                                value:
+                                    "2.0 2afae0d44e2540f472c0635ab62c232b.cloudfront.net (CloudFront)"
+                            }
+                        ],
+                        host: [
+                            {
+                                key: "Host",
+                                value: "example.org"
+                            }
+                        ],
+                        "cache-control": [
+                            {
+                                key: "Cache-Control",
+                                value: "no-cache, cf-no-cache"
+                            }
+                        ]
+                    },
+                    method: "GET",
+                    origin: {
+                        custom: {
+                            customHeaders: {},
+                            domainName: "example.org",
+                            keepaliveTimeout: 5,
+                            path: "",
+                            port: 443,
+                            protocol: "https",
+                            readTimeout: 30,
+                            sslProtocols: ["TLSv1", "TLSv1.1", "TLSv1.2"]
+                        }
+                    },
+                    querystring: "",
+                    uri: "/"
+                }
+            }
+        }
+    ]
+};
+
+
+const originResponseEvent: CloudFrontResponseEvent = {
+    Records: [
+        {
+            cf: {
+                config: {
+                    distributionDomainName: "d111111abcdef8.cloudfront.net",
+                    distributionId: "EDFDVBD6EXAMPLE",
+                    eventType: "origin-response",
+                    requestId: "4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ=="
+                },
+                request: {
+                    clientIp: "203.0.113.178",
+                    headers: {
+                        "x-forwarded-for": [
+                            {
+                                key: "X-Forwarded-For",
+                                value: "203.0.113.178"
+                            }
+                        ],
+                        "user-agent": [
+                            {
+                                key: "User-Agent",
+                                value: "Amazon CloudFront"
+                            }
+                        ],
+                        via: [
+                            {
+                                key: "Via",
+                                value:
+                                    "2.0 8f22423015641505b8c857a37450d6c0.cloudfront.net (CloudFront)"
+                            }
+                        ],
+                        host: [
+                            {
+                                key: "Host",
+                                value: "example.org"
+                            }
+                        ],
+                        "cache-control": [
+                            {
+                                key: "Cache-Control",
+                                value: "no-cache, cf-no-cache"
+                            }
+                        ]
+                    },
+                    method: "GET",
+                    origin: {
+                        custom: {
+                            customHeaders: {},
+                            domainName: "example.org",
+                            keepaliveTimeout: 5,
+                            path: "",
+                            port: 443,
+                            protocol: "https",
+                            readTimeout: 30,
+                            sslProtocols: ["TLSv1", "TLSv1.1", "TLSv1.2"]
+                        }
+                    },
+                    querystring: "",
+                    uri: "/"
+                },
+                response: {
+                    headers: {
+                        "access-control-allow-credentials": [
+                            {
+                                key: "Access-Control-Allow-Credentials",
+                                value: "true"
+                            }
+                        ],
+                        "access-control-allow-origin": [
+                            {
+                                key: "Access-Control-Allow-Origin",
+                                value: "*"
+                            }
+                        ],
+                        date: [
+                            {
+                                key: "Date",
+                                value: "Mon, 13 Jan 2020 20:12:38 GMT"
+                            }
+                        ],
+                        "referrer-policy": [
+                            {
+                                key: "Referrer-Policy",
+                                value: "no-referrer-when-downgrade"
+                            }
+                        ],
+                        server: [
+                            {
+                                key: "Server",
+                                value: "ExampleCustomOriginServer"
+                            }
+                        ],
+                        "x-content-type-options": [
+                            {
+                                key: "X-Content-Type-Options",
+                                value: "nosniff"
+                            }
+                        ],
+                        "x-frame-options": [
+                            {
+                                key: "X-Frame-Options",
+                                value: "DENY"
+                            }
+                        ],
+                        "x-xss-protection": [
+                            {
+                                key: "X-XSS-Protection",
+                                value: "1; mode=block"
+                            }
+                        ],
+                        "content-type": [
+                            {
+                                key: "Content-Type",
+                                value: "text/html; charset=utf-8"
+                            }
+                        ],
+                        "content-length": [
+                            {
+                                key: "Content-Length",
+                                value: "9593"
+                            }
+                        ]
+                    },
+                    status: "200",
+                    statusDescription: "OK"
+                }
+            }
+        }
+    ]
+};


### PR DESCRIPTION
The requestId member is defined on all origin/viewer requests/responses, it is described here : https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html
There is one example for each request/response and they all have a cf.config.requestId.
Added new requests examples in tests in order to have all 4 types availabl

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
