### PR TITLE
[node-telegram-bot-api] Add missing parse_mode for files captions

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -6,6 +6,7 @@
 //                 Kallu609 <https://github.com/Kallu609>
 //                 XC-Zhang <https://github.com/XC-Zhang>
 //                 AdityaThebe <https://github.com/adityathebe>
+//                 Michael Orlov <https://github.com/MiklerGM>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -143,10 +144,12 @@ declare namespace TelegramBot {
     }
 
     interface SendPhotoOptions extends SendBasicOptions {
+        parse_mode?: ParseMode;
         caption?: string;
     }
 
     interface SendAudioOptions extends SendBasicOptions {
+        parse_mode?: ParseMode;
         caption?: string;
         duration?: number;
         performer?: string;
@@ -154,6 +157,7 @@ declare namespace TelegramBot {
     }
 
     interface SendDocumentOptions extends SendBasicOptions {
+        parse_mode?: ParseMode;
         caption?: string;
     }
 
@@ -165,6 +169,7 @@ declare namespace TelegramBot {
     type SendStickerOptions = SendBasicOptions;
 
     interface SendVideoOptions extends SendBasicOptions {
+        parse_mode?: ParseMode;
         duration?: number;
         width?: number;
         height?: number;
@@ -172,6 +177,7 @@ declare namespace TelegramBot {
     }
 
     interface SendVoiceOptions extends SendBasicOptions {
+        parse_mode?: ParseMode;
         caption?: string;
         duration?: number;
     }

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -29,12 +29,17 @@ const res: TelegramBot.InlineQueryResultArticle = {
 MyTelegramBot.answerInlineQuery('queryId', [res, res, res], { is_personal: true });
 MyTelegramBot.forwardMessage(1234, 5678, 'memberID', { disable_notification: true });
 MyTelegramBot.sendPhoto(1234, 'photo/path', { caption: 'Foo' });
+MyTelegramBot.sendPhoto(1234, 'photo/path', { caption: 'Foo', parse_mode: 'HTML' });
 MyTelegramBot.sendAudio(1234, 'audio/path', { caption: 'Foo' });
+MyTelegramBot.sendAudio(1234, 'audio/path', { caption: 'Foo', parse_mode: 'Markdown' });
 MyTelegramBot.sendDocument(1234, 'doc/path', { caption: 'Foo' }, { fileOption: true });
+MyTelegramBot.sendDocument(1234, 'doc/path', { caption: 'Foo', parse_mode: 'HTML' }, { fileOption: true });
 MyTelegramBot.sendSticker(1234, 'sticker/path', { reply_to_message_id: 5678 });
 MyTelegramBot.sendVideo(1234, 'video/path', { caption: 'Foo' });
+MyTelegramBot.sendVideo(1234, 'video/path', { caption: 'Foo', parse_mode: 'MarkdownV2' });
 MyTelegramBot.sendVideoNote(1234, 'video/path', { disable_notification: true });
 MyTelegramBot.sendVoice(1234, 'voice/path', { caption: 'Foo' });
+MyTelegramBot.sendVoice(1234, 'voice/path', { caption: 'Foo', parse_mode: 'HTML' });
 MyTelegramBot.sendChatAction(1234, 'typing');
 MyTelegramBot.kickChatMember(1234, 'myUserID');
 MyTelegramBot.unbanChatMember(1234, 'myUserID');


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
https://core.telegram.org/bots/api#sendphoto
https://github.com/yagop/node-telegram-bot-api/blob/master/doc/api.md#TelegramBot+sendPhoto
https://github.com/yagop/node-telegram-bot-api/blob/5169d79bd92495d169f9e49302b9f5c630c6ccfc/src/telegram.js#L729-L742
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
