### PR TITLE
react-router - Fix Prompt's `message` typing

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -48,7 +48,7 @@ export interface MemoryRouterProps {
 export class MemoryRouter extends React.Component<MemoryRouterProps, any> {}
 
 export interface PromptProps {
-    message: string | ((location: H.Location) => string | boolean);
+    message: string | ((location: H.Location, action: H.Action) => string | boolean);
     when?: boolean;
 }
 export class Prompt extends React.Component<PromptProps, any> {}

--- a/types/react-router/test/Prompt.tsx
+++ b/types/react-router/test/Prompt.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { Prompt } from 'react-router'
+
+const PromptTest: React.FC = ({ children }) => {
+  return (
+    <Prompt
+      message={(location, action) => {
+        if (action === 'POP') {
+          console.log("Backing up...")
+        }
+
+        return location.pathname.startsWith("/app")
+          ? true
+          : `Are you sure you want to go to ${location.pathname}?`
+      }}
+      when={true}
+    />
+  )
+};
+
+export default PromptTest;

--- a/types/react-router/test/Prompt.tsx
+++ b/types/react-router/test/Prompt.tsx
@@ -1,21 +1,21 @@
-import * as React from 'react'
-import { Prompt } from 'react-router'
+import * as React from 'react';
+import { Prompt } from 'react-router';
 
 const PromptTest: React.FC = ({ children }) => {
   return (
     <Prompt
       message={(location, action) => {
         if (action === 'POP') {
-          console.log("Backing up...")
+          console.log("Backing up...");
         }
 
         return location.pathname.startsWith("/app")
           ? true
-          : `Are you sure you want to go to ${location.pathname}?`
+          : `Are you sure you want to go to ${location.pathname}?`;
       }}
       when={true}
     />
-  )
+  );
 };
 
 export default PromptTest;

--- a/types/react-router/test/examples-from-react-router-website/README.md
+++ b/types/react-router/test/examples-from-react-router-website/README.md
@@ -2,4 +2,4 @@ Examples taken from react-router website.
 
 Please keep them in sync and as close as possible to the original ones.
 
-See https://github.com/ReactTraining/react-router/tree/22bd52c901ef0312348c2b02549c7102bd5653ae/packages/react-router-website/modules/examples
+See https://github.com/ReactTraining/react-router/tree/master/packages/react-router-dom/examples

--- a/types/react-router/test/examples-from-react-router-website/README.md
+++ b/types/react-router/test/examples-from-react-router-website/README.md
@@ -1,5 +1,7 @@
-Examples taken from react-router website.
+Examples taken from react-router monorepo documentation.
 
-Please keep them in sync and as close as possible to the original ones.
+Please keep them in sync and as close as possible to the original source examples.
 
-See https://github.com/ReactTraining/react-router/tree/master/packages/react-router-dom/examples
+[`react-router`](https://github.com/ReactTraining/react-router/tree/65bbc09230c60530458068e03aaa42ef95ae6a29/packages/react-router/docs/api)
+[`react-router-dom`](https://github.com/ReactTraining/react-router/tree/65bbc09230c60530458068e03aaa42ef95ae6a29/packages/react-router-dom/examples)
+

--- a/types/react-router/tsconfig.json
+++ b/types/react-router/tsconfig.json
@@ -38,6 +38,7 @@
         "test/hooks.tsx",
         "test/NavigateWithContext.tsx",
         "test/MemoryRouter.tsx",
+        "test/Prompt.tsx",
         "test/Switch.tsx",
         "test/InheritingRoute.tsx",
         "test/WithRouter.tsx",


### PR DESCRIPTION
## Template
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.) 
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/react-router/pull/7279

## My own words
- None of the existing tests need to leverage the action param in the callback, so I didnt update them 🤷‍♂️
- I opened [this PR](https://github.com/ReactTraining/react-router/pull/7279) in `react-router` to make the fact reflected in their docs as well.