### PR TITLE
[@types/carbon-components-react] Fixed MultiSelect and MultiSelect.Filterable types

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -22,6 +22,7 @@ import {
     FormItem,
     FileUploaderDropContainer,
     FileUploaderItem,
+    MultiSelect,
 } from 'carbon-components-react';
 import Link from 'carbon-components-react/lib/components/UIShell/Link';
 
@@ -443,5 +444,31 @@ const fileUploaderItem = (
         onDelete={ (event, content) => {} }
         status="edit"
         uuid="id1"
+    />
+)
+
+const multiSelect = (
+    <MultiSelect
+    id="clusters"
+    initialSelectedItems={['one']}
+    items={['one', 'two']}
+    light
+    placeholder="Filter"
+    titleText="Choose an item"
+    itemToString={item => item}
+    onChange={({ selectedItems }) => {}}
+    />
+)
+
+const multiSelectFilterable = (
+    <MultiSelect.Filterable
+    id="clusters"
+    initialSelectedItems={['one']}
+    items={['one', 'two']}
+    light
+    placeholder="Filter"
+    titleText="Choose an item"
+    itemToString={item => item}
+    onChange={({ selectedItems }) => {}}
     />
 )

--- a/types/carbon-components-react/lib/components/MultiSelect/FilterableMultiSelect.d.ts
+++ b/types/carbon-components-react/lib/components/MultiSelect/FilterableMultiSelect.d.ts
@@ -2,17 +2,17 @@ import * as React from "react";
 import { DownshiftTypedProps, ListBoxBaseItemType } from "../../../typings/shared";
 import { MultiSelectProps } from "./MultiSelect";
 
-interface InheritedProps<ItemType extends ListBoxBaseItemType> extends MultiSelectProps<ItemType> { }
+interface InheritedProps<T extends ListBoxBaseItemType> extends MultiSelectProps<T> { }
 
-interface FilterItemsExtra<ItemType> {
+interface FilterItemsExtra<T> {
     inputValue: string,
-    itemToString: NonNullable<DownshiftTypedProps<ItemType>["itemToString"]>,
+    itemToString: NonNullable<DownshiftTypedProps<T>["itemToString"]>,
 }
 
-export interface FilterableMultiSelectProps<ItemType extends ListBoxBaseItemType = string> extends InheritedProps<ItemType> {
-    filterItems?(items: ReadonlyArray<ItemType>, extra: FilterItemsExtra<ItemType>): ItemType[],
+export interface FilterableMultiSelectProps<T extends ListBoxBaseItemType = string> extends InheritedProps<T> {
+    filterItems?(items: ReadonlyArray<T>, extra: FilterItemsExtra<T>): T[],
 }
 
-declare class FilterableMultiSelect extends React.Component<FilterableMultiSelectProps> { }
+declare class FilterableMultiSelect <T extends ListBoxBaseItemType = string>extends React.Component<FilterableMultiSelectProps<T>> { }
 
 export default FilterableMultiSelect;

--- a/types/carbon-components-react/lib/components/MultiSelect/MultiSelect.d.ts
+++ b/types/carbon-components-react/lib/components/MultiSelect/MultiSelect.d.ts
@@ -27,10 +27,13 @@ export interface MultiSelectProps<T extends ListBoxBaseItemType = string> extend
     open?: boolean,
     selectionFeedback?: "fixed" | "top" | "top-after-reopen",
     useTitleInItem?: boolean,
+    placeholder?: string,
+    titleText?: string,
+    onChange: ({ selectedItems }: { selectedItems: T[] }) => void,
 }
 
 declare class MultiSelect<T extends ListBoxBaseItemType = string> extends React.Component<MultiSelectProps<T>> {
-    static readonly Filterable: FilterableMultiSelect;
+    static readonly Filterable: typeof FilterableMultiSelect;
 }
 
 export default MultiSelect;

--- a/types/carbon-components-react/lib/components/MultiSelect/MultiSelect.d.ts
+++ b/types/carbon-components-react/lib/components/MultiSelect/MultiSelect.d.ts
@@ -27,7 +27,7 @@ export interface MultiSelectProps<T extends ListBoxBaseItemType = string> extend
     open?: boolean,
     selectionFeedback?: "fixed" | "top" | "top-after-reopen",
     useTitleInItem?: boolean,
-    placeholder?: string,
+    placeholder: string,
     titleText?: string,
     onChange: ({ selectedItems }: { selectedItems: T[] }) => void,
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.