### PR TITLE
[draft.js] Add missing aria props, KeyBindingUtil.usesMacOSHeuristics, and change comments to JSDoc

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -158,6 +158,7 @@ declare namespace Draft {
                 ariaLabel?: string;
                 ariaLabelledBy?: boolean;
                 ariaMultiline?: boolean;
+                ariaOwneeID?: string;
 
                 role?: string;
 

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -134,6 +134,7 @@ declare namespace Draft {
                 ariaDescribedBy?: string;
                 ariaExpanded?: boolean;
                 ariaLabel?: string;
+                ariaLabelledBy?: boolean;
                 ariaMultiline?: boolean;
 
                 role?: string;

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -16,8 +16,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
-import * as React from 'react';
 import * as Immutable from 'immutable';
+import * as React from 'react';
 
 type SyntheticKeyboardEvent = React.KeyboardEvent<{}>;
 type SyntheticEvent = React.SyntheticEvent<{}>;
@@ -40,7 +40,7 @@ declare namespace Draft {
             type DraftBlockRenderMap = Immutable.Map<DraftBlockType, DraftBlockRenderConfig>;
 
             type DraftStyleMap = {
-                [styleName: string]: React.CSSProperties
+                [styleName: string]: React.CSSProperties;
             };
 
             type EditorCommand = DraftEditorCommand | string;
@@ -83,7 +83,7 @@ declare namespace Draft {
                  * Specify whether text directionality should be forced in a direction
                  * regardless of input characters.
                  */
-                 textDirectionality?: DraftTextDirectionality;
+                textDirectionality?: DraftTextDirectionality;
 
                 /**
                  * For a given `ContentBlock` object, return an object that specifies
@@ -97,24 +97,24 @@ declare namespace Draft {
                  * an element tag and an optional react element wrapper. This configuration
                  * is used for both rendering and paste processing.
                  */
-                blockRenderMap?: DraftBlockRenderMap
+                blockRenderMap?: DraftBlockRenderMap;
 
                 /**
                  * Function that allows to define class names to apply to the given block when it is rendered.
                  */
-                 blockStyleFn?(block: ContentBlock): string;
+                blockStyleFn?(block: ContentBlock): string;
 
                 /**
                  * Provide a map of inline style names corresponding to CSS style objects
                  * that will be rendered for matching ranges.
                  */
-                 customStyleMap?: DraftStyleMap;
+                customStyleMap?: DraftStyleMap;
 
                 /**
                  * Define a function to transform inline styles to CSS objects
                  * that are applied to spans of text.
                  */
-                 customStyleFn?: (style: DraftInlineStyle, block: ContentBlock) => React.CSSProperties;
+                customStyleFn?: (style: DraftInlineStyle, block: ContentBlock) => React.CSSProperties;
 
                 /**
                  * A function that accepts a synthetic key event and returns
@@ -134,7 +134,7 @@ declare namespace Draft {
                  * Note: spellcheck is always disabled for IE. If enabled in Safari, OSX
                  * autocorrect is enabled as well.
                  */
-                 spellCheck?: boolean;
+                spellCheck?: boolean;
 
                 /**
                  * Set whether to remove all style information from pasted content. If your
@@ -177,14 +177,17 @@ declare namespace Draft {
                  * Useful for managing special behavior for pressing the `Return` key. E.g.
                  * removing the style from an empty list item.
                  */
-                handleReturn?(e: SyntheticKeyboardEvent, editorState: EditorState): DraftHandleValue,
+                handleReturn?(e: SyntheticKeyboardEvent, editorState: EditorState): DraftHandleValue;
 
-                 /**
-                  * Map a key command string provided by your key binding function to a
-                  * specified behavior.
-                  */
-                handleKeyCommand?(command: EditorCommand, editorState: EditorState, eventTimeStamp: number): DraftHandleValue,
-
+                /**
+                 * Map a key command string provided by your key binding function to a
+                 * specified behavior.
+                 */
+                handleKeyCommand?(
+                    command: EditorCommand,
+                    editorState: EditorState,
+                    eventTimeStamp: number,
+                ): DraftHandleValue;
 
                 /**
                  * Handle intended text insertion before the insertion occurs. This may be
@@ -193,55 +196,58 @@ declare namespace Draft {
                  * emoji Unicode character, or replacing ASCII quote characters with smart
                  * quotes.
                  */
-                handleBeforeInput?(chars: string, editorState: EditorState, eventTimeStamp: number): DraftHandleValue,
+                handleBeforeInput?(chars: string, editorState: EditorState, eventTimeStamp: number): DraftHandleValue;
 
-                handlePastedText?(text: string, html: string|undefined, editorState: EditorState): DraftHandleValue,
+                handlePastedText?(text: string, html: string | undefined, editorState: EditorState): DraftHandleValue;
 
-                handlePastedFiles?(files: Array<Blob>): DraftHandleValue,
+                handlePastedFiles?(files: Array<Blob>): DraftHandleValue;
 
                 /** Handle dropped files */
-                handleDroppedFiles?(selection: SelectionState, files: Array<Blob>): DraftHandleValue,
+                handleDroppedFiles?(selection: SelectionState, files: Array<Blob>): DraftHandleValue;
 
                 /** Handle other drops to prevent default text movement/insertion behaviour */
-                handleDrop?(selection: SelectionState, dataTransfer: Object, isInternal: DraftDragType): DraftHandleValue,
+                handleDrop?(
+                    selection: SelectionState,
+                    dataTransfer: Object,
+                    isInternal: DraftDragType,
+                ): DraftHandleValue;
 
                 // Non-cancelable event triggers.
-                onEscape?(e: SyntheticKeyboardEvent): void,
-                onTab?(e: SyntheticKeyboardEvent): void,
-                onUpArrow?(e: SyntheticKeyboardEvent): void,
-                onDownArrow?(e: SyntheticKeyboardEvent): void,
-                onRightArrow?(e: SyntheticKeyboardEvent): void,
-                onLeftArrow?(e: SyntheticKeyboardEvent): void,
+                onEscape?(e: SyntheticKeyboardEvent): void;
+                onTab?(e: SyntheticKeyboardEvent): void;
+                onUpArrow?(e: SyntheticKeyboardEvent): void;
+                onDownArrow?(e: SyntheticKeyboardEvent): void;
+                onRightArrow?(e: SyntheticKeyboardEvent): void;
+                onLeftArrow?(e: SyntheticKeyboardEvent): void;
 
-                onBlur?(e: SyntheticEvent): void,
-                onFocus?(e: SyntheticEvent): void,
+                onBlur?(e: SyntheticEvent): void;
+                onFocus?(e: SyntheticEvent): void;
             }
 
-            type DraftTextAlignment = "left" | "center" | "right";
+            type DraftTextAlignment = 'left' | 'center' | 'right';
 
-            type DraftTextDirectionality = "LTR" | "RTL" | "NEUTRAL";
+            type DraftTextDirectionality = 'LTR' | 'RTL' | 'NEUTRAL';
         }
 
         namespace Components {
-            class DraftEditorBlock extends React.Component<any, {}> {
-            }
+            class DraftEditorBlock extends React.Component<any, {}> {}
         }
 
         namespace Selection {
             interface FakeClientRect {
-                left: number,
-                width: number,
-                right: number,
-                top: number,
-                bottom: number,
-                height: number,
+                left: number;
+                width: number;
+                right: number;
+                top: number;
+                bottom: number;
+                height: number;
             }
 
             /**
              * Return the bounding ClientRect for the visible DOM selection, if any.
              * In cases where there are no selected ranges or the bounding rect is
              * temporarily invalid, return null.
-            */
+             */
             function getVisibleSelectionRect(global: any): FakeClientRect;
         }
 
@@ -261,6 +267,13 @@ declare namespace Draft {
                 static hasCommandModifier(e: SyntheticKeyboardEvent): boolean;
 
                 static isSoftNewlineEvent(e: SyntheticKeyboardEvent): boolean;
+
+                /**
+                 * Check whether heuristics that only apply to macOS are used
+                 * internally, for example when determining the key combination
+                 * used as command modifier.
+                 */
+                static usesMacOSHeuristics(): boolean;
             }
 
             /**
@@ -277,93 +290,91 @@ declare namespace Draft {
              * controls. These commands should map to operations that modify content or
              * selection state and update the editor state accordingly.
              */
-            type DraftEditorCommand = (
+            type DraftEditorCommand =
                 /**
                  * Self-explanatory.
                  */
-                "undo" |
-                "redo" |
+                | 'undo'
+                | 'redo'
 
                 /**
                  * Perform a forward deletion.
                  */
-                "delete" |
+                | 'delete'
 
                 /**
                  * Perform a forward deletion to the next word boundary after the selection.
                  */
-                "delete-word" |
+                | 'delete-word'
 
                 /**
                  * Perform a backward deletion.
                  */
-                "backspace" |
+                | 'backspace'
 
                 /**
                  * Perform a backward deletion to the previous word boundary before the
                  * selection.
                  */
-                "backspace-word" |
+                | 'backspace-word'
 
                 /**
                  * Perform a backward deletion to the beginning of the current line.
                  */
-                "backspace-to-start-of-line" |
+                | 'backspace-to-start-of-line'
 
                 /**
                  * Toggle styles. Commands may be intepreted to modify inline text ranges
                  * or block types.
                  */
-                "bold" |
-                "code" |
-                "italic" |
-                "strikethrough" |
-                "underline" |
+                | 'bold'
+                | 'code'
+                | 'italic'
+                | 'strikethrough'
+                | 'underline'
 
                 /**
                  * Split a block in two.
                  */
-                "split-block" |
+                | 'split-block'
 
                 /**
                  * Self-explanatory.
                  */
-                "transpose-characters" |
-                "move-selection-to-start-of-block" |
-                "move-selection-to-end-of-block" |
+                | 'transpose-characters'
+                | 'move-selection-to-start-of-block'
+                | 'move-selection-to-end-of-block'
 
                 /**
                  * Commands to support the "secondary" clipboard provided by certain
                  * browsers and operating systems.
                  */
-                "secondary-cut" |
-                "secondary-paste"
-            );
+                | 'secondary-cut'
+                | 'secondary-paste';
 
             /**
              * A type that allows us to avoid passing boolean arguments
              * around to indicate whether a drag type is internal or external.
              */
-            type DraftDragType = "internal" | "external";
+            type DraftDragType = 'internal' | 'external';
 
             /**
              * The list of default valid block types.
              */
-            type CoreDraftBlockType = (
-                "unstyled" |
-                "paragraph" |
-                "header-one" |
-                "header-two" |
-                "header-three" |
-                "header-four" |
-                "header-five" |
-                "header-six" |
-                "unordered-list-item" |
-                "ordered-list-item" |
-                "blockquote" |
-                "code-block" |
-                "atomic"
-            );
+            type CoreDraftBlockType =
+                | 'unstyled'
+                | 'paragraph'
+                | 'header-one'
+                | 'header-two'
+                | 'header-three'
+                | 'header-four'
+                | 'header-five'
+                | 'header-six'
+                | 'unordered-list-item'
+                | 'ordered-list-item'
+                | 'blockquote'
+                | 'code-block'
+                | 'atomic';
 
             type CustomBlockType = string;
 
@@ -373,40 +384,29 @@ declare namespace Draft {
              * A type that allows us to avoid passing boolean arguments
              * around to indicate whether a deletion is forward or backward.
              */
-            type DraftRemovalDirection = "backward" | "forward";
+            type DraftRemovalDirection = 'backward' | 'forward';
 
             /**
              * A type that allows us to avoid returning boolean values
              * to indicate whether an event was handled or not.
              */
-            type DraftHandleValue = "handled" | "not-handled";
+            type DraftHandleValue = 'handled' | 'not-handled';
 
             /**
              * A type that defines if an fragment shall be inserted before or after
              * another fragment or if the selected fragment shall be replaced
              */
-            type DraftInsertionType = "replace" | "before" | "after";
+            type DraftInsertionType = 'replace' | 'before' | 'after';
 
             /**
              * Valid inline styles.
              */
-            type DraftInlineStyleType = (
-                "BOLD" |
-                "CODE" |
-                "ITALIC" |
-                "STRIKETHROUGH" |
-                "UNDERLINE"
-            )
+            type DraftInlineStyleType = 'BOLD' | 'CODE' | 'ITALIC' | 'STRIKETHROUGH' | 'UNDERLINE';
 
             /**
              * Default entity types.
              */
-            type ComposedEntityType = (
-              "LINK" |
-              "TOKEN" |
-              "PHOTO" |
-              "IMAGE"
-            )
+            type ComposedEntityType = 'LINK' | 'TOKEN' | 'PHOTO' | 'IMAGE';
 
             /**
              * Possible entity types.
@@ -439,18 +439,18 @@ declare namespace Draft {
              *   entity will delete only the segments affected by the deletion. Example:
              *   Facebook User mentions.
              */
-            type DraftEntityMutability = "MUTABLE" | "IMMUTABLE" | "SEGMENTED";
+            type DraftEntityMutability = 'MUTABLE' | 'IMMUTABLE' | 'SEGMENTED';
         }
 
         namespace Decorators {
             import ContentBlock = Draft.Model.ImmutableData.ContentBlock;
 
             /**
-            * An interface for document decorator classes, allowing the creation of
-            * custom decorator classes.
-            *
-            * See `CompositeDraftDecorator` for the most common use case.
-            */
+             * An interface for document decorator classes, allowing the creation of
+             * custom decorator classes.
+             *
+             * See `CompositeDraftDecorator` for the most common use case.
+             */
             interface DraftDecoratorType {
                 /**
                  * Given a `ContentBlock`, return an immutable List of decorator keys.
@@ -486,7 +486,11 @@ declare namespace Draft {
              *   - "props": Props to be passed into the React component that will be used.
              */
             interface DraftDecorator {
-                strategy: (block: ContentBlock, callback: (start: number, end: number) => void, contentState: ContentState) => void;
+                strategy: (
+                    block: ContentBlock,
+                    callback: (start: number, end: number) => void,
+                    contentState: ContentState,
+                ) => void;
                 component: Function;
                 props?: object;
             }
@@ -546,9 +550,9 @@ declare namespace Draft {
              * a `ComposedText` object, not for use with `DraftEntity.get()`.
              */
             interface RawDraftEntityRange {
-                key: number,
-                offset: number,
-                length: number,
+                key: number;
+                offset: number;
+                length: number;
             }
 
             /**
@@ -588,7 +592,11 @@ declare namespace Draft {
                 entityMap: { [key: string]: RawDraftEntity };
             }
 
-            function convertFromHTMLtoContentBlocks(html: string, DOMBuilder?: Function, blockRenderMap?: DraftBlockRenderMap): { contentBlocks: Array<ContentBlock>, entityMap: any };
+            function convertFromHTMLtoContentBlocks(
+                html: string,
+                DOMBuilder?: Function,
+                blockRenderMap?: DraftBlockRenderMap,
+            ): { contentBlocks: Array<ContentBlock>; entityMap: any };
             function convertFromRawToDraftState(rawState: RawDraftContentState): ContentState;
             function convertFromDraftStateToRaw(contentState: ContentState): RawDraftContentState;
         }
@@ -727,7 +735,11 @@ declare namespace Draft {
                  * considered a boundary state, and set the provided ContentState as the
                  * new current content.
                  */
-                static push(editorState: EditorState, contentState: ContentState, changeType: EditorChangeType): EditorState;
+                static push(
+                    editorState: EditorState,
+                    contentState: ContentState,
+                    changeType: EditorChangeType,
+                ): EditorState;
 
                 /**
                  * Make the top ContentState in the undo stack the new current content and
@@ -763,7 +775,10 @@ declare namespace Draft {
                  */
                 getInlineStyleOverride(): DraftInlineStyle;
 
-                static setInlineStyleOverride(editorState: EditorState, inlineStyleOverride: DraftInlineStyle): EditorState;
+                static setInlineStyleOverride(
+                    editorState: EditorState,
+                    inlineStyleOverride: DraftInlineStyle,
+                ): EditorState;
 
                 /**
                  * Get the appropriate inline style for the editor state. If an
@@ -794,12 +809,18 @@ declare namespace Draft {
                 /**
                  * Execute a callback for every contiguous range of styles within the block.
                  */
-                findStyleRanges(filterFn: (value: CharacterMetadata) => boolean, callback: (start: number, end: number) => void): void;
+                findStyleRanges(
+                    filterFn: (value: CharacterMetadata) => boolean,
+                    callback: (start: number, end: number) => void,
+                ): void;
 
                 /**
                  * Execute a callback for every contiguous range of entities within the block.
                  */
-                findEntityRanges(filterFn: (value: CharacterMetadata) => boolean, callback: (start: number, end: number) => void): void;
+                findEntityRanges(
+                    filterFn: (value: CharacterMetadata) => boolean,
+                    callback: (start: number, end: number) => void,
+                ): void;
             }
 
             class ContentState extends Record {
@@ -813,7 +834,6 @@ declare namespace Draft {
                 mergeEntityData(key: string, toMerge: { [key: string]: any }): ContentState;
                 replaceEntityData(key: string, toMerge: { [key: string]: any }): ContentState;
                 addEntity(instance: DraftEntityInstance): ContentState;
-
 
                 getBlockMap(): BlockMap;
                 getSelectionBefore(): SelectionState;
@@ -878,22 +898,21 @@ declare namespace Draft {
                 entity?: string;
             }
 
-            type EditorChangeType = (
-                "adjust-depth" |
-                "apply-entity" |
-                "backspace-character" |
-                "change-block-data" |
-                "change-block-type" |
-                "change-inline-style" |
-                "delete-character" |
-                "insert-characters" |
-                "insert-fragment" |
-                "redo" |
-                "remove-range" |
-                "spellcheck-change" |
-                "split-block" |
-                "undo"
-            )
+            type EditorChangeType =
+                | 'adjust-depth'
+                | 'apply-entity'
+                | 'backspace-character'
+                | 'change-block-data'
+                | 'change-block-type'
+                | 'change-inline-style'
+                | 'delete-character'
+                | 'insert-characters'
+                | 'insert-fragment'
+                | 'redo'
+                | 'remove-range'
+                | 'spellcheck-change'
+                | 'split-block'
+                | 'undo';
 
             class BlockMapBuilder {
                 static createFromArray(blocks: Array<ContentBlock>): BlockMap;
@@ -924,7 +943,12 @@ declare namespace Draft {
 
             class AtomicBlockUtils {
                 static insertAtomicBlock(editorState: EditorState, entityKey: string, character: string): EditorState;
-                static moveAtomicBlock(editorState: EditorState, atomicBlock: ContentBlock, targetRange: SelectionState, insertionMode?: DraftInsertionType): EditorState;
+                static moveAtomicBlock(
+                    editorState: EditorState,
+                    atomicBlock: ContentBlock,
+                    targetRange: SelectionState,
+                    insertionMode?: DraftInsertionType,
+                ): EditorState;
             }
 
             /**
@@ -938,23 +962,75 @@ declare namespace Draft {
              * These functions encapsulate some of the most common transaction sequences.
              */
             class DraftModifier {
-                static replaceText(contentState: ContentState, rangeToReplace: SelectionState, text: string, inlineStyle?: DraftInlineStyle, entityKey?: string): ContentState;
-                static insertText(contentState: ContentState, targetRange: SelectionState, text: string, inlineStyle?: DraftInlineStyle, entityKey?: string): ContentState;
-                static moveText(contentState: ContentState, removalRange: SelectionState, targetRange: SelectionState): ContentState;
-                static replaceWithFragment(contentState: ContentState, targetRange: SelectionState, fragment: BlockMap): ContentState;
+                static replaceText(
+                    contentState: ContentState,
+                    rangeToReplace: SelectionState,
+                    text: string,
+                    inlineStyle?: DraftInlineStyle,
+                    entityKey?: string,
+                ): ContentState;
+                static insertText(
+                    contentState: ContentState,
+                    targetRange: SelectionState,
+                    text: string,
+                    inlineStyle?: DraftInlineStyle,
+                    entityKey?: string,
+                ): ContentState;
+                static moveText(
+                    contentState: ContentState,
+                    removalRange: SelectionState,
+                    targetRange: SelectionState,
+                ): ContentState;
+                static replaceWithFragment(
+                    contentState: ContentState,
+                    targetRange: SelectionState,
+                    fragment: BlockMap,
+                ): ContentState;
 
-                static removeRange(contentState: ContentState, rangeToRemove: SelectionState, removalDirection: DraftRemovalDirection): ContentState;
+                static removeRange(
+                    contentState: ContentState,
+                    rangeToRemove: SelectionState,
+                    removalDirection: DraftRemovalDirection,
+                ): ContentState;
 
                 static splitBlock(contentState: ContentState, selectionState: SelectionState): ContentState;
-                static applyInlineStyle(contentState: ContentState, selectionState: SelectionState, inlineStyle: string): ContentState;
-                static removeInlineStyle(contentState: ContentState, selectionState: SelectionState, inlineStyle: string): ContentState;
+                static applyInlineStyle(
+                    contentState: ContentState,
+                    selectionState: SelectionState,
+                    inlineStyle: string,
+                ): ContentState;
+                static removeInlineStyle(
+                    contentState: ContentState,
+                    selectionState: SelectionState,
+                    inlineStyle: string,
+                ): ContentState;
 
-                static setBlockType(contentState: ContentState, selectionState: SelectionState, blockType: DraftBlockType): ContentState;
-                static setBlockType(contentState: ContentState, selectionState: SelectionState, blockType: string): ContentState;
+                static setBlockType(
+                    contentState: ContentState,
+                    selectionState: SelectionState,
+                    blockType: DraftBlockType,
+                ): ContentState;
+                static setBlockType(
+                    contentState: ContentState,
+                    selectionState: SelectionState,
+                    blockType: string,
+                ): ContentState;
 
-                static setBlockData(contentState: ContentState, selectionState: SelectionState, blockData: Immutable.Map<any, any>): ContentState;
-                static mergeBlockData(contentState: ContentState, selectionState: SelectionState, blockData: Immutable.Map<any, any>): ContentState;
-                static applyEntity(contentState: ContentState, selectionState: SelectionState, entityKey: string | null): ContentState;
+                static setBlockData(
+                    contentState: ContentState,
+                    selectionState: SelectionState,
+                    blockData: Immutable.Map<any, any>,
+                ): ContentState;
+                static mergeBlockData(
+                    contentState: ContentState,
+                    selectionState: SelectionState,
+                    blockData: Immutable.Map<any, any>,
+                ): ContentState;
+                static applyEntity(
+                    contentState: ContentState,
+                    selectionState: SelectionState,
+                    entityKey: string | null,
+                ): ContentState;
             }
 
             class RichTextEditorUtil {
@@ -989,7 +1065,11 @@ declare namespace Draft {
                  */
                 static toggleInlineStyle(editorState: EditorState, inlineStyle: string): EditorState;
 
-                static toggleLink(editorState: EditorState, targetSelection: SelectionState, entityKey: string | null): EditorState;
+                static toggleLink(
+                    editorState: EditorState,
+                    targetSelection: SelectionState,
+                    entityKey: string | null,
+                ): EditorState;
 
                 /**
                  * When a collapsed cursor is at the start of an empty styled block, allow
@@ -1061,12 +1141,10 @@ export {
     EditorBlock,
     EditorState,
     EditorChangeType,
-
     DraftDecorator,
     CompositeDecorator,
     Entity,
     EntityInstance,
-
     BlockMapBuilder,
     CharacterMetadata,
     ContentBlock,
@@ -1074,15 +1152,12 @@ export {
     SelectionState,
     DraftInlineStyle,
     BlockMap,
-
     AtomicBlockUtils,
     KeyBindingUtil,
     Modifier,
     RichUtils,
-
     DefaultDraftBlockRenderMap,
     DefaultDraftInlineStyle,
-
     RawDraftInlineStyleRange,
     RawDraftEntityRange,
     RawDraftEntity,
@@ -1091,11 +1166,9 @@ export {
     convertFromRaw,
     convertToRaw,
     convertFromHTML,
-
     genKey,
     getDefaultKeyBinding,
     getVisibleSelectionRect,
-
     DraftEditorCommand,
     DraftDragType,
     DraftBlockType,
@@ -1107,5 +1180,5 @@ export {
     DraftRemovalDirection,
     DraftHandleValue,
     DraftInsertionType,
-    DraftStyleMap
+    DraftStyleMap,
 };

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -51,9 +51,9 @@ declare namespace Draft {
              * state of the editor. See `DraftEditorProps` for details.
              */
             class DraftEditor extends React.Component<DraftEditorProps, {}> {
-                // Force focus back onto the editor node.
+                /** Force focus back onto the editor node. */
                 focus(): void;
-                // Remove focus from the editor node.
+                /** Remove focus from the editor node. */
                 blur(): void;
             }
 
@@ -73,52 +73,74 @@ declare namespace Draft {
 
                 placeholder?: string;
 
-                // Specify whether text alignment should be forced in a direction
-                // regardless of input characters.
+                /**
+                 * Specify whether text alignment should be forced in a direction
+                 * regardless of input characters.
+                 */
                 textAlignment?: DraftTextAlignment;
 
-                // Specify whether text directionality should be forced in a direction
-                // regardless of input characters.
-                textDirectionality?: DraftTextDirectionality;
+                /**
+                 * Specify whether text directionality should be forced in a direction
+                 * regardless of input characters.
+                 */
+                 textDirectionality?: DraftTextDirectionality;
 
-                // For a given `ContentBlock` object, return an object that specifies
-                // a custom block component and/or props. If no object is returned,
-                // the default `TextEditorBlock` is used.
+                /**
+                 * For a given `ContentBlock` object, return an object that specifies
+                 * a custom block component and/or props. If no object is returned,
+                 * the default `TextEditorBlock` is used.
+                 */
                 blockRendererFn?(block: ContentBlock): any;
 
-                // Provide a map of block rendering configurations. Each block type maps to
-                // an element tag and an optional react element wrapper. This configuration
-                // is used for both rendering and paste processing.
+                /**
+                 * Provide a map of block rendering configurations. Each block type maps to
+                 * an element tag and an optional react element wrapper. This configuration
+                 * is used for both rendering and paste processing.
+                 */
                 blockRenderMap?: DraftBlockRenderMap
 
-                // Function that allows to define class names to apply to the given block when it is rendered.
-                blockStyleFn?(block: ContentBlock): string;
+                /**
+                 * Function that allows to define class names to apply to the given block when it is rendered.
+                 */
+                 blockStyleFn?(block: ContentBlock): string;
 
-                // Provide a map of inline style names corresponding to CSS style objects
-                // that will be rendered for matching ranges.
-                customStyleMap?: DraftStyleMap;
+                /**
+                 * Provide a map of inline style names corresponding to CSS style objects
+                 * that will be rendered for matching ranges.
+                 */
+                 customStyleMap?: DraftStyleMap;
 
-                // Define a function to transform inline styles to CSS objects
-                // that are applied to spans of text.
-                customStyleFn?: (style: DraftInlineStyle, block: ContentBlock) => React.CSSProperties;
+                /**
+                 * Define a function to transform inline styles to CSS objects
+                 * that are applied to spans of text.
+                 */
+                 customStyleFn?: (style: DraftInlineStyle, block: ContentBlock) => React.CSSProperties;
 
-                // A function that accepts a synthetic key event and returns
-                // the matching DraftEditorCommand constant, or null if no command should
-                // be invoked.
+                /**
+                 * A function that accepts a synthetic key event and returns
+                 * the matching DraftEditorCommand constant, or null if no command should
+                 * be invoked.
+                 */
                 keyBindingFn?(e: SyntheticKeyboardEvent): EditorCommand | null;
 
-                // Set whether the `DraftEditor` component should be editable. Useful for
-                // temporarily disabling edit behavior or allowing `DraftEditor` rendering
-                // to be used for consumption purposes.
+                /**
+                 * Set whether the `DraftEditor` component should be editable. Useful for
+                 * temporarily disabling edit behavior or allowing `DraftEditor` rendering
+                 * to be used for consumption purposes.
+                 */
                 readOnly?: boolean;
 
-                // Note: spellcheck is always disabled for IE. If enabled in Safari, OSX
-                // autocorrect is enabled as well.
-                spellCheck?: boolean;
+                /**
+                 * Note: spellcheck is always disabled for IE. If enabled in Safari, OSX
+                 * autocorrect is enabled as well.
+                 */
+                 spellCheck?: boolean;
 
-                // Set whether to remove all style information from pasted content. If your
-                // use case should not have any block or inline styles, it is recommended
-                // that you set this to `true`.
+                /**
+                 * Set whether to remove all style information from pasted content. If your
+                 * use case should not have any block or inline styles, it is recommended
+                 * that you set this to `true`.
+                 */
                 stripPastedStyles?: boolean;
 
                 tabIndex?: number;
@@ -141,43 +163,48 @@ declare namespace Draft {
 
                 webDriverTestID?: string;
 
-                // If using server-side rendering, this prop is required to be set to
-                // avoid client/server mismatches.
+                /**
+                 * If using server-side rendering, this prop is required to be set to
+                 * avoid client/server mismatches.
+                 */
                 editorKey?: string;
 
-                /**
-                 * Cancelable event handlers, handled from the top level down. A handler
-                 * that returns `handled` will be the last handler to execute for that event.
-                 */
+                // Cancelable event handlers, handled from the top level down. A handler
+                // that returns `handled` will be the last handler to execute for that event.
 
-                // Useful for managing special behavior for pressing the `Return` key. E.g.
-                // removing the style from an empty list item.
+                /**
+                 * Useful for managing special behavior for pressing the `Return` key. E.g.
+                 * removing the style from an empty list item.
+                 */
                 handleReturn?(e: SyntheticKeyboardEvent, editorState: EditorState): DraftHandleValue,
 
-                // Map a key command string provided by your key binding function to a
-                // specified behavior.
+                 /**
+                  * Map a key command string provided by your key binding function to a
+                  * specified behavior.
+                  */
                 handleKeyCommand?(command: EditorCommand, editorState: EditorState, eventTimeStamp: number): DraftHandleValue,
 
-                // Handle intended text insertion before the insertion occurs. This may be
-                // useful in cases where the user has entered characters that you would like
-                // to trigger some special behavior. E.g. immediately converting `:)` to an
-                // emoji Unicode character, or replacing ASCII quote characters with smart
-                // quotes.
+                
+                /**
+                 * Handle intended text insertion before the insertion occurs. This may be
+                 * useful in cases where the user has entered characters that you would like
+                 * to trigger some special behavior. E.g. immediately converting `:)` to an
+                 * emoji Unicode character, or replacing ASCII quote characters with smart
+                 * quotes.
+                 */
                 handleBeforeInput?(chars: string, editorState: EditorState, eventTimeStamp: number): DraftHandleValue,
 
                 handlePastedText?(text: string, html: string|undefined, editorState: EditorState): DraftHandleValue,
 
                 handlePastedFiles?(files: Array<Blob>): DraftHandleValue,
 
-                // Handle dropped files
+                /** Handle dropped files */
                 handleDroppedFiles?(selection: SelectionState, files: Array<Blob>): DraftHandleValue,
 
-                // Handle other drops to prevent default text movement/insertion behaviour
+                /** Handle other drops to prevent default text movement/insertion behaviour */
                 handleDrop?(selection: SelectionState, dataTransfer: Object, isInternal: DraftDragType): DraftHandleValue,
 
-                /**
-                 * Non-cancelable event triggers.
-                 */
+                // Non-cancelable event triggers.
                 onEscape?(e: SyntheticKeyboardEvent): void,
                 onTab?(e: SyntheticKeyboardEvent): void,
                 onUpArrow?(e: SyntheticKeyboardEvent): void,

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -185,7 +185,7 @@ declare namespace Draft {
                   */
                 handleKeyCommand?(command: EditorCommand, editorState: EditorState, eventTimeStamp: number): DraftHandleValue,
 
-                
+
                 /**
                  * Handle intended text insertion before the insertion occurs. This may be
                  * useful in cases where the user has entered characters that you would like


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`ariaLabelledBy`](https://github.com/facebook/draft-js/blob/6e87246506ca59060cb4c6ebc7a9ac3e97609a2a/src/component/base/DraftEditorProps.js#L95), [`ariaOwneeID`](https://github.com/facebook/draft-js/blob/6e87246506ca59060cb4c6ebc7a9ac3e97609a2a/src/component/base/DraftEditorProps.js#L97), [`usesMacOSHeuristics`](https://draftjs.org/docs/api-reference-key-binding-util/#usesmacosheuristics)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
 * **I'm not sure if I should or not - `ariaLabelledBy` is from `v0.10.5` but `ariaOwneeID` is from `v0.11.0` and I don't know if the rest of the changes from 11 are integrated.**

# Add missing aria props:
This adds `ariaLabelledBy` and `ariaOwneeID` to the props definition as they are supported (see links above) but weren't included.

# Add usesMacOSHeuristics:
This adds the missing definition for the static `usesMacOSHeuristics` on `KeyBindingUtils`.

# Change comments for JSDoc
This changes some comments that were in the type definition from the `//` style to the `/** */` style so they are treated as JSDoc since they were documenting individual members.
