### PR TITLE
Fix ejs tests for TS 3.9

### DIFF
--- a/types/ejs/test/ejs.cjs.test.ts
+++ b/types/ejs/test/ejs.cjs.test.ts
@@ -71,7 +71,6 @@ ejs.cache = LRU(100);
 
 /** @see https://github.com/mde/ejs/tree/v2.5.7#custom-delimiters */
 ejs.delimiter = '%';
-delete ejs.delimiter;
 
 // https://github.com/mde/ejs#options
 const renderOptions: ejs.Options = {


### PR DESCRIPTION
TS 3.9 forbids deleting a property that isn't marked optional or undefined. ejs's tests delete `delimiter` after setting it, even though it doesn't have undefined in its type. The documentation in the link above doesn't mention `delete`, so I removed the test.

Adding undefined to the type might be the right change, though.