### PR TITLE
fix(node): backport stream.finished options since v10

### DIFF
--- a/types/node/v10/stream.d.ts
+++ b/types/node/v10/stream.d.ts
@@ -244,9 +244,15 @@ declare module "stream" {
 
         class PassThrough extends Transform { }
 
+        interface FinishedOptions {
+            error?: boolean;
+            readable?: boolean;
+            writable?: boolean;
+        }
+        function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, options: FinishedOptions, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;
         function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;
         namespace finished {
-            function __promisify__(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream): Promise<void>;
+            function __promisify__(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, options?: FinishedOptions): Promise<void>;
         }
 
         function pipeline<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: T, callback?: (err: NodeJS.ErrnoException | null) => void): T;

--- a/types/node/v11/stream.d.ts
+++ b/types/node/v11/stream.d.ts
@@ -246,9 +246,15 @@ declare module "stream" {
 
         class PassThrough extends Transform { }
 
+        interface FinishedOptions {
+            error?: boolean;
+            readable?: boolean;
+            writable?: boolean;
+        }
+        function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, options: FinishedOptions, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;
         function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;
         namespace finished {
-            function __promisify__(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream): Promise<void>;
+            function __promisify__(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, options?: FinishedOptions): Promise<void>;
         }
 
         function pipeline<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: T, callback?: (err: NodeJS.ErrnoException | null) => void): T;

--- a/types/node/v11/test/stream.ts
+++ b/types/node/v11/test/stream.ts
@@ -159,7 +159,10 @@ function simplified_stream_ctor_test() {
 }
 
 function streamPipelineFinished() {
-    const cancel = finished(process.stdin, (err?: Error | null) => {});
+    let cancel = finished(process.stdin, (err?: Error | null) => {});
+    cancel();
+
+    cancel = finished(process.stdin, { readable: false }, (err?: Error | null) => {});
     cancel();
 
     pipeline(process.stdin, process.stdout, (err?: Error | null) => {});
@@ -168,6 +171,7 @@ function streamPipelineFinished() {
 async function asyncStreamPipelineFinished() {
     const fin = promisify(finished);
     await fin(process.stdin);
+    await fin(process.stdin, { readable: false });
 
     const pipe = promisify(pipeline);
     await pipe(process.stdin, process.stdout);

--- a/types/node/v12/stream.d.ts
+++ b/types/node/v12/stream.d.ts
@@ -262,9 +262,15 @@ declare module "stream" {
 
         class PassThrough extends Transform { }
 
+        interface FinishedOptions {
+            error?: boolean;
+            readable?: boolean;
+            writable?: boolean;
+        }
+        function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, options: FinishedOptions, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;
         function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, callback: (err?: NodeJS.ErrnoException | null) => void): () => void;
         namespace finished {
-            function __promisify__(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream): Promise<void>;
+            function __promisify__(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, options?: FinishedOptions): Promise<void>;
         }
 
         function pipeline<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: T, callback?: (err: NodeJS.ErrnoException | null) => void): T;

--- a/types/node/v12/test/stream.ts
+++ b/types/node/v12/test/stream.ts
@@ -163,7 +163,10 @@ function simplified_stream_ctor_test() {
 }
 
 function streamPipelineFinished() {
-    const cancel = finished(process.stdin, (err?: Error | null) => {});
+    let cancel = finished(process.stdin, (err?: Error | null) => {});
+    cancel();
+
+    cancel = finished(process.stdin, { readable: false }, (err?: Error | null) => {});
     cancel();
 
     pipeline(process.stdin, process.stdout, (err?: Error | null) => {});
@@ -172,6 +175,7 @@ function streamPipelineFinished() {
 async function asyncStreamPipelineFinished() {
     const fin = promisify(finished);
     await fin(process.stdin);
+    await fin(process.stdin, { readable: false });
 
     const pipe = promisify(pipeline);
     await pipe(process.stdin, process.stdout);


### PR DESCRIPTION
These definitions were originally added to the current version in #41975, but were omitted from earlier versions.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

The `opts` argument has always been supported, though it was not documented in v10:

Source Refs:
- https://github.com/nodejs/node/blob/v10.20.1/lib/internal/streams/end-of-stream.js#L17
- https://github.com/nodejs/node/blob/v11.15.0/lib/internal/streams/end-of-stream.js#L16
- https://github.com/nodejs/node/blob/v12.16.2/lib/internal/streams/end-of-stream.js#L28

Doc refs:
- https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_stream_finished_stream_callback
- https://nodejs.org/dist/latest-v11.x/docs/api/stream.html#stream_stream_finished_stream_options_callback
- https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#stream_stream_finished_stream_options_callback


- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
