### PR TITLE
added ref-napi buffer prototype functions

### DIFF
--- a/types/ref-napi/index.d.ts
+++ b/types/ref-napi/index.d.ts
@@ -186,3 +186,27 @@ export declare var types: {
     int32: Type; uchar: Type; size_t: Type;
     uint32: Type; short: Type;
 };
+
+declare global {
+  interface Buffer{
+    address: typeof address;
+    isNull: typeof isNull;
+    ref: typeof ref;
+    deref: typeof deref;
+    readObject: typeof readObject;
+    writeObject: typeof writeObject;
+    readPointer: typeof readPointer;
+    writePointer: typeof writePointer;
+    readCString: typeof readCString;
+    writeCString: typeof writeCString;
+    readInt64BE: typeof readInt64BE;
+    writeInt64BE: typeof writeInt64BE;
+    readUInt64BE: typeof readUInt64BE;
+    writeUInt64BE: typeof writeUInt64BE;
+    readInt64LE: typeof readInt64LE;
+    writeInt64LE: typeof writeInt64LE;
+    reinterpret: typeof reinterpret;
+    reinterpretUntilZeros: typeof reinterpretUntilZeros;
+    type?: Type;
+  }
+}

--- a/types/ref-napi/index.d.ts
+++ b/types/ref-napi/index.d.ts
@@ -188,7 +188,7 @@ export declare var types: {
 };
 
 declare global {
-  interface Buffer{
+  interface Buffer {
     address: typeof address;
     isNull: typeof isNull;
     ref: typeof ref;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/node-ffi-napi/ref-napi/blob/latest/lib/ref.js>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

### Note

1. The original typing does not include tests and my changes fully depend on the previous code. Therefore I could not write tests that are purely based on my changes.
2. function `hexAddress` is not implemented yet, therefore its typing is not included