### PR TITLE
fix(multer): re-add stream property to File interface

### DIFF
--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -11,6 +11,7 @@
 // TypeScript Version: 2.8
 
 import { Request, RequestHandler } from 'express';
+import { Readable } from 'stream';
 
 declare global {
     namespace Express {
@@ -31,13 +32,18 @@ declare global {
                 mimetype: string;
                 /** Size of the file in bytes. */
                 size: number;
-                /** `DiskStorage` Directory to which this file has been uploaded. */
+                /**
+                 * A readable stream of this file. Only available to the `_handleFile`
+                 * callback for custom `StorageEngine`s.
+                 */
+                stream: Readable;
+                /** `DiskStorage` only: Directory to which this file has been uploaded. */
                 destination: string;
-                /** `DiskStorage` Name of this file within `destination`. */
+                /** `DiskStorage` only: Name of this file within `destination`. */
                 filename: string;
-                /** `DiskStorage` Full path to the uploaded file. */
+                /** `DiskStorage` only: Full path to the uploaded file. */
                 path: string;
-                /** `MemoryStorage` A Buffer containing the entire file. */
+                /** `MemoryStorage` only: A Buffer containing the entire file. */
                 buffer: Buffer;
             }
         }


### PR DESCRIPTION
Reverts the changes to type definitions made by #42025, which break custom `StorageEngine` implementations.

The `stream` property is defined [here](https://github.com/expressjs/multer/blob/805170c61530e1f1cafd818c9b63d16a9dd46c36/lib/make-middleware.js#L128) before the file object is passed to the `_handleFile` method of a `StorageEngine`. From [the StorageEngine docs](https://github.com/expressjs/multer/blob/master/StorageEngine.md):

> The file data will be given to you as a stream (`file.stream`). You should pipe this data somewhere, and when you are done, call `cb` with some information on the file.

Also updated the JSDoc comments to indicate that certain properties of `File` objects are available only in certain situations.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source code](https://github.com/expressjs/multer/blob/805170c61530e1f1cafd818c9b63d16a9dd46c36/lib/make-middleware.js#L128), [documentation](https://github.com/expressjs/multer/blob/master/StorageEngine.md)