### PR TITLE
Adding Types for siren-parser

### DIFF
--- a/types/siren-parser/Action.d.ts
+++ b/types/siren-parser/Action.d.ts
@@ -1,0 +1,30 @@
+import { Field } from './Field';
+
+export default function(action: object): Action;
+
+export interface Action {
+    name: string;
+    href: string;
+    class?: string[];
+    method?: string;
+    title?: string;
+    type?: string;
+    fields?: Field[];
+
+    hasClass(cls: string | RegExp): boolean;
+    hasField(fieldName: string | RegExp): boolean;
+    hasFieldByName(fieldName: string | RegExp): boolean;
+    hasFieldByClass(fieldClass: string | RegExp): boolean;
+    hasFieldByType(fieldType: string | RegExp): boolean;
+
+    getField(fieldName: string | RegExp): Field | undefined;
+    getFieldByName(fieldName: string | RegExp): Field | undefined;
+    getFieldByClass(fieldClass: string | RegExp): Field | undefined;
+    getFieldsByClass(fieldClass: string | RegExp): Field[];
+    getFieldByClasses(fieldClasses: ReadonlyArray<string | RegExp>): Field | undefined;
+    getFieldsByClasses(fieldClasses: ReadonlyArray<string | RegExp>): Field[];
+    getFieldByType(fieldType: string | RegExp): Field | undefined;
+    getFieldsByType(fieldType: string | RegExp): Field[];
+}
+
+export { Field, FieldType } from './Field';

--- a/types/siren-parser/Field.d.ts
+++ b/types/siren-parser/Field.d.ts
@@ -1,0 +1,33 @@
+export default function(field: object): Field;
+
+export interface Field {
+    name: string;
+    class?: string[];
+    type?: FieldType;
+    title?: string;
+    value?: any;
+
+    hasClass(cls: string | RegExp): boolean;
+}
+
+export enum FieldType {
+    Hidden = 'hidden',
+    Text = 'text',
+    Search = 'search',
+    Telephone = 'tel',
+    Url = 'url',
+    Email = 'email',
+    Password = 'password',
+    DateTime = 'datetime',
+    Date = 'date',
+    Month = 'month',
+    Week = 'week',
+    Time = 'time',
+    LocalDateTime = 'datetime-local',
+    Number = 'number',
+    Range = 'range',
+    Color = 'color',
+    Checkbox = 'checkbox',
+    Radio = 'radio',
+    File = 'file'
+}

--- a/types/siren-parser/Link.d.ts
+++ b/types/siren-parser/Link.d.ts
@@ -1,0 +1,11 @@
+export default function(link: object): Link;
+
+export interface Link {
+    rel: string[];
+    class?: string[];
+    href: string;
+    title?: string;
+    type?: string;
+
+    hasClass(cls: string | RegExp): boolean;
+}

--- a/types/siren-parser/chai.d.ts
+++ b/types/siren-parser/chai.d.ts
@@ -1,0 +1,31 @@
+/// <reference types="Chai" />
+
+declare namespace Chai {
+    interface Assertion {
+        classes(...classes: string[]): void;
+        href(href: string): void;
+        method(method: string): void;
+        name(name: string): void;
+        rels(...rels: string[]): void;
+        title(title: string): void;
+        type(type: string): void;
+        value(value: any): void;
+    }
+
+    interface TypeComparison {
+        sirenAction: Assertion;
+        sirenActions: Assertion;
+        sirenEntity: Assertion;
+        sirenEntities: Assertion;
+        sirenLink: Assertion;
+        sirenLinks: Assertion;
+        sirenProperty: Assertion;
+        sirenProperties: Assertion;
+        sirenField: Assertion;
+        sirenFields: Assertion;
+    }
+
+    interface KeyFilter {
+        with: Assertion;
+    }
+}

--- a/types/siren-parser/index.d.ts
+++ b/types/siren-parser/index.d.ts
@@ -1,0 +1,143 @@
+// Type definitions for siren-parser 8.2
+// Project: https://github.com/Brightspace/node-siren-parser
+// Definitions by: Dillon Redding <https://github.com/dillonredding>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
+
+export default function parseSiren(siren: string | object): Entity;
+
+export interface Entity {
+    class?: string[];
+    properties?: object;
+    entities?: Entity[];
+    links?: Link[];
+    actions?: Action[];
+    title?: string;
+    // embedded link properties
+    rel?: string[];
+    href?: string;
+    type?: string;
+
+    hasAction(actionName: string | RegExp): boolean;
+    hasActionByName(actionName: string | RegExp): boolean;
+    hasActionByClass(actionClass: string | RegExp): boolean;
+    hasActionByMethod(actionMethod: string | RegExp): boolean;
+    hasActionByType(actionType: string | RegExp): boolean;
+    hasClass(cls: string | RegExp): boolean;
+    hasEntity(entityRel: string | RegExp): boolean;
+    hasEntityByRel(entityRel: string | RegExp): boolean;
+    hasSubEntityByRel(entityRel: string | RegExp): boolean;
+    hasEntityByClass(entityClass: string | RegExp): boolean;
+    hasSubEntityByClass(entityClass: string | RegExp): boolean;
+    hasEntityByType(entityType: string | RegExp): boolean;
+    hasSubEntityByType(entityType: string | RegExp): boolean;
+    hasLink(linkRel: string | RegExp): boolean;
+    hasLinkByRel(linkRel: string | RegExp): boolean;
+    hasLinkByClass(linkClass: string | RegExp): boolean;
+    hasLinkByType(linkType: string | RegExp): boolean;
+    hasProperty(property: string | RegExp): boolean;
+
+    getAction(actionName: string | RegExp): Action | undefined;
+    getActionByName(actionName: string | RegExp): Action | undefined;
+    getActionByClass(actionClass: string | RegExp): Action | undefined;
+    getActionsByClass(actionClass: string | RegExp): Action[];
+    getActionByClasses(actionClasses: ReadonlyArray<string | RegExp>): Action | undefined;
+    getActionsByClasses(actionClasses: ReadonlyArray<string | RegExp>): Action[];
+    getActionByMethod(actionMethod: string | RegExp): Action | undefined;
+    getActionsByMethod(actionMethod: string | RegExp): Action[];
+    getActionByType(actionType: string | RegExp): Action | undefined;
+    getActionsByType(actionType: string | RegExp): Action[];
+
+    getLink(linkRel: string | RegExp): Link | undefined;
+    getLinks(linkRel: string | RegExp): Link[];
+    getLinkByRel(linkRel: string | RegExp): Link | undefined;
+    getLinksByRel(linkRel: string | RegExp): Link[];
+    getLinkByRels(linkRels: ReadonlyArray<string | RegExp>): Link | undefined;
+    getLinksByRels(linkRels: ReadonlyArray<string | RegExp>): Link[];
+    getLinkByClass(linkClass: string | RegExp): Link | undefined;
+    getLinksByClass(linkClass: string | RegExp): Link[];
+    getLinkByClasses(linkClasses: ReadonlyArray<string | RegExp>): Link | undefined;
+    getLinksByClasses(linkClasses: ReadonlyArray<string | RegExp>): Link[];
+    getLinkByType(linkType: string | RegExp): Link | undefined;
+    getLinksByType(linkType: string | RegExp): Link[];
+
+    getSubEntity(entityRel: string | RegExp): Entity | undefined;
+    getSubEntities(entityRel: string | RegExp): Entity[];
+    getSubEntityByRel(entityRel: string | RegExp): Entity | undefined;
+    getSubEntitiesByRel(entityRel: string | RegExp): Entity[];
+    getSubEntityByRels(entityRels: ReadonlyArray<string | RegExp>): Entity | undefined;
+    getSubEntitiesByRels(entityRels: ReadonlyArray<string | RegExp>): Entity[];
+    getSubEntityByClass(entityClass: string | RegExp): Entity | undefined;
+    getSubEntitiesByClass(entityClass: string | RegExp): Entity[];
+    getSubEntityByClasses(entityClasses: ReadonlyArray<string | RegExp>): Entity | undefined;
+    getSubEntitiesByClasses(entityClasses: ReadonlyArray<string | RegExp>): Entity[];
+    getSubEntityByType(entityType: string | RegExp): Entity | undefined;
+    getSubEntitiesByType(entityType: string | RegExp): Entity[];
+}
+
+export interface Link {
+    rel: string[];
+    class?: string[];
+    href: string;
+    title?: string;
+    type?: string;
+
+    hasClass(cls: string | RegExp): boolean;
+}
+
+export interface Action {
+    name: string;
+    href: string;
+    class?: string[];
+    method?: string;
+    title?: string;
+    type?: string;
+    fields?: Field[];
+
+    hasClass(cls: string | RegExp): boolean;
+    hasField(fieldName: string | RegExp): boolean;
+    hasFieldByName(fieldName: string | RegExp): boolean;
+    hasFieldByClass(fieldClass: string | RegExp): boolean;
+    hasFieldByType(fieldType: string | RegExp): boolean;
+
+    getField(fieldName: string | RegExp): Field | undefined;
+    getFieldByName(fieldName: string | RegExp): Field | undefined;
+    getFieldByClass(fieldClass: string | RegExp): Field | undefined;
+    getFieldsByClass(fieldClass: string | RegExp): Field[];
+    getFieldByClasses(fieldClasses: ReadonlyArray<string | RegExp>): Field | undefined;
+    getFieldsByClasses(fieldClasses: ReadonlyArray<string | RegExp>): Field[];
+    getFieldByType(fieldType: string | RegExp): Field | undefined;
+    getFieldsByType(fieldType: string | RegExp): Field[];
+}
+
+export interface Field {
+    name: string;
+    class?: string[];
+    type?: FieldType;
+    title?: string;
+    value?: any;
+
+    hasClass(cls: string | RegExp): boolean;
+}
+
+export enum FieldType {
+    Hidden = 'hidden',
+    Text = 'text',
+    Search = 'search',
+    Telephone = 'tel',
+    Url = 'url',
+    Email = 'email',
+    Password = 'password',
+    DateTime = 'datetime',
+    Date = 'date',
+    Month = 'month',
+    Week = 'week',
+    Time = 'time',
+    LocalDateTime = 'datetime-local',
+    Number = 'number',
+    Range = 'range',
+    Color = 'color',
+    Checkbox = 'checkbox',
+    Radio = 'radio',
+    File = 'file'
+}

--- a/types/siren-parser/index.d.ts
+++ b/types/siren-parser/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Brightspace/node-siren-parser
 // Definitions by: Dillon Redding <https://github.com/dillonredding>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 3.0
 
 import { Link } from './Link';
 import { Action } from './Action';

--- a/types/siren-parser/index.d.ts
+++ b/types/siren-parser/index.d.ts
@@ -78,5 +78,15 @@ export interface Entity {
     getSubEntitiesByType(entityType: string | RegExp): Entity[];
 }
 
+declare global {
+    namespace D2L {
+        namespace Hypermedia {
+            namespace Siren {
+                function Parse(siren: string | object): Entity;
+            }
+        }
+    }
+}
+
 export { Link } from './Link';
 export { Action, Field, FieldType } from './Action';

--- a/types/siren-parser/index.d.ts
+++ b/types/siren-parser/index.d.ts
@@ -4,7 +4,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.7
 
-export default function parseSiren(siren: string | object): Entity;
+import { Link } from './Link';
+import { Action } from './Action';
+
+export default function(entity: string | object): Entity;
 
 export interface Entity {
     class?: string[];
@@ -75,69 +78,5 @@ export interface Entity {
     getSubEntitiesByType(entityType: string | RegExp): Entity[];
 }
 
-export interface Link {
-    rel: string[];
-    class?: string[];
-    href: string;
-    title?: string;
-    type?: string;
-
-    hasClass(cls: string | RegExp): boolean;
-}
-
-export interface Action {
-    name: string;
-    href: string;
-    class?: string[];
-    method?: string;
-    title?: string;
-    type?: string;
-    fields?: Field[];
-
-    hasClass(cls: string | RegExp): boolean;
-    hasField(fieldName: string | RegExp): boolean;
-    hasFieldByName(fieldName: string | RegExp): boolean;
-    hasFieldByClass(fieldClass: string | RegExp): boolean;
-    hasFieldByType(fieldType: string | RegExp): boolean;
-
-    getField(fieldName: string | RegExp): Field | undefined;
-    getFieldByName(fieldName: string | RegExp): Field | undefined;
-    getFieldByClass(fieldClass: string | RegExp): Field | undefined;
-    getFieldsByClass(fieldClass: string | RegExp): Field[];
-    getFieldByClasses(fieldClasses: ReadonlyArray<string | RegExp>): Field | undefined;
-    getFieldsByClasses(fieldClasses: ReadonlyArray<string | RegExp>): Field[];
-    getFieldByType(fieldType: string | RegExp): Field | undefined;
-    getFieldsByType(fieldType: string | RegExp): Field[];
-}
-
-export interface Field {
-    name: string;
-    class?: string[];
-    type?: FieldType;
-    title?: string;
-    value?: any;
-
-    hasClass(cls: string | RegExp): boolean;
-}
-
-export enum FieldType {
-    Hidden = 'hidden',
-    Text = 'text',
-    Search = 'search',
-    Telephone = 'tel',
-    Url = 'url',
-    Email = 'email',
-    Password = 'password',
-    DateTime = 'datetime',
-    Date = 'date',
-    Month = 'month',
-    Week = 'week',
-    Time = 'time',
-    LocalDateTime = 'datetime-local',
-    Number = 'number',
-    Range = 'range',
-    Color = 'color',
-    Checkbox = 'checkbox',
-    Radio = 'radio',
-    File = 'file'
-}
+export { Link } from './Link';
+export { Action, Field, FieldType } from './Action';

--- a/types/siren-parser/siren-parser-tests.ts
+++ b/types/siren-parser/siren-parser-tests.ts
@@ -1,0 +1,146 @@
+import parseSiren from 'siren-parser';
+import * as sirenSuperagent from 'siren-parser/superagent';
+import * as superagent from 'superagent';
+
+parseSiren('{"class":["foo","bar"]}');
+
+const siren = {
+    title: 'My title',
+    class: ['outer'],
+    links: [{
+        rel: ['self', 'crazy'],
+        href: 'http://example.com'
+    }, {
+        rel: ['crazy'],
+        href: 'http://example2.com'
+    }],
+    actions: [{
+        name: 'fancy-action',
+        href: 'http://example.com',
+        title: 'A fancy action!',
+        method: 'GET',
+        fields: [{
+            name: 'max',
+            title: 'Maximum value'
+        }]
+    }],
+    entities: [{
+        class: ['inner', 'smaller'],
+        rel: ['child'],
+        links: [{
+            rel: ['self'],
+            href: 'http://example.com/child',
+            title: 'Child entity'
+        }]
+    }],
+    properties: {
+        one: 1,
+        two: 2,
+        pi: 'is exactly three'
+    }
+};
+
+const entity = parseSiren(siren);
+
+// expect(entity).to.have.sirenAction('fancy-action');
+// expect(entity).to.have.a.sirenAction.with.method('GET');
+// expect(entity).to.have.sirenLinks.with.classes('foo', 'bar'); // Will pass if at least 1 of resource's actions have each given class
+// expect(entity).to.have.sirenLinks.all.with.classes('foo', 'bar'); // Passes only if all of resource's actions have all given class
+// expect(entity).to.have.a.sirenEntity.with.a.sirenEntity.with.title('foo');
+
+sirenSuperagent.perform(superagent, entity.getAction('fancy-action')!)
+    .send({key: 'value'})
+    .parse(sirenSuperagent.parse)
+    .end((err, res) => {
+        const resource = res.body;
+        // chai.expect(resource).to.have.sirenProperty('some-field');
+    });
+
+superagent.parse['application/vnd.siren+json'] = sirenSuperagent.parse;
+
+// Entity
+entity.rel;
+entity.title;
+entity.type;
+entity.properties;
+entity.class;
+entity.actions;
+entity.links;
+entity.entities;
+
+// Entity.hasXByY
+entity.hasActionByName('fancy-action');
+entity.hasClass('inner');
+entity.hasSubEntityByRel('child');
+entity.hasSubEntityByType('child');
+entity.hasLinkByRel('crazy');
+entity.hasProperty('three');
+
+// Entity.getXByY
+entity.getActionByName('fancy-action');
+entity.getLinkByRel('self');
+entity.getLinksByRel('crazy');
+entity.getSubEntitiesByRel('child');
+entity.getSubEntityByRel('child');
+entity.getSubEntityByRel('child');
+entity.getSubEntityByClass('inner');
+entity.getSubEntitiesByClass('inner');
+
+// Entity.getXByY'es
+entity.getActionByClasses(['crazy', /self/]);
+entity.getActionsByClasses(['crazy', /cool/]);
+entity.getLinkByClasses(['crazy', /self/]);
+entity.getLinksByClasses(['crazy', /cool/]);
+entity.getLinkByRels(['thing1', /thing2/]);
+entity.getLinksByRels(['thing1', /thing2/]);
+entity.getSubEntityByClasses(['crazy', /self/]);
+entity.getSubEntitiesByClasses(['crazy', /cool/]);
+entity.getSubEntityByRels(['thing1', /thing2/]);
+entity.getSubEntitiesByRels(['thing1', /thing2/]);
+
+// Link
+const link = entity.getLink('crazy');
+link?.rel;
+link?.href;
+link?.class;
+link?.title;
+link?.type;
+
+// Link.hasClass
+link?.hasClass('foo');
+
+// Action
+const action = entity.getActionByName('fancy-action');
+action?.name;
+action?.href;
+action?.class;
+action?.method;
+action?.title;
+action?.type;
+action?.fields;
+
+// Action.hasXByY
+action?.hasFieldByName('max');
+action?.hasFieldByClass('max');
+action?.hasFieldByType('max');
+action?.hasClass('max');
+
+// Action.getXByY
+action?.getFieldByName('crazy');
+action?.getFieldByClass('crazy');
+action?.getFieldsByClass('crazy');
+action?.getFieldByClasses(['crazy', /self/]);
+action?.getFieldsByClasses(['crazy', /self/]);
+action?.getFieldByType('crazy');
+action?.getFieldsByType('crazy');
+
+// Field
+const field = action?.getField('max');
+field?.name;
+field?.value;
+field?.class;
+field?.type;
+field?.title;
+
+// Field.hasClass
+field?.hasClass('foo');

--- a/types/siren-parser/siren-parser-tests.ts
+++ b/types/siren-parser/siren-parser-tests.ts
@@ -42,6 +42,8 @@ const siren = {
 
 const entity = parseSiren(siren);
 
+D2L.Hypermedia.Siren.Parse(siren);
+
 // expect(entity).to.have.sirenAction('fancy-action');
 // expect(entity).to.have.a.sirenAction.with.method('GET');
 // expect(entity).to.have.sirenLinks.with.classes('foo', 'bar'); // Will pass if at least 1 of resource's actions have each given class

--- a/types/siren-parser/siren-parser-tests.ts
+++ b/types/siren-parser/siren-parser-tests.ts
@@ -104,47 +104,53 @@ entity.getSubEntitiesByRels(['thing1', /thing2/]);
 
 // Link
 const link = entity.getLink('crazy');
-link?.rel;
-link?.href;
-link?.class;
-link?.title;
-link?.type;
+if (link) {
+    link.rel;
+    link.href;
+    link.class;
+    link.title;
+    link.type;
 
-// Link.hasClass
-link?.hasClass('foo');
+    // Link.hasClass
+    link.hasClass('foo');
+}
 
 // Action
 const action = entity.getActionByName('fancy-action');
-action?.name;
-action?.href;
-action?.class;
-action?.method;
-action?.title;
-action?.type;
-action?.fields;
+if (action) {
+    action.name;
+    action.href;
+    action.class;
+    action.method;
+    action.title;
+    action.type;
+    action.fields;
 
-// Action.hasXByY
-action?.hasFieldByName('max');
-action?.hasFieldByClass('max');
-action?.hasFieldByType('max');
-action?.hasClass('max');
+    // Action.hasXByY
+    action.hasFieldByName('max');
+    action.hasFieldByClass('max');
+    action.hasFieldByType('max');
+    action.hasClass('max');
 
-// Action.getXByY
-action?.getFieldByName('crazy');
-action?.getFieldByClass('crazy');
-action?.getFieldsByClass('crazy');
-action?.getFieldByClasses(['crazy', /self/]);
-action?.getFieldsByClasses(['crazy', /self/]);
-action?.getFieldByType('crazy');
-action?.getFieldsByType('crazy');
+    // Action.getXByY
+    action.getFieldByName('crazy');
+    action.getFieldByClass('crazy');
+    action.getFieldsByClass('crazy');
+    action.getFieldByClasses(['crazy', /self/]);
+    action.getFieldsByClasses(['crazy', /self/]);
+    action.getFieldByType('crazy');
+    action.getFieldsByType('crazy');
 
-// Field
-const field = action?.getField('max');
-field?.name;
-field?.value;
-field?.class;
-field?.type;
-field?.title;
+    // Field
+    const field = action.getField('max');
+    if (field) {
+        field.name;
+        field.value;
+        field.class;
+        field.type;
+        field.title;
 
-// Field.hasClass
-field?.hasClass('foo');
+        // Field.hasClass
+        field.hasClass('foo');
+    }
+}

--- a/types/siren-parser/siren-parser-tests.ts
+++ b/types/siren-parser/siren-parser-tests.ts
@@ -1,6 +1,8 @@
 import parseSiren from 'siren-parser';
-import * as sirenSuperagent from 'siren-parser/superagent';
 import * as superagent from 'superagent';
+import * as sirenSuperagent from 'siren-parser/superagent';
+import * as chai from 'chai';
+import 'siren-parser/chai';
 
 parseSiren('{"class":["foo","bar"]}');
 
@@ -44,18 +46,18 @@ const entity = parseSiren(siren);
 
 D2L.Hypermedia.Siren.Parse(siren);
 
-// expect(entity).to.have.sirenAction('fancy-action');
-// expect(entity).to.have.a.sirenAction.with.method('GET');
-// expect(entity).to.have.sirenLinks.with.classes('foo', 'bar'); // Will pass if at least 1 of resource's actions have each given class
-// expect(entity).to.have.sirenLinks.all.with.classes('foo', 'bar'); // Passes only if all of resource's actions have all given class
-// expect(entity).to.have.a.sirenEntity.with.a.sirenEntity.with.title('foo');
+chai.expect(entity).to.have.sirenAction('fancy-action');
+chai.expect(entity).to.have.a.sirenAction.with.method('GET');
+chai.expect(entity).to.have.sirenLinks.with.classes('foo', 'bar');
+chai.expect(entity).to.have.sirenLinks.all.with.classes('foo', 'bar');
+chai.expect(entity).to.have.a.sirenEntity.with.a.sirenEntity.with.title('foo');
 
 sirenSuperagent.perform(superagent, entity.getAction('fancy-action')!)
     .send({key: 'value'})
     .parse(sirenSuperagent.parse)
     .end((err, res) => {
         const resource = res.body;
-        // chai.expect(resource).to.have.sirenProperty('some-field');
+        chai.expect(resource).to.have.sirenProperty('some-field');
     });
 
 superagent.parse['application/vnd.siren+json'] = sirenSuperagent.parse;

--- a/types/siren-parser/superagent.d.ts
+++ b/types/siren-parser/superagent.d.ts
@@ -1,0 +1,6 @@
+import { Action, Entity } from './index';
+import { SuperAgentRequest, Response } from 'superagent';
+
+export function parse(res: string): Entity;
+export function parse(res: Response, fn: (err: Error | null, body: Entity) => void): void;
+export function perform(request: any, action: Action): SuperAgentRequest;

--- a/types/siren-parser/tsconfig.json
+++ b/types/siren-parser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "siren-parser-tests.ts"
+  ]
+}

--- a/types/siren-parser/tslint.json
+++ b/types/siren-parser/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.