### PR TITLE
[emoji-mart] Missing theme prop

### DIFF
--- a/types/emoji-mart/dist-es/utils/shared-props.d.ts
+++ b/types/emoji-mart/dist-es/utils/shared-props.d.ts
@@ -92,5 +92,4 @@ export interface PickerProps {
     notFound?(): React.Component;
     notFoundEmoji?: string;
     icons?: CustomIcons;
-    darkMode?: boolean;
 }

--- a/types/emoji-mart/dist-es/utils/shared-props.d.ts
+++ b/types/emoji-mart/dist-es/utils/shared-props.d.ts
@@ -69,6 +69,7 @@ export interface PickerProps {
     i18n?: PartialI18n;
     style?: React.CSSProperties;
     title?: string;
+    theme?: string;
     emoji?: string;
     color?: string;
     set?: EmojiSet;

--- a/types/emoji-mart/dist-es/utils/shared-props.d.ts
+++ b/types/emoji-mart/dist-es/utils/shared-props.d.ts
@@ -69,7 +69,7 @@ export interface PickerProps {
     i18n?: PartialI18n;
     style?: React.CSSProperties;
     title?: string;
-    theme?: string;
+    theme?: "auto" | "light" | "dark";
     emoji?: string;
     color?: string;
     set?: EmojiSet;

--- a/types/emoji-mart/index.d.ts
+++ b/types/emoji-mart/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for emoji-mart 2.11
+// Type definitions for emoji-mart 3.0.0
 // Project: https://github.com/missive/emoji-mart
 // Definitions by: Jessica Franco <https://github.com/Jessidhia>
 //                 Nick Winans <https://github.com/Nicell>
 //                 Elvis Wolcott <https://github.com/elvis-wolcott>
 //                 Yunho Seo <https://github.com/seoyunho>
+//                 Tarrence van As <https://github.com/tarrencev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 

--- a/types/emoji-mart/index.d.ts
+++ b/types/emoji-mart/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for emoji-mart 3.0.0
+// Type definitions for emoji-mart 3.0
 // Project: https://github.com/missive/emoji-mart
 // Definitions by: Jessica Franco <https://github.com/Jessidhia>
 //                 Nick Winans <https://github.com/Nicell>


### PR DESCRIPTION
Adding new `theme` prop exposed in latest `v3.0.0` release, as described:

https://github.com/missive/emoji-mart#picker

https://github.com/missive/emoji-mart/blob/master/CHANGELOG.md