### PR TITLE
[react-table] More strict types for columns

### DIFF
--- a/types/react-table/Readme.md
+++ b/types/react-table/Readme.md
@@ -1,5 +1,15 @@
 # Types for react-table v7
 
+## Changelog
+
+This Changelog corresponds
+
+### 2020-04-09 (react-table 7.0.4)
+
+A number of breaking changes related to changing `Column<D>` from `interface` to `type` and making the columns types stricter overall. For more information and migration guide see [the Pull Request for these changes](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43714).
+
+## Configuration Using Declaration Merging
+
 These types depend upon declaration merging to work well.
 
 To get started, create a file `react-table-config.d.ts` using the example further down this readme, place it in your source tree (e.g. into a types folder). This expands the default types with all of the plugin extensions currently in the type definitions.

--- a/types/react-table/Readme.md
+++ b/types/react-table/Readme.md
@@ -2,7 +2,7 @@
 
 ## Changelog
 
-### 2020-04-09 (react-table 7.0.4)
+### 2020-04-09 (@types/react-table 7.0.14, react-table 7.0.4)
 
 A number of breaking changes related to changing `Column<D>` from `interface` to `type` and making the columns types stricter overall. For more information and migration guide see [the Pull Request for these changes](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43714).
 

--- a/types/react-table/Readme.md
+++ b/types/react-table/Readme.md
@@ -2,8 +2,6 @@
 
 ## Changelog
 
-This Changelog corresponds
-
 ### 2020-04-09 (react-table 7.0.4)
 
 A number of breaking changes related to changing `Column<D>` from `interface` to `type` and making the columns types stricter overall. For more information and migration guide see [the Pull Request for these changes](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43714).

--- a/types/react-table/Readme.md
+++ b/types/react-table/Readme.md
@@ -153,7 +153,7 @@ declare module 'react-table' {
       UseResizeColumnsColumnProps<D>,
       UseSortByColumnProps<D> {}
 
-  export interface Cell<D extends object = {}>
+  export interface Cell<D extends object = {}, V = any>
     extends UseGroupByCellProps<D>,
       UseRowStateCellProps<D> {}
 

--- a/types/react-table/Readme.md
+++ b/types/react-table/Readme.md
@@ -140,7 +140,7 @@ declare module 'react-table' {
       UseRowStateState<D>,
       UseSortByState<D> {}
 
-  export interface Column<D extends object = {}>
+  export interface ColumnInterface<D extends object = {}>
     extends UseFiltersColumnOptions<D>,
       UseGlobalFiltersColumnOptions<D>,
       UseGroupByColumnOptions<D>,

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -43,7 +43,7 @@ export interface TableOptions<D extends object> extends UseTableOptions<D> {}
 
 export interface TableInstance<D extends object = {}>
     extends Omit<TableOptions<D>, 'columns' | 'pageCount'>,
-        UseTableInstanceProps<D> {}
+    UseTableInstanceProps<D> {}
 
 export interface TableState<D extends object = {}> {
     hiddenColumns?: Array<IdType<D>>;
@@ -53,11 +53,30 @@ export interface Hooks<D extends object = {}> extends UseTableHooks<D> {}
 
 export interface Cell<D extends object = {}> extends UseTableCellProps<D> {}
 
-export interface Column<D extends object = {}> extends UseTableColumnOptions<D> {}
+export interface ColumnInterface<D extends object = {}> extends UseTableColumnOptions<D> {}
+
+export interface ColumnGroupInterface<D extends object> {
+    columns: Array<Column<D>>;
+}
+
+export type ColumnGroup<D extends object = {}> = ColumnInterface<D> &
+    ColumnGroupInterface<D> &
+    (
+        | { Header: string; }
+        | ({ id: IdType<D>; } & {
+            Header: Renderer<HeaderProps<D>>;
+        })
+    );
+
+export type Column<D extends object = {}> = ColumnInterface<D> &
+    (
+        | ({ accessor: IdType<D> } | { Header: string } | { id: IdType<D> })
+        | ColumnGroup<D>
+    );
 
 export interface ColumnInstance<D extends object = {}>
     extends Omit<Column<D>, 'id' | 'columns'>,
-        UseTableColumnProps<D> {}
+    UseTableColumnProps<D> {}
 
 export interface HeaderGroup<D extends object = {}> extends ColumnInstance<D>, UseTableHeaderGroupProps<D> {}
 
@@ -184,16 +203,15 @@ export interface UseTableHooks<D extends object> extends Record<string, any> {
     useFinalInstance: Array<(instance: TableInstance<D>) => void>;
 }
 
-export interface UseTableColumnOptions<D extends object>
-    extends Accessor<D>,
-        Partial<{
-            columns: Array<Column<D>>;
-            Header: Renderer<HeaderProps<D>>;
-            Cell: Renderer<CellProps<D>>;
-            width?: number | string;
-            minWidth?: number;
-            maxWidth?: number;
-        }> {}
+export interface UseTableColumnOptions<D extends object> {
+    id?: IdType<D>;
+    accessor?: Accessor<D>;
+    Header?: Renderer<HeaderProps<D>>;
+    Cell?: Renderer<CellProps<D>>;
+    width?: number | string;
+    minWidth?: number;
+    maxWidth?: number;
+}
 
 type UpdateHiddenColumns<D extends object> = (oldHidden: Array<IdType<D>>) => Array<IdType<D>>;
 
@@ -275,23 +293,18 @@ export type CellProps<D extends object> = TableInstance<D> & {
     column: ColumnInstance<D>;
     row: Row<D>;
     cell: Cell<D>;
+    value: CellValue;
 };
 
-// NOTE: At least one of (id | accessor | Header as string) required
-export interface Accessor<D extends object> {
-    accessor?:
-        | IdType<D>
-        | ((
-              originalRow: D,
-              index: number,
-              sub: {
-                  subRows: D[];
-                  depth: number;
-                  data: D[];
-              },
-          ) => CellValue);
-    id?: IdType<D>;
-}
+export type Accessor<D extends object> = IdType<D> | ((
+    originalRow: D,
+    index: number,
+    sub: {
+        subRows: D[];
+        depth: number;
+        data: D[];
+    },
+) => CellValue);
 
 //#endregion
 

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -63,37 +63,43 @@ export interface ColumnGroupInterface<D extends object> {
     columns: Array<Column<D>>;
 }
 
-export type ColumnGroup<D extends object = {}> = ColumnInterface<D> &
-    ColumnGroupInterface<D> &
-    (
+export type ColumnGroup<D extends object = {}> =
+    & ColumnInterface<D>
+    & ColumnGroupInterface<D>
+    & (
         | { Header: string; }
         | ({ id: IdType<D>; } & {
             Header: Renderer<HeaderProps<D>>;
         })
-    ) &
+    )
     // Not used, but needed for backwards compatibility
-    { accessor?: Accessor<D>; };
+    & { accessor?: Accessor<D>; };
 
 type ValueOf<T> = T[keyof T];
 
 // The accessors like `foo.bar` are not supported, use functions instead
-export type ColumnWithStrictAccessor<D extends object = {}> = ValueOf<{
-    [K in keyof D]: {
-        accessor: K;
-    } & ColumnInterfaceBasedOnValue<D, D[K]>;
-}>;
+export type ColumnWithStrictAccessor<D extends object = {}> =
+    & ColumnInterface<D>
+    & ValueOf<{
+        [K in keyof D]: {
+            accessor: K;
+        } & ColumnInterfaceBasedOnValue<D, D[K]>;
+    }>;
 
 export type ColumnWithLooseAccessor<D extends object = {}> =
-    ColumnInterfaceBasedOnValue<D> &
-    ({ Header: string } | { id: IdType<D> }) &
-    { accessor?: Accessor<D>; };
+    & ColumnInterface<D>
+    & ColumnInterfaceBasedOnValue<D>
+    & (
+        | { Header: string }
+        | { id: IdType<D> }
+        | { accessor: keyof D extends never ? IdType<D> : never }
+    )
+    & { accessor?: keyof D extends never ? IdType<D> | Accessor<D> : Accessor<D>; };
 
-export type Column<D extends object = {}> = ColumnInterface<D> &
-    (
-        | ColumnWithStrictAccessor<D>
-        | ColumnWithLooseAccessor<D>
-        | ColumnGroup<D>
-    );
+export type Column<D extends object = {}> =
+    | ColumnGroup<D>
+    | ColumnWithLooseAccessor<D>
+    | ColumnWithStrictAccessor<D>;
 
 export interface ColumnInstance<D extends object = {}>
     extends Omit<ColumnInterface<D>, 'id'>,

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -15,6 +15,8 @@
 // no-unnecessary-generics is disabled because many of these definitions are either used in a generic
 // context or the signatures are required to match for declaration merging
 
+// The changelog for the important changes is located in the Readme.md
+
 import {
     ComponentType,
     DependencyList,

--- a/types/react-table/react-table-tests.tsx
+++ b/types/react-table/react-table-tests.tsx
@@ -107,7 +107,7 @@ declare module 'react-table' {
             UseRowStateState<D>,
             UseSortByState<D> {}
 
-    interface Column<D extends object = {}>
+    interface ColumnInterface<D extends object = {}>
         extends UseFiltersColumnOptions<D>,
             UseGlobalFiltersColumnOptions<D>,
             UseGroupByColumnOptions<D>,


### PR DESCRIPTION
**There are some breaking changes**, but I feel like needed ones (it would be nice if this was like this from the start, but oh well). The changes are tested on our codebase, a number of changes was needed, but most of them were good, and some bugs and inconsistencies in types were found due to more strict typing, which is a nice win.

## Changes

before | after
-|-
![image](https://user-images.githubusercontent.com/177485/78716441-30544e80-791f-11ea-96a9-45a9abef9e32.png) | ![image](https://user-images.githubusercontent.com/177485/78716647-8d500480-791f-11ea-9f0d-fe276658a8d6.png)

- Adds a `value` to the `Cell` renderer, reflecting the change from `7.0.1` — https://github.com/tannerlinsley/react-table/pull/2073.
- Changes the `Column` from `interface` to `type`, see the below motivation for this.
- Makes the `Column` a union type, properly handling various combinations of `id`, `Header` and `accessor`.
- Attempts to properly type the `value` (and `cell: { value }`) of the `Cell` renderer in case the accessor is a string that corresponds with the key in Data.
- Adds some new useful interfaces that can be used in merge declarations to extend various types of columns like `ColumnInterfaceBasedOnValue` (would benefit from the string accessor-typed values), `ColumnGroupInterface` (could allow extending only groups) and some others.

## Migration / breaking changes

- If the `Column<D>` was extended in merge declarations. It must be replaced with `ColumnInterface<D>`. Example: 

    ```diff
    - interface Column<D extends object = {}>
    + interface ColumnInterface<D extends object = {}>
        extends UseFiltersColumnOptions<D>,
            UseGlobalFiltersColumnOptions<D>,
            UseGroupByColumnOptions<D>,
    ```

- “Getter”-style string accessors (or other string accessors not corresponding with the data keys) are prohibited. They must be replaced with functional accessors. Example:

    ```diff
    -     { Header: 'Name', accessor: 'attributes.title' },
    +     { Header: 'Name', accessor: ({ attributes: { title } }) => title },

    ```

    Alternatively, but not recommended, `@ts-ignore` can be used:

    ```diff
    +     // @ts-ignore
        { Header: 'Name', accessor: 'attributes.title' },
    ```

- `Cell` renderer now would have a proper type for `value` when the `accessor` is a string that corresponds with the data key, but otherwise its arguments would be implicitly `any`, leading to the need to type them properly. Example:

    ```diff
        accessor: row => row['http.status_code'],
    -     Cell: ({ cell: { value } }) => (value ? format(value) : null),
    +     Cell: ({ value }: { value?: string }) => (value ? format(value) : null),
    ```

     This would be true even not for the `value` property, but for anything, including the inner `row` and others). This is unfortunate, but is easily fixed by using the proper types from `react-table` (I hope one day TS would fix the issue preventing those from working, or a workaround would be found). Example:

    ```diff
        Cell: ({
    -         cell: {
    -             value,
    -             row: { original }
    -         }
    +         value,
    +         row: { original }
    +     }: {
    +         value: number;
    +         row: Row<DataType>;
        }) => {
    ```

## Motivation

Current `react-table` definition is quite loose on two things:

1. The required options in `Column` and distinction between a regular column and a group (the one that contains nested `columns`). All of the options for these (`id`, `Header` and `accessor`) are made optional, while in reality some of those are required in certain conditions.

2. The `Cell` renderer (and potentially other renderers) has a `value` (=== `cell { value }`) which is currently typed `any`. This leads to potential bugs.

The first problem was not very complicated to fix — by using union types. However, that makes the `Column` to be a `type` instead of an `interface`. So, for usage in merge declaration there is a new interface created — `ColumnInterface` and the Readme is changed to reflect this.

The second one was harder — it is not possible to implement this without breaking the compatibility, due to two issues: 

1. `react-table` supports accessors that look like `foo.bar` to get sub-properties inside objects. In TypeScript it is not possible to discriminate between unknown strings and a list of known strings, so in the new types such strings are not available, and if they're used anywhere, they would need to be migrated to functional accessors. But this is good, as it is not possible to ensure that a string accessor like `foo.bar` would actually exist. It is neat as a shortcut, but dangerous otherwise.

2. TypeScript has an issue with discriminating between two types that doesn't have a required field to discriminate against, that leads to the `Cell` renderers loosing the type of the callback arguments. See this [TypeScript Playground](https://www.typescriptlang.org/play/?ssl=17&ssc=1&pln=18&pc=1#code/C4TwDgpgBAaghgGwK4QPIDMA8AVAfFAXimwG0BrCEAe3WIF0AoBgSwDtgIAndOAY2gDCVZAFtWAITgBnCABNUreMgiYAIgBpYhKHFYh8AbwZQTUARAQIA-AC4oACiphgzKqyl2DUAG6IUdmCgAXwBKQnxvKmZZAG4GIKZQSDNhJDEAdWZgAAsAZWBOZl5gAEFefikpKk41fCIlFAxMI1MoEgBpKDYoCmpaVTpPY1bTPgqqzjt24ZMgqAAyFNEJaTkFBpUNKFUOulx4-YYkwVSMrOyAGSoqGTLx6trtFtHyiErq2wcwgnxdEDi5oshMtJDJ5Io-JtDsclmlWI8iMC4ZkcvlCsU7m8Jo8AD6ws45K43CCY941VTQ8DQACSHBETyg6GudlYaQARlxNGy4JMoFICmwAObBJi8Nz8qAiECqODAOB2WkQEQkOjaEheJlUOwARi5PLsAHI4AbgpoNcyoABmPW8g1sk1BOhxBhi9zAKBi5YefHwxUiXAqtUzKDPEY6V5kw2ag3qYOtcyWOz2Ly+ZTBb74V1VBAQAB0CCogvsqZQIVjrSC5dMoZGYyx1UN3M4MbjpgTCCTKch6fCHvFwjzBaLJYgZeDleDNdadcjX17drgAC8W2GTO3Oz5u6Fe1mB-nC8XIWOK0wnQwgA) — note how in last column there is a `Binding element 'value' implicitly has an 'any' type.` error (possible related issue in TS — https://github.com/microsoft/TypeScript/issues/35769). I didn't find a workaround for that, _however_, in my opinion this can also be good in a number of cases, as for functional accessors the `value` would've been `any` (as it was before these changes) and that could be dangerous. Making you properly type these arguments would mean the code would be more bullet-proof.

- - -

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`value` in the `Cell` renderer](https://github.com/tannerlinsley/react-table/pull/2073), [columns options](https://react-table.js.org/api/useTable#column-options).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
