### PR TITLE
webpack-env's Node.Require cache includes undefined in signature

### DIFF
--- a/types/webpack-env/index.d.ts
+++ b/types/webpack-env/index.d.ts
@@ -59,7 +59,7 @@ declare namespace __WebpackModuleApi {
          * Multiple requires to the same module result in only one module execution and only one export. Therefore a cache in the runtime exists. Removing values from this cache cause new module execution and a new export. This is only needed in rare cases (for compatibility!).
          */
         cache: {
-            [id: string]: NodeModule;
+            [id: string]: NodeModule | undefined;
         }
     }
 


### PR DESCRIPTION
Missed in #43941 because webpack-env isn't an intra-DT dependent of node -- some external node dependents also depend on webpack-env.

I think it's either @storybook/react or @storybook/addons, but I haven't tracked it down yet. I'll send a PR after I do.

Fixes Definitely Typed tests.