### PR TITLE
Add missing /// <reference types="node" />

### DIFF
--- a/types/jsforce/index.d.ts
+++ b/types/jsforce/index.d.ts
@@ -13,6 +13,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
+/// <reference types="node" />
 export * from './api/analytics';
 export * from './api/apex';
 export * from './api/chatter';

--- a/types/undertaker/index.d.ts
+++ b/types/undertaker/index.d.ts
@@ -5,6 +5,7 @@
 //                 Evan Yamanishi <https://github.com/sh0ji>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
 import * as Registry from "undertaker-registry";
 import { Duplex } from "stream";
 import { EventEmitter } from "events";

--- a/types/undertaker/undertaker-tests.ts
+++ b/types/undertaker/undertaker-tests.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import * as fs from "fs";
 import Undertaker = require("undertaker");
 import Registry = require("undertaker-registry");


### PR DESCRIPTION
https://github.com/microsoft/types-publisher/pull/765#issuecomment-619060782

This change adds `/// <reference types="node" />` to types that import a Node.js built-in module without having a dependency on `@types/node`.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).