### PR TITLE
[types/ember__array] Fix type for `compact`, `firstObject` and `lastObject`

### DIFF
--- a/types/ember/test/ember-module-tests.ts
+++ b/types/ember/test/ember-module-tests.ts
@@ -226,10 +226,11 @@ const ma1: Ember.MutableArray<string> = [
 ];
 ma1.addObject('!'); // $ExpectType string
 ma1.filterBy(''); // $ExpectType NativeArray<string>
+ma1.firstObject; // $ExpectType string | undefined
+ma1.lastObject; // $ExpectType string | undefined
 // Ember.MutableEnumerable
-// tslint:disable-next-line:prefer-const
-let me1: Ember.MutableEnumerable<[string]> = null as any;
-me1.compact(); // $ExpectType NativeArray<[string]>
+const me1: Ember.MutableEnumerable<string | null | undefined> = ['foo', undefined, null];
+me1.compact(); // $ExpectType NativeArray<string>
 // Ember.Namespace
 const myNs = Ember.Namespace.extend({});
 // Ember.NativeArray

--- a/types/ember/test/route.ts
+++ b/types/ember/test/route.ts
@@ -21,7 +21,7 @@ Route.extend({
 
 Route.extend({
     afterModel(posts: Posts, transition: Transition) {
-        if (posts.length === 1) {
+        if (posts.firstObject) {
             this.transitionTo('post.show', posts.firstObject);
         }
     },

--- a/types/ember__array/-private/enumerable.d.ts
+++ b/types/ember__array/-private/enumerable.d.ts
@@ -14,13 +14,13 @@ interface Enumerable<T> {
      * used by bindings and other parts of the framework to extract a single
      * object if the enumerable contains only one item.
      */
-    firstObject: ComputedProperty<T | undefined>;
+    firstObject: T | undefined;
     /**
      * Helper method returns the last object from a collection. If your enumerable
      * contains only one object, this method should always return that object.
      * If your enumerable is empty, this method should return `undefined`.
      */
-    lastObject: ComputedProperty<T | undefined>;
+    lastObject: T | undefined;
     /**
      * @deprecated Use `Enumerable#includes` instead.
      */
@@ -135,7 +135,7 @@ interface Enumerable<T> {
     /**
      * Returns a copy of the array with all `null` and `undefined` elements removed.
      */
-    compact(): NativeArray<T>;
+    compact(): NativeArray<NonNullable<T>>;
     /**
      * Returns a new enumerable that excludes the passed value. The default
      * implementation returns an array regardless of the receiver type.

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -16,7 +16,7 @@ Route.extend({
 
 Route.extend({
     afterModel(posts: Posts, transition: Transition) {
-        if (posts.length === 1) {
+        if (posts.firstObject) {
             this.transitionTo('post.show', posts.firstObject);
         }
     },


### PR DESCRIPTION
Adresses https://github.com/typed-ember/ember-cli-typescript/issues/1145

Does this need a test?  I honestly tried to do it, but failed to create a failing test. This dtslint thing just won't produce the error that normal TypeScript [produces](https://www.typescriptlang.org/play/#)