### PR TITLE
[redis] Add error type to retry_delay

### DIFF
--- a/types/redis-mock/redis-mock-tests.ts
+++ b/types/redis-mock/redis-mock-tests.ts
@@ -4,6 +4,7 @@ declare const value: any;
 let valueArr: any[];
 declare const commandArr: any[][];
 let num = 1;
+let num_or_error: number | Error = 1;
 const str = "hi";
 let bool = false;
 const err: Error = new Error();
@@ -52,7 +53,7 @@ client = redis.createClient({
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 
 bool = client.connected;
-num = client.retry_delay;
+num_or_error = client.retry_delay;
 num = client.retry_backoff;
 valueArr = client.command_queue;
 valueArr = client.offline_queue;

--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -1185,7 +1185,7 @@ export interface RedisClient extends Commands<boolean>, EventEmitter {
     connected: boolean;
     command_queue_length: number;
     offline_queue_length: number;
-    retry_delay: number;
+    retry_delay: number | Error;
     retry_backoff: number;
     command_queue: any[];
     offline_queue: any[];

--- a/types/redis/redis-tests.ts
+++ b/types/redis/redis-tests.ts
@@ -49,6 +49,7 @@ client = redis.createClient({
 
 const connected: boolean = client.connected;
 const retry_delay: number = client.retry_delay;
+const retry_delay: Error = new Error('Retry failed');
 const retry_backoff: number = client.retry_backoff;
 const command_queue: any[] = client.command_queue;
 const offline_queue: any[] = client.offline_queue;

--- a/types/redis/redis-tests.ts
+++ b/types/redis/redis-tests.ts
@@ -48,8 +48,7 @@ client = redis.createClient({
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 
 const connected: boolean = client.connected;
-const retry_delay: number = client.retry_delay;
-const retry_delay: Error = new Error('Retry failed');
+const retry_delay: number | Error = client.retry_delay;
 const retry_backoff: number = client.retry_backoff;
 const command_queue: any[] = client.command_queue;
 const offline_queue: any[] = client.offline_queue;

--- a/types/redis/ts3.1/index.d.ts
+++ b/types/redis/ts3.1/index.d.ts
@@ -1167,7 +1167,7 @@ export interface RedisClient extends Commands<boolean>, EventEmitter {
     connected: boolean;
     command_queue_length: number;
     offline_queue_length: number;
-    retry_delay: number;
+    retry_delay: number | Error;
     retry_backoff: number;
     command_queue: any[];
     offline_queue: any[];

--- a/types/redis/ts3.1/redis-tests.ts
+++ b/types/redis/ts3.1/redis-tests.ts
@@ -49,6 +49,7 @@ client = redis.createClient({
 
 const connected: boolean = client.connected;
 const retry_delay: number = client.retry_delay;
+const retry_delay: Error = new Error('Retry failed');
 const retry_backoff: number = client.retry_backoff;
 const command_queue: any[] = client.command_queue;
 const offline_queue: any[] = client.offline_queue;

--- a/types/redis/ts3.1/redis-tests.ts
+++ b/types/redis/ts3.1/redis-tests.ts
@@ -48,8 +48,7 @@ client = redis.createClient({
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 
 const connected: boolean = client.connected;
-const retry_delay: number = client.retry_delay;
-const retry_delay: Error = new Error('Retry failed');
+const retry_delay: number | Error = client.retry_delay;
 const retry_backoff: number = client.retry_backoff;
 const command_queue: any[] = client.command_queue;
 const offline_queue: any[] = client.offline_queue;


### PR DESCRIPTION
`retry_delay` can also be an error if retry fails.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/NodeRedis/node-redis/blob/da31ade348f9b98ebc5a3164d59a93576a865906/index.js#L553-L558
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
