### PR TITLE
[MongoDB] Improve cursor implementation when use as async iterator

### DIFF
--- a/types/agenda/index.d.ts
+++ b/types/agenda/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Meir Gottlieb <https://github.com/meirgottlieb>
 //                 Jeff Principe <https://github.com/princjef>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 /// <reference types="node" />
 

--- a/types/connect-mongodb-session/index.d.ts
+++ b/types/connect-mongodb-session/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kcbanner/connect-mongodb-session
 // Definitions by: Nattapong Sirilappanich <https://github.com/NattapongSiri>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 /// <reference types="express-session" />
 

--- a/types/gridfs-stream/index.d.ts
+++ b/types/gridfs-stream/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/aheckmann/gridfs-stream
 // Definitions by: Lior Mualem <https://github.com/liorm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 /// <reference types="node" />
 

--- a/types/joigoose/index.d.ts
+++ b/types/joigoose/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/yoitsro/joigoose
 // Definitions by: Karoline <https://github.com/boothwhack>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import * as Mongoose from "mongoose";
 import * as Joi from "joi";

--- a/types/migrate-mongo/index.d.ts
+++ b/types/migrate-mongo/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/seppevs/migrate-mongo#readme
 // Definitions by: Amit Beckenstein <https://github.com/amitbeck>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.1
+// Minimum TypeScript Version: 3.2
 
 import * as mongo from 'mongodb';
 

--- a/types/mongodb-queue/index.d.ts
+++ b/types/mongodb-queue/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/chilts/mongodb-queue
 // Definitions by: FiveOFive <https://github.com/FiveOFive>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import { Db, MongoError } from 'mongodb';
 

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2143,6 +2143,7 @@ type DefaultSchema = any;
 
 /** http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html */
 export class Cursor<T = Default> extends Readable {
+    [Symbol.asyncIterator](): AsyncIterableIterator<T>;
     sortValue: string;
     timeout: boolean;
     readPreference: ReadPreference;

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -30,7 +30,7 @@
 //                 Igor Strebezhev <https://github.com/xamgore>
 //                 Valentin Agachi <https://github.com/avaly>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 // Documentation: https://mongodb.github.io/node-mongodb-native/3.1/api/
 

--- a/types/mongodb/test/cursor.ts
+++ b/types/mongodb/test/cursor.ts
@@ -1,4 +1,4 @@
-import { connect, Cursor, ReadPreference } from 'mongodb';
+import { connect, ReadPreference } from 'mongodb';
 import { connectionString } from './index';
 
 async function run() {
@@ -6,32 +6,32 @@ async function run() {
   const db = client.db('test');
   const collection = db.collection('test.find');
 
-  let cursor: Cursor<{ foo: number }>;
-  cursor = collection.find();
-  cursor = cursor.addCursorFlag('', true);
-  cursor = cursor.addQueryModifier('', true);
-  cursor = cursor.batchSize(1);
-  cursor = cursor.comment('');
-  cursor = cursor.filter({ a: 1 });
-  cursor = cursor.hint({ age: 1 });
-  cursor = cursor.hint('age_1');
-  cursor = cursor.limit(1);
-  cursor = cursor.map(result => ({ foo: result.foo }));
-  cursor = cursor.max({ age: 130 });
-  cursor = cursor.min({ age: 18 });
-  cursor = cursor.maxAwaitTimeMS(1);
-  cursor = cursor.maxScan({});
-  cursor = cursor.maxTimeMS(1);
-  cursor = cursor.project({});
-  cursor = cursor.returnKey({});
-  cursor = cursor.setCursorOption('', {});
-  cursor = cursor.setReadPreference('primary');
-  cursor = cursor.setReadPreference(ReadPreference.SECONDARY_PREFERRED);
-  cursor = cursor.showRecordId({});
-  cursor = cursor.skip(1);
-  cursor = cursor.snapshot({});
-  cursor = cursor.sort({});
-  cursor = cursor.stream();
+  const cursor = collection // $ExpectType Cursor<{ foo: number; }>
+    .find<{ age: number }>()
+    .addCursorFlag('', true)
+    .addQueryModifier('', true)
+    .batchSize(1)
+    .comment('')
+    .filter({ a: 1 })
+    .hint({ age: 1 })
+    .hint('age_1')
+    .limit(1)
+    .max({ age: 130 })
+    .min({ age: 18 })
+    .maxAwaitTimeMS(1)
+    .maxScan({})
+    .maxTimeMS(1)
+    .project({})
+    .returnKey({})
+    .setCursorOption('', {})
+    .setReadPreference('primary')
+    .setReadPreference(ReadPreference.SECONDARY_PREFERRED)
+    .showRecordId({})
+    .skip(1)
+    .snapshot({})
+    .sort({})
+    .map(result => ({ foo: result.age }))
+    .stream();
 
   for await (const item of cursor) {
     item.foo; // $ExpectType number

--- a/types/mongodb/test/cursor.ts
+++ b/types/mongodb/test/cursor.ts
@@ -6,7 +6,7 @@ async function run() {
   const db = client.db('test');
   const collection = db.collection('test.find');
 
-  let cursor: Cursor;
+  let cursor: Cursor<{ foo: number }>;
   cursor = collection.find();
   cursor = cursor.addCursorFlag('', true);
   cursor = cursor.addQueryModifier('', true);
@@ -16,7 +16,7 @@ async function run() {
   cursor = cursor.hint({ age: 1 });
   cursor = cursor.hint('age_1');
   cursor = cursor.limit(1);
-  cursor = cursor.map(result => {});
+  cursor = cursor.map(result => ({ foo: result.foo }));
   cursor = cursor.max({ age: 130 });
   cursor = cursor.min({ age: 18 });
   cursor = cursor.maxAwaitTimeMS(1);
@@ -32,4 +32,8 @@ async function run() {
   cursor = cursor.snapshot({});
   cursor = cursor.sort({});
   cursor = cursor.stream();
+
+  for await (const item of cursor) {
+    item.foo; // $ExpectType number
+  }
 }

--- a/types/mongodb/tslint.json
+++ b/types/mongodb/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "await-promise": false,
         "ban-types": false,
         "callable-types": false,
         "comment-format": false,

--- a/types/mongoose-auto-increment/index.d.ts
+++ b/types/mongoose-auto-increment/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/codetunnel/mongoose-auto-increment
 // Definitions by: Aya Morisawa <https://github.com/AyaMorisawa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import { Connection, Schema, Mongoose } from 'mongoose';
 

--- a/types/mongoose-autopopulate/index.d.ts
+++ b/types/mongoose-autopopulate/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mongodb-js/mongoose-autopopulate
 // Definitions by: Ranjit Singh <https://github.com/rann91>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import { Schema } from 'mongoose';
 

--- a/types/mongoose-deep-populate/index.d.ts
+++ b/types/mongoose-deep-populate/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/buunguyen/mongoose-deep-populate
 // Definitions by: Aya Morisawa <https://github.com/AyaMorisawa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import { Mongoose, Schema } from 'mongoose';
 

--- a/types/mongoose-geojson-schema/index.d.ts
+++ b/types/mongoose-geojson-schema/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/rideamigoscorp/mongoose-geojson-schema#readme
 // Definitions by: Bond <https://github.com/bondz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import mongoose = require('mongoose');
 

--- a/types/mongoose-lean-virtuals/index.d.ts
+++ b/types/mongoose-lean-virtuals/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/vkarpov15/mongoose-lean-virtuals
 // Definitions by: Isaac Herrera <https://github.com/isaacdecoded>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import { Schema } from 'mongoose';
 

--- a/types/mongoose-mock/index.d.ts
+++ b/types/mongoose-mock/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/JohanObrink/mongoose-mock
 // Definitions by: jt000 <https://github.com/jt000>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import mongoose = require('mongoose');
 

--- a/types/mongoose-paginate-v2/index.d.ts
+++ b/types/mongoose-paginate-v2/index.d.ts
@@ -7,7 +7,7 @@
 //                 Dongjun Lee <https://github.com/ChazEpps>
 //                 gamsterX <https://github.com/gamsterx>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 //
 // Based on type declarations for mongoose-paginate 5.0.0.
 

--- a/types/mongoose-promise/index.d.ts
+++ b/types/mongoose-promise/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://mongoosejs.com/
 // Definitions by: simonxca <https://github.com/simonxca>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 /// <reference types="mongoose" />
 /// <reference types="mpromise" />

--- a/types/mongoose-simple-random/index.d.ts
+++ b/types/mongoose-simple-random/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/larryprice/mongoose-simple-random
 // Definitions by: TypeScript Bot <https://github.com/typescript-bot>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import mongoose = require('mongoose');
 declare function pluginFunc(schema: mongoose.Schema): void;

--- a/types/mongoose-unique-validator/index.d.ts
+++ b/types/mongoose-unique-validator/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/blakehaswell/mongoose-unique-validator#readme
 // Definitions by: Steve Hipwell <https://github.com/stevehipwell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import { Schema } from "mongoose";
 

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -37,10 +37,10 @@
 //                 Dongjun Lee <https://github.com/ChazEpps>
 //                 Valentin Agachi <https://github.com/avaly>
 //                 Jan Nemcik <https://github.com/JanNemcik>
-//                 Cl3dson <https://github.com/cl3dson> 
+//                 Cl3dson <https://github.com/cl3dson>
 //                 Richard Simko <https://github.com/richardsimko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 /// <reference types="mongodb" />
 /// <reference types="node" />
@@ -107,7 +107,7 @@ declare module "mongoose" {
       ? mongodb.Condition<T[P]>
       : mongodb.Condition<T[P] | string>;
   } &
-    mongodb.RootQuerySelector<T>;  
+    mongodb.RootQuerySelector<T>;
 
   /* FilterQuery alias type for using as type for filter/conditions parameters */
   export type FilterQuery<T> = MongooseFilterQuery<DocumentDefinition<T>>;
@@ -363,7 +363,7 @@ declare module "mongoose" {
      * Each state change emits its associated event name.
      */
     readyState: number;
-      
+
     /** Connected database name */
     name: string
 

--- a/types/mongoose/v4/index.d.ts
+++ b/types/mongoose/v4/index.d.ts
@@ -6,7 +6,7 @@
 //                 murbanowicz <https://github.com/murbanowicz>
 //                 Samuel Bodin <https://github.com/bodinsamuel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 /// <reference types="mongodb" />
 /// <reference types="node" />

--- a/types/mongorito/index.d.ts
+++ b/types/mongorito/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/vadimdemedes/mongorito, https://github.com/vdemedes/mongorito
 // Definitions by: Pinguet62 <https://github.com/pinguet62>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import { Collection, CommonOptions, Db, IndexOptions, Long, MongoClientOptions, ReadPreference } from 'mongodb';
 

--- a/types/mongration/index.d.ts
+++ b/types/mongration/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/awapps/mongration#readme
 // Definitions by: Anton Lobashev <https://github.com/soulthreads>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import { Db } from 'mongodb';
 

--- a/types/multer-gridfs-storage/index.d.ts
+++ b/types/multer-gridfs-storage/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/devconcept/multer-gridfs-storage
 // Definitions by: devconcept <https://github.com/devconcept>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import { EventEmitter } from 'events';
 import { Express } from 'express';

--- a/types/multer-gridfs-storage/v1/index.d.ts
+++ b/types/multer-gridfs-storage/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/devconcept/multer-gridfs-storage
 // Definitions by: devconcept <https://github.com/devconcept>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import { EventEmitter } from 'events';
 import { Express } from 'express';

--- a/types/multer-gridfs-storage/v2/index.d.ts
+++ b/types/multer-gridfs-storage/v2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/devconcept/multer-gridfs-storage
 // Definitions by: devconcept <https://github.com/devconcept>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import { EventEmitter } from 'events';
 import { Express } from 'express';

--- a/types/multer-gridfs-storage/v3/index.d.ts
+++ b/types/multer-gridfs-storage/v3/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/devconcept/multer-gridfs-storage
 // Definitions by: devconcept <https://github.com/devconcept>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import { EventEmitter } from 'events';
 import { Express } from 'express';

--- a/types/resourcejs/index.d.ts
+++ b/types/resourcejs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/travist/resourcejs
 // Definitions by: Shaun Luttin <https://github.com/shaunluttin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// Minimum TypeScript Version: 3.2
 
 import express = require("express");
 import mongoose = require("mongoose");


### PR DESCRIPTION
Today, when we use `for await` on a cursor, the inferred type is `any` because of the `Readable` class.

```typescript
class Readable extends Stream implements NodeJS.ReadableStream {
  // ...
  [Symbol.asyncIterator](): AsyncIterableIterator<any>;
  // ...
}
```

I propose to override this implementation at the cursor level to be able to pass the generic type in the `AsyncIterableIterator` type ;)

What do you think?

---

`Type 'Cursor<{ foo: number; }>' is not an array type or a string type`
I had to specify TypeScript 3.2 as minimum version because of this error in the 3.1 version.

`Invalid 'for-await-of' of a non-AsyncIterable value.`
And disable the `await-promise` rule. I had some troubles with this bug: https://github.com/palantir/tslint/issues/3997