### PR TITLE
[@types/pixelmatch] Accept Uint8ClampedArray for image data

### DIFF
--- a/types/pixelmatch/index.d.ts
+++ b/types/pixelmatch/index.d.ts
@@ -2,15 +2,16 @@
 // Project: https://github.com/mapbox/pixelmatch#readme
 // Definitions by: Oleg Repin <https://github.com/iamolegga>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 Damian Frizzi <https://github.com/damianfrizzi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
 declare function Pixelmatch(
     /** Image data of the first image to compare. Note: image dimensions must be equal. */
-    img1: Buffer | Uint8Array,
+    img1: Buffer | Uint8Array | Uint8ClampedArray,
     /** Image data of the second image to compare. Note: image dimensions must be equal. */
-    img2: Buffer | Uint8Array,
+    img2: Buffer | Uint8Array | Uint8ClampedArray,
     /** Image data to write the diff to, or null if don't need a diff image. */
     output: Buffer | Uint8Array | null,
     /** Width of the images. Note that all three images need to have the same dimensions. */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mapbox/pixelmatch/blob/master/README.md#pixelmatchimg1-img2-output-width-height-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
