### PR TITLE
[ioBroker] getForeignObjectsAsync always returns a Record

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -762,18 +762,18 @@ declare global {
             getForeignObjectsAsync(
                 pattern: string,
                 options?: unknown,
-            ): Promise<CallbackReturnTypeOf<GetObjectsCallback>>;
+            ): Promise<NonNullCallbackReturnTypeOf<GetObjectsCallback>>;
             getForeignObjectsAsync(
                 pattern: string,
                 type: ObjectType,
                 options?: unknown,
-            ): Promise<CallbackReturnTypeOf<GetObjectsCallback>>;
+            ): Promise<NonNullCallbackReturnTypeOf<GetObjectsCallback>>;
             getForeignObjectsAsync(
                 pattern: string,
                 type: ObjectType,
                 enums: EnumList,
                 options?: unknown,
-            ): Promise<CallbackReturnTypeOf<GetObjectsCallback>>;
+            ): Promise<NonNullCallbackReturnTypeOf<GetObjectsCallback>>;
             /** Creates or overwrites an object (which might not belong to this adapter) in the object db */
             setForeignObject(id: string, obj: ioBroker.SettableObject, callback?: SetObjectCallback): void;
             setForeignObject(

--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -908,24 +908,24 @@ declare global {
             // tslint:disable:unified-signatures
             setState(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 callback?: SetStateCallback,
             ): void;
             setState(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 callback?: SetStateCallback,
             ): void;
             setState(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 options: unknown,
                 callback?: SetStateCallback,
             ): void;
             setState(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateCallback,
@@ -933,41 +933,41 @@ declare global {
             /** Writes a value into the states DB. */
             setStateAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack?: boolean,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             setStateAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 options?: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             setStateAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 options: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             /** Writes a value into the states DB only if it has changed. */
             setStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 callback?: SetStateChangedCallback,
             ): void;
             setStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 callback?: SetStateChangedCallback,
             ): void;
             setStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 options: unknown,
                 callback?: SetStateChangedCallback,
             ): void;
             setStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateChangedCallback,
@@ -975,41 +975,41 @@ declare global {
             /** Writes a value into the states DB only if it has changed. */
             setStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack?: boolean,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
             setStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 options?: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
             setStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 options: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
             /** Writes a value (which might not belong to this adapter) into the states DB. */
             setForeignState(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 callback?: SetStateCallback,
             ): void;
             setForeignState(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 callback?: SetStateCallback,
             ): void;
             setForeignState(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 options: unknown,
                 callback?: SetStateCallback,
             ): void;
             setForeignState(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateCallback,
@@ -1017,41 +1017,41 @@ declare global {
             /** Writes a value (which might not belong to this adapter) into the states DB. */
             setForeignStateAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack?: boolean,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             setForeignStateAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 options?: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             setForeignStateAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 options: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
             /** Writes a value (which might not belong to this adapter) into the states DB only if it has changed. */
             setForeignStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 callback?: SetStateChangedCallback,
             ): void;
             setForeignStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 callback?: SetStateChangedCallback,
             ): void;
             setForeignStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 options: unknown,
                 callback?: SetStateChangedCallback,
             ): void;
             setForeignStateChanged(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 options: unknown,
                 callback?: SetStateChangedCallback,
@@ -1059,17 +1059,17 @@ declare global {
             /** Writes a value (which might not belong to this adapter) into the states DB only if it has changed. */
             setForeignStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack?: boolean,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
             setForeignStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 options?: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
             setForeignStateChangedAsync(
                 id: string,
-                state: string | number | boolean | State | SettableState,
+                state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 options: unknown,
             ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -190,7 +190,8 @@ adapter.getObjectAsync("obj.id").then(obj => obj && obj._id.toLowerCase());
 adapter.getForeignObjectAsync("obj.id").then(obj => obj && obj._id.toLowerCase());
 
 adapter.getForeignObjects("*", (err, objs) => objs!["foo"]._id.toLowerCase());
-adapter.getForeignObjectsAsync("*").then(objs => objs!["foo"]._id.toLowerCase());
+// getForeignObjectsAsync always returns a Record when it doesn't throw
+adapter.getForeignObjectsAsync("*").then(objs => objs["foo"]._id.toLowerCase());
 
 adapter.setObject("id", {
     _id: "id",

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -400,3 +400,13 @@ const folderObj: ioBroker.FolderObject = {
 // Repro from https://github.com/ioBroker/ioBroker.js-controller/issues/782
 // $ExpectError
 adapter.setState("id", {ack: false});
+
+// null is a valid state value
+adapter.setState("id", null);
+adapter.setForeignState("id", null);
+adapter.setStateAsync("id", null);
+adapter.setForeignStateAsync("id", null);
+adapter.setStateChanged("id", null);
+adapter.setForeignStateChanged("id", null);
+adapter.setStateChangedAsync("id", null);
+adapter.setForeignStateChangedAsync("id", null);


### PR DESCRIPTION
**NOTE:**
This PR includes a commit from #43957 because I wanted to avoid a merge conflict. I hope this is okay.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ioBroker/ioBroker.js-controller/blob/7d0b6e9c2d9cc20ea42bb7723bafcbd527150e34/lib/adapter.js#L2650
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
