### PR TITLE
Added Users find overrides for User and/or UserList response

### DIFF
--- a/types/intercom-client/User.d.ts
+++ b/types/intercom-client/User.d.ts
@@ -1,6 +1,10 @@
 import { Company } from './Company';
 
-export type UserIdentifier = { id: string } | { user_id: string } | { email: string };
+export interface UserEmailIdentifier {
+    email: string;
+}
+export type UserIdIdentifier = { id: string } | { user_id: string };
+export type UserIdentifier = UserIdIdentifier | UserEmailIdentifier;
 
 export interface Avatar {
     type: 'avatar';

--- a/types/intercom-client/index.d.ts
+++ b/types/intercom-client/index.d.ts
@@ -9,7 +9,14 @@
 // TypeScript Version: 2.2
 /// <reference types="node" />
 
-import { List as UserList, User, UserIdentifier, CreateUpdateUser } from './User';
+import {
+    List as UserList,
+    User,
+    UserIdIdentifier,
+    UserEmailIdentifier,
+    UserIdentifier,
+    CreateUpdateUser,
+} from './User';
 import { List as LeadList, Lead, LeadIdentifier } from './Lead';
 import { Visitor, VisitorIdentifier } from './Visitor';
 import { CompanyIdentifier, List as CompanyList, Company } from './Company';
@@ -59,8 +66,12 @@ export class Users {
     update(user: UserIdentifier & Partial<CreateUpdateUser>): Promise<ApiResponse<User>>;
     update(user: UserIdentifier & Partial<CreateUpdateUser>, cb: callback<ApiResponse<User>>): void;
 
-    find(identifier: UserIdentifier): Promise<ApiResponse<User>>;
-    find(identifier: UserIdentifier, cb: callback<ApiResponse<User>>): void;
+    find(identifier: UserIdIdentifier): Promise<ApiResponse<User>>;
+    find(identifier: UserIdIdentifier, cb: callback<ApiResponse<User>>): void;
+    find(identifier: UserEmailIdentifier): Promise<ApiResponse<UserList>>;
+    find(identifier: UserEmailIdentifier, cb: callback<ApiResponse<UserList>>): void;
+    find(identifier: UserIdentifier): Promise<ApiResponse<User | UserList>>;
+    find(identifier: UserIdentifier, cb: callback<ApiResponse<User | UserList>>): void;
 
     list(): Promise<ApiResponse<UserList>>;
     list(cb: callback<ApiResponse<UserList>>): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

**Intercom API version tested: 1.4**

**The motivation for these changes:**
The definition of this method has been changed back and forth a few times now. Does the `find` method return `User` or `UserList`? (#42230, #43600) Hopefully, this PR will solve the mystery of the evolving method since, spoiler alert, it returns both.

How do I know this? Does the documentation say anything about it? No, not what I can find.
But I have tested this myself with Intercom API version 1.4.

When searching for a user by `id` or `user_id` you'll either get a `User` or have a 404 not found thrown in your face.

When searching for `email` you will get a `UserList` back, no matter if there's only one result or more.