### PR TITLE
fix: fixing the types for browse function results

### DIFF
--- a/types/tryghost__content-api/index.d.ts
+++ b/types/tryghost__content-api/index.d.ts
@@ -51,7 +51,8 @@ export interface Twitter {
     twitter_description?: Nullable<string>;
 }
 
-export interface SocialMedia extends Facebook, Twitter {}
+export interface SocialMedia extends Facebook, Twitter {
+}
 
 export interface Settings extends Metadata, CodeInjection, SocialMedia {
     title?: string;
@@ -178,9 +179,14 @@ interface BrowseResults<T> extends Array<T> {
     meta: { pagination: Pagination };
 }
 
-export interface PostsOrPages extends BrowseResults<PostOrPage>{}
-export interface Authors extends BrowseResults<Author>{}
-export interface Tags extends BrowseResults<Tag>{}
+export interface PostsOrPages extends BrowseResults<PostOrPage> {
+}
+
+export interface Authors extends BrowseResults<Author> {
+}
+
+export interface Tags extends BrowseResults<Tag> {
+}
 
 export interface SettingsResponse extends Settings {
     meta: any;
@@ -232,7 +238,7 @@ export interface GhostAPI {
 
 declare var GhostContentAPI: {
     (options: GhostContentAPIOptions): GhostAPI;
-    new (options: GhostContentAPIOptions): GhostAPI;
+    new(options: GhostContentAPIOptions): GhostAPI;
 };
 
 export default GhostContentAPI;

--- a/types/tryghost__content-api/index.d.ts
+++ b/types/tryghost__content-api/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Kevin Nguyen <https://github.com/knguyen0125>
 //                 Anton Van Eechaute <https://github.com/antonve>
 //                 Yashar Moradi <https://github.com/maveric1977>
+//                 Oliver Emery <https://github.com/thrymgjol>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export type ArrayOrValue<T> = T | T[];
@@ -52,7 +53,7 @@ export interface Twitter {
 
 export interface SocialMedia extends Facebook, Twitter {}
 
-export interface Setting extends Metadata, CodeInjection, SocialMedia {
+export interface Settings extends Metadata, CodeInjection, SocialMedia {
     title?: string;
     description?: string;
     logo?: string;
@@ -106,11 +107,11 @@ export interface PostOrPage extends Identification, Excerpt, CodeInjection, Meta
 
     // Post or Page
     title?: string;
-    html?: string | null;
+    html?: Nullable<string>;
     plaintext?: Nullable<string>;
 
     // Image
-    feature_image?: string | null;
+    feature_image?: Nullable<string>;
     featured?: boolean;
 
     // Dates
@@ -119,10 +120,13 @@ export interface PostOrPage extends Identification, Excerpt, CodeInjection, Meta
     published_at?: Nullable<string>;
 
     // Custom Template for posts and pages
-    custom_template?: string | null;
+    custom_template?: Nullable<string>;
 
     // Post or Page
     page?: boolean;
+
+    // Reading time
+    reading_time?: number,
 
     // Tags - Only shown when using Include param
     tags?: Tag[];
@@ -136,7 +140,7 @@ export interface PostOrPage extends Identification, Excerpt, CodeInjection, Meta
     canonical_url?: Nullable<string>;
 }
 
-export type GhostData = PostOrPage | Author | Tag | Setting;
+export type GhostData = PostOrPage | Author | Tag | Settings;
 
 export type IncludeParam = 'authors' | 'tags' | 'count.posts';
 
@@ -170,29 +174,16 @@ export interface ReadFunction<T> {
     (data: { id: Nullable<string> } | { slug: Nullable<string> }, options?: Params, memberToken?: Nullable<string>): Promise<T>;
 }
 
-export interface PostObject {
-    posts: PostOrPage[];
+interface BrowseResults<T> extends Array<T> {
     meta: { pagination: Pagination };
 }
 
-export interface AuthorsObject {
-    authors: Author[];
-    meta: { pagination: Pagination };
-}
+export interface PostsOrPages extends BrowseResults<PostOrPage>{}
+export interface Authors extends BrowseResults<Author>{}
+export interface Tags extends BrowseResults<Tag>{}
 
-export interface TagsObject {
-    tags: Tag[];
-    meta: { pagination: Pagination };
-}
-
-export interface PagesObject {
-    pages: PostOrPage[];
-    meta: { pagination: Pagination };
-}
-
-export interface SettingsObject {
-    settings: Setting;
-    meta: {};
+export interface SettingsResponse extends Settings {
+    meta: any;
 }
 
 export interface GhostError {
@@ -219,24 +210,29 @@ export interface GhostContentAPIOptions {
 
 export interface GhostAPI {
     posts: {
-        browse: BrowseFunction<PostObject>;
+        browse: BrowseFunction<PostsOrPages>;
         read: ReadFunction<PostOrPage>;
     };
     authors: {
-        browse: BrowseFunction<AuthorsObject>;
+        browse: BrowseFunction<Authors>;
         read: ReadFunction<Author>;
     };
     tags: {
-        browse: BrowseFunction<TagsObject>;
+        browse: BrowseFunction<Tags>;
         read: ReadFunction<Tag>;
     };
     pages: {
-        browse: BrowseFunction<PagesObject>;
+        browse: BrowseFunction<PostsOrPages>;
         read: ReadFunction<PostOrPage>;
     };
     settings: {
-        browse: BrowseFunction<SettingsObject>;
+        browse: BrowseFunction<SettingsResponse>;
     };
 }
 
-export default function GhostContentAPI(options: GhostContentAPIOptions): GhostAPI;
+declare var GhostContentAPI: {
+    (options: GhostContentAPIOptions): GhostAPI;
+    new (options: GhostContentAPIOptions): GhostAPI;
+};
+
+export default GhostContentAPI;

--- a/types/tryghost__content-api/index.d.ts
+++ b/types/tryghost__content-api/index.d.ts
@@ -126,7 +126,7 @@ export interface PostOrPage extends Identification, Excerpt, CodeInjection, Meta
     page?: boolean;
 
     // Reading time
-    reading_time?: number,
+    reading_time?: number;
 
     // Tags - Only shown when using Include param
     tags?: Tag[];

--- a/types/tryghost__content-api/tryghost__content-api-tests.ts
+++ b/types/tryghost__content-api/tryghost__content-api-tests.ts
@@ -1,12 +1,9 @@
-import GhostContentAPI, { PostOrPage } from '@tryghost/content-api';
+import GhostContentAPI from '@tryghost/content-api';
 
-const api = GhostContentAPI({ url: 'test', version: 'v3', key: '' }); // $ExpectType GhostAPI
+const api = new GhostContentAPI({ url: 'test', version: 'v3', key: '' }); // $ExpectType GhostAPI
 
-let pages: PostOrPage[];
-const pagesBrowsePromise = api.pages.browse(); // $ExpectType Promise<PagesObject>
+const pagesBrowsePromise = api.pages.browse(); // $ExpectType Promise<PostsOrPages>
 
-pagesBrowsePromise.then(pageObject => {
-    pages = pageObject.pages;
-
+pagesBrowsePromise.then(pages => {
     api.pages.read(pages[0], { include: 'authors' }); // $ExpectType Promise<PostOrPage>
 });


### PR DESCRIPTION
* Added the missing reading_time to the PostOrPage type
* Introduces the BrowseResults (an array augmented with metadata)
* Included a Constructor function

BREAKING CHANGE: The following types are remapped as follows:
* `PostObject` --> `PostsOrPages`
* `AuthorsObject` --> `Authors`
* `TagsObject` --> `Tags`
* `Setting` --> `Settings`
* `SettingsObject` --> `SettingsResponse`

Partly inspired by this [PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42750/) from @thrymgjol 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [x] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [x] Delete the package's directory.
- [x] Add it to `notNeededPackages.json`.
