### PR TITLE
fix(ejs): correct `delimiter` property definition

### DIFF
--- a/types/ejs/index.d.ts
+++ b/types/ejs/index.d.ts
@@ -119,7 +119,7 @@ export let closeDelimiter: string;
  *
  * @default '%'
  */
-export let delimiter: string;
+export let delimiter: string | undefined;
 
 /**
  * Promise implementation -- defaults to the native implementation if available
@@ -377,9 +377,8 @@ export interface Options {
 	closeDelimiter?: string;
 
 	/**
-	 * The delimiter used in template compilation.
-	 *
-	 * @default ejs.delimiter
+	 * Character to use with angle brackets for open/close
+	 * @default '%'
 	 */
 	delimiter?: string;
 

--- a/types/ejs/test/ejs.cjs.test.ts
+++ b/types/ejs/test/ejs.cjs.test.ts
@@ -70,6 +70,7 @@ ejs.clearCache();
 ejs.cache = LRU(100);
 
 /** @see https://github.com/mde/ejs/tree/v2.5.7#custom-delimiters */
+ejs.delimiter; // $ExpectType string | undefined
 ejs.delimiter = '%';
 
 // https://github.com/mde/ejs#options

--- a/types/ejs/test/ejs.umd.test.ts
+++ b/types/ejs/test/ejs.umd.test.ts
@@ -15,6 +15,9 @@ ejs.clearCache;
 // $ExpectType Cache
 ejs.cache;
 
+// $ExpectType string | undefined
+ejs.delimiter;
+
 expectType<{
 	(template: string, opts: ejs.Options & { async: true; client?: false }): ejs.AsyncTemplateFunction;
 	(template: string, opts: ejs.Options & { async: true; client: true }): ejs.AsyncClientFunction;


### PR DESCRIPTION
As per discussion here:
- #44163

The `delimiter` at module level is undefined:
https://github.com/mde/ejs/blob/685f5ef0bc720c6cc51004e22c1d6329df6bad29/lib/ejs.js

The default value of `delimiter` options is not module-level value, but
`%` (see above link)

This is default module behavior:

```js
const ejs = require('ejs');
const assert = require('assert');

assert(typeof ejs.delimiter === 'undefined');
```

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes