### PR TITLE
[node] change ProcessEnv back to interface to not break custom overrides

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -133,7 +133,7 @@ declare module "child_process" {
         uid?: number;
         gid?: number;
         cwd?: string;
-        env?: NodeJS.Dict<string>;
+        env?: NodeJS.ProcessEnv;
     }
 
     interface CommonOptions extends ProcessEnvOptions {

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -676,8 +676,8 @@ declare namespace NodeJS {
         isTTY?: true;
     }
 
-    // Alias for compability
-    type ProcessEnv = Dict<string>;
+    // Alias for compatibility
+    interface ProcessEnv extends Dict<string> {}
 
     interface HRTime {
         (time?: [number, number]): [number, number];
@@ -787,7 +787,7 @@ declare namespace NodeJS {
         cwd(): string;
         debugPort: number;
         emitWarning(warning: string | Error, name?: string, ctor?: Function): void;
-        env: Dict<string>;
+        env: ProcessEnv;
         exit(code?: number): never;
         exitCode?: number;
         getgid(): number;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Changing `ProcessEnv` from an interface to a type breaks the case where someone is trying to extend that interface to define their own environment variables, e.g.

```ts
declare namespace NodeJs {
  interface ProcessEnv {
    MY_ENV: "abc" | "123"
  }
}
```

This PR restores that functionality, and subsequently fixes the failing tests.