### PR TITLE
[ioBroker] add user property to state and make val required in setState

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -28,7 +28,7 @@ declare global {
 
         interface State {
             /** The value of the state. */
-            val: any;
+            val: string | number | boolean | any[] | Record<string, any> | null;
 
             /** Direction flag: false for desired value and true for actual value. Default: false. */
             ack: boolean;
@@ -42,6 +42,9 @@ declare global {
             /** Name of the adapter instance which set the value, e.g. "system.adapter.web.0" */
             from: string;
 
+            /** The user who set this value */
+            user?: string;
+
             /** Optional time in seconds after which the state is reset to null */
             expire?: number;
 
@@ -51,6 +54,7 @@ declare global {
             /** Optional comment */
             c?: string;
         }
+        type SettableState = Partial<Omit<State, "val">> & Pick<State, "val">;
 
         type Session = any; // TODO: implement
 
@@ -888,24 +892,24 @@ declare global {
             // tslint:disable:unified-signatures
             setState(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 callback?: SetStateCallback,
             ): void;
             setState(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack: boolean,
                 callback?: SetStateCallback,
             ): void;
             setState(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 options: unknown,
                 callback?: SetStateCallback,
             ): void;
             setState(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateCallback,
@@ -913,41 +917,41 @@ declare global {
             /** Writes a value into the states DB. */
             setStateAsync(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack?: boolean,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             setStateAsync(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 options?: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             setStateAsync(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack: boolean,
                 options: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             /** Writes a value into the states DB only if it has changed. */
             setStateChanged(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 callback?: SetStateChangedCallback,
             ): void;
             setStateChanged(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack: boolean,
                 callback?: SetStateChangedCallback,
             ): void;
             setStateChanged(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 options: unknown,
                 callback?: SetStateChangedCallback,
             ): void;
             setStateChanged(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateChangedCallback,
@@ -955,41 +959,41 @@ declare global {
             /** Writes a value into the states DB only if it has changed. */
             setStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack?: boolean,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
             setStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 options?: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
             setStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack: boolean,
                 options: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
             /** Writes a value (which might not belong to this adapter) into the states DB. */
             setForeignState(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 callback?: SetStateCallback,
             ): void;
             setForeignState(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack: boolean,
                 callback?: SetStateCallback,
             ): void;
             setForeignState(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 options: unknown,
                 callback?: SetStateCallback,
             ): void;
             setForeignState(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateCallback,
@@ -997,41 +1001,41 @@ declare global {
             /** Writes a value (which might not belong to this adapter) into the states DB. */
             setForeignStateAsync(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack?: boolean,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             setForeignStateAsync(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 options?: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             setForeignStateAsync(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack: boolean,
                 options: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             /** Writes a value (which might not belong to this adapter) into the states DB only if it has changed. */
             setForeignStateChanged(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 callback?: SetStateChangedCallback,
             ): void;
             setForeignStateChanged(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack: boolean,
                 callback?: SetStateChangedCallback,
             ): void;
             setForeignStateChanged(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 options: unknown,
                 callback?: SetStateChangedCallback,
             ): void;
             setForeignStateChanged(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateChangedCallback,
@@ -1039,17 +1043,17 @@ declare global {
             /** Writes a value (which might not belong to this adapter) into the states DB only if it has changed. */
             setForeignStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack?: boolean,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
             setForeignStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 options?: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
             setForeignStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | Partial<State>,
+                state: string | number | boolean | State | SettableState,
                 ack: boolean,
                 options: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -41,6 +41,7 @@ function stateChangeHandler(id: string, state: ioBroker.State | null | undefined
         state.from.toLowerCase();
         state.lc.toFixed();
         state.q && state.q.toFixed();
+        state.user && state.user.toLowerCase();
         state.ts.toFixed();
         state.val;
     }
@@ -363,3 +364,7 @@ function repro3() {
         list; // $ExpectType StateObject[]
     });
 }
+
+// Repro from https://github.com/ioBroker/ioBroker.js-controller/issues/782
+// $ExpectError
+adapter.setState("id", {ack: false});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ioBroker/ioBroker.docs/blob/master/docs/en/dev/objectsschema.md#states
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
