### PR TITLE
koa-ratelimit: Missing support for ioredis

### DIFF
--- a/types/koa-ratelimit/index.d.ts
+++ b/types/koa-ratelimit/index.d.ts
@@ -7,6 +7,7 @@
 
 import { Middleware, Context } from "koa";
 import { RedisClient } from "redis";
+import { Redis } from "ioredis";
 
 declare function KoaRatelimit(options?: KoaRatelimit.MiddlewareOptions): Middleware;
 
@@ -37,7 +38,7 @@ declare namespace KoaRatelimit {
         /**
          * The database powering the backing rate-limiter package.
          */
-        db: RedisClient | Map<any, any>;
+        db: Redis | RedisClient | Map<any, any>;
 
         /**
          * The length of a single limiting period. This value is expressed


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/ratelimit#with-a-redis-driver
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Using `ioredis` is actually the example from the README.