### PR TITLE
Fix ember tests for TS 3.9

### DIFF
--- a/types/ember/test/object.ts
+++ b/types/ember/test/object.ts
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 const LifetimeHooks = Ember.Object.extend({
-    resource: null as {} | null,
+    resource: undefined as {} | undefined,
 
     init() {
         this._super();

--- a/types/ember/v2/test/object.ts
+++ b/types/ember/v2/test/object.ts
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 const LifetimeHooks = Ember.Object.extend({
-    resource: null as {} | null,
+    resource: undefined as {} | undefined,
 
     init() {
         this._super();

--- a/types/ember__object/test/object.ts
+++ b/types/ember__object/test/object.ts
@@ -1,7 +1,7 @@
 import EmberObject, { computed, notifyPropertyChange } from "@ember/object";
 
 const LifetimeHooks = EmberObject.extend({
-    resource: null as {} | null,
+    resource: undefined as {} | undefined,
 
     init() {
         this._super();


### PR DESCRIPTION
TS 3.9 forbids deleting properties that aren't optional or undefined. This exposed a bug in ember tests where the tests were deleting a property
with the type `{} | null`. I changed the type to `{} | undefined` to reflect what will actually happen at runtime.