### PR TITLE
Fixed spelling of recid in secp256k1

### DIFF
--- a/types/secp256k1/index.d.ts
+++ b/types/secp256k1/index.d.ts
@@ -115,7 +115,7 @@ export function signatureImport(signature: Uint8Array): Uint8Array;
  * - Compose 32-byte scalar `s = k^-1 * (r * d + m)`. Reject nonce if `s` is zero.
  * - The signature is `(r, s)`.
  */
-export function ecdsaSign(message: Uint8Array, privateKey: Uint8Array, options?: SignOptions): {signature: Uint8Array, recId: number};
+export function ecdsaSign(message: Uint8Array, privateKey: Uint8Array, options?: SignOptions): {signature: Uint8Array, recid: number};
 
 /**
  * Verify an ECDSA signature.
@@ -133,7 +133,7 @@ export function ecdsaVerify(signature: Uint8Array, message: Uint8Array, publicKe
 /**
  * Recover an ECDSA public key from a signature.
  */
-export function ecdsaRecover(signature: Uint8Array, recId: number, message: Uint8Array, compressed?: boolean): Uint8Array;
+export function ecdsaRecover(signature: Uint8Array, recid: number, message: Uint8Array, compressed?: boolean): Uint8Array;
 
 /**
  * Compute an EC Diffie-Hellman secret and applied sha256 to compressed public key.

--- a/types/secp256k1/secp256k1-tests.ts
+++ b/types/secp256k1/secp256k1-tests.ts
@@ -1,4 +1,4 @@
-import { SignOptions, ecdsaSign } from "secp256k1";
+import { SignOptions, ecdsaSign, ecdsaRecover } from "secp256k1";
 
 const opts: SignOptions = {
     data: Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72])
@@ -8,4 +8,6 @@ const message = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
 
 const prvKey = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
 
-ecdsaSign(message, prvKey, opts);
+const ret = ecdsaSign(message, prvKey, opts);
+
+const recovered = ecdsaRecover(ret.signature, ret.recid, message)

--- a/types/secp256k1/secp256k1-tests.ts
+++ b/types/secp256k1/secp256k1-tests.ts
@@ -10,4 +10,4 @@ const prvKey = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
 
 const ret = ecdsaSign(message, prvKey, opts);
 
-const recovered = ecdsaRecover(ret.signature, ret.recid, message)
+const recovered = ecdsaRecover(ret.signature, ret.recid, message);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/cryptocoinjs/secp256k1-node/blob/d9f7bf09a4c6f9ffd91615adf9c6d2b301107fa4/lib/index.js#L260
https://github.com/cryptocoinjs/secp256k1-node/blob/d9f7bf09a4c6f9ffd91615adf9c6d2b301107fa4/lib/index.js#L288
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
