### PR TITLE
[ipld-block] Add types for ipld-block

### DIFF
--- a/types/ipld-block/index.d.ts
+++ b/types/ipld-block/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for ipld-block 0.9
+// Project: https://github.com/ipld/js-ipld-block
+// Definitions by: Felix Kopp <https://github.com/sandtler>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node" />
+
+import CID = require('cids');
+
+declare class Block {
+    static isBlock(val: any): boolean;
+
+    constructor(data: Buffer, cid: CID);
+
+    readonly data: Buffer;
+    readonly cid: CID;
+}
+
+export = Block;

--- a/types/ipld-block/ipld-block-tests.ts
+++ b/types/ipld-block/ipld-block-tests.ts
@@ -1,0 +1,18 @@
+import Block = require('ipld-block');
+import CID = require('cids');
+
+Block.isBlock(null); // $ExpectType boolean
+
+new Block(null, new CID('')); // $ExpectError
+new Block(new Buffer(''), null); // $ExpectError
+
+const testBlock = new Block(
+    Buffer.from('0000'),
+    new CID('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu'),
+);
+
+testBlock.data = new Buffer(''); // $ExpectError
+testBlock.cid = new CID(''); // $ExpectError
+
+testBlock.data; // $ExpectType Buffer
+testBlock.cid; // $ExpectType CID

--- a/types/ipld-block/package.json
+++ b/types/ipld-block/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "cids": "~0.8.0"
+    }
+}

--- a/types/ipld-block/tsconfig.json
+++ b/types/ipld-block/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ipld-block-tests.ts"
+    ]
+}

--- a/types/ipld-block/tslint.json
+++ b/types/ipld-block/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
