### PR TITLE
Add @parcel/watcher

### DIFF
--- a/types/parcel__watcher/index.d.ts
+++ b/types/parcel__watcher/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for @parcel/watcher 2.0
+// Project: https://github.com/parcel-bundler/watcher#readme
+// Definitions by: Matt Kane <https://github.com/ascorbic>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node"/>
+
+export class ParcelWatcherSubscription {
+    unsubscribe(): Promise<void>;
+}
+
+export type ParcelWatcherEventType = 'create' | 'update' | 'delete';
+
+export interface ParcelWatcherEvent {
+    type: ParcelWatcherEventType;
+    path: string;
+}
+
+export type ParcelWatcherBackend = 'fs-events' | 'watchman' | 'inotify' | 'windows' | 'brute-force';
+
+export interface ParcelWatcherOptions {
+    ignore?: string[];
+    backend?: ParcelWatcherBackend;
+}
+
+export type ParcelWatcherCallback = (error?: Error, events?: ParcelWatcherEvent[]) => any;
+
+export function getEventsSince(
+    dirPath: string,
+    snapshotPath: string,
+    options?: ParcelWatcherOptions,
+): Promise<ParcelWatcherEvent[]>;
+
+export function subscribe(
+    dirPath: string,
+    callback: ParcelWatcherCallback,
+    options?: ParcelWatcherOptions,
+): Promise<ParcelWatcherSubscription>;
+
+export function unsubscribe(
+    dirPath: string,
+    callback: ParcelWatcherCallback,
+    options?: ParcelWatcherOptions,
+): Promise<void>;
+
+export function writeSnapshot(dirPath: string, snapshotPath: string, options?: ParcelWatcherOptions): Promise<void>;

--- a/types/parcel__watcher/parcel__watcher-tests.ts
+++ b/types/parcel__watcher/parcel__watcher-tests.ts
@@ -1,0 +1,33 @@
+import {
+    subscribe,
+    unsubscribe,
+    getEventsSince,
+    ParcelWatcherEvent,
+    ParcelWatcherCallback,
+    writeSnapshot,
+    ParcelWatcherSubscription,
+} from '@parcel/watcher';
+import * as path from 'path';
+
+const handler: ParcelWatcherCallback = (err?: Error, events?: ParcelWatcherEvent[]) => {
+    if (err) {
+        throw err;
+    }
+    console.log(events);
+};
+
+const subscriptionPromise = subscribe(process.cwd(), handler);
+
+subscriptionPromise.then((subscription: ParcelWatcherSubscription) => {
+    subscription.unsubscribe();
+});
+
+unsubscribe(process.cwd(), handler);
+
+const snapshotPath = path.join(process.cwd(), 'snapshot.txt');
+
+getEventsSince(process.cwd(), snapshotPath).then((events: ParcelWatcherEvent[]) => {
+    console.log;
+});
+
+writeSnapshot(process.cwd(), snapshotPath, { backend: 'inotify' });

--- a/types/parcel__watcher/tsconfig.json
+++ b/types/parcel__watcher/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@parcel/watcher": ["parcel__watcher"]
+        }
+    },
+    "files": ["index.d.ts", "parcel__watcher-tests.ts"]
+}

--- a/types/parcel__watcher/tslint.json
+++ b/types/parcel__watcher/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

