### PR TITLE
[@types/ssh2-streams] Fix parseKey return type

### DIFF
--- a/types/ssh2-streams/index.d.ts
+++ b/types/ssh2-streams/index.d.ts
@@ -1686,7 +1686,7 @@ export interface Stats extends Attributes {
 }
 
 export namespace utils {
-    export function parseKey(keyData: string | Buffer, passphrase?: string): ParsedKey | {}[];
+    export function parseKey(keyData: string | Buffer, passphrase?: string): ParsedKey | ParsedKey[] | Error | null;
 }
 
 export interface ParsedKey {


### PR DESCRIPTION
`parseKey` can return a key ([via](https://github.com/mscdex/ssh2-streams/blob/4bc26e937551fb86f03b24c397f738ac2a9dcae8/lib/keyParser.js#L1444) [`PPK_Private.parse()`](https://github.com/mscdex/ssh2-streams/blob/4bc26e937551fb86f03b24c397f738ac2a9dcae8/lib/keyParser.js#L1209)), or `null` (see same function), or `Error` (trivially in `parseKey`), or an array of keys (via [`OpenSSH_Private `](https://github.com/mscdex/ssh2-streams/blob/4bc26e937551fb86f03b24c397f738ac2a9dcae8/lib/keyParser.js#L639)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See commit message.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
