### PR TITLE
fix(react-dom): correct test-utils/act typing on non-strict codebases.

### DIFF
--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for React (react-dom) 16.9
-// Project: http://facebook.github.io/react/
+// Project: https://reactjs.org
 // Definitions by: Asana <https://asana.com>
 //                 AssureSign <http://www.assuresign.com>
 //                 Microsoft <https://microsoft.com>

--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -286,11 +286,14 @@ export function createRenderer(): ShallowRenderer;
  *
  * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
  */
-// the "void | undefined" is here to forbid any sneaky "Promise" returns.
-export function act(callback: () => void | undefined): void;
-// the "void | undefined" is here to forbid any sneaky return values
+// NOTES
+// - the order of these signatures matters - typescript will check the signatures in source order.
+//   If the `() => void` signature is first, it'll erroneously match a Promise returning function for users with
+//   `strictNullChecks: false`.
+// - the "void | undefined" types are there to forbid any non-void return values for users with `strictNullChecks: true`
 // tslint:disable-next-line: void-return
 export function act(callback: () => Promise<void | undefined>): Promise<undefined>;
+export function act(callback: () => void | undefined): void;
 
 // Intentionally doesn't extend PromiseLike<never>.
 // Ideally this should be as hard to accidentally use as possible.


### PR DESCRIPTION
Fixes https://github.com/typescript-eslint/typescript-eslint/issues/1913

TS matches signatures in source order. For users with `strictNullChecks: false`, it will always match `() => void` signature if it's the first one.
Switching the order means TS will attempt to match the `() => Promise<void>` signature first, so `Promise` returning functions will be correctly typed.

Tests passing fine. [Tested first using the playground](https://www.typescriptlang.org/play/?strictNullChecks=false#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXykwAowoIIAjQgawC54iBKeAXgD54A3HLYeAH3hpQiLKhDBG9brwDcAKFCRYCFOmx4CxUuSpg6DZu3gAFGDgC2WAM4gAPDL6DhIUeOBspp81dt2XbhJsCvJQ1gCe6EhomLj4GCDWGEzwAN7y8JnwYHhJ8AAerFrJYZFghqwcqfAAvowKWdm5GPDhRYTJKcbVdQo18org0HDR6nHFAEwkZJQ09F0cZpY29o4CQqgiYkFeS772AdseCkrDqjEa+B1TOrP680Yca86brkdejiGlUWqxmglJKbMdKNHKoPKFFiTIjfcoLNK1eoZLJgvJtKHXIjwnpI-pAA)

-----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
