### PR TITLE
[@types/meteor] Add arrayFilters to Update method in meteor/mongo 1.9.1

### DIFF
--- a/types/meteor/globals/mongo.d.ts
+++ b/types/meteor/globals/mongo.d.ts
@@ -170,6 +170,7 @@ declare module Mongo {
         update(selector: Selector<T> | ObjectID | string, modifier: Modifier<T>, options?: {
             multi?: boolean;
             upsert?: boolean;
+            arrayFilters? : { [identifier: string]: any }[];
         }, callback?: Function): number;
         upsert(selector: Selector<T> | ObjectID | string, modifier: Modifier<T>, options?: {
             multi?: boolean;

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -173,7 +173,7 @@ declare module "meteor/mongo" {
             update(selector: Selector<T> | ObjectID | string, modifier: Modifier<T>, options?: {
                 multi?: boolean;
                 upsert?: boolean;
-                arrayFilters? : any[];
+                arrayFilters? : { [identifier: string]: any }[];
             }, callback?: Function): number;
             upsert(selector: Selector<T> | ObjectID | string, modifier: Modifier<T>, options?: {
                 multi?: boolean;

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -173,6 +173,7 @@ declare module "meteor/mongo" {
             update(selector: Selector<T> | ObjectID | string, modifier: Modifier<T>, options?: {
                 multi?: boolean;
                 upsert?: boolean;
+                arrayFilters? : any[];
             }, callback?: Function): number;
             upsert(selector: Selector<T> | ObjectID | string, modifier: Modifier<T>, options?: {
                 multi?: boolean;


### PR DESCRIPTION
arrayFilters was added to meteor/mongo@1.9.1
updating type to reflect

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/meteor/meteor/commit/f0a94c60fd10c66d714f3a71d6444d1bae725d98>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
