### PR TITLE
[node-fetch] fix blob() return type

### DIFF
--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -140,7 +140,7 @@ export class Blob {
 export class Body {
     constructor(body?: any, opts?: { size?: number; timeout?: number });
     arrayBuffer(): Promise<ArrayBuffer>;
-    blob(): Promise<Buffer>;
+    blob(): Promise<Blob>;
     body: NodeJS.ReadableStream;
     bodyUsed: boolean;
     buffer(): Promise<Buffer>;

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -11,6 +11,7 @@
 //                 ExE Boss <https://github.com/ExE-Boss>
 //                 Alex Savin <https://github.com/alexandrusavin>
 //                 Alexis Tyler <https://github.com/OmgImAlexis>
+//                 Jakub Kisielewski <https://github.com/kbkk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -84,6 +84,19 @@ function test_fetchUrlObject() {
     handlePromise(fetch(new URL("https://example.org")));
 }
 
+async function test_responseReturnTypes() {
+    const response = await fetch(new URL("https://example.org"));
+
+    // $ExpectType Blob
+    const blob = await response.clone().blob();
+
+    // $ExpectType string
+    const text = await response.clone().text();
+
+    // $ExpectType Buffer
+    const buffer = await response.clone().buffer();
+}
+
 function test_fetchUrlObjectWithRequestObject() {
     const requestOptions: RequestInit = {
         method: "POST",


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/node-fetch/node-fetch/blob/bb9c96de8059821b9f3dfdc85128b6131d144bf2/src/body.js#L94
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
