### PR TITLE
feat: add types of keccak

### DIFF
--- a/types/keccak/index.d.ts
+++ b/types/keccak/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for keccak 3.0
+// Project: https://github.com/cryptocoinjs/keccak#readme
+// Definitions by: odan <https://github.com/odanado>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { Transform, TransformOptions } from 'stream';
+export class Keccak extends Transform {
+    constructor(
+        rate: number,
+        capacity: number,
+        delimitedSuffix: number | null,
+        hashBitLength: number,
+        options: TransformOptions,
+    );
+    update(data: string | Buffer, encoding?: BufferEncoding): Keccak;
+    digest(encoding?: BufferEncoding): Buffer;
+}
+
+export class Shake extends Transform {
+    constructor(rate: number, capacity: number, delimitedSuffix: number | null, options: TransformOptions);
+    update(data: string | Buffer, encoding?: BufferEncoding): Shake;
+    squeeze(dataByteLength: number, encoding?: BufferEncoding): Buffer;
+}
+
+export type KeccakAlgorithm = 'keccak224' | 'keccak256' | 'keccak384' | 'keccak512';
+export type Sha3Algorithm = 'sha3-224' | 'sha3-256' | 'sha3-384' | 'sha3-512';
+export type ShakeAlgorithm = 'shake128' | 'shake256';
+
+declare function create(algorithm: KeccakAlgorithm | Sha3Algorithm, options?: TransformOptions): Keccak;
+
+declare function create(algorithm: ShakeAlgorithm, options?: TransformOptions): Shake;
+
+export default create;

--- a/types/keccak/keccak-tests.ts
+++ b/types/keccak/keccak-tests.ts
@@ -1,10 +1,10 @@
-import create from "keccak";
+import create from 'keccak';
 
-const keccak = create("keccak224"); // $ExpectType Keccak
-keccak.update("alice").digest(); // $ExpectType Buffer
+const keccak = create('keccak224'); // $ExpectType Keccak
+keccak.update('alice').digest(); // $ExpectType Buffer
 
-const sha3 = create("sha3-224"); // $ExpectType Keccak
-sha3.update("alice").digest(); // $ExpectType Buffer
+const sha3 = create('sha3-224'); // $ExpectType Keccak
+sha3.update('alice').digest(); // $ExpectType Buffer
 
-const shake = create("shake128"); // $ExpectType Shake
-shake.update("alice").squeeze(42); // $ExpectType Buffer
+const shake = create('shake128'); // $ExpectType Shake
+shake.update('alice').squeeze(42); // $ExpectType Buffer

--- a/types/keccak/keccak-tests.ts
+++ b/types/keccak/keccak-tests.ts
@@ -1,0 +1,10 @@
+import create from "keccak";
+
+const keccak = create("keccak224"); // $ExpectType Keccak
+keccak.update("alice").digest(); // $ExpectType Buffer
+
+const sha3 = create("sha3-224"); // $ExpectType Keccak
+sha3.update("alice").digest(); // $ExpectType Buffer
+
+const shake = create("shake128"); // $ExpectType Shake
+shake.update("alice").squeeze(42); // $ExpectType Buffer

--- a/types/keccak/tsconfig.json
+++ b/types/keccak/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "keccak-tests.ts"
+    ]
+}

--- a/types/keccak/tslint.json
+++ b/types/keccak/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
