### PR TITLE
find-replace types added

### DIFF
--- a/types/find-replace/find-replace-tests.ts
+++ b/types/find-replace/find-replace-tests.ts
@@ -1,0 +1,15 @@
+import findReplace = require("find-replace");
+
+const numbers = [1, 2, 3, 4, 5];
+const resultTyped = findReplace<number>(
+    numbers,
+    num => num === 3,
+    num => num * 2
+);
+
+const colours = ['red', 'white', 'blue', 'white'];
+const resultAny = findReplace(
+    colours,
+    colour => colour === 'red',
+    (colour: any) => colour.split('')
+);

--- a/types/find-replace/index.d.ts
+++ b/types/find-replace/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for find-replace 4.0
+// Project: https://github.com/75lb/find-replace
+// Definitions by: Zamaletdinov <https://github.com/Zamaletdinov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Replace or remove multiple items in an array
+ *
+ * `array` - The input array
+ *
+ * `findFn` - A predicate which, if returns true causes the current item to be operated on
+ *
+ * `...replaceWiths`:
+ *
+ * * If not specified, each found value will be removed.
+ * * If specified, each found value will be replaced with this value.
+ * * If the replaceWith value is a function, it will be invoked with the found value and its result used as the replace value.
+ * * If the replaceWith function returns an array, the found value will be replaced with each item in the array (not replaced with the array itself).
+ */
+declare function findReplace<T>(array: T[], findFn: (x: T) => boolean, ...replaceWiths: Array<T | ((x: T) => T)>): T[];
+declare function findReplace(array: any[], findFn: (x: any) => boolean, ...replaceWiths: any[]): any[];
+
+export = findReplace;

--- a/types/find-replace/index.d.ts
+++ b/types/find-replace/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for find-replace 4.0
-// Project: https://github.com/75lb/find-replace
-// Definitions by: Zamaletdinov <https://github.com/Zamaletdinov>
+// Project: https://github.com/75lb/find-replace#readme
+// Definitions by: Renat Zamaletdinov <https://github.com/Zamaletdinov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**

--- a/types/find-replace/index.d.ts
+++ b/types/find-replace/index.d.ts
@@ -20,4 +20,5 @@
 declare function findReplace<T>(array: T[], findFn: (x: T) => boolean, ...replaceWiths: Array<T | ((x: T) => T)>): T[];
 declare function findReplace(array: any[], findFn: (x: any) => boolean, ...replaceWiths: any[]): any[];
 
+export as namespace findReplace;
 export = findReplace;

--- a/types/find-replace/tsconfig.json
+++ b/types/find-replace/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true
+    },
+    "files": ["index.d.ts", "find-replace-tests.ts"]
+}

--- a/types/find-replace/tsconfig.json
+++ b/types/find-replace/tsconfig.json
@@ -1,16 +1,23 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es6"],
+        "lib": [
+            "es6"
+        ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",
-        "typeRoots": ["../"],
+        "typeRoots": [
+            "../"
+        ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "strictFunctionTypes": true
+        "forceConsistentCasingInFileNames": true
     },
-    "files": ["index.d.ts", "find-replace-tests.ts"]
+    "files": [
+        "index.d.ts",
+        "find-replace-tests.ts"
+    ]
 }

--- a/types/find-replace/tslint.json
+++ b/types/find-replace/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/find-replace/tslint.json
+++ b/types/find-replace/tslint.json
@@ -1,3 +1,1 @@
-{
-    "extends": "dtslint/dt.json"
-}
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
