### PR TITLE
fix: exports of eslint-plugin-prettier changed

### DIFF
--- a/types/eslint-plugin-prettier/eslint-plugin-prettier-tests.ts
+++ b/types/eslint-plugin-prettier/eslint-plugin-prettier-tests.ts
@@ -1,28 +1,4 @@
-import * as utils from 'eslint-plugin-prettier';
+import { configs, rules } from 'eslint-plugin-prettier';
 
-declare function log(...args: Array<string | number>): void;
-
-utils.showInvisibles(' some string ');
-
-utils.generateDifferences('abc', 'def').forEach(difference => {
-    const {
-        operation,
-        offset,
-        deleteText = '',
-        insertText = '',
-    } = difference;
-
-    switch (operation) {
-        case 'delete':
-            log('delete', offset, deleteText);
-            break;
-        case 'insert':
-            log('insert', offset, insertText);
-            break;
-        case 'replace':
-            log('replace', offset, insertText, deleteText);
-            break;
-        default:
-            throw new Error(`Unexpected operation: '${operation}'`);
-    }
-});
+configs.recommended;
+rules.prettier;

--- a/types/eslint-plugin-prettier/index.d.ts
+++ b/types/eslint-plugin-prettier/index.d.ts
@@ -1,29 +1,15 @@
-// Type definitions for eslint-plugin-prettier 2.2
+// Type definitions for eslint-plugin-prettier 3.1
 // Project: https://github.com/prettier/eslint-plugin-prettier
 // Definitions by: Ika <https://github.com/ikatyang>
+//                 JounQin <https://github.com/JounQin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/**
- * Converts invisible characters to a commonly recognizable visible form.
- * @param str The string with invisibles to convert.
- */
-export function showInvisibles(str: string): string;
+import { Linter, Rule } from 'eslint';
 
-/**
- * Generate results for differences between source code and formatted version.
- * @param source The original source.
- * @param formatted The formatted source.
- */
-export function generateDifferences(
-    source: string,
-    formatted: string,
-): Difference[];
+export const configs: {
+    recommended: Linter.Config;
+};
 
-export interface Difference {
-    operation: 'insert' | 'delete' | 'replace';
-    offset: number;
-    insertText?: string;
-    deleteText?: string;
-}
-
-export const rules: any;
+export const rules: {
+    prettier: Rule.RuleModule;
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/prettier/eslint-plugin-prettier/blob/master/eslint-plugin-prettier.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

