### PR TITLE
update(email-templates): update to version 7

### DIFF
--- a/types/email-templates/email-templates-tests.ts
+++ b/types/email-templates/email-templates-tests.ts
@@ -1,5 +1,6 @@
 import EmailTemplates = require('email-templates');
 import { createTransport } from 'nodemailer';
+import path = require('path');
 
 const email = new EmailTemplates({
     message: {
@@ -7,6 +8,9 @@ const email = new EmailTemplates({
     },
     transport: {
         jsonTransport: true
+    },
+    getPath: (type, template) => {
+        return path.join(template, type);
     }
 });
 
@@ -20,6 +24,11 @@ email.juiceResources('<p>bob</p><style>div{color:red;}</style><div/>');
 email.render('mars/html.pug');
 email.render('mars/html.pug', {name: 'elon'});
 const sendPromise: Promise<any> = email.send({template: 'mars', message: {to: 'elon@spacex.com'}, locals: {name: 'Elon'}});
+email.send({template: 'mars', message: {to: 'elon@spacex.com'}, locals: {name: 'Elon'}})
+.then(res => {
+    console.log('res.originalMessage', res.originalMessage);
+})
+.catch(console.error);
 emailNoTransporter.render('mars/html.pug', {name: 'elon'});
 
 interface Locals {

--- a/types/email-templates/email-templates-tests.ts
+++ b/types/email-templates/email-templates-tests.ts
@@ -2,6 +2,10 @@ import EmailTemplates = require('email-templates');
 import { createTransport } from 'nodemailer';
 import path = require('path');
 
+const locals = {
+    locale: 'en',
+    name: 'Elon',
+};
 const email = new EmailTemplates({
     message: {
       from: 'Test@testing.com'
@@ -9,9 +13,11 @@ const email = new EmailTemplates({
     transport: {
         jsonTransport: true
     },
-    getPath: (type, template) => {
-        return path.join(template, type);
-    }
+    /** returns different template based on current locale */
+    getPath: (type, template, locales) => {
+        const locale = locales.locale;
+        return path.join(template, locale, type);
+    },
 });
 
 const emailNoTransporter = new EmailTemplates({
@@ -22,14 +28,14 @@ const emailNoTransporter = new EmailTemplates({
 
 email.juiceResources('<p>bob</p><style>div{color:red;}</style><div/>');
 email.render('mars/html.pug');
-email.render('mars/html.pug', {name: 'elon'});
-const sendPromise: Promise<any> = email.send({template: 'mars', message: {to: 'elon@spacex.com'}, locals: {name: 'Elon'}});
-email.send({template: 'mars', message: {to: 'elon@spacex.com'}, locals: {name: 'Elon'}})
+email.render('mars/html.pug', locals);
+const sendPromise: Promise<any> = email.send({template: 'mars', message: {to: 'elon@spacex.com'}, locals});
+email.send({template: 'mars', message: {to: 'elon@spacex.com'}, locals})
 .then(res => {
     console.log('res.originalMessage', res.originalMessage);
 })
 .catch(console.error);
-emailNoTransporter.render('mars/html.pug', {name: 'elon'});
+emailNoTransporter.render('mars/html.pug', locals);
 
 interface Locals {
     firstName: string;
@@ -61,7 +67,7 @@ withTransportInstance.send({
 });
 
 email.renderAll('mars');
-const promise = email.renderAll('mars', {name: 'elon'});
+const promise = email.renderAll('mars', locals);
 promise.then(value => {
     const subject: string | undefined = value.subject;
     const html: string | undefined = value.html;

--- a/types/email-templates/index.d.ts
+++ b/types/email-templates/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for node-email-templates 6.0
+// Type definitions for node-email-templates 7.0
 // Project: https://github.com/niftylettuce/email-templates
 // Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>
 //                 Matus Gura <https://github.com/gurisko>
 //                 Jacob Copeland <https://github.com/blankstar85>
 //                 Vesa Poikajärvi <https://github.com/vesse>
 //                 Philipp Katz <https://github.com/qqilihq>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.3
 
@@ -114,6 +115,12 @@ interface EmailConfig<T = any> {
      */
     i18n?: any;
     /**
+     * defaults to false, unless you pass your own render function,
+     * and in that case it will be automatically set to true.
+     * @default false
+     */
+    customRender?: boolean;
+    /**
      * Pass a custom render function if necessary
      */
     render?: (view: string, locals?: T) => Promise<any>;
@@ -140,6 +147,11 @@ interface EmailConfig<T = any> {
      * <https://github.com/Automattic/juice>
      */
     juiceResources?: any;
+    /**
+     * a function that returns the path to a template file
+     * @default (path: string, template: string) => string
+     */
+    getPath?: (path: string, template: string, locals: any) => string;
 }
 
 interface EmailOptions<T = any> {
@@ -189,7 +201,7 @@ declare class EmailTemplate<T = any> {
     /**
      * Send the Email
      */
-    send(options: EmailOptions<T>): any;
+    send(options: EmailOptions<T>): Promise<any>;
 }
 
 declare namespace EmailTemplate {


### PR DESCRIPTION
As the primary api surface was not changed at all in v7, this commit:
- bump version to 7
- add missing `getPath` method to Email config
- mark return type of `send` method explicit Promise

https://github.com/forwardemail/email-templates/compare/v6.1.1...v7.0.0
https://github.com/forwardemail/email-templates/blob/2a3042893d2e596f690f0148010df7e504c1ad69/README.md#L705

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.