### PR TITLE
Fix datadog-statsd-metrics-collector constructor definition

### DIFF
--- a/types/datadog-statsd-metrics-collector/datadog-statsd-metrics-collector-tests.ts
+++ b/types/datadog-statsd-metrics-collector/datadog-statsd-metrics-collector-tests.ts
@@ -5,6 +5,7 @@ const client = new datadog.StatsD('localhost');
 
 // constructors
 let collector = new Collector(client);
+collector = new Collector(null);
 collector = new Collector(client, 1000);
 
 // interface

--- a/types/datadog-statsd-metrics-collector/index.d.ts
+++ b/types/datadog-statsd-metrics-collector/index.d.ts
@@ -6,7 +6,7 @@
 import dogstatsd = require('node-dogstatsd');
 
 declare class Collector implements dogstatsd.StatsDClient {
-    constructor(client: dogstatsd.StatsDClient, delayMilliseconds?: number);
+    constructor(client: dogstatsd.StatsDClient | null, delayMilliseconds?: number);
 
     timing(stat: string, time: number, sample_rate?: number, tags?: string[]): void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/xzyfer/datadog-statsd-metrics-collector/blob/master/index.js#L36
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
