### PR TITLE
[draft-js] Change ariaLabelledBy type to string

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -156,7 +156,7 @@ declare namespace Draft {
                 ariaDescribedBy?: string;
                 ariaExpanded?: boolean;
                 ariaLabel?: string;
-                ariaLabelledBy?: boolean;
+                ariaLabelledBy?: string;
                 ariaMultiline?: boolean;
                 ariaOwneeID?: string;
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/draft-js/blob/6e87246506ca59060cb4c6ebc7a9ac3e97609a2a/src/component/base/DraftEditorProps.js#L95
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

I screwed up in my last PR (#43736) and accidentally gave `ariaLabelledBy` the type of `boolean` when it obviously should be `string`. This is just a quick fix for that.
