### PR TITLE
supertest: supertest.agent() supports request methods like superagent.agent

### DIFF
--- a/types/supertest/index.d.ts
+++ b/types/supertest/index.d.ts
@@ -5,40 +5,36 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-import * as superagent from "superagent"
+import * as superagent from 'superagent';
 
 export = supertest;
 
 declare function supertest(app: any): supertest.SuperTest<supertest.Test>;
 declare namespace supertest {
-    interface Response extends superagent.Response {
-    }
+    interface Response extends superagent.Response {}
 
-    interface Request extends superagent.SuperAgentRequest {
-    }
+    interface Request extends superagent.SuperAgentRequest {}
 
     type CallbackHandler = (err: any, res: Response) => void;
     interface Test extends superagent.SuperAgentRequest {
-      app?: any;
-      url: string;
-      serverAddress(app: any, path: string): string;
-      expect(status: number, callback?: CallbackHandler): this;
-      expect(status: number, body: any, callback?: CallbackHandler): this;
-      expect(checker: (res: Response) => any, callback?: CallbackHandler): this;
-      expect(body: string, callback?: CallbackHandler): this;
-      expect(body: RegExp, callback?: CallbackHandler): this;
-      expect(body: Object, callback?: CallbackHandler): this;
-      expect(field: string, val: string, callback?: CallbackHandler): this;
-      expect(field: string, val: RegExp, callback?: CallbackHandler): this;
-      end(callback?: CallbackHandler): this;
+        app?: any;
+        url: string;
+        serverAddress(app: any, path: string): string;
+        expect(status: number, callback?: CallbackHandler): this;
+        expect(status: number, body: any, callback?: CallbackHandler): this;
+        expect(checker: (res: Response) => any, callback?: CallbackHandler): this;
+        expect(body: string, callback?: CallbackHandler): this;
+        expect(body: RegExp, callback?: CallbackHandler): this;
+        expect(body: Object, callback?: CallbackHandler): this;
+        expect(field: string, val: string, callback?: CallbackHandler): this;
+        expect(field: string, val: RegExp, callback?: CallbackHandler): this;
+        end(callback?: CallbackHandler): this;
     }
 
     interface AgentOptions {
-      ca?: any;
+        ca?: any;
     }
-    function agent(app?: any, options?: AgentOptions): SuperTest<Test>;
+    function agent(app?: any, options?: AgentOptions): SuperTest<Test> & Request;
 
-    interface SuperTest<T extends superagent.SuperAgentRequest> extends superagent.SuperAgent<T> {
-    }
-
+    interface SuperTest<T extends superagent.SuperAgentRequest> extends superagent.SuperAgent<T> {}
 }

--- a/types/supertest/supertest-tests.ts
+++ b/types/supertest/supertest-tests.ts
@@ -4,76 +4,66 @@ import express = require('express');
 const app = express();
 const request: supertest.SuperTest<supertest.Test> = supertest(app);
 
-(request
-  .get('/user') as supertest.Test)
-  .expect('Content-Type', /json/)
-  .expect('Content-Length', '20')
-  .expect(201)
-  .end((err, res) => {
-    if (err) throw err;
-  });
+(request.get('/user') as supertest.Test)
+    .expect('Content-Type', /json/)
+    .expect('Content-Length', '20')
+    .expect(201)
+    .end((err, res) => {
+        if (err) throw err;
+    });
 
 // cookie scenario
 const agent = supertest.agent();
-request
-  .post('/login')
-  .end((err: any, res: supertest.Response) => {
+request.post('/login').end((err: any, res: supertest.Response) => {
     if (err) throw err;
     agent.saveCookies(res);
 
     const req = request.get('/admin') as supertest.Test;
     agent.attachCookies(req);
     req.expect(200, (err: any, res: supertest.Response) => {
-      if (err) throw err;
+        if (err) throw err;
     });
-  });
+});
 
 // cookie scenario, new version
 const client = supertest.agent(app);
-client
-  .post('/login')
-  .end((err: any, res: supertest.Response) => {
+client.post('/login').end((err: any, res: supertest.Response) => {
     if (err) throw err;
 
-    (client.get('/admin') as supertest.Test)
-      .expect(200, (err: any, res: supertest.Response) => {
+    (client.get('/admin') as supertest.Test).expect(200, (err: any, res: supertest.Response) => {
         if (err) throw err;
-      });
-  });
+    });
+});
 
 // allow passing trusted CA as option to TestAgent
 supertest.agent(app, {
-  ca: 'test ca',
+    ca: 'test ca',
 });
 
+// agent has request methods
+supertest.agent(app).set({ host: 'google.com' });
+
 // functional expect
-(request
-  .get('/') as supertest.Test)
-  .expect(hasPreviousAndNextKeys)
-  .end((err: any, res: supertest.Response) => {
+(request.get('/') as supertest.Test).expect(hasPreviousAndNextKeys).end((err: any, res: supertest.Response) => {
     if (err) throw err;
-  });
+});
 
 function hasPreviousAndNextKeys(res: supertest.Response) {
-  if (!('next' in res.body)) return "missing next key";
-  if (!('prev' in res.body)) throw new Error("missing prev key");
+    if (!('next' in res.body)) return 'missing next key';
+    if (!('prev' in res.body)) throw new Error('missing prev key');
 }
 
 // functional expect without response type
-(request
-  .get('/') as supertest.Test)
-  .expect(res => {
-    if (!('next' in res.body)) return "missing next key";
-    if (!('prev' in res.body)) throw new Error("missing prev key");
-  })
-  .end((err: any, res: supertest.Response) => {
-    if (err) throw err;
-  });
+(request.get('/') as supertest.Test)
+    .expect(res => {
+        if (!('next' in res.body)) return 'missing next key';
+        if (!('prev' in res.body)) throw new Error('missing prev key');
+    })
+    .end((err: any, res: supertest.Response) => {
+        if (err) throw err;
+    });
 
 // object expect
-(request
-  .get('/') as supertest.Test)
-  .expect(200, { foo: 'bar' })
-  .end((err: any, res: supertest.Response) => {
+(request.get('/') as supertest.Test).expect(200, { foo: 'bar' }).end((err: any, res: supertest.Response) => {
     if (err) throw err;
-  });
+});


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://visionmedia.github.io/superagent/#default-options-for-multiple-requests -- SuperAgent's ``request.agent()`` extends Request and supports request methods like setting headers that are supplied on every request the agent performs.  This PR enhances supertest.agent() to support these Request methods.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Note that the index.d.ts file has many changes.  I ran prettier on them i.e. `npm run prettier --write types/supertest`.  If you don't want this LMK and I'll back out.

The only change by me was changing this line:

`function agent(app?: any, options?: AgentOptions): SuperTest<Test>;`
to
`function agent(app?: any, options?: AgentOptions): SuperTest<Test> & Request;`