### PR TITLE
[sinon-chrome] workaround for 'debugger' being a reserved keyword

### DIFF
--- a/types/sinon-chrome/index.d.ts
+++ b/types/sinon-chrome/index.d.ts
@@ -42,6 +42,19 @@ declare namespace SinonChrome {
 
     export var csi: Sinon.SinonSpy;
     export var loadTimes: Sinon.SinonSpy;
+
+    // Workaround for debugger being a reserved word and can't be exported as a namespace normally
+    // until https://github.com/Microsoft/TypeScript/issues/7840 is fixed
+    namespace _debugger {
+        export var attach: SinonChromeStub;
+        export var detach: SinonChromeStub;
+        export var getTargets: SinonChromeStub;
+        export var sendCommand: SinonChromeStub;
+
+        export var onDetach: SinonChrome.events.Event;
+        export var onEvent: SinonChrome.events.Event;
+    }
+    export { _debugger as debugger };
 }
 
 declare namespace SinonChrome.events {
@@ -175,18 +188,6 @@ declare namespace SinonChrome.cookies {
     export var remove: SinonChromeStub;
     export var set: SinonChromeStub;
 }
-
-/* TODO: Uncomment once https://github.com/Microsoft/TypeScript/issues/7840 is fixed
-declare module SinonChrome.debugger {
-    export var attach: SinonChromeStub;
-    export var detach: SinonChromeStub;
-    export var getTargets: SinonChromeStub;
-    export var sendCommand: SinonChromeStub;
-
-    export var onDetach: SinonChrome.events.Event;
-    export var onEvent: SinonChrome.events.Event;
-}
-*/
 
 declare namespace SinonChrome.declarativeContent {
     export var PageStateMatcher: SinonChromeStub;


### PR DESCRIPTION
The `debugger` namespace was commented out due to 'debugger' being a reserved word, waiting for [this bug to be fixed](https://github.com/Microsoft/TypeScript/issues/7840). This workaround allows adding back the namespace definition.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
