### PR TITLE
[browser-pack] update browser-pack definition to 6.1.0 from 6.0.1

### DIFF
--- a/types/browser-pack/browser-pack-tests.ts
+++ b/types/browser-pack/browser-pack-tests.ts
@@ -1,31 +1,33 @@
 import browserPack = require("browser-pack");
 
-module BrowserPackTest {
+function packIt(opts: browserPack.Options) {
+    const packOpts: browserPack.Options = {
+        basedir: opts.basedir || "./",
+        externalRequireName: opts.externalRequireName || "require",
+        hasExports: opts.hasExports || false,
+        prelude: opts.prelude || undefined,
+        preludePath: opts.preludePath || undefined,
+        raw: opts.raw || false,
+        sourceMapPrefix: opts.sourceMapPrefix || '//#',
+        sourceRoot: opts.sourceRoot || undefined,
+        standalone: opts.standalone || undefined,
+        standaloneModule: opts.standaloneModule || undefined,
+    };
 
-    export function packIt(opts?: browserPack.Options) {
-        var packOpts: browserPack.Options = {
-            basedir: opts.basedir || "./",
-            externalRequireName: opts.externalRequireName || "require",
-            hasExports: opts.hasExports || false,
-            prelude: opts.prelude || undefined,
-            preludePath: opts.preludePath || undefined,
-            raw: opts.raw || false,
-            sourceMapPrefix: opts.sourceMapPrefix || '//#',
-            standalone: opts.standalone || undefined,
-            standaloneModule: opts.standaloneModule || undefined,
-        };
+    const bpack1 = browserPack(); // 'opts' is optional
+    const bpack2 = browserPack({ raw: true }); // options literal
+    const bpack3 = browserPack(packOpts); // all options
 
-        var res = browserPack(); // 'opts' are optional
-        var res2 = browserPack(packOpts);
+    // return value is a stream
+    const bpack4 = bpack1.pipe(bpack2);
 
-        // ensure return value is a stream
-        var res3 = res.pipe(res2);
+    bpack3.on("error", (err) => {
+        console.error("browser-pack error: ", err);
+    });
 
-        res.on("error", function (err: any) {
-            console.error("browser-pack error: ", err);
-        });
-    }
-
+    bpack4.end(() => {
+        console.log("end");
+    });
 }
 
-export = BrowserPackTest;
+export = packIt;

--- a/types/browser-pack/index.d.ts
+++ b/types/browser-pack/index.d.ts
@@ -1,58 +1,81 @@
-// Type definitions for browser-pack v6.0.1
+// Type definitions for browser-pack 6.1
 // Project: https://github.com/substack/browser-pack
 // Definitions by: TeamworkGuy2 <https://github.com/TeamworkGuy2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
-/** pack node-style source files from a json stream into a browser bundle
+/**
+ * pack node-style source files from a json stream into a browser bundle
  */
 declare namespace browserPack {
-
-    export interface Options {
-        /** Whether the bundle should include require= (or the opts.externalRequireName) so that
+    interface Options {
+        /**
+         * Whether the bundle should include require= (or the opts.externalRequireName) so that
          * require() is available outside the bundle
          */
         hasExports?: boolean;
 
-        /** A string to use in place of 'require' if opts.hasExports is specified, default is 'require'
+        /**
+         * A string to use in place of 'require' if opts.hasExports is specified, default is 'require'
          */
         externalRequireName?: string;
 
-        /** Specify a custom prelude, but know what you're doing first. See the prelude.js file in
+        /**
+         * Specify a custom prelude, but know what you're doing first. See the prelude.js file in
          * this repo for the default prelude. If you specify a custom prelude, you must also specify
          * a valid opts.preludePath to the prelude source file for sourcemaps to work
          */
         prelude?: string;
 
-        /** prelude.js path if a custom opts.prelude is specified
+        /**
+         * prelude.js path if a custom opts.prelude is specified
          */
         preludePath?: string;
 
-        /** Used if opts.preludePath is undefined, this is used to resolve the prelude.js file location, default: 'process.cwd()'
+        /**
+         * Used if opts.preludePath is undefined, this is used to resolve the prelude.js file location, default: 'process.cwd()'
          */
         basedir?: string;
 
-        /** if given, the writable end of the stream will expect objects to be written to
+        /**
+         * If given, the writable end of the stream will expect objects to be written to
          * it instead of expecting a stream of json text it will need to parse, default false
          */
         raw?: boolean;
 
-        /** External string name to use for UMD, if not provided, UMD declaration is not wrapped around output
+        /**
+         * External string name to use for UMD, if not provided, UMD declaration is not wrapped around output
          */
         standalone?: string;
 
-        /** Sets the internal module name to export for standalone
+        /**
+         * Sets the internal module name to export for standalone
          */
         standaloneModule?: string;
 
-        /** If given and source maps are computed, the opts.sourceMapPrefix string will be used instead of default: '//#'
+        /**
+         * If given and source maps are computed, the opts.sourceMapPrefix string will be used instead of default: '//#'
          */
         sourceMapPrefix?: string;
+
+        /**
+         * If given and source maps are computed, the root for the output source map will be defined. (default is no root)
+         */
+        sourceRoot?: string;
     }
 }
 
-/** pack node-style source files from a json stream into a browser bundle
+/**
+ * Pack node-style source files from a json stream into a browser bundle.
+ * Source objects are written to browser-pack using 'write(row)'. browser-pack uses these properties of each row:
+ *  - 'id' - A unique ID for this module.
+ *  - 'deps' - An object mapping 'require()' argument strings to dependency row IDs, used for resolution at runtime.
+ *  - 'entry' - When true, this module will be executed when the bundle loads. Otherwise, it will only be executed once some other module 'require()'s it.
+ *  - 'order' - When 'row.entry' is true, this number indicates the order in which different entry modules are executed.
+ *  - 'source' - The contents of the module.
+ *  - 'nomap' - When true, a source map is not generated for this module.
+ *  - 'sourceFile' - The file name to use for this module in the source map.
  */
 declare function browserPack(opts?: browserPack.Options): NodeJS.ReadWriteStream;
 export = browserPack;

--- a/types/browser-pack/tsconfig.json
+++ b/types/browser-pack/tsconfig.json
@@ -6,8 +6,8 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
         "strictFunctionTypes": true,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/browser-pack/tslint.json
+++ b/types/browser-pack/tslint.json
@@ -1,20 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "callable-types": false,
-        "dt-header": false,
-        "eofline": false,
-        "export-just-namespace": false,
-        "jsdoc-format": false,
-        "no-internal-module": false,
-        "no-namespace": false,
-        "no-padding": false,
-        "no-redundant-jsdoc": false,
-        "no-var-keyword": false,
-        "only-arrow-functions": false,
-        "prefer-const": false,
-        "prefer-method-signature": false,
-        "space-before-function-paren": false,
-        "strict-export-declare-modifiers": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
Add 'sourceRoot' option, update documentation, and cleaned up tsconfig and tslint for definition; see browser-pack pulls:
* https://github.com/browserify/browser-pack/pull/74
* https://github.com/browserify/browser-pack/pull/89

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * https://github.com/browserify/browser-pack/pull/74
  * https://github.com/browserify/browser-pack/pull/89
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.