### PR TITLE
XRM type: added "title" to Navigation.AlertStrings

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -4223,6 +4223,10 @@ declare namespace Xrm {
              *  The message to be displyed in the alert dialog.
              */
             text: string;
+            /**
+             * (Optional) String. The title of the alert dialog.
+             */
+            title?: string;
         }
 
         interface ConfirmStrings {


### PR DESCRIPTION
Addded missing "title" property  to Xrm.Navigation.AlertStrings as documented in Microsoft clientAPI documentation.

https://docs.microsoft.com/en-us/powerapps/developer/model-driven-apps/clientapi/reference/xrm-navigation/openalertdialog