### PR TITLE
Fix when tests for TS 3.9

### DIFF
--- a/types/when/when-tests.ts
+++ b/types/when/when-tests.ts
@@ -199,7 +199,7 @@ when.unfold(function (x) {
 }, function (x) {
 	return x < 10;
 }, function (y) {
-	delete y.foo;
+	delete (y as { foo?: string }).foo;
 }, 0);
 
 /* when.promise(resolver) */


### PR DESCRIPTION
TS 3.9 forbids deleting a property that isn't optional or undefined. One of when.unfold's tests deletes a property like this, so I added a cast to make it compile.

I could also have added a type parameter, but that would require a lot more typing.