### PR TITLE
feat: add definition for prettier-linter-helpers v1.0

### DIFF
--- a/types/prettier-linter-helpers/index.d.ts
+++ b/types/prettier-linter-helpers/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for prettier-linter-helpers 1.0
+// Project: https://github.com/prettier/prettier-linter-helpers
+// Definitions by: JounQin <https://github.com/JounQin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Converts invisible characters to a commonly recognizable visible form.
+ * @param str - The string with invisibles to convert.
+ * @returns The converted string.
+ */
+export function showInvisibles(str: string): string;
+
+export interface GenerateDifferences {
+    /**
+     * Generate results for differences between source code and formatted version.
+     *
+     * @param source - The original source.
+     * @param prettierSource - The Prettier formatted source.
+     * @returns An array containing { operation, offset, insertText, deleteText }
+     */
+    (source: string, prettierSource: string): Difference[];
+    INSERT: 'insert';
+    DELETE: 'delete';
+    REPLACE: 'replace';
+}
+
+export const generateDifferences: GenerateDifferences;
+
+export interface Difference {
+    operation: 'insert' | 'delete' | 'replace';
+    offset: number;
+    insertText?: string;
+    deleteText?: string;
+}

--- a/types/prettier-linter-helpers/prettier-linter-helpers-tests.ts
+++ b/types/prettier-linter-helpers/prettier-linter-helpers-tests.ts
@@ -1,0 +1,27 @@
+import { generateDifferences, showInvisibles } from 'prettier-linter-helpers';
+
+declare function log(...args: Array<string | number>): void;
+
+showInvisibles(' some string ');
+
+generateDifferences('abc', 'def').forEach(difference => {
+    const { operation, offset, deleteText = '', insertText = '' } = difference;
+
+    switch (operation) {
+        case 'delete':
+            log('delete', offset, deleteText);
+            break;
+        case 'insert':
+            log('insert', offset, insertText);
+            break;
+        case 'replace':
+            log('replace', offset, insertText, deleteText);
+            break;
+        default:
+            throw new Error(`Unexpected operation: '${operation}'`);
+    }
+});
+
+generateDifferences.INSERT;
+generateDifferences.DELETE;
+generateDifferences.REPLACE;

--- a/types/prettier-linter-helpers/tsconfig.json
+++ b/types/prettier-linter-helpers/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "prettier-linter-helpers-tests.ts"
+    ]
+}

--- a/types/prettier-linter-helpers/tslint.json
+++ b/types/prettier-linter-helpers/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
https://github.com/prettier/prettier-linter-helpers

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

