### PR TITLE
[node-gettext] Update v3.0.0 typings

### DIFF
--- a/types/node-gettext/index.d.ts
+++ b/types/node-gettext/index.d.ts
@@ -5,6 +5,9 @@
 // TypeScript Version: 2.2
 export = GetText;
 declare class GetText {
+    static getLanguageCode(locale: string): string;
+    readonly locale: string;
+    readonly domain: string;
     constructor(options?: { debug?: boolean; sourceLocale?: string });
     addTranslations(locale: string, domain: string, translations: object): void;
     dgettext(domain: string, msgid: string): string;
@@ -16,12 +19,11 @@ declare class GetText {
     gettext(msgid: string): string;
     ngettext(msgid: string, msgidPlural: string, count: number): string;
     npgettext(msgctxt: string, msgid: string, msgidPlural: string, count: number): string;
-    off(eventName: 'error', callback: (error: any) => void): void;
-    on(eventName: 'error', callback: (error: any) => void): void;
+    off(eventName: 'error', callback: (error: Error) => void): void;
+    on(eventName: 'error', callback: (error: Error) => void): void;
     pgettext(msgctxt: string, msgid: string): string;
     setLocale(locale: string): void;
     setTextDomain(domain: string): void;
-    static getLanguageCode(locale: string): string;
     textdomain(domain: string): void;
     warn(message: string): void;
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.


This PR refines some types that were fixed in the v3.0 release:

1. `error` event handlers return `Error` objects, not `any`.
    Github issue: https://github.com/alexanderwallin/node-gettext/issues/50
    Fixed in: https://github.com/alexanderwallin/node-gettext/commit/099ad988a01f7958e7b32b9512d15006e9a32efb
1. Add readonly `locale` and `domain` fields to declarations
    Github issue: https://github.com/alexanderwallin/node-gettext/issues/48
    Fixed: see this PR, updated typings.
    Source: https://github.com/alexanderwallin/node-gettext/blob/master/lib/gettext.js#L24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/definitelytyped/definitelytyped/43822)
<!-- Reviewable:end -->
