### PR TITLE
Add types for baretest 1.0

### DIFF
--- a/types/baretest/baretest-tests.ts
+++ b/types/baretest/baretest-tests.ts
@@ -33,6 +33,5 @@ test("you shouldn't return from an async test function", async () => {
 
 (async () => {
     const result = await test.run();
-    result; // $ExpectType false | undefined
-    // TODO expect result type to be `boolean` after https://github.com/volument/baretest/pull/11 is merged and released
+    result; // $ExpectType boolean
 })();

--- a/types/baretest/baretest-tests.ts
+++ b/types/baretest/baretest-tests.ts
@@ -1,0 +1,38 @@
+import baretest = require('baretest');
+
+const test = baretest('my program');
+
+function doSetup(): void {}
+function doCleanup(): void {}
+function assertSomeThings(): void {}
+
+test.before(doSetup);
+
+test.after(doCleanup);
+
+test('it can do things', assertSomeThings);
+
+test.skip('it can create world peace', assertSomeThings);
+
+test('it can do things asynchronously', async () => {
+    return;
+});
+
+// $ExpectError
+test("you shouldn't return from a test function", () => {
+    return 2 + 2;
+});
+
+// $ExpectError
+test("you shouldn't take parameters in a test function", (people: number) => {});
+
+// $ExpectError
+test("you shouldn't return from an async test function", async () => {
+    return 'data from an API under test';
+});
+
+(async () => {
+    const result = await test.run();
+    result; // $ExpectType false | undefined
+    // TODO expect result type to be `boolean` after https://github.com/volument/baretest/pull/11 is merged and released
+})();

--- a/types/baretest/index.d.ts
+++ b/types/baretest/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for baretest 1.0
+// Project: https://volument.com/baretest
+// Definitions by: Rory O’Kane <https://github.com/roryokane>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = baretest;
+
+declare function baretest(headline: string): TesterFunctionObject;
+
+type TesterFunctionObject = TesterFunction & TesterSubFunctions;
+
+type TesterFunction = (name: string, fn: SyncOrAsyncVoidFunction) => void;
+interface TesterSubFunctions {
+    only: (name: string, fn: SyncOrAsyncVoidFunction) => void;
+    skip: (name?: string, fn?: SyncOrAsyncVoidFunction) => void;
+    before: (fn: SyncOrAsyncVoidFunction) => void;
+    after: (fn: SyncOrAsyncVoidFunction) => void;
+    run: () => Promise<undefined | false>; // TODO make this `Promise<boolean>` after https://github.com/volument/baretest/pull/11 is merged and released
+}
+
+type SyncOrAsyncVoidFunction = () => void | Promise<void>;

--- a/types/baretest/index.d.ts
+++ b/types/baretest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for baretest 1.0
+// Type definitions for baretest 2.0
 // Project: https://volument.com/baretest
 // Definitions by: Rory O’Kane <https://github.com/roryokane>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -15,7 +15,7 @@ interface TesterSubFunctions {
     skip: (name?: string, fn?: SyncOrAsyncVoidFunction) => void;
     before: (fn: SyncOrAsyncVoidFunction) => void;
     after: (fn: SyncOrAsyncVoidFunction) => void;
-    run: () => Promise<undefined | false>; // TODO make this `Promise<boolean>` after https://github.com/volument/baretest/pull/11 is merged and released
+    run: () => Promise<boolean>;
 }
 
 type SyncOrAsyncVoidFunction = () => void | Promise<void>;

--- a/types/baretest/tsconfig.json
+++ b/types/baretest/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "baretest-tests.ts"
+    ]
+}

--- a/types/baretest/tslint.json
+++ b/types/baretest/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
These files were based on the template written with `npx dts-gen --dt --name baretest --template module`.

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
    - I don’t understand this instruction. I think you should [reword it](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
        - I apparently changed my “own code”—what “own code”? If you meant the types and tests I am submitting, you should say “your code” or “this PR’s code”. “My own code” sounds like my projects that use the Baretest library, but I don’t see how those are relevant.
        - What should I “compile and run”? None of the files I’m adding should be compiled to JavaScript and ran. They should be *imported* by users or *type-checked* and *linted* when I run the tests.
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
