### PR TITLE
[node-fetch] Fix interable members (were wrongly typed to `Iterator`)

### DIFF
--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -117,10 +117,10 @@ export class Headers implements Iterable<[string, string]> {
     raw(): { [k: string]: string[] };
     set(name: string, value: string): void;
 
-    // Iterator methods
-    entries(): Iterator<[string, string]>;
-    keys(): Iterator<string>;
-    values(): Iterator<[string]>;
+    // Iterable methods
+    entries(): IterableIterator<[string, string]>;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<[string]>;
     [Symbol.iterator](): Iterator<[string, string]>;
 }
 

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -159,10 +159,15 @@ function handlePromise(
         });
 }
 
-function test_headersRaw() {
+function test_headers() {
     const headers = new Headers();
     const myHeader = "foo";
     headers.raw()[myHeader]; // $ExpectType string[]
+
+    [...headers]; // $ExpectType [string, string][]
+    [...headers.entries()]; // $ExpectType [string, string][]
+    [...headers.keys()]; // $ExpectType string[]
+    [...headers.values()]; // $ExpectType [string][]
 }
 
 function test_isRedirect() {

--- a/types/node-fetch/tsconfig.json
+++ b/types/node-fetch/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
+        "target": "ES6",
         "lib": [
             "es6"
         ],

--- a/types/node-fetch/tsconfig.json
+++ b/types/node-fetch/tsconfig.json
@@ -2,13 +2,9 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es5",
             "es6"
         ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
+        "strict": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - See the equivalent DOM definitions: https://github.com/microsoft/TypeScript/blob/c28bd6579d0a03742799d7310a1977843a222750/lib/lib.dom.iterable.d.ts#L116
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
