### PR TITLE
cordova-plugin-bluetoothclassic-serial is on npm now

### DIFF
--- a/types/cordova-plugin-bluetoothclassic-serial/index.d.ts
+++ b/types/cordova-plugin-bluetoothclassic-serial/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package cordova-plugin-bluetoothClassic-serial 0.9
+// Type definitions for package cordova-plugin-bluetoothClassic-serial 0.9
 // Project: https://github.com/soltius/BluetoothClassicSerial
 // Definitions by: Wouter Roosendaal <https://github.com/tuvokki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
So remove the 'non-npm' attribute.

Note that the package on npm is a fork of the source package for `@types/cordova-plugin-bluetoothclassic-serial`. However:

1. Nobody really uses the @types package anyway -- I'm just fixing a build break on Definitely Typed.
2. The fork's types are probably close enough to the original's types.