### PR TITLE
Fix anltr4's Token.d.ts definition

### DIFF
--- a/types/antlr4/Token.d.ts
+++ b/types/antlr4/Token.d.ts
@@ -1,3 +1,5 @@
+import { InputStream } from './InputStream';
+
 export class Token {
     readonly text: string;
     source: any;
@@ -11,7 +13,7 @@ export class Token {
 
     getTokenSource(): any;
 
-    getInputStream(): any;
+    getInputStream(): InputStream;
 
     static readonly INVALID_TYPE: number;
     static readonly EPSILON: number;

--- a/types/antlr4/antlr4-tests.ts
+++ b/types/antlr4/antlr4-tests.ts
@@ -1,4 +1,4 @@
-import { InputStream, CommonTokenStream, Lexer, Parser, ParserRuleContext } from 'antlr4';
+import { Interval, InputStream, CommonTokenStream, Lexer, Parser, ParserRuleContext } from 'antlr4';
 import { TerminalNode } from 'antlr4/tree/Tree';
 
 export declare class CLexer extends Lexer {
@@ -2156,3 +2156,12 @@ const parser = new CParser(tokenStream);
 // execute the parse, and generate the parse tree
 const tree = parser.compilationUnit();
 console.log(tree);
+
+// fix Token.d.ts:
+function getOriginalText(ctx: ParserRuleContext): string {
+    const a: number = ctx.start.start;
+    const b: number = ctx.stop.stop;
+    const wrong = ctx.start.getInputStream().getText(new Interval(a, b));
+    const text = ctx.start.getInputStream().getText(a, b);
+    return text;
+}

--- a/types/antlr4/antlr4-tests.ts
+++ b/types/antlr4/antlr4-tests.ts
@@ -2161,7 +2161,7 @@ console.log(tree);
 function getOriginalText(ctx: ParserRuleContext): string {
     const a: number = ctx.start.start;
     const b: number = ctx.stop.stop;
-    const wrong = ctx.start.getInputStream().getText(new Interval(a, b));
+    // WRONG: const wrong = ctx.start.getInputStream().getText(new Interval(a, b));
     const text = ctx.start.getInputStream().getText(a, b);
     return text;
 }

--- a/types/antlr4/index.d.ts
+++ b/types/antlr4/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for antlr4 4.7
 // Project: https://github.com/antlr/antlr4
 // Definitions by: Marlon Chatman <https://github.com/mcchatman8009>
+//                 Matteo Mortari <https://github.com/tarilabs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 export * from './Lexer';
 export * from './Parser';


### PR DESCRIPTION
Problem statement: the `Token` definition currently returns `any` when calling `.getInputStream()`:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/069f404e6611098c620a265d05782db36efb4fc6/types/antlr4/Token.d.ts#L14

an utility function using Token's Inputstream might call its function by using wrong arguments as there is there no type safety while dealing with `any`. 

This PR fixes `Token.d.ts` to return the correct `InputStream` type instead of any, and the provided new test is ensuring the correct usage of the antlr4's API.

See commit f680679 demonstrating the ambiguity problem in the test
See commit 35d0af1 demonstrating the change in `Token.d.ts`, resolving the ambiguity, the test now reflect only the correct usage of the antlr4's API.

> source code which provides context for the suggested changes:

https://github.com/antlr/antlr4/blob/4.7/runtime/JavaScript/src/antlr4/InputStream.js#L95

I followed the instruction of the readme with commit 270bac0 and raising this PR for suggesting this code change.
I will include the requested template form below.
Thanks!
Ciao,
 -- Matteo

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/antlr/antlr4/blob/4.7/runtime/JavaScript/src/antlr4/InputStream.js#L95
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
(no change, it's still about antlr 4.7)
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
