### PR TITLE
[@types/jquery] Update generic type variable for find function

### DIFF
--- a/types/jquery-ajax-chain/jquery-ajax-chain-tests.ts
+++ b/types/jquery-ajax-chain/jquery-ajax-chain-tests.ts
@@ -94,7 +94,7 @@ function test_optional_parameters(): void {
         transform: function (xmlResponse): Object {
 
             let $tempXmlResponse: JQuery,
-                $tempItems: JQuery,
+                $tempItems: JQuery<Element>,
                 nextCallDataObj: Object;
 
             $tempXmlResponse = $(xmlResponse);

--- a/types/jquery/JQuery.d.ts
+++ b/types/jquery/JQuery.d.ts
@@ -4135,7 +4135,7 @@ $( "p" )
      */
     find<K extends keyof HTMLElementTagNameMap>(selector_element: K | JQuery<K>): JQuery<HTMLElementTagNameMap[K]>;
     find<K extends keyof SVGElementTagNameMap>(selector_element: K | JQuery<K>): JQuery<SVGElementTagNameMap[K]>;
-    find<E extends HTMLElement>(selector_element: JQuery.Selector | E | JQuery<E>): JQuery<E>;
+    find<E extends Element>(selector_element: JQuery.Selector | E | JQuery<E>): JQuery<E>;
     /**
      * Stop the currently-running animation, remove all queued animations, and complete all animations for the matched elements.
      * @param queue The name of the queue in which to stop animations.

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -24,7 +24,7 @@
 //                 Terry Mun <https://github.com/terrymun>
 //                 Martin Badin <https://github.com/martin-badin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.7
 
 /// <reference types="sizzle" />
 /// <reference path="JQueryStatic.d.ts" />

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -5852,7 +5852,7 @@ function JQuery() {
             // $ExpectType JQuery<HTMLSpanElement>
             $('p').find('span');
 
-            // $ExpectType JQuery<HTMLElement>
+            // $ExpectType JQuery<Element>
             $('p').find('.class-name');
 
             // $ExpectType JQuery<HTMLElement>
@@ -5860,6 +5860,9 @@ function JQuery() {
 
             // $ExpectType JQuery<HTMLSpanElement>
             $('p').find(new HTMLSpanElement());
+
+            // $ExpectType JQuery<Element>
+            $('p').find(new Element());
 
             // $ExpectType JQuery<HTMLElement>
             $('p').find($('span'));

--- a/types/jqueryui/jqueryui-tests.ts
+++ b/types/jqueryui/jqueryui-tests.ts
@@ -405,7 +405,7 @@ function test_sortable() {
         drop: function (event, ui) {
             var $item = $(this);
             var $list = $($item.find("a").attr("href"))
-                .find(".connectedSortable");
+                .find<HTMLElement>(".connectedSortable");
             ui.draggable.hide("slow", function () {
                 $tabs.tabs("select", $tab_items.index($item));
                 $(this).appendTo($list).show("slow");


### PR DESCRIPTION
This PR fixes the generic type of the find function reported in my previous PR also I upgrade TS version to 2.7 because we are using now `SVGElementTagNameMap` which was added to version 2.7 in this PR https://github.com/microsoft/TypeScript/issues/14783.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43857#issuecomment-616574030

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
