### PR TITLE
Fix koa-basic-auth with ESNext modules

### DIFF
--- a/types/koa-basic-auth/index.d.ts
+++ b/types/koa-basic-auth/index.d.ts
@@ -6,9 +6,13 @@
 
 import * as Koa from "koa";
 
-declare function auth(opts: {
-    name: string;
-    pass: string;
-}): Koa.Middleware;
+declare function auth(opts: auth.Options): Koa.Middleware;
+
+declare namespace auth {
+    interface Options {
+        name: string;
+        pass: string;
+    }
+}
 
 export = auth;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~

**Steps to reproduce / Current behavior:**

* Use `"module": "ESNext"` in your `tsconfig.json`
* `import * as auth from "koa-basic-auth";` gives following error:
  > This module can only be referenced with ECMAScript imports/exports by turning on the 'allowSyntheticDefaultImports' flag and referencing its default export.ts(2497)

Now, with the added namespace, the error doesn't show up anymore.