### PR TITLE
Hexo: add RendererData to exported module.

### DIFF
--- a/types/hexo/hexo-tests.ts
+++ b/types/hexo/hexo-tests.ts
@@ -436,7 +436,7 @@ h.on('ready', () => {
     }
 
     {
-        h.extend.renderer.register('ts', 'js', (data, options) => {
+        h.extend.renderer.register('ts', 'js', (data: Hexo.extend.RendererData, options) => {
             console.log(data.path);
             console.log(data.text);
             return 'result';

--- a/types/hexo/hexo-tests.ts
+++ b/types/hexo/hexo-tests.ts
@@ -89,7 +89,7 @@ h.init().then(async () => {
     h.source.unwatch();
 
     await h.load();
-    h.call('config', {_: ['arg1']}, (err, value) => {});
+    h.call('config', { _: ['arg1'] }, (err, value) => {});
 
     await h.exit();
 });
@@ -161,7 +161,7 @@ h.on('ready', () => {
     }
 
     {
-        h.locals.set('some-data', () =>  'some vlue');
+        h.locals.set('some-data', () => 'some vlue');
         h.locals.remove('some-data');
         h.locals.toObject();
         h.locals.invalidate();
@@ -207,12 +207,12 @@ h.on('ready', () => {
                 console.log(content);
             });
 
-            file.read({encoding: 'utf8', flag: 'r'}, (err, content) => {
+            file.read({ encoding: 'utf8', flag: 'r' }, (err, content) => {
                 console.log(err, content.toString());
                 console.log(content);
             });
 
-            file.readSync({encoding: 'utf8', flag: 'r'});
+            file.readSync({ encoding: 'utf8', flag: 'r' });
 
             file.stat((err, stat) => {
                 console.log(err);
@@ -255,16 +255,16 @@ h.on('ready', () => {
         };
 
         let _string = '';
-        h.render.render({text: 'example', engine: 'swig'}).then(result => {
+        h.render.render({ text: 'example', engine: 'swig' }).then(result => {
             _string = result;
         });
-        h.render.render({path: __filename}).then(result => {
+        h.render.render({ path: __filename }).then(result => {
             _string = result;
         });
-        h.render.render({text: ''}, {foo: 'foo'}).then(result => {
+        h.render.render({ text: '' }, { foo: 'foo' }).then(result => {
             _string = result;
         });
-        _string = h.render.renderSync({text: 'example'});
+        _string = h.render.renderSync({ text: 'example' });
 
         _string = h.render.getOutput('ejs');
     }
@@ -316,12 +316,10 @@ h.on('ready', () => {
         const options: Hexo.extend.Console.Options = {};
         options.usage = '[layout] <title>';
         options.arguments = [
-            {name: 'layout', desc: 'Post layout'},
-            {name: 'title', desc: 'Post title'},
+            { name: 'layout', desc: 'Post layout' },
+            { name: 'title', desc: 'Post title' },
         ];
-        options.options = [
-            {name: '-r, --replace', desc: 'Replace existing files'},
-        ];
+        options.options = [{ name: '-r, --replace', desc: 'Replace existing files' }];
         options.desc = 'desc';
 
         h.extend.console.register('name', 'description', options, args => {
@@ -429,18 +427,26 @@ h.on('ready', () => {
 
     {
         let f: Hexo.Box.File;
-        h.extend.processor.register('pattern', file => f = file);
-        h.extend.processor.register(/pattern/, file => f = file);
-        h.extend.processor.register((str) => true , file => f = file);
-        h.extend.processor.register(file => f = file);
+        h.extend.processor.register('pattern', file => (f = file));
+        h.extend.processor.register(/pattern/, file => (f = file));
+        h.extend.processor.register(
+            str => true,
+            file => (f = file),
+        );
+        h.extend.processor.register(file => (f = file));
     }
 
     {
-        h.extend.renderer.register('ts', 'js', (data: Hexo.extend.RendererData, options) => {
-            console.log(data.path);
-            console.log(data.text);
-            return 'result';
-        }, true);
+        h.extend.renderer.register(
+            'ts',
+            'js',
+            (data: Hexo.extend.RendererData, options) => {
+                console.log(data.path);
+                console.log(data.text);
+                return 'result';
+            },
+            true,
+        );
 
         h.extend.renderer.register('ts', 'js', (data, options) => Promise.resolve('result'), false);
         h.extend.renderer.register('ts', 'js', (data, options) => Promise.resolve('result'));

--- a/types/hexo/index.d.ts
+++ b/types/hexo/index.d.ts
@@ -70,7 +70,7 @@ interface HexoConfig {
     /**
      * Default values of each segment in permalink
      */
-    readonly permalink_defaults: string|null;
+    readonly permalink_defaults: string | null;
 
     /**
      * Source folder. Where your content is stored
@@ -110,7 +110,7 @@ interface HexoConfig {
     /**
      * Paths that will be copied to public raw, without being rendered. You can use glob expressions for path matching.
      */
-    readonly skip_render: string|string[]|null;
+    readonly skip_render: string | string[] | null;
 
     /**
      * The filename format for new posts
@@ -164,7 +164,7 @@ interface HexoConfig {
         readonly enable: boolean;
         readonly line_number: boolean;
         readonly auto_detect: boolean;
-        readonly tab_replace: string|null;
+        readonly tab_replace: string | null;
     };
 
     /**
@@ -175,12 +175,12 @@ interface HexoConfig {
     /**
      * Category slugs
      */
-    readonly category_map: {[key: string]: string|number};
+    readonly category_map: { [key: string]: string | number };
 
     /**
      * Tag slugs
      */
-    readonly tag_map: {[key: string]: string|number};
+    readonly tag_map: { [key: string]: string | number };
 
     /**
      * Date format
@@ -207,12 +207,12 @@ interface HexoConfig {
     /**
      * Theme name. false disables theming
      */
-    readonly theme: string|false;
+    readonly theme: string | false;
 
     /**
      * Theme configuration. Include any custom theme settings under this key to override theme defaults.
      */
-    readonly theme_config: {[key: string]: string|number};
+    readonly theme_config: { [key: string]: string | number };
 
     /**
      * Deployment settings
@@ -222,12 +222,12 @@ interface HexoConfig {
     /**
      * Hexo by default ignores hidden files and folders, but setting this field will make Hexo process them
      */
-    readonly include ?: string[];
+    readonly include?: string[];
 
     /**
      * Hexo process will ignore files list under this field
      */
-    readonly exclude ?: string[];
+    readonly exclude?: string[];
     readonly ignore: string[];
 }
 
@@ -264,7 +264,7 @@ interface Site {
     pages: Model<Hexo.Locals.Page>;
     categories: Model<Hexo.Locals.Category>;
     tags: Model<Hexo.Locals.Tag>;
-    data: {[key: string]: any};
+    data: { [key: string]: any };
 }
 
 declare class Hexo extends EventEmitter {
@@ -339,13 +339,13 @@ declare class Hexo extends EventEmitter {
     readonly theme_script_dir: string;
     readonly config_path: string;
     readonly env: {
-      readonly args: ParsedArgs;
-      readonly debug: boolean;
-      readonly safe: boolean;
-      readonly silent: boolean;
-      readonly env: string;
-      readonly version: string;
-      readonly init: boolean;
+        readonly args: ParsedArgs;
+        readonly debug: boolean;
+        readonly safe: boolean;
+        readonly silent: boolean;
+        readonly env: string;
+        readonly version: string;
+        readonly init: boolean;
     };
 
     /**
@@ -424,7 +424,7 @@ declare class Hexo extends EventEmitter {
     /**
      * Emitted after a new post has been created. This event returns the post data:
      */
-    on(ev: 'new', fn: (post: {path: string, content: string}) => void): this;
+    on(ev: 'new', fn: (post: { path: string; content: string }) => void): this;
 
     /**
      * Emitted before processing begins. This event returns a path representing the root directory of the box.
@@ -494,8 +494,8 @@ declare namespace Hexo {
             full_source: string;
             path: string;
             permalink: string;
-            prev?: null|Page;
-            next?: null|Page;
+            prev?: null | Page;
+            next?: null | Page;
             raw?: string;
             photos?: string[];
             link?: string;
@@ -529,27 +529,27 @@ declare namespace Hexo {
             register(name: string, fn: (args: ParsedArgs) => void): void;
         }
         namespace Console {
-          interface Options {
-              /**
-               * The usage of a console command.
-               */
-              usage?: string;
+            interface Options {
+                /**
+                 * The usage of a console command.
+                 */
+                usage?: string;
 
-              /**
-               * The description of each argument of a console command.
-               */
-              arguments?: Array<{name: string, desc: string}>;
+                /**
+                 * The description of each argument of a console command.
+                 */
+                arguments?: Array<{ name: string; desc: string }>;
 
-              /**
-               * The description of each option of a console command.
-               */
-              options?: Array<{name: string, desc: string}>;
+                /**
+                 * The description of each option of a console command.
+                 */
+                options?: Array<{ name: string; desc: string }>;
 
-              /**
-               * More detailed information about a console command.
-               */
-              desc?: string;
-          }
+                /**
+                 * More detailed information about a console command.
+                 */
+                desc?: string;
+            }
         }
 
         interface Deployer {
@@ -557,7 +557,7 @@ declare namespace Hexo {
         }
         namespace Deployer {
             interface Config {
-                readonly type: string|undefined;
+                readonly type: string | undefined;
                 readonly [key: string]: any;
             }
         }
@@ -568,12 +568,20 @@ declare namespace Hexo {
             /**
              * Executed before a post is rendered. Refer to post rendering to learn the execution steps.
              */
-            register(type: 'before_post_render', fn: (data: { content: string, [key: string]: any }) => { content: string, [key: string]: any }|void, priority?: number): void;
+            register(
+                type: 'before_post_render',
+                fn: (data: { content: string; [key: string]: any }) => { content: string; [key: string]: any } | void,
+                priority?: number,
+            ): void;
 
             /**
              * Executed after a post is rendered. Refer to post rendering to learn the execution steps.
              */
-            register(type: 'after_post_render', fn: (data: { content: string, [key: string]: any }) => { content: string, [key: string]: any }|void, priority?: number): void;
+            register(
+                type: 'after_post_render',
+                fn: (data: { content: string; [key: string]: any }) => { content: string; [key: string]: any } | void,
+                priority?: number,
+            ): void;
 
             /**
              * Executed before Hexo is about to exit – this will run right after `hexo.exit` is called.
@@ -593,7 +601,11 @@ declare namespace Hexo {
             /**
              * Modify [local variables](https://hexo.io/docs/variables) in templates.
              */
-            register(type: 'template_locals', fn: (locals: TemplateLocals) => TemplateLocals|void, priority?: number): void;
+            register(
+                type: 'template_locals',
+                fn: (locals: TemplateLocals) => TemplateLocals | void,
+                priority?: number,
+            ): void;
 
             /**
              * Executed after Hexo is initialized – this will run right after `hexo.init` completes.
@@ -603,7 +615,11 @@ declare namespace Hexo {
             /**
              * Executed when creating a post to determine the path of new posts.
              */
-            register(type: 'new_post_path', fn: (data: Post.Data, replace: boolean|undefined) => void, priority?: number): void;
+            register(
+                type: 'new_post_path',
+                fn: (data: Post.Data, replace: boolean | undefined) => void,
+                priority?: number,
+            ): void;
 
             /**
              * Used to determine the permalink of posts.
@@ -613,7 +629,11 @@ declare namespace Hexo {
             /**
              * Executed after rendering finishes. You can see rendering for more info.
              */
-            register(type: 'after_render:html', fn: (result: string, data: {path: string, text: string, [key: string]: any}) => string|void, priority?: number): void;
+            register(
+                type: 'after_render:html',
+                fn: (result: string, data: { path: string; text: string; [key: string]: any }) => string | void,
+                priority?: number,
+            ): void;
 
             /**
              * Executed after generated files and cache are removed with hexo clean command.
@@ -623,7 +643,11 @@ declare namespace Hexo {
             /**
              * Add middleware to the server. app is a Connect instance.
              */
-            register(type: 'server_middleware', fn: (app: connect.Server) => connect.Server|void, priority?: number): void;
+            register(
+                type: 'server_middleware',
+                fn: (app: connect.Server) => connect.Server | void,
+                priority?: number,
+            ): void;
 
             unregister(type: string, fn: (...args: any[]) => any): void;
             exec(type: string, data?: any, options?: Filter.Options): any;
@@ -631,33 +655,33 @@ declare namespace Hexo {
         }
         namespace Filter {
             interface Options {
-              /**
-               * `hexo` object.
-               */
-              context?: Hexo;
-              /**
-               * Arguments. This must be an array.
-               */
-              args?: any[];
+                /**
+                 * `hexo` object.
+                 */
+                context?: Hexo;
+                /**
+                 * Arguments. This must be an array.
+                 */
+                args?: any[];
             }
         }
 
         interface Generator {
-            register(name: string, fn: (locals: Site) => Generator.Return| Generator.Return[]): void;
+            register(name: string, fn: (locals: Site) => Generator.Return | Generator.Return[]): void;
         }
         namespace Generator {
             interface Return {
-              /**
-               * Path not including the prefixing `/` .
-               */
-              path: string;
+                /**
+                 * Path not including the prefixing `/` .
+                 */
+                path: string;
 
-              /**
-               * Layout. Specify the layouts for rendering. The value can be a string or an array. If it’s ignored then the route will return data directly.
-               */
-              layout: string|string[];
+                /**
+                 * Layout. Specify the layouts for rendering. The value can be a string or an array. If it’s ignored then the route will return data directly.
+                 */
+                layout: string | string[];
 
-              data: any;
+                data: any;
             }
         }
 
@@ -675,8 +699,18 @@ declare namespace Hexo {
         }
 
         interface Renderer {
-            register(srcExt: string, outExt: string, fn: (data: RendererData, options: any) => string, sync: true): void;
-            register(srcExt: string, outExt: string, fn: (data: RendererData, options: any) => Promise<string>, sync: false): void;
+            register(
+                srcExt: string,
+                outExt: string,
+                fn: (data: RendererData, options: any) => string,
+                sync: true,
+            ): void;
+            register(
+                srcExt: string,
+                outExt: string,
+                fn: (data: RendererData, options: any) => Promise<string>,
+                sync: false,
+            ): void;
             register(srcExt: string, outExt: string, fn: (data: RendererData, options: any) => Promise<string>): void;
         }
 
@@ -692,7 +726,11 @@ declare namespace Hexo {
         }
 
         interface Tag {
-            register(name: string, fn: (args: string[], content: string|undefined) => string, options?: Tag.Options): void;
+            register(
+                name: string,
+                fn: (args: string[], content: string | undefined) => string,
+                options?: Tag.Options,
+            ): void;
         }
         namespace Tag {
             interface Options {
@@ -706,12 +744,12 @@ declare namespace Hexo {
         /**
          * The `get` method returns a `Stream`.
          */
-        get(path: string): Router.RouteStream|undefined;
+        get(path: string): Router.RouteStream | undefined;
 
         /**
          * The `set` method takes a string, a `Buffer` or a function.
          */
-        set(path: string, data: string|Buffer|util.Pattern<boolean>|Router.Data): this;
+        set(path: string, data: string | Buffer | util.Pattern<boolean> | Router.Data): this;
 
         /**
          * Remove a Path
@@ -775,7 +813,7 @@ declare namespace Hexo {
          * You can use path matching as described above to restrict what exactly the processor should process.
          * Register a new processor with the `addProcessor` method.
          */
-        addProcessor(pattern: string|RegExp|util.Pattern<boolean>, fn: (file: Box.File) => void): void;
+        addProcessor(pattern: string | RegExp | util.Pattern<boolean>, fn: (file: Box.File) => void): void;
     }
     namespace Box {
         interface File {
@@ -792,7 +830,7 @@ declare namespace Hexo {
             /**
              * File type. The value can be `create` , `update` , `skip`, `delete` .
              */
-            readonly type: 'create' | 'update' |  'skip' | 'delete';
+            readonly type: 'create' | 'update' | 'skip' | 'delete';
 
             /**
              * The information from path matching.
@@ -802,13 +840,16 @@ declare namespace Hexo {
             /**
              * Read a file
              */
-            read(option?: {encoding?: string|null, flag?: string}, fn?: (err: any, result: string|Buffer) => void): Promise<string|Buffer>;
-            read(fn?: (err: any, result: string|Buffer) => void): Promise<string|Buffer>;
+            read(
+                option?: { encoding?: string | null; flag?: string },
+                fn?: (err: any, result: string | Buffer) => void,
+            ): Promise<string | Buffer>;
+            read(fn?: (err: any, result: string | Buffer) => void): Promise<string | Buffer>;
 
             /**
              * Read a file synchronously
              */
-            readSync(option?: {encoding?: string|null, flag?: string}): string|Buffer;
+            readSync(option?: { encoding?: string | null; flag?: string }): string | Buffer;
 
             /**
              * Read the status of a file
@@ -874,7 +915,7 @@ declare namespace Hexo {
         publish(data: Post.Data, replace?: boolean, fn?: (err: any) => void): Promise<void>;
         publish(data: Post.Data, fn?: (err: any) => void): Promise<void>;
 
-        render(source: string|null|undefined, data: Post.RenderData, fn: (err: any) => void): Promise<void>;
+        render(source: string | null | undefined, data: Post.RenderData, fn: (err: any) => void): Promise<void>;
     }
     namespace Post {
         interface Data {
@@ -884,10 +925,10 @@ declare namespace Hexo {
             path?: string;
             date?: moment.MomentInput;
         }
-      interface RenderData {
-          engine?: string;
-          content?: string;
-      }
+        interface RenderData {
+            engine?: string;
+            content?: string;
+        }
     }
 
     interface Theme extends Box {
@@ -896,7 +937,7 @@ declare namespace Hexo {
         /**
          * Get a View
          */
-        getView(path: string): View|undefined;
+        getView(path: string): View | undefined;
 
         /**
          * Set a View
@@ -931,7 +972,15 @@ interface TemplateLocals {
      * Underscore object
      */
     _: underscore.UnderscoreStatic;
-    page: Hexo.Locals.Post | Hexo.Locals.Page | Hexo.Locals.Category | Hexo.Locals.Tag | IndexPage | ArchivePage | CategoryPage | TagPage;
+    page:
+        | Hexo.Locals.Post
+        | Hexo.Locals.Page
+        | Hexo.Locals.Category
+        | Hexo.Locals.Tag
+        | IndexPage
+        | ArchivePage
+        | CategoryPage
+        | TagPage;
     path: string;
     url: string;
 

--- a/types/hexo/index.d.ts
+++ b/types/hexo/index.d.ts
@@ -675,9 +675,20 @@ declare namespace Hexo {
         }
 
         interface Renderer {
-            register(srcExt: string, outExt: string, fn: (data: HexoRendererData, options: any) => string, sync: true): void;
-            register(srcExt: string, outExt: string, fn: (data: HexoRendererData, options: any) => Promise<string>, sync: false): void;
-            register(srcExt: string, outExt: string, fn: (data: HexoRendererData, options: any) => Promise<string>): void;
+            register(srcExt: string, outExt: string, fn: (data: RendererData, options: any) => string, sync: true): void;
+            register(srcExt: string, outExt: string, fn: (data: RendererData, options: any) => Promise<string>, sync: false): void;
+            register(srcExt: string, outExt: string, fn: (data: RendererData, options: any) => Promise<string>): void;
+        }
+
+        interface RendererData {
+            /**
+             * File content.
+             */
+            readonly text: string;
+            /**
+             * File path.
+             */
+            readonly path?: string;
         }
 
         interface Tag {
@@ -960,17 +971,6 @@ interface CategoryPage extends IndexPage {
 
 interface TagPage extends IndexPage {
     tag: string;
-}
-
-interface HexoRendererData {
-    /**
-     * File content.
-     */
-    readonly text: string;
-    /**
-     * File path.
-     */
-    readonly path?: string;
 }
 
 export = Hexo;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I ran prettier as suggested in the README, however this has changed a lot of existing code. These formatting changes are in separate commit so it's easier to review, but can revert this part of the PR if necessary.

This PR isn't adding or changing any definitions. It's moving an existing, internal definition, `HexoRendererData`, to be part of the exported module. The definition is used in a callback in the public API. With the definition internal it wasn't possible to define and type annotate a callback.

Definition is already tested but only using type inference. Added explicit annotation in test to test export of definition.