### PR TITLE
[forge-apis] Add missing type definitions

### DIFF
--- a/types/forge-apis/forge-apis-tests.ts
+++ b/types/forge-apis/forge-apis-tests.ts
@@ -286,8 +286,27 @@ projectsApi.getProject('', '', authClientTwoLegged, authToken);
 projectsApi.getProjectHub('', '', authClientTwoLegged, authToken);
 // $ExpectType Promise<ApiResponse>
 projectsApi.getProjectTopFolders('', '', authClientTwoLegged, authToken);
+
 // $ExpectType Promise<ApiResponse>
-projectsApi.postStorage('', {}, authClientTwoLegged, authToken);
+projectsApi.postStorage('', {
+    jsonapi: {
+       version: '1.0'
+    },
+    data: {
+       type: 'objects',
+       attributes: {
+          name: '{{Filename}}'
+       },
+       relationships: {
+          target: {
+             data: {
+                type: 'folders',
+                id: '{{FolderId}}'
+             }
+          }
+       }
+    }
+ }, authClientTwoLegged, authToken);
 
 // $ExpectType UserProfileApi
 const userProfileApi = new UserProfileApi();

--- a/types/forge-apis/index.d.ts
+++ b/types/forge-apis/index.d.ts
@@ -723,7 +723,7 @@ export class HubsApi {
 
 export interface CreateStorageDataAttributes {
     name: string;
-    extension: BaseAttributesExtensionObject;
+    extension?: BaseAttributesExtensionObject;
 }
 
 export interface CreateItemDataRelationshipsTipData {
@@ -1047,6 +1047,7 @@ export interface CreateStorageDataRelationships {
 }
 
 export interface CreateStorageData {
+    type: string;
     attributes?: CreateStorageDataAttributes;
     relationships?: CreateStorageDataRelationships;
 }


### PR DESCRIPTION
Please fill in this template.

- [*] Use a meaningful title for the pull request. Include the name of the package modified.
- [*] Test the change in your own code. (Compile and run.)
- [*] Add or edit tests to reflect the change. (Run with `npm test`.)
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [*] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: 

     - https://github.com/Autodesk-Forge/forge-api-nodejs-client/blob/98bed64c1aa4ee1585e16a264cf1b9b73fc75cf3/src/model/CreateStorageDataAttributes.js#L52
     - https://forge.autodesk.com/en/docs/data/v2/reference/http/projects-project_id-storage-POST/

- [*] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [*] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [*] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.