### PR TITLE
update vuelidate type definition

### DIFF
--- a/types/vuelidate/index.d.ts
+++ b/types/vuelidate/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Jan Esser <https://github.com/janesser>
 //                 Jubair Saidi <https://github.com/jubairsaidi>
 //                 Orblazer <https://github.com/orblazer>
+//                 Yuri Krylov <https://github.com/shadrus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 

--- a/types/vuelidate/lib/validators.d.ts
+++ b/types/vuelidate/lib/validators.d.ts
@@ -21,6 +21,8 @@ export interface ValidationRule {
 
 export type CustomRule = (value: any, parentVm?: any) => boolean | Promise<boolean>
 
+export type ValidationFunc = () => ValidationRule;
+
 export interface Helpers {
     withParams(params: Params, rule: CustomRule | ValidationRule): ValidationRule
     req(value: any): boolean
@@ -51,5 +53,5 @@ export function macAddress(): ValidationRule
 export function sameAs(field: string | ((vm: any, parentVm?: Vue) => any)): ValidationRule
 export function url(): ValidationRule
 export function not(validator: ValidationRule | CustomRule): ValidationRule
-export function or(...validators: Array<ValidationRule | CustomRule>): ValidationRule
-export function and(...validators: Array<ValidationRule | CustomRule>): ValidationRule
+export function or(...validators: Array<ValidationFunc | CustomRule>): ValidationRule
+export function and(...validators: Array<ValidationFunc | CustomRule>): ValidationRule

--- a/types/vuelidate/vuelidate-tests.ts
+++ b/types/vuelidate/vuelidate-tests.ts
@@ -1,10 +1,22 @@
 import { Validation } from 'vuelidate'
-import { required, integer, decimal,  minLength, sameAs, helpers, CustomRule } from 'vuelidate/lib/validators'
+import {
+    required,
+    integer,
+    decimal,
+    minLength,
+    sameAs,
+    or,
+    helpers,
+    CustomRule,
+    ipAddress,
+    url, and
+} from 'vuelidate/lib/validators'
 
 import Vue, { ComponentOptions } from 'vue'
 
 // excerpt from vue-class-component/src/declarations.ts
 type VueClass<V> = { new(...args: any[]): V & Vue } & typeof Vue
+
 // excerpt from vue-class-component/src/index.ts
 function Component(options: ComponentOptions<Vue> | VueClass<Vue>): any {
     return null; // mocked
@@ -18,7 +30,7 @@ const contains = (param: string): CustomRule =>
     (value: string) => !helpers.req(value) || value.indexOf(param) >= 0
 
 const mustBeCool3 = helpers.withParams(
-    { type: 'mustBeCool3' },
+    {type: 'mustBeCool3'},
     (value: any) => !helpers.req(value) || value.indexOf('cool') >= 0
 )
 
@@ -27,13 +39,13 @@ const mustBeCool3Result: boolean = mustBeCool3(50)
 const mustBeCool4 = helpers.regex('mustBeCool4', /^.*cool.*$/)
 
 const mustBeSame = (reference: string) => helpers.withParams(
-    { type: 'mustBeSame' },
+    {type: 'mustBeSame'},
     (value: any, parentVm?: Vue) =>
         value === helpers.ref(reference, self, parentVm)
 )
 
 const mustHaveLength = (minLen: number) => helpers.withParams(
-    { type: 'mustHaveLength' },
+    {type: 'mustHaveLength'},
     (value: any) =>
         helpers.len(value) > minLen
 )
@@ -69,10 +81,10 @@ const mustHaveLength = (minLen: number) => helpers.withParams(
             required,
             decimal
         },
-        flatA: { required },
-        flatB: { required },
+        flatA: {required},
+        flatB: {required},
         forGroup: {
-            nested: { required }
+            nested: {required}
         },
         validationGroup: ['age', 'coolFactor', 'flatA', 'flatB', 'forGroup.nested'],
         people: {
@@ -105,6 +117,14 @@ const mustHaveLength = (minLen: number) => helpers.withParams(
             mustBeCool2,
             containsA: contains('a'),
             mustBeCool3
+        },
+        hostOrLong: {
+            required,
+            or: or(url, minLength(50))
+        },
+        coolHost: {
+            required,
+            and: and(url, mustBeCool)
         }
     }
 })
@@ -134,6 +154,7 @@ export class ValidComponent extends Vue {
     myField = ''
 
     touchMap = new WeakMap()
+
     delayTouch(v: Validation) {
         v.$reset()
         if (this.touchMap.has(v)) {
@@ -180,8 +201,8 @@ export class ValidComponent extends Vue {
     validations() {
         const self = this as Valid2Component // assert
         return self.myToggle
-            ? { myField1: required, myField2: contains('maybe') }
-            : { myField1: contains('maybe'), myField2: required }
+            ? {myField1: required, myField2: contains('maybe')}
+            : {myField1: contains('maybe'), myField2: required}
     }
 })
 export class Valid2Component extends Vue {


### PR DESCRIPTION
Vuelidate has some provided validators.
Two of them 'or' and 'and' can get function as an argument. 
For example, we need something like:
```javascript
validations: {
  multiusername: {
    required,
    mycustomval: or(email, alphaNum)
  }
}
```
But current type definitions waits for email(), alphaNum(), which results are boolean, not functions.
During code execution we have exception.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/vuelidate/vuelidate/blob/master/src/validators/and.js> <https://github.com/vuelidate/vuelidate/blob/master/src/validators/or.js>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
