### PR TITLE
chore(node): mark object values as undefine-able

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -133,7 +133,7 @@ declare module "child_process" {
         uid?: number;
         gid?: number;
         cwd?: string;
-        env?: NodeJS.ProcessEnv;
+        env?: NodeJS.Dict<string>;
     }
 
     interface CommonOptions extends ProcessEnvOptions {

--- a/types/node/cluster.d.ts
+++ b/types/node/cluster.d.ts
@@ -100,9 +100,7 @@ declare module "cluster" {
         settings: ClusterSettings;
         setupMaster(settings?: ClusterSettings): void;
         worker?: Worker;
-        workers?: {
-            [index: string]: Worker | undefined
-        };
+        workers?: NodeJS.Dict<Worker>;
 
         readonly SCHED_NONE: number;
         readonly SCHED_RR: number;
@@ -184,9 +182,7 @@ declare module "cluster" {
     const settings: ClusterSettings;
     function setupMaster(settings?: ClusterSettings): void;
     const worker: Worker;
-    const workers: {
-        [index: string]: Worker | undefined
-    };
+    const workers: NodeJS.Dict<Worker>;
 
     /**
      * events.EventEmitter

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -669,9 +669,8 @@ declare namespace NodeJS {
         isTTY?: true;
     }
 
-    interface ProcessEnv {
-        [key: string]: string | undefined;
-    }
+    // Alias for compability
+    type ProcessEnv = Dict<string>;
 
     interface HRTime {
         (time?: [number, number]): [number, number];
@@ -781,7 +780,7 @@ declare namespace NodeJS {
         cwd(): string;
         debugPort: number;
         emitWarning(warning: string | Error, name?: string, ctor?: Function): void;
-        env: ProcessEnv;
+        env: Dict<string>;
         exit(code?: number): never;
         exitCode?: number;
         getgid(): number;
@@ -1066,15 +1065,11 @@ declare namespace NodeJS {
     type TypedArray = Uint8Array | Uint8ClampedArray | Uint16Array | Uint32Array | Int8Array | Int16Array | Int32Array | Float32Array | Float64Array;
     type ArrayBufferView = TypedArray | DataView;
 
-    interface NodeRequireCache {
-        [path: string]: NodeModule;
-    }
-
     interface Require {
         /* tslint:disable-next-line:callable-types */
         (id: string): any;
         resolve: RequireResolve;
-        cache: NodeRequireCache;
+        cache: Dict<NodeModule>;
         /**
          * @deprecated
          */
@@ -1087,11 +1082,10 @@ declare namespace NodeJS {
         paths(request: string): string[] | null;
     }
 
-    interface RequireExtensions {
+    interface RequireExtensions extends Dict<(m: Module, filename: string) => any> {
         '.js': (m: Module, filename: string) => any;
         '.json': (m: Module, filename: string) => any;
         '.node': (m: Module, filename: string) => any;
-        [ext: string]: (m: Module, filename: string) => any;
     }
     interface Module {
         exports: any;
@@ -1102,5 +1096,13 @@ declare namespace NodeJS {
         parent: Module | null;
         children: Module[];
         paths: string[];
+    }
+
+    interface Dict<T> {
+        [key: string]: T | undefined;
+    }
+
+    interface ReadOnlyDict<T> {
+        readonly [key: string]: T | undefined;
     }
 }

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -5,7 +5,7 @@ declare module "http" {
     import { Socket, Server as NetServer } from "net";
 
     // incoming headers will never contain number
-    interface IncomingHttpHeaders {
+    interface IncomingHttpHeaders extends NodeJS.Dict<string | string[]> {
         'accept'?: string;
         'accept-language'?: string;
         'accept-patch'?: string;
@@ -60,12 +60,10 @@ declare module "http" {
         'via'?: string;
         'warning'?: string;
         'www-authenticate'?: string;
-        [header: string]: string | string[] | undefined;
     }
 
     // outgoing headers allows numbers (as they are converted internally to strings)
-    interface OutgoingHttpHeaders {
-        [header: string]: number | string | string[] | undefined;
+    interface OutgoingHttpHeaders extends NodeJS.Dict<number | string | string[]> {
     }
 
     interface ClientRequestArgs {
@@ -309,7 +307,7 @@ declare module "http" {
         socket: Socket;
         headers: IncomingHttpHeaders;
         rawHeaders: string[];
-        trailers: { [key: string]: string | undefined };
+        trailers: NodeJS.Dict<string>;
         rawTrailers: string[];
         setTimeout(msecs: number, callback?: () => void): this;
         /**
@@ -358,12 +356,8 @@ declare module "http" {
     class Agent {
         maxFreeSockets: number;
         maxSockets: number;
-        readonly sockets: {
-            readonly [key: string]: Socket[];
-        };
-        readonly requests: {
-            readonly [key: string]: IncomingMessage[];
-        };
+        readonly sockets: NodeJS.ReadOnlyDict<Socket[]>;
+        readonly requests: NodeJS.ReadOnlyDict<IncomingMessage[]>;
 
         constructor(opts?: AgentOptions);
 

--- a/types/node/os.d.ts
+++ b/types/node/os.d.ts
@@ -46,7 +46,7 @@ declare module "os" {
     function cpus(): CpuInfo[];
     function type(): string;
     function release(): string;
-    function networkInterfaces(): { [index: string]: NetworkInterfaceInfo[] };
+    function networkInterfaces(): NodeJS.Dict<NetworkInterfaceInfo[]>;
     function homedir(): string;
     function userInfo(options: { encoding: 'buffer' }): UserInfo<Buffer>;
     function userInfo(options?: { encoding: string }): UserInfo<string>;

--- a/types/node/querystring.d.ts
+++ b/types/node/querystring.d.ts
@@ -8,10 +8,9 @@ declare module "querystring" {
         decodeURIComponent?: (str: string) => string;
     }
 
-    interface ParsedUrlQuery { [key: string]: string | string[]; }
+    interface ParsedUrlQuery extends NodeJS.Dict<string | string[]> { }
 
-    interface ParsedUrlQueryInput {
-        [key: string]: string | number | boolean | string[] | number[] | boolean[] | undefined | null;
+    interface ParsedUrlQueryInput extends NodeJS.Dict<string | number | boolean | string[] | number[] | boolean[] | null> {
     }
 
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;

--- a/types/node/repl.d.ts
+++ b/types/node/repl.d.ts
@@ -146,7 +146,7 @@ declare module "repl" {
         /**
          * The commands registered via `replServer.defineCommand()`.
          */
-        readonly commands: { readonly [name: string]: REPLCommand | undefined };
+        readonly commands: NodeJS.ReadOnlyDict<REPLCommand>;
         /**
          * A value indicating whether the REPL is currently in "editor mode".
          *

--- a/types/node/scripts/generate-inspector/generate-substitute-args.ts
+++ b/types/node/scripts/generate-inspector/generate-substitute-args.ts
@@ -90,7 +90,7 @@ const createPostFunctions = (command: schema.Command, domain: string): string[] 
  * substituted into ./inspector.d.ts.template.
  * @param protocol The parsed contents of the JSON file from which the DevTools Protocol docs are generated.
  */
-export const generateSubstituteArgs = (protocol: schema.Schema): { [propName: string]: string[] } => {
+export const generateSubstituteArgs = (protocol: schema.Schema): NodeJS.Dict<string[]> => {
     const interfaceDefinitions: string[] = protocol.domains
         .map(item => {
             const typePool = (item.types || []).concat(filterNull([

--- a/types/node/scripts/generate-inspector/index.ts
+++ b/types/node/scripts/generate-inspector/index.ts
@@ -53,7 +53,7 @@ function writeProtocolsToFile(jsonProtocols: string[]) {
     const template = readFileSync(`${__dirname}/inspector.d.ts.template`, "utf8");
 
     const inspectorDts = substitute(template, substituteArgs).split("\n")
-        .map(line => trimRight(line))
+        .map(trimRight)
         .join("\n");
 
     writeFileSync("./inspector.d.ts", inspectorDts, "utf8");

--- a/types/node/scripts/generate-inspector/utils.ts
+++ b/types/node/scripts/generate-inspector/utils.ts
@@ -73,7 +73,7 @@ export const createDocs = ({ deprecated, description, experimental }: Documentab
  */
 export const substitute = (
     str: string,
-    args: { [propName: string]: string[] },
+    args: NodeJS.Dict<string[]>,
 ): string => {
     return str.split("\n")
         .map(line => {
@@ -81,11 +81,11 @@ export const substitute = (
             const matches = line.match(regex);
             if (matches) {
                 const [_0, prefix, argName] = matches;
-                if (args[argName]) {
-                    return args[argName].map(l => prefix + l);
-                } else {
-                    return [];
+                const arg = args[argName];
+                if (arg) {
+                    return arg.map(l => prefix + l);
                 }
+                return [];
             }
             return [line];
         })

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -37,8 +37,8 @@ const resolved2: string = customRequire2.resolve('test');
 const paths1: string[] | null  = customRequire1.resolve.paths('test');
 const paths2: string[] | null  = customRequire2.resolve.paths('test');
 
-const cachedModule1: Module = customRequire1.cache['/path/to/module.js'];
-const cachedModule2: Module = customRequire2.cache['/path/to/module.js'];
+const cachedModule1: Module | undefined = customRequire1.cache['/path/to/module.js'];
+const cachedModule2: Module | undefined = customRequire2.cache['/path/to/module.js'];
 
 const main1: Module | undefined = customRequire1.main;
 const main2: Module | undefined = customRequire2.main;

--- a/types/node/test/os.ts
+++ b/types/node/test/os.ts
@@ -39,7 +39,7 @@ import * as os from 'os';
 }
 
 {
-    let result: { [index: string]: os.NetworkInterfaceInfo[] };
+    let result: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
 
     result = os.networkInterfaces();
 }

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -38,7 +38,7 @@ declare module "tls" {
         subject: Certificate;
         issuer: Certificate;
         subjectaltname: string;
-        infoAccess: { [index: string]: string[] | undefined };
+        infoAccess: NodeJS.Dict<string[]>;
         modulus: string;
         exponent: string;
         valid_from: string;

--- a/types/node/ts3.5/wasi.d.ts
+++ b/types/node/ts3.5/wasi.d.ts
@@ -17,9 +17,7 @@ declare module 'wasi' {
          * directories within the sandbox. The corresponding values in `preopens` are
          * the real paths to those directories on the host machine.
          */
-        preopens?: {
-            [key: string]: string;
-        };
+        preopens?: NodeJS.Dict<string>;
 
         /**
          * By default, WASI applications terminate the Node.js
@@ -49,6 +47,6 @@ declare module 'wasi' {
          * should be passed as the `wasi_unstable` import during the instantiation of a
          * [`WebAssembly.Instance`][].
          */
-        readonly wasiImport: { [key: string]: any }; // TODO: Narrow to DOM types
+        readonly wasiImport: NodeJS.Dict<any>; // TODO: Narrow to DOM types
     }
 }

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -92,7 +92,7 @@ declare module "url" {
     }
 
     class URLSearchParams implements Iterable<[string, string]> {
-        constructor(init?: URLSearchParams | string | { [key: string]: string | string[] | undefined } | Iterable<[string, string]> | Array<[string, string]>);
+        constructor(init?: URLSearchParams | string | NodeJS.Dict<string | string[]> | Iterable<[string, string]> | Array<[string, string]>);
         append(name: string, value: string): void;
         delete(name: string): void;
         entries(): IterableIterator<[string, string]>;

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -12,9 +12,7 @@ declare module "util" {
     function inspect(object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;
     function inspect(object: any, options: InspectOptions): string;
     namespace inspect {
-        let colors: {
-            [color: string]: [number, number] | undefined
-        };
+        let colors: NodeJS.Dict<[number, number]>;
         let styles: {
             [K in Style]: string
         };

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -1,7 +1,5 @@
 declare module "vm" {
-    interface Context {
-        [key: string]: any;
-    }
+    interface Context extends NodeJS.Dict<any> { }
     interface BaseOptions {
         /**
          * Specifies the filename used in stack traces produced by this script.

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -62,7 +62,7 @@ declare module "worker_threads" {
          * were passed as CLI options to the script.
          */
         argv?: any[];
-        env?: NodeJS.ProcessEnv | typeof SHARE_ENV;
+        env?: NodeJS.Dict<string> | typeof SHARE_ENV;
         eval?: boolean;
         workerData?: any;
         stdin?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Does not apply
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

NodeJS typings have been a little inconsistent with their use of making objects with index signatures have ` | undefined` for their properties.

[Which I have contributed to...](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/2b7def6f58415d444b84aca6f6cb1c4b216bd403#r38450075)

This change introduces 2 utility dictionary types that make things more consistent.

Pro:
- More type safety
- Consistency

Contra:
- This is breaking (however breaking changes have been allowed in the past if they contribute to type safety or types were outright wrong).
- These types should probably be provided by TS itself as utilities (similar to `ReadOnlyArray` and friends).
- There is an ongoing debate about this (see link above) and https://github.com/Microsoft/TypeScript/issues/13778