### PR TITLE
[serverless] Add ApiGatewayEvent type

### DIFF
--- a/types/serverless/classes/PluginManager.d.ts
+++ b/types/serverless/classes/PluginManager.d.ts
@@ -1,8 +1,8 @@
-import Serverless = require("../index");
-import Plugin = require("./Plugin");
+import Serverless = require('../index');
+import Plugin = require('./Plugin');
 
 declare class PluginManager {
-    constructor(serverless: Serverless)
+    constructor(serverless: Serverless);
 
     setCliOptions(options: Serverless.Options): void;
     setCliCommands(commands: {}): void;

--- a/types/serverless/classes/Service.d.ts
+++ b/types/serverless/classes/Service.d.ts
@@ -1,4 +1,4 @@
-import Serverless = require("../index");
+import Serverless = require('../index');
 
 declare namespace Service {
     interface Custom {
@@ -10,21 +10,21 @@ declare class Service {
     custom: Service.Custom;
 
     provider: {
-      compiledCloudFormationTemplate: {
-        Resources: {
-          [key: string]: any;
+        compiledCloudFormationTemplate: {
+            Resources: {
+                [key: string]: any;
+            };
+            Outputs?: {
+                [key: string]: any;
+            };
         };
-        Outputs?: {
-          [key: string]: any;
-        };
-      };
 
-      name: string;
-      stage: string;
-      region: string;
-      runtime?: string;
-      timeout?: number;
-      versionFunctions: boolean;
+        name: string;
+        stage: string;
+        region: string;
+        runtime?: string;
+        timeout?: number;
+        versionFunctions: boolean;
     };
     constructor(serverless: Serverless, data: {});
 

--- a/types/serverless/classes/Utils.d.ts
+++ b/types/serverless/classes/Utils.d.ts
@@ -1,4 +1,4 @@
-import Serverless = require("../index");
+import Serverless = require('../index');
 
 declare class Utils {
     constructor(serverless: Serverless);

--- a/types/serverless/classes/YamlParser.d.ts
+++ b/types/serverless/classes/YamlParser.d.ts
@@ -1,7 +1,7 @@
-import Serverless = require("../index");
+import Serverless = require('../index');
 
 declare class YamlParser {
-    constructor(serverless: Serverless)
+    constructor(serverless: Serverless);
     parse(yamlFilePath: string): Promise<any>;
 }
 

--- a/types/serverless/index.d.ts
+++ b/types/serverless/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for serverless 1.18
+// Type definitions for serverless 1.67
 // Project: https://github.com/serverless/serverless#readme
 // Definitions by: Hassan Khan <https://github.com/hassankhan>
 //                 Jonathan M. Wilbur <https://github.com/JonathanWilbur>
 //                 Alex Pavlenko <https://github.com/a-pavlenko>
+//                 Frédéric Barthelet <https://github.com/fredericbarthelet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import Service = require('./classes/Service');
@@ -11,6 +12,7 @@ import PluginManager = require('./classes/PluginManager');
 import Utils = require('./classes/Utils');
 import YamlParser = require('./classes/YamlParser');
 import AwsProvider = require('./plugins/aws/provider/awsProvider');
+import ApiGatewayValidate = require('./plugins/aws/package/compile/events/apiGateway/lib/validate');
 
 declare namespace Serverless {
     interface Options {
@@ -34,11 +36,11 @@ declare namespace Serverless {
         timeout?: number;
         memorySize?: number;
         environment?: { [name: string]: string };
+        events: Event[];
     }
 
-    interface Event {
-        eventName: string;
-    }
+    // Other events than ApiGatewayEvent are available
+    type Event = ApiGatewayValidate.ApiGatewayEvent | object;
 
     interface Package {
         include: string[];

--- a/types/serverless/plugins/aws/package/compile/events/apiGateway/lib/validate.d.ts
+++ b/types/serverless/plugins/aws/package/compile/events/apiGateway/lib/validate.d.ts
@@ -1,0 +1,23 @@
+export type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'options' | 'head' | 'delete' | 'any';
+
+// Event configuration evolves depending on current lifecycle at getEventInFunction method invokaction
+export interface ApiGatewayEvent {
+    http:
+        | string
+        | {
+              path: string;
+              mehtod: HttpMethod;
+              authorizer?: any;
+              cors?: any;
+              integration?: string;
+          };
+}
+
+export function getHttp<T extends object>(
+    event: { http: T | string },
+    functionName: string,
+): { path: string; method: string } | T;
+
+export function getHttpPath(http: { path: string }, functionName: string): string;
+
+export function getHttpMethod(http: { method: string }, functionName: string): HttpMethod;

--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -1,7 +1,7 @@
-import Serverless = require("../../../index");
+import Serverless = require('../../../index');
 
 declare class Aws {
-    constructor(serverless: Serverless, options: Serverless.Options)
+    constructor(serverless: Serverless, options: Serverless.Options);
 
     naming: { [key: string]: () => string };
     getProviderName(): string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
> This PR aims to fix an issue regarding Serverless.Event type declaration - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/serverless/index.d.ts#L39. Event was declared as containing one property `eventName` of type string. However, according to https://github.com/serverless/serverless/blob/v1.18.1/lib/classes/Service.js#L208, even in version 1.18 back when this definition was written, `eventName` refers to the name of the property, not its value. This PR takes as well the opportunity to introduce one of the many events available, the `ApiGatewayEvent` definition.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.