### PR TITLE
feat(confusing-browser-globals): new type definition

### DIFF
--- a/types/confusing-browser-globals/confusing-browser-globals-tests.ts
+++ b/types/confusing-browser-globals/confusing-browser-globals-tests.ts
@@ -1,0 +1,8 @@
+import globals = require('confusing-browser-globals');
+
+globals; // $ExpectType ConfusingGlobal[]
+globals[0]; // $ExpectTYpe string
+Array.isArray(globals); // $ExpectType boolean
+const rules = {
+    'no-restricted-globals': ['error'].concat(globals),
+};

--- a/types/confusing-browser-globals/index.d.ts
+++ b/types/confusing-browser-globals/index.d.ts
@@ -1,0 +1,72 @@
+// Type definitions for confusing-browser-globals 1.0
+// Project: https://github.com/facebook/create-react-app/tree/master/packages/confusing-browser-globals#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type ConfusingGlobal =
+    | 'addEventListener'
+    | 'blur'
+    | 'close'
+    | 'closed'
+    | 'confirm'
+    | 'defaultStatus'
+    | 'defaultstatus'
+    | 'event'
+    | 'external'
+    | 'find'
+    | 'focus'
+    | 'frameElement'
+    | 'frames'
+    | 'history'
+    | 'innerHeight'
+    | 'innerWidth'
+    | 'length'
+    | 'location'
+    | 'locationbar'
+    | 'menubar'
+    | 'moveBy'
+    | 'moveTo'
+    | 'name'
+    | 'onblur'
+    | 'onerror'
+    | 'onfocus'
+    | 'onload'
+    | 'onresize'
+    | 'onunload'
+    | 'open'
+    | 'opener'
+    | 'opera'
+    | 'outerHeight'
+    | 'outerWidth'
+    | 'pageXOffset'
+    | 'pageYOffset'
+    | 'parent'
+    | 'print'
+    | 'removeEventListener'
+    | 'resizeBy'
+    | 'resizeTo'
+    | 'screen'
+    | 'screenLeft'
+    | 'screenTop'
+    | 'screenX'
+    | 'screenY'
+    | 'scroll'
+    | 'scrollbars'
+    | 'scrollBy'
+    | 'scrollTo'
+    | 'scrollX'
+    | 'scrollY'
+    | 'self'
+    | 'status'
+    | 'statusbar'
+    | 'stop'
+    | 'toolbar'
+    | 'top';
+
+declare const ConfusingGlobals: ConfusingGlobal[];
+
+/**
+ * A curated list of browser globals that commonly cause confusion
+ * and are not recommended to use without an explicit window. qualifier.
+ */
+export = ConfusingGlobals;

--- a/types/confusing-browser-globals/tsconfig.json
+++ b/types/confusing-browser-globals/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "confusing-browser-globals-tests.ts"
+    ]
+}

--- a/types/confusing-browser-globals/tslint.json
+++ b/types/confusing-browser-globals/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- declaration file
- tests

https://github.com/facebook/create-react-app/tree/master/packages/confusing-browser-globals#confusing-browser-globals

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
