### PR TITLE
[prosemirror-view] use ClipboardEvent over Event for handlePaste

### DIFF
--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -474,7 +474,7 @@ export interface EditorProps<S extends Schema = any> {
    * pasted content parsed by the editor, but you can directly access
    * the event to get at the raw content.
    */
-  handlePaste?: ((view: EditorView<S>, event: Event, slice: Slice<S>) => boolean) | null;
+  handlePaste?: ((view: EditorView<S>, event: ClipboardEvent, slice: Slice<S>) => boolean) | null;
   /**
    * Called when something is dropped on the editor. `moved` will be
    * true if this drop moves from the current selection (which should


### PR DESCRIPTION
clarify type of event arg to [Clipboard event](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent/ClipboardEvent) rather than a generic event, since this event should have a `clipboardData` property. This fixes some typescript issues.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/ProseMirror/prosemirror-view/pull/72>