### PR TITLE
feat(speed-measure-webpack-plugin): new type definition

### DIFF
--- a/types/speed-measure-webpack-plugin/index.d.ts
+++ b/types/speed-measure-webpack-plugin/index.d.ts
@@ -1,0 +1,70 @@
+// Type definitions for speed-measure-webpack-plugin 1.3
+// Project: https://github.com/stephencookdev/speed-measure-webpack-plugin#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Configuration } from 'webpack';
+
+/**
+ * See how fast (or not) your plugins and loaders are, so you can optimise your builds
+ */
+declare class SpeedMeasurePlugin {
+    constructor(options?: SpeedMeasurePlugin.Options);
+
+    wrap(config: Configuration): Configuration;
+}
+
+declare namespace SpeedMeasurePlugin {
+    type OutputFormat =
+        /** produces a JSON blob */
+        | 'json'
+        /** produces a human readable output */
+        | 'human'
+        /** produces a more verbose version of the human readable output */
+        | 'humanVerbose'
+        /** output the response */
+        | ((json: any) => string);
+
+    type OutputTarget =
+        /** specifies the path to a file to output to */
+        | string
+        /** calls the function with the output as the first parameter */
+        | ((output: string, ...rest: any[]) => void);
+
+    /**
+     * Pass these into the constructor, as an object:
+     */
+    interface Options {
+        /**
+         * If truthy, this plugin does nothing at all.
+         * @default false
+         */
+        disable?: boolean;
+        /**
+         * Determines in what format this plugin prints its measurements
+         * @default 'human'
+         */
+        outputFormat?: OutputFormat;
+        outputTarget?: OutputTarget;
+        /**
+         * By default, SMP derives plugin names through plugin.constructor.name.
+         * For some plugins this doesn't work (or you may want to override this default).
+         * This option takes an object of pluginName: PluginConstructor
+         */
+        pluginNames?: {
+            [key: string]: object;
+        };
+        /**
+         * By default, SMP measures loaders in groups.
+         * If truthy, this plugin will give per-loader timing information.
+         * This flag is experimental. Some loaders will have inaccurate results:
+         * loaders using separate processes (e.g. thread-loader)
+         * loaders emitting file output (e.g. file-loader)
+         * We will find solutions to these issues before removing the (experimental) flag on this option.
+         * @default false
+         */
+        granularLoaderData?: boolean;
+    }
+}
+
+export = SpeedMeasurePlugin;

--- a/types/speed-measure-webpack-plugin/speed-measure-webpack-plugin-tests.ts
+++ b/types/speed-measure-webpack-plugin/speed-measure-webpack-plugin-tests.ts
@@ -1,0 +1,44 @@
+import SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
+import { Options } from 'speed-measure-webpack-plugin';
+import UglifyJSPlugin = require('uglifyjs-webpack-plugin');
+import HtmlWebpackPlugin = require('html-webpack-plugin');
+import { Configuration } from 'webpack';
+
+const uglify = new UglifyJSPlugin();
+
+const defualtOptions = new SpeedMeasurePlugin();
+
+const options: Options = {
+    disable: true,
+    granularLoaderData: true,
+    pluginNames: {
+        customUglifyName: uglify,
+    },
+    outputFormat: 'human',
+    outputTarget: console.log,
+};
+
+const smp = new SpeedMeasurePlugin(options);
+const webpackConfig = smp.wrap({
+    plugins: [new HtmlWebpackPlugin()],
+});
+
+// basic
+
+const basic: Configuration = {
+    entry: {
+        app: ['./app.js'],
+    },
+    output: {
+        filename: 'someLibName.js',
+    },
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                use: [{ loader: 'babel-loader' }],
+            },
+        ],
+    },
+};
+smp.wrap(basic);

--- a/types/speed-measure-webpack-plugin/tsconfig.json
+++ b/types/speed-measure-webpack-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "speed-measure-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/speed-measure-webpack-plugin/tslint.json
+++ b/types/speed-measure-webpack-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition file for version 1.3
- tests

https://github.com/stephencookdev/speed-measure-webpack-plugin#usage

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.