### PR TITLE
[react-router] Improve return type of useParams

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -162,7 +162,7 @@ export function useHistory<HistoryLocationState = H.LocationState>(): H.History<
 
 export function useLocation<S = H.LocationState>(): H.Location<S>;
 
-export function useParams<Params extends { [K in keyof Params]?: string } = {}>(): { [p in keyof Params]: keyof Params[p] extends undefined ? string | undefined : string  };
+export function useParams<Params extends { [K in keyof Params]?: string } = {}>(): Params;
 
 export function useRouteMatch<Params extends { [K in keyof Params]?: string } = {}>(): match<Params>;
 export function useRouteMatch<Params extends { [K in keyof Params]?: string } = {}>(

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -162,7 +162,7 @@ export function useHistory<HistoryLocationState = H.LocationState>(): H.History<
 
 export function useLocation<S = H.LocationState>(): H.Location<S>;
 
-export function useParams<Params extends { [K in keyof Params]?: string } = {}>(): Params;
+export function useParams<Params extends { [K in keyof Params]?: string } = {}>(): { [K in keyof Params]: Params[K] };
 
 export function useRouteMatch<Params extends { [K in keyof Params]?: string } = {}>(): match<Params>;
 export function useRouteMatch<Params extends { [K in keyof Params]?: string } = {}>(

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -162,7 +162,7 @@ export function useHistory<HistoryLocationState = H.LocationState>(): H.History<
 
 export function useLocation<S = H.LocationState>(): H.Location<S>;
 
-export function useParams<Params extends { [K in keyof Params]?: string } = {}>(): { [K in keyof Params]: Params[K] };
+export function useParams<Params extends { [K in keyof Params]?: string } = {}>(): Params;
 
 export function useRouteMatch<Params extends { [K in keyof Params]?: string } = {}>(): match<Params>;
 export function useRouteMatch<Params extends { [K in keyof Params]?: string } = {}>(

--- a/types/react-router/test/hooks.tsx
+++ b/types/react-router/test/hooks.tsx
@@ -11,7 +11,7 @@ interface OptionalParams {
 }
 
 interface TypedParams {
-    t: 'a'| 'b' | 'c';
+    t: 'a' | 'b' | 'c';
 }
 
 interface LocationState {
@@ -25,7 +25,7 @@ const HooksTest: React.FC = () => {
     const params = useParams<Params>();
     // $ExpectType { id?: string | undefined; s: string | undefined; }
     const optionalParams = useParams<OptionalParams>();
-    // $ExpectType { t: 'a'| 'b' | 'c'; }
+    // $ExpectType { t: "a" | "b" | "c"; }
     const typedParams = useParams<TypedParams>();
     // $ExpectType match<Params> | null
     const match1 = useRouteMatch<Params>('/:id');

--- a/types/react-router/test/hooks.tsx
+++ b/types/react-router/test/hooks.tsx
@@ -10,6 +10,10 @@ interface OptionalParams {
     s: string | undefined;
 }
 
+interface TypedParams {
+    t: 'a'| 'b' | 'c';
+}
+
 interface LocationState {
     s: string;
 }
@@ -21,6 +25,8 @@ const HooksTest: React.FC = () => {
     const params = useParams<Params>();
     // $ExpectType { id?: string | undefined; s: string | undefined; }
     const optionalParams = useParams<OptionalParams>();
+    // $ExpectType { t: 'a'| 'b' | 'c'; }
+    const typedParams = useParams<TypedParams>();
     // $ExpectType match<Params> | null
     const match1 = useRouteMatch<Params>('/:id');
     // $ExpectType match<Params> | null
@@ -36,6 +42,7 @@ const HooksTest: React.FC = () => {
     params.id.replace;
     optionalParams.id && optionalParams.id.replace;
     optionalParams.s && optionalParams.s.replace;
+    typedParams.t.replace;
     match1 && match1.params.id.replace;
     match2 && match2.params.id.replace;
     match3 && match3.params.id.replace;

--- a/types/react-router/test/hooks.tsx
+++ b/types/react-router/test/hooks.tsx
@@ -23,9 +23,9 @@ const HooksTest: React.FC = () => {
     const location = useLocation<LocationState>();
     const { id } = useParams();
     const params = useParams<Params>();
-    // $ExpectType { id?: string | undefined; s: string | undefined; }
+    // $ExpectType OptionalParams
     const optionalParams = useParams<OptionalParams>();
-    // $ExpectType { t: "a" | "b" | "c"; }
+    // $ExpectType TypedParams
     const typedParams = useParams<TypedParams>();
     // $ExpectType match<Params> | null
     const match1 = useRouteMatch<Params>('/:id');


### PR DESCRIPTION
`useParams` loose param type:
```ts
const { param1 } = useParams<{ param1: 'value1' | 'value2' }>();
// param1 is just string, but should be 'value1' | 'value2'
```
Current changes are especially useful with something like this:
```ts
<Router path="/some/path/:param(value1|value2)">
</Router>
```
This allows the use of type checking in all subsequent uses.