### PR TITLE
Add missing types for react-calendar 3.0

### DIFF
--- a/types/react-calendar/index.d.ts
+++ b/types/react-calendar/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-calendar 3.0
 // Project: https://github.com/wojtekmaj/react-calendar
-// Definitions by: Stéphane Saquet <https://github.com/Guymestef>
+// Definitions by: Stéphane Saquet <https://github.com/Guymestef>, Katie Soldau <https://github.com/ksoldau>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.5
 
@@ -18,6 +18,10 @@ export interface CalendarProps {
   activeStartDate?: Date;
   calendarType?: CalendarType;
   className?: string | string[];
+  defaultActiveStartDate?: Date;
+  defaultValue?: Date | Date[];
+  defaultView?: Detail;
+  formatLongDate?: FormatterCallback;
   formatMonth?: FormatterCallback;
   formatMonthYear?: FormatterCallback;
   formatShortWeekday?: FormatterCallback;
@@ -27,6 +31,7 @@ export interface CalendarProps {
   maxDetail?: Detail;
   minDate?: Date;
   minDetail?: Detail;
+  navigationAriaLabel?: string;
   navigationLabel?: (props: { date: Date, view: Detail, label: string }) => string | JSX.Element | null;
   next2AriaLabel?: string;
   next2Label?: string | JSX.Element | null;
@@ -34,6 +39,7 @@ export interface CalendarProps {
   nextLabel?: string | JSX.Element;
   onActiveStartDateChange?: ViewCallback;
   onChange?: OnChangeDateCallback;
+  onViewChange?: ViewCallback;
   onClickDay?: DateCallback;
   onClickDecade?: DateCallback;
   onClickMonth?: DateCallback;
@@ -48,6 +54,7 @@ export interface CalendarProps {
   renderChildren?: (props: CalendarTileProperties) => JSX.Element | null; // For backwards compatibility
   returnValue?: "start" | "end" | "range";
   selectRange?: boolean;
+  showDoubleView?: boolean;
   showFixedNumberOfWeeks?: boolean;
   showNavigation?: boolean;
   showNeighboringMonth?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
  Note: see other Note below

- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
  Note: It doesn't seem that Prettier has previously run on this file, so I didn't run it on this PR even though it's mentioned that it should be done in the common mistakes page provided above.
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
  Note: I can't seem to run `npm run lint react-calendar` as I get this error: 
![image](https://user-images.githubusercontent.com/3526718/78741849-ca5adc00-799d-11ea-91b8-1402d224fb96.png)

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wojtekmaj/react-calendar
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. 
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
