### PR TITLE
Change dummy value for mime source in hapi tests

### DIFF
--- a/types/hapi/test/server/server-mime.ts
+++ b/types/hapi/test/server/server-mime.ts
@@ -6,7 +6,7 @@ const options: ServerOptions = {
     mime: {
         override: {
             'node/module': {
-                source: 'steve',
+                source: 'apache',
                 compressible: false,
                 extensions: ['node', 'module', 'npm'],
                 type: 'node/module'

--- a/types/hapi/v16/test/server/mime.ts
+++ b/types/hapi/v16/test/server/mime.ts
@@ -7,7 +7,7 @@ const options: Hapi.ServerOptions = {
     mime: {
         override: {
             'node/module': {
-                source: 'steve',
+                source: 'apache',
                 compressible: false,
                 extensions: ['node', 'module', 'npm'],
                 type: 'node/module'

--- a/types/hapi/v17/test/server/server-mime.ts
+++ b/types/hapi/v17/test/server/server-mime.ts
@@ -6,7 +6,7 @@ const options: ServerOptions = {
     mime: {
         override: {
             'node/module': {
-                source: 'steve',
+                source: 'apache',
                 compressible: false,
                 extensions: ['node', 'module', 'npm'],
                 type: 'node/module'

--- a/types/hapi__hapi/test/server/server-mime.ts
+++ b/types/hapi__hapi/test/server/server-mime.ts
@@ -6,7 +6,7 @@ const options: ServerOptions = {
     mime: {
         override: {
             'node/module': {
-                source: 'steve',
+                source: 'apache',
                 compressible: false,
                 extensions: ['node', 'module', 'npm'],
                 type: 'node/module'


### PR DESCRIPTION
At least, I think 'steve' is a dummy value. Since
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44029/files,
@types/mime-db requires MimeEntry.source to be one of three values:

`"iana" | "apache" | "nginx"`.

So I changed the tests to use 'apache' instead. This stops hapi from passing tests, so I don't know how the mime-db CI run missed this.