### PR TITLE
inline-css: add removeHtmlSelectors option

### DIFF
--- a/types/inline-css/index.d.ts
+++ b/types/inline-css/index.d.ts
@@ -17,6 +17,7 @@ declare namespace InlineCss {
         preserveMediaQueries?: boolean;
         applyWidthAttributes?: boolean;
         applyTableAttributes?: boolean;
+        removeHtmlSelectors?: boolean;
     }
 }
 

--- a/types/inline-css/inline-css-tests.ts
+++ b/types/inline-css/inline-css-tests.ts
@@ -1,10 +1,9 @@
-
 import inlineCss = require('inline-css');
 
 var str: string;
 var bool: boolean;
 
-var options:inlineCss.Options;
+var options: inlineCss.Options;
 
 str = options.url;
 str = options.extraCss;
@@ -16,19 +15,19 @@ bool = options.removeLinkTags;
 bool = options.preserveMediaQueries;
 bool = options.applyWidthAttributes;
 bool = options.applyTableAttributes;
+bool = options.removeHtmlSelectors;
 
 options = {
-	url: str,
-	extraCss: str,
-	applyStyleTags: bool,
-	applyLinkTags: bool,
-	removeStyleTags: bool,
-	removeLinkTags: bool,
-	preserveMediaQueries: bool,
-	applyWidthAttributes: bool,
-	applyTableAttributes: bool
+    url: str,
+    extraCss: str,
+    applyStyleTags: bool,
+    applyLinkTags: bool,
+    removeStyleTags: bool,
+    removeLinkTags: bool,
+    preserveMediaQueries: bool,
+    applyWidthAttributes: bool,
+    applyTableAttributes: bool,
+    removeHtmlSelectors: bool,
 };
 
-inlineCss(str, options).then((value:string) => {
-
-});
+inlineCss(str, options).then((value: string) => {});


### PR DESCRIPTION
add missing removeHtmlSelectors option to inline-css type definition

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/inline-css
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header: no version in the header currently. This option is there since around 4 years ago
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
