### PR TITLE
Update prompts: fixing a spelling error

### DIFF
--- a/types/prompts/index.d.ts
+++ b/types/prompts/index.d.ts
@@ -81,7 +81,7 @@ declare namespace prompts {
         float?: boolean;
         round?: number;
         increment?: number;
-        seperator?: string;
+        separator?: string;
         active?: string;
         inactive?: string;
         choices?: Choice[];


### PR DESCRIPTION
The property `separator` was misspelled `seperator` (with an "e"). This is causing lots of problems when using the `list` type of prompt.