### PR TITLE
feat(@hapi/mimos): rework 4.1 version definition

### DIFF
--- a/types/hapi__mimos/hapi__mimos-tests.ts
+++ b/types/hapi__mimos/hapi__mimos-tests.ts
@@ -1,0 +1,40 @@
+import Mimos = require('@hapi/mimos');
+
+let mimos: Mimos;
+
+// new Mimos([options])
+
+const options: Mimos.MimosOptions = {
+    override: {
+        'node/module': {
+            source: 'iana',
+            compressible: true,
+            extensions: ['node', 'module', 'npm'],
+            type: 'node/module',
+        },
+        'application/javascript': {
+            source: 'iana',
+            charset: 'UTF-8',
+            compressible: true,
+            extensions: ['js', 'javascript'],
+            type: 'text/javascript',
+        },
+        'text/html': {
+            predicate: mime => {
+                mime.foo = mime.source === 'iana' ? 'test' : 'bar';
+                return mime;
+            },
+        },
+    },
+};
+mimos = new Mimos(options); // $ExpectType Mimos
+
+// mimos.path
+
+mimos = new Mimos();
+mimos.path('/static/public/app.js'); // $ExpectType MimosOptionsValue
+
+// mimos.type
+
+mimos = new Mimos();
+const mime = mimos.type('text/plain'); // $ExpectType MimeEntry

--- a/types/hapi__mimos/index.d.ts
+++ b/types/hapi__mimos/index.d.ts
@@ -3,27 +3,62 @@
 // Definitions by: AJP <https://github.com/AJamesPhillips>
 //                 Silas Rech <https://github.com/lenovouser>
 //                 Linus Unnebäck <https://github.com/LinusU>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
 import { MimeEntry } from 'mime-db';
 
-/**
- *
- * @see {@link https://github.com/hapijs/mimos#new-mimosoptions}
- */
-export interface MimosOptions {
+declare namespace Mimos {
     /**
-     * an object hash that is merged into the built in mime information specified here {@link https://github.com/jshttp/mime-db}. Each key value pair represents a single mime object. Each override value should follow this schema:
-     *  * the key is the lower-cased correct mime-type. (Ex. "application/javascript").
-     *  * the value should an object @see MimosOptionsValue
+     *
+     * @see {@link https://github.com/hapijs/mimos#new-mimosoptions}
      */
-    override: {[index: string]: MimosOptionsValue};
+    interface MimosOptions {
+        /**
+         * an object hash that is merged into the built in mime information specified here {@link https://github.com/jshttp/mime-db}.
+         * Each key value pair represents a single mime object.
+         * Each override value should follow this schema:
+         *  * the key is the lower-cased correct mime-type. (Ex. "application/javascript").
+         *  * the value should an object @see MimosOptionsValue
+         */
+        override: {
+            [type: string]: MimosOptionsValue & {
+                /**
+                 * Method with signature function(mime) when this mime type is found in the database,
+                 * this function will run. This allows you make customizations to mime based on developer criteria.
+                 */
+                predicate?: (
+                    mime: MimosOptionsValue & {
+                        [key: string]: any;
+                    },
+                ) => MimosOptionsValue & {
+                    [key: string]: any;
+                };
+            };
+        };
+    }
+
+    interface MimosOptionsValue extends MimeEntry {
+        /**
+         * Specify the type value of result objects, defaults to key.
+         */
+        type?: string;
+    }
 }
 
-export interface MimosOptionsValue extends MimeEntry {
-    /** specify the type value of result objects, defaults to key. See the example below for more clarification. */
-    type?: string;
-    /** method with signature function(mime) when this mime type is found in the database, this function will run. This allows you make customizations to mime based on developer criteria. */
-    predicate?: (mime: MimosOptionsValue) => MimosOptionsValue;
+declare class Mimos {
+    /**
+     * Creates a new Mimos object.
+     */
+    constructor(options?: Mimos.MimosOptions);
+    /**
+     * Returns mime object
+     */
+    path(path: string): Mimos.MimosOptionsValue;
+    /**
+     * Returns mime object
+     */
+    type(type: string): MimeEntry;
 }
+
+export = Mimos;

--- a/types/hapi__mimos/tsconfig.json
+++ b/types/hapi__mimos/tsconfig.json
@@ -22,6 +22,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "hapi__mimos-tests.ts"
     ]
 }

--- a/types/hapi__mimos/tslint.json
+++ b/types/hapi__mimos/tslint.json
@@ -1,21 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "callable-types": false,
-        "max-line-length": false,
-        "no-redundant-jsdoc": false,
-        "npm-naming": [
-            true,
-            {
-                "errors": [
-                    [
-                        "NeedsExportEquals",
-                        false
-                    ]
-                ],
-                "mode": "code"
-            }
-        ],
-        "prefer-method-signature": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
This commit tries to re-align package definition with declared version
4.1 - before it could be moved to v5

- correct export
- namespace for types and aliases
- test added

https://github.com/hapijs/mimos/tree/v4.1.1

/cc @luiso1979

Thanks!

Fixes #43987

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
n-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.