### PR TITLE
downloadjs - Add Uint8Array as input type

### DIFF
--- a/types/downloadjs/downloadjs-tests.ts
+++ b/types/downloadjs/downloadjs-tests.ts
@@ -4,7 +4,7 @@ download('hello world', 'dlText.txt', 'text/plain');
 download('data:text/plain,hello%20world', 'dlDataUrlText.txt', 'text/plain');
 
 download(new Blob(['hello world']), 'dlTextBlob.txt', 'text/plain');
-download(new UintArray8([1, 2, 3]), 'dlUintArray8.html', 'text/html');
+download(new Uint8Array([1, 2, 3]), 'dlUintArray8.html', 'text/html');
 
 download('/robots.txt');
 

--- a/types/downloadjs/downloadjs-tests.ts
+++ b/types/downloadjs/downloadjs-tests.ts
@@ -4,6 +4,7 @@ download('hello world', 'dlText.txt', 'text/plain');
 download('data:text/plain,hello%20world', 'dlDataUrlText.txt', 'text/plain');
 
 download(new Blob(['hello world']), 'dlTextBlob.txt', 'text/plain');
+download(new UintArray8([1, 2, 3]), 'dlUintArray8.html', 'text/html');
 
 download('/robots.txt');
 

--- a/types/downloadjs/index.d.ts
+++ b/types/downloadjs/index.d.ts
@@ -7,5 +7,5 @@
 
 declare namespace download {
 }
-declare function download(data: string | File | Blob | UintArray8, filename?: string, mimeType?: string): XMLHttpRequest | boolean;
+declare function download(data: string | File | Blob | Uint8Array, filename?: string, mimeType?: string): XMLHttpRequest | boolean;
 export = download;

--- a/types/downloadjs/index.d.ts
+++ b/types/downloadjs/index.d.ts
@@ -7,5 +7,5 @@
 
 declare namespace download {
 }
-declare function download(data: string | File | Blob, filename?: string, mimeType?: string): XMLHttpRequest | boolean;
+declare function download(data: string | File | Blob | UintArray8, filename?: string, mimeType?: string): XMLHttpRequest | boolean;
 export = download;


### PR DESCRIPTION
The `downloadjs` README has an example usage of accepting an `Uint8Array` input type. See https://github.com/rndme/download#text-uint8-array----live-demo. I have also personally verified this functionality on Chrome Version 80.0.3987.162 (Official Build) (64-bit).