### PR TITLE
Same type defaults for StringSchemaConstructor and StringSchema

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -101,8 +101,8 @@ export interface MixedSchema<T = any> extends Schema<T> {
 }
 
 export interface StringSchemaConstructor {
-    <T extends string | null | undefined = undefined>(): T extends string ? StringSchema<T> : StringSchema;
-    new <T extends string | null | undefined = undefined>(): T extends string ? StringSchema<T> : StringSchema;
+    <T extends string | null | undefined = string>(): T extends string ? StringSchema<T> : StringSchema;
+    new <T extends string | null | undefined = string>(): T extends string ? StringSchema<T> : StringSchema;
 }
 
 export interface StringSchema<T extends string | null | undefined = string> extends Schema<T> {


### PR DESCRIPTION
The following code should compile just fine with `"strict": false`

```
const scheme = yup
  .string()
  .strict(true)
  .oneOf(["WEB", "MOBILE", "BROWSER"]);
```

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] ~Add or edit tests to reflect the change. (Run with `npm test`.)~
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: Failing CodeSandbox example https://codesandbox.io/s/adoring-stonebraker-nyr9n?file=/src/index.ts
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] ~Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~

