### PR TITLE
Implemented abs-svg-path typings

### DIFF
--- a/types/abs-svg-path/abs-svg-path-tests.ts
+++ b/types/abs-svg-path/abs-svg-path-tests.ts
@@ -1,2 +1,2 @@
-import abs from 'abs-svg-path';
+import abs = require('abs-svg-path');
 const absolutized = abs([['M', 10, 10], ['l', 100, 100]]); // $ExpectType Array

--- a/types/abs-svg-path/abs-svg-path-tests.ts
+++ b/types/abs-svg-path/abs-svg-path-tests.ts
@@ -1,0 +1,2 @@
+import abs from 'abs-svg-path';
+const absolutized = abs([['M', 10, 10], ['l', 100, 100]]); // $ExpectType Array

--- a/types/abs-svg-path/index.d.ts
+++ b/types/abs-svg-path/index.d.ts
@@ -1,0 +1,43 @@
+// Type definitions for abs-svg-path 0.1.1
+// Project: https://github.com/jkroso/abs-svg-path
+// Definitions by: Liam Martens <https://github.com/LiamMartens>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type RelMoveCommand = ['m', number, number];
+type AbsMoveCommand = ['M', number, number];
+type MoveCommand = RelMoveCommand | AbsMoveCommand;
+type RelLineCommand = ['l', number, number];
+type AbsLineCommand = ['L', number, number];
+type LineCommand = RelLineCommand | AbsLineCommand;
+type RelHorizontalCommand = ['h', number];
+type AbsHorizontalCommand = ['H', number];
+type HorizontalCommand = RelHorizontalCommand | AbsHorizontalCommand;
+type RelVerticalCommand = ['v', number];
+type AbsVerticalCommand = ['V', number];
+type VerticalCommand = RelVerticalCommand | AbsVerticalCommand;
+type RelClosePathCommand = ['z'];
+type AbsClosePathCommand = ['Z'];
+type ClosePathCommand = RelClosePathCommand | AbsClosePathCommand;
+type RelBezierCurveCommand = ['c', number, number, number, number, number, number];
+type AbsBezierCurveCommand = ['C', number, number, number, number, number, number];
+type BezierCurveCommand = RelBezierCurveCommand | AbsBezierCurveCommand;
+type RelFollowingBezierCurveCommand = ['s', number, number, number, number];
+type AbsFollowingBezierCurveCommand = ['S', number, number, number, number];
+type FollowingBezierCurveCommand = RelFollowingBezierCurveCommand | AbsFollowingBezierCurveCommand;
+type RelQuadraticCurveCommand = ['q', number, number, number, number];
+type AbsQuadraticCurveCommand = ['Q', number, number, number, number];
+type QuadraticCurveCommand = RelQuadraticCurveCommand | AbsQuadraticCurveCommand;
+type RelFollowingQuadraticCurveCommand = ['t', number, number];
+type AbsFollowingQuadraticCurveCommand = ['T', number, number];
+type FollowingQuadraticCurveCommand = RelFollowingQuadraticCurveCommand | AbsFollowingQuadraticCurveCommand;
+type RelArcCommand = ['a', number, number, number, number, number, number, number];
+type AbsArcCommand = ['A', number, number, number, number, number, number, number];
+type ArcCommand = RelArcCommand | AbsArcCommand;
+type AnyCommand = MoveCommand | LineCommand | HorizontalCommand | VerticalCommand |
+    ClosePathCommand | BezierCurveCommand | FollowingBezierCurveCommand |
+    QuadraticCurveCommand | FollowingQuadraticCurveCommand | ArcCommand;
+type AbsAnyCommand = AbsMoveCommand | AbsLineCommand | AbsHorizontalCommand | AbsVerticalCommand |
+    AbsClosePathCommand | AbsBezierCurveCommand | AbsFollowingBezierCurveCommand |
+    AbsQuadraticCurveCommand | AbsFollowingQuadraticCurveCommand | AbsArcCommand;
+declare function absolutize(path: AnyCommand[]): AbsAnyCommand[];
+export = absolutize;

--- a/types/abs-svg-path/tsconfig.json
+++ b/types/abs-svg-path/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "abs-svg-path-tests.ts"
+    ]
+}

--- a/types/abs-svg-path/tslint.json
+++ b/types/abs-svg-path/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
