### PR TITLE
[express] change default generic type of ReqQuery to any and Query type should accept undefined

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -39,9 +39,9 @@ app.get<{}, any, any, {q: string, u?: string }>('/:foo', req => {
     req.query.a; // $ExpectError
 });
 
-// Query will be defaulted to Query type
+// Query will be defaulted to any type
 app.get('/:foo', req => {
-    req.query; // $ExpectType Query
+    req.query; // $ExpectType any
 });
 
 // Default types

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -33,8 +33,9 @@ app.get<{ foo: string }>('/:foo', req => {
 app.get<{ foo: number }>('/:foo', () => {}); // $ExpectError
 
 // Query can be a custom type
-app.get<{}, any, any, {q: string}>('/:foo', req => {
+app.get<{}, any, any, {q: string, u?: string }>('/:foo', req => {
     req.query.q; // $ExpectType string
+    req.query.u; // $ExpectType string | undefined
     req.query.a; // $ExpectError
 });
 

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -43,17 +43,17 @@ export type Params = ParamsDictionary | ParamsArray;
 // Return type of qs.parse, the default query parser (https://expressjs.com/en/api.html#app-settings-property).
 export interface Query { [key: string]: undefined | string | Query | Array<string | Query>; }
 
-export interface RequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query> {
+export interface RequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any> {
     // tslint:disable-next-line callable-types (This is extended from and can't extend from a type alias in ts<2.2
     (req: Request<P, ResBody, ReqBody, ReqQuery>, res: Response<ResBody>, next: NextFunction): any;
 }
 
-export type ErrorRequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query> =
+export type ErrorRequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any> =
     (err: any, req: Request<P, ResBody, ReqBody, ReqQuery>, res: Response<ResBody>, next: NextFunction) => any;
 
 export type PathParams = string | RegExp | Array<string | RegExp>;
 
-export type RequestHandlerParams<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query>
+export type RequestHandlerParams<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any>
     = RequestHandler<P, ResBody, ReqBody, ReqQuery>
     | ErrorRequestHandler<P, ResBody, ReqBody, ReqQuery>
     | Array<RequestHandler<P>
@@ -61,9 +61,9 @@ export type RequestHandlerParams<P extends Params = ParamsDictionary, ResBody = 
 
 export interface IRouterMatcher<T, Method extends 'all' | 'get' | 'post' | 'put' | 'delete' | 'patch' | 'options' | 'head' = any> {
     // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
-    <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query>(path: PathParams, ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery>>): T;
+    <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any>(path: PathParams, ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery>>): T;
     // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
-    <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query>(path: PathParams, ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery>>): T;
+    <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any>(path: PathParams, ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery>>): T;
     (path: PathParams, subApplication: Application): T;
 }
 
@@ -213,7 +213,7 @@ export type Errback = (err: Error) => void;
  *     app.get<ParamsArray>(/user\/(.*)/, (req, res) => res.send(req.params[0]));
  *     app.get<ParamsArray>('/user/*', (req, res) => res.send(req.params[0]));
  */
-export interface Request<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query> extends http.IncomingMessage, Express.Request {
+export interface Request<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = any> extends http.IncomingMessage, Express.Request {
     /**
      * Return request header.
      *

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -41,7 +41,7 @@ export type ParamsArray = string[];
 export type Params = ParamsDictionary | ParamsArray;
 
 // Return type of qs.parse, the default query parser (https://expressjs.com/en/api.html#app-settings-property).
-export interface Query { [key: string]: string | Query | Array<string | Query>; }
+export interface Query { [key: string]: undefined | string | Query | Array<string | Query>; }
 
 export interface RequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = Query> {
     // tslint:disable-next-line callable-types (This is extended from and can't extend from a type alias in ts<2.2


### PR DESCRIPTION
The latest v4.17.4 introduce 1 breaking change and 1 bug.

1. The default value of generic for ReqQuery is Query. It breaks some codebase that have already implemented their own type casting.

```ts
# example
export type ReqParam = { category: string };

export interface MyCustomRequest extends Request<ReqParam > {
    query: {
        sort?: 'asc' | 'desc';
    };
}

export const myRequestHandler: RequestHandler<ReqParam> = (
    req: MyCustomRequest ,
    res,
    next,
) => {
    req.params.category // string
    req.query.sort // undefined or 'asc' or 'desc'
};
```

2. Express.js doesn't guarantee value from `req.query`, so `undefined` value is possible.

```ts
req.query.foobar // it may be undefined or string or string[]
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
