### PR TITLE
[iv-viewer] Add iv-viewer

### DIFF
--- a/types/iv-viewer/index.d.ts
+++ b/types/iv-viewer/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for iv-viewer 2.0
+// Project: https://github.com/s-yadav/iv-viewer#readme
+// Definitions by: Robert Wettstädt <https://github.com/robert-wettstaedt>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
+
+interface Options {
+    zoomValue?: number;
+    snapView?: boolean;
+    maxZoom?: number;
+    refreshOnResize?: boolean;
+    zoomOnMouseWheel?: boolean;
+}
+
+declare class ImageViewer {
+    constructor(element: Element | null, options?: Options);
+    destroy(): void;
+    hideSnapView(): void;
+    load(imageSrc: string, hiResImageSrc?: string): void;
+    refresh(): void;
+    resetZoom(animate?: boolean): void;
+    showSnapView(noTimeout?: boolean): void;
+    zoom(perc: number, point?: { x: number; y: number }): void;
+}
+
+declare namespace ImageViewer {
+    class FullScreenViewer extends ImageViewer {
+        constructor(options?: Options);
+        hide: () => void;
+        show: (imageSrc: string, hiResImageSrc?: string) => void;
+    }
+
+    export { ImageViewer, FullScreenViewer };
+}
+
+export = ImageViewer;

--- a/types/iv-viewer/iv-viewer-tests.ts
+++ b/types/iv-viewer/iv-viewer-tests.ts
@@ -1,0 +1,25 @@
+import ImageViewer, { FullScreenViewer, ImageViewer as NestedImageViewer } from 'iv-viewer';
+
+const iv = new ImageViewer(new Element());
+iv.destroy(); // $ExpectType void
+iv.destroy(); // $ExpectType void
+iv.hideSnapView(); // $ExpectType void
+iv.load(''); // $ExpectType void
+iv.refresh(); // $ExpectType void
+iv.resetZoom(); // $ExpectType void
+iv.showSnapView(); // $ExpectType void
+iv.zoom(0); // $ExpectType void
+
+new NestedImageViewer(new Element());
+
+const fsv = new FullScreenViewer();
+fsv.hide(); // $ExpectType void
+fsv.show(''); // $ExpectType void
+fsv.destroy(); // $ExpectType void
+fsv.destroy(); // $ExpectType void
+fsv.hideSnapView(); // $ExpectType void
+fsv.load(''); // $ExpectType void
+fsv.refresh(); // $ExpectType void
+fsv.resetZoom(); // $ExpectType void
+fsv.showSnapView(); // $ExpectType void
+fsv.zoom(0); // $ExpectType void

--- a/types/iv-viewer/tsconfig.json
+++ b/types/iv-viewer/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "iv-viewer-tests.ts"
+    ]
+}

--- a/types/iv-viewer/tslint.json
+++ b/types/iv-viewer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
