### PR TITLE
Created typings and test file for cloudmersive-virus-api-client

### DIFF
--- a/types/cloudmersive-virus-api-client/cloudmersive-virus-api-client-tests.ts
+++ b/types/cloudmersive-virus-api-client/cloudmersive-virus-api-client-tests.ts
@@ -1,0 +1,45 @@
+import * as CloudmersiveVirusApiClient from 'cloudmersive-virus-api-client';
+// $ExpectType typeof WebsiteThreatType
+CloudmersiveVirusApiClient.WebsiteThreatType;
+// $ExpectType typeof CollectionFormatEnum
+CloudmersiveVirusApiClient.CollectionFormatEnum;
+// $ExpectType IVirusFound
+CloudmersiveVirusApiClient.VirusFound;
+// $ExpectType IVirusScanAdvancedResult
+CloudmersiveVirusApiClient.VirusScanAdvancedResult;
+// $ExpectType IVirusScanResult
+CloudmersiveVirusApiClient.VirusScanResult;
+// $ExpectType IWebsiteScanResult
+CloudmersiveVirusApiClient.WebsiteScanResult;
+// $ExpectType IWebsiteScanRequest
+CloudmersiveVirusApiClient.WebsiteScanRequest;
+// $ExpectType IApiClient
+const defaultClient = CloudmersiveVirusApiClient.ApiClient;
+// $ExpectType Date
+defaultClient.parseDate('1970-01-01');
+// $ExpectType void
+defaultClient.constructFromObject({}, {}, {});
+// $ExpectType any
+defaultClient.convertToType({}, {});
+// $ExpectType CollectionFormatEnum
+defaultClient.CollectionFormatEnum;
+// $ExpectType IApiInstance
+const defaultInstance = defaultClient.instance;
+// $ExpectType IApiInstanceAuthentications
+const APIKey = defaultInstance.authentications.Apikey;
+APIKey.apiKey = '';
+// $ExpectType ScanApi
+const apiInstance = new CloudmersiveVirusApiClient.ScanApi();
+// $ExpectType any
+apiInstance.scanFile(
+    Buffer.alloc(10),
+    (error: any, data: CloudmersiveVirusApiClient.IVirusScanResult, response: any) => {},
+);
+// $ExpectType any
+apiInstance.scanFileAdvanced(
+    Buffer.alloc(10),
+    { allowExecutables: false, allowInvalidFiles: false, allowScripts: false, restrictFileTypes: '' },
+    (error: any, data: CloudmersiveVirusApiClient.IVirusScanAdvancedResult, response: any) => {},
+);
+// $ExpectType any
+apiInstance.scanWebsite('', (error: any, data: CloudmersiveVirusApiClient.IWebsiteScanResult, response: any) => {});

--- a/types/cloudmersive-virus-api-client/cloudmersive-virus-api-client-tests.ts
+++ b/types/cloudmersive-virus-api-client/cloudmersive-virus-api-client-tests.ts
@@ -3,17 +3,17 @@ import * as CloudmersiveVirusApiClient from 'cloudmersive-virus-api-client';
 CloudmersiveVirusApiClient.WebsiteThreatType;
 // $ExpectType typeof CollectionFormatEnum
 CloudmersiveVirusApiClient.CollectionFormatEnum;
-// $ExpectType IVirusFound
+// $ExpectType VirusFound
 CloudmersiveVirusApiClient.VirusFound;
-// $ExpectType IVirusScanAdvancedResult
+// $ExpectType VirusScanAdvancedResult
 CloudmersiveVirusApiClient.VirusScanAdvancedResult;
-// $ExpectType IVirusScanResult
+// $ExpectType VirusScanResult
 CloudmersiveVirusApiClient.VirusScanResult;
-// $ExpectType IWebsiteScanResult
+// $ExpectType WebsiteScanResult
 CloudmersiveVirusApiClient.WebsiteScanResult;
-// $ExpectType IWebsiteScanRequest
+// $ExpectType WebsiteScanRequest
 CloudmersiveVirusApiClient.WebsiteScanRequest;
-// $ExpectType IApiClient
+// $ExpectType ApiClient
 const defaultClient = CloudmersiveVirusApiClient.ApiClient;
 // $ExpectType Date
 defaultClient.parseDate('1970-01-01');
@@ -23,23 +23,23 @@ defaultClient.constructFromObject({}, {}, {});
 defaultClient.convertToType({}, {});
 // $ExpectType CollectionFormatEnum
 defaultClient.CollectionFormatEnum;
-// $ExpectType IApiInstance
+// $ExpectType ApiInstance
 const defaultInstance = defaultClient.instance;
-// $ExpectType IApiInstanceAuthentications
-const APIKey = defaultInstance.authentications.Apikey;
-APIKey.apiKey = '';
+// $ExpectType ApiInstanceAuthentications
+const APKey = defaultInstance.authentications.Apikey;
+APKey.apiKey = '';
 // $ExpectType ScanApi
-const apiInstance = new CloudmersiveVirusApiClient.ScanApi();
+const apinstance = new CloudmersiveVirusApiClient.ScanApi();
 // $ExpectType any
-apiInstance.scanFile(
+apinstance.scanFile(
     Buffer.alloc(10),
-    (error: any, data: CloudmersiveVirusApiClient.IVirusScanResult, response: any) => {},
+    (error: any, data: CloudmersiveVirusApiClient.VirusScanResult, response: any) => {},
 );
 // $ExpectType any
-apiInstance.scanFileAdvanced(
+apinstance.scanFileAdvanced(
     Buffer.alloc(10),
     { allowExecutables: false, allowInvalidFiles: false, allowScripts: false, restrictFileTypes: '' },
-    (error: any, data: CloudmersiveVirusApiClient.IVirusScanAdvancedResult, response: any) => {},
+    (error: any, data: CloudmersiveVirusApiClient.VirusScanAdvancedResult, response: any) => {},
 );
 // $ExpectType any
-apiInstance.scanWebsite('', (error: any, data: CloudmersiveVirusApiClient.IWebsiteScanResult, response: any) => {});
+apinstance.scanWebsite('', (error: any, data: CloudmersiveVirusApiClient.WebsiteScanResult, response: any) => {});

--- a/types/cloudmersive-virus-api-client/index.d.ts
+++ b/types/cloudmersive-virus-api-client/index.d.ts
@@ -1,0 +1,329 @@
+// Type definitions for cloudmersive-virus-api-client 1.1
+// Project: https://www.npmjs.com/package/cloudmersive-virus-api-client (Does not have to be to GitHub, but prefer linking to a source code repository rather than to a project website.)
+// Definitions by: Jason Luboff<https://github.com/JLuboff>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+///<reference types="node" />
+
+import * as http from 'http';
+export enum CollectionFormatEnum {
+    /**
+     * Comma-separated values. Value: <code>csv</code>
+     */
+    CSV = ',',
+    /**
+     * Space-separated values. Value: <code>ssv</code>
+     */
+    SSV = ' ',
+    /**
+     * Tab-separated values. Value: <code>tsv</code>
+     */
+    TSV = '\t',
+    /**
+     * Pipe(|)-separated values. Value: <code>pipes</code>
+     */
+    PIPES = '|',
+    /**
+     * Native array. Value: <code>multi</code>
+     */
+    MULTI = 'multi',
+}
+
+export enum WebsiteThreatType {
+    None = 'None',
+    Malware = 'Malware',
+    Phising = 'Phishing',
+    ForcedDownload = 'ForcedDownload',
+    UnableToConnect = 'UnableToConnect',
+}
+export interface IApiInstanceAuthentications {
+    type: 'apiKey';
+    in: 'header';
+    name: 'Apikey';
+    apiKey: string;
+}
+
+export interface IApiInstance {
+    /**
+     * @param basePath string - The base URL against which to resolve every API
+     * call's (relative) path.
+     * default https://api.cloudmersive.com
+     */
+    basePath: string;
+    /**
+     * @param authentications object - The authentication methods to be included for all API calls.
+     */
+    authentications: { Apikey: IApiInstanceAuthentications };
+    /**
+     * @param defaultHeaders string[] - The default HTTP headers to be included for all API calls.
+     * default {}
+     */
+    defaultHeaders: string[];
+    /**
+     * @param timeout number - The default HTTP timeout for all API calls.
+     * default 60000
+     */
+    timeout: number;
+    /**
+     * If set to false an additional timestamp parameter is added to all API GET calls to
+     * prevent browser caching
+     * @param cache boolean - If set to false an additional timestamp parameter is added to
+     * all API GET calls to prevent browser caching
+     * default true
+     */
+    cache: boolean;
+    /**
+     * @param enableCookies boolean - If set to true, the client will save the cookies
+     * from each server response, and return them in the next request.
+     * default false
+     */
+    enableCookies: boolean;
+    /**
+     * @param agent http.Agent - Used to save and return cookies in a node.js (
+     * non-browser) setting, if this.enableCookies is set to true.
+     */
+    agent: http.Agent;
+    /**
+     * @param requestAgent null | http.Agent - Allow user to override superagent agent
+     */
+    requestAgent: null | http.Agent;
+}
+
+export interface IApiClient {
+    instance: IApiInstance;
+    CollectionFormatEnum: CollectionFormatEnum;
+    /**
+     * Parses an ISO-8601 string representation of a date value.
+     * @param str string - The date value as a string.
+     * @returns Date - The parsed date object.
+     */
+    parseDate: { (str: string): Date };
+    /**
+     * Converts a value to the specified type.
+     * @param data string | Object - The data to convert, as a string or object.
+     * @param type any - The type to return.
+     * Pass a string for simple types or the constructor function for a complex type. Pass an
+     * array containing the type name to return an array of that type. To return an object, pass
+     * an object with one property whose name is the key type and whose value is the corresponding
+     *  value type: all properties on <code>data<code> will be converted to this type.
+     * @returns An instance of the specified type or null or undefined if data is null or undefined.
+     */
+    convertToType: { (data: string | object, type: any): any };
+    /**
+     * Constructs a new map or array model from REST data.
+     * @param data any - The REST data.
+     * @param obj any - The target object or array.
+     */
+    constructFromObject: { (data: any, obj: any, itemType: any): void };
+}
+
+export interface IScanFileAdvancedOptions {
+    /**
+     * @param allowExecutables boolean
+     * Set to false to block executable files (program code) from being allowed in the input file.
+     * Default is false (recommended).
+     */
+    allowExecutables: boolean;
+    /**
+     * @param allowInvalidFiles boolean
+     * Set to false to block invalid files, such as a PDF file that is not really a valid PDF file,
+     * or a Word Document that is not a valid Word Document.
+     * Default is false (recommended).
+     */
+    allowInvalidFiles: boolean;
+    /**
+     * @param allowScripts boolean
+     * Set to false to block script files, such as a PHP files, Pythong scripts, and other malicious
+     * content or security threats that can be embedded in the file. Set to true to allow these
+     * file types.
+     * Default is false (recommended).
+     */
+    allowScripts: boolean;
+    /**
+     * @param restrictFileTypes string
+     * Specify a restricted set of file formats to allow as clean as a comma-separated list of
+     * file formats, such as .pdf,.docx,.png would allow only PDF, PNG and Word document files.
+     *  All files must pass content verification against this list of file formats, if they do
+     * not, then the result will be returned as CleanResult=false.
+     * Set restrictFileTypes parameter to null or empty string to disable;
+     * default is disabled.
+     */
+    restrictFileTypes: string;
+}
+
+export interface IScanFile {
+    (inputFile: Buffer, callback: (error: any, data: IVirusScanResult, response: any) => any): any;
+}
+
+export interface IScanFileAdvanced {
+    (
+        inputFile: Buffer,
+        opts: IScanFileAdvancedOptions,
+        callback: (error: any, data: IVirusScanAdvancedResult, response: any) => any,
+    ): any;
+}
+
+export interface IScanWebsite {
+    (input: string, callback: (error: any, data: IWebsiteScanResult, response: any) => any): any;
+}
+
+export interface IVirusFound {
+    /**
+     * @param FileName string
+     * Name of the file containing the virus
+     */
+    FileName: string;
+    /**
+     * @param VirusName string
+     * Name of the virus that was found
+     */
+    VirusName: string;
+}
+
+export interface IVirusScanResult {
+    /**
+     * @param CleanResult boolean
+     * True if the scan contained no viruses, false otherwise
+     */
+    CleanResult: boolean;
+    /**
+     * @param FoundViruses null | IVirusFound
+     * Array of viruses found, if any
+     */
+    FoundViruses: null | IVirusFound[];
+}
+
+export interface IVirusScanAdvancedResult extends IVirusScanResult {
+    /**
+     * @param ContainsExecutable boolean
+     * True if the scan contained an executable (application code),
+     * which can be a significant risk factor
+     */
+    ContainsExecutable: boolean;
+    /**
+     * @param ContainsInvalidFile boolean
+     * True if the scan contained an invalid file (such as a PDF that is not a valid PDF,
+     * Word Document that is not a valid Word Document, etc.), which can be a significant risk facto
+     */
+    ContainsInvalidFile: boolean;
+    /**
+     * @param ContainsScript boolean
+     * True if the scan contained a script (such as a PHP script, Python script, etc.) which can
+     * be a significant risk factor
+     */
+    ContainsScript: boolean;
+    /**
+     * @param ContainsRestrictedFileFormat boolean
+     * True if the uploaded file is of a type that is not allowed based on the optional
+     * restrictFileTypes parameter, false otherwise;
+     * if restrictFileTypes is not set, this will always be false
+     */
+    ContainsRestrictedFileFormat: boolean;
+    /**
+     * @param VerifiedFileFormat string
+     * For file format verification-supported file formats, the contents-verified file format
+     *  of the file. Null indicates that the file format is not supported for contents verification.
+     *  If a Virus or Malware is found, this field will always be set to Null.
+     */
+    VerifiedFileFormat: string;
+}
+
+export interface IWebsiteScanRequest {
+    /**
+     * @param Url string
+     * URL of the website to scan; should begin with http:// or https://
+     */
+    Url: string;
+}
+
+export interface IWebsiteScanResult extends IVirusScanResult {
+    /**
+     * @param WebsiteThreatType None, Malware, Phishing, ForcedDownload, UnableToConnect
+     *Type of threat returned; can be None, Malware, ForcedDownload or Phishing
+     */
+    WebsiteThreatType: WebsiteThreatType;
+    /**
+     * @param WebsiteHttpResponseCode number (int32)
+     * The remote server URL HTTP reasponse code; useful for debugging issues with scanning;
+     * typically if the remote server returns a 200 or 300-series code this means a successful
+     * response, while a 400 or 500 series code would represent an error returned from the
+     * remote server for the provided URL.
+     */
+    WebsiteHttpResponseCode: number;
+}
+
+export interface IScanApi {
+    /**
+     * Scan a file for viruses
+     * Scan files and content for viruses.
+     * Leverage continuously updated signatures for millions of threats, and advanced
+     * high-performance scanning capabilities.  Over 17 million virus and malware signatures.
+     * Continuous cloud-based updates.  Wide file format support including Office, PDF, HTML, Flash.
+     * Zip support including .Zip, .Rar, .DMG, .Tar, and other archive formats.
+     * Multi-threat scanning across viruses, malware, trojans, ransomware, and spyware.
+     * High-speed in-memory scanning delivers subsecond typical response time.
+     * @param inputFile buffer - Input file to perform the operation on.
+     * @param callback function - The callback function, accepting three arguments:
+     * error, data, response
+     */
+    scanFile: IScanFile;
+    /**
+     * Advanced Scan a file for viruses
+     * Advanced Scan files with 360-degree Content Protection across Viruses and Malware,
+     * executables, invalid files, scripts, and even restrictions on accepted file types
+     * with complete content verification. Customize threat rules to your needs.
+     * Leverage continuously updated signatures for millions of threats,
+     * and advanced high-performance scanning capabilities.
+     * Over 17 million virus and malware signatures.
+     * Continuous cloud-based updates.
+     * Block threats beyond viruses including executables, scripts, invalid files, and more.
+     * Optionally limit input files to a specific set of file types(eg PDF and Word Documents only).
+     *  Wide file format support including Office, PDF, HTML, Flash.
+     * Zip support including .Zip, .Rar, .DMG, .Tar, and other archive formats.
+     * Multi-threat scanning across viruses, malware, trojans, ransomware, and spyware.
+     * High-speed in-memory scanning delivers subsecond typical response time.
+     * @param inputFile buffer - Input file to perform the operation on.
+     * @param opts object - Optional parameters
+     * @param opts.allowExecutables boolean - Set to false to block executable files (program code)
+     * from being allowed in the input file.  Default is false (recommended).
+     * @param opts.allowInvalidFiles boolean - Set to false to block invalid files, such as a
+     * PDF file that is not really a valid PDF file, or a Word Document that is not a
+     * valid Word Document.
+     * Default is false (recommended).
+     * @param opts.allowScripts boolean - Set to false to block script files, such as a
+     * PHP files, Python scripts, and other malicious content or security threats that
+     * can be embedded in the file.
+     * Set to true to allow these file types.  Default is false (recommended).
+     * @param opts.restrictFileTypes boolean - Specify a restricted set of file formats to
+     * allow as clean as a comma-separated list of file formats, such as .pdf,.docx,.png
+     * would allow only PDF, PNG and Word document files.  All files must pass content
+     * verification against this list of file formats, if they do not, then the result
+     * will be returned as CleanResult&#x3D;false. Set restrictFileTypes parameter to null or
+     * empty string to disable; default is disabled.
+     * @param callback function - The callback function, accepting three arguments:
+     * error, data, response
+     */
+    scanFileAdvanced: IScanFileAdvanced;
+    /**
+     * Scan a website for malicious content and threats
+     * Operation includes scanning the content of the URL for various types
+     * of malicious content and threats, including viruses and threats (including Phishing).
+     * @param input string - URL of the website to scan; should begin with http:// or https://
+     * @param callback function - The callback function, accepting three arguments:
+     * error, data, response
+     */
+    scanWebsite: IScanWebsite;
+}
+
+export class ScanApi implements IScanApi {
+    constructor(apiClient?: IApiClient);
+    scanFile: IScanFile;
+    scanFileAdvanced: IScanFileAdvanced;
+    scanWebsite: IScanWebsite;
+}
+export const ApiClient: IApiClient;
+export const VirusFound: IVirusFound;
+export const VirusScanAdvancedResult: IVirusScanAdvancedResult;
+export const VirusScanResult: IVirusScanResult;
+export const WebsiteScanResult: IWebsiteScanResult;
+export const WebsiteScanRequest: IWebsiteScanRequest;
+// }

--- a/types/cloudmersive-virus-api-client/index.d.ts
+++ b/types/cloudmersive-virus-api-client/index.d.ts
@@ -1,8 +1,9 @@
 // Type definitions for cloudmersive-virus-api-client 1.1
-// Project: https://www.npmjs.com/package/cloudmersive-virus-api-client (Does not have to be to GitHub, but prefer linking to a source code repository rather than to a project website.)
-// Definitions by: Jason Luboff<https://github.com/JLuboff>
+// Project: https://github.com/Cloudmersive/Cloudmersive.APIClient.NodeJS.Virus
+// Definitions by: Jason Luboff <https://github.com/JLuboff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-///<reference types="node" />
+
+/// <reference types="node" />
 
 import * as http from 'http';
 export enum CollectionFormatEnum {
@@ -35,14 +36,14 @@ export enum WebsiteThreatType {
     ForcedDownload = 'ForcedDownload',
     UnableToConnect = 'UnableToConnect',
 }
-export interface IApiInstanceAuthentications {
+export interface ApiInstanceAuthentications {
     type: 'apiKey';
     in: 'header';
     name: 'Apikey';
     apiKey: string;
 }
 
-export interface IApiInstance {
+export interface ApiInstance {
     /**
      * @param basePath string - The base URL against which to resolve every API
      * call's (relative) path.
@@ -52,7 +53,7 @@ export interface IApiInstance {
     /**
      * @param authentications object - The authentication methods to be included for all API calls.
      */
-    authentications: { Apikey: IApiInstanceAuthentications };
+    authentications: { Apikey: ApiInstanceAuthentications };
     /**
      * @param defaultHeaders string[] - The default HTTP headers to be included for all API calls.
      * default {}
@@ -88,8 +89,8 @@ export interface IApiInstance {
     requestAgent: null | http.Agent;
 }
 
-export interface IApiClient {
-    instance: IApiInstance;
+export interface ApiClient {
+    instance: ApiInstance;
     CollectionFormatEnum: CollectionFormatEnum;
     /**
      * Parses an ISO-8601 string representation of a date value.
@@ -116,7 +117,7 @@ export interface IApiClient {
     constructFromObject: { (data: any, obj: any, itemType: any): void };
 }
 
-export interface IScanFileAdvancedOptions {
+export interface ScanFileAdvancedOptions {
     /**
      * @param allowExecutables boolean
      * Set to false to block executable files (program code) from being allowed in the input file.
@@ -150,23 +151,23 @@ export interface IScanFileAdvancedOptions {
     restrictFileTypes: string;
 }
 
-export interface IScanFile {
-    (inputFile: Buffer, callback: (error: any, data: IVirusScanResult, response: any) => any): any;
+export interface ScanFile {
+    (inputFile: Buffer, callback: (error: any, data: VirusScanResult, response: any) => any): any;
 }
 
-export interface IScanFileAdvanced {
+export interface ScanFileAdvanced {
     (
         inputFile: Buffer,
-        opts: IScanFileAdvancedOptions,
-        callback: (error: any, data: IVirusScanAdvancedResult, response: any) => any,
+        opts: ScanFileAdvancedOptions,
+        callback: (error: any, data: VirusScanAdvancedResult, response: any) => any,
     ): any;
 }
 
-export interface IScanWebsite {
-    (input: string, callback: (error: any, data: IWebsiteScanResult, response: any) => any): any;
+export interface ScanWebsite {
+    (input: string, callback: (error: any, data: WebsiteScanResult, response: any) => any): any;
 }
 
-export interface IVirusFound {
+export interface VirusFound {
     /**
      * @param FileName string
      * Name of the file containing the virus
@@ -179,7 +180,7 @@ export interface IVirusFound {
     VirusName: string;
 }
 
-export interface IVirusScanResult {
+export interface VirusScanResult {
     /**
      * @param CleanResult boolean
      * True if the scan contained no viruses, false otherwise
@@ -189,10 +190,10 @@ export interface IVirusScanResult {
      * @param FoundViruses null | IVirusFound
      * Array of viruses found, if any
      */
-    FoundViruses: null | IVirusFound[];
+    FoundViruses: null | VirusFound[];
 }
 
-export interface IVirusScanAdvancedResult extends IVirusScanResult {
+export interface VirusScanAdvancedResult extends VirusScanResult {
     /**
      * @param ContainsExecutable boolean
      * True if the scan contained an executable (application code),
@@ -227,7 +228,7 @@ export interface IVirusScanAdvancedResult extends IVirusScanResult {
     VerifiedFileFormat: string;
 }
 
-export interface IWebsiteScanRequest {
+export interface WebsiteScanRequest {
     /**
      * @param Url string
      * URL of the website to scan; should begin with http:// or https://
@@ -235,10 +236,10 @@ export interface IWebsiteScanRequest {
     Url: string;
 }
 
-export interface IWebsiteScanResult extends IVirusScanResult {
+export interface WebsiteScanResult extends VirusScanResult {
     /**
      * @param WebsiteThreatType None, Malware, Phishing, ForcedDownload, UnableToConnect
-     *Type of threat returned; can be None, Malware, ForcedDownload or Phishing
+     * Type of threat returned; can be None, Malware, ForcedDownload or Phishing
      */
     WebsiteThreatType: WebsiteThreatType;
     /**
@@ -251,7 +252,7 @@ export interface IWebsiteScanResult extends IVirusScanResult {
     WebsiteHttpResponseCode: number;
 }
 
-export interface IScanApi {
+export interface ScanApi {
     /**
      * Scan a file for viruses
      * Scan files and content for viruses.
@@ -265,7 +266,7 @@ export interface IScanApi {
      * @param callback function - The callback function, accepting three arguments:
      * error, data, response
      */
-    scanFile: IScanFile;
+    scanFile: ScanFile;
     /**
      * Advanced Scan a file for viruses
      * Advanced Scan files with 360-degree Content Protection across Viruses and Malware,
@@ -302,7 +303,7 @@ export interface IScanApi {
      * @param callback function - The callback function, accepting three arguments:
      * error, data, response
      */
-    scanFileAdvanced: IScanFileAdvanced;
+    scanFileAdvanced: ScanFileAdvanced;
     /**
      * Scan a website for malicious content and threats
      * Operation includes scanning the content of the URL for various types
@@ -311,19 +312,19 @@ export interface IScanApi {
      * @param callback function - The callback function, accepting three arguments:
      * error, data, response
      */
-    scanWebsite: IScanWebsite;
+    scanWebsite: ScanWebsite;
 }
 
-export class ScanApi implements IScanApi {
-    constructor(apiClient?: IApiClient);
-    scanFile: IScanFile;
-    scanFileAdvanced: IScanFileAdvanced;
-    scanWebsite: IScanWebsite;
+export class ScanApi implements ScanApi {
+    constructor(apiClient?: ApiClient);
+    scanFile: ScanFile;
+    scanFileAdvanced: ScanFileAdvanced;
+    scanWebsite: ScanWebsite;
 }
-export const ApiClient: IApiClient;
-export const VirusFound: IVirusFound;
-export const VirusScanAdvancedResult: IVirusScanAdvancedResult;
-export const VirusScanResult: IVirusScanResult;
-export const WebsiteScanResult: IWebsiteScanResult;
-export const WebsiteScanRequest: IWebsiteScanRequest;
+export const ApiClient: ApiClient;
+export const VirusFound: VirusFound;
+export const VirusScanAdvancedResult: VirusScanAdvancedResult;
+export const VirusScanResult: VirusScanResult;
+export const WebsiteScanResult: WebsiteScanResult;
+export const WebsiteScanRequest: WebsiteScanRequest;
 // }

--- a/types/cloudmersive-virus-api-client/tsconfig.json
+++ b/types/cloudmersive-virus-api-client/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "cloudmersive-virus-api-client-tests.ts"
+    ]
+}

--- a/types/cloudmersive-virus-api-client/tslint.json
+++ b/types/cloudmersive-virus-api-client/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Currently no typings are available for any Cloudmersive API. This is the typings for one of those API's (file virus scan). 

Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
