### PR TITLE
[camunda-external-task-client-js] fixed incorrect return types on getAll and getAllTyped

### DIFF
--- a/types/camunda-external-task-client-js/camunda-external-task-client-js-tests.ts
+++ b/types/camunda-external-task-client-js/camunda-external-task-client-js-tests.ts
@@ -42,6 +42,9 @@ client.subscribe('', {}, (args: HandlerArgs) => {
     task.topicName;
     task.workerId;
 
-    taskService.handleFailure(task, {});
-    taskService.complete(task);
+    taskService.unlock(task); // $ExpectType Promise<void>
+    taskService.extendLock(task, 0); // $ExpectType Promise<void>
+    taskService.handleBpmnError(task, ''); // $ExpectType Promise<void>
+    taskService.handleFailure(task, {}); // $ExpectType Promise<void>
+    taskService.complete(task); // $ExpectType Promise<void>
 });

--- a/types/camunda-external-task-client-js/camunda-external-task-client-js-tests.ts
+++ b/types/camunda-external-task-client-js/camunda-external-task-client-js-tests.ts
@@ -2,7 +2,7 @@ import { Client, HandlerArgs, Task, TaskService, TopicSubscription, Variables } 
 
 new Client({ baseUrl: '' }); // $ExpectType Client
 new Variables(); // $ExpectType Variables
-new Variables().set('a', 42).getAllTyped(); // $ExpectType TypedValue[]
+new Variables().set('a', 42).getAllTyped(); // $ExpectType TypedValueMap
 
 const client: Client = new Client({ baseUrl: '' }); // $ExpectType Client
 client.on('subscribe', (topic: string, topicSubscription: TopicSubscription) => {});

--- a/types/camunda-external-task-client-js/index.d.ts
+++ b/types/camunda-external-task-client-js/index.d.ts
@@ -90,11 +90,11 @@ export interface TypedValue {
 }
 
 export interface TaskService {
-    complete(task: Task, processVariables?: Variables, localVariables?: Variables): void;
-    handleFailure(task: Task, options?: HandleFailureOptions): void;
-    handleBpmnError(task: Task, errorCode: string, errorMessage?: string, variables?: Variables): void;
-    extendLock(task: Task, newDuration: number): void;
-    unlock(task: Task): void;
+    complete(task: Task, processVariables?: Variables, localVariables?: Variables): Promise<void>;
+    handleFailure(task: Task, options?: HandleFailureOptions): Promise<void>;
+    handleBpmnError(task: Task, errorCode: string, errorMessage?: string, variables?: Variables): Promise<void>;
+    extendLock(task: Task, newDuration: number): Promise<void>;
+    unlock(task: Task): Promise<void>;
 }
 
 export interface HandleFailureOptions {

--- a/types/camunda-external-task-client-js/index.d.ts
+++ b/types/camunda-external-task-client-js/index.d.ts
@@ -33,15 +33,23 @@ export interface ClientConfig {
     use?: Middleware | Middleware[];
 }
 
+export interface ValueMap {
+    [key: string]: Value;
+}
+
+export interface TypedValueMap {
+    [key: string]: TypedValue;
+}
+
 export class Variables {
     get(variableName: string): Value;
     getTyped(variableName: string): TypedValue;
-    getAll(): Value[];
-    getAllTyped(): TypedValue[];
+    getAll(): ValueMap;
+    getAllTyped(): TypedValueMap;
     set(variableName: string, value: Value): Variables;
     setTyped(variableName: string, typedValue: TypedValue): Variables;
-    setAll(values: { [key: string]: Value }): Variables;
-    setAllTyped(typedValues: { [key: string]: TypedValue }): Variables;
+    setAll(values: ValueMap): Variables;
+    setAllTyped(typedValues: TypedValueMap): Variables;
 }
 
 export type Handler = (args: HandlerArgs) => void;


### PR DESCRIPTION
Fixed incorrect return types on Variables.getAll and Variables.getAllTyped of the [camunda-external-task-client-js](https://github.com/camunda/camunda-external-task-client-js) library. These functions return a map/object in the library but the typings incorrectly specify an array.

Also fixed incorrect return types on all methods in TaskService. These functions return promises in the library but the typings incorrectly specify void.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [camunda-external-task-client-js docs for getAll and getAllTyped](https://github.com/camunda/camunda-external-task-client-js/blob/master/docs/Variables.md#variablesgetall)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
