### PR TITLE
types(discord-rpc): update types for {start,end}Timestamp

### DIFF
--- a/types/discord-rpc/index.d.ts
+++ b/types/discord-rpc/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Jason Bothell <https://github.com/jasonhaxstuff>
 //                 Jack Baron <https://github.com/lolPants>
 //                 Dylan Hackworth <https://github.com/dylhack>
+//                 Sankarsan Kampa <https://github.com/k3rn31p4nic>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { EventEmitter } from 'events';
@@ -186,8 +187,8 @@ export interface VoiceSettings {
 export interface Presence {
 	state?: string;
 	details?: string;
-	startTimestamp?: number;
-	endTimestamp?: number;
+	startTimestamp?: number | Date;
+	endTimestamp?: number | Date;
 	largeImageKey?: string;
 	largeImageText?: string;
 	smallImageKey?: string;


### PR DESCRIPTION
`startTimestamp` & `endTimestamp` supports both `Date` & `number` but only `number` was defined.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/discordjs/RPC/blob/cfddf66c372abe430a284ff3ea885e8cc0477f99/src/client.js#L484-L489
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
