### PR TITLE
[@types/bull] Fix getJobs and getJobCountByTypes's argument to use JobStatus

### DIFF
--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -681,10 +681,10 @@ declare namespace Bull {
     removeRepeatableByKey(key: string): Promise<void>;
 
     /**
-     * Returns a promise that will return an array of job instances of the given types.
+     * Returns a promise that will return an array of job instances of the given job statuses.
      * Optional parameters for range and ordering are provided.
      */
-    getJobs(types: string[], start?: number, end?: number, asc?: boolean): Promise<Array<Job<T>>>;
+    getJobs(types: JobStatus[], start?: number, end?: number, asc?: boolean): Promise<Array<Job<T>>>;
 
     /**
      * Returns a object with the logs according to the start and end arguments. The returned count
@@ -698,9 +698,9 @@ declare namespace Bull {
     getJobCounts(): Promise<JobCounts>;
 
     /**
-     * Returns a promise that resolves with the job counts for the given queue of the given types.
+     * Returns a promise that resolves with the job counts for the given queue of the given job statuses.
      */
-    getJobCountByTypes(types: string[] | string): Promise<JobCounts>;
+    getJobCountByTypes(types: JobStatus[] | JobStatus): Promise<JobCounts>;
 
     /**
      * Returns a promise that resolves with the quantity of completed jobs.


### PR DESCRIPTION
Use `JobStatus`, not `string`

[docs](https://github.com/OptimalBits/bull/blob/c06af988a766af997cefe1e7909d35efda84f5de/REFERENCE.md#queuegetjobs)

Reading the  code and found that `getJobs` is [here](https://github.com/OptimalBits/bull/blob/a2643495a6de7795226da96f43631a0af4427d38/lib/getters.js#L163),  and  it relys on [`getRanges`](https://github.com/OptimalBits/bull/blob/a2643495a6de7795226da96f43631a0af4427d38/lib/getters.js#L125) which [seems to take the argument as `JobStatus`](https://github.com/OptimalBits/bull/blob/a2643495a6de7795226da96f43631a0af4427d38/lib/getters.js#L17)