### PR TITLE
[convert-units] Make `convert` function `value` param optional.

### DIFF
--- a/types/convert-units/convert-units-tests.ts
+++ b/types/convert-units/convert-units-tests.ts
@@ -4,3 +4,16 @@ const convertedMass = convert(25).from('mcg').to('t');
 const convertedMassBack =  convert(convertedMass).from('t').to('mcg');
 
 const unit = convert(66).getUnit<'mcg'>('mcg');
+
+// Using `convert` without a value.
+const measures = convert().measures();
+const allUnits = convert().possibilities();
+const massUnits = convert().possibilities('mass');
+const distanceUnits = convert().from('m').possibilities();
+const kgDescription = convert().describe('kg');
+
+const kgAbbr: string = kgDescription.abbr;
+const kgMeasure: string = kgDescription.measure;
+const kgSystem: string  = kgDescription.system;
+const kgSingular: string = kgDescription.singular;
+const kgPlural: string = kgDescription.plural;

--- a/types/convert-units/index.d.ts
+++ b/types/convert-units/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/ben-ng/convert-units#readme
 // Definitions by: vladkampov <https://github.com/vladkampov>
 //                 ben-ng <https://github.com/ben-ng>
+//                 Toby Bell <https://github.com/tobybell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
@@ -129,6 +130,6 @@ declare class Convert {
     measures(): measure[];
 }
 
-declare function convert(value: number): Convert;
+declare function convert(value?: number): Convert;
 
 export = convert;


### PR DESCRIPTION
The `convert` function can be used with no `value` argument, but previously the type definition for this module required it.

Example usage with no `value` argument: https://github.com/ben-ng/convert-units

- Made `value` param for `convert(value)` function optional.
- Added tests for that use case.
