### PR TITLE
Expose ExpressJS functionality of `next('router')`

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -43,6 +43,16 @@ app.get('/:foo', req => {
     req.query; // $ExpectType Query
 });
 
+// Next can receive a Error parameter to delegate to Error handler
+app.get('/nexterr', (req, res, next) => {
+    next(new Error("dummy")); // $ExpectType void
+});
+
+// Next can receive a 'router' parameter to fall back to next router
+app.get('/nextrouter', (req, res, next) => {
+    next('router'); // $ExpectType void
+});
+
 // Default types
 app.post("/", (req, res) => {
     req.params[0]; // $ExpectType string

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -30,12 +30,12 @@ import { EventEmitter } from "events";
 import { Options as RangeParserOptions, Result as RangeParserResult, Ranges as RangeParserRanges } from "range-parser";
 
 export interface NextFunction {
-    (err?: any): void; // tslint:disable-line callable-types (In ts2.1 it thinks the type alias has no call signatures)
+    (err?: any): void;
     /**
      * "Break-out" of a router by calling {next('router')};
      * @see {https://expressjs.com/en/guide/using-middleware.html#middleware.router}
      */
-    (deferToNext: "router"): void; // tslint:disable-line callable-types (In ts2.1 it thinks the type alias has no call signatures)
+    (deferToNext: "router"): void;
 }
 
 export interface Dictionary<T> { [key: string]: T; }

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -30,8 +30,12 @@ import { EventEmitter } from "events";
 import { Options as RangeParserOptions, Result as RangeParserResult, Ranges as RangeParserRanges } from "range-parser";
 
 export interface NextFunction {
-    // tslint:disable-next-line callable-types (In ts2.1 it thinks the type alias has no call signatures)
-    (err?: any): void;
+    (err?: any): void; // tslint:disable-line callable-types (In ts2.1 it thinks the type alias has no call signatures)
+    /**
+     * "Break-out" of a router by calling {next('router')};
+     * @see {https://expressjs.com/en/guide/using-middleware.html#middleware.router}
+     */
+    (deferToNext: "router"): void; // tslint:disable-line callable-types (In ts2.1 it thinks the type alias has no call signatures)
 }
 
 export interface Dictionary<T> { [key: string]: T; }


### PR DESCRIPTION
Quoting [documentation](https://expressjs.com/en/guide/using-middleware.html#middleware.router):

<blockquote>
To skip the rest of the router’s middleware functions, call next('router') to pass control back out of the router instance.

This example shows a middleware sub-stack that handles GET requests to the /user/:id path.
<pre language="javascript">
var app = express()
var router = express.Router()

// predicate the router with a check and bail out when needed
router.use(function (req, res, next) {
  if (!req.headers['x-auth']) return next('router')
  next()
})

router.get('/user/:id', function (req, res) {
  res.send('hello, user!')
})

// use the router and 401 anything falling through
app.use('/admin', router, function (req, res) {
  res.sendStatus(401)
})
</pre></blockquote>

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] https://expressjs.com/en/guide/using-middleware.html#middleware.router
- [x] This has been in ExpressJS [for a long time, see commit](https://github.com/expressjs/express/commit/9722202df964bfbfc0f579e4baeb5a4e1b43b344), at least 5.0.0-alpha.7 5.0.0-alpha.6 5.0.0-alpha.5 5.0.0-alpha.4 4.17.1 4.17.0 4.16.4 4.16.3 4.16.2 4.16.1 4.16.0 4.15.5 4.15.4 4.15.3 4.15.2 4.15.1 4.15.0
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

