### PR TITLE
shopify-buy LineItem.compare_at_price can be null

### DIFF
--- a/types/shopify-buy/index.d.ts
+++ b/types/shopify-buy/index.d.ts
@@ -4,6 +4,7 @@
 //                 Stephen Traiforos <https://github.com/straiforos>
 //                 Rosana Ruiz <https://github.com/totemika>
 //                 Juan Manuel Incaurgarat <https://github.com/kilinkis>
+//                 Chris Worman <https://github.com/chrisworman-pela>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 

--- a/types/shopify-buy/index.d.ts
+++ b/types/shopify-buy/index.d.ts
@@ -330,7 +330,7 @@ declare namespace ShopifyBuy {
          * previously before the product went on sale.
          * If no compareAtPrice is set then this value will be null. An example value: "5.00".
          */
-        compare_at_price: string;
+        compare_at_price: string | null;
 
         /**
          * Variant's weight in grams. If no weight is set then 0 is returned.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/362fec0309fc4fec1efe241fd292b07197467f4f/types/shopify-buy/index.d.ts#L331>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Authors: @openminder, @straiforos, @kilinkis
