### PR TITLE
Add typing for random-number-csprng

### DIFF
--- a/types/random-number-csprng/index.d.ts
+++ b/types/random-number-csprng/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for random-number-csprng 1.0
+// Project: https://github.com/joepie91/node-random-number-csprng
+// Definitions by: nacam403 <https://github.com/nacam403>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Returns a Promise that resolves to a random number within the specified range.
+ *
+ * @param minimum The lowest possible integer in the range.
+ * @param maximum The highest possible integer in the range. Inclusive.
+ * @param cb Callback function
+ */
+declare function randomNumber(minimum: number, maximum: number, cb?: () => void): Promise<number>;
+export = randomNumber;

--- a/types/random-number-csprng/random-number-csprng-tests.ts
+++ b/types/random-number-csprng/random-number-csprng-tests.ts
@@ -1,0 +1,4 @@
+import randomNumber = require('random-number-csprng');
+
+randomNumber(1, 10); // $ExpectType Promise<number>
+randomNumber(1, 10, () => {}); // $ExpectType Promise<number>

--- a/types/random-number-csprng/tsconfig.json
+++ b/types/random-number-csprng/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "random-number-csprng-tests.ts"
+    ]
+}

--- a/types/random-number-csprng/tslint.json
+++ b/types/random-number-csprng/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
