### PR TITLE
update(twemoji): add support for UMD module

### DIFF
--- a/types/twemoji/index.d.ts
+++ b/types/twemoji/index.d.ts
@@ -1,8 +1,16 @@
 // Type definitions for twemoji 12.1
 // Project: https://github.com/twitter/twemoji
 // Definitions by: Markus Tacker <https://github.com/coderbyheart>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
+
+/**
+ * A simple library that provides standard Unicode emoji support across all platforms.
+ * Twemoji v12.0 adheres to the Unicode 12.0 spec and supports the Emoji 12.0 spec
+ * The Twemoji library offers support for 3,075 emojis.
+ */
+export as namespace twemoji;
 
 /**
  * default assets url, by default will be Twitter Inc. CDN

--- a/types/twemoji/test/twemoji-tests.common-js.ts
+++ b/types/twemoji/test/twemoji-tests.common-js.ts
@@ -1,0 +1,22 @@
+import twemoji = require('twemoji');
+
+twemoji.parse('foo', {
+    base: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/12.0.4/2/',
+    folder: 'svg',
+    ext: '.svg',
+});
+
+const foo: HTMLElement = document.querySelector<HTMLElement>('#foo')!;
+twemoji.parse(foo, {
+    base: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/12.0.4/2/',
+    folder: 'svg',
+    ext: '.svg',
+});
+
+twemoji.convert.fromCodePoint('1f1e8');
+
+twemoji.convert.toCodePoint('\ud83c\udde8\ud83c\uddf3');
+
+if (twemoji.test('foo')) {
+    console.log('emoji All The Things!');
+}

--- a/types/twemoji/test/twemoji-tests.global.ts
+++ b/types/twemoji/test/twemoji-tests.global.ts
@@ -1,12 +1,10 @@
-import twemoji = require('twemoji');
-
 twemoji.parse('foo', {
     base: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/12.0.4/2/',
     folder: 'svg',
     ext: '.svg',
 });
 
-const foo: HTMLElement = undefined;
+const foo: HTMLElement = document.querySelector<HTMLElement>('#foo')!;
 twemoji.parse(foo, {
     base: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/12.0.4/2/',
     folder: 'svg',
@@ -17,6 +15,6 @@ twemoji.convert.fromCodePoint('1f1e8');
 
 twemoji.convert.toCodePoint('\ud83c\udde8\ud83c\uddf3');
 
-if (twemoji.test("foo")) {
-    console.log("emoji All The Things!");
+if (twemoji.test('foo')) {
+    console.log('emoji All The Things!');
 }

--- a/types/twemoji/tsconfig.json
+++ b/types/twemoji/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
@@ -19,6 +19,7 @@
     },
     "files": [
         "index.d.ts",
-        "twemoji-tests.ts"
+        "test/twemoji-tests.common-js.ts",
+        "test/twemoji-tests.global.ts"
     ]
 }


### PR DESCRIPTION
This is minor change, providing support for UMD module, allowing to use
the definition file directly in other scenarios.

- definition file change with namespace export
- document library export
- split tests for CommonJS and global code tests

Usage is promoted as UMD module via CDN:
https://github.com/twitter/twemoji#cdn-support

Use-case:
- vanilla JS
- TS configured to not emit, check JS for errors:

```js
/// <reference types="twemoji" />

window.addEventListener('DOMContentLoaded', event => {
    const div = document.createElement('div');
    div.textContent = 'I \u2764\uFE0F emoji!';
    document.body.appendChild(div);
    twemoji.parse(document.body);
});
```

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)