### PR TITLE
Fix yoga-layout types for setMeasureFunc() and unsetMeasureFunc()

### DIFF
--- a/types/yoga-layout/index.d.ts
+++ b/types/yoga-layout/index.d.ts
@@ -230,6 +230,12 @@ declare namespace Yoga {
 
     type YogaExperimentalFeature = typeof EXPERIMENTAL_FEATURE_WEB_FLEX_BASIS;
 
+    type YogaMeasureMode =
+        | typeof MEASURE_MODE_COUNT
+        | typeof MEASURE_MODE_UNDEFINED
+        | typeof MEASURE_MODE_EXACTLY
+        | typeof MEASURE_MODE_AT_MOST;
+
     interface YogaNode {
         calculateLayout(
             width?: number,
@@ -304,7 +310,7 @@ declare namespace Yoga {
         setMaxHeightPercent(maxHeight: number): void;
         setMaxWidth(maxWidth: number | string): void;
         setMaxWidthPercent(maxWidth: number): void;
-        setMeasureFunc(measureFunc: (() => any) | null): void;
+        setMeasureFunc(measureFunc: (width: number, widthMeasureMode: YogaMeasureMode, height: number, heightMeasureMode: YogaMeasureMode) => { width?: number; height?: number } | null): void;
         setMinHeight(minHeight: number | string): void;
         setMinHeightPercent(minHeight: number): void;
         setMinWidth(minWidth: number | string): void;
@@ -318,7 +324,7 @@ declare namespace Yoga {
         setWidth(width: number | string): void;
         setWidthAuto(): void;
         setWidthPercent(width: number): void;
-        unsetMeasureFun(): void;
+        unsetMeasureFunc(): void;
     }
 
     interface YogaConfig {

--- a/types/yoga-layout/yoga-layout-tests.ts
+++ b/types/yoga-layout/yoga-layout-tests.ts
@@ -16,6 +16,11 @@ node1.setHeight(100);
 node1.setDisplay(DISPLAY_FLEX);
 
 const node2 = Node.create();
+node2.setMeasureFunc((_width: number, _widthMeasureMode: yoga.YogaMeasureMode, _height: number, _heightMeasureMode: yoga.YogaMeasureMode) => ({
+    width: 100,
+    height: 100
+}));
+node2.unsetMeasureFunc();
 node2.setWidth(100);
 node2.setHeight(100);
 


### PR DESCRIPTION
# Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/yoga/blob/master/javascript/sources/Node.hh#L147-L148
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

# Description

This PR adds proper types to `setMeasureFunc()` and fixes a typo in `unsetMeasureFunc()` name (it was `unsetMeasureFun()` before).
