### PR TITLE
[resolve]: update to v1.17

### DIFF
--- a/types/resolve/index.d.ts
+++ b/types/resolve/index.d.ts
@@ -40,7 +40,7 @@ type readFileCallback = (err: Error | null, file?: Buffer) => void;
  * Callback invoked when resolving a potential symlink
  *
  * @param error
- * @param isFile If the given file exists
+ * @param resolved Absolute path to the resolved file
  */
 type realpathCallback = (err: Error | null, resolved?: string) => void;
 

--- a/types/resolve/index.d.ts
+++ b/types/resolve/index.d.ts
@@ -1,5 +1,5 @@
-// Type definitions for resolve 1.14.1
-// Project: https://github.com/substack/node-resolve
+// Type definitions for resolve 1.17.0
+// Project: https://github.com/browserify/resolve
 // Definitions by: Mario Nebl <https://github.com/marionebl>
 //                 Klaus Meinhardt <https://github.com/ajafff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -35,6 +35,14 @@ type existsCallback = (err: Error | null, isFile?: boolean) => void;
  * @param isFile If the given file exists
  */
 type readFileCallback = (err: Error | null, file?: Buffer) => void;
+
+/**
+ * Callback invoked when resolving a potential symlink
+ *
+ * @param error
+ * @param isFile If the given file exists
+ */
+type realpathCallback = (err: Error | null, resolved?: string) => void;
 
 /**
  * Asynchronously resolve the module path string id into cb(err, res [, pkg]), where pkg (if defined) is the data from package.json
@@ -80,8 +88,10 @@ declare namespace resolve {
     pathFilter?: (pkg: any, path: string, relativePath: string) => string;
     /** require.paths array to use if nothing is found on the normal node_modules recursive walk (probably don't use this) */
     paths?: string | ReadonlyArray<string>;
+    /** return the list of candidate paths where the packages sources may be found (probably don't use this) */
+    packageIterator?: (request: string, start: string, getPackageCandidates: () => string[], opts: Opts) => string[];
     /** directory (or directories) in which to recursively look for modules. (default to 'node_modules') */
-    moduleDirectory?: string | ReadonlyArray<string>
+    moduleDirectory?: string | ReadonlyArray<string>;
     /**
      * if true, doesn't resolve `basedir` to real path before resolving.
      * This is the way Node resolves dependencies when executed with the --preserve-symlinks flag.
@@ -99,6 +109,8 @@ declare namespace resolve {
     isFile?: (file: string, cb: existsCallback) => void;
     /** function to asynchronously test whether a directory exists */
     isDirectory?: (directory: string, cb: existsCallback) => void;
+    /** function to asynchronously resolve a potential symlink to its real path */
+    realpath?: (file: string, cb: realpathCallback) => void;
   }
 
   export interface SyncOpts extends Opts {
@@ -108,6 +120,8 @@ declare namespace resolve {
     isFile?: (file: string) => boolean;
     /** function to synchronously test whether a directory exists */
     isDirectory?: (directory: string) => boolean;
+    /** function to synchronously resolve a potential symlink to its real path */
+    realpathSync?: (file: string) => string;
   }
 
   export var sync: typeof resolveSync;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/browserify/resolve/pull/205
  - https://github.com/browserify/resolve/pull/218
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.