### PR TITLE
Make the default theme empty so users can extend it

### DIFF
--- a/types/react-with-styles/index.d.ts
+++ b/types/react-with-styles/index.d.ts
@@ -4,7 +4,7 @@
 //                 Brie Bunge <https://github.com/brieb>
 //                 Joe Lencioni <https://github.com/lencioni>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.2
 
 import * as React from 'react';
 import * as PropTypes from 'prop-types';

--- a/types/react-with-styles/index.d.ts
+++ b/types/react-with-styles/index.d.ts
@@ -10,7 +10,8 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { CSSProperties } from 'aphrodite';
 
-interface Theme { [key: string]: any; }
+// tslint:disable-next-line no-empty-interface
+interface Theme {}
 
 interface WithStylesProps<T = Theme> {
     /**

--- a/types/react-with-styles/lib/WithStylesContext.d.ts
+++ b/types/react-with-styles/lib/WithStylesContext.d.ts
@@ -1,4 +1,4 @@
 import { Context } from "react";
 
-declare const context: Context<{ stylesInterface: any, stylesTheme: any }>;
+declare const context: Context<{ stylesInterface: any, stylesTheme: any, direction?: any }>;
 export default context;

--- a/types/react-with-styles/react-with-styles-tests.ts
+++ b/types/react-with-styles/react-with-styles-tests.ts
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { withStyles, WithStylesProps, css } from 'react-with-styles';
 
+declare module 'react-with-styles' {
+  export interface Theme {
+    unit: number;
+  }
+}
+ 
 const Component: React.FC<WithStylesProps> = ({ styles }) =>
   React.createElement('div', { ...css(styles.wrapper) });
 

--- a/types/react-with-styles/react-with-styles-tests.ts
+++ b/types/react-with-styles/react-with-styles-tests.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { withStyles, WithStylesProps, css } from 'react-with-styles';
 
 declare module 'react-with-styles' {
-  export interface Theme {
+  interface Theme {
     unit: number;
   }
 }

--- a/types/react-with-styles/react-with-styles-tests.ts
+++ b/types/react-with-styles/react-with-styles-tests.ts
@@ -6,7 +6,7 @@ declare module 'react-with-styles' {
     unit: number;
   }
 }
- 
+
 const Component: React.FC<WithStylesProps> = ({ styles }) =>
   React.createElement('div', { ...css(styles.wrapper) });
 


### PR DESCRIPTION
Similar to styled-components we're allowing users to declare their themes using interface augmentation. 