### PR TITLE
created types for @rdfjs/express-handler

### DIFF
--- a/types/rdfjs__express-handler/index.d.ts
+++ b/types/rdfjs__express-handler/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for @rdfjs/express-handler 1.0
+// Project: https://github.com/rdfjs-base/express-handler
+// Definitions by: tpluscode <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Stream, DatasetCore, DatasetCoreFactory } from 'rdf-js';
+import { Request, Response, RequestHandler } from 'express';
+import formats = require('@rdfjs/formats-common');
+
+declare module 'express' {
+    interface Request {
+        dataset(parserOptions?: any): Promise<DatasetCore>;
+        quadStream(parserOptions?: any): Stream;
+    }
+
+    interface Response {
+        dataset(dataset: DatasetCore): Promise<void>;
+        quadStream(stream: Stream): Promise<void>;
+    }
+}
+
+interface RdfHandlerOptions {
+    factory?: DatasetCoreFactory;
+    formats?: typeof formats;
+    defaultMediaType?: string;
+}
+
+interface RdfHandler {
+    (options?: RdfHandlerOptions): RequestHandler;
+    attach(req: Request, res: Response): Promise<void>;
+}
+
+declare const middleware: RdfHandler;
+
+export = middleware;

--- a/types/rdfjs__express-handler/rdfjs__express-handler-tests.ts
+++ b/types/rdfjs__express-handler/rdfjs__express-handler-tests.ts
@@ -1,0 +1,42 @@
+import express = require('express');
+import { EventEmitter } from 'events';
+import { DatasetCore, DatasetCoreFactory, Stream } from 'rdf-js';
+import { SinkMap } from '@rdfjs/sink-map';
+import rdfHandler = require('@rdfjs/express-handler');
+
+const factory: DatasetCoreFactory = <any> {};
+const formats: {
+    parsers: SinkMap<EventEmitter, Stream>;
+    serializers: SinkMap<Stream, EventEmitter>;
+} = <any> {};
+
+const app = express();
+
+app.use(rdfHandler());
+app.use(rdfHandler({
+    factory,
+    formats,
+    defaultMediaType: 'text/turtle'
+}));
+
+async function streams(req: express.Request, res: express.Response) {
+    let stream: Stream = req.quadStream();
+    stream = req.quadStream({
+        baseIRI: 'foo'
+    });
+
+    await res.quadStream(stream);
+}
+
+async function datasets(req: express.Request, res: express.Response) {
+    let dataset: DatasetCore = await req.dataset();
+    dataset = await req.dataset({
+        baseIRI: 'foo'
+    });
+
+    await res.dataset(dataset);
+}
+
+async function attach(req: express.Request, res: express.Response) {
+    await rdfHandler.attach(req, res);
+}

--- a/types/rdfjs__express-handler/tsconfig.json
+++ b/types/rdfjs__express-handler/tsconfig.json
@@ -1,0 +1,34 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@rdfjs/express-handler": [
+                "rdfjs__express-handler"
+            ],
+            "@rdfjs/formats-common": [
+                "rdfjs__formats-common"
+            ],
+            "@rdfjs/sink-map": [
+                "rdfjs__sink-map"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "rdfjs__express-handler-tests.ts"
+    ]
+}

--- a/types/rdfjs__express-handler/tslint.json
+++ b/types/rdfjs__express-handler/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.