### PR TITLE
webpack: Add typings for ChunkGroup, and mainTemplate hooks

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -923,11 +923,31 @@ declare namespace webpack {
             toString(): string;
         }
 
+        type GroupOptions = string | { name?: string; };
+
         class ChunkGroup {
         }
 
         class ChunkHash {
         }
+
+        interface SourcePosition {
+            line: number;
+            column?: number;
+        }
+
+        interface RealDependencyLocation {
+            start: SourcePosition;
+            end?: SourcePosition;
+            index?: number;
+        }
+
+        interface SynteticDependencyLocation {
+            name: string;
+            index?: number;
+        }
+
+        type DependencyLocation = SynteticDependencyLocation | RealDependencyLocation;
 
         class Dependency {
             constructor();
@@ -1201,6 +1221,8 @@ declare namespace webpack {
             missingDependencies: SortableSet<string>;
             hash?: string;
             getStats(): Stats;
+            addChunkInGroup(groupOptions: GroupOptions): ChunkGroup;
+            addChunkInGroup(groupOptions: GroupOptions, module: Module, loc: DependencyLocation, request: string): ChunkGroup;
             addModule(module: CompilationModule, cacheGroup: any): any;
             // tslint:disable-next-line:ban-types
             addEntry(context: any, entry: any, name: any, callback: Function): void;

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -27,6 +27,7 @@
 
 /// <reference types="node" />
 
+import { Hash as CryptoHash } from 'crypto';
 import {
   Tapable,
   HookMap,
@@ -1143,6 +1144,8 @@ declare namespace webpack {
             requireExtensions: SyncWaterfallHook<string, Chunk, string>;
             requireEnsure: SyncWaterfallHook<string, Chunk, string>;
             localVars: SyncWaterfallHook<string, Chunk, string>;
+            afterStartup: SyncWaterfallHook<string, Chunk, string>;
+            hashForChunk: SyncHook<CryptoHash, Chunk>;
           };
           outputOptions: Output;
           requireFn: string;

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -927,6 +927,18 @@ declare namespace webpack {
         type GroupOptions = string | { name?: string; };
 
         class ChunkGroup {
+            chunks: Chunk[];
+            childrenIterable: SortableSet<ChunkGroup>;
+            parentsIterable: SortableSet<ChunkGroup>;
+            insertChunk(chunk: Chunk, before: Chunk): boolean;
+            getNumberOfChildren(): number;
+            setModuleIndex(module: Module, index: number): void;
+            getModuleIndex(module: Module): number | undefined;
+            setModuleIndex2(module: Module, index: number): void;
+            getModuleIndex2(module: Module): number | undefined;
+            addChild(chunk: ChunkGroup): boolean;
+            removeChild(chunk: ChunkGroup): boolean;
+            setParents(newParents: Iterable<ChunkGroup>): void;
         }
 
         class ChunkHash {

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -929,6 +929,23 @@ class DefinePlugin extends webpack.Plugin {
     }
 }
 
+class ChunkGroupTestPlugin extends webpack.Plugin {
+    apply(compiler: webpack.Compiler) {
+        compiler.hooks.compilation.tap("ChunkGroupTestPlugin", compilation  => {
+            const namedChunkGroupA = compilation.addChunkInGroup('vendors-a');
+            const namedChunkGroupB = compilation.addChunkInGroup({ name: 'vendors-b' });
+            const unnamedChunkGroup = compilation.addChunkInGroup({});
+
+            compilation.hooks.optimizeModules.tap("ChunkGroupTestPlugin", modules => {
+                for (const module of modules) {
+                    compilation.addChunkInGroup('module', module, { start: { line: 0 } }, 'module.js');
+                    break;
+                }
+            });
+        });
+    }
+}
+
 configuration = {
     module: {
         rules: [

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -315,6 +315,18 @@ configuration = {
         mainTemplate.hooks.localVars.tap('SomePlugin', resource => {
           return resource.trimLeft();
         });
+        mainTemplate.hooks.afterStartup.tap('SomePlugin', (resource, chunk) => {
+            if (chunk.name) {
+                return `/* In named chunk: ${chunk.name} */ ${resource};`;
+            } else {
+                return resource;
+            }
+        });
+        mainTemplate.hooks.hashForChunk.tap('SomePlugin', (hash, chunk) => {
+            if (chunk.name) {
+                hash.update(chunk.name);
+            }
+        });
         if (mainTemplate.hooks.jsonpScript == null) {
           return;
         }

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -947,11 +947,33 @@ class ChunkGroupTestPlugin extends webpack.Plugin {
             const namedChunkGroupA = compilation.addChunkInGroup('vendors-a');
             const namedChunkGroupB = compilation.addChunkInGroup({ name: 'vendors-b' });
             const unnamedChunkGroup = compilation.addChunkInGroup({});
-
+            if (namedChunkGroupA.getNumberOfChildren() > 0) {
+                for (const chunk of namedChunkGroupA.chunks) {}
+            }
+            Array.from(namedChunkGroupA.childrenIterable).forEach(childGroup => {
+                namedChunkGroupA.removeChild(childGroup);
+                namedChunkGroupA.addChild(childGroup);
+            });
+            Array.from(namedChunkGroupA.parentsIterable).forEach(parentGroup => {});
+            namedChunkGroupA.setParents([namedChunkGroupB]);
+            namedChunkGroupA.setParents(new Set([unnamedChunkGroup]));
             compilation.hooks.optimizeModules.tap("ChunkGroupTestPlugin", modules => {
                 for (const module of modules) {
-                    compilation.addChunkInGroup('module', module, { start: { line: 0 } }, 'module.js');
+                    const group = compilation.addChunkInGroup('module', module, { start: { line: 0 } }, 'module.js');
+                    if (module.index) {
+                        group.setModuleIndex(module, module.index);
+                    }
+                    if (module.index2) {
+                        group.setModuleIndex2(module, module.index2);
+                    }
+                    console.log(group.getModuleIndex(module), group.getModuleIndex2(module));
                     break;
+                }
+            });
+            compilation.hooks.optimizeChunks.tap("ChunkGroupTestPlugin", chunks => {
+                const firstChunk = chunks[0];
+                for (const groupChunk of namedChunkGroupA.chunks) {
+                    namedChunkGroupA.insertChunk(firstChunk, groupChunk);
                 }
             });
         });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  + [compilation.addChunkInGroup](https://github.com/webpack/webpack/blob/v4.41.6/lib/Compilation.js#L1485)
  + [mainTemplate.hooks.afterStartup](https://github.com/webpack/webpack/blob/v4.41.6/lib/MainTemplate.js#L102)
  + [mainTemplate.hooks.hashForChunk](https://github.com/webpack/webpack/blob/v4.41.6/lib/MainTemplate.js#L127)
  + [ChunkGroup.chunks](https://github.com/webpack/webpack/blob/v4.41.6/lib/ChunkGroup.js#L70)
  + [ChunkGroup.childrenIterable](https://github.com/webpack/webpack/blob/v4.41.6/lib/ChunkGroup.js#L240)
  + [ChunkGroup.parentsIterable](https://github.com/webpack/webpack/blob/v4.41.6/lib/ChunkGroup.js#L281)
  + [ChunkGroup.insertChunk](https://github.com/webpack/webpack/blob/v4.41.6/lib/ChunkGroup.js#L158)
  + [ChunkGroup.getNumberOfChildren](https://github.com/webpack/webpack/blob/v4.41.6/lib/ChunkGroup.js#L236)
  + [ChunkGroup.{set,get}ModuleIndex{,2}](https://github.com/webpack/webpack/blob/v4.41.6/lib/ChunkGroup.js#L456-L492)
  + [ChunkGroup.addChild](https://github.com/webpack/webpack/blob/v4.41.6/lib/ChunkGroup.js#L224)
  + [ChunkGroup.removeChild](https://github.com/webpack/webpack/blob/v4.41.6/lib/ChunkGroup.js#L244)
  + [ChunkGroup.setParents](https://github.com/webpack/webpack/blob/v4.41.6/lib/ChunkGroup.js#L266)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
