### PR TITLE
fix(node): move worker_threads module functions to correct scope

### DIFF
--- a/types/node/test/worker_threads.ts
+++ b/types/node/test/worker_threads.ts
@@ -44,7 +44,9 @@ import { Readable } from "stream";
         subChannel.port2.on('message', (value) => {
             console.log('received:', value);
         });
-        worker.moveMessagePortToContext(new workerThreads.MessagePort(), createContext());
+        const movedPort = workerThreads.moveMessagePortToContext(
+            new workerThreads.MessagePort(), createContext());
+        workerThreads.receiveMessageOnPort(movedPort);
     } else {
         workerThreads.parentPort!.once('message', (value) => {
             assert(value.hereIsYourPort instanceof workerThreads.MessagePort);

--- a/types/node/v12/test/worker_threads.ts
+++ b/types/node/v12/test/worker_threads.ts
@@ -37,7 +37,9 @@ import { createContext } from "vm";
         subChannel.port2.on('message', (value) => {
             console.log('received:', value);
         });
-        worker.moveMessagePortToContext(new workerThreads.MessagePort(), createContext());
+        const movedPort = workerThreads.moveMessagePortToContext(
+            new workerThreads.MessagePort(), createContext());
+        workerThreads.receiveMessageOnPort(movedPort);
     } else {
         workerThreads.parentPort!.once('message', (value) => {
             assert(value.hereIsYourPort instanceof workerThreads.MessagePort);

--- a/types/node/v12/worker_threads.d.ts
+++ b/types/node/v12/worker_threads.d.ts
@@ -80,29 +80,6 @@ declare module "worker_threads" {
          * Returns a Promise for the exit code that is fulfilled when the `exit` event is emitted.
          */
         terminate(): Promise<number>;
-        /**
-         * Transfer a `MessagePort` to a different `vm` Context. The original `port`
-         * object will be rendered unusable, and the returned `MessagePort` instance will
-         * take its place.
-         *
-         * The returned `MessagePort` will be an object in the target context, and will
-         * inherit from its global `Object` class. Objects passed to the
-         * `port.onmessage()` listener will also be created in the target context
-         * and inherit from its global `Object` class.
-         *
-         * However, the created `MessagePort` will no longer inherit from
-         * `EventEmitter`, and only `port.onmessage()` can be used to receive
-         * events using it.
-         */
-        moveMessagePortToContext(port: MessagePort, context: Context): MessagePort;
-
-        /**
-         * Receive a single message from a given `MessagePort`. If no message is available,
-         * `undefined` is returned, otherwise an object with a single `message` property
-         * that contains the message payload, corresponding to the oldest message in the
-         * `MessagePort`’s queue.
-         */
-        receiveMessageOnPort(port: MessagePort): {} | undefined;
 
         addListener(event: "error", listener: (err: Error) => void): this;
         addListener(event: "exit", listener: (exitCode: number) => void): this;
@@ -152,4 +129,28 @@ declare module "worker_threads" {
         off(event: "online", listener: () => void): this;
         off(event: string | symbol, listener: (...args: any[]) => void): this;
     }
+
+    /**
+     * Transfer a `MessagePort` to a different `vm` Context. The original `port`
+     * object will be rendered unusable, and the returned `MessagePort` instance will
+     * take its place.
+     *
+     * The returned `MessagePort` will be an object in the target context, and will
+     * inherit from its global `Object` class. Objects passed to the
+     * `port.onmessage()` listener will also be created in the target context
+     * and inherit from its global `Object` class.
+     *
+     * However, the created `MessagePort` will no longer inherit from
+     * `EventEmitter`, and only `port.onmessage()` can be used to receive
+     * events using it.
+     */
+    function moveMessagePortToContext(port: MessagePort, context: Context): MessagePort;
+
+    /**
+     * Receive a single message from a given `MessagePort`. If no message is available,
+     * `undefined` is returned, otherwise an object with a single `message` property
+     * that contains the message payload, corresponding to the oldest message in the
+     * `MessagePort`’s queue.
+     */
+    function receiveMessageOnPort(port: MessagePort): { message: any } | undefined;
 }

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -105,29 +105,6 @@ declare module "worker_threads" {
          * Returns a Promise for the exit code that is fulfilled when the `exit` event is emitted.
          */
         terminate(): Promise<number>;
-        /**
-         * Transfer a `MessagePort` to a different `vm` Context. The original `port`
-         * object will be rendered unusable, and the returned `MessagePort` instance will
-         * take its place.
-         *
-         * The returned `MessagePort` will be an object in the target context, and will
-         * inherit from its global `Object` class. Objects passed to the
-         * `port.onmessage()` listener will also be created in the target context
-         * and inherit from its global `Object` class.
-         *
-         * However, the created `MessagePort` will no longer inherit from
-         * `EventEmitter`, and only `port.onmessage()` can be used to receive
-         * events using it.
-         */
-        moveMessagePortToContext(port: MessagePort, context: Context): MessagePort;
-
-        /**
-         * Receive a single message from a given `MessagePort`. If no message is available,
-         * `undefined` is returned, otherwise an object with a single `message` property
-         * that contains the message payload, corresponding to the oldest message in the
-         * `MessagePort`’s queue.
-         */
-        receiveMessageOnPort(port: MessagePort): {} | undefined;
 
         /**
          * Returns a readable stream for a V8 snapshot of the current state of the Worker.
@@ -187,4 +164,28 @@ declare module "worker_threads" {
         off(event: "online", listener: () => void): this;
         off(event: string | symbol, listener: (...args: any[]) => void): this;
     }
+
+    /**
+     * Transfer a `MessagePort` to a different `vm` Context. The original `port`
+     * object will be rendered unusable, and the returned `MessagePort` instance will
+     * take its place.
+     *
+     * The returned `MessagePort` will be an object in the target context, and will
+     * inherit from its global `Object` class. Objects passed to the
+     * `port.onmessage()` listener will also be created in the target context
+     * and inherit from its global `Object` class.
+     *
+     * However, the created `MessagePort` will no longer inherit from
+     * `EventEmitter`, and only `port.onmessage()` can be used to receive
+     * events using it.
+     */
+    function moveMessagePortToContext(port: MessagePort, context: Context): MessagePort;
+
+    /**
+     * Receive a single message from a given `MessagePort`. If no message is available,
+     * `undefined` is returned, otherwise an object with a single `message` property
+     * that contains the message payload, corresponding to the oldest message in the
+     * `MessagePort`’s queue.
+     */
+    function receiveMessageOnPort(port: MessagePort): { message: any } | undefined;
 }


### PR DESCRIPTION
`moveMessagePortToContext()` and `receiveMessageOnPort()` live on
the `worker_threads` module itself, not as methods on the
`Worker` class.

Also, fix the return value for `receiveMessageOnPort()`, which is
either `undefined` or an object with a `message` property.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). (Done but fails for unrelated files.)

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/worker_threads.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

...