### PR TITLE
[sanitize-html] Use correct htmlparser2 options type

### DIFF
--- a/types/sanitize-html/index.d.ts
+++ b/types/sanitize-html/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sanitize-html 1.22.0
+// Type definitions for sanitize-html 1.23.0
 // Project: https://github.com/punkave/sanitize-html
 // Definitions by: Rogier Schouten <https://github.com/rogierschouten>
 //                 Afshin Darian <https://github.com/afshin>
@@ -10,12 +10,11 @@
 //                 Jianrong Yu <https://github.com/YuJianrong>
 //                 GP <https://github.com/paambaati>
 //                 tomotetra <https://github.com/tomotetra>
+//                 Dariusz Syncerek <https://github.com/dsyncerek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-///<reference types="htmlparser2"/>
-
-import { Options } from "htmlparser2";
+import { ParserOptions } from "htmlparser2";
 
 export = sanitize;
 
@@ -67,7 +66,7 @@ declare namespace sanitize {
     nonTextTags?: string[];
     selfClosing?: string[];
     transformTags?: { [tagName: string]: string | Transformer };
-    parser?: Options;
+    parser?: ParserOptions;
     disallowedTagsMode?: DisallowedTagsModes;
   }
 

--- a/types/sanitize-html/package.json
+++ b/types/sanitize-html/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "htmlparser2": "^4.1.0"
+  }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/fb55/htmlparser2/blob/master/src/Parser.ts#L102>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.