### PR TITLE
fix(webpack): correct Stats class details

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1416,7 +1416,10 @@ declare namespace webpack {
         startTime?: number;
         endTime?: number;
 
-        static filterWarnings(warnings: string[], warningsFilter?: (warning: string) => boolean): string[];
+        static filterWarnings(
+          warnings: string[],
+          warningsFilter?: Array<string | RegExp | ((warning: string) => boolean)>
+        ): string[];
         /**
          * Returns the default json options from the stats preset.
          * @param preset The preset to be transformed into json options.

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -22,6 +22,7 @@
 //                 Daniel Chin <https://github.com/danielthank>
 //                 Daiki Ihara <https://github.com/sasurau4>
 //                 Dion Shi <https://github.com/dionshihk>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -1409,20 +1410,30 @@ declare namespace webpack {
         apply(resolver: any /* EnhancedResolve.Resolver */): void;
     }
 
-    abstract class Stats {
+    class Stats {
         compilation: compilation.Compilation;
         hash?: string;
         startTime?: number;
         endTime?: number;
+
+        static filterWarnings(warnings: string[], warningsFilter?: (warning: string) => boolean): string[];
         /**
          * Returns the default json options from the stats preset.
          * @param preset The preset to be transformed into json options.
          */
         static presetToOptions(preset?: Stats.Preset): Stats.ToJsonOptionsObject;
+
+        constructor(compilation: compilation.Compilation);
+
+        formatFilePath(filePath: string): string;
         /** Returns true if there were errors while compiling. */
         hasErrors(): boolean;
         /** Returns true if there were warnings while compiling. */
         hasWarnings(): boolean;
+        /** Remove a prefixed "!" that can be specified to reverse sort order */
+        normalizeFieldKey(field: string): string;
+        /** if a field is prefixed by a "!" reverse sort order */
+        sortOrderRegular(field: string): boolean;
         /** Returns compilation information as a JSON object. */
         toJson(options?: Stats.ToJsonOptions, forToString?: boolean): Stats.ToJsonOutput;
         /** Returns a formatted string of the compilation information (similar to CLI output). */

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -1166,3 +1166,14 @@ class LoggingPlugin extends webpack.Plugin {
         });
     }
 }
+
+// Stats Microsoft/DefinitelyTyped#43952
+import { Stats } from 'webpack';
+
+compiler.hooks.compilation.tap('SomePlugin', compilation => {
+    const stats = new Stats(compilation); // $ExpectType Stats
+    Stats.filterWarnings([], warning => true); // $ExpectType string[]
+    stats.formatFilePath('app/src/'); // $ExpectType string
+    stats.normalizeFieldKey('field'); // $ExpectType string
+    stats.sortOrderRegular('!field'); // $ExpectType boolean
+});

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -1168,7 +1168,7 @@ class LoggingPlugin extends webpack.Plugin {
 }
 
 // Stats Microsoft/DefinitelyTyped#43952
-import { Stats } from 'webpack';
+const { Stats } = webpack;
 
 compiler.hooks.compilation.tap('SomePlugin', compilation => {
     const stats = new Stats(compilation); // $ExpectType Stats

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -1172,7 +1172,7 @@ const { Stats } = webpack;
 
 compiler.hooks.compilation.tap('SomePlugin', compilation => {
     const stats = new Stats(compilation); // $ExpectType Stats
-    Stats.filterWarnings([], warning => true); // $ExpectType string[]
+    Stats.filterWarnings([], [(warning: string) => true]); // $ExpectType string[]
     stats.formatFilePath('app/src/'); // $ExpectType string
     stats.normalizeFieldKey('field'); // $ExpectType string
     stats.sortOrderRegular('!field'); // $ExpectType boolean


### PR DESCRIPTION
- remove abstract keyword for Stats class
- add constructor with options
- add class and instance methods
- update tests

https://github.com/webpack/webpack/blob/71eb5931dbd7db125109a95692065333cea936a9/lib/Stats.js

/cc @ernestostifano

Thanks!

Fixes #43952

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)