### PR TITLE
Fixed bug in auth0-lock, `connection_scopes` should be `connection_sc…

### DIFF
--- a/types/auth0-lock/index.d.ts
+++ b/types/auth0-lock/index.d.ts
@@ -86,7 +86,7 @@ interface Auth0LockThemeOptions {
 // https://auth0.com/docs/libraries/lock/v10/sending-authentication-parameters
 interface Auth0LockAuthParamsOptions {
     access_token?: any;
-    connection_scopes?: any;
+    connection_scope?: any;
     device?: any;
     nonce?: any;
     protocol?: any;


### PR DESCRIPTION
…ope`

Fixed bug in auth0-lock, `connection_scopes` should be `connection_scope`.
https://auth0.com/docs/connections/adding-scopes-for-an-external-idp#2-pass-scopes-to-authorize-endpoint

The relevant field in the JS library:
https://github.com/auth0/lock/blob/a79d7b7061fd78314630808d6b53b7bc21840370/src/quick-auth/actions.js#L16

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://auth0.com/docs/connections/adding-scopes-for-an-external-idp#2-pass-scopes-to-authorize-endpoint
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.  **Not applicable**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.  **Not applicable**
