### PR TITLE
[electron-prompt] Fix type property for options

### DIFF
--- a/types/electron-prompt/electron-prompt-tests.ts
+++ b/types/electron-prompt/electron-prompt-tests.ts
@@ -2,6 +2,7 @@ import prompt = require('electron-prompt');
 import { BrowserWindow } from 'electron';
 
 prompt({
+    type: 'input',
     inputAttrs: {
         type: 'url',
     },

--- a/types/electron-prompt/index.d.ts
+++ b/types/electron-prompt/index.d.ts
@@ -49,7 +49,7 @@ declare namespace prompt {
          * The type of input field, either `'input'` for a standard text input
          * field or 'select' for a dropdown type input. Defaults to `'input'`.
          */
-        type?: `'input'` | 'select';
+        type?: 'input' | 'select';
         /**
          * Whether the label should be interpreted as HTML or not. Defaults to
          * `false`.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/p-sam/electron-prompt
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Re-opening https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43865 since the original author didn't respond anymore.