### PR TITLE
[@types/hapi__hapi] Supporting v17's Hapi.server new syntax

### DIFF
--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -3964,6 +3964,11 @@ export class Server {
     validator(joi: Root): void;
 }
 
+/**
+ * Factory function to create a new server object (introduced in v17).
+ */
+export function server(opts?: ServerOptions): Server;
+
 /* + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +
  +                                                                           +
  +                                                                           +

--- a/types/hapi__hapi/test/factory/server.ts
+++ b/types/hapi__hapi/test/factory/server.ts
@@ -1,0 +1,18 @@
+// https://github.com/hapijs/hapi/blob/master/API.md#-serveroptions
+import * as Hapi from '@hapi/hapi';
+
+const server = Hapi.server({
+    port: 8000,
+});
+
+server.route({
+    path: '/',
+    method: 'GET',
+    handler(request, h) {
+        return 'Hello World';
+    }
+});
+
+server.start();
+
+console.log('Server started at: ' + server.info.uri);

--- a/types/hapi__hapi/tsconfig.json
+++ b/types/hapi__hapi/tsconfig.json
@@ -44,6 +44,7 @@
     },
     "files": [
         "index.d.ts",
+        "test/factory/server.ts",
         "test/request/auth.ts",
         "test/request/catch-all.ts",
         "test/request/event-types.ts",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://hapi.dev/api/?v=19.1.1#-serveroptions

**Description**

Follow up to #41359 in order to close #32994. The factory function is the preferred approach outlined in the [Getting Started section](https://hapi.dev/tutorials) and documented in the [API reference](https://hapi.dev/api/#-serveroptions). Currently, both the factory function and `new Server` syntax are supported, so it's best to provide types for both.