### PR TITLE
feat: add types for babel-plugin-glaze

### DIFF
--- a/types/babel-plugin-glaze/babel-plugin-glaze-tests.tsx
+++ b/types/babel-plugin-glaze/babel-plugin-glaze-tests.tsx
@@ -3,9 +3,5 @@ function CustomComponent() {
 }
 
 function App() {
-    return (
-        <div sx={{ fontWeight: 'bold' }}>
-            <CustomComponent />
-        </div>
-    );
+    return <CustomComponent sx={{ fontWeight: 'bold' }} />;
 }

--- a/types/babel-plugin-glaze/babel-plugin-glaze-tests.tsx
+++ b/types/babel-plugin-glaze/babel-plugin-glaze-tests.tsx
@@ -1,0 +1,11 @@
+function CustomComponent() {
+    return <p sx={{ color: 'green' }}>Hello, world!</p>;
+}
+
+function App() {
+    return (
+        <div sx={{ fontWeight: 'bold' }}>
+            <CustomComponent />
+        </div>
+    );
+}

--- a/types/babel-plugin-glaze/index.d.ts
+++ b/types/babel-plugin-glaze/index.d.ts
@@ -2,10 +2,10 @@
 // Project: https://github.com/kripod/glaze/blob/master/packages/babel-plugin-glaze/README.md
 // Definitions by: Kristóf Poduszló <https://github.com/DefinitelyTyped>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-import {} from 'react';
+// TypeScript Version: 3.8
 
 import { ThemedStyle } from 'glaze';
+import {} from 'react';
 
 declare module 'react' {
     interface Attributes {

--- a/types/babel-plugin-glaze/index.d.ts
+++ b/types/babel-plugin-glaze/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for babel-plugin-glaze 0.5
 // Project: https://github.com/kripod/glaze/blob/master/packages/babel-plugin-glaze/README.md
-// Definitions by: Kristóf Poduszló <https://github.com/DefinitelyTyped>
+// Definitions by: Kristóf Poduszló <https://github.com/kripod>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.8
 

--- a/types/babel-plugin-glaze/index.d.ts
+++ b/types/babel-plugin-glaze/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for babel-plugin-glaze 0.5
+// Project: https://github.com/kripod/glaze/blob/master/packages/babel-plugin-glaze/README.md
+// Definitions by: Kristóf Poduszló <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import {} from 'react';
+
+import { ThemedStyle } from 'glaze';
+
+declare module 'react' {
+    interface Attributes {
+        sx?: ThemedStyle;
+    }
+}

--- a/types/babel-plugin-glaze/package.json
+++ b/types/babel-plugin-glaze/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "glaze": ">=0.5.1"
+    "glaze": ">=0.5.1",
+    "treat": "^1.2.4"
   }
 }

--- a/types/babel-plugin-glaze/package.json
+++ b/types/babel-plugin-glaze/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "glaze": ">=0.5.1"
+  }
+}

--- a/types/babel-plugin-glaze/tsconfig.json
+++ b/types/babel-plugin-glaze/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
+            "dom",
             "es6"
         ],
         "noImplicitAny": true,

--- a/types/babel-plugin-glaze/tsconfig.json
+++ b/types/babel-plugin-glaze/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "babel-plugin-glaze-tests.tsx"
+    ]
+}

--- a/types/babel-plugin-glaze/tsconfig.json
+++ b/types/babel-plugin-glaze/tsconfig.json
@@ -5,6 +5,7 @@
             "dom",
             "es6"
         ],
+        "jsx": "preserve",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/babel-plugin-glaze/tslint.json
+++ b/types/babel-plugin-glaze/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Before evaluating this PR, please merge https://github.com/microsoft/types-publisher/pull/766 to avoid a build failure.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
