### PR TITLE
feat: add types for gsheets

### DIFF
--- a/types/gsheets/gsheets-tests.ts
+++ b/types/gsheets/gsheets-tests.ts
@@ -1,0 +1,5 @@
+import * as gsheets from 'gsheets';
+
+gsheets.getSpreadsheet(''); // $ExpectType Promise<Spreadsheet>
+gsheets.getWorksheet('', ''); // $ExpectType Promise<Worksheet>
+gsheets.getWorksheetById('', ''); // $ExpectType Promise<WorksheetFromId>

--- a/types/gsheets/index.d.ts
+++ b/types/gsheets/index.d.ts
@@ -1,0 +1,122 @@
+// Type definitions for gsheets 2.0
+// Project: https://github.com/interactivethings/gsheets
+// Definitions by: Kyle Nazario <https://github.com/kyle-n>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*
+ * - Numeric cells are converted to numbers
+ * - Empty cells are converted to `null`
+ * - Beware of cells formatted as dates! Their values will be returned as Excel-style
+ * [DATEVALUE](http://office.microsoft.com/en-001/excel-help/datevalue-function-HP010062284.aspx) numbers (i.e.
+ * based on the number of days since January 1, 1900)
+ */
+export interface Row {
+    [headerColName: string]: string | number | null;
+}
+
+/*
+ * - Empty rows are omitted
+ * - `updated` is an ISO-formatted date string
+ */
+export interface Worksheet {
+    updated: string;
+    title: string;
+    data: Row[] | null;
+}
+
+/*
+ * - Empty rows are omitted
+ * - `updated` is an ISO-formatted date string
+ */
+export interface WorksheetFromId extends Worksheet {
+    data: Row[];
+}
+
+/*
+ * - `updated` is an ISO-formatted date string
+ */
+export interface Spreadsheet {
+    updated: string;
+    title: string;
+    worksheets: Array<{
+        id: string;
+        title: string;
+    }>;
+}
+
+/*
+ * Returns the contents of a worksheet, specified by its title. Note that this generates
+ * **two** requests (to resolve a worksheet's title). If you know a worksheet's ID (e.g. via a previous call to
+ * `getSpreadsheet`), use `getWorksheetById`.
+ *
+ * For empty worksheets `data` is `null`.
+ *
+ * ---
+ *
+ * Example response:
+ *
+ * ```
+ * {
+ *   "updated": "2014-11-19T10:20:18.068Z",
+ *   "title": "foobar",
+ *   "data": [
+ *     {
+ *       "foo": "bar",
+ *       "baz": 42,
+ *       "boing": null
+ *     },
+ *     // more rows ...
+ *   ]
+ * }
+ * ```
+ */
+export function getWorksheet(spreadsheetId: string, worksheetTitle: string): Promise<Worksheet>;
+
+/*
+ * Returns the contents of a worksheet, specified by its ID.
+ *
+ * For empty worksheets `data` is `[]`.
+ *
+ * ---
+ *
+ * Example response:
+ *
+ * ```
+ * {
+ *   "updated": "2014-11-19T10:20:18.068Z",
+ *   "title": "foobar",
+ *   "data": [
+ *     {
+ *       "foo": "bar",
+ *       "baz": 42,
+ *       "boing": null
+ *     },
+ *     // more rows ...
+ *   ]
+ * }
+ * ```
+ */
+export function getWorksheetById(spreadsheetId: string, worksheetId: string): Promise<WorksheetFromId>;
+
+/*
+ * Returns information about a spreadsheet including a list of worksheets.
+ *
+ * ---
+ *
+ * Example response:
+ *
+ * ```
+ * {
+ *   "updated": "2014-11-19T10:20:18.068Z",
+ *   "title": "My Awesome Spreadsheet",
+ *   "worksheets": [
+ *     {
+ *       "id": "od6",
+ *       "title": "foobar"
+ *     },
+ *     // more worksheets ...
+ *   ]
+ * }
+ * ```
+ */
+export function getSpreadsheet(spreadsheetId: string): Promise<Spreadsheet>;

--- a/types/gsheets/tsconfig.json
+++ b/types/gsheets/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "gsheets-tests.ts"
+    ]
+}

--- a/types/gsheets/tslint.json
+++ b/types/gsheets/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.