### PR TITLE
[mongoose]: allow numbers to be typed corrently when used as _id

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -98,12 +98,15 @@ declare module "mongoose" {
    * which would result in a passing conditional, because `never` is included in all types.
    */
   export type MongooseFilterQuery<T> = {
-    [P in keyof T]?: P extends '_id' ?
-      mongodb.Condition<string | mongodb.ObjectId | { _id: mongodb.ObjectId }> :
-      [Extract<T[P], mongodb.ObjectId>] extends [never] ?
-        mongodb.Condition<T[P]> :
-        mongodb.Condition<T[P] | string>;
-  } & mongodb.RootQuerySelector<T>;
+    [P in keyof T]?: P extends '_id'
+      ? [Extract<T[P], mongodb.ObjectId>] extends [never]
+        ? mongodb.Condition<T[P]>
+        : mongodb.Condition<T[P] | string | { _id: mongodb.ObjectId }>
+      : [Extract<T[P], mongodb.ObjectId>] extends [never]
+      ? mongodb.Condition<T[P]>
+      : mongodb.Condition<T[P] | string>;
+  } &
+    mongodb.RootQuerySelector<T>;  
 
   /* FilterQuery alias type for using as type for filter/conditions parameters */
   export type FilterQuery<T> = MongooseFilterQuery<DocumentDefinition<T>>;

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -2447,3 +2447,21 @@ Animal2.find().distinct('_id').byName('fido').exec(function(err, animal) {
 Animal2.findOne().where({ type: 'dog' }).byName('fido').exec(function(err, animal) {
   console.log(animal);
 });
+
+
+/* Filter query */
+
+interface Foobar extends mongoose.Document {
+  _id: number;
+  name: string;
+  type: string;
+  tags: string[];
+}
+var foobarSchema = new mongoose.Schema({
+  _id: Number,
+  name: String,
+  type: String,
+  tags: { type: [String], index: true } // field level
+});
+var Foobar = mongoose.model<Foobar, mongoose.Model<Foobar>>('AnimFoobarl', foobarSchema);
+Foobar.find({ _id: 123 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
