### PR TITLE
[@types/pino-http] Add missing getPath to autoLoggingOptions

### DIFF
--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 //                 Jeremy Forsythe <https://github.com/jdforsythe>
 //                 Griffin Yourick <https://github.com/tough-griff>
+//                 Jorge Barnaby <https://github.com/yorch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 

--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -38,6 +38,7 @@ declare namespace PinoHttp {
 
     interface autoLoggingOptions {
         ignorePaths?: string[];
+        getPath?: (req: IncomingMessage) => string;
     }
 }
 

--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pino-http 4.4
+// Type definitions for pino-http 5.0
 // Project: https://github.com/pinojs/pino-http#readme
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 //                 Jeremy Forsythe <https://github.com/jdforsythe>
@@ -39,7 +39,7 @@ declare namespace PinoHttp {
 
     interface autoLoggingOptions {
         ignorePaths?: string[];
-        getPath?: (req: IncomingMessage) => string;
+        getPath?: (req: IncomingMessage) => string | undefined;
     }
 }
 

--- a/types/pino-http/pino-http-tests.ts
+++ b/types/pino-http/pino-http-tests.ts
@@ -20,7 +20,7 @@ pinoHttp({ useLevel: 'error' });
 pinoHttp({ prettyPrint: true });
 pinoHttp({ autoLogging: false });
 pinoHttp({ autoLogging: { ignorePaths: ['/health'] } });
-pinoHttp({ autoLogging: { ignorePaths: ['/health'], getPath: (req) => req.originalUrl } });
+pinoHttp({ autoLogging: { ignorePaths: ['/health'], getPath: (req) => req.url } });
 pinoHttp(new Writable());
 pinoHttp({
     customLogLevel(req, res) {

--- a/types/pino-http/pino-http-tests.ts
+++ b/types/pino-http/pino-http-tests.ts
@@ -20,6 +20,7 @@ pinoHttp({ useLevel: 'error' });
 pinoHttp({ prettyPrint: true });
 pinoHttp({ autoLogging: false });
 pinoHttp({ autoLogging: { ignorePaths: ['/health'] } });
+pinoHttp({ autoLogging: { ignorePaths: ['/health'], getPath: (req) => req.originalUrl } });
 pinoHttp(new Writable());
 pinoHttp({
     customLogLevel(req, res) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/pino-http/blob/master/logger.js#L45
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)