### PR TITLE
Add back rule for microsoft/vscode#94716

### DIFF
--- a/types/vscode/tslint.json
+++ b/types/vscode/tslint.json
@@ -17,7 +17,6 @@
         "no-single-declare-module": false,
         "no-unnecessary-class": false,
         "no-unnecessary-generics": false,
-        "member-access": false,
         "npm-naming": false,
         "prefer-method-signature": false,
         "strict-export-declare-modifiers": false,


### PR DESCRIPTION
We removed `member-access` rule to publish VS Code 1.44 types. See:
- https://github.com/microsoft/vscode/issues/94716
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43745

Now we have fixed the API we want to bring back the rules.