### PR TITLE
[aws-lambda] add userNotFound property

### DIFF
--- a/types/aws-lambda/test/cognito-tests.ts
+++ b/types/aws-lambda/test/cognito-tests.ts
@@ -57,6 +57,7 @@ const handler: CognitoUserPoolTriggerHandler = async (event, context, callback) 
     str = event.request.challengeAnswer!;
     strOrUndefined = event.request.password;
     str = event.request.clientMetadata!['action'];
+    boolOrUndefined = event.request.userNotFound;
     boolOrUndefined = event.response.answerCorrect;
     strOrUndefined = event.response.smsMessage;
     strOrUndefined = event.response.emailMessage;

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger.d.ts
@@ -67,6 +67,7 @@ export interface CognitoUserPoolTriggerEvent {
         challengeAnswer?: string;
         password?: string;
         clientMetadata?: { [key: string]: string };
+        userNotFound?: boolean;
     };
     response: {
         autoConfirmUser?: boolean;


### PR DESCRIPTION
The several cognito triggers declare request contains userNotFound property as boolean with conditions.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-authentication.html
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
