### PR TITLE
[prosemirror-view] add test helpers to definition

### DIFF
--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -20,6 +20,11 @@ import {
 import { EditorState, Selection, Transaction } from 'prosemirror-state';
 import { Mapping } from 'prosemirror-transform';
 
+// Exported for testing
+export function __serializeForClipboard<S extends Schema = any>(view: EditorView<S>, slice: Slice<S>): { dom: HTMLElement, text: string };
+export function __parseFromClipboard<S extends Schema = any>(view: EditorView<S>, text: string, html: string, plainText: boolean, $context: ResolvedPos<S>): Slice<S>;
+export function __endComposition(view: EditorView, forceUpdate?: boolean): boolean;
+
 /**
  * The `spec` for a widget decoration
  */


### PR DESCRIPTION
Some test helpers were not exported in the type definition. These are useful for testing copy/paste behaviour.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ProseMirror/prosemirror-view/blob/master/src/index.js#L13-L15