### PR TITLE
node/globals.d.ts Add BufferEncoding interface to toString method

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -327,7 +327,7 @@ declare class Buffer extends Uint8Array {
     write(string: string, encoding?: BufferEncoding): number;
     write(string: string, offset: number, encoding?: BufferEncoding): number;
     write(string: string, offset: number, length: number, encoding?: BufferEncoding): number;
-    toString(encoding?: string, start?: number, end?: number): string;
+    toString(encoding?: BufferEncoding, start?: number, end?: number): string;
     toJSON(): { type: 'Buffer'; data: number[] };
     equals(otherBuffer: Uint8Array): boolean;
     compare(


### PR DESCRIPTION
I imagine that this is the correct typing for the method.

I made this change locally and it helped me a lot.