### PR TITLE
[express-server-static-core] Allow mixed arrays in query params

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -41,7 +41,7 @@ export type ParamsArray = string[];
 export type Params = ParamsDictionary | ParamsArray;
 
 // Return type of qs.parse, the default query parser (https://expressjs.com/en/api.html#app-settings-property).
-export interface Query { [key: string]: string | string[] | Query | Query[]; }
+export interface Query { [key: string]: string | Query | Array<string | Query>; }
 
 export interface RequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query> {
     // tslint:disable-next-line callable-types (This is extended from and can't extend from a type alias in ts<2.2


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ljharb/qs#parsing-objects
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~


The express default query parser ([qs.parse](https://github.com/ljharb/qs)) can return an array that mixes strings and objects. This PR changes the typing of `Query` to represent that case.

Example of a case now covered that was previously not represented by the type:

```js 
> const qs = require('qs')
> qs.parse('a=string&a[key]=value')
{ a: [ 'string', { key: 'value' } ] }
```
