### PR TITLE
update(puppeteer): `product` option support

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for puppeteer 2.0
+// Type definitions for puppeteer 2.1
 // Project: https://github.com/GoogleChrome/puppeteer#readme
 // Definitions by: Marvin Hagemeister <https://github.com/marvinhagemeister>
 //                 Christopher Deutsch <https://github.com/cdeutsch>
@@ -8,6 +8,7 @@
 //                 Jason Kaczmarsky <https://github.com/JasonKaz>
 //                 Dave Cardwell <https://github.com/davecardwell>
 //                 Andrés Ortiz <https://github.com/angrykoala>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -41,6 +42,8 @@ export interface JSONObject {
 export type SerializableOrJSHandle = Serializable | JSHandle;
 
 export type Platform = "mac" | "win32" | "win64" | "linux";
+
+export type Product = "chrome" | "firefox";
 
 /** Defines `$eval` and `$$eval` for Page, Frame and ElementHandle. */
 export interface Evalable {
@@ -2030,6 +2033,12 @@ export interface Target {
 
 export interface LaunchOptions extends ChromeArgOptions, BrowserOptions, Timeoutable {
   /**
+   * Which browser to launch.
+   * At this time, this is either `chrome` or `firefox`. See also `PUPPETEER_PRODUCT`.
+   * @default 'chrome'
+   */
+  product?: Product;
+  /**
    * Path to a Chromium executable to run instead of bundled Chromium. If
    * executablePath is a relative path, then it is resolved relative to current
    * working directory.
@@ -2213,6 +2222,7 @@ export interface BrowserFetcher {
   download(revision: string, progressCallback?: (downloadBytes: number, totalBytes: number) => void): Promise<RevisionInfo>;
   localRevisions(): Promise<string[]>;
   platform(): Platform;
+  product(): Product;
   remove(revision: string): Promise<void>;
   revisionInfo(revision: string): RevisionInfo;
 }
@@ -2228,6 +2238,7 @@ export interface RevisionInfo {
   url: string;
   /** whether the revision is locally available on disk */
   local: boolean;
+  product: Product;
 }
 
 export interface FetcherOptions {
@@ -2237,6 +2248,10 @@ export interface FetcherOptions {
   path?: string;
   /** Possible values are: `mac`, `win32`, `win64`, `linux`. Defaults to the current platform. */
   platform?: Platform;
+  /**
+   * @default 'chrome'
+   */
+  product?: Product;
 }
 
 /** Attaches Puppeteer to an existing Chromium instance */

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -213,6 +213,22 @@ puppeteer.launch().then(async browser => {
   browser.close();
 })();
 
+// `product` support
+(async () => {
+    await puppeteer.launch({
+        product: 'chrome',
+    });
+    await puppeteer.launch({
+        product: 'firefox',
+    });
+    const options: puppeteer.FetcherOptions = {
+        product: 'firefox',
+      };
+      const browserFetcher = puppeteer.createBrowserFetcher(options);
+      browserFetcher.product(); // $ExpectType Product
+      browserFetcher.revisionInfo('revision').product; // $ExpectType Product
+})();
+
 // Launching with default viewport disabled
 (async () => {
   await puppeteer.launch({


### PR DESCRIPTION
- product option support as per 2.1
- version bump
- test updated

https://github.com/puppeteer/puppeteer/releases/tag/v2.1.0
https://github.com/puppeteer/puppeteer/pull/5137/

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.