### PR TITLE
Add types for package react-combine-reducers

### DIFF
--- a/types/react-combine-reducers/index.d.ts
+++ b/types/react-combine-reducers/index.d.ts
@@ -2,13 +2,10 @@
 // Project: https://github.com/ankita1010/react-combine-reducers#readme
 // Definitions by: Raphaël Léger <https://github.com/raphael-leger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-import { Reducer, ReducerState } from "react";
+import { Reducer, ReducerState } from 'react';
 
 export default function combineReducers<R extends Reducer<any, any>>(
-reducers: {
-  [K in keyof ReducerState<R>]: [
-    Reducer<ReducerState<R>[K], any>,
-    ReducerState<R>[K]
-  ];
-}
+    reducers: {
+        [K in keyof ReducerState<R>]: [Reducer<ReducerState<R>[K], any>, ReducerState<R>[K]];
+    },
 ): [R, ReducerState<R>];

--- a/types/react-combine-reducers/index.d.ts
+++ b/types/react-combine-reducers/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for react-combine-reducers 1.0
+// Project: https://github.com/ankita1010/react-combine-reducers#readme
+// Definitions by: Raphaël Léger <https://github.com/raphael-leger>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import { Reducer, ReducerState } from "react";
+
+export default function combineReducers<R extends Reducer<any, any>>(
+reducers: {
+  [K in keyof ReducerState<R>]: [
+    Reducer<ReducerState<R>[K], any>,
+    ReducerState<R>[K]
+  ];
+}
+): [R, ReducerState<R>];

--- a/types/react-combine-reducers/index.d.ts
+++ b/types/react-combine-reducers/index.d.ts
@@ -2,10 +2,12 @@
 // Project: https://github.com/ankita1010/react-combine-reducers#readme
 // Definitions by: Raphaël Léger <https://github.com/raphael-leger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.1
 import { Reducer, ReducerState } from 'react';
 
-export default function combineReducers<R extends Reducer<any, any>>(
+declare function combineReducers<R extends Reducer<any, any>>(
     reducers: {
         [K in keyof ReducerState<R>]: [Reducer<ReducerState<R>[K], any>, ReducerState<R>[K]];
     },
 ): [R, ReducerState<R>];
+export = combineReducers;

--- a/types/react-combine-reducers/react-combine-reducers-tests.ts
+++ b/types/react-combine-reducers/react-combine-reducers-tests.ts
@@ -1,33 +1,36 @@
 import combineReducers from 'react-combine-reducers';
 
-type SimpleAction = { type: string; payload: any };
+interface SimpleAction {
+    type: string;
+    payload: any;
+}
 
-type GreeniesState = {
+interface GreeniesState {
     fruit: 'apple' | 'pear' | 'kiwi';
     vegetable: 'carrot' | 'eggplant';
-};
+}
 
-type ProteinsState = {
+interface ProteinsState {
     similiCarne: 'tofu' | 'seitan';
     vegetable: 'bean' | 'artichoke';
-};
+}
 
-type DrinkState = {
+interface DrinkState {
     beverage: 'water' | 'juice';
     numberOfGlasses: number;
-};
+}
 
-type DessertState = {
+interface DessertState {
     cake: 'chocolate' | 'cherry';
     drink: 'tea' | 'coffee';
-};
+}
 
-type FullMealState = {
+interface FullMealState {
     proteins: ProteinsState;
     greenies: GreeniesState;
     dessert: DessertState;
     drink: DrinkState;
-};
+}
 
 type FullMealReducer = (state: FullMealState, action: SimpleAction) => FullMealState;
 
@@ -68,23 +71,23 @@ combineReducers<FullMealReducer>({});
 // $ExpectError
 combineReducers<FullMealReducer>();
 
-// $ExpectError
 combineReducers<FullMealReducer>({
+    // $ExpectError
     books: ['The Book Thief'],
 });
 
-// $ExpectError
 combineReducers<FullMealReducer>({
+    // $ExpectError
     proteins: [100],
 });
 
-// $ExpectError
 combineReducers<FullMealReducer>({
+    // $ExpectError
     proteins: [3, proteinsReducer],
 });
 
-// $ExpectError
 combineReducers<FullMealReducer>({
+    // $ExpectError
     proteins: [proteinsReducer, 3],
 });
 
@@ -99,7 +102,6 @@ combineReducers<FullMealReducer>({
     ],
 });
 
-// $ExpectError
 combineReducers<FullMealReducer>({
     proteins: [
         proteinsReducer,
@@ -109,6 +111,7 @@ combineReducers<FullMealReducer>({
         },
     ],
     greenies: [
+        // $ExpectError
         proteinsReducer,
         {
             fruit: 'kiwi',
@@ -116,6 +119,7 @@ combineReducers<FullMealReducer>({
         },
     ],
     drink: [
+        // $ExpectError
         proteinsReducer,
         {
             beverage: 'juice',
@@ -123,6 +127,7 @@ combineReducers<FullMealReducer>({
         },
     ],
     dessert: [
+        // $ExpectError
         proteinsReducer,
         {
             cake: 'chocolate',
@@ -176,7 +181,6 @@ fullMealReducer(3, {});
 // $ExpectError
 fullMealReducer({}, {});
 
-// $ExpectError
 fullMealReducer(
     {
         proteins: {
@@ -196,6 +200,7 @@ fullMealReducer(
             drink: 'tea',
         },
     },
+    // $ExpectError
     67,
 );
 

--- a/types/react-combine-reducers/react-combine-reducers-tests.ts
+++ b/types/react-combine-reducers/react-combine-reducers-tests.ts
@@ -1,78 +1,66 @@
-import combineReducers from "react-combine-reducers";
+import combineReducers from 'react-combine-reducers';
 
 type SimpleAction = { type: string; payload: any };
 
 type GreeniesState = {
-  fruit: 'apple' | 'pear' | 'kiwi';
-  vegetable: 'carrot' | 'eggplant';
+    fruit: 'apple' | 'pear' | 'kiwi';
+    vegetable: 'carrot' | 'eggplant';
 };
 
 type ProteinsState = {
-  similiCarne: 'tofu' | 'seitan';
-  vegetable: 'bean' | 'artichoke';
+    similiCarne: 'tofu' | 'seitan';
+    vegetable: 'bean' | 'artichoke';
 };
 
 type DrinkState = {
-  beverage: 'water' | 'juice';
-  numberOfGlasses: number;
+    beverage: 'water' | 'juice';
+    numberOfGlasses: number;
 };
 
 type DessertState = {
-  cake: 'chocolate' | 'cherry';
-  drink: 'tea' | 'coffee';
+    cake: 'chocolate' | 'cherry';
+    drink: 'tea' | 'coffee';
 };
 
 type FullMealState = {
-  proteins: ProteinsState;
-  greenies: GreeniesState;
-  dessert: DessertState;
-  drink: DrinkState;
-}
+    proteins: ProteinsState;
+    greenies: GreeniesState;
+    dessert: DessertState;
+    drink: DrinkState;
+};
 
 type FullMealReducer = (state: FullMealState, action: SimpleAction) => FullMealState;
 
-const proteinsReducer = (
-  proteinsState: ProteinsState,
-  action: SimpleAction
-) => {
-  switch (action) {
-    default:
-      return proteinsState;
-  }
-}
+const proteinsReducer = (proteinsState: ProteinsState, action: SimpleAction) => {
+    switch (action) {
+        default:
+            return proteinsState;
+    }
+};
 
-const drinkReducer = (
-  drinkState: DrinkState,
-  action: SimpleAction
-) => {
-  switch (action) {
-    default:
-      return drinkState;
-  }
-}
+const drinkReducer = (drinkState: DrinkState, action: SimpleAction) => {
+    switch (action) {
+        default:
+            return drinkState;
+    }
+};
 
-const dessertReducer = (
-  dessertState: DessertState,
-  action: SimpleAction
-) => {
-  switch (action) {
-    default:
-      return dessertState;
-  }
-}
+const dessertReducer = (dessertState: DessertState, action: SimpleAction) => {
+    switch (action) {
+        default:
+            return dessertState;
+    }
+};
 
-const greeniesReducer = (
-  greeniesState: GreeniesState,
-  action: SimpleAction
-) => {
-  switch (action) {
-    default:
-      return greeniesState;
-  }
-}
+const greeniesReducer = (greeniesState: GreeniesState, action: SimpleAction) => {
+    switch (action) {
+        default:
+            return greeniesState;
+    }
+};
 
 // $ExpectError
-combineReducers("");
+combineReducers('');
 
 // $ExpectError
 combineReducers<FullMealReducer>({});
@@ -82,69 +70,96 @@ combineReducers<FullMealReducer>();
 
 // $ExpectError
 combineReducers<FullMealReducer>({
-  books: ["The Book Thief"]
+    books: ['The Book Thief'],
 });
 
 // $ExpectError
 combineReducers<FullMealReducer>({
-  proteins: [100]
+    proteins: [100],
 });
 
 // $ExpectError
 combineReducers<FullMealReducer>({
-  proteins: [3, proteinsReducer],
+    proteins: [3, proteinsReducer],
 });
 
 // $ExpectError
 combineReducers<FullMealReducer>({
-  proteins: [proteinsReducer, 3],
+    proteins: [proteinsReducer, 3],
 });
 
 // $ExpectError
 combineReducers<FullMealReducer>({
-  proteins: [proteinsReducer, {
-    similiCarne: 'tofu',
-    vegetable: 'artichoke'
-  }],
+    proteins: [
+        proteinsReducer,
+        {
+            similiCarne: 'tofu',
+            vegetable: 'artichoke',
+        },
+    ],
 });
 
 // $ExpectError
 combineReducers<FullMealReducer>({
-  proteins: [proteinsReducer, {
-    similiCarne: 'tofu',
-    vegetable: 'artichoke'
-  }],
-  greenies: [proteinsReducer, {
-    fruit: 'kiwi',
-    vegetable: 'eggplant'
-  }],
-  drink: [proteinsReducer, {
-    beverage: 'juice',
-    numberOfGlasses: 2
-  }],
-  dessert: [proteinsReducer, {
-    cake: 'chocolate',
-    drink: 'tea',
-  }]
+    proteins: [
+        proteinsReducer,
+        {
+            similiCarne: 'tofu',
+            vegetable: 'artichoke',
+        },
+    ],
+    greenies: [
+        proteinsReducer,
+        {
+            fruit: 'kiwi',
+            vegetable: 'eggplant',
+        },
+    ],
+    drink: [
+        proteinsReducer,
+        {
+            beverage: 'juice',
+            numberOfGlasses: 2,
+        },
+    ],
+    dessert: [
+        proteinsReducer,
+        {
+            cake: 'chocolate',
+            drink: 'tea',
+        },
+    ],
 });
 
 const [fullMealReducer, initialMeal] = combineReducers<FullMealReducer>({
-  proteins: [proteinsReducer, {
-    similiCarne: 'tofu',
-    vegetable: 'artichoke'
-  }],
-  greenies: [greeniesReducer, {
-    fruit: 'kiwi',
-    vegetable: 'eggplant'
-  }],
-  drink: [drinkReducer, {
-    beverage: 'juice',
-    numberOfGlasses: 2
-  }],
-  dessert: [dessertReducer, {
-    cake: 'chocolate',
-    drink: 'tea',
-  }],
+    proteins: [
+        proteinsReducer,
+        {
+            similiCarne: 'tofu',
+            vegetable: 'artichoke',
+        },
+    ],
+    greenies: [
+        greeniesReducer,
+        {
+            fruit: 'kiwi',
+            vegetable: 'eggplant',
+        },
+    ],
+    drink: [
+        drinkReducer,
+        {
+            beverage: 'juice',
+            numberOfGlasses: 2,
+        },
+    ],
+    dessert: [
+        dessertReducer,
+        {
+            cake: 'chocolate',
+            drink: 'tea',
+        },
+    ],
 });
 
 initialMeal.dessert;
@@ -162,45 +177,51 @@ fullMealReducer(3, {});
 fullMealReducer({}, {});
 
 // $ExpectError
-fullMealReducer({
-  proteins: {
-    similiCarne: 'tofu',
-    vegetable: 'artichoke'
-  },
-  greenies:  {
-    fruit: 'kiwi',
-    vegetable: 'eggplant'
-  },
-  drink: {
-    beverage: 'juice',
-    numberOfGlasses: 2
-  },
-  dessert: {
-    cake: 'chocolate',
-    drink: 'tea',
-  },
-}, 67);
+fullMealReducer(
+    {
+        proteins: {
+            similiCarne: 'tofu',
+            vegetable: 'artichoke',
+        },
+        greenies: {
+            fruit: 'kiwi',
+            vegetable: 'eggplant',
+        },
+        drink: {
+            beverage: 'juice',
+            numberOfGlasses: 2,
+        },
+        dessert: {
+            cake: 'chocolate',
+            drink: 'tea',
+        },
+    },
+    67,
+);
 
-fullMealReducer({
-  proteins: {
-    similiCarne: 'tofu',
-    vegetable: 'artichoke'
-  },
-  greenies:  {
-    fruit: 'kiwi',
-    vegetable: 'eggplant'
-  },
-  drink: {
-    beverage: 'juice',
-    numberOfGlasses: 2
-  },
-  dessert: {
-    cake: 'chocolate',
-    drink: 'tea',
-  },
-}, {
-  type: 'eat',
-  payload: 'everything'
-});
+fullMealReducer(
+    {
+        proteins: {
+            similiCarne: 'tofu',
+            vegetable: 'artichoke',
+        },
+        greenies: {
+            fruit: 'kiwi',
+            vegetable: 'eggplant',
+        },
+        drink: {
+            beverage: 'juice',
+            numberOfGlasses: 2,
+        },
+        dessert: {
+            cake: 'chocolate',
+            drink: 'tea',
+        },
+    },
+    {
+        type: 'eat',
+        payload: 'everything',
+    },
+);
 
 export { fullMealReducer, initialMeal };

--- a/types/react-combine-reducers/react-combine-reducers-tests.ts
+++ b/types/react-combine-reducers/react-combine-reducers-tests.ts
@@ -1,0 +1,206 @@
+import combineReducers from "react-combine-reducers";
+
+type SimpleAction = { type: string; payload: any };
+
+type GreeniesState = {
+  fruit: 'apple' | 'pear' | 'kiwi';
+  vegetable: 'carrot' | 'eggplant';
+};
+
+type ProteinsState = {
+  similiCarne: 'tofu' | 'seitan';
+  vegetable: 'bean' | 'artichoke';
+};
+
+type DrinkState = {
+  beverage: 'water' | 'juice';
+  numberOfGlasses: number;
+};
+
+type DessertState = {
+  cake: 'chocolate' | 'cherry';
+  drink: 'tea' | 'coffee';
+};
+
+type FullMealState = {
+  proteins: ProteinsState;
+  greenies: GreeniesState;
+  dessert: DessertState;
+  drink: DrinkState;
+}
+
+type FullMealReducer = (state: FullMealState, action: SimpleAction) => FullMealState;
+
+const proteinsReducer = (
+  proteinsState: ProteinsState,
+  action: SimpleAction
+) => {
+  switch (action) {
+    default:
+      return proteinsState;
+  }
+}
+
+const drinkReducer = (
+  drinkState: DrinkState,
+  action: SimpleAction
+) => {
+  switch (action) {
+    default:
+      return drinkState;
+  }
+}
+
+const dessertReducer = (
+  dessertState: DessertState,
+  action: SimpleAction
+) => {
+  switch (action) {
+    default:
+      return dessertState;
+  }
+}
+
+const greeniesReducer = (
+  greeniesState: GreeniesState,
+  action: SimpleAction
+) => {
+  switch (action) {
+    default:
+      return greeniesState;
+  }
+}
+
+// $ExpectError
+combineReducers("");
+
+// $ExpectError
+combineReducers<FullMealReducer>({});
+
+// $ExpectError
+combineReducers<FullMealReducer>();
+
+// $ExpectError
+combineReducers<FullMealReducer>({
+  books: ["The Book Thief"]
+});
+
+// $ExpectError
+combineReducers<FullMealReducer>({
+  proteins: [100]
+});
+
+// $ExpectError
+combineReducers<FullMealReducer>({
+  proteins: [3, proteinsReducer],
+});
+
+// $ExpectError
+combineReducers<FullMealReducer>({
+  proteins: [proteinsReducer, 3],
+});
+
+// $ExpectError
+combineReducers<FullMealReducer>({
+  proteins: [proteinsReducer, {
+    similiCarne: 'tofu',
+    vegetable: 'artichoke'
+  }],
+});
+
+// $ExpectError
+combineReducers<FullMealReducer>({
+  proteins: [proteinsReducer, {
+    similiCarne: 'tofu',
+    vegetable: 'artichoke'
+  }],
+  greenies: [proteinsReducer, {
+    fruit: 'kiwi',
+    vegetable: 'eggplant'
+  }],
+  drink: [proteinsReducer, {
+    beverage: 'juice',
+    numberOfGlasses: 2
+  }],
+  dessert: [proteinsReducer, {
+    cake: 'chocolate',
+    drink: 'tea',
+  }]
+});
+
+const [fullMealReducer, initialMeal] = combineReducers<FullMealReducer>({
+  proteins: [proteinsReducer, {
+    similiCarne: 'tofu',
+    vegetable: 'artichoke'
+  }],
+  greenies: [greeniesReducer, {
+    fruit: 'kiwi',
+    vegetable: 'eggplant'
+  }],
+  drink: [drinkReducer, {
+    beverage: 'juice',
+    numberOfGlasses: 2
+  }],
+  dessert: [dessertReducer, {
+    cake: 'chocolate',
+    drink: 'tea',
+  }],
+});
+
+initialMeal.dessert;
+initialMeal.drink;
+initialMeal.proteins;
+initialMeal.greenies;
+
+// $ExpectError
+initialMeal.lamps;
+
+// $ExpectError
+fullMealReducer(3, {});
+
+// $ExpectError
+fullMealReducer({}, {});
+
+// $ExpectError
+fullMealReducer({
+  proteins: {
+    similiCarne: 'tofu',
+    vegetable: 'artichoke'
+  },
+  greenies:  {
+    fruit: 'kiwi',
+    vegetable: 'eggplant'
+  },
+  drink: {
+    beverage: 'juice',
+    numberOfGlasses: 2
+  },
+  dessert: {
+    cake: 'chocolate',
+    drink: 'tea',
+  },
+}, 67);
+
+fullMealReducer({
+  proteins: {
+    similiCarne: 'tofu',
+    vegetable: 'artichoke'
+  },
+  greenies:  {
+    fruit: 'kiwi',
+    vegetable: 'eggplant'
+  },
+  drink: {
+    beverage: 'juice',
+    numberOfGlasses: 2
+  },
+  dessert: {
+    cake: 'chocolate',
+    drink: 'tea',
+  },
+}, {
+  type: 'eat',
+  payload: 'everything'
+});
+
+export { fullMealReducer, initialMeal };

--- a/types/react-combine-reducers/tsconfig.json
+++ b/types/react-combine-reducers/tsconfig.json
@@ -1,23 +1,24 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictFunctionTypes": true,
-        "strictNullChecks": true,
-        "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
-        "types": [],
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.d.ts",
-        "react-combine-reducers-tests.ts"
-    ]
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "esModuleInterop": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "react-combine-reducers-tests.ts"
+  ]
 }

--- a/types/react-combine-reducers/tsconfig.json
+++ b/types/react-combine-reducers/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-combine-reducers-tests.ts"
+    ]
+}

--- a/types/react-combine-reducers/tslint.json
+++ b/types/react-combine-reducers/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Add types for the following package :
https://github.com/ankita1010/react-combine-reducers


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
