### PR TITLE
[webpack-hot-middleware] Add missing 'path' option to ClientOptions

### DIFF
--- a/types/webpack-hot-middleware/index.d.ts
+++ b/types/webpack-hot-middleware/index.d.ts
@@ -20,6 +20,7 @@ declare function WebpackHotMiddleware(
 
 declare namespace WebpackHotMiddleware {
 	interface ClientOptions {
+		path?: string;
 		reload?: boolean;
 		name?: string;
 		timeout?: number;

--- a/types/webpack-hot-middleware/webpack-hot-middleware-tests.ts
+++ b/types/webpack-hot-middleware/webpack-hot-middleware-tests.ts
@@ -13,6 +13,7 @@ webpackHotMiddlewareInstance = webpackHotMiddleware(compiler, {
 });
 
 const clientOpts: webpackHotMiddleware.ClientOptions = {
+	path: '/__webpack_hmr',
 	reload: true,
 	name: '__webpack_hmr_custom_bundle_name',
 	timeout: 1000,


### PR DESCRIPTION
The purpose of this PR is to add the missing `path` option to `ClientOptions` that was apparently added only to `MiddlewareOptions` during the `Options` split in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43625

`path` is listed as a client option in the README:
https://github.com/webpack-contrib/webpack-hot-middleware#client

Also it is referenced in the source code:
https://github.com/webpack-contrib/webpack-hot-middleware/blob/cb29abb9dde435a1ac8e9b19f82d7d36b1093198/client.js#L46