### PR TITLE
[marked] Fix type of parameters href and title - they may be null

### DIFF
--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -137,8 +137,8 @@ declare namespace marked {
         codespan(code: string): string;
         br(): string;
         del(text: string): string;
-        link(href: string, title: string, text: string): string;
-        image(href: string, title: string, text: string): string;
+        link(href: string | null, title: string | null, text: string): string;
+        image(href: string | null, title: string | null, text: string): string;
         text(text: string): string;
     }
 
@@ -148,8 +148,8 @@ declare namespace marked {
         codespan(text: string): string;
         del(text: string): string;
         text(text: string): string;
-        link(href: string, title: string, text: string): string;
-        image(href: string, title: string, text: string): string;
+        link(href: string | null, title: string | null, text: string): string;
+        image(href: string | null, title: string | null, text: string): string;
         br(): string;
     }
 
@@ -190,7 +190,7 @@ declare namespace marked {
 
     type TokensList = Token[] & {
         links: {
-            [key: string]: { href: string; title: string; }
+            [key: string]: { href: string | null; title: string | null; }
         }
     };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    + [src/Renderer.js:136](https://github.com/markedjs/marked/blob/35bcb7d5dba17c80e6227cae951501082ef93629/src/Renderer.js#L136)
    + [src/Renderer.js:140](https://github.com/markedjs/marked/blob/35bcb7d5dba17c80e6227cae951501082ef93629/src/Renderer.js#L140)
    + [src/Renderer.js:136](https://github.com/markedjs/marked/blob/35bcb7d5dba17c80e6227cae951501082ef93629/src/Renderer.js#L136)
    + [src/Renderer.js:154](https://github.com/markedjs/marked/blob/35bcb7d5dba17c80e6227cae951501082ef93629/src/Renderer.js#L154)
- If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
    + No, it was like this even in version 0.7 and probably since ever.
- If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
    + N/A