### PR TITLE
Fix #43740: [istanbul-lib-source-maps] transformCoverage return a promise

### DIFF
--- a/types/istanbul-lib-source-maps/index.d.ts
+++ b/types/istanbul-lib-source-maps/index.d.ts
@@ -33,7 +33,7 @@ export interface MapStore {
     getSourceMapSync(filePath: string): any;
     addInputSourceMapsSync(coverageData: any): void;
     sourceFinder(filePath: string): string;
-    transformCoverage(coverageMap: CoverageMap): CoverageMap;
+    transformCoverage(coverageMap: CoverageMap): Promise<CoverageMap>;
     dispose(): void;
 }
 

--- a/types/istanbul-lib-source-maps/istanbul-lib-source-maps-tests.ts
+++ b/types/istanbul-lib-source-maps/istanbul-lib-source-maps-tests.ts
@@ -26,7 +26,7 @@ store.registerURL('foo', 'foo');
 
 const map = new CoverageMap({});
 const transformed = store.transformCoverage(map);
-transformed.data;
+transformed.then(obj => obj.data);
 
 store.dispose();
 


### PR DESCRIPTION
In version 4, transformCoverage return a promise.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/istanbuljs/istanbuljs/blob/master/packages/istanbul-lib-source-maps/lib/map-store.js#L172>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.