### PR TITLE
[@hapi/call]: adding constructor argument

### DIFF
--- a/types/hapi__call/hapi__call-tests.ts
+++ b/types/hapi__call/hapi__call-tests.ts
@@ -1,6 +1,6 @@
 import { Route, Router } from '@hapi/call';
 
-const router = new Router();
+const router = new Router({ isCaseSensitive: false });
 
 router.add({ method: 'get', path: '/user/{userId}'}, { id: 'get_user'});
 

--- a/types/hapi__call/index.d.ts
+++ b/types/hapi__call/index.d.ts
@@ -23,6 +23,7 @@ export interface Match<P = any, D = any> {
 export type Route<P = any, D = any> = Match<P, D> | Error;
 
 export class Router {
+    constructor(routerOptions?: RouterOptions)
     add(definition: RouteDefinition, data?: any): void;
     route(method: string, path: string): Route;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://hapi.dev/module/call/api/?v=8.0.0#new-routeroptions
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

