### PR TITLE
update(uglfy-js): Minor updates and version bump

### DIFF
--- a/types/uglify-js/index.d.ts
+++ b/types/uglify-js/index.d.ts
@@ -1,18 +1,24 @@
-// Type definitions for UglifyJS 3.0
+// Type definitions for UglifyJS 3.9
 // Project: https://github.com/mishoo/UglifyJS2
 // Definitions by: Alan Agius <https://github.com/alan-agius4>
 //                 Tanguy Krotoff <https://github.com/tkrotoff>
 //                 John Reilly <https://github.com/johnnyreilly>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
 import { RawSourceMap } from 'source-map';
 export interface ParseOptions {
-    /** Support top level `return` statements */
+    /**
+     * Support top level `return` statements
+     * @default false
+     */
     bare_returns?: boolean;
+    /** @default true */
     html5_comments?: boolean;
-    /** Support `#!command` as the first line */
+    /**
+     * Support `#!command` as the first line
+     * @default true
+     */
     shebang?: boolean;
 }
 
@@ -352,16 +358,61 @@ export enum OutputQuoteStyle {
 }
 
 export interface MinifyOptions {
-    /** Pass true to return compressor warnings in result.warnings. Use the value `verbose` for more detailed warnings. */
+    /**
+     * Pass `true` to return compressor warnings in result.warnings.
+     * Use the value `verbose` for more detailed warnings.
+     * @default false
+     */
     warnings?: boolean | 'verbose';
+    /**
+     * Pass an object if you wish to specify some additional parse options.
+     */
     parse?: ParseOptions;
-    compress?: boolean | CompressOptions;
+    /**
+     * Pass `false` to skip compressing entirely.
+     * Pass an object to specify custom compress options.
+     * @default {}
+     */
+    compress?: false | CompressOptions;
+    /**
+     * Pass `false` to skip mangling names,
+     * or pass an object to specify mangle options (see below).
+     * @default true
+     */
     mangle?: boolean | MangleOptions;
+    /**
+     * Pass an object if you wish to specify additional output options.
+     * The defaults are optimized for best compression
+     */
     output?: OutputOptions;
+    /**
+     * Pass an object if you wish to specify source map options.
+     * @default false
+     */
     sourceMap?: boolean | SourceMapOptions;
+    /**
+     * Set to `true` if you wish to enable top level variable and function name mangling
+     * and to drop unused variables and functions.
+     * @default false
+     */
     toplevel?: boolean;
+    /**
+     * Pass an empty object {} or a previously used nameCache object
+     * if you wish to cache mangled variable and property names across multiple invocations of minify().
+     * Note: this is a read/write property. `minify()` will read the name cache state of this object
+     * and update it during minification so that it may be reused or externally persisted by the user
+     */
     nameCache?: object;
+    /**
+     * Set to true to support IE8
+     * @default false
+     */
     ie8?: boolean;
+    /**
+     * Pass true to prevent discarding or mangling of function names.
+     * Useful for code relying on Function.prototype.name.
+     * @default false
+     */
     keep_fnames?: boolean;
 }
 

--- a/types/uglify-js/uglify-js-tests.ts
+++ b/types/uglify-js/uglify-js-tests.ts
@@ -5,19 +5,22 @@ import { OutputQuoteStyle, minify } from 'uglify-js';
 let code: any;
 
 code = {
-    "file1.js": "function add(first, second) { return first + second; }",
-    "file2.js": "console.log(add(1 + 2, 3 + 4));"
+    'file1.js': 'function add(first, second) { return first + second; }',
+    'file2.js': 'console.log(add(1 + 2, 3 + 4));',
 };
 
 minify(code);
 
 code = "function add(first, second) { return first + second; }";
-minify(code);
+minify(code, { toplevel: true });
 
 minify(code, {
+    warnings: true,
     output: {
-        quote_style: OutputQuoteStyle.AlwaysDouble
-    }
+        beautify: true,
+        preamble: '/* uglified */',
+        quote_style: OutputQuoteStyle.AlwaysDouble,
+    },
 });
 
 const output = minify(code, {
@@ -25,14 +28,20 @@ const output = minify(code, {
     mangle: {
         properties: {
             regex: /reg/
-        }
+        },
+        toplevel: true,
     },
     sourceMap: {
         filename: 'foo.map'
     },
     compress: {
-        arguments: true
-    }
+        arguments: true,
+        global_defs: {
+            "@console.log": "alert"
+        },
+        passes: 2,
+    },
+    nameCache: {},
 });
 
 const compressOptions = {


### PR DESCRIPTION
- bump to version 3.9
- correct options for Minify compress options as it accepts only false
or configuration object as per JSDoc comment
- add JSDoc comments for Minify options
- minor addition to the tests
- remove TS version header line as no longer valid (current defaults to
TS 2.8 or newer)

https://github.com/mishoo/UglifyJS2/releases/tag/v3.9.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.