### PR TITLE
Add support for type and innerType public API's

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for yup 0.26
+// Type definitions for yup 0.28
 // Project: https://github.com/jquense/yup
 // Definitions by: Dominik Hardtke <https://github.com/dhardtke>,
 //                 Vladyslav Tserman <https://github.com/vtserman>,

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -49,6 +49,7 @@ export type TestOptionsMessage<Extra extends Record<string, any> = {}, R = any> 
     | ((params: Extra & Partial<TestMessageParams>) => R);
 
 export interface Schema<T> {
+    type: string;
     clone(): this;
     label(label: string): this;
     meta(metadata: any): this;
@@ -220,6 +221,7 @@ export interface NotRequiredArraySchema<T> extends BasicArraySchema<T[] | undefi
 }
 
 export interface ArraySchema<T> extends BasicArraySchema<T[]> {
+    innerType: Schema<T>;
     of<U>(type: Schema<U>): ArraySchema<U>;
     nullable(isNullable?: true): NullableArraySchema<T>;
     nullable(isNullable: false | boolean): ArraySchema<T>;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -128,6 +128,7 @@ error.errors = ['error'];
 
 // mixed
 let mixed: MixedSchema = yup.mixed();
+mixed.type;
 mixed.clone();
 mixed.label('label');
 mixed.meta({ meta: 'value' });
@@ -303,6 +304,7 @@ yup.object()
 
 // String schema
 function strSchemaTests(strSchema: yup.StringSchema) {
+    strSchema.type;
     strSchema.isValid('hello'); // => true
     strSchema.required();
     strSchema.required('req');
@@ -357,6 +359,7 @@ yup.string<123>();
 
 // Number schema
 const numSchema = yup.number(); // $ExpectType NumberSchema<number>
+numSchema.type;
 numSchema.isValid(10); // => true
 numSchema.min(5);
 numSchema.min(5, 'message');
@@ -394,10 +397,12 @@ numSchema
 
 // Boolean Schema
 const boolSchema = yup.boolean();
+boolSchema.type;
 boolSchema.isValid(true); // => true
 
 // Date Schema
 const dateSchema = yup.date();
+dateSchema.type;
 dateSchema.isValid(new Date()); // => true
 dateSchema.min(new Date());
 dateSchema.min('2017-11-12');
@@ -412,6 +417,9 @@ dateSchema.max('2017-11-12', () => 'message');
 
 // Array Schema
 const arrSchema = yup.array().of(yup.number().min(2));
+arrSchema.type;
+arrSchema.innerType;
+arrSchema.innerType.type;
 arrSchema.isValid([2, 3]); // => true
 arrSchema.isValid([1, -24]); // => false
 arrSchema.required();
@@ -459,7 +467,7 @@ yup.object().shape({
 yup.object({
     num: yup.number(),
 });
-
+objSchema.type;
 objSchema.from('prop', 'myProp');
 objSchema.from('prop', 'myProp', true);
 objSchema.noUnknown();


### PR DESCRIPTION
A recent change to yup made schema.type and array.innerType public API's. This PR adds them to the type definition. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/yup/commit/8f00d507093846a7b6c4e08ef6320c9f24a07ad8
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~

