### PR TITLE
helmet: Allow referrerPolicy.policy to be an array of strings

### DIFF
--- a/types/helmet/helmet-tests.ts
+++ b/types/helmet/helmet-tests.ts
@@ -233,7 +233,8 @@ function noSniffTest() {
  * @summary Test for {@see helmet#referrerPolicy} function.
  */
 function referrerPolicyTest() {
-    app.use(helmet.referrerPolicy({ policy: 'same-origin' }))
+    app.use(helmet.referrerPolicy({ policy: 'same-origin' }));
+    app.use(helmet.referrerPolicy({ policy: ['no-referrer', 'origin', 'strict-origin', 'strict-origin-when-cross-origin'] }));
 }
 
 /**

--- a/types/helmet/index.d.ts
+++ b/types/helmet/index.d.ts
@@ -164,7 +164,7 @@ declare namespace helmet {
     }
 
     export interface IHelmetReferrerPolicyConfiguration {
-        policy?: string;
+        policy?: string | string[];
     }
 
     export interface IHelmetXssFilterConfiguration {


### PR DESCRIPTION
(Let me know if I’ve broken any rules with the way I’ve done this. I’m still pretty new to it all 😁)

Setting a referrer policy as an array of strings is permitted. This will result in a comma-separated list of policies, where the last policy understood by the browser would be the one applied. See [MDN on the Referrer-Policy header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#Specifying_a_fallback_policy) as well as [Helmet’s documentation](https://helmetjs.github.io/docs/referrer-policy/) (near the bottom).

This is a setup I’ve been using on [monicajean.photography](https://monicajean.photography) successfully, so I can confirm that it works in the wild as well.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
    - I wasn’t sure what to do about this one. I did `npm run prettier -- --write types/helmet/**/*.ts`, but it changed quite a few lines of code that weren’t mine, and that didn’t seem like a good idea, so I went without. Also, it recommends using `ReadonlyArray` over `string[]` when the array’s parameters won’t be written to; I went for style consistency and used `string[]` so it would match the rest of the file.
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - [MDN: `Referrer-Policy` header fallbacks](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#Specifying_a_fallback_policy)
    - [Helmet’s docs, with an example of an array of `Referrer-Policy` strings near the bottom](https://helmetjs.github.io/docs/referrer-policy/)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. _(It does not.)_
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. _(This change is pretty minor.)_