### PR TITLE
Fix jsen tests for TS 3.9

### DIFF
--- a/types/jsen/jsen-tests.ts
+++ b/types/jsen/jsen-tests.ts
@@ -2369,7 +2369,7 @@ const doesNotThrow = (func: Function) => {
                 },
                 additionalProperties: false
             },
-            options = {
+            options: jsen.JsenSettings = {
                 greedy: true,
                 schemas: {
                     external: {


### PR DESCRIPTION
TS 3.9 forbids deleting a property that isn't marked optional or undefined. jsen's tests do this in order to test before/after `greedy` is set, but because the options object doesn't have a type annotation, the compiler doesn't know that `greedy` is optional. I added the type annotation.