### PR TITLE
[carbon-components-react] getExpandHeaderProps, make few fields optional as they are in reality

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -180,6 +180,7 @@ const t4 = (
         }}
     />
 );
+
 // RenderProps are compatible with sub-elements
 interface T5RowType extends DataTableRow {
     col1: number;
@@ -202,6 +203,7 @@ const t5 = (
                 <DataTable.Table {...renderProps.getTableProps()}>
                     <DataTable.TableHead>
                         <DataTable.TableRow>
+                            <DataTable.TableExpandHeader {...renderProps.getExpandHeaderProps()} />
                             <DataTable.TableSelectAll
                                 {...renderProps.getSelectionProps()}
                             />

--- a/types/carbon-components-react/lib/components/DataTable/DataTable.d.ts
+++ b/types/carbon-components-react/lib/components/DataTable/DataTable.d.ts
@@ -56,9 +56,9 @@ export interface DataTableCustomRowData<R extends DataTableRow = DataTableRow> {
 
 export interface DataTableCustomRowProps<R extends DataTableRow = DataTableRow> {
     ariaLabel?: string,
-    disabled: R["disabled"],
-    isExpanded: R["isExpanded"],
-    isSelected: R["isSelected"],
+    disabled?: R["disabled"],
+    isExpanded?: R["isExpanded"],
+    isSelected?: R["isSelected"],
     key: R["id"],
     onExpand(event: React.MouseEvent<HTMLElement>): void,
 }

--- a/types/carbon-components-react/lib/components/DataTable/DataTable.d.ts
+++ b/types/carbon-components-react/lib/components/DataTable/DataTable.d.ts
@@ -102,6 +102,12 @@ export interface DataTableCustomHeaderProps<H extends { key: string } = DataTabl
     sortDirection: DataTableSortState;
 }
 
+export interface DataTableExpandHeaderData {
+    ariaLabel?: string;
+    isExpanded?: boolean;
+    onExpand?(event: React.MouseEvent<HTMLElement>): void;
+  }
+
 // endregion Header Types
 
 // region Cell Types
@@ -146,6 +152,9 @@ export interface DataTableCustomRenderProps<
     getHeaderProps<E extends object = ReactAttr>(
         data: ShapeOf<DataTableCustomHeaderData<H>, E>
     ): ShapeOf<DataTableCustomHeaderProps<H>, E>;
+    getExpandHeaderProps<E extends object = ReactAttr<HTMLTableHeaderCellElement>>(
+        data?: ShapeOf<DataTableExpandHeaderData, E>,
+      ): ShapeOf<DataTableExpandHeaderData, E>;
     getRowProps<E extends object = ReactAttr<HTMLTableRowElement>>(
         data: ShapeOf<DataTableCustomRowData<R>, E>
     ): ShapeOf<DataTableCustomRowProps<R>, E>;

--- a/types/carbon-components-react/lib/components/DataTable/TableExpandRow.d.ts
+++ b/types/carbon-components-react/lib/components/DataTable/TableExpandRow.d.ts
@@ -8,7 +8,7 @@ interface InheritedProps extends ReactAttr<HTMLTableRowElement> {
 export interface TableExpandRowProps extends InheritedProps {
     expandHeader?: string,
     expandIconDescription?: string,
-    isExpanded: boolean,
+    isExpanded?: boolean,
     onExpand(event: React.MouseEvent<HTMLButtonElement>): void,
 }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/pull/5682/files
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

About the last one. My changes do bring some of the definitions up to date, but I also know that there are missing few exports of the components. I am not able at this moment to track all changes. My changes are backward compatible.