### PR TITLE
[react-map-gl] Add missing type and improve PointerEvent type

### DIFF
--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -48,6 +48,7 @@ export interface MapboxProps extends Partial<ViewState> {
     container?: object;
     gl?: object;
     mapboxApiAccessToken?: string;
+    mapboxApiUrl?: string;
     attributionControl?: boolean;
     preserveDrawingBuffer?: boolean;
     reuseMaps?: boolean;
@@ -202,7 +203,7 @@ export class MapController implements BaseMapController {
     updateViewport(newMapState: MapState, extraProps: any, extraState: ExtraState): void;
 }
 
-export interface PointerEvent {
+export interface PointerEvent extends MouseEvent {
     type: string;
     point: [number, number];
     lngLat: [number, number];

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -125,7 +125,7 @@ class MyMap extends React.Component<{}, State> {
                         id="raster-tiles-source"
                         type="raster"
                         scheme="tms"
-                        tiles={['path/to/tiles/{z}/{x}/{y}.png']}
+                        tiles={["path/to/tiles/{z}/{x}/{y}.png"]}
                         tileSize={256}
                     >
                         <Layer

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -170,9 +170,9 @@ class MyMap extends React.Component<{}, State> {
 
     private readonly setRefInteractive = (el: InteractiveMap) => {
         this.map = el.getMap();
-    };
+    }
 
     private readonly setRefStatic = (el: StaticMap) => {
         this.map = el.getMap();
-    };
+    }
 }

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -1,22 +1,24 @@
+import * as MapboxGL from 'mapbox-gl';
 import * as React from 'react';
+
 import {
-    InteractiveMap,
     CanvasOverlay,
-    SVGOverlay,
-    HTMLOverlay,
+    CanvasRedrawOptions,
     FullscreenControl,
     GeolocateControl,
-    ScaleControl,
-    CanvasRedrawOptions,
+    HTMLOverlay,
     HTMLRedrawOptions,
-    SVGRedrawOptions,
-    StaticMap,
-    ViewportProps,
-    Source,
+    InteractiveMap,
     Layer,
     LinearInterpolator,
+    SVGOverlay,
+    SVGRedrawOptions,
+    ScaleControl,
+    Source,
+    StaticMap,
+    ViewportProps,
 } from 'react-map-gl';
-import * as MapboxGL from 'mapbox-gl';
+
 import { FeatureCollection } from 'geojson';
 
 interface State {
@@ -53,9 +55,13 @@ class MyMap extends React.Component<{}, State> {
                 <InteractiveMap
                     {...this.state.viewport}
                     mapboxApiAccessToken="pk.test"
+                    mapboxApiUrl="http://url.test"
                     ref={this.setRefInteractive}
                     onViewportChange={viewport => this.setState({ viewport })}
                     onViewStateChange={({ viewState }) => this.setState({ viewport: viewState })}
+                    onContextMenu={event => {
+                        event.preventDefault();
+                    }}
                 >
                     <FullscreenControl className="test-class" container={document.querySelector('body')} />
                     <GeolocateControl
@@ -119,7 +125,7 @@ class MyMap extends React.Component<{}, State> {
                         id="raster-tiles-source"
                         type="raster"
                         scheme="tms"
-                        tiles={["path/to/tiles/{z}/{x}/{y}.png"]}
+                        tiles={['path/to/tiles/{z}/{x}/{y}.png']}
                         tileSize={256}
                     >
                         <Layer
@@ -164,9 +170,9 @@ class MyMap extends React.Component<{}, State> {
 
     private readonly setRefInteractive = (el: InteractiveMap) => {
         this.map = el.getMap();
-    }
+    };
 
     private readonly setRefStatic = (el: StaticMap) => {
         this.map = el.getMap();
-    }
+    };
 }


### PR DESCRIPTION
Add missing `mapboxApiUrl` type to the MapboxProps. This was throwing a TypeScript error for a valid prop.

Extend PointerEvent with MouseEvent as it is a MouseEvent with additional fields. This was throwing a TypeScript error when trying to do things like `event.preventDefault();`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://visgl.github.io/react-map-gl/docs/api-reference/static-map
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
