### PR TITLE
[mongoose-paginate-v2] Add custom PaginateOptions for all queries

### DIFF
--- a/types/mongoose-paginate-v2/index.d.ts
+++ b/types/mongoose-paginate-v2/index.d.ts
@@ -90,3 +90,6 @@ declare module 'mongoose' {
 import mongoose = require('mongoose');
 declare function _(schema: mongoose.Schema): void;
 export = _;
+declare namespace _ {
+    const paginate: { options: mongoose.PaginateOptions };
+}


### PR DESCRIPTION
As of mongoose-paginate-v2 documentation https://github.com/aravindnc/mongoose-paginate-v2#set-custom-default-options-for-all-queries

```ts
import mongoosePaginate from 'mongoose-paginate-v2';

mongoosePaginate.paginate.options = {
  customLabels: {
    docs: 'data',
    totalDocs: 'count',
  },
};
```
