### PR TITLE
Eliminate return only generic in gapi.client

### DIFF
--- a/types/gapi.client/index.d.ts
+++ b/types/gapi.client/index.d.ts
@@ -24,7 +24,7 @@ declare namespace gapi {
          * Creates a HTTP request for making RESTful requests.
          * An object encapsulating the various arguments for this method.
          */
-        function request<T>(args: {
+        function request(args: {
             /**
              * The URL to handle the request
              */
@@ -50,7 +50,7 @@ declare namespace gapi {
             //  */
             // callback?: () => any;
         // tslint:disable-next-line:no-unnecessary-generics
-        }): Request<T>;
+        }): Request<any>;
 
         /**
          * Sets the API key for the application.

--- a/types/gapi.client/index.d.ts
+++ b/types/gapi.client/index.d.ts
@@ -49,7 +49,6 @@ declare namespace gapi {
             //  * If supplied, the request is executed immediately and no gapi.client.HttpRequest object is returned
             //  */
             // callback?: () => any;
-        // tslint:disable-next-line:no-unnecessary-generics
         }): Request<any>;
 
         /**
@@ -142,8 +141,7 @@ declare namespace gapi {
         /**
          * Creates a batch object for batching individual requests.
          */
-        // tslint:disable-next-line:no-unnecessary-generics
-        function newBatch<T>(): Batch<T>;
+        function newBatch(): Batch<any>;
     }
 
     namespace auth {


### PR DESCRIPTION
This typing construct adds no information.
