### PR TITLE
Align style typings for react-native-material-menu

### DIFF
--- a/types/react-native-material-menu/index.d.ts
+++ b/types/react-native-material-menu/index.d.ts
@@ -4,20 +4,20 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { ComponentClass, ReactElement, Component } from 'react';
-import { TextStyle } from 'react-native';
+import { TextStyle, TextProps, ViewStyle } from 'react-native';
 
 export interface MenuProps {
     button?: ReactElement;
-    style?: StyleMedia;
+    style?: ViewStyle;
     onHidden?: () => void;
     animationDuration?: number;
 }
 export interface MenuItemProps {
     disabled?: boolean;
     disabledTextColor?: string;
-    ellipsizeMode?: 'clip' | 'tail';
+    ellipsizeMode?: TextProps["ellipsizeMode"];
     onPress?: () => void;
-    style?: StyleMedia;
+    style?: ViewStyle;
     textStyle?: TextStyle;
     underlayColor?: string;
 }


### PR DESCRIPTION
StyleMedia is not a react-native types and now respected with what library expects

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
