### PR TITLE
fix(plotly.js): nested property attributes fix

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -85,21 +85,19 @@ export type PlotRestyleEvent = [
 	number[]	// array of traces updated
 ];
 
-export interface PlotAxis {
-	range: [number, number];
-	autorange: boolean;
-}
-
 export interface PlotScene {
 	center: Point;
 	eye: Point;
 	up: Point;
 }
 
-export interface PlotRelayoutEvent {
-	xaxis: PlotAxis;
-	yaxis: PlotAxis;
-	scene: PlotScene;
+export interface PlotRelayoutEvent extends Partial<Layout> {
+	"xaxis.range[0]"?: number;
+	"xaxis.range[1]"?: number;
+	"yaxis.range[0]"?: number;
+	"yaxis.range[1]"?: number;
+	"xaxis.autorange"?: boolean;
+	"yaxis.autorange"?: boolean;
 }
 
 export interface ClickAnnotationEvent {

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -493,6 +493,15 @@ function rand() {
 		}, [0]);
 	});
 
+	myPlot.on('plotly_relayout', eventdata => {
+		eventdata["xaxis.autorange"]; // $ExpectType boolean | undefined
+		eventdata["xaxis.autorange"]; // $ExpectType boolean | undefined
+		eventdata["xaxis.range[0]"]; // $ExpectType number | undefined
+		eventdata["xaxis.range[1]"]; // $ExpectType number | undefined
+		eventdata["yaxis.range[0]"]; // $ExpectType number | undefined
+		eventdata["yaxis.range[1]"]; // $ExpectType number | undefined
+	});
+
 	myPlot.on('plotly_restyle', (data) => {
 		console.log('restyling');
 	});


### PR DESCRIPTION
This changes the shape of the PlotlyRelayoutEvent to use string based
property access as per-discussion here:
https://github.com/plotly/plotly.js/issues/1877

See:
https://plotly.com/javascript/plotlyjs-events/
https://plotly.com/javascript/zoom-events/#binding-to-zoom-events

/cc @mmakrzem

Thanks!

Fixes: #43735

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes