### PR TITLE
hapi-pino: updated type definitions for v8

### DIFF
--- a/types/hapi-pino/hapi-pino-tests.ts
+++ b/types/hapi-pino/hapi-pino-tests.ts
@@ -37,7 +37,7 @@ function example1() {
             },
         })
         .then(() => {
-            server.logger().debug('using logger object directly');
+            server.logger.debug('using logger object directly');
 
             server.route({
                 method: 'GET',

--- a/types/hapi-pino/index.d.ts
+++ b/types/hapi-pino/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for hapi-pino 8.0.0
+// Type definitions for hapi-pino 8.0
 // Project: https://github.com/pinojs/hapi-pino#readme
 // Definitions by: Rodrigo Saboya <https://github.com/saboya>
 //                 Todd Bealmear <https://github.com/todd>

--- a/types/hapi-pino/index.d.ts
+++ b/types/hapi-pino/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for hapi-pino 6.4
+// Type definitions for hapi-pino 8.0.0
 // Project: https://github.com/pinojs/hapi-pino#readme
 // Definitions by: Rodrigo Saboya <https://github.com/saboya>
 //                 Todd Bealmear <https://github.com/todd>
@@ -14,7 +14,7 @@ import { Plugin, Request } from '@hapi/hapi';
 
 declare module '@hapi/hapi' {
     interface Server {
-        logger: () => pino.Logger;
+        logger: pino.Logger;
     }
 
     interface Request {

--- a/types/hapi-pino/index.d.ts
+++ b/types/hapi-pino/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Rodrigo Saboya <https://github.com/saboya>
 //                 Todd Bealmear <https://github.com/todd>
 //                 Matt Jeanes <https://github.com/BlooJeans>
-//                 Matt Jeanes <https://github.com/GoPro16>
+//                 Kyle Gray <https://github.com/GoPro16>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/hapi-pino/index.d.ts
+++ b/types/hapi-pino/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Rodrigo Saboya <https://github.com/saboya>
 //                 Todd Bealmear <https://github.com/todd>
 //                 Matt Jeanes <https://github.com/BlooJeans>
+//                 Matt Jeanes <https://github.com/GoPro16>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Commit Link](https://github.com/pinojs/hapi-pino/pull/99/commits/a9b2ec9e43b2bbb491cb93d947e37a90ceee314a)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
