### PR TITLE
bytebuffer - Add proper overloads for functions to reflect returned types

### DIFF
--- a/types/bytebuffer/bytebuffer-tests.ts
+++ b/types/bytebuffer/bytebuffer-tests.ts
@@ -1,8 +1,14 @@
+import * as ByteBuffer from 'bytebuffer';
 
+var bb = new ByteBuffer().writeIString('Hello world!').flip();
+console.log(bb.readIString() + ' from bytebuffer.js');
 
-import ByteBuffer = require("bytebuffer");
-
-var bb = new ByteBuffer()
-            .writeIString("Hello world!")
-            .flip();
-console.log(bb.readIString()+" from bytebuffer.js");
+// Test overloads typings
+const shouldBeBuffer = bb.writeVString('test');
+if (shouldBeBuffer !== bb) {
+    throw new Error('writeVString without offset specified, should return itself.');
+}
+const shouldBeNumber = bb.writeVString('test', 4);
+if (typeof shouldBeNumber !== 'number') {
+    throw new Error('Invalid type returned!');
+}

--- a/types/bytebuffer/index.d.ts
+++ b/types/bytebuffer/index.d.ts
@@ -1,22 +1,22 @@
 // Type definitions for bytebuffer.js 5.0.0
 // Project: https://github.com/dcodeIO/bytebuffer.js
-// Definitions by: Denis Cappellin <https://github.com/cappellin>
+// Definitions by: Denis Cappellin <https://github.com/dcappellin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Definitions by: SINTEF-9012 <https://github.com/SINTEF-9012>
+// Definitions by: Marek Urbanowicz <https://github.com/murbanowicz>
 
 /// <reference types="node" />
-import Long = require("long");
+import Long = require('long');
 
 declare namespace ByteBuffer {}
 export = ByteBuffer;
 export as namespace ByteBuffer;
 
-declare class ByteBuffer
-{
+declare class ByteBuffer {
     /**
      * Constructs a new ByteBuffer.
      */
-    constructor( capacity?: number, littleEndian?: boolean, noAssert?: boolean );
+    constructor(capacity?: number, littleEndian?: boolean, noAssert?: boolean);
 
     /**
      * Big endian constant that can be used instead of its boolean value. Evaluates to false.
@@ -106,77 +106,82 @@ declare class ByteBuffer
     /**
      * Allocates a new ByteBuffer backed by a buffer of the specified capacity.
      */
-    static allocate( capacity?: number, littleEndian?: boolean, noAssert?: boolean ): ByteBuffer;
+    static allocate(capacity?: number, littleEndian?: boolean, noAssert?: boolean): ByteBuffer;
 
     /**
      * Decodes a base64 encoded string to binary like window.atob does.
      */
-    static atob( b64: string ): string;
+    static atob(b64: string): string;
 
     /**
      * Encodes a binary string to base64 like window.btoa does.
      */
-    static btoa( str: string ): string;
+    static btoa(str: string): string;
 
     /**
      * Calculates the number of UTF8 bytes of a string.
      */
-    static calculateUTF8Bytes( str: string ): number;
+    static calculateUTF8Bytes(str: string): number;
 
     /**
      * Calculates the number of UTF8 characters of a string.JavaScript itself uses UTF- 16, so that a string's length property does not reflect its actual UTF8 size if it contains code points larger than 0xFFFF.
      */
-    static calculateUTF8Chars( str: string ): number;
+    static calculateUTF8Chars(str: string): number;
 
     /**
      * Calculates the number of UTF8 bytes of a string. This is an alias of ByteBuffer#calculateUTF8Bytes.
      */
-    static calculateString( str: string ): number;
+    static calculateString(str: string): number;
 
     /**
      * Calculates the actual number of bytes required to store a 32bit base 128 variable-length integer.
      */
-    static calculateVarint32( value: number ): number;
+    static calculateVarint32(value: number): number;
 
     /**
      * Calculates the actual number of bytes required to store a 64bit base 128 variable-length integer.
      */
-    static calculateVarint64( value: number | Long ): number;
+    static calculateVarint64(value: number | Long): number;
 
     /**
      * Concatenates multiple ByteBuffers into one.
      */
-    static concat( buffers: Array<ByteBuffer | Buffer | ArrayBuffer | Uint8Array | string>, encoding?: string | boolean, litteEndian?: boolean, noAssert?: boolean ): ByteBuffer;
+    static concat(
+        buffers: Array<ByteBuffer | Buffer | ArrayBuffer | Uint8Array | string>,
+        encoding?: string | boolean,
+        litteEndian?: boolean,
+        noAssert?: boolean,
+    ): ByteBuffer;
 
     /**
      * Decodes a base64 encoded string to a ByteBuffer.
      */
-    static fromBase64( str: string, littleEndian?: boolean, noAssert?: boolean ): ByteBuffer;
+    static fromBase64(str: string, littleEndian?: boolean, noAssert?: boolean): ByteBuffer;
 
     /**
      * Decodes a binary encoded string, that is using only characters 0x00-0xFF as bytes, to a ByteBuffer.
      */
-    static fromBinary( str: string, littleEndian?: boolean, noAssert?: boolean ): ByteBuffer;
+    static fromBinary(str: string, littleEndian?: boolean, noAssert?: boolean): ByteBuffer;
 
     /**
      * Decodes a hex encoded string with marked offsets to a ByteBuffer.
      */
-    static fromDebug( str: string, littleEndian?: boolean, noAssert?: boolean ): ByteBuffer;
+    static fromDebug(str: string, littleEndian?: boolean, noAssert?: boolean): ByteBuffer;
 
     /**
      * Decodes a hex encoded string to a ByteBuffer.
      */
-    static fromHex( str: string, littleEndian?: boolean, noAssert?: boolean ): ByteBuffer;
+    static fromHex(str: string, littleEndian?: boolean, noAssert?: boolean): ByteBuffer;
 
     /**
      * Decodes an UTF8 encoded string to a ByteBuffer.
      */
-    static fromUTF8( str: string, littleEndian?: boolean, noAssert?: boolean ): ByteBuffer;
+    static fromUTF8(str: string, littleEndian?: boolean, noAssert?: boolean): ByteBuffer;
 
     /**
      * Gets the backing buffer type.
      */
-    static isByteBuffer( bb: any ): boolean;
+    static isByteBuffer(bb: any): boolean;
 
     /**
      * Wraps a buffer or a string. Sets the allocated ByteBuffer's ByteBuffer#offset to 0 and its ByteBuffer#limit to the length of the wrapped data.
@@ -185,52 +190,61 @@ declare class ByteBuffer
      * @param littleEndian Whether to use little or big endian byte order. Defaults to ByteBuffer.DEFAULT_ENDIAN.
      * @param noAssert Whether to skip assertions of offsets and values. Defaults to ByteBuffer.DEFAULT_NOASSERT.
      */
-    static wrap( buffer: ByteBuffer | Buffer | ArrayBuffer | Uint8Array | string, enc?: string | boolean, littleEndian?: boolean, noAssert?: boolean ): ByteBuffer;
+    static wrap(
+        buffer: ByteBuffer | Buffer | ArrayBuffer | Uint8Array | string,
+        enc?: string | boolean,
+        littleEndian?: boolean,
+        noAssert?: boolean,
+    ): ByteBuffer;
 
     /**
      * Decodes a zigzag encoded signed 32bit integer.
      */
-    static zigZagDecode32( n: number ): number;
+    static zigZagDecode32(n: number): number;
 
     /**
      * Decodes a zigzag encoded signed 64bit integer.
      */
-    static zigZagDecode64( n: number | Long ): Long;
+    static zigZagDecode64(n: number | Long): Long;
 
     /**
      * Zigzag encodes a signed 32bit integer so that it can be effectively used with varint encoding.
      */
-    static zigZagEncode32( n: number ): number;
+    static zigZagEncode32(n: number): number;
 
     /**
      * Zigzag encodes a signed 64bit integer so that it can be effectively used with varint encoding.
      */
-    static zigZagEncode64( n: number | Long ): Long;
+    static zigZagEncode64(n: number | Long): Long;
 
     /**
      * Switches (to) big endian byte order.
      */
-    BE( bigEndian?: boolean ): ByteBuffer;
+    BE(bigEndian?: boolean): ByteBuffer;
 
     /**
      * Switches (to) little endian byte order.
      */
-    LE( bigEndian?: boolean ): ByteBuffer;
+    LE(bigEndian?: boolean): ByteBuffer;
 
     /**
      * Appends some data to this ByteBuffer. This will overwrite any contents behind the specified offset up to the appended data's length.
      */
-    append( source: ByteBuffer | Buffer | ArrayBuffer | Uint8Array | string, encoding?: string | number, offset?: number ): ByteBuffer;
+    append(
+        source: ByteBuffer | Buffer | ArrayBuffer | Uint8Array | string,
+        encoding?: string | number,
+        offset?: number,
+    ): ByteBuffer;
 
     /**
      * Appends this ByteBuffer's contents to another ByteBuffer. This will overwrite any contents behind the specified offset up to the length of this ByteBuffer's data.
      */
-    appendTo( target: ByteBuffer, offset?: number ): ByteBuffer;
+    appendTo(target: ByteBuffer, offset?: number): ByteBuffer;
 
     /**
      * Enables or disables assertions of argument types and offsets. Assertions are enabled by default but you can opt to disable them if your code already makes sure that everything is valid.
      */
-    assert( assert: boolean ): ByteBuffer;
+    assert(assert: boolean): ByteBuffer;
 
     /**
      * Gets the capacity of this ByteBuffer's backing buffer.
@@ -246,32 +260,32 @@ declare class ByteBuffer
     /**
      * Creates a cloned instance of this ByteBuffer, preset with this ByteBuffer's values for ByteBuffer#offset, ByteBuffer#markedOffset and ByteBuffer#limit.
      */
-    clone( copy?: boolean ): ByteBuffer;
+    clone(copy?: boolean): ByteBuffer;
 
     /**
      * Compacts this ByteBuffer to be backed by a ByteBuffer#buffer of its contents' length. Contents are the bytes between ByteBuffer#offset and ByteBuffer#limit. Will set offset = 0 and limit = capacity and adapt ByteBuffer#markedOffset to the same relative position if set.
      */
-    compact( begin?: number, end?: number ): ByteBuffer;
+    compact(begin?: number, end?: number): ByteBuffer;
 
     /**
      * Creates a copy of this ByteBuffer's contents. Contents are the bytes between ByteBuffer#offset and ByteBuffer#limit.
      */
-    copy( begin?: number, end?: number ): ByteBuffer;
+    copy(begin?: number, end?: number): ByteBuffer;
 
     /**
      * Copies this ByteBuffer's contents to another ByteBuffer. Contents are the bytes between ByteBuffer#offset and ByteBuffer#limit.
      */
-    copyTo( target: ByteBuffer, targetOffset?: number, sourceOffset?: number, sourceLimit?: number ): ByteBuffer;
+    copyTo(target: ByteBuffer, targetOffset?: number, sourceOffset?: number, sourceLimit?: number): ByteBuffer;
 
     /**
      * Makes sure that this ByteBuffer is backed by a ByteBuffer#buffer of at least the specified capacity. If the current capacity is exceeded, it will be doubled. If double the current capacity is less than the required capacity, the required capacity will be used instead.
      */
-    ensureCapacity( capacity: number ): ByteBuffer;
+    ensureCapacity(capacity: number): ByteBuffer;
 
     /**
      * Overwrites this ByteBuffer's contents with the specified value. Contents are the bytes between ByteBuffer#offset and ByteBuffer#limit.
      */
-    fill( value: number | string, begin?: number, end?: number ): ByteBuffer;
+    fill(value: number | string, begin?: number, end?: number): ByteBuffer;
 
     /**
      * Makes this ByteBuffer ready for a new sequence of write or relative read operations. Sets limit = offset and offset = 0. Make sure always to flip a ByteBuffer when all relative read or write operations are complete.
@@ -281,156 +295,169 @@ declare class ByteBuffer
     /**
      * Marks an offset on this ByteBuffer to be used later.
      */
-    mark( offset?: number ): ByteBuffer;
+    mark(offset?: number): ByteBuffer;
 
     /**
      * Sets the byte order.
      */
-    order( littleEndian: boolean ): ByteBuffer;
+    order(littleEndian: boolean): ByteBuffer;
 
     /**
      * Prepends some data to this ByteBuffer. This will overwrite any contents before the specified offset up to the prepended data's length. If there is not enough space available before the specified offset, the backing buffer will be resized and its contents moved accordingly.
      */
-    prepend( source: ByteBuffer | string | ArrayBuffer | Buffer, encoding?: string | number, offset?: number ): ByteBuffer;
+    prepend(
+        source: ByteBuffer | string | ArrayBuffer | Buffer,
+        encoding?: string | number,
+        offset?: number,
+    ): ByteBuffer;
 
     /**
      * Prepends this ByteBuffer to another ByteBuffer. This will overwrite any contents before the specified offset up to the prepended data's length. If there is not enough space available before the specified offset, the backing buffer will be resized and its contents moved accordingly.
      */
-    prependTo( target: ByteBuffer, offset?: number ): ByteBuffer;
+    prependTo(target: ByteBuffer, offset?: number): ByteBuffer;
 
     /**
      * Prints debug information about this ByteBuffer's contents.
      */
-    printDebug( out?: ( text: string ) => void ): void;
+    printDebug(out?: (text: string) => void): void;
 
     /**
      * Reads an 8bit signed integer. This is an alias of ByteBuffer#readInt8.
      */
-    readByte( offset?: number ): number;
+    readByte(offset?: number): number;
 
     /**
      * Reads the specified number of bytes
      */
-    readBytes( length: number, offset?: number): ByteBuffer;
+    readBytes(length: number, offset?: number): ByteBuffer;
 
     /**
      * Reads a NULL-terminated UTF8 encoded string. For this to work the string read must not contain any NULL characters itself.
      */
-    readCString( offset?: number ): string;
+    readCString(): string;
+    readCString(offset: number): { string: string; length: number };
 
     /**
      * Reads a 64bit float. This is an alias of ByteBuffer#readFloat64.
      */
-    readDouble( offset?: number ): number;
+    readDouble(offset?: number): number;
 
     /**
      * Reads a 32bit float. This is an alias of ByteBuffer#readFloat32.
      */
-    readFloat( offset?: number ): number;
+    readFloat(offset?: number): number;
 
     /**
      * Reads a 32bit float.
      */
-    readFloat32( offset?: number ): number;
+    readFloat32(offset?: number): number;
 
     /**
      * Reads a 64bit float.
      */
-    readFloat64( offset?: number ): number;
+    readFloat64(offset?: number): number;
 
     /**
      * Reads a length as uint32 prefixed UTF8 encoded string.
      */
-    readIString( offset?: number ): string | { string: string; length: number };
+    readIString(): string;
+    readIString(offset: number): { string: string; length: number };
 
     /**
      * Reads a 32bit signed integer.This is an alias of ByteBuffer#readInt32.
      */
-    readInt( offset?: number ): number;
+    readInt(offset?: number): number;
 
     /**
      * Reads a 16bit signed integer.
      */
-    readInt16( offset?: number ): number;
+    readInt16(offset?: number): number;
 
     /**
      * Reads a 32bit signed integer.
      */
-    readInt32( offset?: number ): number;
+    readInt32(offset?: number): number;
 
     /**
      * Reads a 64bit signed integer.
      */
-    readInt64( offset?: number ): Long;
+    readInt64(offset?: number): Long;
 
     /**
      * Reads an 8bit signed integer.
      */
-    readInt8( offset?: number ): number;
+    readInt8(offset?: number): number;
 
     /**
      * Reads a 64bit signed integer. This is an alias of ByteBuffer#readInt64.
      */
-    readLong( offset?: number ): Long;
+    readLong(offset?: number): Long;
 
     /**
      * Reads a 16bit signed integer. This is an alias of ByteBuffer#readInt16.
      */
-    readShort( offset?: number ): number;
+    readShort(offset?: number): number;
 
     /**
      * Reads an UTF8 encoded string. This is an alias of ByteBuffer#readUTF8String.
      */
-    readString( length: number, metrics?: number, offset?: number ): string;
+    readString(length: number, metrics?: number): string;
+    readString(length: number, metrics: number, offset: number): { string: string; length: number };
 
     /**
      * Reads an UTF8 encoded string.
      */
-    readUTF8String( chars: number, metrics?: number, offset?: number ): string | { string: string; length: number };
+    readUTF8String(chars: number, metrics?: number): string;
+    readUTF8String(chars: number, metrics: number, offset: number): { string: string; length: number };
 
     /**
      * Reads a 16bit unsigned integer.
      */
-    readUint16( offset?: number ): number;
+    readUint16(offset?: number): number;
 
     /**
      * Reads a 32bit unsigned integer.
      */
-    readUint32( offset?: number ): number;
+    readUint32(offset?: number): number;
 
     /**
      * Reads a 64bit unsigned integer.
      */
-    readUint64( offset?: number ): Long;
+    readUint64(offset?: number): Long;
     /**
      * Reads an 8bit unsigned integer.
      */
-    readUint8( offset?: number ): number;
+    readUint8(offset?: number): number;
 
     /**
      * Reads a length as varint32 prefixed UTF8 encoded string.
      */
-    readVString( offset?: number ): string;
+    readVString(): string;
+    readVString(offset: number): { string: string; length: number };
 
     /**
      * Reads a 32bit base 128 variable-length integer.
      */
-    readVarint32( offset?: number ): number;
+    readVarint32(): number;
+    readVarint32(offset: number): { value: number; length: number };
 
     /**
      * Reads a zig-zag encoded 32bit base 128 variable-length integer.
      */
-    readVarint32ZigZag( offset?: number ): number;
+    readVarint32ZigZag(): number;
+    readVarint32ZigZag(offset: number): { value: number; length: number };
 
     /**
      * Reads a 64bit base 128 variable-length integer. Requires Long.js.
      */
-    readVarint64( offset?: number ): Long;
+    readVarint64(): Long;
+    readVarint64(offset: number): { value: Long; length: number };
 
     /**
      * Reads a zig-zag encoded 64bit base 128 variable-length integer. Requires Long.js.
      */
-    readVarint64ZigZag( offset?: number ): Long;
+    readVarint64ZigZag(): Long;
+    readVarint64ZigZag(offset: number): { value: Long; length: number };
 
     /**
      * Gets the number of remaining readable bytes. Contents are the bytes between ByteBuffer#offset and ByteBuffer#limit, so this returns limit - offset.
@@ -445,45 +472,45 @@ declare class ByteBuffer
     /**
      * Resizes this ByteBuffer to be backed by a buffer of at least the given capacity. Will do nothing if already that large or larger.
      */
-    resize( capacity: number ): ByteBuffer;
+    resize(capacity: number): ByteBuffer;
 
     /**
      * Reverses this ByteBuffer's contents
      */
-    reverse( begin?: number, end?: number ): ByteBuffer;
+    reverse(begin?: number, end?: number): ByteBuffer;
 
     /**
      * Skips the next length bytes. This will just advance
      */
-    skip( length: number ): ByteBuffer;
+    skip(length: number): ByteBuffer;
 
     /**
      * Slices this ByteBuffer by creating a cloned instance with offset = begin and limit = end.
      */
-    slice( begin?: number, end?: number ): ByteBuffer;
+    slice(begin?: number, end?: number): ByteBuffer;
 
     /**
      * Returns a raw buffer compacted to contain this ByteBuffer's contents. Contents are the bytes between ByteBuffer#offset and ByteBuffer#limit. Will transparently ByteBuffer#flip this ByteBuffer if offset > limit but the actual offsets remain untouched. This is an alias of ByteBuffer#toBuffer.
      */
-    toArrayBuffer( forceCopy?: boolean ): ArrayBuffer;
+    toArrayBuffer(forceCopy?: boolean): ArrayBuffer;
 
     /**
      * Encodes this ByteBuffer's contents to a base64 encoded string.
      */
-    toBase64( begin?: number, end?: number ): string;
+    toBase64(begin?: number, end?: number): string;
 
     /**
      * Encodes this ByteBuffer to a binary encoded string, that is using only characters 0x00-0xFF as bytes.
      */
-    toBinary( begin?: number, end?: number ): string;
+    toBinary(begin?: number, end?: number): string;
 
     /**
      * Returns a copy of the backing buffer that contains this ByteBuffer's contents. Contents are the bytes between ByteBuffer#offset and ByteBuffer#limit. Will transparently ByteBuffer#flip this ByteBuffer if offset > limit but the actual offsets remain untouched.
      */
-    toBuffer( forceCopy?: boolean ): Buffer;
+    toBuffer(forceCopy?: boolean): Buffer;
 
     /**
-      *Encodes this ByteBuffer to a hex encoded string with marked offsets. Offset symbols are:
+     *Encodes this ByteBuffer to a hex encoded string with marked offsets. Offset symbols are:
      *  < : offset,
      *  ' : markedOffset,
      *  > : limit,
@@ -492,17 +519,17 @@ declare class ByteBuffer
      *  ] : markedOffset and limit,
      *  ! : offset, markedOffset and limit
      */
-    toDebug( columns?: boolean ): string | Array<string>
+    toDebug(columns?: boolean): string | Array<string>;
 
     /**
      * Encodes this ByteBuffer's contents to a hex encoded string.
      */
-    toHex( begin?: number, end?: number ): string;
+    toHex(begin?: number, end?: number): string;
 
     /**
      * Converts the ByteBuffer's contents to a string.
      */
-    toString( encoding?: string ): string;
+    toString(encoding?: string): string;
 
     /**
      * Encodes this ByteBuffer's contents between ByteBuffer#offset and ByteBuffer#limit to an UTF8 encoded string.
@@ -512,130 +539,141 @@ declare class ByteBuffer
     /**
      * Writes an 8bit signed integer. This is an alias of ByteBuffer#writeInt8.
      */
-    writeByte( value: number, offset?: number ): ByteBuffer;
+    writeByte(value: number, offset?: number): ByteBuffer;
 
     /**
      * Writes an array of bytes. This is an alias for append
      */
-    writeBytes( source: ByteBuffer | Buffer | ArrayBuffer | Uint8Array | string, encoding?: string | number, offset?: number ): ByteBuffer;
+    writeBytes(
+        source: ByteBuffer | Buffer | ArrayBuffer | Uint8Array | string,
+        encoding?: string | number,
+        offset?: number,
+    ): ByteBuffer;
 
     /**
      * Writes a NULL-terminated UTF8 encoded string. For this to work the specified string must not contain any NULL characters itself.
      */
-    writeCString( str: string, offset?: number ): ByteBuffer;
+    writeCString(str: string, offset?: number): ByteBuffer;
 
     /**
      * Writes a 64bit float. This is an alias of ByteBuffer#writeFloat64.
      */
-    writeDouble( value: number, offset?: number ): ByteBuffer;
+    writeDouble(value: number, offset?: number): ByteBuffer;
 
     /**
      * Writes a 32bit float. This is an alias of ByteBuffer#writeFloat32.
      */
-    writeFloat( value: number, offset?: number ): ByteBuffer;
+    writeFloat(value: number, offset?: number): ByteBuffer;
 
     /**
      * Writes a 32bit float.
      */
-    writeFloat32( value: number, offset?: number ): ByteBuffer;
+    writeFloat32(value: number, offset?: number): ByteBuffer;
 
     /**
      * Writes a 64bit float.
      */
-    writeFloat64( value: number, offset?: number ): ByteBuffer;
+    writeFloat64(value: number, offset?: number): ByteBuffer;
 
     /**
      * Writes a length as uint32 prefixed UTF8 encoded string.
      */
-    writeIString( str: string, offset?: number ): ByteBuffer;
+    writeIString(str: string, offset?: number): ByteBuffer;
 
     /**
      * Writes a 32bit signed integer. This is an alias of ByteBuffer#writeInt32.
      */
-    writeInt( value: number, offset?: number ): ByteBuffer;
+    writeInt(value: number, offset?: number): ByteBuffer;
 
     /**
      * Writes a 16bit signed integer.
      */
-    writeInt16( value: number, offset?: number ): ByteBuffer;
+    writeInt16(value: number, offset?: number): ByteBuffer;
 
     /**
      * Writes a 32bit signed integer.
      */
-    writeInt32( value: number, offset?: number ): ByteBuffer;
+    writeInt32(value: number, offset?: number): ByteBuffer;
 
     /**
      * Writes a 64bit signed integer.
      */
-    writeInt64( value: number | Long, offset?: number ): ByteBuffer;
+    writeInt64(value: number | Long, offset?: number): ByteBuffer;
 
     /**
      * Writes an 8bit signed integer.
      */
-    writeInt8( value: number, offset?: number ): ByteBuffer;
+    writeInt8(value: number, offset?: number): ByteBuffer;
 
     /**
      * Write a 64bit signed integer. This is an alias of ByteBuffer#writeInt64.
      */
-     writeLong( value: number | Long, offset?: number ): ByteBuffer;
+    writeLong(value: number | Long, offset?: number): ByteBuffer;
 
     /**
      * Writes a 16bit signed integer. This is an alias of ByteBuffer#writeInt16.
      */
-    writeShort( value: number, offset?: number ): ByteBuffer;
+    writeShort(value: number, offset?: number): ByteBuffer;
 
     /**
      * Writes an UTF8 encoded string. This is an alias of ByteBuffer#writeUTF8String.
      */
-    writeString( str: string, offset?: number ): ByteBuffer | number;
+    writeString(str: string): ByteBuffer;
+    writeString(str: string, offset: number): number;
 
     /**
      * Writes an UTF8 encoded string.
      */
-    writeUTF8String( str: string, offset?: number ): ByteBuffer | number;
+    writeUTF8String(str: string): ByteBuffer;
+    writeUTF8String(str: string, offset?: number): number;
 
     /**
      * Writes a 16bit unsigned integer.
      */
-    writeUint16( value: number, offset?: number ): ByteBuffer;
+    writeUint16(value: number, offset?: number): ByteBuffer;
 
     /**
      * Writes a 32bit unsigned integer.
      */
-    writeUint32( value: number, offset?: number ): ByteBuffer;
+    writeUint32(value: number, offset?: number): ByteBuffer;
 
     /**
      * Writes a 64bit unsigned integer.
      */
-    writeUint64( value: number | Long, offset?: number ): ByteBuffer;
+    writeUint64(value: number | Long, offset?: number): ByteBuffer;
 
     /**
      * Writes an 8bit unsigned integer.
      */
-    writeUint8( value: number, offset?: number ): ByteBuffer;
+    writeUint8(value: number, offset?: number): ByteBuffer;
 
     /**
      * Writes a length as varint32 prefixed UTF8 encoded string.
      */
-    writeVString( str: string, offset?: number ): ByteBuffer | number;
+    writeVString(str: string): ByteBuffer;
+    writeVString(str: string, offset: number): number;
 
     /**
      * Writes a 32bit base 128 variable-length integer.
      */
-    writeVarint32( value: number, offset?: number ): ByteBuffer | number;
+    writeVarint32(value: number): ByteBuffer;
+    writeVarint32(value: number, offset: number): number;
 
     /**
      * Writes a zig-zag encoded 32bit base 128 variable-length integer.
      */
-    writeVarint32ZigZag( value: number, offset?: number ): ByteBuffer | number;
+    writeVarint32ZigZag(value: number): ByteBuffer;
+    writeVarint32ZigZag(value: number, offset: number): number;
 
     /**
      * Writes a 64bit base 128 variable-length integer.
      */
-    writeVarint64( value: number | Long, offset?: number ): ByteBuffer;
+    writeVarint64(value: number | Long): ByteBuffer;
+    writeVarint64(value: number | Long, offset: number): number;
 
     /**
      * Writes a zig-zag encoded 64bit base 128 variable-length integer.
      */
-    writeVarint64ZigZag( value: number | Long, offset?: number ): ByteBuffer | number;
+    writeVarint64ZigZag(value: number | Long): ByteBuffer;
+    writeVarint64ZigZag(value: number | Long, offset: number): number;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/protobufjs/bytebuffer.js/wiki/API#bytebufferreadistringoffset

Returned types for changed functions are strictly related to the functions signatures, so I did add them, so there is no need to cast the values anymore as the returned types with omitted or not omited offset are predictable.

