### PR TITLE
Added parse-svg-path typings

### DIFF
--- a/types/parse-svg-path/index.d.ts
+++ b/types/parse-svg-path/index.d.ts
@@ -16,4 +16,6 @@ type ArcCommand = ['A' | 'a', number, number, number, number, number, number, nu
 type AnyCommand = MoveCommand | LineCommand | HorizontalCommand | VerticalCommand |
     ClosePathCommand | BezierCurveCommand | FollowingBezierCurveCommand |
     QuadraticCurveCommand | FollowingQuadraticCurveCommand | ArcCommand;
-export default function parse(path: string): AnyCommand[];
+declare function parse(path: string): AnyCommand[];
+export = parse;
+

--- a/types/parse-svg-path/index.d.ts
+++ b/types/parse-svg-path/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for parse-svg-path 0.1.2
+// Project: https://github.com/jkroso/parse-svg-path
+// Definitions by: Liam Martens <https://github.com/LiamMartens>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type MoveCommand = ['M' | 'm', number, number];
+type LineCommand = ['L' | 'l', number, number];
+type HorizontalCommand = ['H' | 'h', number];
+type VerticalCommand = ['V' | 'v', number];
+type ClosePathCommand = ['Z' | 'z'];
+type BezierCurveCommand = ['C' | 'c', number, number, number, number, number, number];
+type FollowingBezierCurveCommand = ['S' | 's', number, number, number, number];
+type QuadraticCurveCommand = ['Q' | 'q', number, number, number, number];
+type FollowingQuadraticCurveCommand = ['T' | 't', number, number];
+type ArcCommand = ['A' | 'a', number, number, number, number, number, number, number];
+type AnyCommand = MoveCommand | LineCommand | HorizontalCommand | VerticalCommand |
+    ClosePathCommand | BezierCurveCommand | FollowingBezierCurveCommand |
+    QuadraticCurveCommand | FollowingQuadraticCurveCommand | ArcCommand;
+export default function parse(path: string): AnyCommand[];

--- a/types/parse-svg-path/parse-svg-path-tests.ts
+++ b/types/parse-svg-path/parse-svg-path-tests.ts
@@ -1,4 +1,4 @@
-import parse from 'parse-svg-path';
+import parse = require('parse-svg-path');
 const parsed = parse('M 10 10 L 100 100'); // $ExpectType Array
 parsed.forEach(command => {
     const type = command[0]; // $ExpectType string

--- a/types/parse-svg-path/parse-svg-path-tests.ts
+++ b/types/parse-svg-path/parse-svg-path-tests.ts
@@ -1,0 +1,6 @@
+import parse from 'parse-svg-path';
+const parsed = parse('M 10 10 L 100 100'); // $ExpectType Array
+parsed.forEach(command => {
+    const type = command[0]; // $ExpectType string
+    const arg = command[1]; // $ExpectType number
+});

--- a/types/parse-svg-path/tsconfig.json
+++ b/types/parse-svg-path/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parse-svg-path-tests.ts"
+    ]
+}

--- a/types/parse-svg-path/tslint.json
+++ b/types/parse-svg-path/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] /If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
