### PR TITLE
react-native-html-to-pdf typings added

### DIFF
--- a/types/react-native-html-to-pdf/index.d.ts
+++ b/types/react-native-html-to-pdf/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for react-native-html-to-pdf 0.8
+// Project: https://github.com/christopherdro/react-native-html-to-pdf
+// Definitions by: euZebe <https://github.com/euzebe>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface Options {
+    html: string;
+    fileName?: string;
+    base64?: boolean;
+    directory?: string;
+    height?: number;
+    width?: number;
+
+    // iOS only
+    paddingLeft?: number;
+    paddingRight?: number;
+    paddingTop?: number;
+    paddingBottom?: number;
+    padding?: number;
+    bgColor?: string;
+
+    // android only
+    fonts?: string[];
+}
+
+export interface Pdf {
+    filePath?: string;
+    base64?: string;
+}
+
+export function convert(options: Options): Promise<Pdf>;

--- a/types/react-native-html-to-pdf/react-native-html-to-pdf-tests.ts
+++ b/types/react-native-html-to-pdf/react-native-html-to-pdf-tests.ts
@@ -1,0 +1,10 @@
+import { Options, convert, Pdf } from 'react-native-html-to-pdf';
+
+const options: Options = {
+    html: `<h1>Hello world!</h1>`,
+    base64: true,
+};
+
+convert(options).then((pdf: Pdf) => {
+    // get the generated base64 content or filePath
+});

--- a/types/react-native-html-to-pdf/tsconfig.json
+++ b/types/react-native-html-to-pdf/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-native-html-to-pdf-tests.ts"
+    ]
+}

--- a/types/react-native-html-to-pdf/tslint.json
+++ b/types/react-native-html-to-pdf/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.