### PR TITLE
add types for floreal

### DIFF
--- a/types/floreal/date.d.ts
+++ b/types/floreal/date.d.ts
@@ -1,0 +1,34 @@
+declare class FlorealDate {
+    constructor(value?: number | string);
+
+    toFullDateString(): string;
+    toShortDateString(): string;
+
+    setYear(year: string): void;
+    setYearDecimal(year: number): void;
+    setMonth(month: number): void;
+    setDay(day: number): void;
+    setDate(year: number, month: number, day: number): void;
+
+    year(): string;
+    yearDecimal(): number;
+    isYearSextile(): boolean;
+    firstDayOfYear(): Date;
+    dayOfYear(): number;
+    month(): number;
+    isComplementaryDay(): boolean;
+    monthName(): string;
+    dayOfMonth(): number;
+    day(): number;
+    dayOfDecade(): number;
+    dayOfWeek(): number;
+    decade(): number;
+    dayName(): string;
+    dayTitle(): string;
+
+    static day_names: string[];
+
+    static first_day_of_year(year: any): any;
+}
+
+export = FlorealDate;

--- a/types/floreal/floreal-tests.ts
+++ b/types/floreal/floreal-tests.ts
@@ -1,0 +1,10 @@
+import { Date } from 'floreal';
+
+const fd1 = new Date();
+const fd2 = new Date('1799-11-09');
+
+fd1.dayName(); // $ExpectType: string
+fd2.firstDayOfYear(); // $ExpectType: Date
+fd1.foo(); // $ExpectError
+fd1.setYear('XII');
+fd1.setYearDecimal(12);

--- a/types/floreal/index.d.ts
+++ b/types/floreal/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for floreal 1.1
+// Project: https://github.com/seeschloss/floreal
+// Definitions by: mike castleman <https://github.com/mlc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import FlorealDate = require('./date');
+export { FlorealDate as Date };

--- a/types/floreal/tsconfig.json
+++ b/types/floreal/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "floreal-tests.ts"
+    ]
+}

--- a/types/floreal/tslint.json
+++ b/types/floreal/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
[`floreal`](https://github.com/seeschloss/floreal) is a library for manipulating dates with the French Republican calendar of the 18th century. This PR adds types for that library.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
