### PR TITLE
[mongodb] UpdateQuery accepts array objects with optional _id

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1262,6 +1262,8 @@ export type MatchKeysAndValues<TSchema> = ReadonlyPartial<TSchema> & DotAndArray
 
 type Unpacked<Type> = Type extends Array<infer Element> ? Element : Type;
 
+type UpdateOptionalId<T> = T extends { _id?: any } ? OptionalId<T> : T;
+
 export type SortValues = -1 | 1;
 
 export type AddToSetOperators<Type> = {
@@ -1276,14 +1278,14 @@ export type ArrayOperator<Type> = {
 };
 
 export type SetFields<TSchema> = ({
-    readonly [key in KeysOfAType<TSchema, any[] | undefined>]?: Unpacked<TSchema[key]> | AddToSetOperators<TSchema[key]>;
+    readonly [key in KeysOfAType<TSchema, any[] | undefined>]?: UpdateOptionalId<Unpacked<TSchema[key]>> | AddToSetOperators<Array<UpdateOptionalId<Unpacked<TSchema[key]>>>>;
 } &
     NotAcceptedFields<TSchema, any[] | undefined>) & {
     readonly [key: string]: AddToSetOperators<any> | any;
 };
 
 export type PushOperator<TSchema> = ({
-    readonly [key in KeysOfAType<TSchema, any[]>]?: Unpacked<TSchema[key]> | ArrayOperator<TSchema[key]>;
+    readonly [key in KeysOfAType<TSchema, any[]>]?: UpdateOptionalId<Unpacked<TSchema[key]>> | ArrayOperator<Array<UpdateOptionalId<Unpacked<TSchema[key]>>>>;
 } &
     NotAcceptedFields<TSchema, any[]>) & {
     readonly [key: string]: ArrayOperator<any> | any;

--- a/types/mongodb/test/collection/updateX.ts
+++ b/types/mongodb/test/collection/updateX.ts
@@ -1,4 +1,4 @@
-import { connect, UpdateQuery } from 'mongodb';
+import { connect, ObjectId, UpdateQuery } from 'mongodb';
 import { connectionString } from '../index';
 
 // collection.updateX tests
@@ -7,8 +7,9 @@ async function run() {
     const db = client.db('test');
 
     interface SubTestModel {
+        _id: ObjectId;
         field1: string;
-        field2: string;
+        field2?: string;
     }
 
     type FruitTypes = 'apple' | 'pear';
@@ -78,6 +79,8 @@ async function run() {
 
     buildUpdateQuery({ $set: { numberField: 1 } });
     buildUpdateQuery({ $set: { stringField: 'a' } });
+    // $ExpectError
+    buildUpdateQuery({ $set: { stringField: 123 } });
     buildUpdateQuery({ $set: { 'dot.notation': 2 } });
     buildUpdateQuery({ $set: { 'subInterfaceArray.$': -10 } });
     buildUpdateQuery({ $set: { 'subInterfaceArray.$[bla]': 40 } });
@@ -85,6 +88,8 @@ async function run() {
 
     buildUpdateQuery({ $setOnInsert: { numberField: 1 } });
     buildUpdateQuery({ $setOnInsert: { stringField: 'a' } });
+    // $ExpectError
+    buildUpdateQuery({ $setOnInsert: { stringField: 123 } });
     buildUpdateQuery({ $setOnInsert: { 'dot.notation': 2 } });
     buildUpdateQuery({ $setOnInsert: { 'subInterfaceArray.$': -10 } });
     buildUpdateQuery({ $setOnInsert: { 'subInterfaceArray.$[bla]': 40 } });
@@ -107,10 +112,36 @@ async function run() {
     buildUpdateQuery({ $rename: { numberField2: 'stringField' } });
 
     buildUpdateQuery({ $addToSet: { fruitTags: 'stringField' } });
+    // $ExpectError
+    buildUpdateQuery({ $addToSet: { fruitTags: 123 } });
     buildUpdateQuery({ $addToSet: { fruitTags: { $each: ['stringField'] } } });
     buildUpdateQuery({ $addToSet: { maybeFruitTags: 'apple' } });
     buildUpdateQuery({ $addToSet: { 'dot.notation': 'stringField' } });
     buildUpdateQuery({ $addToSet: { 'dot.notation': { $each: ['stringfield'] } } });
+    buildUpdateQuery({
+        $addToSet: {
+            subInterfaceArray: { field1: 'foo' }
+        }
+    });
+    buildUpdateQuery({
+        $addToSet: {
+            subInterfaceArray: {
+                _id: new ObjectId(),
+                field1: 'foo'
+            }
+        }
+    });
+    buildUpdateQuery({
+        $addToSet: {
+            subInterfaceArray: {
+                $each: [{ field1: 'foo' }]
+            }
+        }
+    });
+    buildUpdateQuery({
+        // $ExpectError
+        $addToSet: { subInterfaceArray: { field1: 123 } }
+    });
 
     buildUpdateQuery({ $pop: { fruitTags: 1 } });
     buildUpdateQuery({ $pop: { fruitTags: -1 } });
@@ -118,22 +149,54 @@ async function run() {
     buildUpdateQuery({ $pop: { 'subInterfaceArray.$[]': -1 } });
 
     buildUpdateQuery({ $pull: { fruitTags: 'a' } });
+    // $ExpectError
+    buildUpdateQuery({ $pull: { fruitTags: 123 } });
     buildUpdateQuery({ $pull: { fruitTags: { $in: ['a'] } } });
     buildUpdateQuery({ $pull: { maybeFruitTags: 'apple' } });
     buildUpdateQuery({ $pull: { 'dot.notation': 1 } });
     buildUpdateQuery({ $pull: { 'subInterfaceArray.$[]': { $in: ['a'] } } });
     buildUpdateQuery({ $pull: { subInterfaceArray: { field1: 'a' } }});
+    buildUpdateQuery({ $pull: { subInterfaceArray: { _id: { $in: [new ObjectId()] } }  }});
     buildUpdateQuery({ $pull: { subInterfaceArray: { field1: { $in: ['a'] } }  }});
 
     buildUpdateQuery({ $push: { fruitTags: 'a' } });
+    // $ExpectError
+    buildUpdateQuery({ $push: { fruitTags: 123 } });
     buildUpdateQuery({ $push: { fruitTags: { $each: ['a'] } } });
     buildUpdateQuery({ $push: { fruitTags: { $each: ['a'], $slice: 3 } } });
     buildUpdateQuery({ $push: { fruitTags: { $each: ['a'], $position: 1 } } });
     buildUpdateQuery({ $push: { fruitTags: { $each: ['a'], $sort: 1 } } });
     buildUpdateQuery({ $push: { fruitTags: { $each: ['a'], $sort: -1 } } });
+    buildUpdateQuery({ $push: { fruitTags: { $each: ['stringField'] } } });
     buildUpdateQuery({ $push: { fruitTags: { $each: ['a'], $sort: { 'sub.field': -1 } } } });
     buildUpdateQuery({ $push: { maybeFruitTags: 'apple' } });
-    // buildUpdateQuery({ $push: { fruitTags: { $each: ['stringField'] } } });
+    buildUpdateQuery({
+        $push: {
+            subInterfaceArray: { field1: 'foo' }
+        }
+    });
+    buildUpdateQuery({
+        $push: {
+            subInterfaceArray: {
+                _id: new ObjectId(),
+                field1: 'foo'
+            }
+        }
+    });
+    buildUpdateQuery({
+        $push: {
+            subInterfaceArray: {
+                $each: [{
+                    field1: 'foo',
+                    field2: 'bar'
+                }]
+            }
+        }
+    });
+    buildUpdateQuery({
+        // $ExpectError
+        $push: { subInterfaceArray: { field1: 123 } }
+    });
     // buildUpdateQuery({ $push: { 'dot.notation': 1 } });
     // buildUpdateQuery({ $push: { 'subInterfaceArray.$[]': { $in: ['a'] } } });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mongodb.com/manual/reference/operator/update-array/
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

The `_id` gets created automatically inside array objects, we should not need to pass it in.