### PR TITLE
[memoizee]: automatically get normalizer argument type

### DIFF
--- a/types/memoizee/index.d.ts
+++ b/types/memoizee/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Juan Picado <https://github.com/juanpicado>
 //                 Patrick Muff <https://github.com/dislick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.1
 
 declare namespace memoizee {
   interface Options<F extends (...args: any[]) => any> {

--- a/types/memoizee/index.d.ts
+++ b/types/memoizee/index.d.ts
@@ -1,10 +1,11 @@
 // Type definitions for memoizee 0.4
 // Project: https://github.com/medikoo/memoizee
 // Definitions by: Juan Picado <https://github.com/juanpicado>
+//                 Patrick Muff <https://github.com/dislick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace memoizee {
-  interface Options {
+  interface Options<F extends (...args: any[]) => any> {
     length?: number | false;
     maxAge?: number;
     max?: number;
@@ -13,7 +14,7 @@ declare namespace memoizee {
     dispose?(value: any): void;
     async?: boolean;
     primitive?: boolean;
-    normalizer?(args: any[]): string;
+    normalizer?(args: Parameters<F>): string;
     resolvers?: Array<(arg: any) => any>;
   }
 
@@ -24,6 +25,6 @@ declare namespace memoizee {
 }
 
 // tslint:disable-next-line ban-types
-declare function memoizee<F extends Function>(f: F, options?: memoizee.Options): F & memoizee.Memoized<F>;
+declare function memoizee<F extends (...args: any[]) => any>(f: F, options?: memoizee.Options<F>): F & memoizee.Memoized<F>;
 
 export = memoizee;

--- a/types/memoizee/memoizee-tests.ts
+++ b/types/memoizee/memoizee-tests.ts
@@ -26,7 +26,7 @@ memoized.clear('bar', 7); // Dispose called with bar7 value
 memoized.delete('foo', 0);
 const mFn = memoize((hash: any) => {
     // body of memoized function
-}, { normalizer: (args: any[]) => {
+}, { normalizer: (args) => {
     // args is arguments object as accessible in memoized function
     return JSON.stringify(args[0]);
 } });
@@ -59,3 +59,9 @@ setTimeout(() => {
 setTimeout(() => {
   memoized('foo', 3);
 }, 1300);
+
+memoize((foo: string, bar: number) => 42, {
+  normalizer: ([foo, bar]) => { // normalizer argument should be typed
+    return foo + bar.toFixed();
+  }
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/medikoo/memoizee#cache-id-resolution-normalization
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

### Changes

The memoizee package memoizes a function. As a second argument it accepts options, one of which is a cache id normalizer:

```typescript
memoize((foo: string, bar: number) => 42, {
  normalizer: (args) => { // previously args has been any[]
    return args[0] + args[1].toFixed();
  }
});
```

This PR now adds type definitions to the `args` parameter of the normalizer function.

```typescript
memoize((foo: string, bar: number) => 42, {
  normalizer: (args) => { // args is now [string, number|
    return args[0] + args[1].toFixed();
  }
});
```