### PR TITLE
passport-saml-metadata: new package

### DIFF
--- a/types/passport-saml-metadata/index.d.ts
+++ b/types/passport-saml-metadata/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for passport-saml-metadata 2.2
+// Project: https://github.com/compwright/passport-saml-metadata#readme
+// Definitions by: Gabriel Fournier <https://github.com/carboneater>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.8
+
+import { SamlConfig } from "passport-saml";
+
+export function claimsToCamelCase(claims: any, claimSchema: any): any;
+
+interface FetchAxiosConfig {
+    backupStore: Map<string, string>;
+    responseType: string;
+    timeout: number;
+}
+export function fetch<
+    T extends FetchAxiosConfig = FetchAxiosConfig,
+>(config: {
+    client?: {get(url: string, params?: Partial<T>): Promise<{data: string}>};
+    url: string;
+} & Partial<T>): Promise<MetadataReaderInstance>;
+
+interface MetadataReaderInstance {
+    readonly claimSchema: {[name: string]: { camelCase: string; description: string; name: string; }};
+    readonly encryptionCert?: string;
+    readonly encryptionCerts?: string[];
+    readonly identifierFormat?: string;
+    readonly identityProviderUrl?: string;
+    readonly logoutUrl?: string;
+    readonly signingCert?: string;
+    readonly signingCerts?: string[];
+}
+
+interface MetadataConstructorOptions {
+    authnRequestBinding: string;
+    throwExceptions: boolean;
+}
+declare class MetadataReader {
+    constructor(metadata: string, options?: Partial<MetadataConstructorOptions>);
+    get claimSchema(): {[name: string]: { camelCase: string; description: string; name: string; }};
+}
+
+export function metadata(config: SamlConfig): (() => void);
+
+export function toPassportConfig(reader?: MetadataReaderInstance, options?: { multipleCerts: boolean }): SamlConfig;

--- a/types/passport-saml-metadata/index.d.ts
+++ b/types/passport-saml-metadata/index.d.ts
@@ -8,38 +8,32 @@ import { SamlConfig } from "passport-saml";
 
 export function claimsToCamelCase(claims: any, claimSchema: any): any;
 
-interface FetchAxiosConfig {
+export interface FetchAxiosConfig {
     backupStore: Map<string, string>;
     responseType: string;
     timeout: number;
 }
-export function fetch<
-    T extends FetchAxiosConfig = FetchAxiosConfig,
->(config: {
-    client?: {get(url: string, params?: Partial<T>): Promise<{data: string}>};
+export function fetch(config: {
+    client?: {get(url: string, params?: Partial<FetchAxiosConfig>): Promise<{data: string}>};
     url: string;
-} & Partial<T>): Promise<MetadataReaderInstance>;
+} & Partial<FetchAxiosConfig>): Promise<MetadataReader>;
 
-interface MetadataReaderInstance {
-    readonly claimSchema: {[name: string]: { camelCase: string; description: string; name: string; }};
-    readonly encryptionCert?: string;
-    readonly encryptionCerts?: string[];
-    readonly identifierFormat?: string;
-    readonly identityProviderUrl?: string;
-    readonly logoutUrl?: string;
-    readonly signingCert?: string;
-    readonly signingCerts?: string[];
-}
-
-interface MetadataConstructorOptions {
+export interface MetadataConstructorOptions {
     authnRequestBinding: string;
     throwExceptions: boolean;
 }
-declare class MetadataReader {
+export class MetadataReader {
     constructor(metadata: string, options?: Partial<MetadataConstructorOptions>);
     get claimSchema(): {[name: string]: { camelCase: string; description: string; name: string; }};
+    get encryptionCert(): string|undefined;
+    get encryptionCerts(): string[];
+    get identifierFormat(): string|undefined;
+    get identityProviderUrl(): string|undefined;
+    get logoutUrl(): string|undefined;
+    get signingCert(): string|undefined;
+    get signingCerts(): string[];
 }
 
 export function metadata(config: SamlConfig): (() => void);
 
-export function toPassportConfig(reader?: MetadataReaderInstance, options?: { multipleCerts: boolean }): SamlConfig;
+export function toPassportConfig(reader?: MetadataReader, options?: { multipleCerts: boolean }): SamlConfig;

--- a/types/passport-saml-metadata/index.d.ts
+++ b/types/passport-saml-metadata/index.d.ts
@@ -4,36 +4,4 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.8
 
-import { SamlConfig } from "passport-saml";
-
-export function claimsToCamelCase(claims: any, claimSchema: any): any;
-
-export interface FetchAxiosConfig {
-    backupStore: Map<string, string>;
-    responseType: string;
-    timeout: number;
-}
-export function fetch(config: {
-    client?: {get(url: string, params?: Partial<FetchAxiosConfig>): Promise<{data: string}>};
-    url: string;
-} & Partial<FetchAxiosConfig>): Promise<MetadataReader>;
-
-export interface MetadataConstructorOptions {
-    authnRequestBinding: string;
-    throwExceptions: boolean;
-}
-export class MetadataReader {
-    constructor(metadata: string, options?: Partial<MetadataConstructorOptions>);
-    get claimSchema(): {[name: string]: { camelCase: string; description: string; name: string; }};
-    get encryptionCert(): string|undefined;
-    get encryptionCerts(): string[];
-    get identifierFormat(): string|undefined;
-    get identityProviderUrl(): string|undefined;
-    get logoutUrl(): string|undefined;
-    get signingCert(): string|undefined;
-    get signingCerts(): string[];
-}
-
-export function metadata(config: SamlConfig): (() => void);
-
-export function toPassportConfig(reader?: MetadataReader, options?: { multipleCerts: boolean }): SamlConfig;
+export * from "./src";

--- a/types/passport-saml-metadata/passport-saml-metadata-tests.ts
+++ b/types/passport-saml-metadata/passport-saml-metadata-tests.ts
@@ -1,0 +1,21 @@
+import { claimsToCamelCase, fetch, metadata, MetadataReader, toPassportConfig } from "passport-saml-metadata";
+import { Profile, Strategy, VerifiedCallback } from "passport-saml";
+
+// From README Example
+fetch({ url: "https:saml.test.com/metadata.xml" }).then(
+    (reader) => {
+        const config = toPassportConfig(reader);
+        config.protocol = 'saml2';
+
+        new Strategy(config, (profile: Profile, done: VerifiedCallback) => {
+            profile = claimsToCamelCase(profile, reader.claimSchema);
+            done(null, profile);
+        });
+    }
+);
+
+const reader = new MetadataReader("xml string");
+const otherReader = new MetadataReader("Other String", {authnRequestBinding: "HTTP-POST", throwExceptions: true});
+const config = toPassportConfig(reader, {multipleCerts : true});
+
+metadata(config)(); // matches the code, not the doc

--- a/types/passport-saml-metadata/passport-saml-metadata-tests.ts
+++ b/types/passport-saml-metadata/passport-saml-metadata-tests.ts
@@ -1,4 +1,4 @@
-import { claimsToCamelCase, fetch, metadata, MetadataReader, toPassportConfig } from "passport-saml-metadata";
+import { claimsToCamelCase, fetch, metadata, MetadataReader, toPassportConfig } from "passport-saml-metadata/src";
 import { Profile, Strategy, VerifiedCallback } from "passport-saml";
 
 // From README Example

--- a/types/passport-saml-metadata/src/fetch.d.ts
+++ b/types/passport-saml-metadata/src/fetch.d.ts
@@ -1,0 +1,12 @@
+export interface FetchAxiosConfig {
+    backupStore: Map<string, string>;
+    responseType: string;
+    timeout: number;
+}
+
+export type FetchConfig = {
+    client?: {get(url: string, params?: Partial<FetchAxiosConfig>): Promise<{data: string}>};
+    url: string;
+} & Partial<FetchAxiosConfig>;
+
+export function fetch(config: FetchConfig): Promise<string>;

--- a/types/passport-saml-metadata/src/index.d.ts
+++ b/types/passport-saml-metadata/src/index.d.ts
@@ -1,0 +1,7 @@
+import { FetchConfig } from "./fetch";
+import { MetadataReader } from "./reader";
+
+export function fetch(config: FetchConfig): Promise<MetadataReader>;
+export { metadata } from "./metadata";
+export { claimsToCamelCase, toPassportConfig } from "./passport";
+export { MetadataReader } from "./reader";

--- a/types/passport-saml-metadata/src/metadata.d.ts
+++ b/types/passport-saml-metadata/src/metadata.d.ts
@@ -1,0 +1,3 @@
+import { SamlConfig } from "passport-saml";
+
+export function metadata(config: SamlConfig): (() => void);

--- a/types/passport-saml-metadata/src/passport.d.ts
+++ b/types/passport-saml-metadata/src/passport.d.ts
@@ -1,0 +1,6 @@
+import { SamlConfig } from "passport-saml";
+import { MetadataReader } from "./reader";
+
+export function claimsToCamelCase(claims: any, claimSchema: any): any;
+
+export function toPassportConfig(reader?: MetadataReader, options?: { multipleCerts: boolean }): SamlConfig;

--- a/types/passport-saml-metadata/src/reader.d.ts
+++ b/types/passport-saml-metadata/src/reader.d.ts
@@ -1,0 +1,15 @@
+export interface MetadataConstructorOptions {
+    authnRequestBinding: string;
+    throwExceptions: boolean;
+}
+export class MetadataReader {
+    constructor(metadata: string, options?: Partial<MetadataConstructorOptions>);
+    get claimSchema(): {[name: string]: { camelCase: string; description: string; name: string; }};
+    get encryptionCert(): string|undefined;
+    get encryptionCerts(): string[];
+    get identifierFormat(): string|undefined;
+    get identityProviderUrl(): string|undefined;
+    get logoutUrl(): string|undefined;
+    get signingCert(): string|undefined;
+    get signingCerts(): string[];
+}

--- a/types/passport-saml-metadata/tsconfig.json
+++ b/types/passport-saml-metadata/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "strict": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "passport-saml-metadata-tests.ts"
+    ]
+}

--- a/types/passport-saml-metadata/tsconfig.json
+++ b/types/passport-saml-metadata/tsconfig.json
@@ -8,7 +8,6 @@
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
-        "strict": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/passport-saml-metadata/tslint.json
+++ b/types/passport-saml-metadata/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Definitions for passport-saml-metadata library.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

On a semi-unrelated note: I had lots of fun converting my single `index.d.ts` into multiple `.d.ts` to mirror the lib hierarchy.  
I also noticed most other packages only have a central `index.d.ts`.  
Is mirroring the lib layout a new requirement or one that's not strictly enforced?

Either way, here are my types.

Enjoy!