### PR TITLE
[co-body] Remove koa dependency

### DIFF
--- a/types/co-body/index.d.ts
+++ b/types/co-body/index.d.ts
@@ -5,15 +5,13 @@
 // TypeScript Version: 2.3
 
 /// <reference types="node"/>
-/// <reference types="koa"/>
 /// <reference types="qs"/>
 
 import * as http from 'http';
-import * as Koa from 'koa';
 import * as qs from 'qs';
 
 declare namespace CoBody {
-    type Context = http.IncomingMessage | Koa.Context;
+    type Context = http.IncomingMessage | { req: http.IncomingMessage };
 
     export interface Parse {
         (context: Context, options?: Options): Promise<any>;


### PR DESCRIPTION
The readme of the library says:

> This lib also supports `ctx.req` in Koa (or other libraries), so that you may simply use `this` instead of `this.req`.

So this removes the direct dependency on Koa and instead support Koa-like inputs.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cojs/co-body#readme
- ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- ~Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)~
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~