### PR TITLE
[gunzip-maybe] Creation of Types 

### DIFF
--- a/types/gunzip-maybe/gunzip-maybe-tests.ts
+++ b/types/gunzip-maybe/gunzip-maybe-tests.ts
@@ -1,4 +1,4 @@
-import gunzip from "gunzip-maybe"
-import * as fs from "fs"
+import gunzip from "gunzip-maybe";
+import * as fs from "fs";
 
-fs.createReadStream("file.gz").pipe(gunzip()).pipe(fs.createWriteStream("file"))
+fs.createReadStream("file.gz").pipe(gunzip()).pipe(fs.createWriteStream("file"));

--- a/types/gunzip-maybe/gunzip-maybe-tests.ts
+++ b/types/gunzip-maybe/gunzip-maybe-tests.ts
@@ -1,0 +1,4 @@
+import gunzip from "gunzip-maybe"
+import * as fs from "fs"
+
+fs.createReadStream("file.gz").pipe(gunzip()).pipe(fs.createWriteStream("file"))

--- a/types/gunzip-maybe/index.d.ts
+++ b/types/gunzip-maybe/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for gunzip-maybe 1.4
+// Project: https://github.com/mafintosh/gunzip-maybe
+// Definitions by: Thomas Hobson <https://github.com/hexf>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import * as stream from "stream"
+
+declare function gunzip(maxRecursion?: number): stream.Transform
+
+export = gunzip
+

--- a/types/gunzip-maybe/index.d.ts
+++ b/types/gunzip-maybe/index.d.ts
@@ -5,9 +5,8 @@
 
 /// <reference types="node" />
 
-import * as stream from "stream"
+import * as stream from "stream";
 
-declare function gunzip(maxRecursion?: number): stream.Transform
+declare function gunzip(maxRecursion?: number): stream.Transform;
 
-export = gunzip
-
+export = gunzip;

--- a/types/gunzip-maybe/tsconfig.json
+++ b/types/gunzip-maybe/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "gunzip-maybe-tests.ts"
+    ]
+}

--- a/types/gunzip-maybe/tslint.json
+++ b/types/gunzip-maybe/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
