### PR TITLE
[angular-route] Add support for IRouteProvider eagerInstantiationEnabled

### DIFF
--- a/types/angular-route/angular-route-tests.ts
+++ b/types/angular-route/angular-route-tests.ts
@@ -6,6 +6,15 @@
  */
 
 declare var $routeProvider: ng.route.IRouteProvider;
+if (!$routeProvider.eagerInstantiationEnabled()) {
+    throw new Error("The default of $routeProvider.eagerInstantiationEnabled should be true.");
+}
+
+$routeProvider.eagerInstantiationEnabled(false);
+if ($routeProvider.eagerInstantiationEnabled()) {
+    throw new Error("$routeProvider.eagerInstantiationEnabled is expected to be false.");
+}
+
 $routeProvider
     .when('/projects/:projectId/dashboard', {
         controller: 'I am a string',

--- a/types/angular-route/index.d.ts
+++ b/types/angular-route/index.d.ts
@@ -201,6 +201,20 @@ declare module 'angular' {
              */
             caseInsensitiveMatch?: boolean;
             /**
+             * Call this method as a setter to enable/disable eager instantiation of the $route service upon application bootstrap.
+             * 
+             * Instantiating $route early is necessary for capturing the initial $locationChangeStart event and navigating to the appropriate route. Usually, $route is instantiated in time by the ngView directive. Yet, in cases where ngView is included in an asynchronously loaded template (e.g. in another directive's template), the directive factory might not be called soon enough for $route to be instantiated before the initial $locationChangeSuccess event is fired. Eager instantiation ensures that $route is always instantiated in time, regardless of when ngView will be loaded.
+             *
+             * The default value is true.
+             * 
+             * @param enabled If provided, update the internal eagerInstantiationEnabled flag.
+             */
+            eagerInstantiationEnabled(enabled: boolean) : IRouteProvider;
+            /**
+             * Call this method as a getter (i.e. without any arguments) to get the current value of the eagerInstantiationEnabled flag.
+             */
+            eagerInstantiationEnabled() : boolean;
+            /**
              * Sets route definition that will be used on route change when no other route definition is matched.
              *
              * @params Mapping information to be assigned to $route.current.

--- a/types/angular-route/index.d.ts
+++ b/types/angular-route/index.d.ts
@@ -202,11 +202,11 @@ declare module 'angular' {
             caseInsensitiveMatch?: boolean;
             /**
              * Call this method as a setter to enable/disable eager instantiation of the $route service upon application bootstrap.
-             * 
+             *
              * Instantiating $route early is necessary for capturing the initial $locationChangeStart event and navigating to the appropriate route. Usually, $route is instantiated in time by the ngView directive. Yet, in cases where ngView is included in an asynchronously loaded template (e.g. in another directive's template), the directive factory might not be called soon enough for $route to be instantiated before the initial $locationChangeSuccess event is fired. Eager instantiation ensures that $route is always instantiated in time, regardless of when ngView will be loaded.
              *
              * The default value is true.
-             * 
+             *
              * @param enabled If provided, update the internal eagerInstantiationEnabled flag.
              */
             eagerInstantiationEnabled(enabled: boolean) : IRouteProvider;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://docs.angularjs.org/api/ngRoute/provider/$routeProvider#eagerInstantiationEnabled>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.