### PR TITLE
seamless-immutable. allow immutable instance for merge method

### DIFF
--- a/types/seamless-immutable/index.d.ts
+++ b/types/seamless-immutable/index.d.ts
@@ -67,7 +67,7 @@ declare namespace SeamlessImmutable {
         asMutable(opts: AsMutableOptions<true>): T;
         asMutable(opts: AsMutableOptions): T | { [K in keyof T]: Immutable<T[K]> };
 
-        merge(part: DeepPartial<T>, config?: MergeConfig): Immutable<T>;
+        merge(part: DeepPartial<T | Immutable<T>>, config?: MergeConfig): Immutable<T>;
 
         update<K extends keyof T>(property: K, updaterFunction: (value: T[K], ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
         update<TValue>(property: string, updaterFunction: (value: TValue, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;


### PR DESCRIPTION
Please fill in this template.

- [+] Use a meaningful title for the pull request. Include the name of the package modified.
- [+] Test the change in your own code. (Compile and run.)
- [-] Add or edit tests to reflect the change. (Run with `npm test`.)
- [+] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [+] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [+] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/rtfeldman/seamless-immutable/blob/2d870b14a01e222493c686a7644181185f859558/seamless-immutable.development.js#L631>>

Simple example of code before change:
```
    case types.PROGRAM_ACCEPTED: {
      let { instance } = state
      if (!instance) return state

      instance = instance.merge({
        is_accepted: true,
      })

      return state.merge({
        instance: instance.asMutable({ deep: true }),  // this is annoying
      })
    }
```
We have to do `asMutable` to get typescript compatibility. But it is a buggy trick actually. 
This issue always appear when we trying to change child nodes. 


What I expect to use: (with no errors)
```
    case types.PROGRAM_ACCEPTED: {
      let { instance } = state
      if (!instance) return state

      instance = instance.merge({
        is_accepted: true,
      })

      return state.merge({ instance }) // here was typescript error before update.
    }
```
Both examples works as expected.
In library source code I found that method will use instance we passed, instead of creating new one. So I feel change is ok.

