### PR TITLE
fix: headers are optional

### DIFF
--- a/types/vertx3-eventbus-client/index.d.ts
+++ b/types/vertx3-eventbus-client/index.d.ts
@@ -14,9 +14,9 @@ declare namespace EventBus {
     onopen(): any;
     onerror(error: Error): any;
     onclose(): any;
-    registerHandler(address: string, headers: any, callback: (error: Error, message: any) => any): any;
-    unregisterHandler(address: string, headers: any, callback: (error: Error, message: any) => any): any;
-    send(address: string, message: any, headers: any, callback?: (error: Error, message: any) => any): any;
+    registerHandler(address: string, headers?: object, callback?: (error: Error, message: any) => any): any;
+    unregisterHandler(address: string, headers?: object, callback?: (error: Error, message: any) => any): any;
+    send(address: string, message: any, headers?: object, callback?: (error: Error, message: any) => any): any;
     publish(address: string, message: any, headers?: any): any;
     enableReconnect(enable: boolean): void;
     enablePing(enable: boolean): void;


### PR DESCRIPTION
for references see: https://github.com/vert-x3/vertx-web/blob/14d183b9e79f568e69fe7c5b683e61a833e6829f/vertx-web/src/client/vertx-eventbus.js#L282-L284

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/vert-x3/vertx-web/blob/14d183b9e79f568e69fe7c5b683e61a833e6829f/vertx-web/src/client/vertx-eventbus.js#L282-L284
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

