### PR TITLE
fix: add missing size property typing to carbon-components-react Modal

### DIFF
--- a/types/carbon-components-react/lib/components/Modal/Modal.d.ts
+++ b/types/carbon-components-react/lib/components/Modal/Modal.d.ts
@@ -14,6 +14,7 @@ export interface ModalProps extends InheritedProps {
     modalHeading?: React.ReactNode,
     modalLabel?: React.ReactNode,
     open?: boolean,
+    size?: "xs" | "sm" | "lg",
     onRequestClose?(event: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLDivElement>): void,
     onRequestSubmit?(event: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLDivElement>): void,
     onSecondarySubmit?: ModalProps["onRequestClose"],


### PR DESCRIPTION
The Modal carbon component accepts a `size` property, but the typing file does not cover this property. This PR adds the typing for this property.

reference: https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/Modal/Modal.js#L141

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
