### PR TITLE
Fix return of messages callbacks on class Socket

### DIFF
--- a/types/phoenix/index.d.ts
+++ b/types/phoenix/index.d.ts
@@ -71,10 +71,10 @@ export class Socket {
   log(kind: string, message: string, data: any): void;
   hasLogger(): boolean;
 
-  onOpen(callback: () => void): void;
-  onClose(callback: () => void): void;
-  onError(callback: () => void): void;
-  onMessage(callback: () => void): void;
+  onOpen(callback: (cb: any) => void): void;
+  onClose(callback: (cb: any) => void): void;
+  onError(callback: (cb: any) => void): void;
+  onMessage(callback: (cb: any) => void): void;
 
   makeRef(): string;
 }


### PR DESCRIPTION
There are parameters in the callback returns:

onOpen(callback: () => void): void;
onClose(callback: () => void): void;
onError(callback: () => void): void;
onMessage(callback: () => void): void;