### PR TITLE
[pino] add formatters to pino's LoggerOptions

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pino 5.17
+// Type definitions for pino 6.0
 // Project: https://github.com/pinojs/pino.git, http://getpino.io
 // Definitions by: Peter Snider <https://github.com/psnider>
 //                 BendingBender <https://github.com/BendingBender>
@@ -444,6 +444,35 @@ declare namespace P {
          * key-value object added as child logger to each log line. If set to null the base child logger is not added
          */
         base?: { [key: string]: any } | null;
+
+        /**
+         * An object containing functions for formatting the shape of the log lines.
+         * These functions should return a JSONifiable object and should never throw.
+         * These functions allow for full customization of the resulting log lines.
+         * For example, they can be used to change the level key name or to enrich the default metadata.
+         */
+        formatters?: {
+          /**
+           * Changes the shape of the log level.
+           * The default shape is { level: number }.
+           * The function takes two arguments, the label of the level (e.g. 'info') and the numeric value (e.g. 30).
+           */
+          level?: (level: string, number: number) => object;
+          /**
+           * Changes the shape of the bindings.
+           * The default shape is { pid, hostname }.
+           * The function takes a single argument, the bindings object.
+           * It will be called every time a child logger is created.
+           */
+          bindings?: (bindings: Bindings) => object;
+          /**
+           * Changes the shape of the log object.
+           * This function will be called every time one of the log methods (such as .info) is called.
+           * All arguments passed to the log method, except the message, will be pass to this function.
+           * By default it does not change the shape of the log object.
+           */
+          log?: (object: object) => object;
+        };
     }
 
     interface PrettyOptions {


### PR DESCRIPTION
A new option that deprecates other ones, please see https://github.com/pinojs/pino/blob/master/docs/api.md\#formatters-object for more details.

I require assistance adding the npm tests, but I've compiled and run this locally.

In the application code, the following works:

```
const formatters = {
  level(label: string) {
    return {level: label};
  },
  bindings(bindings: {[key: string]: string}) {
    return {name: bindings.name};
  },
  log(object: object) {
    return object;
  },
};

pino({
  formatters,
});
```


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)



