### PR TITLE
yup: add generics to string to support string literal return

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -101,8 +101,8 @@ export interface MixedSchema<T = any> extends Schema<T> {
 }
 
 export interface StringSchemaConstructor {
-    (): StringSchema;
-    new (): StringSchema;
+    <T extends string | null | undefined = undefined>(): T extends string ? StringSchema<T> : StringSchema;
+    new <T extends string | null | undefined = undefined>(): T extends string ? StringSchema<T> : StringSchema;
 }
 
 export interface StringSchema<T extends string | null | undefined = string> extends Schema<T> {

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -302,48 +302,58 @@ yup.object()
     });
 
 // String schema
+function strSchemaTests(strSchema: yup.StringSchema) {
+    strSchema.isValid('hello'); // => true
+    strSchema.required();
+    strSchema.required('req');
+    strSchema.required(() => 'req');
+    strSchema.length(5, 'message');
+    strSchema.length(5, () => 'message');
+    strSchema.length(5, ({ length }) => `must be ${length}`);
+    // $ExpectError
+    strSchema.length(5, ({ min }) => `must be ${min}`);
+    strSchema.min(5, 'message');
+    strSchema.min(5, () => 'message');
+    strSchema.min(5, ({ min }) => `more than ${min}`);
+    // $ExpectError
+    strSchema.min(5, ({ max }) => `more than ${max}`);
+    strSchema.max(5, 'message');
+    strSchema.max(5, () => 'message');
+    strSchema.max(5, ({ max }) => `less than ${max}`);
+    // $ExpectError
+    strSchema.max(5, ({ min }) => `less than ${min}`);
+    strSchema.matches(/(hi|bye)/);
+    strSchema.matches(/(hi|bye)/, 'invalid');
+    strSchema.matches(/(hi|bye)/, () => 'invalid');
+    strSchema.matches(/(hi|bye)/, ({ regex }) => `Does not match ${regex}`);
+    strSchema.email();
+    strSchema.email('invalid');
+    strSchema.email(() => 'invalid');
+    strSchema.email(({ regex }) => `Does not match ${regex}`);
+    strSchema.url();
+    strSchema.url('bad url');
+    strSchema.url(() => 'bad url');
+    strSchema.url(({ regex }) => `Does not match ${regex}`);
+    strSchema.ensure();
+    strSchema.trim();
+    strSchema.trim('trimmed');
+    strSchema.trim(() => 'trimmed');
+    strSchema.lowercase();
+    strSchema.lowercase('lower');
+    strSchema.lowercase(() => 'lower');
+    strSchema.uppercase();
+    strSchema.uppercase('upper');
+    strSchema.uppercase(() => 'upper');
+}
+
 const strSchema = yup.string(); // $ExpectType StringSchema<string>
-strSchema.isValid('hello'); // => true
-strSchema.required();
-strSchema.required('req');
-strSchema.required(() => 'req');
-strSchema.length(5, 'message');
-strSchema.length(5, () => 'message');
-strSchema.length(5, ({ length }) => `must be ${length}`);
+strSchemaTests(strSchema);
+
+const strLiteralSchema = yup.string<'foo' | 'bar'>(); // $ExpectType StringSchema<"foo"> | StringSchema<"bar">
+strSchemaTests(strLiteralSchema);
+
 // $ExpectError
-strSchema.length(5, ({ min }) => `must be ${min}`);
-strSchema.min(5, 'message');
-strSchema.min(5, () => 'message');
-strSchema.min(5, ({ min }) => `more than ${min}`);
-// $ExpectError
-strSchema.min(5, ({ max }) => `more than ${max}`);
-strSchema.max(5, 'message');
-strSchema.max(5, () => 'message');
-strSchema.max(5, ({ max }) => `less than ${max}`);
-// $ExpectError
-strSchema.max(5, ({ min }) => `less than ${min}`);
-strSchema.matches(/(hi|bye)/);
-strSchema.matches(/(hi|bye)/, 'invalid');
-strSchema.matches(/(hi|bye)/, () => 'invalid');
-strSchema.matches(/(hi|bye)/, ({ regex }) => `Does not match ${regex}`);
-strSchema.email();
-strSchema.email('invalid');
-strSchema.email(() => 'invalid');
-strSchema.email(({ regex }) => `Does not match ${regex}`);
-strSchema.url();
-strSchema.url('bad url');
-strSchema.url(() => 'bad url');
-strSchema.url(({ regex }) => `Does not match ${regex}`);
-strSchema.ensure();
-strSchema.trim();
-strSchema.trim('trimmed');
-strSchema.trim(() => 'trimmed');
-strSchema.lowercase();
-strSchema.lowercase('lower');
-strSchema.lowercase(() => 'lower');
-strSchema.uppercase();
-strSchema.uppercase('upper');
-strSchema.uppercase(() => 'upper');
+yup.string<123>();
 
 // Number schema
 const numSchema = yup.number(); // $ExpectType NumberSchema<number>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This adds the ability to provide a generic parameter when using `string()` that will be passed along and used as the output type instead of the default, which is just `string`. It allows folks using yup to validate a string literal by telling the compiler what to expect. It is fully backwards compatible with all existing tests and simply extends the behavior for those who need it.

Here are examples. Without:

```typescript
interface StringLiteralObject {
  foo: 'bar';
}

function onlyAcceptsStringLiteral(obj: StringLiteralObject) {
  return obj.foo;
}

const LiteralSchema = yup.object<StringLiteralObject>().shape({
  foo: yup.string()
});

const exampleObject: StringLiteralObject = { foo: 'bar' };

const castObject = LiteralSchema.cast(exampleObject);

onlyAcceptsStringLiteral(castObject);
```

Fails with this error:

![image](https://user-images.githubusercontent.com/4097271/79142253-361bbb00-7d89-11ea-8159-529da212e091.png)

By replacing our definition of `LiteralSchema` by adding the generic parameter:

```typescript
const LiteralSchema = yup.object<StringLiteralObject>().shape({
  // We could also do `StringLiteralObject['foo']`
  foo: yup.string<'bar'>()
});
```

The `cast` is now successful, the output type matches the hint provided to the compiler.

![image](https://user-images.githubusercontent.com/4097271/79142351-5ba8c480-7d89-11ea-9d4a-57913a5c0c21.png)


Naturally, this does not provide any enhancements to the actual cast or validation process, so the user has the responsibility of ensuring that input and output values are consistent. IMO anything beyond that is outside the scope of what we can expect from these definitions.

A nice improvement would be for string keys to automatically infer the type from the parameter provided to `object` and let the parameter provided to `string()` override that if given. I'm not sure how that can be done without some heavier changes to these definitions that I'm not prepared to explore right now.

In the tests, you'll see that I added a function that accepts a `strSchema` so I can run the same tests with both the no-generic version and one with a string literal. There's also a test to demonstrate a failure when an invalid type is defined.