### PR TITLE
[sharp] update typings to 0.25

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sharp 0.24
+// Type definitions for sharp 0.25
 // Project: https://github.com/lovell/sharp
 // Definitions by: François Nguyen <https://github.com/lith-light-g>
 //                 Wooseop Kim <https://github.com/wooseopkim>
@@ -247,27 +247,6 @@ declare namespace sharp {
          * @returns A promise that resolves with a stats object
          */
         stats(): Promise<Stats>;
-
-        /**
-         * Do not process input images where the number of pixels (width _ height) exceeds this limit.
-         * Assumes image dimensions contained in the input metadata can be trusted.
-         * The default limit is 268402689 (0x3FFF _ 0x3FFF) pixels.
-         * @param limit An integral Number of pixels, zero or false to remove limit, true to use default limit.
-         * @throws {Error} Invalid limit
-         * @returns A sharp instance that can be used to chain operations
-         * @deprecated since version 0.24.0 - moved to @see sharp.SharpOptions
-         */
-        limitInputPixels(limit: number | boolean): Sharp;
-
-        /**
-         * An advanced setting that switches the libvips access method to VIPS_ACCESS_SEQUENTIAL.
-         * This will reduce memory usage and can improve performance on some systems.
-         * The default behaviour before function call is false, meaning the libvips access method is not sequential.
-         * @param sequentialRead true to enable and false to disable (defaults to true)
-         * @returns A sharp instance that can be used to chain operations
-         * @deprecated since version 0.24.0 - moved to @see sharp.SharpOptions
-         */
-        sequentialRead(sequentialRead?: boolean): Sharp;
 
         //#endregion
 
@@ -968,7 +947,7 @@ declare namespace sharp {
         skipBlanks?: number;
         /** Tile container, with value fs (filesystem) or zip (compressed file). (optional, default 'fs') */
         container?: string;
-        /** Filesystem layout, possible values are dz, zoomify or google. (optional, default 'dz') */
+        /** Filesystem layout, possible values are dz, iiif, zoomify or google. (optional, default 'dz') */
         layout?: TileLayout;
     }
 
@@ -1022,7 +1001,7 @@ declare namespace sharp {
         srgb: string;
     }
 
-    type TileLayout = 'dz' | 'zoomify' | 'google';
+    type TileLayout = 'dz' | 'iiif' | 'zoomify' | 'google';
 
     type Blend = 'clear' | 'source' | 'over' | 'in' | 'out' | 'atop' | 'dest' | 'dest-over' | 'dest-in' | 'dest-out' | 'dest-atop'  | 'xor' | 'add' | 'saturate' | 'multiply' | 'screen' | 'overlay'
                  | 'darken' | 'lighten' | 'colour-dodge' | 'colour-dodge' | 'colour-burn' | 'colour-burn' | 'hard-light' | 'soft-light' | 'difference' | 'exclusion';

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -253,3 +253,22 @@ sharp('input.gif')
     .modulate({ hue: 180 })
     .modulate({ brightness: 0.5, saturation: 0.5, hue: 90 })
 ;
+
+// From https://sharp.pixelplumbing.com/api-output#examples-9
+// Extract raw RGB pixel data from JPEG input
+sharp('input.jpg')
+  .raw()
+  .toBuffer({ resolveWithObject: true })
+  .then(({data, info}) => {
+    console.log(data);
+    console.log(info);
+  });
+
+// From https://sharp.pixelplumbing.com/api-output#examples-9
+// Extract alpha channel as raw pixel data from PNG input
+sharp('input.png')
+.ensureAlpha()
+.extractChannel(3)
+.toColourspace('b-w')
+.raw()
+.toBuffer();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - Remove methods limitInputPixels() and sequentialRead() (previously deprecated in v0.24.0): https://sharp.pixelplumbing.com/changelog#v0250---7th-march-2020
    - Add 'iiif' option to .tile(): https://github.com/lovell/sharp/pull/2098
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.