### PR TITLE
Fix CryptoJS WordArray types

### DIFF
--- a/types/crypto-js/index.d.ts
+++ b/types/crypto-js/index.d.ts
@@ -47,7 +47,7 @@ declare namespace CryptoJS {
 		toString(encoder?: Encoder): string;
 	}
 	export interface WordArray {
-		iv: string | LibWordArray;
+		iv: string;
 		salt: string;
 		ciphertext: string;
 		key?: string;

--- a/types/crypto-js/index.d.ts
+++ b/types/crypto-js/index.d.ts
@@ -57,7 +57,7 @@ declare namespace CryptoJS {
 		toString(encoder?: Encoder): string;
 	};
 	interface CipherOption {
-		iv?: LibWordArray;
+		iv?: string | LibWordArray;
 		mode?: Mode;
 		padding?: Padding;
 		[option: string]: any;

--- a/types/crypto-js/index.d.ts
+++ b/types/crypto-js/index.d.ts
@@ -30,7 +30,7 @@ declare namespace CryptoJS {
 	interface StreamCipher extends Cipher {}
 
 	interface CipherHelper {
-		encrypt(message: string | LibWordArray, secretPassphrase: string | WordArray, option?: CipherOption): WordArray;
+		encrypt(message: string | WordArray, secretPassphrase: string | WordArray, option?: CipherOption): WordArray;
 		decrypt(encryptedMessage: string | WordArray, secretPassphrase: string | WordArray, option?: CipherOption): DecryptedMessage;
 	}
 	interface Encryptor {
@@ -47,7 +47,7 @@ declare namespace CryptoJS {
 		toString(encoder?: Encoder): string;
 	}
 	export interface WordArray {
-		iv: string;
+		iv: string | WordArray;
 		salt: string;
 		ciphertext: string;
 		key?: string;
@@ -147,7 +147,7 @@ declare namespace CryptoJS {
 		lib: {
 			WordArray: {
 				create: (v: any) => LibWordArray;
-				random: (v: number) => LibWordArray;
+				random: (v: number) => WordArray;
 			};
 		};
 		mode: {

--- a/types/crypto-js/index.d.ts
+++ b/types/crypto-js/index.d.ts
@@ -47,7 +47,7 @@ declare namespace CryptoJS {
 		toString(encoder?: Encoder): string;
 	}
 	export interface WordArray {
-		iv: string | WordArray;
+		iv: string | LibWordArray;
 		salt: string;
 		ciphertext: string;
 		key?: string;
@@ -57,7 +57,7 @@ declare namespace CryptoJS {
 		toString(encoder?: Encoder): string;
 	};
 	interface CipherOption {
-		iv?: string | LibWordArray;
+		iv?: string | WordArray;
 		mode?: Mode;
 		padding?: Padding;
 		[option: string]: any;

--- a/types/crypto-js/index.d.ts
+++ b/types/crypto-js/index.d.ts
@@ -57,7 +57,7 @@ declare namespace CryptoJS {
 		toString(encoder?: Encoder): string;
 	};
 	interface CipherOption {
-		iv?: string;
+		iv?: LibWordArray;
 		mode?: Mode;
 		padding?: Padding;
 		[option: string]: any;


### PR DESCRIPTION
`encrypt()` `message` parameter is a `WordArray`, not a `LibWordArray`.
[See documentation](https://github.com/brix/crypto-js/blob/31d00127a7c87066c51abe56e7b8be3a32141cae/cipher-core.js#L665)

`iv` can be also `WordArray`
[See Documentation](https://github.com/brix/crypto-js/blob/31d00127a7c87066c51abe56e7b8be3a32141cae/cipher-core.js#L793)

`random()` returns a `WordArray`, not a `LibWordArray`.
[See documentation](https://github.com/brix/crypto-js/blob/31d00127a7c87066c51abe56e7b8be3a32141cae/crypto-js.js#L349)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
