### PR TITLE
:bug: Typo in Dockerode: IPv4Address(Ipv4Address) in NetworkContainer

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -411,7 +411,7 @@ declare namespace Dockerode {
         Name: string;
         EndpointID: string;
         MacAddress: string;
-        Ipv4Address: string;
+        IPv4Address: string;
         IPv6Address: string;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [doc of docker](https://docs.docker.com/engine/api/v1.40/#operation/NetworkInspect)

```
"Containers": {
    "19a4d5d687db25203351ed79d478946f861258f018fe384f229f2efa4b23513c": {
        "Name": "test",
        "EndpointID": "628cadb8bcb92de107b2a1e516cbffe463e321f548feb37697cce00ad694f21a",
        "MacAddress": "02:42:ac:13:00:02",
        "IPv4Address": "172.19.0.2/16",
        "IPv6Address": ""
    }
},
```


---

Before this fix, `NetworkContainer[containerId].IPv4Address` can't pass the type check, though it can return the right value.