### PR TITLE
Add missing context param to JSXElementConstructor type constructor signature

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -82,7 +82,7 @@ declare namespace React {
 
     type JSXElementConstructor<P> =
         | ((props: P) => ReactElement | null)
-        | (new (props: P) => Component<P, any>);
+        | (new (props: P, context?: any) => Component<P, any>);
 
     interface RefObject<T> {
         readonly current: T | null;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -426,3 +426,15 @@ type propTypesTest1 = typeof testPropTypes extends DeclaredPropTypes<TestPropTyp
 type propTypesTest2 = typeof testPropTypes extends DeclaredPropTypes<TestPropTypesProps2> ? true : false;
 // $ExpectType true
 type propTypesTest3 = typeof testPropTypes extends DeclaredPropTypes<TestPropTypesProps3> ? true : false;
+
+class WithLegacyContextConstructor extends React.Component {
+    static contextTypes = {
+        color: PropTypes.string
+    };
+
+    constructor(props: any, context: any) {
+        super(props, context);
+    }
+}
+
+type WithLegacyContextConstructorProps = React.ComponentProps<typeof WithLegacyContextConstructor>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods>>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)


The fix allows getting component props with ComponentProps type for components with a constructor that includes context param: 

```
import React, { ComponentProps } from 'react'

export interface ButtonProps {
    label: string;
}

class ButtonComponent extends React.Component<ButtonProps> {
  constructor(props: ButtonProps, context: any) {
        super(props, context);
  }

  public render() {
    return <button> {this.props.label} </button>
  }
}

export type DetectedProps = ComponentProps<typeof ButtonComponent>;
```