### PR TITLE
fixes to the types for fitBound function

### DIFF
--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -6,113 +6,124 @@
 
 import * as React from 'react';
 
-export type BootstrapURLKeys = ({ key: string; } | { client: string; v: string; }) & { language?: string; region?: string; libraries?: string[] | string; };
+export type BootstrapURLKeys = ({ key: string } | { client: string; v: string }) & {
+    language?: string;
+    region?: string;
+    libraries?: string[] | string;
+};
 
 export interface MapTypeStyle {
-  elementType?: string;
-  featureType?: string;
-  stylers: any[];
+    elementType?: string;
+    featureType?: string;
+    stylers: any[];
 }
 
 export interface MapOptions {
-  // Any options from https://developers.google.com/maps/documentation/javascript/reference/3/#MapOptions
-  // excluding 'zoom' and 'center' which get set via props.
-  backgroundColor?: string;
-  clickableIcons?: boolean;
-  controlSize?: number;
-  disableDefaultUI?: boolean;
-  disableDoubleClickZoom?: boolean;
-  draggable?: boolean;
-  draggableCursor?: string;
-  draggingCursor?: string;
-  fullscreenControl?: boolean;
-  fullscreenControlOptions?: { position: number };
-  gestureHandling?: string;
-  heading?: number;
-  keyboardShortcuts?: boolean;
-  mapTypeControl?: boolean;
-  mapTypeControlOptions?: any;
-  mapTypeId?: string;
-  minZoom?: number;
-  maxZoom?: number;
-  noClear?: boolean;
-  options?: (maps: Maps) => Props;
-  panControl?: boolean;
-  panControlOptions?: { position: number };
-  rotateControl?: boolean;
-  rotateControlOptions?: { position: number };
-  scaleControl?: boolean;
-  scaleControlOptions?: any;
-  scrollwheel?: boolean;
-  streetView?: any;
-  streetViewControl?: boolean;
-  streetViewControlOptions?: { position: number };
-  styles?: MapTypeStyle[];
-  tilt?: number;
-  zoomControl?: boolean;
-  zoomControlOptions?: { position: number };
-  minZoomOverride?: boolean; // Not a standard option; specific to google-map-react: https://github.com/google-map-react/google-map-react/pull/154
+    // Any options from https://developers.google.com/maps/documentation/javascript/reference/3/#MapOptions
+    // excluding 'zoom' and 'center' which get set via props.
+    backgroundColor?: string;
+    clickableIcons?: boolean;
+    controlSize?: number;
+    disableDefaultUI?: boolean;
+    disableDoubleClickZoom?: boolean;
+    draggable?: boolean;
+    draggableCursor?: string;
+    draggingCursor?: string;
+    fullscreenControl?: boolean;
+    fullscreenControlOptions?: { position: number };
+    gestureHandling?: string;
+    heading?: number;
+    keyboardShortcuts?: boolean;
+    mapTypeControl?: boolean;
+    mapTypeControlOptions?: any;
+    mapTypeId?: string;
+    minZoom?: number;
+    maxZoom?: number;
+    noClear?: boolean;
+    options?: (maps: Maps) => Props;
+    panControl?: boolean;
+    panControlOptions?: { position: number };
+    rotateControl?: boolean;
+    rotateControlOptions?: { position: number };
+    scaleControl?: boolean;
+    scaleControlOptions?: any;
+    scrollwheel?: boolean;
+    streetView?: any;
+    streetViewControl?: boolean;
+    streetViewControlOptions?: { position: number };
+    styles?: MapTypeStyle[];
+    tilt?: number;
+    zoomControl?: boolean;
+    zoomControlOptions?: { position: number };
+    minZoomOverride?: boolean; // Not a standard option; specific to google-map-react: https://github.com/google-map-react/google-map-react/pull/154
 }
 
 export interface Maps {
-  Animation: any;
-  ControlPosition: any;
-  MapTypeControlStyle: any;
-  MapTypeId: any;
-  NavigationControlStyle: any;
-  ScaleControlStyle: any;
-  StrokePosition: any;
-  SymbolPath: any;
-  ZoomControlStyle: any;
-  DirectionsStatus: any;
-  DirectionsTravelMode: any;
-  DirectionsUnitSystem: any;
-  DistanceMatrixStatus: any;
-  DistanceMatrixElementStatus: any;
-  ElevationStatus: any;
-  GeocoderLocationType: any;
-  GeocoderStatus: any;
-  KmlLayerStats: any;
-  MaxZoomStatus: any;
-  StreetViewStatus: any;
-  TransitMode: any;
-  TransitRoutePreference: any;
-  TravelMode: any;
-  UnitSystem: any;
+    Animation: any;
+    ControlPosition: any;
+    MapTypeControlStyle: any;
+    MapTypeId: any;
+    NavigationControlStyle: any;
+    ScaleControlStyle: any;
+    StrokePosition: any;
+    SymbolPath: any;
+    ZoomControlStyle: any;
+    DirectionsStatus: any;
+    DirectionsTravelMode: any;
+    DirectionsUnitSystem: any;
+    DistanceMatrixStatus: any;
+    DistanceMatrixElementStatus: any;
+    ElevationStatus: any;
+    GeocoderLocationType: any;
+    GeocoderStatus: any;
+    KmlLayerStats: any;
+    MaxZoomStatus: any;
+    StreetViewStatus: any;
+    TransitMode: any;
+    TransitRoutePreference: any;
+    TravelMode: any;
+    UnitSystem: any;
 }
 
 export interface Bounds {
-  nw: Coords;
-  ne: Coords;
-  sw: Coords;
-  se: Coords;
+    nw: Coords;
+    ne: Coords;
+    sw: Coords;
+    se: Coords;
 }
 
 export interface Point {
-  x: number;
-  y: number;
+    x: number;
+    y: number;
+}
+
+export interface NESWBounds {
+    ne: Coords;
+    sw: Coords;
+    nw?: Coords;
+    se?: Coords;
 }
 
 export interface Coords {
-  lat: number;
-  lng: number;
+    lat: number;
+    lng: number;
 }
 
 export interface Size {
-  width: number;
-  height: number;
+    width: number;
+    height: number;
 }
 
 export interface ClickEventValue extends Point, Coords {
-  event: any;
+    event: any;
 }
 
 export interface ChangeEventValue {
-  center: Coords;
-  zoom: number;
-  bounds: Bounds;
-  marginBounds: Bounds;
-  size: Size;
+    center: Coords;
+    zoom: number;
+    bounds: Bounds;
+    marginBounds: Bounds;
+    size: Size;
 }
 
 export interface Props {
@@ -144,7 +155,7 @@ export interface Props {
     onMapTypeIdChange?(args: any): void;
     distanceToMouse?(pt: Point, mousePos: Point, markerProps?: object): number;
     googleMapLoader?(bootstrapURLKeys: any): void;
-    onGoogleApiLoaded?(maps: { map: any; maps: any, ref: Element | null }): void;
+    onGoogleApiLoaded?(maps: { map: any; maps: any; ref: Element | null }): void;
     onTilesLoaded?(): void;
     yesIWantToUseGoogleMapApiInternals?: boolean;
     style?: React.HTMLProps<HTMLDivElement>;
@@ -154,5 +165,5 @@ export interface Props {
 export default class GoogleMapReact extends React.Component<Props> {}
 
 export interface ChildComponentProps extends Coords {
-  $hover?: boolean;
+    $hover?: boolean;
 }

--- a/types/google-map-react/utils.d.ts
+++ b/types/google-map-react/utils.d.ts
@@ -9,9 +9,13 @@ export function convertNeSwToNwSe(boundCorder: { ne: Coords; sw: Coords }): { nw
 export function convertNwSeToNeSw(boundCorder: { nw: Coords; se: Coords }): { ne: Coords; sw: Coords };
 
 export function fitBounds(
-    bounds: Bounds,
+    bounds: NESWBounds,
     size: Size,
-): { center: { metersPerLatDegree: number; metersPerLngDegree: number }; zoom: number; newBounds: Bounds };
+): {
+    center: { lat: number; lng: number };
+    zoom: number;
+    newBounds: Bounds;
+};
 
 export function meters2ScreenPixels(meters: number, coords: Coords, zoom: number): { w: number; h: number };
 


### PR DESCRIPTION
This PR is a fix for optional co-ordinates within Bounds argument in `fitBounds` function; 
Renamed the returned lat & lng keys from the `fitBounds` function. 

Without the above fix, the function `fitBounds` is unusable in Typescript.

The `fitBounds` function signature is here: https://github.com/google-map-react/google-map-react/blob/88038c293dff16d6211c564624c08925e4ff1987/src/utils/utils.js#L147

Tested locally. There are no tests for the types for Google-Map-React in the package. 