### PR TITLE
[html] Add types for html

### DIFF
--- a/types/html/html-tests.ts
+++ b/types/html/html-tests.ts
@@ -1,0 +1,12 @@
+import { prettyPrint } from 'html';
+
+prettyPrint('<h2><strong>Hello, <a href="http://example.com">World</a>!</strong></h2>'); // $ExpectType string
+prettyPrint('<h2><strong>Hello, <a href="http://example.com">World</a>!</strong></h2>', {}); // $ExpectType string
+prettyPrint('<h2><strong>Hello, <a href="http://example.com">World</a>!</strong></h2>', {
+    brace_style: 'collapse',
+    indent_scripts: 'keep',
+    indent_size: 2,
+    indent_char: ' ',
+    max_char: 5,
+    unformatted: [],
+});

--- a/types/html/index.d.ts
+++ b/types/html/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for html 1.0
+// Project: https://github.com/maxogden/commonjs-html-prettyprinter
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface PrintOptions {
+    /**
+     * Put braces on the same line as control statements (`collapse`),
+     * or put braces on own line (Allman / ANSI style, `expand`),
+     * or just put end braces on own line (`end-expand`). Default: `collapse`.
+     */
+    brace_style?: 'collapse' | 'expand' | 'end-expand';
+    /** Default: `normal`. */
+    indent_scripts?: 'keep' | 'separate' | 'normal';
+    /** indentation size. Default: 4. */
+    indent_size?: number;
+    /** character to indent with. Default: " " (space). */
+    indent_char?: string;
+    /** Maximum amount of characters per line. Default: 70. */
+    max_char?: number;
+    /** list of tags, that shouldn't be reformatted. Defaults to inline tags. */
+    unformatted?: string[];
+}
+
+export function prettyPrint(htmlSource: string, options?: PrintOptions): string;

--- a/types/html/tsconfig.json
+++ b/types/html/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "html-tests.ts"
+    ]
+}

--- a/types/html/tslint.json
+++ b/types/html/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
