### PR TITLE
Add fallback props to PropsWithChildren

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -822,7 +822,7 @@ declare namespace React {
                 : P
             : P;
 
-    type PropsWithChildren<P> = P & { children?: ReactNode };
+    type PropsWithChildren<P extends object = {}> = P & { children?: ReactNode };
 
     /**
      * NOTE: prefer ComponentPropsWithRef, if the ref is forwarded,


### PR DESCRIPTION
I find `PropsWithChildren` to be quite handy as a utility type for components that just render children props. 
But currently we have to explicitly provide props via a generic type, which looks something like this: `FC<PropsWithChildren<{}>>`.

This change would allow us to use `FC<PropsWithChildren>` where Props defaults to an empty object.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
