### PR TITLE
Add types for text-mask-core and text-mask-addons

### DIFF
--- a/types/text-mask-addons/index.d.ts
+++ b/types/text-mask-addons/index.d.ts
@@ -3,12 +3,10 @@
 // Definitions by: josh <https://github.com/huntjosh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'text-mask-addons' {
-    import { Pipe } from 'text-mask-core';
+import { Pipe } from 'text-mask-core';
 
-    export interface DatePipeYears {
-        minYear: number;
-        maxYear: number;
-    }
-    export function createAutoCorrectedDatePipe(dateFormat?: string, validYears?: DatePipeYears): Pipe;
+export interface DatePipeYears {
+    minYear: number;
+    maxYear: number;
 }
+export function createAutoCorrectedDatePipe(dateFormat?: string, validYears?: DatePipeYears): Pipe;

--- a/types/text-mask-addons/index.d.ts
+++ b/types/text-mask-addons/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for text-mask-addons 3.8
+// Project: https://github.com/text-mask/text-mask/tree/master/addons/#readme
+// Definitions by: josh <https://github.com/huntjosh>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'text-mask-addons' {
+    import { Pipe } from 'text-mask-core';
+
+    export interface DatePipeYears {
+        minYear: number;
+        maxYear: number;
+    }
+    export function createAutoCorrectedDatePipe(dateFormat?: string, validYears?: DatePipeYears): Pipe;
+}

--- a/types/text-mask-addons/text-mask-addons-tests.ts
+++ b/types/text-mask-addons/text-mask-addons-tests.ts
@@ -1,0 +1,9 @@
+import { DatePipeYears, createAutoCorrectedDatePipe } from 'text-mask-addons';
+
+function test() {
+    const datePipeYears: DatePipeYears = { minYear: 1, maxYear: 1 };
+    createAutoCorrectedDatePipe();
+    createAutoCorrectedDatePipe('dd-mm-yyy');
+    createAutoCorrectedDatePipe('dd-mm-yyy', undefined);
+    createAutoCorrectedDatePipe('dd-mm-yyy', datePipeYears);
+}

--- a/types/text-mask-addons/tsconfig.json
+++ b/types/text-mask-addons/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/text-mask-addons/tsconfig.json
+++ b/types/text-mask-addons/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "text-mask-addons-tests.ts"
+    ]
+}

--- a/types/text-mask-addons/tslint.json
+++ b/types/text-mask-addons/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/text-mask-core/index.d.ts
+++ b/types/text-mask-core/index.d.ts
@@ -1,33 +1,29 @@
-import * as react from 'react';
-
 // Type definitions for text-mask-core 5.1
 // Project: https://github.com/text-mask/text-mask/core/#readme
 // Definitions by: josh <https://github.com/huntjosh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'text-mask-core' {
-    export type Mask = (string | RegExp)[];
+export type Mask = Array<string | RegExp>;
 
-    export interface PipeAddResult {
-        value: string;
-        indexesOfPipedChars: number[];
-    }
-    export type PipeResult = PipeAddResult | string | false;
-    export type Pipe = (conformedValue: string, config: any) => PipeResult;
-
-    export interface CreateTextMaskConfig {
-        inputElement: HTMLInputElement;
-        mask: Mask;
-        guide?: string;
-        pipe?: Pipe;
-        placeholderChar?: string;
-        keepCharPositions?: boolean;
-        showMask?: boolean;
-    }
-
-    export interface TextMaskInputElement {
-        update: (rawValue?: string) => void;
-    }
-
-    export function createTextMaskInputElement(config: CreateTextMaskConfig): TextMaskInputElement;
+export interface PipeAddResult {
+    value: string;
+    indexesOfPipedChars: number[];
 }
+export type PipeResult = PipeAddResult | string | false;
+export type Pipe = (conformedValue: string, config: any) => PipeResult;
+
+export interface CreateTextMaskConfig {
+    inputElement: HTMLInputElement;
+    mask: Mask;
+    guide?: string;
+    pipe?: Pipe;
+    placeholderChar?: string;
+    keepCharPositions?: boolean;
+    showMask?: boolean;
+}
+
+export interface TextMaskInputElement {
+    update: (rawValue?: string) => void;
+}
+
+export function createTextMaskInputElement(config: CreateTextMaskConfig): TextMaskInputElement;

--- a/types/text-mask-core/index.d.ts
+++ b/types/text-mask-core/index.d.ts
@@ -1,0 +1,33 @@
+import * as react from 'react';
+
+// Type definitions for text-mask-core 5.1
+// Project: https://github.com/text-mask/text-mask/core/#readme
+// Definitions by: josh <https://github.com/huntjosh>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'text-mask-core' {
+    export type Mask = (string | RegExp)[];
+
+    export interface PipeAddResult {
+        value: string;
+        indexesOfPipedChars: number[];
+    }
+    export type PipeResult = PipeAddResult | string | false;
+    export type Pipe = (conformedValue: string, config: any) => PipeResult;
+
+    export interface CreateTextMaskConfig {
+        inputElement: HTMLInputElement;
+        mask: Mask;
+        guide?: string;
+        pipe?: Pipe;
+        placeholderChar?: string;
+        keepCharPositions?: boolean;
+        showMask?: boolean;
+    }
+
+    export interface TextMaskInputElement {
+        update: (rawValue?: string) => void;
+    }
+
+    export function createTextMaskInputElement(config: CreateTextMaskConfig): TextMaskInputElement;
+}

--- a/types/text-mask-core/text-mask-core-tests.ts
+++ b/types/text-mask-core/text-mask-core-tests.ts
@@ -22,13 +22,13 @@ function test() {
     };
 
     const createTextMaskConfig: CreateTextMaskConfig = {
-        inputElement: {} as HTMLInputElement,
+        inputElement: {} as any,
         mask,
         guide: 'a',
         keepCharPositions: true,
         showMask: true,
     };
-    
+
     const textMaskInputElement: TextMaskInputElement = {
         update: (a?: string): void => {},
     };

--- a/types/text-mask-core/text-mask-core-tests.ts
+++ b/types/text-mask-core/text-mask-core-tests.ts
@@ -1,0 +1,37 @@
+import {
+    Mask,
+    PipeAddResult,
+    PipeResult,
+    Pipe,
+    CreateTextMaskConfig,
+    TextMaskInputElement,
+    createTextMaskInputElement,
+} from 'text-mask-core';
+
+function test() {
+    const mask: Mask = ['a'];
+
+    const pipeAddResult: PipeAddResult = { value: 'abc', indexesOfPipedChars: [1] };
+
+    let pipeResult: PipeResult = pipeAddResult;
+    pipeResult = false;
+    pipeResult = 'abc';
+
+    const pipeFunc: Pipe = (value: string, config: any): PipeResult => {
+        return pipeAddResult;
+    };
+
+    const createTextMaskConfig: CreateTextMaskConfig = {
+        inputElement: {} as HTMLInputElement,
+        mask,
+        guide: 'a',
+        keepCharPositions: true,
+        showMask: true,
+    };
+    
+    const textMaskInputElement: TextMaskInputElement = {
+        update: (a?: string): void => {},
+    };
+
+    createTextMaskInputElement(createTextMaskConfig);
+}

--- a/types/text-mask-core/tsconfig.json
+++ b/types/text-mask-core/tsconfig.json
@@ -10,15 +10,12 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
-        "jsx": "react",
-        "experimentalDecorators": true,
         "typeRoots": [
             "../"
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "esModuleInterop": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/text-mask-core/tsconfig.json
+++ b/types/text-mask-core/tsconfig.json
@@ -2,19 +2,23 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictFunctionTypes": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
+        "jsx": "react",
+        "experimentalDecorators": true,
         "typeRoots": [
             "../"
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",

--- a/types/text-mask-core/tsconfig.json
+++ b/types/text-mask-core/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "text-mask-core-tests.ts"
+    ]
+}

--- a/types/text-mask-core/tslint.json
+++ b/types/text-mask-core/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
