### PR TITLE
Fix asynciterator callbacks not accepting undefined

### DIFF
--- a/types/asynciterator/asynciterator-tests.ts
+++ b/types/asynciterator/asynciterator-tests.ts
@@ -1,5 +1,6 @@
 import { ArrayIterator, AsyncIterator, BufferedIterator, ClonedIterator, EmptyIterator, IntegerIterator,
   MultiTransformIterator, SingletonIterator, SimpleTransformIterator, TransformIterator } from "asynciterator";
+import * as fs from "fs";
 
 function test_asynciterator() {
     // We can't instantiate an abstract class.
@@ -64,6 +65,8 @@ function test_asynciterator() {
     const intit2: IntegerIterator = AsyncIterator.range(10, 100);
     const intit3: IntegerIterator = AsyncIterator.range(10);
     const intit4: IntegerIterator = AsyncIterator.range();
+
+    const wrapit = AsyncIterator.wrap(fs.createReadStream('stream.txt'));
 }
 
 function test_emptyiterator() {

--- a/types/asynciterator/asynciterator-tests.ts
+++ b/types/asynciterator/asynciterator-tests.ts
@@ -38,6 +38,15 @@ function test_asynciterator() {
     const str: string = it1.toString();
 
     const stit1: SimpleTransformIterator<number, string> = it1.transform();
+    const stit1_: SimpleTransformIterator<number, string> = it1.transform({
+      transform: (item, done) => {
+        if (item === 0) {
+          done();
+        } else {
+          done('' + item);
+        }
+      },
+    });
     const stit2: SimpleTransformIterator<number, string> = it1.map((number: number) => 'i' + number);
     const stit3: AsyncIterator<string> = it1.map((number: number) => 'i' + number);
     const stit4: AsyncIterator<number> = it2.map(parseInt);

--- a/types/asynciterator/index.d.ts
+++ b/types/asynciterator/index.d.ts
@@ -134,7 +134,7 @@ export class TransformIterator<S, T> extends BufferedIterator<T> {
     source: AsyncIterator<S>;
 
     _validateSource(source: AsyncIterator<S>, allowDestination?: boolean): void;
-    _transform(item: S, done: (result: T) => void): void;
+    _transform(item: S, done: (result?: T) => void): void;
     _closeWhenDone(): void;
 
     constructor(source?: AsyncIterator<S> | TransformIteratorOptions<S>, options?: TransformIteratorOptions<S>);
@@ -148,7 +148,7 @@ export interface SimpleTransformIteratorOptions<S, T> extends TransformIteratorO
 
     filter?(item: S): boolean;
     map?(item: S): T;
-    transform?(item: S, callback: (result: T) => void): void;
+    transform?(item: S, callback: (result?: T) => void): void;
 }
 
 export class SimpleTransformIterator<S, T> extends TransformIterator<S, T> {
@@ -159,7 +159,7 @@ export class SimpleTransformIterator<S, T> extends TransformIterator<S, T> {
 
     _filter?(item: S): boolean;
     _map?(item: S): T;
-    _transform(item: S, done: (result: T) => void): void;
+    _transform(item: S, done: (result?: T) => void): void;
 
     _insert(inserter: AsyncIterator<S>, done: () => void): void;
 

--- a/types/asynciterator/index.d.ts
+++ b/types/asynciterator/index.d.ts
@@ -75,6 +75,8 @@ export abstract class AsyncIterator<T> implements EventEmitter {
     prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
     prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
     eventNames(): Array<string | symbol>;
+
+    static wrap<S>(source?: AsyncIterator<S> | TransformIteratorOptions<S> | NodeJS.ReadableStream, options?: TransformIteratorOptions<S>): TransformIterator<S, any>;
 }
 
 export class EmptyIterator<T> extends AsyncIterator<T> {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/RubenVerborgh/AsyncIterator/
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
