### PR TITLE
fix(update-dom-mediacapture-record): more specific addEventListener typing

### DIFF
--- a/types/dom-mediacapture-record/dom-mediacapture-record-tests.ts
+++ b/types/dom-mediacapture-record/dom-mediacapture-record-tests.ts
@@ -58,3 +58,9 @@ recorder.onpause = null;
 recorder.onresume = null;
 recorder.onstart = null;
 recorder.onstop = null;
+
+recorder.addEventListener('dataavailable', (e: BlobEvent) => {});
+recorder.addEventListener('error', (e: MediaRecorderErrorEvent) => {});
+recorder.addEventListener('pause', onEvent);
+recorder.addEventListener('resume', onEvent);
+recorder.addEventListener('dataavailable', onEvent);

--- a/types/dom-mediacapture-record/index.d.ts
+++ b/types/dom-mediacapture-record/index.d.ts
@@ -58,7 +58,9 @@ declare class MediaRecorder extends EventTarget {
 
     constructor(stream: MediaStream, options?: MediaRecorderOptions);
 
+    addEventListener<K extends keyof MediaRecorderEventMap>(type: K, listener: (this: MediaRecorder, ev: MediaRecorderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof MediaRecorderEventMap>(type: K, listener: (this: MediaRecorder, ev: MediaRecorderEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 
     start(timeslice?: number): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/onerror
  - https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/ondataavailable
  - https://developer.mozilla.org/en-US/docs/Web/API/BlobEvent
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~

----
This PR will make typing more specific for `addEventListener`. The event will also reflect correctly accordingly to the name.