### PR TITLE
Add OkPacket interface for inserts, updates, and deletes

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -320,7 +320,7 @@ export interface Query {
      */
     determinePacket(byte: number, parser: any): any;
 
-    OkPacket: OkPacket;
+    OkPacket: packetCallback;
     ErrorPacket: packetCallback;
     ResultSetHeaderPacket: packetCallback;
     FieldPacket: packetCallback;
@@ -670,6 +670,7 @@ export interface MysqlError extends Error {
 
 // Result from an insert, update, or delete statement.
 export interface OkPacket {
+    fieldCount: number;
     /**
      * The number of affected rows from an insert, update, or delete statement.
      */
@@ -678,6 +679,8 @@ export interface OkPacket {
      * The insert id after inserting a row into a table with an auto increment primary key.
      */
     insertId: number;
+    serverStatus?: number;
+    warningCount?: number;
     /**
      * The server result message from an insert, update, or delete statement.
      */
@@ -686,6 +689,7 @@ export interface OkPacket {
      * The number of changed rows from an update statement. "changedRows" differs from "affectedRows" in that it does not count updated rows whose values were not changed.
      */
     changedRows: number;
+    protocol41: boolean;
 }
 
 export const enum Types {

--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -4,6 +4,7 @@
 // 	                Kacper Polak <https://github.com/kacepe>
 // 	                Krittanan Pingclasai <https://github.com/kpping>
 // 	                James Munro <https://github.com/jdmunro>
+// 	                Sanders DeNardi <https://github.com/sedenardi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -319,7 +320,7 @@ export interface Query {
      */
     determinePacket(byte: number, parser: any): any;
 
-    OkPacket: packetCallback;
+    OkPacket: OkPacket;
     ErrorPacket: packetCallback;
     ResultSetHeaderPacket: packetCallback;
     FieldPacket: packetCallback;
@@ -665,6 +666,26 @@ export interface MysqlError extends Error {
      * Error message from MySQL
      */
     sqlMessage?: string;
+}
+
+// Result from an insert, update, or delete statement.
+export interface OkPacket {
+    /**
+     * The number of affected rows from an insert, update, or delete statement.
+     */
+    affectedRows: number;
+    /**
+     * The insert id after inserting a row into a table with an auto increment primary key.
+     */
+    insertId: number;
+    /**
+     * The server result message from an insert, update, or delete statement.
+     */
+    message: string;
+    /**
+     * The number of changed rows from an update statement. "changedRows" differs from "affectedRows" in that it does not count updated rows whose values were not changed.
+     */
+    changedRows: number;
 }
 
 export const enum Types {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mysqljs/mysql/blob/master/lib/protocol/packets/OkPacket.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This PR adds the interface for the `OkPacket` object type that's returned on insert, update, and delete statements. As you can see from the [mysql source](https://github.com/mysqljs/mysql/blob/master/lib/protocol/packets/OkPacket.js), I did not include all fields. I only included fields which were documented in the library's README, and I used those fields' documentation in the type definition.
