### PR TITLE
Adding new definition to redux-watch

### DIFF
--- a/types/redux-watch/index.d.ts
+++ b/types/redux-watch/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for redux-watch 1.1
+// Project: https://github.com/jprichardson/redux-watch#readme
+// Definitions by: zoltan.boros <https://github.com/zoltan-boros>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * This type is suitable to describe path to a field of an object.
+ * For details refer
+ * @link https://github.com/mariocasciaro/object-path
+ */
+export type FieldPath = string | number | Array<string | number>;
+
+/** Whenever a given state field changes this handler will be called. */
+export type ChangeHandler<T> = (newValue: T, oldValue: T, pathToField: FieldPath) => void;
+
+/** @see ChangeHandlerWrapper */
+export type FieldWatch = () => void;
+
+/**
+ * @returns Function, that wraps the given change handler in. It should be
+ * subscribed to state changes using store.subscribe(). Afterwards, it
+ * calls change handler whenever the watched state field changes.
+ */
+export type ChangeHandlerWrapper<T> = (changeHandler: ChangeHandler<T>) => FieldWatch;
+
+/**
+ * @param getState Function, that returns the Redux store state.
+ * @param pathToField Most commonly dot separated string, or array of strings
+ *      and numbers that form path to a field of the state object. For details
+ *      refer @link https://github.com/mariocasciaro/object-path
+ * @param compare Optional field comparison function. Defaults to strict
+ *      equality check (===).
+ * @returns Function, that listens to changes of the given field of the Redux store
+ *      state. On change it calls its parameter, which is a change handler function.
+ */
+export default function watch(
+    getState: () => any,
+    pathToField?: FieldPath,
+    compare?: (a: any, b: any) => boolean,
+): ChangeHandlerWrapper<any>;

--- a/types/redux-watch/index.d.ts
+++ b/types/redux-watch/index.d.ts
@@ -8,20 +8,20 @@
  * For details refer
  * @link https://github.com/mariocasciaro/object-path
  */
-export type FieldPath = string | number | Array<string | number>;
+type FieldPath = string | number | Array<string | number>;
 
 /** Whenever a given state field changes this handler will be called. */
-export type ChangeHandler<T> = (newValue: T, oldValue: T, pathToField: FieldPath) => void;
+type ChangeHandler<T> = (newValue: T, oldValue: T, pathToField: FieldPath) => void;
 
 /** @see ChangeHandlerWrapper */
-export type FieldWatch = () => void;
+type FieldWatch = () => void;
 
 /**
  * @returns Function, that wraps the given change handler in. It should be
  * subscribed to state changes using store.subscribe(). Afterwards, it
  * calls change handler whenever the watched state field changes.
  */
-export type ChangeHandlerWrapper<T> = (changeHandler: ChangeHandler<T>) => FieldWatch;
+type ChangeHandlerWrapper<T> = (changeHandler: ChangeHandler<T>) => FieldWatch;
 
 /**
  * @param getState Function, that returns the Redux store state.
@@ -33,8 +33,10 @@ export type ChangeHandlerWrapper<T> = (changeHandler: ChangeHandler<T>) => Field
  * @returns Function, that listens to changes of the given field of the Redux store
  *      state. On change it calls its parameter, which is a change handler function.
  */
-export default function watch(
+declare function watch(
     getState: () => any,
     pathToField?: FieldPath,
     compare?: (a: any, b: any) => boolean,
 ): ChangeHandlerWrapper<any>;
+
+export = watch;

--- a/types/redux-watch/redux-watch-tests.ts
+++ b/types/redux-watch/redux-watch-tests.ts
@@ -1,4 +1,4 @@
-import watch, * as RW from 'redux-watch';
+import watch = require('redux-watch');
 
 interface DummyState {
     fieldA: {
@@ -14,15 +14,15 @@ function dummyGetState(): DummyState {
     };
 }
 
-const fieldBChangeHandler: RW.ChangeHandler<string> = (
+const fieldBChangeHandler = (
     newValue: string,
     oldValue: string,
-    pathToField: RW.FieldPath
+    pathToField: any
 ) => {};
 
-const fieldBWatchWrapper: RW.ChangeHandlerWrapper<string> = watch(
+const fieldBWatchWrapper = watch(
     dummyGetState,
     ['fieldA', 'fieldB']
 );
 
-const fieldBWatch: RW.FieldWatch = fieldBWatchWrapper(fieldBChangeHandler);
+const fieldBWatch = fieldBWatchWrapper(fieldBChangeHandler);

--- a/types/redux-watch/redux-watch-tests.ts
+++ b/types/redux-watch/redux-watch-tests.ts
@@ -1,0 +1,28 @@
+import watch, * as RW from 'redux-watch';
+
+interface DummyState {
+    fieldA: {
+        fieldB: string;
+    };
+}
+
+function dummyGetState(): DummyState {
+    return {
+        fieldA: {
+            fieldB: 'some value',
+        },
+    };
+}
+
+const fieldBChangeHandler: RW.ChangeHandler<string> = (
+    newValue: string,
+    oldValue: string,
+    pathToField: RW.FieldPath
+) => {};
+
+const fieldBWatchWrapper: RW.ChangeHandlerWrapper<string> = watch(
+    dummyGetState,
+    ['fieldA', 'fieldB']
+);
+
+const fieldBWatch: RW.FieldWatch = fieldBWatchWrapper(fieldBChangeHandler);

--- a/types/redux-watch/tsconfig.json
+++ b/types/redux-watch/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "redux-watch-tests.ts"
+    ]
+}

--- a/types/redux-watch/tslint.json
+++ b/types/redux-watch/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding a new definition:

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.