### PR TITLE
Fix bittorrent-protocol Wire definition  

### DIFF
--- a/types/bittorrent-protocol/bittorrent-protocol-tests.ts
+++ b/types/bittorrent-protocol/bittorrent-protocol-tests.ts
@@ -26,5 +26,5 @@ net.createServer(socket => {
     });
 
     // Extend wire using the test extension
-    wire.extend('extname', {})
+    wire.extended('extname', {});
 }).listen(6881);

--- a/types/bittorrent-protocol/bittorrent-protocol-tests.ts
+++ b/types/bittorrent-protocol/bittorrent-protocol-tests.ts
@@ -24,4 +24,7 @@ net.createServer(socket => {
     wire.on('unchoke', () => {
         console.log('peer is no longer choking us: ' + wire.peerChoking);
     });
+
+    // Extend wire using the test extension
+    wire.extend('extname', {})
 }).listen(6881);

--- a/types/bittorrent-protocol/index.d.ts
+++ b/types/bittorrent-protocol/index.d.ts
@@ -1,6 +1,8 @@
-// Type definitions for bittorrent-protocol 2.2
+// Type definitions for bittorrent-protocol 3.1
 // Project: https://github.com/webtorrent/bittorrent-protocol
-// Definitions by: Feross Aboukhadijeh <https://github.com/feross>, Tomasz Łaziuk <https://github.com/tlaziuk>
+// Definitions by: Feross Aboukhadijeh <https://github.com/feross>,
+//                 Tomasz Łaziuk <https://github.com/tlaziuk>,
+//                 H1b9b <https://github.com/h1b9b>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -77,7 +79,7 @@ declare namespace BittorrentProtocol {
 
         port(port: number): void;
 
-        extend(ext: number | string, obj: any): void;
+        extended(ext: number | string, obj: any): void;
 
         // TODO: bitfield is a bitfield instance
         on(event: 'bitfield', listener: (bitfield: any) => void): this;


### PR DESCRIPTION
This PR is for a quick change to fix the `BitTorrent.Wire` interface to match the source code.  
Currently the interface contains a `extend` method than matches the `Wire.extended` method  
As no `Wire.extend` method exist in the implementation, `extend` is replaced here by `extended`  
cf: https://github.com/webtorrent/bittorrent-protocol/blob/master/index.js#L372 



- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
Change `Wire.extend` to `Wire.extended` to match the package sources https://github.com/webtorrent/bittorrent-protocol/blob/master/index.js#L372
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.