### PR TITLE
rdf-js: remove triples

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -100,7 +100,7 @@ export class Quad extends BaseQuad implements RDF.Quad {
     toJSON(): string;
 }
 
-export class Triple extends Quad implements RDF.Triple {}
+export class Triple extends Quad implements RDF.Quad {}
 
 export namespace DataFactory {
     function namedNode(value: string): NamedNode;

--- a/types/rdf-ext/rdf-ext-tests.ts
+++ b/types/rdf-ext/rdf-ext-tests.ts
@@ -177,7 +177,7 @@ function static_Triple_fromBaseTerms(): Quad {
     const predicate: NamedNode = <any> {};
     const object: NamedNode = <any> {};
 
-    return rdf.triple(subject, predicate, object);
+    return rdf.quad(subject, predicate, object);
 }
 
 function instance_Quad_fromBaseTerms(): Quad {
@@ -196,7 +196,7 @@ function instance_Triple_fromBaseTerms(): Quad {
     const predicate: NamedNode = <any> {};
     const object: NamedNode = <any> {};
 
-    return factory.triple(subject, predicate, object);
+    return factory.quad(subject, predicate, object);
 }
 
 function Quad_toJSON(): boolean {

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for the RDFJS specification 2.0
+// Type definitions for the RDFJS specification 3.0
 // Project: https://github.com/rdfjs/representation-task-force
 // Definitions by: Ruben Taelman <https://github.com/rubensworks>
 //                 Laurens Rietveld <https://github.com/LaurensRietveld>

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -200,7 +200,7 @@ export interface BaseQuad {
    * @param other The term to compare with.
    * @return True if and only if the argument is a) of the same type b) has all components equal.
    */
-  equals(other: BaseQuad): boolean;
+  equals(other: BaseQuad | null | undefined): boolean;
 }
 
 /**
@@ -232,7 +232,7 @@ export interface Quad extends BaseQuad {
      * @param other The term to compare with.
      * @return True if and only if the argument is a) of the same type b) has all components equal.
      */
-    equals(other: BaseQuad): boolean;
+    equals(other: BaseQuad | null | undefined): boolean;
 }
 
 /**

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -236,15 +236,7 @@ export interface Quad extends BaseQuad {
 }
 
 /**
- * An RDF triple, containing the subject, predicate, object terms.
- *
- * Triple is an alias of Quad.
- */
-// tslint:disable-next-line no-empty-interface
-export interface Triple extends Quad {}
-
-/**
- * A factory for instantiating RDF terms, triples and quads.
+ * A factory for instantiating RDF terms and quads.
  */
 export interface DataFactory<OutQuad extends BaseQuad = Quad, InQuad extends BaseQuad = OutQuad> {
     /**
@@ -287,17 +279,6 @@ export interface DataFactory<OutQuad extends BaseQuad = Quad, InQuad extends Bas
      * @return An instance of DefaultGraph.
      */
     defaultGraph(): DefaultGraph;
-
-    /**
-     * @param subject   The triple subject term.
-     * @param predicate The triple predicate term.
-     * @param object    The triple object term.
-     * @return A new instance of Quad with `Quad.graph` set to DefaultGraph.
-     * @see Quad
-     * @see Triple
-     * @see DefaultGraph
-     */
-    triple(subject: InQuad['subject'], predicate: InQuad['predicate'], object: InQuad['object']): InQuad;
 
     /**
      * @param subject   The quad subject term.

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -1,5 +1,5 @@
 import { BlankNode, DataFactory, Dataset, DatasetCore, DatasetCoreFactory, DatasetFactory, DefaultGraph, Literal,
-  NamedNode, Quad, BaseQuad, Sink, Source, Store, Stream, Triple, Term, Variable, Quad_Graph } from "rdf-js";
+  NamedNode, Quad, BaseQuad, Sink, Source, Store, Stream, Term, Variable, Quad_Graph } from "rdf-js";
 import { EventEmitter } from "events";
 
 function test_terms() {
@@ -55,14 +55,6 @@ function test_quads() {
     const o1: Term = quad.object;
     const g1: Term = quad.graph;
     quad.equals(quad);
-
-    const triple: Triple = quad;
-    const s2: Term = triple.subject;
-    const p2: Term = triple.predicate;
-    const o2: Term = triple.object;
-    const g2: Term = triple.graph;
-    triple.equals(quad);
-    quad.equals(triple);
 }
 
 function test_datafactory() {
@@ -80,7 +72,6 @@ function test_datafactory() {
     const variable: Variable = dataFactory.variable ? dataFactory.variable('v1') : <any> {};
 
     const term: NamedNode = <any> {};
-    const triple: Quad = dataFactory.triple(term, term, term);
     interface QuadBnode extends BaseQuad {
       subject: Term;
       predicate: Term;

--- a/types/rdfjs__dataset/rdfjs__dataset-tests.ts
+++ b/types/rdfjs__dataset/rdfjs__dataset-tests.ts
@@ -8,5 +8,5 @@ const variable: RDF.Variable = rdf.variable('foo');
 const graph: RDF.DefaultGraph = rdf.defaultGraph();
 const defaultGraph: RDF.DefaultGraph = rdf.defaultGraphInstance;
 const namedNode: RDF.NamedNode = rdf.namedNode('foo');
-const triple: RDF.Triple = rdf.triple(namedNode, variable, literal);
+const triple: RDF.Quad = rdf.quad(namedNode, variable, literal);
 const quad: RDF.Quad = rdf.quad(namedNode, variable, literal, graph);


### PR DESCRIPTION
Triples are not specified in the RDF/JS standards.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - _Comment_: Triples are not specified in [the spec](http://rdf.js.org/data-model-spec/). The Graphy library, which is otherwise spec-compliant, provides the `triple` method but prints a warning.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - _Comment_: it aligns the type definitions with the spec, but I'm unsure how the spec is versioned. As it's a breaking change, I'm assuming a major bump is necessary.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
