### PR TITLE
Added pdf-thumbnail typings

### DIFF
--- a/types/pdf-thumbnail/index.d.ts
+++ b/types/pdf-thumbnail/index.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for pdf-thumbnail 1.0
+// Project: https://github.com/nicoFuccella/pdf-thumbnail#readme
+// Definitions by: Kirill Koshil <https://github.com/koshilki>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node" />
+
+export enum Operations {
+    compress = 'compress',
+    crop = 'crop',
+    resize = 'resize',
+}
+
+export interface CompressParams {
+    type?: string;
+    quality?: number;
+}
+
+export interface CropParams {
+    width: number;
+    height: number;
+    x: number;
+    y: number;
+    ratio?: boolean;
+}
+
+export interface ResizeParams {
+    width?: number;
+    height?: number;
+}
+
+export interface OperationsParams {
+    compress: CompressParams;
+    crop: CropParams;
+    resize: ResizeParams;
+}
+
+export type PDFThumbnailOptions = {
+    [op in keyof typeof Operations]?: OperationsParams[op];
+};
+
+export default function pdf(body: NodeJS.ReadableStream | Buffer | string, options?: PDFThumbnailOptions): Promise<NodeJS.ReadableStream>;

--- a/types/pdf-thumbnail/index.d.ts
+++ b/types/pdf-thumbnail/index.d.ts
@@ -4,34 +4,41 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 
-export type Operations = 'compress' | 'crop' | 'resize';
+declare namespace pdf {
+    type Operations = 'compress' | 'crop' | 'resize';
 
-export interface CompressParams {
-    type?: string;
-    quality?: number;
+    interface CompressParams {
+        type?: string;
+        quality?: number;
+    }
+
+    interface CropParams {
+        width: number;
+        height: number;
+        x: number;
+        y: number;
+        ratio?: boolean;
+    }
+
+    interface ResizeParams {
+        width?: number;
+        height?: number;
+    }
+
+    interface OperationsParams {
+        compress: CompressParams;
+        crop: CropParams;
+        resize: ResizeParams;
+    }
+
+    type PDFThumbnailOptions = {
+        [op in Operations]?: OperationsParams[op];
+    };
 }
 
-export interface CropParams {
-    width: number;
-    height: number;
-    x: number;
-    y: number;
-    ratio?: boolean;
-}
+declare function pdf(
+    body: NodeJS.ReadableStream | Buffer | string,
+    options?: pdf.PDFThumbnailOptions,
+): Promise<NodeJS.ReadableStream>;
 
-export interface ResizeParams {
-    width?: number;
-    height?: number;
-}
-
-export interface OperationsParams {
-    compress: CompressParams;
-    crop: CropParams;
-    resize: ResizeParams;
-}
-
-export type PDFThumbnailOptions = {
-    [op in Operations]?: OperationsParams[op];
-};
-
-export default function pdf(body: NodeJS.ReadableStream | Buffer | string, options?: PDFThumbnailOptions): Promise<NodeJS.ReadableStream>;
+export = pdf;

--- a/types/pdf-thumbnail/index.d.ts
+++ b/types/pdf-thumbnail/index.d.ts
@@ -4,11 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 
-export enum Operations {
-    compress = 'compress',
-    crop = 'crop',
-    resize = 'resize',
-}
+export type Operations = 'compress' | 'crop' | 'resize';
 
 export interface CompressParams {
     type?: string;
@@ -35,7 +31,7 @@ export interface OperationsParams {
 }
 
 export type PDFThumbnailOptions = {
-    [op in keyof typeof Operations]?: OperationsParams[op];
+    [op in Operations]?: OperationsParams[op];
 };
 
 export default function pdf(body: NodeJS.ReadableStream | Buffer | string, options?: PDFThumbnailOptions): Promise<NodeJS.ReadableStream>;

--- a/types/pdf-thumbnail/pdf-thumbnail-tests.ts
+++ b/types/pdf-thumbnail/pdf-thumbnail-tests.ts
@@ -1,11 +1,11 @@
-import pdf from 'pdf-thumbnail';
+import pdf = require('pdf-thumbnail');
 
 const buf: Buffer = new Buffer('');
 
 pdf(buf); // $ExpectType Promise<ReadableStream>
 pdf(buf, { unknownOperation: {} }); // $ExpectError
 
-pdf(buf, { compress: { } }); // $ExpectType Promise<ReadableStream>
+pdf(buf, { compress: {} }); // $ExpectType Promise<ReadableStream>
 pdf(buf, { compress: { type: 'JPEG', quality: 70 } }); // $ExpectType Promise<ReadableStream>
 pdf(buf, { compress: { unknownParam: '' } }); // $ExpectError
 
@@ -13,7 +13,7 @@ pdf(buf, { crop: { width: 100, height: 100, x: 0, y: 0 } }); // $ExpectType Prom
 pdf(buf, { crop: { width: 100, height: 100, x: 0, y: 0, ratio: false } }); // $ExpectType Promise<ReadableStream>
 pdf(buf, { crop: { unknownParam: '' } }); // $ExpectError
 
-pdf(buf, { resize: {  } }); // $ExpectType Promise<ReadableStream>
+pdf(buf, { resize: {} }); // $ExpectType Promise<ReadableStream>
 pdf(buf, { resize: { width: 100, height: 100 } }); // $ExpectType Promise<ReadableStream>
 pdf(buf, { resize: { width: '' } }); // $ExpectError
 pdf(buf, { resize: { unknownParam: '' } }); // $ExpectError

--- a/types/pdf-thumbnail/pdf-thumbnail-tests.ts
+++ b/types/pdf-thumbnail/pdf-thumbnail-tests.ts
@@ -1,0 +1,19 @@
+import pdf from 'pdf-thumbnail';
+
+const buf: Buffer = new Buffer('');
+
+pdf(buf); // $ExpectType Promise<ReadableStream>
+pdf(buf, { unknownOperation: {} }); // $ExpectError
+
+pdf(buf, { compress: { } }); // $ExpectType Promise<ReadableStream>
+pdf(buf, { compress: { type: 'JPEG', quality: 70 } }); // $ExpectType Promise<ReadableStream>
+pdf(buf, { compress: { unknownParam: '' } }); // $ExpectError
+
+pdf(buf, { crop: { width: 100, height: 100, x: 0, y: 0 } }); // $ExpectType Promise<ReadableStream>
+pdf(buf, { crop: { width: 100, height: 100, x: 0, y: 0, ratio: false } }); // $ExpectType Promise<ReadableStream>
+pdf(buf, { crop: { unknownParam: '' } }); // $ExpectError
+
+pdf(buf, { resize: {  } }); // $ExpectType Promise<ReadableStream>
+pdf(buf, { resize: { width: 100, height: 100 } }); // $ExpectType Promise<ReadableStream>
+pdf(buf, { resize: { width: '' } }); // $ExpectError
+pdf(buf, { resize: { unknownParam: '' } }); // $ExpectError

--- a/types/pdf-thumbnail/tsconfig.json
+++ b/types/pdf-thumbnail/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "pdf-thumbnail-tests.ts"
+    ]
+}

--- a/types/pdf-thumbnail/tslint.json
+++ b/types/pdf-thumbnail/tslint.json
@@ -1,17 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "npm-naming": [
-            true,
-            {
-                "mode": "code",
-                "errors": [
-                    [
-                        "NoDefaultExport",
-                        false
-                    ]
-                ]
-            }
-        ]
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/pdf-thumbnail/tslint.json
+++ b/types/pdf-thumbnail/tslint.json
@@ -1,0 +1,17 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [
+            true,
+            {
+                "mode": "code",
+                "errors": [
+                    [
+                        "NoDefaultExport",
+                        false
+                    ]
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
