### PR TITLE
[react-query] expose canFetchMore boolean on useInfiniteQuery result

### DIFF
--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -289,6 +289,7 @@ export type PaginatedQueryResult<TResult> =
 export interface InfiniteQueryResult<TResult, TMoreVariable> extends QueryResultBase<TResult[]> {
     data: TResult[];
     isFetchingMore: boolean;
+    canFetchMore?: boolean;
     fetchMore: (moreVariable?: TMoreVariable | false) => Promise<TResult[]> | undefined;
 }
 

--- a/types/react-query/index.d.ts
+++ b/types/react-query/index.d.ts
@@ -289,7 +289,7 @@ export type PaginatedQueryResult<TResult> =
 export interface InfiniteQueryResult<TResult, TMoreVariable> extends QueryResultBase<TResult[]> {
     data: TResult[];
     isFetchingMore: boolean;
-    canFetchMore?: boolean;
+    canFetchMore: boolean | undefined;
     fetchMore: (moreVariable?: TMoreVariable | false) => Promise<TResult[]> | undefined;
 }
 


### PR DESCRIPTION
Docs: https://github.com/tannerlinsley/react-query#load-more--infinite-scroll-with-useinfinitequery
Issue Reference: https://github.com/tannerlinsley/react-query/issues/319

React Query's `useInfiniteQuery` function returns a `canFetchMore` boolean that's used to coordinate updates as a user scrolls an infinite list. The current type definitions are missing this field entirely.

<img width="660" alt="Screen Shot 2020-04-09 at 7 09 55 AM" src="https://user-images.githubusercontent.com/5148596/78893754-78fc2c80-7a31-11ea-87d1-3615e920311d.png">
