### PR TITLE
@types/webpack: Add readFile/readFileSync to OutputFileSystem

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1339,6 +1339,8 @@ declare namespace webpack {
         rmdir(path: string, callback: (err: Error | undefined | null) => void): void;
         unlink(path: string, callback: (err: Error | undefined | null) => void): void;
         writeFile(path: string, data: any, callback: (err: Error | undefined | null) => void): void;
+        readFile(path: string, callback: (err: Error | undefined | null, contents: Buffer) => void): void;
+        readFileSync(path: string): Buffer;
     }
 
     interface SortableSet<T> extends Set<T> {


### PR DESCRIPTION
Sometimes it's required to access files in the output file system, e.g. from the webpack-dev-middleware.
This is done using readFile/readFileSync.

Many tutorials in the internet describe that
https://medium.com/@tkh44/setting-up-your-front-end-dev-environment-with-webpack-with-hapi-b352ab8b2f9c
https://medium.com/@binyamin/creating-a-node-express-webpack-app-with-dev-and-prod-builds-a4962ce51334

And this is even described in books:
https://books.google.de/books?id=sxhKDwAAQBAJ&pg=PA75&lpg=PA75&dq=compiler.outputFileSystem+readFileSync&source=bl&ots=6I8Alr_Qo9&sig=ACfU3U3AF4Flzrp1z0DgRehnKd-y7yncqg&hl=de&sa=X&ved=2ahUKEwjypr7q8_noAhWSUBUIHbNCD5MQ6AEwBXoECAoQAQ#v=onepage&q=compiler.outputFileSystem%20readFileSync&f=false

So, I've added these two methods.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
