### PR TITLE
fix(babel__traverse): fix return values of replace methods

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -1,24 +1,24 @@
-import traverse, { Visitor, NodePath } from "@babel/traverse";
-import * as t from "@babel/types";
+import traverse, { Visitor, NodePath } from '@babel/traverse';
+import * as t from '@babel/types';
 
 // Examples from: https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md
 const MyVisitor: Visitor = {
     Identifier: {
         enter(path) {
             const x: NodePath<t.Identifier> = path;
-            console.log("Entered!");
+            console.log('Entered!');
         },
         exit(path) {
             const x: NodePath<t.Identifier> = path;
-            console.log("Exited!");
-        }
-    }
+            console.log('Exited!');
+        },
+    },
 };
 
 const MyVisitor2: Visitor = {
     Identifier(path) {
-        console.log("Visiting: " + path.node.name);
-    }
+        console.log('Visiting: ' + path.node.name);
+    },
 };
 
 // Example from https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#babel-traverse
@@ -27,10 +27,10 @@ declare const ast: t.Node;
 traverse(ast, {
     enter(path) {
         const node = path.node;
-        if (t.isIdentifier(node) && node.name === "n") {
-            node.name = "x";
+        if (t.isIdentifier(node) && node.name === 'n') {
+            node.name = 'x';
         }
-    }
+    },
 });
 
 // Examples from https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#writing-your-first-babel-plugin
@@ -40,12 +40,20 @@ const v1: Visitor = {
         if (t.isIdentifier(path.node.left)) {
             // ...
         }
-        path.replaceWith(
-            t.binaryExpression("**", path.node.left, t.numericLiteral(2))
-        );
+        path.replaceWith(t.binaryExpression('**', path.node.left, t.numericLiteral(2))) as [
+            NodePath<t.BinaryExpression>,
+        ];
         path.parentPath.replaceWith(
-            t.expressionStatement(t.stringLiteral("Anyway the wind blows, doesn't really matter to me, to me."))
+            t.expressionStatement(t.stringLiteral("Anyway the wind blows, doesn't really matter to me, to me.")),
         );
+        path.replaceInline(t.binaryExpression('**', path.node.left, t.numericLiteral(2))) as [
+            NodePath<t.BinaryExpression>,
+        ];
+        path.replaceWithSourceString('3 * 4') as [NodePath];
+        path.replaceInline([
+            t.binaryExpression('**', path.node.left, t.numericLiteral(2)),
+            t.expressionStatement(t.stringLiteral("Anyway the wind blows, doesn't really matter to me, to me.")),
+        ]) as [NodePath<t.BinaryExpression>, NodePath<t.ExpressionStatement>];
         path.parentPath.remove();
     },
 
@@ -60,10 +68,10 @@ const v1: Visitor = {
 
     ReturnStatement(path) {
         path.replaceWithMultiple([
-            t.expressionStatement(t.stringLiteral("Is this the real life?")),
-            t.expressionStatement(t.stringLiteral("Is this just fantasy?")),
-            t.expressionStatement(t.stringLiteral("(Enjoy singing the rest of the song in your head)")),
-        ]);
+            t.expressionStatement(t.stringLiteral('Is this the real life?')),
+            t.expressionStatement(t.stringLiteral('Is this just fantasy?')),
+            t.expressionStatement(t.stringLiteral('(Enjoy singing the rest of the song in your head)')),
+        ]) as [NodePath<t.ExpressionStatement>, NodePath<t.ExpressionStatement>, NodePath<t.ExpressionStatement>];
     },
 
     FunctionDeclaration(path, state) {
@@ -71,34 +79,34 @@ const v1: Visitor = {
             return a + b;
         }`);
 
-        path.get('body').unshiftContainer('body', t.expressionStatement(t.stringLiteral("Start of function")));
-        path.get('body').pushContainer('body', t.expressionStatement(t.stringLiteral("End of function")));
+        path.get('body').unshiftContainer('body', t.expressionStatement(t.stringLiteral('Start of function')));
+        path.get('body').pushContainer('body', t.expressionStatement(t.stringLiteral('End of function')));
 
         path.insertBefore(t.expressionStatement(t.stringLiteral("Because I'm easy come, easy go.")));
-        path.insertAfter(t.expressionStatement(t.stringLiteral("A little high, little low.")));
+        path.insertAfter(t.expressionStatement(t.stringLiteral('A little high, little low.')));
         path.remove();
 
-        if (path.scope.hasBinding("n")) {
+        if (path.scope.hasBinding('n')) {
             // ...
         }
-        if (path.scope.hasOwnBinding("n")) {
+        if (path.scope.hasOwnBinding('n')) {
             // ...
         }
 
-        const id1 = path.scope.generateUidIdentifier("uid");
+        const id1 = path.scope.generateUidIdentifier('uid');
         id1.type;
         id1.name;
-        const id2 = path.scope.generateUidIdentifier("uid");
+        const id2 = path.scope.generateUidIdentifier('uid');
         id2.type;
         id2.name;
 
         const id = path.scope.generateUidIdentifierBasedOnNode(path.node.id!);
         path.remove();
         path.scope.parent.push({ id });
-        path.scope.parent.push({ id, init: t.stringLiteral('foo'), kind: "const" });
+        path.scope.parent.push({ id, init: t.stringLiteral('foo'), kind: 'const' });
 
-        path.scope.rename("n", "x");
-        path.scope.rename("n");
+        path.scope.rename('n', 'x');
+        path.scope.rename('n');
 
         // $ExpectError
         path.pushContainer('returnType', t.stringLiteral('hello'));
@@ -109,7 +117,7 @@ const v1: Visitor = {
         {
             const [stringPath, booleanPath] = path.replaceWithMultiple([
                 t.stringLiteral('hello'),
-                t.booleanLiteral(false)
+                t.booleanLiteral(false),
             ]);
             // $ExpectType NodePath<BooleanLiteral | StringLiteral>
             stringPath;
@@ -119,7 +127,7 @@ const v1: Visitor = {
         {
             const [stringPath, booleanPath] = path.replaceWithMultiple<[t.StringLiteral, t.BooleanLiteral]>([
                 t.stringLiteral('hello'),
-                t.booleanLiteral(false)
+                t.booleanLiteral(false),
             ]);
             // $ExpectType NodePath<StringLiteral>
             stringPath;
@@ -151,7 +159,7 @@ const v1: Visitor = {
         {
             const [stringPath, booleanPath] = path.unshiftContainer('body', [
                 t.stringLiteral('hello'),
-                t.booleanLiteral(false)
+                t.booleanLiteral(false),
             ]);
             // $ExpectType NodePath<BooleanLiteral | StringLiteral>
             stringPath;
@@ -161,7 +169,7 @@ const v1: Visitor = {
         {
             const [stringPath, booleanPath] = path.pushContainer('body', [
                 t.stringLiteral('hello'),
-                t.booleanLiteral(false)
+                t.booleanLiteral(false),
             ]);
             // $ExpectType NodePath<BooleanLiteral | StringLiteral>
             stringPath;
@@ -171,7 +179,7 @@ const v1: Visitor = {
         {
             const [stringPath, booleanPath] = path.unshiftContainer<[t.StringLiteral, t.BooleanLiteral]>('body', [
                 t.stringLiteral('hello'),
-                t.booleanLiteral(false)
+                t.booleanLiteral(false),
             ]);
             // $ExpectType NodePath<StringLiteral>
             stringPath;
@@ -181,20 +189,20 @@ const v1: Visitor = {
         {
             const [stringPath, booleanPath] = path.pushContainer<[t.StringLiteral, t.BooleanLiteral]>('body', [
                 t.stringLiteral('hello'),
-                t.booleanLiteral(false)
+                t.booleanLiteral(false),
             ]);
             // $ExpectType NodePath<StringLiteral>
             stringPath;
             // $ExpectType NodePath<BooleanLiteral>
             booleanPath;
         }
-    }
+    },
 };
 
 // Binding.kind
 const BindingKindTest: Visitor = {
     Identifier(path) {
-        const kind = path.scope.getBinding("str")!.kind;
+        const kind = path.scope.getBinding('str')!.kind;
         kind === 'module';
         kind === 'const';
         kind === 'let';
@@ -204,7 +212,9 @@ const BindingKindTest: Visitor = {
     },
 };
 
-interface SomeVisitorState { someState: string; }
+interface SomeVisitorState {
+    someState: string;
+}
 
 const VisitorStateTest: Visitor<SomeVisitorState> = {
     enter(path, state) {
@@ -237,11 +247,11 @@ const VisitorStateTest: Visitor<SomeVisitorState> = {
             state;
             // $ExpectType SomeVisitorState
             this;
-        }
-    }
+        },
+    },
 };
 
-traverse(ast, VisitorStateTest, undefined, { someState: "test" });
+traverse(ast, VisitorStateTest, undefined, { someState: 'test' });
 
 const VisitorAliasTest: Visitor = {
     Function() {},

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -8,7 +8,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.4
 
-import * as t from "@babel/types";
+import * as t from '@babel/types';
 
 export type Node = t.Node;
 
@@ -41,7 +41,7 @@ export class Scope {
     parentBlock: Node;
     parent: Scope;
     hub: Hub;
-    bindings: { [name: string]: Binding; };
+    bindings: { [name: string]: Binding };
 
     /** Traverse node with current scope and path. */
     traverse<S>(node: Node | Node[], opts: TraverseOptions<S>, state: S): void;
@@ -105,12 +105,7 @@ export class Scope {
 
     removeData(key: string): void;
 
-    push(opts: {
-        id: t.LVal,
-        init?: t.Expression,
-        unique?: boolean,
-        kind?: "var" | "let" | "const",
-    }): void;
+    push(opts: { id: t.LVal; init?: t.Expression; unique?: boolean; kind?: 'var' | 'let' | 'const' }): void;
 
     getProgramParent(): Scope;
 
@@ -146,11 +141,17 @@ export class Scope {
 }
 
 export class Binding {
-    constructor(opts: { existing: Binding; identifier: t.Identifier; scope: Scope; path: NodePath; kind: "var" | "let" | "const"; });
+    constructor(opts: {
+        existing: Binding;
+        identifier: t.Identifier;
+        scope: Scope;
+        path: NodePath;
+        kind: 'var' | 'let' | 'const';
+    });
     identifier: t.Identifier;
     scope: Scope;
     path: NodePath;
-    kind: "var" | "let" | "const" | "module";
+    kind: 'var' | 'let' | 'const' | 'module';
     referenced: boolean;
     references: number;
     referencePaths: NodePath[];
@@ -158,11 +159,13 @@ export class Binding {
     constantViolations: NodePath[];
 }
 
-export type Visitor<S = {}> = VisitNodeObject<S, Node> & {
-    [Type in Node["type"]]?: VisitNode<S, Extract<Node, { type: Type; }>>;
-} & {
-    [K in keyof t.Aliases]?: VisitNode<S, t.Aliases[K]>
-};
+export type Visitor<S = {}> = VisitNodeObject<S, Node> &
+    {
+        [Type in Node['type']]?: VisitNode<S, Extract<Node, { type: Type }>>;
+    } &
+    {
+        [K in keyof t.Aliases]?: VisitNode<S, t.Aliases[K]>;
+    };
 
 export type VisitNode<S, P> = VisitNodeFunction<S, P> | VisitNodeObject<S, P>;
 
@@ -244,7 +247,7 @@ export class NodePath<T = Node> {
     /** Get the earliest path in the tree where the provided `paths` intersect. */
     getDeepestCommonAncestorFrom(
         paths: NodePath[],
-        filter?: (deepest: Node, i: number, ancestries: NodePath[]) => NodePath
+        filter?: (deepest: Node, i: number, ancestries: NodePath[]) => NodePath,
     ): NodePath;
 
     /**
@@ -285,19 +288,21 @@ export class NodePath<T = Node> {
      * transforming ASTs is an antipattern and SHOULD NOT be encouraged. Even if it's
      * easier to use, your transforms will be extremely brittle.
      */
-    replaceWithSourceString(replacement: any): void;
+    replaceWithSourceString(replacement: any): [NodePath];
 
     /** Replace the current node with another. */
-    replaceWith(replacement: Node | NodePath): void;
+    replaceWith<T extends Node>(replacement: T | NodePath<T>): [NodePath<T>];
 
     /**
      * This method takes an array of statements nodes and then explodes it
      * into expressions. This method retains completion records which is
      * extremely important to retain original semantics.
      */
-    replaceExpressionWithStatements(nodes: Node[]): Node;
+    replaceExpressionWithStatements<Nodes extends Node[]>(nodes: Nodes): NodePaths<Nodes>;
 
-    replaceInline(nodes: Node | Node[]): void;
+    replaceInline<T extends Node | Node[]>(
+        nodes: T,
+    ): T extends Node[] ? { [K in keyof T]: NodePath<T[K]> } : [NodePath<T>];
 
     // ------------------------- evaluation -------------------------
     /**
@@ -458,10 +463,14 @@ export class NodePath<T = Node> {
     getAllPrevSiblings(): NodePath[];
     getAllNextSiblings(): NodePath[];
 
-    get<K extends keyof T>(key: K, context?: boolean | TraversalContext):
-        T[K] extends Array<Node | null | undefined> ? Array<NodePath<T[K][number]>> :
-        T[K] extends Node | null | undefined ? NodePath<T[K]> :
-        never;
+    get<K extends keyof T>(
+        key: K,
+        context?: boolean | TraversalContext,
+    ): T[K] extends Array<Node | null | undefined>
+        ? Array<NodePath<T[K][number]>>
+        : T[K] extends Node | null | undefined
+        ? NodePath<T[K]>
+        : never;
     get(key: string, context?: boolean | TraversalContext): NodePath | NodePath[];
 
     getBindingIdentifiers(duplicates?: boolean): Node[];

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -300,9 +300,7 @@ export class NodePath<T = Node> {
      */
     replaceExpressionWithStatements<Nodes extends Node[]>(nodes: Nodes): NodePaths<Nodes>;
 
-    replaceInline<T extends Node | Node[]>(
-        nodes: T,
-    ): T extends Node[] ? { [K in keyof T]: NodePath<T[K]> } : [NodePath<T>];
+    replaceInline<Nodes extends Node | Node[]>(nodes: Nodes): NodePaths<Nodes>;
 
     // ------------------------- evaluation -------------------------
     /**


### PR DESCRIPTION
These methods have had the same return semantics since 7.0.0.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/babel/babel/blob/v7.0.0/packages/babel-traverse/src/path/replacement.js#L102
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.