### PR TITLE
[@types/puppeteer] add product to FetcherOptions

### DIFF
--- a/types/puppeteer/v1/index.d.ts
+++ b/types/puppeteer/v1/index.d.ts
@@ -2220,7 +2220,7 @@ export interface FetcherOptions {
   /** Possible values are: `mac`, `win32`, `win64`, `linux`. Defaults to the current platform. */
   platform?: Platform;
   /** Possible values are `firefox` and `chrome`. Defaults to chrome. */
-  product?: string;
+  product?: 'chrome' | 'firefox';
 }
 
 /** Attaches Puppeteer to an existing Chromium instance */

--- a/types/puppeteer/v1/index.d.ts
+++ b/types/puppeteer/v1/index.d.ts
@@ -2219,6 +2219,8 @@ export interface FetcherOptions {
   path?: string;
   /** Possible values are: `mac`, `win32`, `win64`, `linux`. Defaults to the current platform. */
   platform?: Platform;
+  /** Possible values are `firefox` and `chrome`. Defaults to chrome. */
+  product?: string;
 }
 
 /** Attaches Puppeteer to an existing Chromium instance */


### PR DESCRIPTION
Hi, first time attempting to contribute.
I think a property (`product`) was missed during this PR to improve puppeteer types: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33499/files#diff-26c1cae70a0e01ff10cdc4e82232b3eaR2217

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://pptr.dev/#?product=Puppeteer&version=v3.0.0&show=api-puppeteercreatebrowserfetcheroptions
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.