### PR TITLE
Add undefined as valid senderId in sendCustomMessage method

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -1204,9 +1204,9 @@ export class CastReceiverContext {
     removeEventListener(type: system.EventType, handler: EventHandler): void;
 
     /**
-     * Sends a message to a specific sender.
+     * Sends a message to a specific sender or broadcasts it to all connected senders (to broadcast pass undefined as a senderId).
      */
-    sendCustomMessage(namespace: string, senderId: string, message: any): void;
+    sendCustomMessage(namespace: string, senderId: string | undefined, message: any): void;
 
     /**
      * This function should be called in response to the feedbackstarted event if the application

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -144,6 +144,14 @@ cast.framework.CastReceiverContext.getInstance().addEventListener(
     () => '¡hola!',
 );
 
+// send custom message to specific sender
+cast.framework.CastReceiverContext.getInstance()
+    .sendCustomMessage('custom-namespace', 'sender-id', {});
+
+// broadcast custom message to all connected senders
+cast.framework.CastReceiverContext.getInstance()
+    .sendCustomMessage('custom-namespace', undefined, {});
+
 const loadingError = new cast.framework.events.ErrorEvent(DetailedErrorCode.LOAD_FAILED, 'Loading failed!');
 
 // PlayerManager message interceptors


### PR DESCRIPTION
This is a small fix in `cast.framework.CastReceiverContext#sendCustomMessage` method. According to the  **[documentation](https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.CastReceiverContext#sendCustomMessage)** this method accepts `undefined` as a `senderId`. In this case message will be brodcasted to all connected senders.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.CastReceiverContext#sendCustomMessage>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.