### PR TITLE
[@types/amplitude-js] - Config - sameSiteCookie is not defined

### DIFF
--- a/types/amplitude-js/index.d.ts
+++ b/types/amplitude-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Amplitude SDK 5.8
+// Type definitions for Amplitude SDK 5.11
 // Project: https://github.com/amplitude/Amplitude-Javascript
 // Definitions by: Arvydas Sidorenko <https://github.com/Asido>
 //                 Dan Manastireanu <https://github.com/danmana>
@@ -35,6 +35,7 @@ export interface Config {
     saveParamsReferrerOncePerSession?: boolean;
     secureCookie?: boolean;
     sessionTimeout?: number;
+    sameSiteCookie?: string;
     useNativeDeviceInfo?: boolean;
     trackingOptions?: {
         city?: boolean;

--- a/types/amplitude-js/index.d.ts
+++ b/types/amplitude-js/index.d.ts
@@ -35,7 +35,7 @@ export interface Config {
     saveParamsReferrerOncePerSession?: boolean;
     secureCookie?: boolean;
     sessionTimeout?: number;
-    sameSiteCookie?: string;
+    sameSiteCookie?: 'Lax' | 'Strict' | 'None';
     useNativeDeviceInfo?: boolean;
     trackingOptions?: {
         city?: boolean;


### PR DESCRIPTION
So the latest amplitude sdk is 5.11.0 where now we can set samSite flag to amplitude cookie.
The interface Config misses the sameSiteCookie property.

Please let me know if any other change is required to add the type in Config interface.

Authors: @asido  @danmana  @HintikkaKimmo 
