### PR TITLE
[akamai-edgeworkers] Update README link

### DIFF
--- a/types/akamai-edgeworkers/README.md
+++ b/types/akamai-edgeworkers/README.md
@@ -1,5 +1,5 @@
 Bindings for the Akamai [EdgeWorker API]. This allows you to write
-your EdgeWorkers in TypeScript
+your EdgeWorkers in TypeScript.
 
 Types are available for the `Request` and `Response` objects, as well as the
 built-in modules.
@@ -55,4 +55,4 @@ function onClientRequest(request: EW.MutableRequest & EW.HasRespondWith) {
 }
 ```
 
-[EdgeWorker API]: https://developer.akamai.com/api/web_performance/edgeworkers/v1.html
+[EdgeWorker API]: https://learn.akamai.com/en-us/webhelp/edgeworkers/edgeworkers-user-guide/GUID-14077BCA-0D9F-422C-8273-2F3E37339D5B.html

--- a/types/akamai-edgeworkers/README.md
+++ b/types/akamai-edgeworkers/README.md
@@ -1,13 +1,13 @@
-Bindings for the Akamai [EdgeWorker API]. This allows you to write 
-your EdgeWorkers in TypeScript.  
+Bindings for the Akamai [EdgeWorker API]. This allows you to write
+your EdgeWorkers in TypeScript
 
-Types are available for the `Request` and `Response` objects, as well as the 
-built-in modules.   
+Types are available for the `Request` and `Response` objects, as well as the
+built-in modules.
 
 # User Guide
 
-EdgeWorkers are written in ECMAScript6, so you need to set your 
-`tsconfig.json` to use `es6` as the compilation target and module 
+EdgeWorkers are written in ECMAScript6, so you need to set your
+`tsconfig.json` to use `es6` as the compilation target and module
 code generator:
 
 ```json5
@@ -15,14 +15,14 @@ code generator:
     "compilerOptions": {
         "module": "es6",
         "target": "es6",
-//...
+        //...
     }
 }
-```    
+```
 
 ## Using the `Request` and `Response` Objects
 
-The predefined EdgeWorker callbacks take Request and Response objects as 
+The predefined EdgeWorker callbacks take Request and Response objects as
 arguments. After you have installed this package, you can create a `main.ts`
 with the following stubs:
 
@@ -35,12 +35,12 @@ export function onOriginResponse(request: EW.EgressOriginRequest, response: EW.E
 export function onClientResponse(request: EW.EgressClientRequest, response: EW.EgressClientResponse) {}
 ```
 
-The triple-slashed first line references this package and pulls `EW` into your 
-namespace. 
+The triple-slashed first line references this package and pulls `EW` into your
+namespace.
 
 ## Using Built-In Modules
 
-Bindings are available for the built-in `cookies` and `url-search-params` 
+Bindings are available for the built-in `cookies` and `url-search-params`
 modules. Once you've added the triple-slash reference to `akamai-edgeworkers`
 you can import them normally:
 
@@ -51,7 +51,7 @@ import { Cookies } from 'cookies';
 
 function onClientRequest(request: EW.MutableRequest & EW.HasRespondWith) {
     const cookie = new Cookies(request.getHeader('cookies') || undefined);
-//...
+    //...
 }
 ```
 

--- a/types/akamai-edgeworkers/index.d.ts
+++ b/types/akamai-edgeworkers/index.d.ts
@@ -170,7 +170,7 @@ declare namespace EW {
         readonly query: string;
 
         /**
-         * The Relative URL of the incoming request. This includes the path as well
+         * The relative URL of the incoming request. This includes the path as well
          * as the query string.
          */
         readonly url: string;
@@ -183,19 +183,19 @@ declare namespace EW {
         readonly userLocation: UserLocation | undefined;
 
         /**
-         * Object containing properties specifying the device characteristics. This
+         * Object containing properties specifying the device characteristics. The
          * value of this property will be null if the contract associated with the
          * request does not have entitlements for EDC.
          */
         readonly device: Device | undefined;
 
         /**
-         * The cpcode used for reporting.
+         * The CP code used for reporting.
          */
         readonly cpCode: number;
     }
 
-    // Legacy interfaces for backwards compatability
+    // Legacy interfaces for backwards compatibility
     interface MutableRequest extends MutatesHeaders, ReadsHeaders, ReadsVariables, Request {
     }
     interface ImmutableRequest extends ReadsHeaders, ReadsVariables, Request {


### PR DESCRIPTION
Update the documentation link in the README to point directly to the JS API, rather than the REST management API docs.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others: N/A — no type changes