### PR TITLE
[sinon-chrome] workaround for `debugger` being a reserved keyword

### DIFF
--- a/types/sinon-chrome/index.d.ts
+++ b/types/sinon-chrome/index.d.ts
@@ -176,8 +176,7 @@ declare namespace SinonChrome.cookies {
     export var set: SinonChromeStub;
 }
 
-/* TODO: Uncomment once https://github.com/Microsoft/TypeScript/issues/7840 is fixed
-declare module SinonChrome.debugger {
+declare module _debugger {
     export var attach: SinonChromeStub;
     export var detach: SinonChromeStub;
     export var getTargets: SinonChromeStub;
@@ -186,7 +185,10 @@ declare module SinonChrome.debugger {
     export var onDetach: SinonChrome.events.Event;
     export var onEvent: SinonChrome.events.Event;
 }
-*/
+// Workaround until https://github.com/Microsoft/TypeScript/issues/7840 is fixed
+export { _debugger as debugger };
+
+
 
 declare namespace SinonChrome.declarativeContent {
     export var PageStateMatcher: SinonChromeStub;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

The `debugger` namespace was commented out due to 'debugger' being a reserved word, waiting for [this bug to be fixed](https://github.com/Microsoft/TypeScript/issues/7840). This workaround allows adding back the namespace definition.