### PR TITLE
`sinon-chai`: fix version of dependency `@types/chai`

### DIFF
--- a/types/sinon-chai/package.json
+++ b/types/sinon-chai/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "@types/chai": "^4.2.0"
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/40956

`@types/sinon-chai` now requires versions of `@types/chai` 4.2.0 and above, because it references `ChaiPlugin`, and `ChaiPlugin` was added in `@types/chai` 4.2.0: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37451#issuecomment-519584606

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.