### PR TITLE
[pg] Made all args in Pool connect callback optional 

### DIFF
--- a/types/pg-pool/index.d.ts
+++ b/types/pg-pool/index.d.ts
@@ -12,7 +12,7 @@ declare class Pool<T extends pg.Client> extends pg.Pool {
     constructor(config?: Pool.Config<T>, client?: Pool.ClientLikeCtr<T>);
 
     connect(): Promise<T & pg.PoolClient>;
-    connect(callback: (err: Error, client: T & pg.PoolClient, done: (release?: any) => void) => void): void;
+    connect(callback: (err?: Error, client?: T & pg.PoolClient, done?: (release?: any) => void) => void): void;
 
     on(event: 'error', listener: (err: Error, client: T & pg.PoolClient) => void): this;
     on(event: 'connect' | 'acquire' | 'remove', listener: (client: T & pg.PoolClient) => void): this;

--- a/types/pg-query-stream/pg-query-stream-tests.ts
+++ b/types/pg-query-stream/pg-query-stream-tests.ts
@@ -3,13 +3,17 @@ import * as pg from 'pg';
 
 const options: QueryStream.Options = {
     highWaterMark: 1000,
-    batchSize: 100
+    batchSize: 100,
 };
 
 const query = new QueryStream('SELECT * FROM generate_series(0, $1) num', [1000000], options);
 
 const pool = new pg.Pool();
 pool.connect((err, client, done) => {
+    if (client == null) {
+        console.error('unable to fetch client from pool');
+        return;
+    }
     const stream = client.query(query);
     stream.on('end', () => {
         client.release();

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -10,7 +10,7 @@ import events = require('events');
 import stream = require('stream');
 import pgTypes = require('pg-types');
 
-import { ConnectionOptions } from "tls";
+import { ConnectionOptions } from 'tls';
 
 export interface ClientConfig {
     user?: string;
@@ -160,7 +160,7 @@ export class Pool extends events.EventEmitter {
     readonly waitingCount: number;
 
     connect(): Promise<PoolClient>;
-    connect(callback: (err: Error, client: PoolClient, done: (release?: any) => void) => void): void;
+    connect(callback: (err?: Error, client?: PoolClient, done?: (release?: any) => void) => void): void;
 
     end(): Promise<void>;
     end(callback: () => void): void;

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -156,12 +156,15 @@ const pool = new Pool({
 });
 console.log(pool.totalCount);
 pool.connect((err, client, done) => {
-    if (err) {
+    if (err || client == null) {
         console.error('error fetching client from pool', err);
         return;
     }
+
     client.query('SELECT $1::int AS number', ['1'], (err, result) => {
-        done();
+        if (done != null) {
+            done();
+        }
 
         if (err) {
             console.error('error running query', err);


### PR DESCRIPTION
The same fix here:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41519

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/blob/master/packages/pg-pool/index.js#L145
https://github.com/brianc/node-postgres/blob/master/packages/pg-pool/test/connection-timeout.js#L70
https://github.com/brianc/node-postgres/blob/master/packages/pg-pool/test/connection-timeout.js#L74
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.