### PR TITLE
update aws-lambda type definition

### DIFF
--- a/types/aws-lambda/test/cognito-tests.ts
+++ b/types/aws-lambda/test/cognito-tests.ts
@@ -49,6 +49,7 @@ const handler: CognitoUserPoolTriggerHandler = async (event, context, callback) 
     event.request.session![0].challengeName === 'DEVICE_SRP_AUTH';
     event.request.session![0].challengeName === 'DEVICE_PASSWORD_VERIFIER';
     event.request.session![0].challengeName === 'ADMIN_NO_SRP_AUTH';
+    event.request.session![0].challengeName === 'SRP_A';
     bool = event.request.session![0].challengeResult;
     strOrUndefined = event.request.session![0].challengeMetadata;
     strOrUndefined = event.request.challengeName;

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger.d.ts
@@ -57,7 +57,8 @@ export interface CognitoUserPoolTriggerEvent {
                 | 'SMS_MFA'
                 | 'DEVICE_SRP_AUTH'
                 | 'DEVICE_PASSWORD_VERIFIER'
-                | 'ADMIN_NO_SRP_AUTH';
+                | 'ADMIN_NO_SRP_AUTH'
+                | 'SRP_A';
             challengeResult: boolean;
             challengeMetadata?: string;
         }>;


### PR DESCRIPTION
In [the document](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-define-auth-challenge.html), type of challengeName must be one of "CUSTOM_CHALLENGE", "PASSWORD_VERIFIER", "SMS_MFA", "DEVICE_SRP_AUTH", "DEVICE_PASSWORD_VERIFIER", or "ADMIN_NO_SRP_AUTH".
But [the example of the document](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-define-auth-challenge.html#node.js) treats challengeName as "SRP_A".
And In my implementation on AWS lambda, challengeName is 'SRP_A' when I use custom authentication with password. 
I have provided feedback this issue to AWS recently, but it does not reflect yet.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-define-auth-challenge.html#node.js
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
