### PR TITLE
feat(react): Add typedefs for useMutableSource (experimental)

### DIFF
--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -38,13 +38,35 @@ import React = require('.');
 
 export {};
 
+/**
+ * Fakes Flow's `$NonMaybeType<mixed>`.
+ * Theoretically same with `NonNullable<unknown>` that doesn't work.
+ *
+ * See https://github.com/facebook/react/commit/322cdcd3abfaca985a001a12247f02c5d31d311e#diff-a91e99777b6cc96255a75b3e7fece2aeR194-R196
+ * See https://www.typescriptlang.org/play/#code/C4TwDgpgBAJAcgewHYFkCGIBGEAq4IoCWAHhACZQC8UAosQMYA2ArmRADzNIDWSCA7kgA0UJM0aMoAHyhc2AM0JJyAPgBQa+V3rBCyKAGUEzAE70IACgDOxsxABcsRKgzY8kIqTIBKKAG8oAF8NAHoQqAABYCsAWghiSB04kxMEEzUjU3MLMQlvAG41MMjouISIJIgUtIzbbLkIRWUfQqA
+ */
 type NonNullableValue = string | number | boolean | object | symbol;
 
+/**
+ * An opaque type that can only be created by `React.createMutableSource` API.
+ */
+type MutableSource<Source extends NonNullableValue, Version extends NonNullableValue> = {
+    /**
+     * External source that React should keep track
+     *
+     * @private
+     */
+    _source: Source,
+
+    /**
+     * Snapshot function the "tearing" has happened while rendering is interrupted.
+     *
+     * @private
+     */
+    _getVersion: (source: Source) => Version,
+};
+
 declare module '.' {
-    type MutableSource<Source extends NonNullableValue, Version extends NonNullableValue> = Pick<{
-        _source: Source,
-        _getVersion: (source: Source) => Version,
-    }, never>;
     type MutableSourceType<T> = T extends MutableSource<infer Source, any> ? Source : never;
     type MutableSourceVersionType<T> = T extends MutableSource<any, infer Version> ? Version : never;
     type MutableSourceSubscribeFn<Source extends NonNullableValue, Version extends NonNullableValue> = (

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -40,31 +40,30 @@ export {};
 
 /**
  * Fakes Flow's `$NonMaybeType<mixed>`.
- * Theoretically same with `NonNullable<unknown>` that doesn't work.
+ * Theoretically same with `NonNullable<unknown>` that doesn't work in TypeScript.
  *
- * See https://github.com/facebook/react/commit/322cdcd3abfaca985a001a12247f02c5d31d311e#diff-a91e99777b6cc96255a75b3e7fece2aeR194-R196
- * See https://www.typescriptlang.org/play/#code/C4TwDgpgBAJAcgewHYFkCGIBGEAq4IoCWAHhACZQC8UAosQMYA2ArmRADzNIDWSCA7kgA0UJM0aMoAHyhc2AM0JJyAPgBQa+V3rBCyKAGUEzAE70IACgDOxsxABcsRKgzY8kIqTIBKKAG8oAF8NAHoQqAABYCsAWghiSB04kxMEEzUjU3MLMQlvAG41MMjouISIJIgUtIzbbLkIRWUfQqA
+ * @see https://github.com/facebook/react/commit/322cdcd3abfaca985a001a12247f02c5d31d311e#diff-a91e99777b6cc96255a75b3e7fece2aeR194-R196
  */
 type NonNullableValue = string | number | boolean | object | symbol;
 
 /**
  * An opaque type that can only be created by `React.createMutableSource` API.
  */
-type MutableSource<Source extends NonNullableValue, Version extends NonNullableValue> = {
+interface MutableSource<Source extends NonNullableValue, Version extends NonNullableValue> {
     /**
      * External source that React should keep track
      *
      * @private
      */
-    _source: Source,
+    _source: Source;
 
     /**
      * Snapshot function the "tearing" has happened while rendering is interrupted.
      *
      * @private
      */
-    _getVersion: (source: Source) => Version,
-};
+    _getVersion: (source: Source) => Version;
+}
 
 declare module '.' {
     type MutableSourceType<T> = T extends MutableSource<infer Source, any> ? Source : never;

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -41,20 +41,20 @@ export {};
 type NonNullableValue = string | number | boolean | object | symbol;
 
 declare module '.' {
-    type MutableSource<TSource extends NonNullableValue, TVersion extends NonNullableValue> = {
-        _source: TSource,
-        _getVersion: (source: TSource) => TVersion,
+    type MutableSource<Source extends NonNullableValue, Version extends NonNullableValue> = {
+        _source: Source,
+        _getVersion: (source: Source) => Version,
     };
-    type MutableSourceType<T> = T extends MutableSource<infer TSource, any> ? TSource : never;
-    type MutableSourceVersionType<T> = T extends MutableSource<any, infer TVersion> ? TVersion : never;
-    type MutableSourceSubscribeFn<TSource extends NonNullableValue, TVersion extends NonNullableValue> = (
-        source: TSource,
-        callback: (version: TVersion) => void,
+    type MutableSourceType<T> = T extends MutableSource<infer Source, any> ? Source : never;
+    type MutableSourceVersionType<T> = T extends MutableSource<any, infer Version> ? Version : never;
+    type MutableSourceSubscribeFn<Source extends NonNullableValue, Version extends NonNullableValue> = (
+        source: Source,
+        callback: (version: Version) => void,
     ) => (void | (() => void));
-    function createMutableSource<TSource extends NonNullableValue, TVersion extends NonNullableValue>(
-        source: TSource,
-        getVersion: (source: TSource) => TVersion,
-    ): MutableSource<TSource, TVersion>;
+    function createMutableSource<Source extends NonNullableValue, Version extends NonNullableValue>(
+        source: Source,
+        getVersion: (source: Source) => Version,
+    ): MutableSource<Source, Version>;
 
     export type SuspenseListRevealOrder = 'forwards' | 'backwards' | 'together';
     export type SuspenseListTailMode = 'collapsed' | 'hidden';
@@ -191,9 +191,9 @@ declare module '.' {
      *
      * @see https://github.com/reactjs/rfcs/pull/147
      */
-    function useMutableSource<TSource extends NonNullableValue, TVersion extends NonNullableValue, TSnapshot>(
-        source: MutableSource<TSource, TVersion>,
-        getSnapshot: (source: TSource) => TSnapshot,
-        subscribe: MutableSourceSubscribeFn<TSource, TVersion>,
-    ): TSnapshot;
+    function useMutableSource<Source extends NonNullableValue, Version extends NonNullableValue, Snapshot>(
+        source: MutableSource<Source, Version>,
+        getSnapshot: (source: Source) => Snapshot,
+        subscribe: MutableSourceSubscribeFn<Source, Version>,
+    ): Snapshot;
 }

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -38,7 +38,7 @@ import React = require('.');
 
 export {};
 
-type NonNullableValue = string | number | boolean | object | symbol | bigint;
+type NonNullableValue = string | number | boolean | object | symbol;
 
 declare module '.' {
     type MutableSource<TSource extends NonNullableValue, TVersion extends NonNullableValue> = {

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -41,10 +41,10 @@ export {};
 type NonNullableValue = string | number | boolean | object | symbol;
 
 declare module '.' {
-    type MutableSource<Source extends NonNullableValue, Version extends NonNullableValue> = {
+    type MutableSource<Source extends NonNullableValue, Version extends NonNullableValue> = Pick<{
         _source: Source,
         _getVersion: (source: Source) => Version,
-    };
+    }, never>;
     type MutableSourceType<T> = T extends MutableSource<infer Source, any> ? Source : never;
     type MutableSourceVersionType<T> = T extends MutableSource<any, infer Version> ? Version : never;
     type MutableSourceSubscribeFn<Source extends NonNullableValue, Version extends NonNullableValue> = (

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -53,7 +53,7 @@ function useExperimentalHooks() {
     const pathname = React.useMutableSource(
         // $ExpectType MutableSource<Window, string>
         locationSource,
-        // $ExpectType MutableSource<Window, string>
+        // $ExpectType (source: Window) => string
         source => source.location.pathname,
         (window, callback) => {
             // $ExpectType Window
@@ -62,7 +62,7 @@ function useExperimentalHooks() {
             callback;
 
             window.addEventListener("popstate", callback);
-            return () => window.removeEventListener("poastate", callback);
+            return () => window.removeEventListener("popstate", callback);
         }
     );
 

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -51,9 +51,7 @@ function useExperimentalHooks() {
 
     // $ExpectType string
     const pathname = React.useMutableSource(
-        // $ExpectType MutableSource<Window, string>
         locationSource,
-        // $ExpectType (source: Window) => string
         source => source.location.pathname,
         (window, callback) => {
             // $ExpectType Window


### PR DESCRIPTION
Reopen #43765

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
