### PR TITLE
[mongodb] UpdateQuery is not readonly

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1234,20 +1234,16 @@ type KeysOfOtherType<TSchema, Type> = {
 }[keyof TSchema];
 
 type AcceptedFields<TSchema, FieldType, AssignableType> = {
-    readonly [key in KeysOfAType<TSchema, FieldType>]?: AssignableType;
+    [key in KeysOfAType<TSchema, FieldType>]?: AssignableType;
 };
 
 /** It avoid uses fields of non Type */
 type NotAcceptedFields<TSchema, FieldType> = {
-    readonly [key in KeysOfOtherType<TSchema, FieldType>]?: never;
+    [key in KeysOfOtherType<TSchema, FieldType>]?: never;
 };
 
 type DotAndArrayNotation<AssignableType> = {
-    readonly [key: string]: AssignableType;
-};
-
-type ReadonlyPartial<TSchema> = {
-    readonly [key in keyof TSchema]?: TSchema[key];
+    [key: string]: AssignableType;
 };
 
 export type OnlyFieldsOfType<TSchema, FieldType = any, AssignableType = FieldType> = AcceptedFields<
@@ -1258,7 +1254,7 @@ export type OnlyFieldsOfType<TSchema, FieldType = any, AssignableType = FieldTyp
     NotAcceptedFields<TSchema, FieldType> &
     DotAndArrayNotation<AssignableType>;
 
-export type MatchKeysAndValues<TSchema> = ReadonlyPartial<TSchema> & DotAndArrayNotation<any>;
+export type MatchKeysAndValues<TSchema> = Partial<TSchema> & DotAndArrayNotation<any>;
 
 type Unpacked<Type> = Type extends Array<infer Element> ? Element : Type;
 
@@ -1278,31 +1274,31 @@ export type ArrayOperator<Type> = {
 };
 
 export type SetFields<TSchema> = ({
-    readonly [key in KeysOfAType<TSchema, any[] | undefined>]?: UpdateOptionalId<Unpacked<TSchema[key]>> | AddToSetOperators<Array<UpdateOptionalId<Unpacked<TSchema[key]>>>>;
+    [key in KeysOfAType<TSchema, any[] | undefined>]?: UpdateOptionalId<Unpacked<TSchema[key]>> | AddToSetOperators<Array<UpdateOptionalId<Unpacked<TSchema[key]>>>>;
 } &
     NotAcceptedFields<TSchema, any[] | undefined>) & {
-    readonly [key: string]: AddToSetOperators<any> | any;
+    [key: string]: AddToSetOperators<any> | any;
 };
 
 export type PushOperator<TSchema> = ({
-    readonly [key in KeysOfAType<TSchema, any[]>]?: UpdateOptionalId<Unpacked<TSchema[key]>> | ArrayOperator<Array<UpdateOptionalId<Unpacked<TSchema[key]>>>>;
+    [key in KeysOfAType<TSchema, any[]>]?: UpdateOptionalId<Unpacked<TSchema[key]>> | ArrayOperator<Array<UpdateOptionalId<Unpacked<TSchema[key]>>>>;
 } &
     NotAcceptedFields<TSchema, any[]>) & {
-    readonly [key: string]: ArrayOperator<any> | any;
+    [key: string]: ArrayOperator<any> | any;
 };
 
 export type PullOperator<TSchema> = ({
-    readonly [key in KeysOfAType<TSchema, any[]>]?: Partial<Unpacked<TSchema[key]>> | ObjectQuerySelector<Unpacked<TSchema[key]>>;
+    [key in KeysOfAType<TSchema, any[]>]?: Partial<Unpacked<TSchema[key]>> | ObjectQuerySelector<Unpacked<TSchema[key]>>;
 } &
     NotAcceptedFields<TSchema, any[]>) & {
-    readonly [key: string]: QuerySelector<any> | any;
+    [key: string]: QuerySelector<any> | any;
 };
 
 export type PullAllOperator<TSchema> = ({
-    readonly [key in KeysOfAType<TSchema, any[]>]?: TSchema[key];
+    [key in KeysOfAType<TSchema, any[]>]?: TSchema[key];
 } &
     NotAcceptedFields<TSchema, any[]>) & {
-    readonly [key: string]: any[];
+    [key: string]: any[];
 };
 
 /** https://docs.mongodb.com/manual/reference/operator/update */

--- a/types/mongodb/test/collection/updateX.ts
+++ b/types/mongodb/test/collection/updateX.ts
@@ -200,6 +200,37 @@ async function run() {
     // buildUpdateQuery({ $push: { 'dot.notation': 1 } });
     // buildUpdateQuery({ $push: { 'subInterfaceArray.$[]': { $in: ['a'] } } });
 
+    const updateMutated: UpdateQuery<TestModel> = {
+        $inc: {
+            numberField: 1
+        },
+        $pull: {
+            fruitTags: 'a'
+        },
+        $push: {
+            fruitTags: 'b'
+        },
+        $set: {
+            stringField: 'foo'
+        },
+        $unset: {
+            numberField: 1
+        }
+    };
+    if (updateMutated.$pull) {
+        delete updateMutated.$pull.fruitTags;
+    }
+    if (updateMutated.$push) {
+        delete updateMutated.$push.numberFfruitTagsield;
+    }
+    if (updateMutated.$set) {
+        delete updateMutated.$set.stringField;
+    }
+    if (updateMutated.$unset) {
+        delete updateMutated.$unset.numberField;
+    }
+    buildUpdateQuery(updateMutated);
+
     collectionTType.updateOne({ stringField: 'bla' }, justASample);
 
     collectionTType.updateMany(


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

There's no reason why an update object can't be mutated before being used. In complex applications building such an object can be influenced by many conditions and factors.