### PR TITLE
Fix client.sessions() parameters in @types/orientjs

### DIFF
--- a/types/orientjs/index.d.ts
+++ b/types/orientjs/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for orientjs 3.0
 // Project: https://github.com/orientechnologies/orientjs
 // Definitions by: [Saeed Tabrizi] <https://github.com/saeedtabrizi>
+//                 [Aleksey Rezvov] <https://github.com/aleksey-rezvov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 // Last Update  : 08-11-2019
@@ -1311,7 +1312,7 @@ declare namespace orientjs {
 
         session(options?: ODatabaseSessionOptions): Promise<ODatabaseSession>;
 
-        sessions(options?: ODatabaseSessionOptions): Promise<ODatabaseSessionPool>;
+        sessions(options?: ODatabaseSessionPoolOptions): Promise<ODatabaseSessionPool>;
         migrator(config?: Migration.MigrationManagerConfig): Migration.MigrationManager;
         createDatabase(options?: DatabaseOptions): Promise<void>;
         dropDatabase(options?: DropDatabaseOptions): Promise<void>;


### PR DESCRIPTION
Fix: client.sessions() now able to accept **pool** parameter, e.g. client.sessions({ name: "demodb", username: "admin", password: "admin", pool: { max: 10}).
Docs: http://orientdb.com/docs/3.1.x/orientjs/Client.html#sessions

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://orientdb.com/docs/3.1.x/orientjs/Client.html#sessions
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

