### PR TITLE
[ioredis] Run 'prettier' on the ioredis package

### DIFF
--- a/types/ioredis/v3/index.d.ts
+++ b/types/ioredis/v3/index.d.ts
@@ -22,9 +22,9 @@ import Promise = require('bluebird');
 import tls = require('tls');
 
 interface RedisStatic {
-    new(port?: number, host?: string, options?: IORedis.RedisOptions): IORedis.Redis;
-    new(host?: string, options?: IORedis.RedisOptions): IORedis.Redis;
-    new(options?: IORedis.RedisOptions): IORedis.Redis;
+    new (port?: number, host?: string, options?: IORedis.RedisOptions): IORedis.Redis;
+    new (host?: string, options?: IORedis.RedisOptions): IORedis.Redis;
+    new (options?: IORedis.RedisOptions): IORedis.Redis;
     (port?: number, host?: string, options?: IORedis.RedisOptions): IORedis.Redis;
     (host?: string, options?: IORedis.RedisOptions): IORedis.Redis;
     (options?: IORedis.RedisOptions): IORedis.Redis;
@@ -38,10 +38,13 @@ export = IORedis;
 declare class Commander {
     getBuiltinCommands(): string[];
     createBuiltinCommand(commandName: string): {};
-    defineCommand(name: string, definition: {
-        numberOfKeys?: number;
-        lua?: string;
-    }): any;
+    defineCommand(
+        name: string,
+        definition: {
+            numberOfKeys?: number;
+            lua?: string;
+        },
+    ): any;
     sendCommand(): void;
 }
 
@@ -71,19 +74,57 @@ declare namespace IORedis {
         getBuffer(key: string, callback: (err: Error, res: Buffer) => void): void;
         getBuffer(key: string): Promise<Buffer>;
 
-        set(key: string, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<string>;
+        set(
+            key: string,
+            value: any,
+            expiryMode?: string | any[],
+            time?: number | string,
+            setMode?: number | string,
+        ): Promise<string>;
 
         set(key: string, value: any, callback: (err: Error, res: string) => void): void;
         set(key: string, value: any, setMode: string | any[], callback: (err: Error, res: string) => void): void;
-        set(key: string, value: any, expiryMode: string, time: number | string, callback: (err: Error, res: string) => void): void;
-        set(key: string, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: string) => void): void;
+        set(
+            key: string,
+            value: any,
+            expiryMode: string,
+            time: number | string,
+            callback: (err: Error, res: string) => void,
+        ): void;
+        set(
+            key: string,
+            value: any,
+            expiryMode: string,
+            time: number | string,
+            setMode: number | string,
+            callback: (err: Error, res: string) => void,
+        ): void;
 
-        setBuffer(key: string, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<Buffer>;
+        setBuffer(
+            key: string,
+            value: any,
+            expiryMode?: string | any[],
+            time?: number | string,
+            setMode?: number | string,
+        ): Promise<Buffer>;
 
         setBuffer(key: string, value: any, callback: (err: Error, res: Buffer) => void): void;
         setBuffer(key: string, value: any, setMode: string, callback: (err: Error, res: Buffer) => void): void;
-        setBuffer(key: string, value: any, expiryMode: string, time: number, callback: (err: Error, res: Buffer) => void): void;
-        setBuffer(key: string, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(
+            key: string,
+            value: any,
+            expiryMode: string,
+            time: number,
+            callback: (err: Error, res: Buffer) => void,
+        ): void;
+        setBuffer(
+            key: string,
+            value: any,
+            expiryMode: string,
+            time: number | string,
+            setMode: number | string,
+            callback: (err: Error, res: Buffer) => void,
+        ): void;
 
         setnx(key: string, value: any, callback: (err: Error, res: any) => void): void;
         setnx(key: string, value: any): Promise<any>;
@@ -140,8 +181,14 @@ declare namespace IORedis {
         lpushx(key: string, value: any, callback: (err: Error, res: number) => void): void;
         lpushx(key: string, value: any): Promise<number>;
 
-        linsert(key: string, direction: "BEFORE" | "AFTER", pivot: string, value: any, callback: (err: Error, res: number) => void): void;
-        linsert(key: string, direction: "BEFORE" | "AFTER", pivot: string, value: any): Promise<number>;
+        linsert(
+            key: string,
+            direction: 'BEFORE' | 'AFTER',
+            pivot: string,
+            value: any,
+            callback: (err: Error, res: number) => void,
+        ): void;
+        linsert(key: string, direction: 'BEFORE' | 'AFTER', pivot: string, value: any): Promise<number>;
 
         rpop(key: string, callback: (err: Error, res: string) => void): void;
         rpop(key: string): Promise<string>;
@@ -156,7 +203,12 @@ declare namespace IORedis {
 
         blpop(...keys: string[]): any;
 
-        brpoplpush(source: string, destination: string, timeout: number, callback: (err: Error, res: any) => void): void;
+        brpoplpush(
+            source: string,
+            destination: string,
+            timeout: number,
+            callback: (err: Error, res: any) => void,
+        ): void;
         brpoplpush(source: string, destination: string, timeout: number): Promise<any>;
 
         llen(key: string, callback: (err: Error, res: number) => void): void;
@@ -228,7 +280,12 @@ declare namespace IORedis {
 
         zrem(key: string, ...members: any[]): any;
 
-        zremrangebyscore(key: string, min: number | string, max: number | string, callback: (err: Error, res: any) => void): void;
+        zremrangebyscore(
+            key: string,
+            min: number | string,
+            max: number | string,
+            callback: (err: Error, res: any) => void,
+        ): void;
         zremrangebyscore(key: string, min: number | string, max: number | string): Promise<any>;
 
         zremrangebyrank(key: string, start: number, stop: number, callback: (err: Error, res: any) => void): void;
@@ -239,18 +296,35 @@ declare namespace IORedis {
         zinterstore(destination: string, numkeys: number, key: string, ...args: string[]): any;
 
         zrange(key: string, start: number, stop: number, callback: (err: Error, res: any) => void): void;
-        zrange(key: string, start: number, stop: number, withScores: "WITHSCORES", callback: (err: Error, res: any) => void): void;
-        zrange(key: string, start: number, stop: number, withScores?: "WITHSCORES"): Promise<any>;
+        zrange(
+            key: string,
+            start: number,
+            stop: number,
+            withScores: 'WITHSCORES',
+            callback: (err: Error, res: any) => void,
+        ): void;
+        zrange(key: string, start: number, stop: number, withScores?: 'WITHSCORES'): Promise<any>;
 
         zrevrange(key: string, start: number, stop: number, callback: (err: Error, res: any) => void): void;
-        zrevrange(key: string, start: number, stop: number, withScores: "WITHSCORES", callback: (err: Error, res: any) => void): void;
-        zrevrange(key: string, start: number, stop: number, withScores?: "WITHSCORES"): Promise<any>;
+        zrevrange(
+            key: string,
+            start: number,
+            stop: number,
+            withScores: 'WITHSCORES',
+            callback: (err: Error, res: any) => void,
+        ): void;
+        zrevrange(key: string, start: number, stop: number, withScores?: 'WITHSCORES'): Promise<any>;
 
         zrangebyscore(key: string, min: number | string, max: number | string, ...args: string[]): any;
 
         zrevrangebyscore(key: string, max: number | string, min: number | string, ...args: string[]): any;
 
-        zcount(key: string, min: number | string, max: number | string, callback: (err: Error, res: number) => void): void;
+        zcount(
+            key: string,
+            min: number | string,
+            max: number | string,
+            callback: (err: Error, res: number) => void,
+        ): void;
         zcount(key: string, min: number | string, max: number | string): Promise<number>;
 
         zcard(key: string, callback: (err: Error, res: number) => void): void;
@@ -375,8 +449,8 @@ declare namespace IORedis {
         bgrewriteaof(callback: (err: Error, res: string) => void): void;
         bgrewriteaof(): Promise<string>;
 
-        shutdown(save: "SAVE" | "NOSAVE", callback: (err: Error, res: any) => void): void;
-        shutdown(save: "SAVE" | "NOSAVE"): Promise<any>;
+        shutdown(save: 'SAVE' | 'NOSAVE', callback: (err: Error, res: any) => void): void;
+        shutdown(save: 'SAVE' | 'NOSAVE'): Promise<any>;
 
         lastsave(callback: (err: Error, res: number) => void): void;
         lastsave(): Promise<number>;
@@ -508,13 +582,39 @@ declare namespace IORedis {
 
         set(key: string, value: any, callback?: (err: Error, res: string) => void): Pipeline;
         set(key: string, value: any, setMode: string, callback?: (err: Error, res: string) => void): Pipeline;
-        set(key: string, value: any, expiryMode: string, time: number, callback?: (err: Error, res: string) => void): Pipeline;
-        set(key: string, value: any, expiryMode: string, time: number, setMode: string, callback?: (err: Error, res: string) => void): Pipeline;
+        set(
+            key: string,
+            value: any,
+            expiryMode: string,
+            time: number,
+            callback?: (err: Error, res: string) => void,
+        ): Pipeline;
+        set(
+            key: string,
+            value: any,
+            expiryMode: string,
+            time: number,
+            setMode: string,
+            callback?: (err: Error, res: string) => void,
+        ): Pipeline;
 
         setBuffer(key: string, value: any, callback?: (err: Error, res: Buffer) => void): Pipeline;
         setBuffer(key: string, value: any, setMode: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
-        setBuffer(key: string, value: any, expiryMode: string, time: number, callback?: (err: Error, res: Buffer) => void): Pipeline;
-        setBuffer(key: string, value: any, expiryMode: string, time: number, setMode: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        setBuffer(
+            key: string,
+            value: any,
+            expiryMode: string,
+            time: number,
+            callback?: (err: Error, res: Buffer) => void,
+        ): Pipeline;
+        setBuffer(
+            key: string,
+            value: any,
+            expiryMode: string,
+            time: number,
+            setMode: string,
+            callback?: (err: Error, res: Buffer) => void,
+        ): Pipeline;
 
         setnx(key: string, value: any, callback?: (err: Error, res: any) => void): Pipeline;
 
@@ -556,7 +656,13 @@ declare namespace IORedis {
 
         lpushx(key: string, value: any, callback?: (err: Error, res: number) => void): Pipeline;
 
-        linsert(key: string, direction: "BEFORE" | "AFTER", pivot: string, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        linsert(
+            key: string,
+            direction: 'BEFORE' | 'AFTER',
+            pivot: string,
+            value: any,
+            callback?: (err: Error, res: number) => void,
+        ): Pipeline;
 
         rpop(key: string, callback?: (err: Error, res: string) => void): Pipeline;
 
@@ -568,7 +674,12 @@ declare namespace IORedis {
 
         blpop(...keys: string[]): Pipeline;
 
-        brpoplpush(source: string, destination: string, timeout: number, callback?: (err: Error, res: any) => void): Pipeline;
+        brpoplpush(
+            source: string,
+            destination: string,
+            timeout: number,
+            callback?: (err: Error, res: any) => void,
+        ): Pipeline;
 
         llen(key: string, callback?: (err: Error, res: number) => void): Pipeline;
 
@@ -578,7 +689,12 @@ declare namespace IORedis {
 
         lrange(key: string, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
 
-        lrangeBuffer(key: string, start: number, stop: number, callback?: (err: Error, res: Buffer[]) => void): Pipeline;
+        lrangeBuffer(
+            key: string,
+            start: number,
+            stop: number,
+            callback?: (err: Error, res: Buffer[]) => void,
+        ): Pipeline;
 
         ltrim(key: string, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
 
@@ -590,7 +706,12 @@ declare namespace IORedis {
 
         srem(key: string, ...members: any[]): Pipeline;
 
-        smove(source: string, destination: string, member: string, callback?: (err: Error, res: string) => void): Pipeline;
+        smove(
+            source: string,
+            destination: string,
+            member: string,
+            callback?: (err: Error, res: string) => void,
+        ): Pipeline;
 
         sismember(key: string, member: string, callback?: (err: Error, res: 1 | 0) => void): Pipeline;
 
@@ -622,7 +743,12 @@ declare namespace IORedis {
 
         zrem(key: string, ...members: any[]): Pipeline;
 
-        zremrangebyscore(key: string, min: number | string, max: number | string, callback?: (err: Error, res: any) => void): Pipeline;
+        zremrangebyscore(
+            key: string,
+            min: number | string,
+            max: number | string,
+            callback?: (err: Error, res: any) => void,
+        ): Pipeline;
 
         zremrangebyrank(key: string, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
 
@@ -631,16 +757,33 @@ declare namespace IORedis {
         zinterstore(destination: string, numkeys: number, key: string, ...args: string[]): Pipeline;
 
         zrange(key: string, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
-        zrange(key: string, start: number, stop: number, withScores: "WITHSCORES", callback?: (err: Error, res: any) => void): Pipeline;
+        zrange(
+            key: string,
+            start: number,
+            stop: number,
+            withScores: 'WITHSCORES',
+            callback?: (err: Error, res: any) => void,
+        ): Pipeline;
 
         zrevrange(key: string, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
-        zrevrange(key: string, start: number, stop: number, withScores: "WITHSCORES", callback?: (err: Error, res: any) => void): Pipeline;
+        zrevrange(
+            key: string,
+            start: number,
+            stop: number,
+            withScores: 'WITHSCORES',
+            callback?: (err: Error, res: any) => void,
+        ): Pipeline;
 
         zrangebyscore(key: string, min: number | string, max: number | string, ...args: string[]): Pipeline;
 
         zrevrangebyscore(key: string, max: number | string, min: number | string, ...args: string[]): Pipeline;
 
-        zcount(key: string, min: number | string, max: number | string, callback?: (err: Error, res: number) => void): Pipeline;
+        zcount(
+            key: string,
+            min: number | string,
+            max: number | string,
+            callback?: (err: Error, res: number) => void,
+        ): Pipeline;
 
         zcard(key: string, callback?: (err: Error, res: number) => void): Pipeline;
 
@@ -665,7 +808,12 @@ declare namespace IORedis {
 
         hincrby(key: string, field: string, increment: number, callback?: (err: Error, res: number) => void): Pipeline;
 
-        hincrbyfloat(key: string, field: string, increment: number, callback?: (err: Error, res: number) => void): Pipeline;
+        hincrbyfloat(
+            key: string,
+            field: string,
+            increment: number,
+            callback?: (err: Error, res: number) => void,
+        ): Pipeline;
 
         hdel(key: string, ...fields: string[]): Pipeline;
 
@@ -726,7 +874,7 @@ declare namespace IORedis {
 
         bgrewriteaof(callback?: (err: Error, res: string) => void): Pipeline;
 
-        shutdown(save: "SAVE" | "NOSAVE", callback?: (err: Error, res: any) => void): Pipeline;
+        shutdown(save: 'SAVE' | 'NOSAVE', callback?: (err: Error, res: any) => void): Pipeline;
 
         lastsave(callback?: (err: Error, res: number) => void): Pipeline;
 
@@ -822,7 +970,7 @@ declare namespace IORedis {
     type ClusterNode = string | number | NodeConfiguration;
 
     interface Cluster extends NodeJS.EventEmitter, Commander {
-        new(nodes: ClusterNode[], options?: ClusterOptions): Redis;
+        new (nodes: ClusterNode[], options?: ClusterOptions): Redis;
         connect(callback: () => void): Promise<any>;
         disconnect(): void;
         nodes(role: string): Redis[];
@@ -895,7 +1043,7 @@ declare namespace IORedis {
         autoResendUnfulfilledCommands?: boolean;
         lazyConnect?: boolean;
         tls?: tls.ConnectionOptions;
-        sentinels?: Array<{ host: string; port: number; }>;
+        sentinels?: Array<{ host: string; port: number }>;
         name?: string;
         /**
          * Enable READONLY mode for the connection. Only available for cluster mode.

--- a/types/ioredis/v3/ioredis-tests.ts
+++ b/types/ioredis/v3/ioredis-tests.ts
@@ -1,4 +1,4 @@
-import Redis = require("ioredis");
+import Redis = require('ioredis');
 const redis = new Redis();
 
 redis.set('foo', 'bar');
@@ -32,7 +32,7 @@ redis.set('key', '100', ['EX', 10, 'NX'], (err, data) => {});
 redis.setBuffer('key', '100', 'NX', 'EX', 10, (err, data) => {});
 
 redis.exists('foo').then(result => result * 1);
-redis.exists('foo', ((err, data) => data * 1));
+redis.exists('foo', (err, data) => data * 1);
 
 const listData = ['foo', 'bar', 'baz'];
 listData.forEach(value => {
@@ -51,21 +51,23 @@ redis.lrangeBuffer('bufferlist', 0, listData.length - 2, (err, results) => {
     });
 });
 
-new Redis();       // Connect to 127.0.0.1:6379
-new Redis(6380);   // 127.0.0.1:6380
-new Redis(6379, '192.168.1.1');       // 192.168.1.1:6379
+new Redis(); // Connect to 127.0.0.1:6379
+new Redis(6380); // 127.0.0.1:6380
+new Redis(6379, '192.168.1.1'); // 192.168.1.1:6379
 new Redis('/tmp/redis.sock');
 new Redis({
-    port: 6379,          // Redis port
-    host: '127.0.0.1',   // Redis host
-    family: 4,           // 4 (IPv4) or 6 (IPv6)
+    port: 6379, // Redis port
+    host: '127.0.0.1', // Redis host
+    family: 4, // 4 (IPv4) or 6 (IPv6)
     password: 'auth',
     db: 0,
-    retryStrategy() { return false; },
+    retryStrategy() {
+        return false;
+    },
     showFriendlyErrorStack: true,
     tls: {
-        servername: 'tlsservername'
-    }
+        servername: 'tlsservername',
+    },
 });
 
 const pub = new Redis();
@@ -103,25 +105,36 @@ pipeline.exec((err, results) => {
 });
 
 // You can even chain the commands:
-redis.pipeline().set('foo', 'bar').del('cc').exec((err, results) => {
-});
+redis
+    .pipeline()
+    .set('foo', 'bar')
+    .del('cc')
+    .exec((err, results) => {});
 
 // `exec` also returns a Promise:
 const promise = redis.pipeline().set('foo', 'bar').get('foo').exec();
-promise.then((result) => {
+promise.then(result => {
     // result === [[null, 'OK'], [null, 'bar']]
 });
 
-redis.pipeline().set('foo', 'bar').get('foo', (err, result) => {
-    // result === 'bar'
-}).exec((err, result) => {
-    // result[1][1] === 'bar'
-});
+redis
+    .pipeline()
+    .set('foo', 'bar')
+    .get('foo', (err, result) => {
+        // result === 'bar'
+    })
+    .exec((err, result) => {
+        // result[1][1] === 'bar'
+    });
 
-redis.pipeline([
-    ['set', 'foo', 'bar'],
-    ['get', 'foo']
-]).exec(() => { /* ... */ });
+redis
+    .pipeline([
+        ['set', 'foo', 'bar'],
+        ['get', 'foo'],
+    ])
+    .exec(() => {
+        /* ... */
+    });
 
 Redis.Command.setArgumentTransformer('set', args => {
     return args;
@@ -132,53 +145,61 @@ Redis.Command.setReplyTransformer('get', (result: any) => {
 });
 
 // multi
-redis.multi().set('foo', 'bar').set('foo', 'baz').get('foo', (err, result) => {
-    // result === 'QUEUED'
-}).exec((err, results) => {
-    // results = [[null, 'OK'], [null, 'OK'], [null, 'baz']]
-});
+redis
+    .multi()
+    .set('foo', 'bar')
+    .set('foo', 'baz')
+    .get('foo', (err, result) => {
+        // result === 'QUEUED'
+    })
+    .exec((err, results) => {
+        // results = [[null, 'OK'], [null, 'OK'], [null, 'baz']]
+    });
 
-redis.multi([
-    ['set', 'foo', 'bar'],
-    ['get', 'foo']
-]).exec((err, results) => {
-    // results = [[null, 'OK'], [null, 'bar']]
-});
+redis
+    .multi([
+        ['set', 'foo', 'bar'],
+        ['get', 'foo'],
+    ])
+    .exec((err, results) => {
+        // results = [[null, 'OK'], [null, 'bar']]
+    });
 
-redis.Promise.onPossiblyUnhandledRejection((error) => {
-});
+redis.Promise.onPossiblyUnhandledRejection(error => {});
 
 const keys = ['foo', 'bar'];
 redis.mget(...keys);
 
+new Redis.Cluster(['localhost']);
+
+new Redis.Cluster([6379]);
+
 new Redis.Cluster([
-    'localhost'
+    {
+        host: 'localhost',
+    },
 ]);
 
 new Redis.Cluster([
-    6379
+    {
+        port: 6379,
+    },
 ]);
 
-new Redis.Cluster([{
-    host: 'localhost'
-}]);
-
-new Redis.Cluster([{
-    port: 6379
-}]);
-
-new Redis.Cluster([{
-    host: 'localhost',
-    port: 6379
-}]);
+new Redis.Cluster([
+    {
+        host: 'localhost',
+        port: 6379,
+    },
+]);
 
 // ClusterRetryStrategy can return non-numbers to stop retrying
 new Redis.Cluster([], {
-    clusterRetryStrategy: (times: number) => null
+    clusterRetryStrategy: (times: number) => null,
 });
 
 new Redis.Cluster([], {
-    clusterRetryStrategy: (times: number) => 1
+    clusterRetryStrategy: (times: number) => 1,
 });
 
 redis.zaddBuffer('foo', 1, Buffer.from('bar')).then(() => {


### PR DESCRIPTION
This is just a formatting diff. I ran `prettier` for #44262 and noticed these unrelated changes, I think it's better to keep them separate from the other PR.

This should also help anyone making changes in the future, such that `npm run prettier -- --write types/ioredis/**/*.ts` runs on a "clean slate".

I ran `npm run test`, but this should be a noop change, that's why I didn't include the full template here. 

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
