### PR TITLE
[react-select]: add missing field

### DIFF
--- a/types/react-select/src/AsyncCreatable.d.ts
+++ b/types/react-select/src/AsyncCreatable.d.ts
@@ -19,7 +19,7 @@ export class AsyncCreatable<OptionType extends OptionTypeBase> extends Component
     blur(): void;
     loadOptions(inputValue: string, callback: (options: OptionsType<OptionType>) => void): void;
     handleInputChange: (newValue: string, actionMeta: InputActionMeta) => string;
-    onChange: (newValue: ValueType<OptionType>, actionMeta: ActionMeta) => void;
+    onChange: (newValue: ValueType<OptionType>, actionMeta: ActionMeta<OptionType>) => void;
 }
 
 export default AsyncCreatable;

--- a/types/react-select/src/Creatable.d.ts
+++ b/types/react-select/src/Creatable.d.ts
@@ -39,7 +39,7 @@ export class Creatable<OptionType extends OptionTypeBase> extends React.Componen
   static defaultProps: Props<any>;
   select: React.Ref<any>;
 
-  onChange: (newValue: ValueType<OptionType>, actionMeta: ActionMeta) => void;
+  onChange: (newValue: ValueType<OptionType>, actionMeta: ActionMeta<OptionType>) => void;
   focus(): void;
   blur(): void;
 }

--- a/types/react-select/src/Select.d.ts
+++ b/types/react-select/src/Select.d.ts
@@ -166,7 +166,7 @@ export interface Props<OptionType extends OptionTypeBase = { label: string; valu
   /* Handle blur events on the control */
   onBlur?: FocusEventHandler;
   /* Handle change events on the select */
-  onChange?: (value: ValueType<OptionType>, action: ActionMeta) => void;
+  onChange?: (value: ValueType<OptionType>, action: ActionMeta<OptionType>) => void;
   /* Handle focus events on the control */
   onFocus?: FocusEventHandler;
   /* Handle change events on the input */

--- a/types/react-select/src/stateManager.d.ts
+++ b/types/react-select/src/stateManager.d.ts
@@ -16,7 +16,7 @@ export interface Props<OptionType extends OptionTypeBase> {
   inputValue?: string;
   menuIsOpen?: boolean;
   value?: ValueType<OptionType>;
-  onChange?: (value: ValueType<OptionType>, actionMeta: ActionMeta) => void;
+  onChange?: (value: ValueType<OptionType>, actionMeta: ActionMeta<OptionType>) => void;
 }
 
 type StateProps<T extends SelectProps<any>> = Pick<T, Exclude<keyof T,
@@ -49,7 +49,7 @@ export class StateManager<
   blur(): void;
   getProp(key: string): any;
   callProp(name: string, ...args: any[]): any;
-  onChange: (value: ValueType<OptionType>, actionMeta: ActionMeta) => void;
+  onChange: (value: ValueType<OptionType>, actionMeta: ActionMeta<OptionType>) => void;
   onInputChange: (value: ValueType<OptionType>, actionMeta: InputActionMeta) => void;
   onMenuOpen: () => void;
   onMenuClose: () => void;

--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -69,6 +69,7 @@ export type ActionTypes =
 export interface ActionMeta {
   action: ActionTypes;
   name?: string;
+  option?: OptionType;
 }
 
 export type InputActionTypes =

--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -66,7 +66,7 @@ export type ActionTypes =
   | 'clear'
   | 'create-option';
 
-export interface ActionMeta {
+export interface ActionMeta<OptionType extends OptionTypeBase> {
   action: ActionTypes;
   name?: string;
   option?: OptionType;


### PR DESCRIPTION
```typescript
onChange={(option, action) => {
  console.log(action) // has field option
}}
```

```js
{
  "action": "select-option",
  "name": undefined,
  "option": {
    "value": "Label",
    "label": "Value"
  }
}
```