### PR TITLE
[@types/chartjs-plugin-colorschemes] Create type definitions

### DIFF
--- a/types/chartjs-plugin-colorschemes/chartjs-plugin-colorschemes-tests.ts
+++ b/types/chartjs-plugin-colorschemes/chartjs-plugin-colorschemes-tests.ts
@@ -1,0 +1,54 @@
+import * as Chart from 'chart.js';
+import { ColorSchemesOptions } from 'chartjs-plugin-colorschemes';
+
+// https://github.com/nagix/chartjs-plugin-colorschemes/blob/master/src/plugins/plugin.colorschemes.js#L12
+const defaults: ColorSchemesOptions = {
+    scheme: 'brewer.Paired12',
+    fillAlpha: 0.5,
+    reverse: false,
+    override: false,
+};
+
+// Supports global defaults
+Chart.defaults.global.plugins = {
+    colorschemes: defaults,
+};
+
+const ctx = new CanvasRenderingContext2D();
+const chartData = {};
+
+// Supports chart options
+// https://github.com/nagix/chartjs-plugin-colorschemes#usage
+let chart = new Chart(ctx, {
+    type: 'bar',
+    data: chartData,
+    options: {
+        plugins: {
+            colorschemes: defaults,
+        },
+    },
+});
+
+// Supports custom function
+// https://github.com/nagix/chartjs-plugin-colorschemes#custom-function
+const customColorFunction = (schemeColors: string[]) => {
+    const myColors = ['#ff0000', '#00ff00', '#0000ff']; // define/generate own colors
+
+    // extend the color scheme with own colors
+    Array.prototype.push.apply(schemeColors, myColors);
+
+    return schemeColors; // optional: this is not needed if the array is modified in place
+};
+
+chart = new Chart(ctx, {
+    type: 'bar',
+    data: chartData,
+    options: {
+        plugins: {
+            colorschemes: {
+                scheme: 'brewer.Paired12',
+                custom: customColorFunction,
+            },
+        },
+    },
+});

--- a/types/chartjs-plugin-colorschemes/index.d.ts
+++ b/types/chartjs-plugin-colorschemes/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for chartjs-plugin-colorschemes 0.4
+// Project: https://nagix.github.io/chartjs-plugin-colorschemes
+// Definitions by: Dan Manastireanu <https://github.com/danmana>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import * as Chart from 'chart.js';
+
+declare module 'chart.js' {
+    interface ChartPluginsOptions {
+        colorschemes?: ColorSchemesOptions;
+    }
+}
+
+export interface ColorSchemesOptions {
+    scheme: string | string[];
+    fillAlpha?: number;
+    reverse?: boolean;
+    override?: boolean;
+    custom?: (schemeColors: string[]) => string[] | void;
+}
+
+declare const ColorSchemesPlugin: Chart.PluginServiceGlobalRegistration & Chart.PluginServiceRegistrationOptions;
+
+export default ColorSchemesPlugin;

--- a/types/chartjs-plugin-colorschemes/tsconfig.json
+++ b/types/chartjs-plugin-colorschemes/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "chartjs-plugin-colorschemes-tests.ts"
+    ]
+}

--- a/types/chartjs-plugin-colorschemes/tslint.json
+++ b/types/chartjs-plugin-colorschemes/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

https://github.com/nagix/chartjs-plugin-colorschemes