### PR TITLE
Fix Webpack hot middleware definition

### DIFF
--- a/types/webpack-hot-middleware/index.d.ts
+++ b/types/webpack-hot-middleware/index.d.ts
@@ -19,7 +19,7 @@ declare function WebpackHotMiddleware(
 ): NextHandleFunction & WebpackHotMiddleware.EventStream;
 
 declare namespace WebpackHotMiddleware {
-	interface ClientOptions {
+	interface Options {
 		path?: string;
 		reload?: boolean;
 		name?: string;

--- a/types/webpack-hot-middleware/webpack-hot-middleware-tests.ts
+++ b/types/webpack-hot-middleware/webpack-hot-middleware-tests.ts
@@ -12,7 +12,7 @@ webpackHotMiddlewareInstance = webpackHotMiddleware(compiler, {
 	heartbeat: 2000
 });
 
-const clientOpts: webpackHotMiddleware.ClientOptions = {
+const clientOpts: webpackHotMiddleware.Options = {
 	path: '/__webpack_hmr',
 	reload: true,
 	name: '__webpack_hmr_custom_bundle_name',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack-contrib/webpack-hot-middleware#config
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


This fixes this problem https://github.com/webpack-contrib/webpack-hot-middleware/issues/380

