### PR TITLE
Update jest tests for pretty-format@25.3

### DIFF
--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -635,12 +635,12 @@ const snapshotSerializerPlugin: jest.SnapshotSerializerPlugin = {
 expect.addSnapshotSerializer(snapshotSerializerPlugin);
 
 expect.addSnapshotSerializer({
-    print: (value: {}) => '',
+    print: (value: unknown) => '',
     test: (value: {}) => value === value,
 });
 
 expect.addSnapshotSerializer({
-    print: (value: {}, serialize: (val: {}) => string, indent: (str: string) => string, opts: {}) => '',
+    print: (value: unknown, serialize: (val: {}) => string, indent: (str: string) => string, opts: {}) => '',
     test: (value: {}) => value === value,
 });
 


### PR DESCRIPTION
pretty-format now requires that `print` must accept `unknown`. Previously pretty-format specified `any`, which let the implementation pretend that it could handle only whichever types it liked.
