### PR TITLE
Enable noUnusedLocals

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -5,6 +5,7 @@
         "module": "commonjs",
         "target": "es6",
         "strict": true,
+        "noUnusedLocals": true,
         "baseUrl": "../types",
         "typeRoots": [
             "../types"

--- a/types/7zip-min/tsconfig.json
+++ b/types/7zip-min/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/a-big-triangle/tsconfig.json
+++ b/types/a-big-triangle/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/abstract-leveldown/tsconfig.json
+++ b/types/abstract-leveldown/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/acc-wizard/tsconfig.json
+++ b/types/acc-wizard/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/accept/tsconfig.json
+++ b/types/accept/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/accounting/tsconfig.json
+++ b/types/accounting/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ace-diff/tsconfig.json
+++ b/types/ace-diff/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/acl/tsconfig.json
+++ b/types/acl/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/actioncable/tsconfig.json
+++ b/types/actioncable/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activedirectory2/tsconfig.json
+++ b/types/activedirectory2/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activestorage/tsconfig.json
+++ b/types/activestorage/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-access/tsconfig.json
+++ b/types/activex-access/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-adox/tsconfig.json
+++ b/types/activex-adox/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-dao/tsconfig.json
+++ b/types/activex-dao/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-infopath/tsconfig.json
+++ b/types/activex-infopath/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-iwshruntimelibrary/tsconfig.json
+++ b/types/activex-iwshruntimelibrary/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-libreoffice/tsconfig.json
+++ b/types/activex-libreoffice/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-msforms/tsconfig.json
+++ b/types/activex-msforms/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-mshtml/tsconfig.json
+++ b/types/activex-mshtml/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-msxml2/tsconfig.json
+++ b/types/activex-msxml2/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-office/tsconfig.json
+++ b/types/activex-office/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-outlook/tsconfig.json
+++ b/types/activex-outlook/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-powerpoint/tsconfig.json
+++ b/types/activex-powerpoint/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-shdocvw/tsconfig.json
+++ b/types/activex-shdocvw/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-stdole/tsconfig.json
+++ b/types/activex-stdole/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/activex-vbide/tsconfig.json
+++ b/types/activex-vbide/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/adal-angular/tsconfig.json
+++ b/types/adal-angular/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/add-zero/tsconfig.json
+++ b/types/add-zero/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/add2home/tsconfig.json
+++ b/types/add2home/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/adhan/tsconfig.json
+++ b/types/adhan/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "esModuleInterop": true,

--- a/types/adobe__es-modules-middleware/tsconfig.json
+++ b/types/adobe__es-modules-middleware/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ag-channel/tsconfig.json
+++ b/types/ag-channel/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ag-simple-broker/tsconfig.json
+++ b/types/ag-simple-broker/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/agent-base/tsconfig.json
+++ b/types/agent-base/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/agilite/tsconfig.json
+++ b/types/agilite/tsconfig.json
@@ -6,6 +6,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "esModuleInterop": true,

--- a/types/agora-rtc-sdk/tsconfig.json
+++ b/types/agora-rtc-sdk/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
 	    "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/airtable/tsconfig.json
+++ b/types/airtable/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ajv-async/tsconfig.json
+++ b/types/ajv-async/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ajv-errors/tsconfig.json
+++ b/types/ajv-errors/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
  	"strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ajv-keywords/tsconfig.json
+++ b/types/ajv-keywords/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ajv-merge-patch/tsconfig.json
+++ b/types/ajv-merge-patch/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ajv-pack/tsconfig.json
+++ b/types/ajv-pack/tsconfig.json
@@ -6,6 +6,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "baseUrl": "../",

--- a/types/ale-url-parser/tsconfig.json
+++ b/types/ale-url-parser/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/alertify/tsconfig.json
+++ b/types/alertify/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/alex/tsconfig.json
+++ b/types/alex/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/alexa-voice-service/tsconfig.json
+++ b/types/alexa-voice-service/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/algebra.js/tsconfig.json
+++ b/types/algebra.js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/align-text/tsconfig.json
+++ b/types/align-text/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/alks-node/tsconfig.json
+++ b/types/alks-node/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/all-the-package-names/tsconfig.json
+++ b/types/all-the-package-names/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/alloy/tsconfig.json
+++ b/types/alloy/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/allure-js-commons/tsconfig.json
+++ b/types/allure-js-commons/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/alpha-bravo/tsconfig.json
+++ b/types/alpha-bravo/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/amap-js-api-control-bar/tsconfig.json
+++ b/types/amap-js-api-control-bar/tsconfig.json
@@ -8,6 +8,7 @@
         "noEmit": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amap-js-api-geocoder/tsconfig.json
+++ b/types/amap-js-api-geocoder/tsconfig.json
@@ -8,6 +8,7 @@
         "noEmit": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amap-js-api-heatmap/tsconfig.json
+++ b/types/amap-js-api-heatmap/tsconfig.json
@@ -8,6 +8,7 @@
         "noEmit": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amap-js-api-indoor-map/tsconfig.json
+++ b/types/amap-js-api-indoor-map/tsconfig.json
@@ -8,6 +8,7 @@
         "noEmit": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amap-js-api-map-type/tsconfig.json
+++ b/types/amap-js-api-map-type/tsconfig.json
@@ -8,6 +8,7 @@
         "noEmit": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amap-js-api-map3d/tsconfig.json
+++ b/types/amap-js-api-map3d/tsconfig.json
@@ -8,6 +8,7 @@
         "noEmit": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amap-js-api-overview/tsconfig.json
+++ b/types/amap-js-api-overview/tsconfig.json
@@ -8,6 +8,7 @@
         "noEmit": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amap-js-api-scale/tsconfig.json
+++ b/types/amap-js-api-scale/tsconfig.json
@@ -8,6 +8,7 @@
         "noEmit": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amazon-cognito-auth-js/tsconfig.json
+++ b/types/amazon-cognito-auth-js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amazon-connect-streams/tsconfig.json
+++ b/types/amazon-connect-streams/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amazon-product-api/tsconfig.json
+++ b/types/amazon-product-api/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amp-message/tsconfig.json
+++ b/types/amp-message/tsconfig.json
@@ -6,6 +6,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/amp/tsconfig.json
+++ b/types/amp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amplifier/tsconfig.json
+++ b/types/amplifier/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amplify-deferred/tsconfig.json
+++ b/types/amplify-deferred/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amplify/tsconfig.json
+++ b/types/amplify/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": false,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/amqp-connection-manager/tsconfig.json
+++ b/types/amqp-connection-manager/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/amqp-rpc/tsconfig.json
+++ b/types/amqp-rpc/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/anchor-js/tsconfig.json
+++ b/types/anchor-js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-agility/tsconfig.json
+++ b/types/angular-agility/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-animate/tsconfig.json
+++ b/types/angular-animate/tsconfig.json
@@ -10,6 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-aria/tsconfig.json
+++ b/types/angular-aria/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/angular-bootstrap-calendar/tsconfig.json
+++ b/types/angular-bootstrap-calendar/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-bootstrap-lightbox/tsconfig.json
+++ b/types/angular-bootstrap-lightbox/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-breadcrumb/tsconfig.json
+++ b/types/angular-breadcrumb/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-clipboard/tsconfig.json
+++ b/types/angular-clipboard/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-cookies/tsconfig.json
+++ b/types/angular-cookies/tsconfig.json
@@ -10,6 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-deferred-bootstrap/tsconfig.json
+++ b/types/angular-deferred-bootstrap/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-dialog-service/tsconfig.json
+++ b/types/angular-dialog-service/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-environment/tsconfig.json
+++ b/types/angular-environment/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-feature-flags/tsconfig.json
+++ b/types/angular-feature-flags/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-file-saver/tsconfig.json
+++ b/types/angular-file-saver/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-file-upload/tsconfig.json
+++ b/types/angular-file-upload/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": false,
         "baseUrl": "../",

--- a/types/angular-formly/tsconfig.json
+++ b/types/angular-formly/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-fullscreen/tsconfig.json
+++ b/types/angular-fullscreen/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-growl-v2/tsconfig.json
+++ b/types/angular-growl-v2/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-http-auth/tsconfig.json
+++ b/types/angular-http-auth/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-httpi/tsconfig.json
+++ b/types/angular-httpi/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-jwt/tsconfig.json
+++ b/types/angular-jwt/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-load/tsconfig.json
+++ b/types/angular-load/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-loading-bar/tsconfig.json
+++ b/types/angular-loading-bar/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-localforage/tsconfig.json
+++ b/types/angular-localforage/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-locker/tsconfig.json
+++ b/types/angular-locker/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-media-queries/tsconfig.json
+++ b/types/angular-media-queries/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-mocks/tsconfig.json
+++ b/types/angular-mocks/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-notifications/tsconfig.json
+++ b/types/angular-notifications/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-notify/tsconfig.json
+++ b/types/angular-notify/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-oauth2/tsconfig.json
+++ b/types/angular-oauth2/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-odata-resources/tsconfig.json
+++ b/types/angular-odata-resources/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": false,
         "baseUrl": "../",

--- a/types/angular-pdfjs-viewer/tsconfig.json
+++ b/types/angular-pdfjs-viewer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-q-spread/tsconfig.json
+++ b/types/angular-q-spread/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-resource/tsconfig.json
+++ b/types/angular-resource/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": false,
         "baseUrl": "../",

--- a/types/angular-route/tsconfig.json
+++ b/types/angular-route/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-sanitize/tsconfig.json
+++ b/types/angular-sanitize/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-scenario/tsconfig.json
+++ b/types/angular-scenario/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-signalr-hub/tsconfig.json
+++ b/types/angular-signalr-hub/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-spinner/tsconfig.json
+++ b/types/angular-spinner/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-storage/tsconfig.json
+++ b/types/angular-storage/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-toastr/tsconfig.json
+++ b/types/angular-toastr/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-toasty/tsconfig.json
+++ b/types/angular-toasty/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-tooltips/tsconfig.json
+++ b/types/angular-tooltips/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-ui-bootstrap/tsconfig.json
+++ b/types/angular-ui-bootstrap/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-ui-notification/tsconfig.json
+++ b/types/angular-ui-notification/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-ui-scroll/tsconfig.json
+++ b/types/angular-ui-scroll/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-ui-tree/tsconfig.json
+++ b/types/angular-ui-tree/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular-xeditable/tsconfig.json
+++ b/types/angular-xeditable/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/angular.throttle/tsconfig.json
+++ b/types/angular.throttle/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/animation-frame/tsconfig.json
+++ b/types/animation-frame/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ansi-escape-sequences/tsconfig.json
+++ b/types/ansi-escape-sequences/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ansi-styles/tsconfig.json
+++ b/types/ansi-styles/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ansi/tsconfig.json
+++ b/types/ansi/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ansicolors/tsconfig.json
+++ b/types/ansicolors/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/any-db/tsconfig.json
+++ b/types/any-db/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/anymatch/tsconfig.json
+++ b/types/anymatch/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/anyproxy/tsconfig.json
+++ b/types/anyproxy/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/aos/tsconfig.json
+++ b/types/aos/tsconfig.json
@@ -7,6 +7,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/apicalypse/tsconfig.json
+++ b/types/apicalypse/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/apimocker/tsconfig.json
+++ b/types/apimocker/tsconfig.json
@@ -8,6 +8,7 @@
         "noEmit": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "forceConsistentCasingInFileNames": true

--- a/types/apollo-upload-client/tsconfig.json
+++ b/types/apollo-upload-client/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/app-module-path/tsconfig.json
+++ b/types/app-module-path/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/appcache-webpack-plugin/tsconfig.json
+++ b/types/appcache-webpack-plugin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/append-query/tsconfig.json
+++ b/types/append-query/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/appframework/tsconfig.json
+++ b/types/appframework/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/apple-mapkit-js/tsconfig.json
+++ b/types/apple-mapkit-js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/apple-music-api/tsconfig.json
+++ b/types/apple-music-api/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/apple-signin-api/tsconfig.json
+++ b/types/apple-signin-api/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/applicationinsights-js/tsconfig.json
+++ b/types/applicationinsights-js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/apptimize__apptimize-web-sdk/tsconfig.json
+++ b/types/apptimize__apptimize-web-sdk/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/aqb/tsconfig.json
+++ b/types/aqb/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/arangodb/tsconfig.json
+++ b/types/arangodb/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "esnext.asynciterable"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/arbiter/tsconfig.json
+++ b/types/arbiter/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/architect/tsconfig.json
+++ b/types/architect/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/are-we-there-yet/tsconfig.json
+++ b/types/are-we-there-yet/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/argon2-browser/tsconfig.json
+++ b/types/argon2-browser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/argparse/tsconfig.json
+++ b/types/argparse/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/argv/tsconfig.json
+++ b/types/argv/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/arr-union/tsconfig.json
+++ b/types/arr-union/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/array-binarysearch.closest/tsconfig.json
+++ b/types/array-binarysearch.closest/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/array-find-index/tsconfig.json
+++ b/types/array-find-index/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/array-foreach/tsconfig.json
+++ b/types/array-foreach/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": false,
         "baseUrl": "../",

--- a/types/array-initial/tsconfig.json
+++ b/types/array-initial/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/array-sort/tsconfig.json
+++ b/types/array-sort/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/array-unique/tsconfig.json
+++ b/types/array-unique/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/array.from/tsconfig.json
+++ b/types/array.from/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/array.prototype.flatmap/tsconfig.json
+++ b/types/array.prototype.flatmap/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/artillery/tsconfig.json
+++ b/types/artillery/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/asap/tsconfig.json
+++ b/types/asap/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ascii-art/tsconfig.json
+++ b/types/ascii-art/tsconfig.json
@@ -7,6 +7,7 @@
         "allowSyntheticDefaultImports": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ascii2mathml/tsconfig.json
+++ b/types/ascii2mathml/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/asciichart/tsconfig.json
+++ b/types/asciichart/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/asciify/tsconfig.json
+++ b/types/asciify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/assert-equal-jsx/tsconfig.json
+++ b/types/assert-equal-jsx/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/assert-plus/tsconfig.json
+++ b/types/assert-plus/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/assert/ts3.7/tsconfig.json
+++ b/types/assert/ts3.7/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es2015"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/assert/tsconfig.json
+++ b/types/assert/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es2015"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/assertsharp/tsconfig.json
+++ b/types/assertsharp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/async-cache/tsconfig.json
+++ b/types/async-cache/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/async-eventemitter/tsconfig.json
+++ b/types/async-eventemitter/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/async-iterable-stream/tsconfig.json
+++ b/types/async-iterable-stream/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/async-polling/tsconfig.json
+++ b/types/async-polling/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/async-stream-emitter/tsconfig.json
+++ b/types/async-stream-emitter/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/async-stream-generator/tsconfig.json
+++ b/types/async-stream-generator/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/async-writer/tsconfig.json
+++ b/types/async-writer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/async.nexttick/tsconfig.json
+++ b/types/async.nexttick/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/atlaskit__button/tsconfig.json
+++ b/types/atlaskit__button/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/atlaskit__calendar/tsconfig.json
+++ b/types/atlaskit__calendar/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/atlaskit__feedback-collector/tsconfig.json
+++ b/types/atlaskit__feedback-collector/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/atlaskit__inline-edit/tsconfig.json
+++ b/types/atlaskit__inline-edit/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/atlaskit__layer/tsconfig.json
+++ b/types/atlaskit__layer/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/atlaskit__single-select/tsconfig.json
+++ b/types/atlaskit__single-select/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/atlaskit__tree/tsconfig.json
+++ b/types/atlaskit__tree/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/atlassian-crowd-client/tsconfig.json
+++ b/types/atlassian-crowd-client/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/atmosphere.js/tsconfig.json
+++ b/types/atmosphere.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/atob-lite/tsconfig.json
+++ b/types/atob-lite/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/atob/tsconfig.json
+++ b/types/atob/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "commonjs",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/atpl/tsconfig.json
+++ b/types/atpl/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/audio-play/tsconfig.json
+++ b/types/audio-play/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/audiobuffer-to-wav/tsconfig.json
+++ b/types/audiobuffer-to-wav/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/audiosprite/tsconfig.json
+++ b/types/audiosprite/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/auth0-angular/tsconfig.json
+++ b/types/auth0-angular/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/auth0-js/v7/tsconfig.json
+++ b/types/auth0-js/v7/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/auth0.widget/tsconfig.json
+++ b/types/auth0.widget/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/authenticator/tsconfig.json
+++ b/types/authenticator/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/auto-launch/tsconfig.json
+++ b/types/auto-launch/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/autocannon/tsconfig.json
+++ b/types/autocannon/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/autosize/tsconfig.json
+++ b/types/autosize/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/awesomplete/tsconfig.json
+++ b/types/awesomplete/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/aws-iot-device-sdk/tsconfig.json
+++ b/types/aws-iot-device-sdk/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/aws-kcl/tsconfig.json
+++ b/types/aws-kcl/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/aws-regions/tsconfig.json
+++ b/types/aws-regions/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/aws-serverless-express/tsconfig.json
+++ b/types/aws-serverless-express/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/aws4/tsconfig.json
+++ b/types/aws4/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/axel/tsconfig.json
+++ b/types/axel/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/axios-case-converter/tsconfig.json
+++ b/types/axios-case-converter/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/axios-token-interceptor/tsconfig.json
+++ b/types/axios-token-interceptor/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/axon/tsconfig.json
+++ b/types/axon/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/azdata/tsconfig.json
+++ b/types/azdata/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["es6"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictNullChecks": true,
 		"strictFunctionTypes": true,
 		"baseUrl": "../",

--- a/types/azure-kusto-data/tsconfig.json
+++ b/types/azure-kusto-data/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/azure-mobile-services-client/tsconfig.json
+++ b/types/azure-mobile-services-client/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/azure-sb/tsconfig.json
+++ b/types/azure-sb/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/azure/tsconfig.json
+++ b/types/azure/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/b-spline/tsconfig.json
+++ b/types/b-spline/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/b64-lite/tsconfig.json
+++ b/types/b64-lite/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/babel-code-frame/tsconfig.json
+++ b/types/babel-code-frame/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/babel-core/tsconfig.json
+++ b/types/babel-core/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/babel-plugin-glaze/tsconfig.json
+++ b/types/babel-plugin-glaze/tsconfig.json
@@ -8,6 +8,7 @@
         "jsx": "preserve",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/babel-plugin-react-pug/tsconfig.json
+++ b/types/babel-plugin-react-pug/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/babel-plugin-syntax-jsx/tsconfig.json
+++ b/types/babel-plugin-syntax-jsx/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/babel-template/tsconfig.json
+++ b/types/babel-template/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/babel-webpack-plugin/tsconfig.json
+++ b/types/babel-webpack-plugin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/babel__code-frame/tsconfig.json
+++ b/types/babel__code-frame/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/babel__standalone/tsconfig.json
+++ b/types/babel__standalone/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/babelify/tsconfig.json
+++ b/types/babelify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/babylon-walk/tsconfig.json
+++ b/types/babylon-walk/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/babylon/tsconfig.json
+++ b/types/babylon/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/backbone.layoutmanager/tsconfig.json
+++ b/types/backbone.layoutmanager/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/backbone.localstorage/tsconfig.json
+++ b/types/backbone.localstorage/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/backlog-js/tsconfig.json
+++ b/types/backlog-js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/backoff/tsconfig.json
+++ b/types/backoff/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/backstopjs/tsconfig.json
+++ b/types/backstopjs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/balanced-match/tsconfig.json
+++ b/types/balanced-match/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/bandagedbd__bdapi/tsconfig.json
+++ b/types/bandagedbd__bdapi/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/barcode/tsconfig.json
+++ b/types/barcode/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/baretest/tsconfig.json
+++ b/types/baretest/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/base64-arraybuffer/tsconfig.json
+++ b/types/base64-arraybuffer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/base64-async/tsconfig.json
+++ b/types/base64-async/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/base64-js/tsconfig.json
+++ b/types/base64-js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/base64-stream/tsconfig.json
+++ b/types/base64-stream/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/base64-url/tsconfig.json
+++ b/types/base64-url/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/base64topdf/tsconfig.json
+++ b/types/base64topdf/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bash-glob/tsconfig.json
+++ b/types/bash-glob/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/basicauth-middleware/tsconfig.json
+++ b/types/basicauth-middleware/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/batch-stream/tsconfig.json
+++ b/types/batch-stream/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/battery-level/tsconfig.json
+++ b/types/battery-level/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bayes-classifier/tsconfig.json
+++ b/types/bayes-classifier/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bazinga-translator/tsconfig.json
+++ b/types/bazinga-translator/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bdfjs/tsconfig.json
+++ b/types/bdfjs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/beanstalkd-worker/tsconfig.json
+++ b/types/beanstalkd-worker/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/beanstalkd/tsconfig.json
+++ b/types/beanstalkd/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bearcat-es6/tsconfig.json
+++ b/types/bearcat-es6/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bech32/tsconfig.json
+++ b/types/bech32/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/behavior3/tsconfig.json
+++ b/types/behavior3/tsconfig.json
@@ -8,6 +8,7 @@
         "strictNullChecks": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/bencode/tsconfig.json
+++ b/types/bencode/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bent/tsconfig.json
+++ b/types/bent/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/better-curry/tsconfig.json
+++ b/types/better-curry/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bgiframe/tsconfig.json
+++ b/types/bgiframe/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bidirectional-map/tsconfig.json
+++ b/types/bidirectional-map/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bigi/tsconfig.json
+++ b/types/bigi/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bigint/tsconfig.json
+++ b/types/bigint/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bignum/tsconfig.json
+++ b/types/bignum/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bigscreen/tsconfig.json
+++ b/types/bigscreen/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/binary-parse-stream/tsconfig.json
+++ b/types/binary-parse-stream/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/binaryextensions/tsconfig.json
+++ b/types/binaryextensions/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bintrees/tsconfig.json
+++ b/types/bintrees/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bit-array/tsconfig.json
+++ b/types/bit-array/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bit-twiddle/tsconfig.json
+++ b/types/bit-twiddle/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/bittorrent-protocol/tsconfig.json
+++ b/types/bittorrent-protocol/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bl/tsconfig.json
+++ b/types/bl/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/blacklist/tsconfig.json
+++ b/types/blacklist/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/blazy/tsconfig.json
+++ b/types/blazy/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": false,
         "baseUrl": "../",

--- a/types/blip-sdk/tsconfig.json
+++ b/types/blip-sdk/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/blob-stream/tsconfig.json
+++ b/types/blob-stream/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/blob-to-buffer/tsconfig.json
+++ b/types/blob-to-buffer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/blocked/tsconfig.json
+++ b/types/blocked/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/blockies/tsconfig.json
+++ b/types/blockies/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/bluebird-retry/tsconfig.json
+++ b/types/bluebird-retry/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bluebird/v1/tsconfig.json
+++ b/types/bluebird/v1/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/bluebird/v2/tsconfig.json
+++ b/types/bluebird/v2/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/blueimp-load-image/tsconfig.json
+++ b/types/blueimp-load-image/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/bmp-js/tsconfig.json
+++ b/types/bmp-js/tsconfig.json
@@ -6,6 +6,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/body-parser-xml/tsconfig.json
+++ b/types/body-parser-xml/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/body-parser/tsconfig.json
+++ b/types/body-parser/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/body-scroll-lock/tsconfig.json
+++ b/types/body-scroll-lock/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/boolify-string/tsconfig.json
+++ b/types/boolify-string/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/boom/v3/tsconfig.json
+++ b/types/boom/v3/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/bootbox/tsconfig.json
+++ b/types/bootbox/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootpag/tsconfig.json
+++ b/types/bootpag/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap-3-typeahead/tsconfig.json
+++ b/types/bootstrap-3-typeahead/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap-colorpicker/tsconfig.json
+++ b/types/bootstrap-colorpicker/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap-datepicker/tsconfig.json
+++ b/types/bootstrap-datepicker/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap-filestyle/tsconfig.json
+++ b/types/bootstrap-filestyle/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap-growl-ifightcrime/tsconfig.json
+++ b/types/bootstrap-growl-ifightcrime/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap-maxlength/tsconfig.json
+++ b/types/bootstrap-maxlength/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap-multiselect/tsconfig.json
+++ b/types/bootstrap-multiselect/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap-notify/tsconfig.json
+++ b/types/bootstrap-notify/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap-select/tsconfig.json
+++ b/types/bootstrap-select/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap-switch/tsconfig.json
+++ b/types/bootstrap-switch/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap-toggle/tsconfig.json
+++ b/types/bootstrap-toggle/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap-touchspin/tsconfig.json
+++ b/types/bootstrap-touchspin/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap-treeview/tsconfig.json
+++ b/types/bootstrap-treeview/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap-validator/tsconfig.json
+++ b/types/bootstrap-validator/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap.paginator/tsconfig.json
+++ b/types/bootstrap.paginator/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap.timepicker/tsconfig.json
+++ b/types/bootstrap.timepicker/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bootstrap.v3.datetimepicker/v3/tsconfig.json
+++ b/types/bootstrap.v3.datetimepicker/v3/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/box-intersect/tsconfig.json
+++ b/types/box-intersect/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/box2d/tsconfig.json
+++ b/types/box2d/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/brace-expansion/tsconfig.json
+++ b/types/brace-expansion/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/braces/tsconfig.json
+++ b/types/braces/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/braintree__sanitize-url/tsconfig.json
+++ b/types/braintree__sanitize-url/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/branch-sdk/tsconfig.json
+++ b/types/branch-sdk/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bresenham/tsconfig.json
+++ b/types/bresenham/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/bristol/tsconfig.json
+++ b/types/bristol/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/bro-fs/tsconfig.json
+++ b/types/bro-fs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/browser-or-node/tsconfig.json
+++ b/types/browser-or-node/tsconfig.json
@@ -11,6 +11,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/browser-pack/tsconfig.json
+++ b/types/browser-pack/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/browser-sync-webpack-plugin/tsconfig.json
+++ b/types/browser-sync-webpack-plugin/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/browserslist-useragent/tsconfig.json
+++ b/types/browserslist-useragent/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/browserslist/tsconfig.json
+++ b/types/browserslist/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bs58/tsconfig.json
+++ b/types/bs58/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bser/tsconfig.json
+++ b/types/bser/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bson/tsconfig.json
+++ b/types/bson/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/btoa-lite/tsconfig.json
+++ b/types/btoa-lite/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/btoa/tsconfig.json
+++ b/types/btoa/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "commonjs",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bucks/tsconfig.json
+++ b/types/bucks/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/buffer-crc32/tsconfig.json
+++ b/types/buffer-crc32/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/buffer-from/tsconfig.json
+++ b/types/buffer-from/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/buffer-json/tsconfig.json
+++ b/types/buffer-json/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/buffer-reader/tsconfig.json
+++ b/types/buffer-reader/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "esModuleInterop": true,

--- a/types/buffer-split/tsconfig.json
+++ b/types/buffer-split/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/buffer-xor/tsconfig.json
+++ b/types/buffer-xor/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es6"],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/bufferhelper/tsconfig.json
+++ b/types/bufferhelper/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/buffers/tsconfig.json
+++ b/types/buffers/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bufferstream/tsconfig.json
+++ b/types/bufferstream/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/build-output-script/tsconfig.json
+++ b/types/build-output-script/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/bull-arena/tsconfig.json
+++ b/types/bull-arena/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "esModuleInterop": true,

--- a/types/bull-board/tsconfig.json
+++ b/types/bull-board/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "esModuleInterop": true,

--- a/types/bull/v2/tsconfig.json
+++ b/types/bull/v2/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": false,
         "baseUrl": "../../",

--- a/types/bulma-calendar/tsconfig.json
+++ b/types/bulma-calendar/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/bump-regex/tsconfig.json
+++ b/types/bump-regex/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bunyan-blackhole/tsconfig.json
+++ b/types/bunyan-blackhole/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bunyan-seq/tsconfig.json
+++ b/types/bunyan-seq/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/burns/tsconfig.json
+++ b/types/burns/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "allowSyntheticDefaultImports": true,

--- a/types/business-rules-engine/tsconfig.json
+++ b/types/business-rules-engine/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bwip-js/tsconfig.json
+++ b/types/bwip-js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/byline/tsconfig.json
+++ b/types/byline/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/byte-range/tsconfig.json
+++ b/types/byte-range/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bytebuffer/tsconfig.json
+++ b/types/bytebuffer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bytes/tsconfig.json
+++ b/types/bytes/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/bytewise/tsconfig.json
+++ b/types/bytewise/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cacache/tsconfig.json
+++ b/types/cacache/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/cache-manager/tsconfig.json
+++ b/types/cache-manager/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cacheable-request/tsconfig.json
+++ b/types/cacheable-request/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cadesplugin/ts3.1/tsconfig.json
+++ b/types/cadesplugin/ts3.1/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/cadesplugin/tsconfig.json
+++ b/types/cadesplugin/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cal-heatmap/tsconfig.json
+++ b/types/cal-heatmap/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/calendar/tsconfig.json
+++ b/types/calendar/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/callback-to-async-iterator/tsconfig.json
+++ b/types/callback-to-async-iterator/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/callsite/tsconfig.json
+++ b/types/callsite/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/calq/tsconfig.json
+++ b/types/calq/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/camelcase-keys-deep/tsconfig.json
+++ b/types/camelcase-keys-deep/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/camunda-external-task-client-js/tsconfig.json
+++ b/types/camunda-external-task-client-js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/can-autoplay/tsconfig.json
+++ b/types/can-autoplay/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/caniuse-api/tsconfig.json
+++ b/types/caniuse-api/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cannon/tsconfig.json
+++ b/types/cannon/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/canvas-confetti/tsconfig.json
+++ b/types/canvas-confetti/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/canvas-fit/tsconfig.json
+++ b/types/canvas-fit/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/canvas-gauges/tsconfig.json
+++ b/types/canvas-gauges/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/canvaskit-wasm/tsconfig.json
+++ b/types/canvaskit-wasm/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/capitalize/tsconfig.json
+++ b/types/capitalize/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/capture-console/tsconfig.json
+++ b/types/capture-console/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/carbon__colors/tsconfig.json
+++ b/types/carbon__colors/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],

--- a/types/carbon__icon-helpers/tsconfig.json
+++ b/types/carbon__icon-helpers/tsconfig.json
@@ -4,6 +4,7 @@
       "lib": ["es6", "DOM"],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/carbon__icons-react/tsconfig.json
+++ b/types/carbon__icons-react/tsconfig.json
@@ -4,6 +4,7 @@
       "lib": ["es6"],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/carbon__layout/tsconfig.json
+++ b/types/carbon__layout/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/carbon__motion/tsconfig.json
+++ b/types/carbon__motion/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/carbon__pictograms-react/tsconfig.json
+++ b/types/carbon__pictograms-react/tsconfig.json
@@ -4,6 +4,7 @@
       "lib": ["es6"],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/carbon__themes/tsconfig.json
+++ b/types/carbon__themes/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/carbon__type/tsconfig.json
+++ b/types/carbon__type/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/card-validator/tsconfig.json
+++ b/types/card-validator/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cash/tsconfig.json
+++ b/types/cash/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cashaddrjs/tsconfig.json
+++ b/types/cashaddrjs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/casperjs/tsconfig.json
+++ b/types/casperjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cassandra-store/tsconfig.json
+++ b/types/cassandra-store/tsconfig.json
@@ -6,6 +6,7 @@
 		],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictNullChecks": true,
 		"strictFunctionTypes": true,
 		"baseUrl": "../",

--- a/types/catbox-redis/tsconfig.json
+++ b/types/catbox-redis/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/catbox/v7/tsconfig.json
+++ b/types/catbox/v7/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/cavy/tsconfig.json
+++ b/types/cavy/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ccapture.js/tsconfig.json
+++ b/types/ccapture.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/center-align/tsconfig.json
+++ b/types/center-align/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cfenv/tsconfig.json
+++ b/types/cfenv/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/cfn-response/tsconfig.json
+++ b/types/cfn-response/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
 	"strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chai-almost/tsconfig.json
+++ b/types/chai-almost/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chai-arrays/tsconfig.json
+++ b/types/chai-arrays/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chai-enzyme/tsconfig.json
+++ b/types/chai-enzyme/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chai-fs/tsconfig.json
+++ b/types/chai-fs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chai-html/tsconfig.json
+++ b/types/chai-html/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/chai-jest-snapshot/tsconfig.json
+++ b/types/chai-jest-snapshot/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chai-json-schema/tsconfig.json
+++ b/types/chai-json-schema/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chai-like/tsconfig.json
+++ b/types/chai-like/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/chai-moment/tsconfig.json
+++ b/types/chai-moment/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chai-oequal/tsconfig.json
+++ b/types/chai-oequal/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chai-style/tsconfig.json
+++ b/types/chai-style/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/chai-uuid/tsconfig.json
+++ b/types/chai-uuid/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chai-xml/tsconfig.json
+++ b/types/chai-xml/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chai/v2/tsconfig.json
+++ b/types/chai/v2/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/chalk-animation/tsconfig.json
+++ b/types/chalk-animation/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chalk-pipe/tsconfig.json
+++ b/types/chalk-pipe/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/change-case-object/tsconfig.json
+++ b/types/change-case-object/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/changelog-parser/tsconfig.json
+++ b/types/changelog-parser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chardet/tsconfig.json
+++ b/types/chardet/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/charset/tsconfig.json
+++ b/types/charset/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chartmogul-node/tsconfig.json
+++ b/types/chartmogul-node/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chayns/tsconfig.json
+++ b/types/chayns/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/check-error/tsconfig.json
+++ b/types/check-error/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/check-sum/tsconfig.json
+++ b/types/check-sum/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/checkstyle-formatter/tsconfig.json
+++ b/types/checkstyle-formatter/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chess.js/tsconfig.json
+++ b/types/chess.js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/chmodr/tsconfig.json
+++ b/types/chmodr/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chocolatechipjs/tsconfig.json
+++ b/types/chocolatechipjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chordsheetjs/tsconfig.json
+++ b/types/chordsheetjs/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chosen-js/tsconfig.json
+++ b/types/chosen-js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chownr/tsconfig.json
+++ b/types/chownr/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/chroma-js/v0/tsconfig.json
+++ b/types/chroma-js/v0/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/chunk-text/tsconfig.json
+++ b/types/chunk-text/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/chunk/tsconfig.json
+++ b/types/chunk/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ci-info/tsconfig.json
+++ b/types/ci-info/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/circular-dependency-plugin/tsconfig.json
+++ b/types/circular-dependency-plugin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/circular-json/tsconfig.json
+++ b/types/circular-json/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/clamp/tsconfig.json
+++ b/types/clamp/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/clean-css/tsconfig.json
+++ b/types/clean-css/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/clean-git-ref/tsconfig.json
+++ b/types/clean-git-ref/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/clean-regexp/tsconfig.json
+++ b/types/clean-regexp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/clear/tsconfig.json
+++ b/types/clear/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/clearbladejs-client/tsconfig.json
+++ b/types/clearbladejs-client/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/clearbladejs-server/tsconfig.json
+++ b/types/clearbladejs-server/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cli-interact/tsconfig.json
+++ b/types/cli-interact/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cli-spinners/tsconfig.json
+++ b/types/cli-spinners/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cli-table/tsconfig.json
+++ b/types/cli-table/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cli-table2/tsconfig.json
+++ b/types/cli-table2/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/client-sessions/tsconfig.json
+++ b/types/client-sessions/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/clientjs/tsconfig.json
+++ b/types/clientjs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cliff/tsconfig.json
+++ b/types/cliff/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/clipboard-js/tsconfig.json
+++ b/types/clipboard-js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/clndr/tsconfig.json
+++ b/types/clndr/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/clockpicker/tsconfig.json
+++ b/types/clockpicker/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/clone-deep/tsconfig.json
+++ b/types/clone-deep/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es6"],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/cloneable-readable/tsconfig.json
+++ b/types/cloneable-readable/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/closure-compiler/tsconfig.json
+++ b/types/closure-compiler/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cloud-env/tsconfig.json
+++ b/types/cloud-env/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cloudmersive-virus-api-client/tsconfig.json
+++ b/types/cloudmersive-virus-api-client/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/clovelced-plugin-audiomanagement/tsconfig.json
+++ b/types/clovelced-plugin-audiomanagement/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cls-hooked/tsconfig.json
+++ b/types/cls-hooked/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/clui/tsconfig.json
+++ b/types/clui/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/clusterize.js/tsconfig.json
+++ b/types/clusterize.js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cmd-shim/tsconfig.json
+++ b/types/cmd-shim/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/co/tsconfig.json
+++ b/types/co/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/code/tsconfig.json
+++ b/types/code/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/codependency/tsconfig.json
+++ b/types/codependency/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/coinbase/tsconfig.json
+++ b/types/coinbase/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/color-check/tsconfig.json
+++ b/types/color-check/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "esModuleInterop": true,

--- a/types/color-diff/tsconfig.json
+++ b/types/color-diff/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],

--- a/types/color-namer/tsconfig.json
+++ b/types/color-namer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/color-rgba/tsconfig.json
+++ b/types/color-rgba/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/color-support/tsconfig.json
+++ b/types/color-support/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/colorbrewer/tsconfig.json
+++ b/types/colorbrewer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/colornames/tsconfig.json
+++ b/types/colornames/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/columnify/tsconfig.json
+++ b/types/columnify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/com.darktalker.cordova.screenshot/tsconfig.json
+++ b/types/com.darktalker.cordova.screenshot/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/com.wikitude.phonegap.wikitudeplugin/tsconfig.json
+++ b/types/com.wikitude.phonegap.wikitudeplugin/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/combinations/tsconfig.json
+++ b/types/combinations/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/combine-reducers/tsconfig.json
+++ b/types/combine-reducers/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/command-exists/tsconfig.json
+++ b/types/command-exists/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/commander-remaining-args/tsconfig.json
+++ b/types/commander-remaining-args/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/commangular/tsconfig.json
+++ b/types/commangular/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/commercetools__enzyme-extensions/tsconfig.json
+++ b/types/commercetools__enzyme-extensions/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/commitlint__load/tsconfig.json
+++ b/types/commitlint__load/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/common-errors/tsconfig.json
+++ b/types/common-errors/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/common-prefix/tsconfig.json
+++ b/types/common-prefix/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/common-tags/tsconfig.json
+++ b/types/common-tags/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/commondir/tsconfig.json
+++ b/types/commondir/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/compare-func/tsconfig.json
+++ b/types/compare-func/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/compare-function/tsconfig.json
+++ b/types/compare-function/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/compass-vertical-rhythm/tsconfig.json
+++ b/types/compass-vertical-rhythm/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/complex.js/tsconfig.json
+++ b/types/complex.js/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/component-emitter/tsconfig.json
+++ b/types/component-emitter/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/compress.js/tsconfig.json
+++ b/types/compress.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/compressible/tsconfig.json
+++ b/types/compressible/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/compression/tsconfig.json
+++ b/types/compression/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/compute-quantile/tsconfig.json
+++ b/types/compute-quantile/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/compute-stdev/tsconfig.json
+++ b/types/compute-stdev/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/concat-map/tsconfig.json
+++ b/types/concat-map/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/concat-stream/tsconfig.json
+++ b/types/concat-stream/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/concurrently/tsconfig.json
+++ b/types/concurrently/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/concurrently/v4/tsconfig.json
+++ b/types/concurrently/v4/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../../",

--- a/types/conditional/tsconfig.json
+++ b/types/conditional/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/conductor-animate/tsconfig.json
+++ b/types/conductor-animate/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/confidence/tsconfig.json
+++ b/types/confidence/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/config-yaml/tsconfig.json
+++ b/types/config-yaml/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/configs-overload/tsconfig.json
+++ b/types/configs-overload/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/configurable/tsconfig.json
+++ b/types/configurable/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/confit/tsconfig.json
+++ b/types/confit/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/connect-azuretables/tsconfig.json
+++ b/types/connect-azuretables/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/connect-ensure-login/tsconfig.json
+++ b/types/connect-ensure-login/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/connect-flash/tsconfig.json
+++ b/types/connect-flash/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/connect-history-api-fallback-exclusions/tsconfig.json
+++ b/types/connect-history-api-fallback-exclusions/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/connect-history-api-fallback/tsconfig.json
+++ b/types/connect-history-api-fallback/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/connect-livereload/tsconfig.json
+++ b/types/connect-livereload/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/connect-modrewrite/tsconfig.json
+++ b/types/connect-modrewrite/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/connect-sequence/tsconfig.json
+++ b/types/connect-sequence/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/connect-slashes/tsconfig.json
+++ b/types/connect-slashes/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/connect-timeout/tsconfig.json
+++ b/types/connect-timeout/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/connect-trim-body/tsconfig.json
+++ b/types/connect-trim-body/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/connect/tsconfig.json
+++ b/types/connect/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/console-log-level/tsconfig.json
+++ b/types/console-log-level/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/console-stamp/tsconfig.json
+++ b/types/console-stamp/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/console-ui/tsconfig.json
+++ b/types/console-ui/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/consumable-stream/tsconfig.json
+++ b/types/consumable-stream/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/contains-path/tsconfig.json
+++ b/types/contains-path/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/content-range/tsconfig.json
+++ b/types/content-range/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/content-type/tsconfig.json
+++ b/types/content-type/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/contentful-resolve-response/tsconfig.json
+++ b/types/contentful-resolve-response/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/contentstack/tsconfig.json
+++ b/types/contentstack/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/contextjs/tsconfig.json
+++ b/types/contextjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/continuation-local-storage/tsconfig.json
+++ b/types/continuation-local-storage/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/conventional-changelog-writer/tsconfig.json
+++ b/types/conventional-changelog-writer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "esModuleInterop": true,

--- a/types/convert-source-map/tsconfig.json
+++ b/types/convert-source-map/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cookie-session/tsconfig.json
+++ b/types/cookie-session/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cookie-signature/tsconfig.json
+++ b/types/cookie-signature/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cookie_js/tsconfig.json
+++ b/types/cookie_js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/copyfiles/tsconfig.json
+++ b/types/copyfiles/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-ionic/tsconfig.json
+++ b/types/cordova-ionic/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-app-version/tsconfig.json
+++ b/types/cordova-plugin-app-version/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-background-mode/tsconfig.json
+++ b/types/cordova-plugin-background-mode/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-badge/tsconfig.json
+++ b/types/cordova-plugin-badge/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-ble-central/tsconfig.json
+++ b/types/cordova-plugin-ble-central/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-bluetoothclassic-serial/tsconfig.json
+++ b/types/cordova-plugin-bluetoothclassic-serial/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-canvascamera/tsconfig.json
+++ b/types/cordova-plugin-canvascamera/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,

--- a/types/cordova-plugin-device-name/tsconfig.json
+++ b/types/cordova-plugin-device-name/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-email-composer/tsconfig.json
+++ b/types/cordova-plugin-email-composer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-file-opener2/tsconfig.json
+++ b/types/cordova-plugin-file-opener2/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-insomnia/tsconfig.json
+++ b/types/cordova-plugin-insomnia/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-keyboard/tsconfig.json
+++ b/types/cordova-plugin-keyboard/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-mapsforge/tsconfig.json
+++ b/types/cordova-plugin-mapsforge/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-ms-adal/tsconfig.json
+++ b/types/cordova-plugin-ms-adal/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-native-keyboard/tsconfig.json
+++ b/types/cordova-plugin-native-keyboard/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-ouralabs/tsconfig.json
+++ b/types/cordova-plugin-ouralabs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-spinner/tsconfig.json
+++ b/types/cordova-plugin-spinner/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-plugin-websql/tsconfig.json
+++ b/types/cordova-plugin-websql/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova-universal-links-plugin/tsconfig.json
+++ b/types/cordova-universal-links-plugin/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova/tsconfig.json
+++ b/types/cordova/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordova_app_version_plugin/tsconfig.json
+++ b/types/cordova_app_version_plugin/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cordovarduino/tsconfig.json
+++ b/types/cordovarduino/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/core-js/tsconfig.json
+++ b/types/core-js/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cors/tsconfig.json
+++ b/types/cors/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/countdown/tsconfig.json
+++ b/types/countdown/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/counterpart/tsconfig.json
+++ b/types/counterpart/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/countries-and-timezones/tsconfig.json
+++ b/types/countries-and-timezones/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/country-data/tsconfig.json
+++ b/types/country-data/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/country-list/tsconfig.json
+++ b/types/country-list/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/country-list/v1/tsconfig.json
+++ b/types/country-list/v1/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/country-select-js/tsconfig.json
+++ b/types/country-select-js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/coverup/tsconfig.json
+++ b/types/coverup/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cpx/tsconfig.json
+++ b/types/cpx/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cqrs-domain/tsconfig.json
+++ b/types/cqrs-domain/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/crc/tsconfig.json
+++ b/types/crc/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/create-hash/tsconfig.json
+++ b/types/create-hash/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/create-hmac/tsconfig.json
+++ b/types/create-hmac/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/create-xpub/tsconfig.json
+++ b/types/create-xpub/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/createjs-lib/tsconfig.json
+++ b/types/createjs-lib/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/createjs/tsconfig.json
+++ b/types/createjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/credential/tsconfig.json
+++ b/types/credential/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/critters-webpack-plugin/tsconfig.json
+++ b/types/critters-webpack-plugin/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cron-converter/tsconfig.json
+++ b/types/cron-converter/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/cron/tsconfig.json
+++ b/types/cron/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/crumb/tsconfig.json
+++ b/types/crumb/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cryptiles/tsconfig.json
+++ b/types/cryptiles/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cryptr/tsconfig.json
+++ b/types/cryptr/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/cson/tsconfig.json
+++ b/types/cson/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/csrf/tsconfig.json
+++ b/types/csrf/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": false,
         "baseUrl": "../",

--- a/types/css-modules-require-hook/tsconfig.json
+++ b/types/css-modules-require-hook/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/css-selector-tokenizer/tsconfig.json
+++ b/types/css-selector-tokenizer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/css-to-style/tsconfig.json
+++ b/types/css-to-style/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es5", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/css-tree/tsconfig.json
+++ b/types/css-tree/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cssbeautify/tsconfig.json
+++ b/types/cssbeautify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cssesc/tsconfig.json
+++ b/types/cssesc/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/csso/tsconfig.json
+++ b/types/csso/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cssom/tsconfig.json
+++ b/types/cssom/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["ES2015"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictFunctionTypes": true,
 		"strictNullChecks": true,
 		"baseUrl": "../",

--- a/types/cssstyle/tsconfig.json
+++ b/types/cssstyle/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["ES2015"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictFunctionTypes": true,
 		"strictNullChecks": true,
 		"baseUrl": "../",

--- a/types/csurf/tsconfig.json
+++ b/types/csurf/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/csvrow/tsconfig.json
+++ b/types/csvrow/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/csvtojson/tsconfig.json
+++ b/types/csvtojson/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cuint/tsconfig.json
+++ b/types/cuint/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/currency-formatter/tsconfig.json
+++ b/types/currency-formatter/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/current-git-branch/tsconfig.json
+++ b/types/current-git-branch/tsconfig.json
@@ -7,6 +7,7 @@
         "noImplicitAny": true,
         "esModuleInterop": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cuss/tsconfig.json
+++ b/types/cuss/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/custom-error-generator/tsconfig.json
+++ b/types/custom-error-generator/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cwd/tsconfig.json
+++ b/types/cwd/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cwise-compiler/tsconfig.json
+++ b/types/cwise-compiler/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cwise-parser/tsconfig.json
+++ b/types/cwise-parser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cwise/tsconfig.json
+++ b/types/cwise/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cyberblast__config/tsconfig.json
+++ b/types/cyberblast__config/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/cyberblast__logger/tsconfig.json
+++ b/types/cyberblast__logger/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/cybozulabs-md5/tsconfig.json
+++ b/types/cybozulabs-md5/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cypress-axe/tsconfig.json
+++ b/types/cypress-axe/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/cypress-cucumber-preprocessor/tsconfig.json
+++ b/types/cypress-cucumber-preprocessor/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/cypress-image-snapshot/tsconfig.json
+++ b/types/cypress-image-snapshot/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/d/tsconfig.json
+++ b/types/d/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/d20/tsconfig.json
+++ b/types/d20/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/d3-box/tsconfig.json
+++ b/types/d3-box/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/d3-cloud/tsconfig.json
+++ b/types/d3-cloud/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": false,
         "baseUrl": "../",

--- a/types/d3-interpolate-path/tsconfig.json
+++ b/types/d3-interpolate-path/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/d3-queue/tsconfig.json
+++ b/types/d3-queue/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/d3-require/tsconfig.json
+++ b/types/d3-require/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/d3-tip/tsconfig.json
+++ b/types/d3-tip/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/d3.slider/tsconfig.json
+++ b/types/d3.slider/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/d3kit/v1/tsconfig.json
+++ b/types/d3kit/v1/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/d3pie/tsconfig.json
+++ b/types/d3pie/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dagre-d3/tsconfig.json
+++ b/types/dagre-d3/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dagre-layout/tsconfig.json
+++ b/types/dagre-layout/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dagre/tsconfig.json
+++ b/types/dagre/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/data-driven/tsconfig.json
+++ b/types/data-driven/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/datadog-metrics/tsconfig.json
+++ b/types/datadog-metrics/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/datadog-statsd-metrics-collector/tsconfig.json
+++ b/types/datadog-statsd-metrics-collector/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/datadog-tracer/tsconfig.json
+++ b/types/datadog-tracer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/datastore-core/tsconfig.json
+++ b/types/datastore-core/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/datastore-level/tsconfig.json
+++ b/types/datastore-level/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/datatables.net-autofill/tsconfig.json
+++ b/types/datatables.net-autofill/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/datatables.net-buttons/tsconfig.json
+++ b/types/datatables.net-buttons/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/datatables.net-fixedheader/tsconfig.json
+++ b/types/datatables.net-fixedheader/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/datatables.net-rowgroup/tsconfig.json
+++ b/types/datatables.net-rowgroup/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/date-and-time/tsconfig.json
+++ b/types/date-and-time/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/date-arithmetic/tsconfig.json
+++ b/types/date-arithmetic/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/date-now/tsconfig.json
+++ b/types/date-now/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/date-range-array/tsconfig.json
+++ b/types/date-range-array/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/date-utils/tsconfig.json
+++ b/types/date-utils/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/date.format.js/tsconfig.json
+++ b/types/date.format.js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dateformat/tsconfig.json
+++ b/types/dateformat/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dateformat/v1/tsconfig.json
+++ b/types/dateformat/v1/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/dayzed/tsconfig.json
+++ b/types/dayzed/tsconfig.json
@@ -8,6 +8,7 @@
         "jsx": "react",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/db-migrate-base/tsconfig.json
+++ b/types/db-migrate-base/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/db-migrate-pg/tsconfig.json
+++ b/types/db-migrate-pg/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dbus/tsconfig.json
+++ b/types/dbus/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/dc/tsconfig.json
+++ b/types/dc/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/deasync/tsconfig.json
+++ b/types/deasync/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/debessmann/tsconfig.json
+++ b/types/debessmann/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/debounce-promise/ts3.1/tsconfig.json
+++ b/types/debounce-promise/ts3.1/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/debounce-promise/tsconfig.json
+++ b/types/debounce-promise/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/debug/tsconfig.json
+++ b/types/debug/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/decode-entities/tsconfig.json
+++ b/types/decode-entities/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/decode-uri-component/tsconfig.json
+++ b/types/decode-uri-component/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/decomment/tsconfig.json
+++ b/types/decomment/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/decompress/tsconfig.json
+++ b/types/decompress/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/deep-assign/tsconfig.json
+++ b/types/deep-assign/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/deep-diff/tsconfig.json
+++ b/types/deep-diff/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/deep-equal-in-any-order/tsconfig.json
+++ b/types/deep-equal-in-any-order/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/deep-equal/tsconfig.json
+++ b/types/deep-equal/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/deep-extend/tsconfig.json
+++ b/types/deep-extend/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/deep-freeze-strict/tsconfig.json
+++ b/types/deep-freeze-strict/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/deezer-sdk/tsconfig.json
+++ b/types/deezer-sdk/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/default-gateway/tsconfig.json
+++ b/types/default-gateway/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/defaults-deep/tsconfig.json
+++ b/types/defaults-deep/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/defaults/tsconfig.json
+++ b/types/defaults/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/defer-promise/tsconfig.json
+++ b/types/defer-promise/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/define-properties/tsconfig.json
+++ b/types/define-properties/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["es6"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictFunctionTypes": true,
 		"strictNullChecks": true,
 		"baseUrl": "../",

--- a/types/defined/tsconfig.json
+++ b/types/defined/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/deglob/tsconfig.json
+++ b/types/deglob/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/deindent/tsconfig.json
+++ b/types/deindent/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/delete-empty/tsconfig.json
+++ b/types/delete-empty/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/deline/tsconfig.json
+++ b/types/deline/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/deluge/tsconfig.json
+++ b/types/deluge/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes" : true,
         "baseUrl": "../",

--- a/types/depd/tsconfig.json
+++ b/types/depd/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/deprecate/tsconfig.json
+++ b/types/deprecate/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/destroy-on-hwm/tsconfig.json
+++ b/types/destroy-on-hwm/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/destroy/tsconfig.json
+++ b/types/destroy/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/detect-emoji-support/tsconfig.json
+++ b/types/detect-emoji-support/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/detect-hover/tsconfig.json
+++ b/types/detect-hover/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/detect-it/tsconfig.json
+++ b/types/detect-it/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/detect-node/tsconfig.json
+++ b/types/detect-node/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/detect-passive-events/tsconfig.json
+++ b/types/detect-passive-events/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/detect-pointer/tsconfig.json
+++ b/types/detect-pointer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/detect-touch-events/tsconfig.json
+++ b/types/detect-touch-events/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/detox/tsconfig.json
+++ b/types/detox/tsconfig.json
@@ -7,6 +7,7 @@
         "target": "ES2015",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dev-ip/tsconfig.json
+++ b/types/dev-ip/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dexie-batch/tsconfig.json
+++ b/types/dexie-batch/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/df-visible/tsconfig.json
+++ b/types/df-visible/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dhtmlxgantt/tsconfig.json
+++ b/types/dhtmlxgantt/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/di-lite/tsconfig.json
+++ b/types/di-lite/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dialog-polyfill/tsconfig.json
+++ b/types/dialog-polyfill/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/dice-coefficient/tsconfig.json
+++ b/types/dice-coefficient/tsconfig.json
@@ -7,6 +7,7 @@
         "esModuleInterop": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/diff/tsconfig.json
+++ b/types/diff/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/diff/v3/tsconfig.json
+++ b/types/diff/v3/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/diff2html/tsconfig.json
+++ b/types/diff2html/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/diffie-hellman/tsconfig.json
+++ b/types/diffie-hellman/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/difflib/tsconfig.json
+++ b/types/difflib/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/dingtalk-robot-sender/tsconfig.json
+++ b/types/dingtalk-robot-sender/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dir-glob/tsconfig.json
+++ b/types/dir-glob/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dir-resolve/tsconfig.json
+++ b/types/dir-resolve/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dir-walker-gen/tsconfig.json
+++ b/types/dir-walker-gen/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/direction/tsconfig.json
+++ b/types/direction/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/dirname-regex/tsconfig.json
+++ b/types/dirname-regex/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dirty-chai/tsconfig.json
+++ b/types/dirty-chai/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/distributions-poisson-quantile/tsconfig.json
+++ b/types/distributions-poisson-quantile/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/distributions/tsconfig.json
+++ b/types/distributions/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "esModuleInterop": true,

--- a/types/djv/tsconfig.json
+++ b/types/djv/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/dkim-signer/tsconfig.json
+++ b/types/dkim-signer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/dlv/tsconfig.json
+++ b/types/dlv/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/doccookies/tsconfig.json
+++ b/types/doccookies/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dock-spawn/tsconfig.json
+++ b/types/dock-spawn/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/docker-events/tsconfig.json
+++ b/types/docker-events/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/docopt/tsconfig.json
+++ b/types/docopt/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/document-ready/tsconfig.json
+++ b/types/document-ready/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "strictFunctionTypes": true,

--- a/types/dogapi/tsconfig.json
+++ b/types/dogapi/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/doge-seed/tsconfig.json
+++ b/types/doge-seed/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dojo/tsconfig.json
+++ b/types/dojo/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dom-clipboard-api/tsconfig.json
+++ b/types/dom-clipboard-api/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dom-inputevent/tsconfig.json
+++ b/types/dom-inputevent/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": false,
         "baseUrl": "../",

--- a/types/dom-matches/tsconfig.json
+++ b/types/dom-matches/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/dom-parser/tsconfig.json
+++ b/types/dom-parser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/domexception/tsconfig.json
+++ b/types/domexception/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["es5", "dom"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictFunctionTypes": true,
 		"strictNullChecks": true,
 		"baseUrl": "../",

--- a/types/domo/tsconfig.json
+++ b/types/domo/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/domready/tsconfig.json
+++ b/types/domready/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/domtagger/tsconfig.json
+++ b/types/domtagger/tsconfig.json
@@ -7,6 +7,7 @@
 		],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictFunctionTypes": true,
 		"strictNullChecks": true,
 		"baseUrl": "../",

--- a/types/domutils/tsconfig.json
+++ b/types/domutils/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dos2unix/tsconfig.json
+++ b/types/dos2unix/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/dot-object/tsconfig.json
+++ b/types/dot-object/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dot-prop-immutable/tsconfig.json
+++ b/types/dot-prop-immutable/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/dot/tsconfig.json
+++ b/types/dot/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dotdir-regex/tsconfig.json
+++ b/types/dotdir-regex/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dotdotdot/tsconfig.json
+++ b/types/dotdotdot/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dotenv-parse-variables/tsconfig.json
+++ b/types/dotenv-parse-variables/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/dotenv-safe/tsconfig.json
+++ b/types/dotenv-safe/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dotfile-regex/tsconfig.json
+++ b/types/dotfile-regex/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dottie/tsconfig.json
+++ b/types/dottie/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/doublearray/tsconfig.json
+++ b/types/doublearray/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/doubleclick-gpt/tsconfig.json
+++ b/types/doubleclick-gpt/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/download/tsconfig.json
+++ b/types/download/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/downloadjs/tsconfig.json
+++ b/types/downloadjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/draft-convert/tsconfig.json
+++ b/types/draft-convert/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/draftjs-to-html/tsconfig.json
+++ b/types/draftjs-to-html/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/drag-timetable/tsconfig.json
+++ b/types/drag-timetable/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dragscroll/tsconfig.json
+++ b/types/dragscroll/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/dragselect/tsconfig.json
+++ b/types/dragselect/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/dragster/tsconfig.json
+++ b/types/dragster/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dragula/tsconfig.json
+++ b/types/dragula/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/driftless/tsconfig.json
+++ b/types/driftless/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/drivelist/tsconfig.json
+++ b/types/drivelist/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dropbox-chooser/tsconfig.json
+++ b/types/dropbox-chooser/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dropboxjs/tsconfig.json
+++ b/types/dropboxjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dropkickjs/tsconfig.json
+++ b/types/dropkickjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dropzone/tsconfig.json
+++ b/types/dropzone/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dropzone/v4/tsconfig.json
+++ b/types/dropzone/v4/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/ds18b20/tsconfig.json
+++ b/types/ds18b20/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/dts-bundle/tsconfig.json
+++ b/types/dts-bundle/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dts-generator/tsconfig.json
+++ b/types/dts-generator/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dtype/tsconfig.json
+++ b/types/dtype/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/du/tsconfig.json
+++ b/types/du/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/duckduckgo-images-api/tsconfig.json
+++ b/types/duckduckgo-images-api/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/duo_web_sdk/tsconfig.json
+++ b/types/duo_web_sdk/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/duosecurity__duo_web/tsconfig.json
+++ b/types/duosecurity__duo_web/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/duplexer2/tsconfig.json
+++ b/types/duplexer2/tsconfig.json
@@ -12,6 +12,7 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/durandal/tsconfig.json
+++ b/types/durandal/tsconfig.json
@@ -10,6 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/durandal/v1/tsconfig.json
+++ b/types/durandal/v1/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": false,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/dush/tsconfig.json
+++ b/types/dush/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/dustjs-linkedin/tsconfig.json
+++ b/types/dustjs-linkedin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dvtng-jss/tsconfig.json
+++ b/types/dvtng-jss/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dw-bxslider-4/tsconfig.json
+++ b/types/dw-bxslider-4/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dwt/v12/tsconfig.json
+++ b/types/dwt/v12/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/dwt/v13/tsconfig.json
+++ b/types/dwt/v13/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/dymo-label-framework/tsconfig.json
+++ b/types/dymo-label-framework/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dynatable/tsconfig.json
+++ b/types/dynatable/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/dynatrace/tsconfig.json
+++ b/types/dynatrace/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/earcut/tsconfig.json
+++ b/types/earcut/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/eases/tsconfig.json
+++ b/types/eases/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/easy-api-request/tsconfig.json
+++ b/types/easy-api-request/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/easy-jsend/tsconfig.json
+++ b/types/easy-jsend/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/easy-rbac/tsconfig.json
+++ b/types/easy-rbac/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/easy-session/tsconfig.json
+++ b/types/easy-session/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/easydate/tsconfig.json
+++ b/types/easydate/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ebml/tsconfig.json
+++ b/types/ebml/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ebongarde-root/tsconfig.json
+++ b/types/ebongarde-root/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/eccrypto/tsconfig.json
+++ b/types/eccrypto/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/echarts/tsconfig.json
+++ b/types/echarts/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ecma-proposal-math-extensions/tsconfig.json
+++ b/types/ecma-proposal-math-extensions/tsconfig.json
@@ -8,6 +8,7 @@
         "target": "es2017",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ecore/tsconfig.json
+++ b/types/ecore/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ecurve/tsconfig.json
+++ b/types/ecurve/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/edmonds-blossom/tsconfig.json
+++ b/types/edmonds-blossom/tsconfig.json
@@ -11,6 +11,7 @@
         "types": [],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,

--- a/types/ee-first/tsconfig.json
+++ b/types/ee-first/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/egg.js/tsconfig.json
+++ b/types/egg.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/egjs__axes/tsconfig.json
+++ b/types/egjs__axes/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ejs-locals/tsconfig.json
+++ b/types/ejs-locals/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/elastic.js/tsconfig.json
+++ b/types/elastic.js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/elasticlunr/tsconfig.json
+++ b/types/elasticlunr/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/electron-clipboard-extended/tsconfig.json
+++ b/types/electron-clipboard-extended/tsconfig.json
@@ -5,6 +5,7 @@
         "noEmit": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/electron-devtools-installer/tsconfig.json
+++ b/types/electron-devtools-installer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/electron-load-devtool/tsconfig.json
+++ b/types/electron-load-devtool/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/electron-localshortcut/tsconfig.json
+++ b/types/electron-localshortcut/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/electron-notifications/tsconfig.json
+++ b/types/electron-notifications/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/electron-notify/tsconfig.json
+++ b/types/electron-notify/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/electron-prompt/tsconfig.json
+++ b/types/electron-prompt/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/electron-settings/tsconfig.json
+++ b/types/electron-settings/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/electron-spellchecker/tsconfig.json
+++ b/types/electron-spellchecker/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/electron-window-state/tsconfig.json
+++ b/types/electron-window-state/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": false,
         "baseUrl": "../",

--- a/types/element-closest/tsconfig.json
+++ b/types/element-closest/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/element-resize-detector/tsconfig.json
+++ b/types/element-resize-detector/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/element-resize-event/tsconfig.json
+++ b/types/element-resize-event/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/elgamal/tsconfig.json
+++ b/types/elgamal/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/elm/tsconfig.json
+++ b/types/elm/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/elo-rank/tsconfig.json
+++ b/types/elo-rank/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/elv/tsconfig.json
+++ b/types/elv/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/ember-feature-flags/tsconfig.json
+++ b/types/ember-feature-flags/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ember-feature-flags/v3/tsconfig.json
+++ b/types/ember-feature-flags/v3/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": false,
         "baseUrl": "../../",

--- a/types/ember/v1/tsconfig.json
+++ b/types/ember/v1/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/ember__controller/tsconfig.json
+++ b/types/ember__controller/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "experimentalDecorators": true,

--- a/types/ember__debug/tsconfig.json
+++ b/types/ember__debug/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ember__ordered-set/tsconfig.json
+++ b/types/ember__ordered-set/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ember__polyfills/tsconfig.json
+++ b/types/ember__polyfills/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ember__string/tsconfig.json
+++ b/types/ember__string/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ember__test/tsconfig.json
+++ b/types/ember__test/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/emissary/tsconfig.json
+++ b/types/emissary/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/emoji-js/tsconfig.json
+++ b/types/emoji-js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/emoji-regex/tsconfig.json
+++ b/types/emoji-regex/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/emojione/tsconfig.json
+++ b/types/emojione/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/empty-dir/tsconfig.json
+++ b/types/empty-dir/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/encodeurl/tsconfig.json
+++ b/types/encodeurl/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/encoding-down/tsconfig.json
+++ b/types/encoding-down/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/end-of-stream/tsconfig.json
+++ b/types/end-of-stream/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/engine-check/tsconfig.json
+++ b/types/engine-check/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/engine.io-client/tsconfig.json
+++ b/types/engine.io-client/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/engine.io/tsconfig.json
+++ b/types/engine.io/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/enigma.js/tsconfig.json
+++ b/types/enigma.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/enquire.js/tsconfig.json
+++ b/types/enquire.js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ensure-posix-path/tsconfig.json
+++ b/types/ensure-posix-path/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/entities/tsconfig.json
+++ b/types/entities/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/env-ci/tsconfig.json
+++ b/types/env-ci/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/envify/tsconfig.json
+++ b/types/envify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/enzyme-adapter-react-15.4/tsconfig.json
+++ b/types/enzyme-adapter-react-15.4/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/enzyme-adapter-react-15/tsconfig.json
+++ b/types/enzyme-adapter-react-15/tsconfig.json
@@ -14,6 +14,7 @@
         "noUnusedParameters": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "forceConsistentCasingInFileNames": true,

--- a/types/enzyme-adapter-react-16/tsconfig.json
+++ b/types/enzyme-adapter-react-16/tsconfig.json
@@ -14,6 +14,7 @@
         "noUnusedParameters": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "forceConsistentCasingInFileNames": true,

--- a/types/enzyme-async-helpers/tsconfig.json
+++ b/types/enzyme-async-helpers/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/eonasdan-bootstrap-datetimepicker/tsconfig.json
+++ b/types/eonasdan-bootstrap-datetimepicker/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/epiceditor/tsconfig.json
+++ b/types/epiceditor/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/epilogue/tsconfig.json
+++ b/types/epilogue/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/epub/tsconfig.json
+++ b/types/epub/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/eq.js/tsconfig.json
+++ b/types/eq.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/error-subclass/tsconfig.json
+++ b/types/error-subclass/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/es-feature-detection/tsconfig.json
+++ b/types/es-feature-detection/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/es-module-lexer/tsconfig.json
+++ b/types/es-module-lexer/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/es-to-primitive/ts3.1/tsconfig.json
+++ b/types/es-to-primitive/ts3.1/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../../",

--- a/types/es-to-primitive/ts3.2/tsconfig.json
+++ b/types/es-to-primitive/ts3.2/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../../",

--- a/types/es-to-primitive/tsconfig.json
+++ b/types/es-to-primitive/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/es6-collections/tsconfig.json
+++ b/types/es6-collections/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/es6-promisify/tsconfig.json
+++ b/types/es6-promisify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/es6-shim/ts3.1/tsconfig.json
+++ b/types/es6-shim/ts3.1/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/es6-shim/tsconfig.json
+++ b/types/es6-shim/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/es6-weak-map/tsconfig.json
+++ b/types/es6-weak-map/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/escape-latex/tsconfig.json
+++ b/types/escape-latex/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/escape-regexp/tsconfig.json
+++ b/types/escape-regexp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/eslint-plugin-prettier/tsconfig.json
+++ b/types/eslint-plugin-prettier/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/eslint/ts3.1/tsconfig.json
+++ b/types/eslint/ts3.1/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/esm/tsconfig.json
+++ b/types/esm/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/espruino/tsconfig.json
+++ b/types/espruino/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/esquery/tsconfig.json
+++ b/types/esquery/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/esrever/tsconfig.json
+++ b/types/esrever/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/estimate/tsconfig.json
+++ b/types/estimate/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/estraverse/tsconfig.json
+++ b/types/estraverse/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/etag/tsconfig.json
+++ b/types/etag/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/eth-lightwallet/tsconfig.json
+++ b/types/eth-lightwallet/tsconfig.json
@@ -6,6 +6,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/eth-sig-util/tsconfig.json
+++ b/types/eth-sig-util/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ethereumjs-abi/tsconfig.json
+++ b/types/ethereumjs-abi/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/event-hooks-webpack-plugin/tsconfig.json
+++ b/types/event-hooks-webpack-plugin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/event-to-promise/tsconfig.json
+++ b/types/event-to-promise/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/events.once/tsconfig.json
+++ b/types/events.once/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/events/tsconfig.json
+++ b/types/events/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/exenv/tsconfig.json
+++ b/types/exenv/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/exif/tsconfig.json
+++ b/types/exif/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/exit/tsconfig.json
+++ b/types/exit/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/expand-tilde/tsconfig.json
+++ b/types/expand-tilde/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/expect.js/tsconfig.json
+++ b/types/expect.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/expectations/tsconfig.json
+++ b/types/expectations/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/expired-storage/tsconfig.json
+++ b/types/expired-storage/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/expired/tsconfig.json
+++ b/types/expired/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/expo-mixpanel-analytics/tsconfig.json
+++ b/types/expo-mixpanel-analytics/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/expo__status-bar-height/tsconfig.json
+++ b/types/expo__status-bar-height/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-async-wrap/tsconfig.json
+++ b/types/express-async-wrap/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-boom/tsconfig.json
+++ b/types/express-boom/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-brute-memcached/tsconfig.json
+++ b/types/express-brute-memcached/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-brute-mongo/tsconfig.json
+++ b/types/express-brute-mongo/tsconfig.json
@@ -11,6 +11,7 @@
         },
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-brute-redis/tsconfig.json
+++ b/types/express-brute-redis/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": false,
         "baseUrl": "../",

--- a/types/express-brute/tsconfig.json
+++ b/types/express-brute/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-cluster/tsconfig.json
+++ b/types/express-cluster/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-debug/tsconfig.json
+++ b/types/express-debug/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-enforces-ssl/tsconfig.json
+++ b/types/express-enforces-ssl/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-fileupload/tsconfig.json
+++ b/types/express-fileupload/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-flash-2/tsconfig.json
+++ b/types/express-flash-2/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-flash-notification/tsconfig.json
+++ b/types/express-flash-notification/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-flash/tsconfig.json
+++ b/types/express-flash/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-form-data/tsconfig.json
+++ b/types/express-form-data/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/express-formidable/tsconfig.json
+++ b/types/express-formidable/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-jwt/tsconfig.json
+++ b/types/express-jwt/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-less/tsconfig.json
+++ b/types/express-less/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-list-endpoints/tsconfig.json
+++ b/types/express-list-endpoints/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-minify/tsconfig.json
+++ b/types/express-minify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-mung/tsconfig.json
+++ b/types/express-mung/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-myconnection/tsconfig.json
+++ b/types/express-myconnection/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": false,
         "baseUrl": "../",

--- a/types/express-mysql-session/tsconfig.json
+++ b/types/express-mysql-session/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-ntlm/tsconfig.json
+++ b/types/express-ntlm/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-paginate/tsconfig.json
+++ b/types/express-paginate/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "esModuleInterop": true,

--- a/types/express-partials/tsconfig.json
+++ b/types/express-partials/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-pino-logger/tsconfig.json
+++ b/types/express-pino-logger/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/express-redis-cache/tsconfig.json
+++ b/types/express-redis-cache/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/express-request-id/tsconfig.json
+++ b/types/express-request-id/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/express-route-fs/tsconfig.json
+++ b/types/express-route-fs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-routemap/tsconfig.json
+++ b/types/express-routemap/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-routes-versioning/tsconfig.json
+++ b/types/express-routes-versioning/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-sanitized/tsconfig.json
+++ b/types/express-sanitized/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-serve-static-core/tsconfig.json
+++ b/types/express-serve-static-core/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-session/tsconfig.json
+++ b/types/express-session/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-sitemap-xml/tsconfig.json
+++ b/types/express-sitemap-xml/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-sslify/tsconfig.json
+++ b/types/express-sslify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/express-status-monitor/tsconfig.json
+++ b/types/express-status-monitor/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/express-to-koa/tsconfig.json
+++ b/types/express-to-koa/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-unless/tsconfig.json
+++ b/types/express-unless/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-urlrewrite/tsconfig.json
+++ b/types/express-urlrewrite/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/express-useragent/v0/tsconfig.json
+++ b/types/express-useragent/v0/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/express-version-route/tsconfig.json
+++ b/types/express-version-route/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/express-wechat-access/tsconfig.json
+++ b/types/express-wechat-access/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/express-ws/tsconfig.json
+++ b/types/express-ws/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/express-xml-bodyparser/tsconfig.json
+++ b/types/express-xml-bodyparser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/extra-watch-webpack-plugin/tsconfig.json
+++ b/types/extra-watch-webpack-plugin/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/extract-files/tsconfig.json
+++ b/types/extract-files/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/extract-zip/tsconfig.json
+++ b/types/extract-zip/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/extsprintf/tsconfig.json
+++ b/types/extsprintf/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ez-plus/tsconfig.json
+++ b/types/ez-plus/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/f1/tsconfig.json
+++ b/types/f1/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/facebook-js-sdk/tsconfig.json
+++ b/types/facebook-js-sdk/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/facebook-locales/tsconfig.json
+++ b/types/facebook-locales/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/facebook-pixel/tsconfig.json
+++ b/types/facebook-pixel/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/facepaint/tsconfig.json
+++ b/types/facepaint/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/falcor-express/tsconfig.json
+++ b/types/falcor-express/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/falcor-router/tsconfig.json
+++ b/types/falcor-router/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fancy-log/tsconfig.json
+++ b/types/fancy-log/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fancybox/tsconfig.json
+++ b/types/fancybox/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/farbtastic/tsconfig.json
+++ b/types/farbtastic/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fast-chunk-string/tsconfig.json
+++ b/types/fast-chunk-string/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/fast-html-parser/tsconfig.json
+++ b/types/fast-html-parser/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fast-isnumeric/tsconfig.json
+++ b/types/fast-isnumeric/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/fast-json-stable-stringify/tsconfig.json
+++ b/types/fast-json-stable-stringify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fast-levenshtein/tsconfig.json
+++ b/types/fast-levenshtein/tsconfig.json
@@ -10,6 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fast-list/tsconfig.json
+++ b/types/fast-list/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fast-memory-cache/tsconfig.json
+++ b/types/fast-memory-cache/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fast-text-encoding/tsconfig.json
+++ b/types/fast-text-encoding/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/fast64/tsconfig.json
+++ b/types/fast64/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fastbitset/tsconfig.json
+++ b/types/fastbitset/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/fastclick/tsconfig.json
+++ b/types/fastclick/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fastify-accepts/tsconfig.json
+++ b/types/fastify-accepts/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/favico.js/tsconfig.json
+++ b/types/favico.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/feather-icons/tsconfig.json
+++ b/types/feather-icons/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],

--- a/types/featherlight/tsconfig.json
+++ b/types/featherlight/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/feathersjs__authentication-client/tsconfig.json
+++ b/types/feathersjs__authentication-client/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/feathersjs__authentication/tsconfig.json
+++ b/types/feathersjs__authentication/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/feathersjs__rest-client/tsconfig.json
+++ b/types/feathersjs__rest-client/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/feathersjs__socket-commons/tsconfig.json
+++ b/types/feathersjs__socket-commons/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/feathersjs__socketio-client/tsconfig.json
+++ b/types/feathersjs__socketio-client/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/feflow__cli/tsconfig.json
+++ b/types/feflow__cli/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fetch-jsonp/tsconfig.json
+++ b/types/fetch-jsonp/tsconfig.json
@@ -16,6 +16,7 @@
         "strictFunctionTypes": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "forceConsistentCasingInFileNames": true,
         "noEmit": true
     },

--- a/types/fetch.io/tsconfig.json
+++ b/types/fetch.io/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ffmpeg-concat/tsconfig.json
+++ b/types/ffmpeg-concat/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ffmpeg-static/tsconfig.json
+++ b/types/ffmpeg-static/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ffmpeg/tsconfig.json
+++ b/types/ffmpeg/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ffprobe-static/tsconfig.json
+++ b/types/ffprobe-static/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fhir-kit-client/tsconfig.json
+++ b/types/fhir-kit-client/tsconfig.json
@@ -9,6 +9,7 @@
         "allowSyntheticDefaultImports": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fhir/tsconfig.json
+++ b/types/fhir/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/field/tsconfig.json
+++ b/types/field/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/figlet/tsconfig.json
+++ b/types/figlet/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/file-exists/tsconfig.json
+++ b/types/file-exists/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/file-size/tsconfig.json
+++ b/types/file-size/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/filesystem/tsconfig.json
+++ b/types/filesystem/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/filewriter/tsconfig.json
+++ b/types/filewriter/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/filing-cabinet/tsconfig.json
+++ b/types/filing-cabinet/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/filter-invalid-dom-props/tsconfig.json
+++ b/types/filter-invalid-dom-props/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/final-form-set-field-data/tsconfig.json
+++ b/types/final-form-set-field-data/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/final-form-set-field-touched/tsconfig.json
+++ b/types/final-form-set-field-touched/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/finch/tsconfig.json
+++ b/types/finch/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/find-cache-dir/tsconfig.json
+++ b/types/find-cache-dir/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/find-cache-dir/v2/tsconfig.json
+++ b/types/find-cache-dir/v2/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/find-config/tsconfig.json
+++ b/types/find-config/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/find-down/tsconfig.json
+++ b/types/find-down/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/find-exec/tsconfig.json
+++ b/types/find-exec/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/find-unused-sass-variables/tsconfig.json
+++ b/types/find-unused-sass-variables/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/fined/tsconfig.json
+++ b/types/fined/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/firebase-client/tsconfig.json
+++ b/types/firebase-client/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/firebase-token-generator/tsconfig.json
+++ b/types/firebase-token-generator/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/firefox-webext-browser/tsconfig.json
+++ b/types/firefox-webext-browser/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/firefox/tsconfig.json
+++ b/types/firefox/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/flagged-respawn/tsconfig.json
+++ b/types/flagged-respawn/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/flake-idgen/tsconfig.json
+++ b/types/flake-idgen/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/flat-cache/tsconfig.json
+++ b/types/flat-cache/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/flexmonster/tsconfig.json
+++ b/types/flexmonster/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/flickity/tsconfig.json
+++ b/types/flickity/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/flipsnap/tsconfig.json
+++ b/types/flipsnap/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/float-equal/tsconfig.json
+++ b/types/float-equal/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/floreal/tsconfig.json
+++ b/types/floreal/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/flot/tsconfig.json
+++ b/types/flot/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/flowdoc/tsconfig.json
+++ b/types/flowdoc/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/flowjs/ts3.1/tsconfig.json
+++ b/types/flowjs/ts3.1/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/flowjs/tsconfig.json
+++ b/types/flowjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fluent-ffmpeg/tsconfig.json
+++ b/types/fluent-ffmpeg/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fluent/tsconfig.json
+++ b/types/fluent/tsconfig.json
@@ -7,6 +7,7 @@
         "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/flush-write-stream/tsconfig.json
+++ b/types/flush-write-stream/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fluxible-router/tsconfig.json
+++ b/types/fluxible-router/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "esModuleInterop": true,

--- a/types/fm-websync/tsconfig.json
+++ b/types/fm-websync/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "commonjs",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fnando__sparkline/tsconfig.json
+++ b/types/fnando__sparkline/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/focus-within/tsconfig.json
+++ b/types/focus-within/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/follow-redirects/tsconfig.json
+++ b/types/follow-redirects/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fontfaceobserver/tsconfig.json
+++ b/types/fontfaceobserver/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fontkit/tsconfig.json
+++ b/types/fontkit/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/fontoxml/tsconfig.json
+++ b/types/fontoxml/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/forever-monitor/tsconfig.json
+++ b/types/forever-monitor/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/forge-apis/tsconfig.json
+++ b/types/forge-apis/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/forge-viewer/tsconfig.json
+++ b/types/forge-viewer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/form-serialize/tsconfig.json
+++ b/types/form-serialize/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/form-serializer/tsconfig.json
+++ b/types/form-serializer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/form-urlencoded/tsconfig.json
+++ b/types/form-urlencoded/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/format-io/tsconfig.json
+++ b/types/format-io/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/format-util/tsconfig.json
+++ b/types/format-util/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/forwarded/tsconfig.json
+++ b/types/forwarded/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/foundation/tsconfig.json
+++ b/types/foundation/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fpsmeter/tsconfig.json
+++ b/types/fpsmeter/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/framebus/tsconfig.json
+++ b/types/framebus/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/franc/tsconfig.json
+++ b/types/franc/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/frappe-gantt/tsconfig.json
+++ b/types/frappe-gantt/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/frctl__fractal/tsconfig.json
+++ b/types/frctl__fractal/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/frecency/tsconfig.json
+++ b/types/frecency/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/freedom/tsconfig.json
+++ b/types/freedom/tsconfig.json
@@ -5,6 +5,7 @@
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fresh/tsconfig.json
+++ b/types/fresh/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/freshy/tsconfig.json
+++ b/types/freshy/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/frida-gum/tsconfig.json
+++ b/types/frida-gum/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/frisby/tsconfig.json
+++ b/types/frisby/tsconfig.json
@@ -7,6 +7,7 @@
         "noEmit": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "types": [],

--- a/types/fromjs/tsconfig.json
+++ b/types/fromjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fs-capacitor/tsconfig.json
+++ b/types/fs-capacitor/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fs-plus/tsconfig.json
+++ b/types/fs-plus/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fs-readfile-promise/tsconfig.json
+++ b/types/fs-readfile-promise/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fscreen/tsconfig.json
+++ b/types/fscreen/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "target": "es6",

--- a/types/ftdomdelegate/tsconfig.json
+++ b/types/ftdomdelegate/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ftp/tsconfig.json
+++ b/types/ftp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ftpd/tsconfig.json
+++ b/types/ftpd/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ftps/tsconfig.json
+++ b/types/ftps/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/fullcalendar__vue/tsconfig.json
+++ b/types/fullcalendar__vue/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "DOM"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/fullname/tsconfig.json
+++ b/types/fullname/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fullpage.js/tsconfig.json
+++ b/types/fullpage.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/function-bind/ts3.3/tsconfig.json
+++ b/types/function-bind/ts3.3/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["es5"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictFunctionTypes": true,
 		"strictNullChecks": true,
 		"baseUrl": "../../",

--- a/types/fusioncharts/tsconfig.json
+++ b/types/fusioncharts/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fuzzaldrin-plus/tsconfig.json
+++ b/types/fuzzaldrin-plus/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fuzzaldrin/tsconfig.json
+++ b/types/fuzzaldrin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fxjs/tsconfig.json
+++ b/types/fxjs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/fxn/tsconfig.json
+++ b/types/fxn/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gae.channel.api/tsconfig.json
+++ b/types/gae.channel.api/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gamepad/tsconfig.json
+++ b/types/gamepad/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gamequery/tsconfig.json
+++ b/types/gamequery/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": false,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gandi-livedns/tsconfig.json
+++ b/types/gandi-livedns/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gapi.analytics/tsconfig.json
+++ b/types/gapi.analytics/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gapi.calendar/tsconfig.json
+++ b/types/gapi.calendar/tsconfig.json
@@ -14,6 +14,7 @@
         "strictFunctionTypes": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "forceConsistentCasingInFileNames": true,
         "noEmit": true
     },

--- a/types/gapi.client.acceleratedmobilepageurl/tsconfig.json
+++ b/types/gapi.client.acceleratedmobilepageurl/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.adexchangebuyer/tsconfig.json
+++ b/types/gapi.client.adexchangebuyer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.adexchangebuyer2/tsconfig.json
+++ b/types/gapi.client.adexchangebuyer2/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.adexchangeseller/tsconfig.json
+++ b/types/gapi.client.adexchangeseller/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.adexperiencereport/tsconfig.json
+++ b/types/gapi.client.adexperiencereport/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.admin/tsconfig.json
+++ b/types/gapi.client.admin/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.adsense/tsconfig.json
+++ b/types/gapi.client.adsense/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.adsensehost/tsconfig.json
+++ b/types/gapi.client.adsensehost/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.analytics/tsconfig.json
+++ b/types/gapi.client.analytics/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.analyticsreporting/tsconfig.json
+++ b/types/gapi.client.analyticsreporting/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.androiddeviceprovisioning/tsconfig.json
+++ b/types/gapi.client.androiddeviceprovisioning/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.androidenterprise/tsconfig.json
+++ b/types/gapi.client.androidenterprise/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.androidmanagement/tsconfig.json
+++ b/types/gapi.client.androidmanagement/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.androidpublisher/tsconfig.json
+++ b/types/gapi.client.androidpublisher/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.appengine/tsconfig.json
+++ b/types/gapi.client.appengine/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.appsactivity/tsconfig.json
+++ b/types/gapi.client.appsactivity/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.appstate/tsconfig.json
+++ b/types/gapi.client.appstate/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.bigquery/tsconfig.json
+++ b/types/gapi.client.bigquery/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.bigquerydatatransfer/tsconfig.json
+++ b/types/gapi.client.bigquerydatatransfer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.blogger/tsconfig.json
+++ b/types/gapi.client.blogger/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.books/tsconfig.json
+++ b/types/gapi.client.books/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.calendar/tsconfig.json
+++ b/types/gapi.client.calendar/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.civicinfo/tsconfig.json
+++ b/types/gapi.client.civicinfo/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.classroom/tsconfig.json
+++ b/types/gapi.client.classroom/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es6", "dom"],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "baseUrl": "../",
     "typeRoots": [

--- a/types/gapi.client.cloudbilling/tsconfig.json
+++ b/types/gapi.client.cloudbilling/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.cloudbuild/tsconfig.json
+++ b/types/gapi.client.cloudbuild/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.clouddebugger/tsconfig.json
+++ b/types/gapi.client.clouddebugger/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.clouderrorreporting/tsconfig.json
+++ b/types/gapi.client.clouderrorreporting/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.cloudfunctions/tsconfig.json
+++ b/types/gapi.client.cloudfunctions/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.cloudiot/tsconfig.json
+++ b/types/gapi.client.cloudiot/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.cloudkms/tsconfig.json
+++ b/types/gapi.client.cloudkms/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.cloudmonitoring/tsconfig.json
+++ b/types/gapi.client.cloudmonitoring/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.cloudresourcemanager/tsconfig.json
+++ b/types/gapi.client.cloudresourcemanager/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.cloudtasks/tsconfig.json
+++ b/types/gapi.client.cloudtasks/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.cloudtrace/tsconfig.json
+++ b/types/gapi.client.cloudtrace/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.clouduseraccounts/tsconfig.json
+++ b/types/gapi.client.clouduseraccounts/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.compute/tsconfig.json
+++ b/types/gapi.client.compute/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.consumersurveys/tsconfig.json
+++ b/types/gapi.client.consumersurveys/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.container/tsconfig.json
+++ b/types/gapi.client.container/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.content/tsconfig.json
+++ b/types/gapi.client.content/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.customsearch/tsconfig.json
+++ b/types/gapi.client.customsearch/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.dataflow/tsconfig.json
+++ b/types/gapi.client.dataflow/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.dataproc/tsconfig.json
+++ b/types/gapi.client.dataproc/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.datastore/tsconfig.json
+++ b/types/gapi.client.datastore/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.deploymentmanager/tsconfig.json
+++ b/types/gapi.client.deploymentmanager/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.dfareporting/tsconfig.json
+++ b/types/gapi.client.dfareporting/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.discovery/tsconfig.json
+++ b/types/gapi.client.discovery/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.dlp/tsconfig.json
+++ b/types/gapi.client.dlp/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.dns/tsconfig.json
+++ b/types/gapi.client.dns/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.doubleclickbidmanager/tsconfig.json
+++ b/types/gapi.client.doubleclickbidmanager/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.doubleclicksearch/tsconfig.json
+++ b/types/gapi.client.doubleclicksearch/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.drive/tsconfig.json
+++ b/types/gapi.client.drive/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.firebasedynamiclinks/tsconfig.json
+++ b/types/gapi.client.firebasedynamiclinks/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.firebaseremoteconfig/tsconfig.json
+++ b/types/gapi.client.firebaseremoteconfig/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.firebaserules/tsconfig.json
+++ b/types/gapi.client.firebaserules/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.firestore/tsconfig.json
+++ b/types/gapi.client.firestore/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.fitness/tsconfig.json
+++ b/types/gapi.client.fitness/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.fusiontables/tsconfig.json
+++ b/types/gapi.client.fusiontables/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.games/tsconfig.json
+++ b/types/gapi.client.games/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.gamesconfiguration/tsconfig.json
+++ b/types/gapi.client.gamesconfiguration/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.gamesmanagement/tsconfig.json
+++ b/types/gapi.client.gamesmanagement/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.genomics/tsconfig.json
+++ b/types/gapi.client.genomics/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.gmail/tsconfig.json
+++ b/types/gapi.client.gmail/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.groupsmigration/tsconfig.json
+++ b/types/gapi.client.groupsmigration/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.groupssettings/tsconfig.json
+++ b/types/gapi.client.groupssettings/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.iam/tsconfig.json
+++ b/types/gapi.client.iam/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.identitytoolkit/tsconfig.json
+++ b/types/gapi.client.identitytoolkit/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.kgsearch/tsconfig.json
+++ b/types/gapi.client.kgsearch/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.language/tsconfig.json
+++ b/types/gapi.client.language/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.licensing/tsconfig.json
+++ b/types/gapi.client.licensing/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.logging/tsconfig.json
+++ b/types/gapi.client.logging/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.manufacturers/tsconfig.json
+++ b/types/gapi.client.manufacturers/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.mirror/tsconfig.json
+++ b/types/gapi.client.mirror/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.ml/tsconfig.json
+++ b/types/gapi.client.ml/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.monitoring/tsconfig.json
+++ b/types/gapi.client.monitoring/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.oauth2/tsconfig.json
+++ b/types/gapi.client.oauth2/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.oslogin/tsconfig.json
+++ b/types/gapi.client.oslogin/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.pagespeedonline/tsconfig.json
+++ b/types/gapi.client.pagespeedonline/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.partners/tsconfig.json
+++ b/types/gapi.client.partners/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.people/tsconfig.json
+++ b/types/gapi.client.people/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.photoslibrary/tsconfig.json
+++ b/types/gapi.client.photoslibrary/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.playcustomapp/tsconfig.json
+++ b/types/gapi.client.playcustomapp/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.playmoviespartner/tsconfig.json
+++ b/types/gapi.client.playmoviespartner/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.plus/tsconfig.json
+++ b/types/gapi.client.plus/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.plusdomains/tsconfig.json
+++ b/types/gapi.client.plusdomains/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.prediction/tsconfig.json
+++ b/types/gapi.client.prediction/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.proximitybeacon/tsconfig.json
+++ b/types/gapi.client.proximitybeacon/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.pubsub/tsconfig.json
+++ b/types/gapi.client.pubsub/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.qpxexpress/tsconfig.json
+++ b/types/gapi.client.qpxexpress/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.reseller/tsconfig.json
+++ b/types/gapi.client.reseller/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.resourceviews/tsconfig.json
+++ b/types/gapi.client.resourceviews/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.runtimeconfig/tsconfig.json
+++ b/types/gapi.client.runtimeconfig/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.safebrowsing/tsconfig.json
+++ b/types/gapi.client.safebrowsing/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.script/tsconfig.json
+++ b/types/gapi.client.script/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.searchconsole/tsconfig.json
+++ b/types/gapi.client.searchconsole/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.servicecontrol/tsconfig.json
+++ b/types/gapi.client.servicecontrol/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.servicemanagement/tsconfig.json
+++ b/types/gapi.client.servicemanagement/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.serviceuser/tsconfig.json
+++ b/types/gapi.client.serviceuser/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.sheets/tsconfig.json
+++ b/types/gapi.client.sheets/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es6", "dom"],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "baseUrl": "../",
     "typeRoots": [

--- a/types/gapi.client.siteverification/tsconfig.json
+++ b/types/gapi.client.siteverification/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.slides/tsconfig.json
+++ b/types/gapi.client.slides/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.sourcerepo/tsconfig.json
+++ b/types/gapi.client.sourcerepo/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.spanner/tsconfig.json
+++ b/types/gapi.client.spanner/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.spectrum/tsconfig.json
+++ b/types/gapi.client.spectrum/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.speech/tsconfig.json
+++ b/types/gapi.client.speech/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.sqladmin/tsconfig.json
+++ b/types/gapi.client.sqladmin/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.storage/tsconfig.json
+++ b/types/gapi.client.storage/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.storagetransfer/tsconfig.json
+++ b/types/gapi.client.storagetransfer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.streetviewpublish/tsconfig.json
+++ b/types/gapi.client.streetviewpublish/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.surveys/tsconfig.json
+++ b/types/gapi.client.surveys/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.tagmanager/tsconfig.json
+++ b/types/gapi.client.tagmanager/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.taskqueue/tsconfig.json
+++ b/types/gapi.client.taskqueue/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.tasks/tsconfig.json
+++ b/types/gapi.client.tasks/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.testing/tsconfig.json
+++ b/types/gapi.client.testing/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.toolresults/tsconfig.json
+++ b/types/gapi.client.toolresults/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.translate/tsconfig.json
+++ b/types/gapi.client.translate/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.urlshortener/tsconfig.json
+++ b/types/gapi.client.urlshortener/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.vault/tsconfig.json
+++ b/types/gapi.client.vault/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.videointelligence/tsconfig.json
+++ b/types/gapi.client.videointelligence/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.vision/tsconfig.json
+++ b/types/gapi.client.vision/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.webfonts/tsconfig.json
+++ b/types/gapi.client.webfonts/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.webmasters/tsconfig.json
+++ b/types/gapi.client.webmasters/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.youtube/tsconfig.json
+++ b/types/gapi.client.youtube/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.youtubeanalytics/tsconfig.json
+++ b/types/gapi.client.youtubeanalytics/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client.youtubereporting/tsconfig.json
+++ b/types/gapi.client.youtubereporting/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.client/tsconfig.json
+++ b/types/gapi.client/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gapi.drive/tsconfig.json
+++ b/types/gapi.drive/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gapi.pagespeedonline/tsconfig.json
+++ b/types/gapi.pagespeedonline/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gapi.people/tsconfig.json
+++ b/types/gapi.people/tsconfig.json
@@ -14,6 +14,7 @@
         "strictFunctionTypes": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "forceConsistentCasingInFileNames": true,
         "noEmit": true
     },

--- a/types/gapi.plus/tsconfig.json
+++ b/types/gapi.plus/tsconfig.json
@@ -14,6 +14,7 @@
         "strictFunctionTypes": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "forceConsistentCasingInFileNames": true,
         "noEmit": true
     },

--- a/types/gapi.translate/tsconfig.json
+++ b/types/gapi.translate/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gapi.urlshortener/tsconfig.json
+++ b/types/gapi.urlshortener/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gapi.youtube/tsconfig.json
+++ b/types/gapi.youtube/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gapi.youtubeanalytics/tsconfig.json
+++ b/types/gapi.youtubeanalytics/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gapi/tsconfig.json
+++ b/types/gapi/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gaze/tsconfig.json
+++ b/types/gaze/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/gdal/tsconfig.json
+++ b/types/gdal/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gematriya/tsconfig.json
+++ b/types/gematriya/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/generate-changelog/tsconfig.json
+++ b/types/generate-changelog/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/generate-json-webpack-plugin/tsconfig.json
+++ b/types/generate-json-webpack-plugin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/generic-functions/tsconfig.json
+++ b/types/generic-functions/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/generic-pool/tsconfig.json
+++ b/types/generic-pool/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gently/tsconfig.json
+++ b/types/gently/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/geobuf/tsconfig.json
+++ b/types/geobuf/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/geojson2osm/tsconfig.json
+++ b/types/geojson2osm/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/geolite2/tsconfig.json
+++ b/types/geolite2/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/geometry-dom/tsconfig.json
+++ b/types/geometry-dom/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/geopattern/tsconfig.json
+++ b/types/geopattern/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gestalt/tsconfig.json
+++ b/types/gestalt/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],

--- a/types/get-certain/tsconfig.json
+++ b/types/get-certain/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/get-emoji/tsconfig.json
+++ b/types/get-emoji/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/get-folder-size/tsconfig.json
+++ b/types/get-folder-size/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/get-func-name/tsconfig.json
+++ b/types/get-func-name/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/get-res/tsconfig.json
+++ b/types/get-res/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/get-value/tsconfig.json
+++ b/types/get-value/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/getenv/tsconfig.json
+++ b/types/getenv/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],

--- a/types/getpass/tsconfig.json
+++ b/types/getpass/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gettext-parser/tsconfig.json
+++ b/types/gettext-parser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/gettext.js/tsconfig.json
+++ b/types/gettext.js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gfc/tsconfig.json
+++ b/types/gfc/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gh-pages/tsconfig.json
+++ b/types/gh-pages/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ghauth/tsconfig.json
+++ b/types/ghauth/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ghost-storage-base/tsconfig.json
+++ b/types/ghost-storage-base/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/gifffer/tsconfig.json
+++ b/types/gifffer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gijgo/tsconfig.json
+++ b/types/gijgo/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/giphy-api/tsconfig.json
+++ b/types/giphy-api/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/giraffe/tsconfig.json
+++ b/types/giraffe/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": false,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/git-add-remote/tsconfig.json
+++ b/types/git-add-remote/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/git-branch-is/tsconfig.json
+++ b/types/git-branch-is/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/git-branch/tsconfig.json
+++ b/types/git-branch/tsconfig.json
@@ -6,6 +6,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/git-config-path/tsconfig.json
+++ b/types/git-config-path/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/git-config/tsconfig.json
+++ b/types/git-config/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/git-diff-parser/tsconfig.json
+++ b/types/git-diff-parser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/git-raw-commits/tsconfig.json
+++ b/types/git-raw-commits/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "esModuleInterop": true,

--- a/types/git-repo-name/tsconfig.json
+++ b/types/git-repo-name/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/git-rev-sync/tsconfig.json
+++ b/types/git-rev-sync/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/git-rev/tsconfig.json
+++ b/types/git-rev/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/git-root-dir/tsconfig.json
+++ b/types/git-root-dir/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/git-semver-tags/tsconfig.json
+++ b/types/git-semver-tags/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "esModuleInterop": true,

--- a/types/git-url-parse/tsconfig.json
+++ b/types/git-url-parse/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/git-user-email/tsconfig.json
+++ b/types/git-user-email/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/git-user-name/tsconfig.json
+++ b/types/git-user-name/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/git-username/tsconfig.json
+++ b/types/git-username/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/git/tsconfig.json
+++ b/types/git/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/github-url-from-git/tsconfig.json
+++ b/types/github-url-from-git/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/github-url-to-object/tsconfig.json
+++ b/types/github-url-to-object/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gl-react-dom/tsconfig.json
+++ b/types/gl-react-dom/tsconfig.json
@@ -11,6 +11,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/gl-react-expo/tsconfig.json
+++ b/types/gl-react-expo/tsconfig.json
@@ -11,6 +11,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/gl-react-headless/tsconfig.json
+++ b/types/gl-react-headless/tsconfig.json
@@ -11,6 +11,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/gl-react-native/tsconfig.json
+++ b/types/gl-react-native/tsconfig.json
@@ -11,6 +11,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/gl-react/tsconfig.json
+++ b/types/gl-react/tsconfig.json
@@ -10,6 +10,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/gl-shader/tsconfig.json
+++ b/types/gl-shader/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gl-texture2d/tsconfig.json
+++ b/types/gl-texture2d/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gl-vec2/tsconfig.json
+++ b/types/gl-vec2/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gl-vec3/tsconfig.json
+++ b/types/gl-vec3/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gl-vec4/tsconfig.json
+++ b/types/gl-vec4/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gl/tsconfig.json
+++ b/types/gl/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gldatepicker/tsconfig.json
+++ b/types/gldatepicker/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/glidejs/tsconfig.json
+++ b/types/glidejs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/glob-expand/tsconfig.json
+++ b/types/glob-expand/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/glob-to-regexp/tsconfig.json
+++ b/types/glob-to-regexp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/global-agent/tsconfig.json
+++ b/types/global-agent/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/global-modules-path/tsconfig.json
+++ b/types/global-modules-path/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/global-modules/tsconfig.json
+++ b/types/global-modules/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/global-paths/tsconfig.json
+++ b/types/global-paths/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/global-prefix/tsconfig.json
+++ b/types/global-prefix/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/globalize/tsconfig.json
+++ b/types/globalize/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/globalthis/tsconfig.json
+++ b/types/globalthis/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/globalyzer/tsconfig.json
+++ b/types/globalyzer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/globjoin/tsconfig.json
+++ b/types/globjoin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/globrex/tsconfig.json
+++ b/types/globrex/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/good-storage/tsconfig.json
+++ b/types/good-storage/tsconfig.json
@@ -6,6 +6,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/google-adwords-scripts/tsconfig.json
+++ b/types/google-adwords-scripts/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/google-apps-script-oauth2/tsconfig.json
+++ b/types/google-apps-script-oauth2/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/google-cloud__tasks/ts3.1/tsconfig.json
+++ b/types/google-cloud__tasks/ts3.1/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "paths": {

--- a/types/google-cloud__text-to-speech/tsconfig.json
+++ b/types/google-cloud__text-to-speech/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/google-ddns/tsconfig.json
+++ b/types/google-ddns/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/google-fonts/tsconfig.json
+++ b/types/google-fonts/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/google-images/tsconfig.json
+++ b/types/google-images/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/google-translate-api/tsconfig.json
+++ b/types/google-translate-api/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["es6"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictNullChecks": true,
 		"baseUrl": "../",
 		"typeRoots": ["../"],

--- a/types/google.analytics/tsconfig.json
+++ b/types/google.analytics/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/google.feeds/tsconfig.json
+++ b/types/google.feeds/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/google.geolocation/tsconfig.json
+++ b/types/google.geolocation/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/google.script.client-side/tsconfig.json
+++ b/types/google.script.client-side/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/google__maps/tsconfig.json
+++ b/types/google__maps/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/google__markerclustererplus/tsconfig.json
+++ b/types/google__markerclustererplus/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/googlemaps/tsconfig.json
+++ b/types/googlemaps/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/googlepay/tsconfig.json
+++ b/types/googlepay/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/graceful-fs/v2/tsconfig.json
+++ b/types/graceful-fs/v2/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/gradient-string/tsconfig.json
+++ b/types/gradient-string/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/graphite-udp/tsconfig.json
+++ b/types/graphite-udp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/graphite/tsconfig.json
+++ b/types/graphite/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/graphql-deduplicator/tsconfig.json
+++ b/types/graphql-deduplicator/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/graphql-depth-limit/tsconfig.json
+++ b/types/graphql-depth-limit/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/graphql-errors/tsconfig.json
+++ b/types/graphql-errors/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6", "esnext.asynciterable"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],

--- a/types/graphql-iso-date/tsconfig.json
+++ b/types/graphql-iso-date/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/graphql-upload/tsconfig.json
+++ b/types/graphql-upload/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/graphviz/tsconfig.json
+++ b/types/graphviz/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/grasp/tsconfig.json
+++ b/types/grasp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gravatar/tsconfig.json
+++ b/types/gravatar/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gray-percentage/tsconfig.json
+++ b/types/gray-percentage/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/graylog2/tsconfig.json
+++ b/types/graylog2/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/grecaptcha/tsconfig.json
+++ b/types/grecaptcha/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/grecaptcha/v0/tsconfig.json
+++ b/types/grecaptcha/v0/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/gregorian-calendar/tsconfig.json
+++ b/types/gregorian-calendar/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/grid-template-parser/tsconfig.json
+++ b/types/grid-template-parser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/group-array/tsconfig.json
+++ b/types/group-array/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/growing-io/tsconfig.json
+++ b/types/growing-io/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/grunt/tsconfig.json
+++ b/types/grunt/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gsheets/tsconfig.json
+++ b/types/gsheets/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/gtag.js/tsconfig.json
+++ b/types/gtag.js/tsconfig.json
@@ -7,6 +7,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/gtin/tsconfig.json
+++ b/types/gtin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/guid/tsconfig.json
+++ b/types/guid/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-angular-templatecache/tsconfig.json
+++ b/types/gulp-angular-templatecache/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-autoprefixer/tsconfig.json
+++ b/types/gulp-autoprefixer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-batch/tsconfig.json
+++ b/types/gulp-batch/tsconfig.json
@@ -10,6 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-bump/tsconfig.json
+++ b/types/gulp-bump/tsconfig.json
@@ -12,6 +12,7 @@
         "types": [],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "forceConsistentCasingInFileNames": true,

--- a/types/gulp-cache/tsconfig.json
+++ b/types/gulp-cache/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-cached/tsconfig.json
+++ b/types/gulp-cached/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-change/tsconfig.json
+++ b/types/gulp-change/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-changed/tsconfig.json
+++ b/types/gulp-changed/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-cheerio/tsconfig.json
+++ b/types/gulp-cheerio/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-clean-dest/tsconfig.json
+++ b/types/gulp-clean-dest/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-coffeeify/tsconfig.json
+++ b/types/gulp-coffeeify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-coffeelint/tsconfig.json
+++ b/types/gulp-coffeelint/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-concat/tsconfig.json
+++ b/types/gulp-concat/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-connect/tsconfig.json
+++ b/types/gulp-connect/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-copy/tsconfig.json
+++ b/types/gulp-copy/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-csso/tsconfig.json
+++ b/types/gulp-csso/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-debug/tsconfig.json
+++ b/types/gulp-debug/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-diff/tsconfig.json
+++ b/types/gulp-diff/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-espower/tsconfig.json
+++ b/types/gulp-espower/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-filter/tsconfig.json
+++ b/types/gulp-filter/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-flatten/tsconfig.json
+++ b/types/gulp-flatten/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-gh-pages/tsconfig.json
+++ b/types/gulp-gh-pages/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-gzip/tsconfig.json
+++ b/types/gulp-gzip/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-header/tsconfig.json
+++ b/types/gulp-header/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-help-doc/tsconfig.json
+++ b/types/gulp-help-doc/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-help/tsconfig.json
+++ b/types/gulp-help/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-html-prettify/tsconfig.json
+++ b/types/gulp-html-prettify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "esModuleInterop": true,

--- a/types/gulp-html-replace/tsconfig.json
+++ b/types/gulp-html-replace/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-htmlmin/tsconfig.json
+++ b/types/gulp-htmlmin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-if/tsconfig.json
+++ b/types/gulp-if/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-image-resize/tsconfig.json
+++ b/types/gulp-image-resize/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-image/tsconfig.json
+++ b/types/gulp-image/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-imagemin/tsconfig.json
+++ b/types/gulp-imagemin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-insert/tsconfig.json
+++ b/types/gulp-insert/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-install/tsconfig.json
+++ b/types/gulp-install/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-intercept/tsconfig.json
+++ b/types/gulp-intercept/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/gulp-istanbul/tsconfig.json
+++ b/types/gulp-istanbul/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-jade/tsconfig.json
+++ b/types/gulp-jade/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-jasmine-browser/tsconfig.json
+++ b/types/gulp-jasmine-browser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-json-editor/tsconfig.json
+++ b/types/gulp-json-editor/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-json-validator/tsconfig.json
+++ b/types/gulp-json-validator/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-jsonmin/tsconfig.json
+++ b/types/gulp-jsonmin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-jsonminify/tsconfig.json
+++ b/types/gulp-jsonminify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-jspm/tsconfig.json
+++ b/types/gulp-jspm/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-less/tsconfig.json
+++ b/types/gulp-less/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-load-plugins/tsconfig.json
+++ b/types/gulp-load-plugins/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-minify-css/tsconfig.json
+++ b/types/gulp-minify-css/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-minify-html/tsconfig.json
+++ b/types/gulp-minify-html/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-minify/tsconfig.json
+++ b/types/gulp-minify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/gulp-mocha/tsconfig.json
+++ b/types/gulp-mocha/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-newer/tsconfig.json
+++ b/types/gulp-newer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-ng-annotate/tsconfig.json
+++ b/types/gulp-ng-annotate/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-nodemon/tsconfig.json
+++ b/types/gulp-nodemon/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-plumber/tsconfig.json
+++ b/types/gulp-plumber/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-postcss/tsconfig.json
+++ b/types/gulp-postcss/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/gulp-protractor/tsconfig.json
+++ b/types/gulp-protractor/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-pug-i18n/tsconfig.json
+++ b/types/gulp-pug-i18n/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-remember/tsconfig.json
+++ b/types/gulp-remember/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-replace/tsconfig.json
+++ b/types/gulp-replace/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-responsive-images/tsconfig.json
+++ b/types/gulp-responsive-images/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-rev-replace/tsconfig.json
+++ b/types/gulp-rev-replace/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-rev/tsconfig.json
+++ b/types/gulp-rev/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-ruby-sass/tsconfig.json
+++ b/types/gulp-ruby-sass/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-sass-variables/tsconfig.json
+++ b/types/gulp-sass-variables/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/gulp-sass/tsconfig.json
+++ b/types/gulp-sass/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-size/tsconfig.json
+++ b/types/gulp-size/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-sort/tsconfig.json
+++ b/types/gulp-sort/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-strip-comments/tsconfig.json
+++ b/types/gulp-strip-comments/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-strip-debug/tsconfig.json
+++ b/types/gulp-strip-debug/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-stylus/tsconfig.json
+++ b/types/gulp-stylus/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/gulp-svg-sprite/tsconfig.json
+++ b/types/gulp-svg-sprite/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-svgmin/tsconfig.json
+++ b/types/gulp-svgmin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/gulp-tap/tsconfig.json
+++ b/types/gulp-tap/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/gulp-task-listing/tsconfig.json
+++ b/types/gulp-task-listing/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-template/tsconfig.json
+++ b/types/gulp-template/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-tsd/tsconfig.json
+++ b/types/gulp-tsd/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-useref/tsconfig.json
+++ b/types/gulp-useref/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gulp-zip/tsconfig.json
+++ b/types/gulp-zip/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/gunzip-maybe/tsconfig.json
+++ b/types/gunzip-maybe/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/gzip-js/tsconfig.json
+++ b/types/gzip-js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/halfred/tsconfig.json
+++ b/types/halfred/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hammerjs/tsconfig.json
+++ b/types/hammerjs/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hammerjs/v1/tsconfig.json
+++ b/types/hammerjs/v1/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/handlebars-helpers/tsconfig.json
+++ b/types/handlebars-helpers/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hapi-auth-basic/tsconfig.json
+++ b/types/hapi-auth-basic/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hapi-auth-bearer-token/tsconfig.json
+++ b/types/hapi-auth-bearer-token/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hapi-auth-cookie/tsconfig.json
+++ b/types/hapi-auth-cookie/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hapi-decorators/tsconfig.json
+++ b/types/hapi-decorators/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "experimentalDecorators": true,

--- a/types/hapi-server-session/tsconfig.json
+++ b/types/hapi-server-session/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/hapi/v12/tsconfig.json
+++ b/types/hapi/v12/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/hapi/v15/tsconfig.json
+++ b/types/hapi/v15/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/hapi/v8/tsconfig.json
+++ b/types/hapi/v8/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/hapi__b64/tsconfig.json
+++ b/types/hapi__b64/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/hapi__basic/tsconfig.json
+++ b/types/hapi__basic/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hapi__call/tsconfig.json
+++ b/types/hapi__call/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/hapi__catbox-memcached/tsconfig.json
+++ b/types/hapi__catbox-memcached/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/hapi__catbox-redis/tsconfig.json
+++ b/types/hapi__catbox-redis/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hapi__cookie/tsconfig.json
+++ b/types/hapi__cookie/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hapi__crumb/tsconfig.json
+++ b/types/hapi__crumb/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hapi__hawk/tsconfig.json
+++ b/types/hapi__hawk/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/hapi__sntp/tsconfig.json
+++ b/types/hapi__sntp/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/hard-source-webpack-plugin/tsconfig.json
+++ b/types/hard-source-webpack-plugin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hark/tsconfig.json
+++ b/types/hark/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/harmon/tsconfig.json
+++ b/types/harmon/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/harmony-proxy/tsconfig.json
+++ b/types/harmony-proxy/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/has-ansi/tsconfig.json
+++ b/types/has-ansi/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hash-it/tsconfig.json
+++ b/types/hash-it/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/hash-sum/tsconfig.json
+++ b/types/hash-sum/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hasher/tsconfig.json
+++ b/types/hasher/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hashids/tsconfig.json
+++ b/types/hashids/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hashmap/v1/tsconfig.json
+++ b/types/hashmap/v1/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/hashring/tsconfig.json
+++ b/types/hashring/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/hashset/tsconfig.json
+++ b/types/hashset/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hashtable/tsconfig.json
+++ b/types/hashtable/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hashtag-regex/tsconfig.json
+++ b/types/hashtag-regex/tsconfig.json
@@ -5,6 +5,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/hat/tsconfig.json
+++ b/types/hat/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/haversine/tsconfig.json
+++ b/types/haversine/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hdkey/tsconfig.json
+++ b/types/hdkey/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/headroom/tsconfig.json
+++ b/types/headroom/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hedron/tsconfig.json
+++ b/types/hedron/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hellosign-embedded/tsconfig.json
+++ b/types/hellosign-embedded/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/heredatalens/tsconfig.json
+++ b/types/heredatalens/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/heremaps/tsconfig.json
+++ b/types/heremaps/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hexo-bunyan/tsconfig.json
+++ b/types/hexo-bunyan/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/highcharts-ng/tsconfig.json
+++ b/types/highcharts-ng/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/highland/tsconfig.json
+++ b/types/highland/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/highlight-words-core/tsconfig.json
+++ b/types/highlight-words-core/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/highlight.js/v7/tsconfig.json
+++ b/types/highlight.js/v7/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/history.js/tsconfig.json
+++ b/types/history.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/history/v3/tsconfig.json
+++ b/types/history/v3/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/hls-parser/tsconfig.json
+++ b/types/hls-parser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/hogan.js/tsconfig.json
+++ b/types/hogan.js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/holderjs/tsconfig.json
+++ b/types/holderjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/honeybadger/tsconfig.json
+++ b/types/honeybadger/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hopscotch/tsconfig.json
+++ b/types/hopscotch/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/host-validation/tsconfig.json
+++ b/types/host-validation/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hosted-git-info/tsconfig.json
+++ b/types/hosted-git-info/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hostile/tsconfig.json
+++ b/types/hostile/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/hoxy/tsconfig.json
+++ b/types/hoxy/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/hpp/tsconfig.json
+++ b/types/hpp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/html-entities/tsconfig.json
+++ b/types/html-entities/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/html-minifier-terser/tsconfig.json
+++ b/types/html-minifier-terser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/html-minifier/tsconfig.json
+++ b/types/html-minifier/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/html-minifier/v1/tsconfig.json
+++ b/types/html-minifier/v1/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/html-parser/tsconfig.json
+++ b/types/html-parser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/html-pdf/tsconfig.json
+++ b/types/html-pdf/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/html-to-text/tsconfig.json
+++ b/types/html-to-text/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/html-truncate/tsconfig.json
+++ b/types/html-truncate/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/html-validator/tsconfig.json
+++ b/types/html-validator/tsconfig.json
@@ -6,6 +6,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "baseUrl": "../",

--- a/types/html-void-elements/tsconfig.json
+++ b/types/html-void-elements/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/html/tsconfig.json
+++ b/types/html/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/html2canvas/tsconfig.json
+++ b/types/html2canvas/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/html5-history/tsconfig.json
+++ b/types/html5-history/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/html5-to-pdf/tsconfig.json
+++ b/types/html5-to-pdf/tsconfig.json
@@ -9,6 +9,7 @@
         "target": "es2017",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/html5plus/tsconfig.json
+++ b/types/html5plus/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/htmlbars-inline-precompile/tsconfig.json
+++ b/types/htmlbars-inline-precompile/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/htmlescape/tsconfig.json
+++ b/types/htmlescape/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/htmlparser2/tsconfig.json
+++ b/types/htmlparser2/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/http-assert/tsconfig.json
+++ b/types/http-assert/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/http-aws-es/tsconfig.json
+++ b/types/http-aws-es/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/http-cache-semantics/tsconfig.json
+++ b/types/http-cache-semantics/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/http-codes/tsconfig.json
+++ b/types/http-codes/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/http-errors/tsconfig.json
+++ b/types/http-errors/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/http-proxy-agent/tsconfig.json
+++ b/types/http-proxy-agent/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/http-server/tsconfig.json
+++ b/types/http-server/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/httperr/tsconfig.json
+++ b/types/httperr/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hubot/tsconfig.json
+++ b/types/hubot/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hubspot-pace/tsconfig.json
+++ b/types/hubspot-pace/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/human-date/tsconfig.json
+++ b/types/human-date/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/humane-js/tsconfig.json
+++ b/types/humane-js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/humanize-duration/tsconfig.json
+++ b/types/humanize-duration/tsconfig.json
@@ -7,6 +7,7 @@
         "allowSyntheticDefaultImports": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/humanize-ms/tsconfig.json
+++ b/types/humanize-ms/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/humanize-plus/tsconfig.json
+++ b/types/humanize-plus/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/humanparser/tsconfig.json
+++ b/types/humanparser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hummus-recipe/tsconfig.json
+++ b/types/hummus-recipe/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],

--- a/types/humps/tsconfig.json
+++ b/types/humps/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hyco-ws/tsconfig.json
+++ b/types/hyco-ws/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "experimentalDecorators": true,

--- a/types/hyper-aws4/tsconfig.json
+++ b/types/hyper-aws4/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/hypertext-application-language/tsconfig.json
+++ b/types/hypertext-application-language/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/hyphen/tsconfig.json
+++ b/types/hyphen/tsconfig.json
@@ -5,6 +5,7 @@
             "es6"
         ],
         "strict": true,
+        "noUnusedLocals": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/hystrixjs/tsconfig.json
+++ b/types/hystrixjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/i18n-abide/tsconfig.json
+++ b/types/i18n-abide/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/i18n-js/tsconfig.json
+++ b/types/i18n-js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/i18next-node-fs-backend/tsconfig.json
+++ b/types/i18next-node-fs-backend/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/iab-vpaid/tsconfig.json
+++ b/types/iab-vpaid/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/iarna__toml/tsconfig.json
+++ b/types/iarna__toml/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/ibm-mobilefirst/tsconfig.json
+++ b/types/ibm-mobilefirst/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ibm-openapi-validator/tsconfig.json
+++ b/types/ibm-openapi-validator/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ical/tsconfig.json
+++ b/types/ical/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/icheck/tsconfig.json
+++ b/types/icheck/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/icon-gen/tsconfig.json
+++ b/types/icon-gen/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/identicon.js/tsconfig.json
+++ b/types/identicon.js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/idyll-compiler/tsconfig.json
+++ b/types/idyll-compiler/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],

--- a/types/idyll/tsconfig.json
+++ b/types/idyll/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],

--- a/types/iferr/tsconfig.json
+++ b/types/iferr/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/iframe-resizer/tsconfig.json
+++ b/types/iframe-resizer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ifvisible/tsconfig.json
+++ b/types/ifvisible/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/ignite-ui/tsconfig.json
+++ b/types/ignite-ui/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ignore-styles/tsconfig.json
+++ b/types/ignore-styles/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ignore-walk/tsconfig.json
+++ b/types/ignore-walk/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/iltorb/tsconfig.json
+++ b/types/iltorb/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/image-thumbnail/tsconfig.json
+++ b/types/image-thumbnail/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/imagemapster/tsconfig.json
+++ b/types/imagemapster/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/imagemin-gifsicle/tsconfig.json
+++ b/types/imagemin-gifsicle/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/imagemin-jpegtran/tsconfig.json
+++ b/types/imagemin-jpegtran/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/imagemin-optipng/tsconfig.json
+++ b/types/imagemin-optipng/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/imagemin-pngquant/tsconfig.json
+++ b/types/imagemin-pngquant/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/imagemin-svgo/tsconfig.json
+++ b/types/imagemin-svgo/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/imagemin-webp/tsconfig.json
+++ b/types/imagemin-webp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/imagemin/tsconfig.json
+++ b/types/imagemin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/images/tsconfig.json
+++ b/types/images/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/imagesloaded/tsconfig.json
+++ b/types/imagesloaded/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/imap-simple/tsconfig.json
+++ b/types/imap-simple/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/imgur-rest-api/tsconfig.json
+++ b/types/imgur-rest-api/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/immediate/tsconfig.json
+++ b/types/immediate/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/imperium/tsconfig.json
+++ b/types/imperium/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "esModuleInterop": true,

--- a/types/impress/tsconfig.json
+++ b/types/impress/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/imsi-grok/tsconfig.json
+++ b/types/imsi-grok/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/imul/tsconfig.json
+++ b/types/imul/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ineum/tsconfig.json
+++ b/types/ineum/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/inflation/tsconfig.json
+++ b/types/inflation/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/inflected/tsconfig.json
+++ b/types/inflected/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/inflection/tsconfig.json
+++ b/types/inflection/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/inherits/tsconfig.json
+++ b/types/inherits/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/init-package-json/tsconfig.json
+++ b/types/init-package-json/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/inline-critical/tsconfig.json
+++ b/types/inline-critical/tsconfig.json
@@ -7,6 +7,7 @@
         "esModuleInterop": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/inline-css/tsconfig.json
+++ b/types/inline-css/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/inquirer-npm-name/tsconfig.json
+++ b/types/inquirer-npm-name/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/inquirer/tsconfig.json
+++ b/types/inquirer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/insert-css/tsconfig.json
+++ b/types/insert-css/tsconfig.json
@@ -11,6 +11,7 @@
         "noImplicitAny": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictFunctionTypes": true,

--- a/types/insert-text-at-cursor/tsconfig.json
+++ b/types/insert-text-at-cursor/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/insight/tsconfig.json
+++ b/types/insight/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/inspectlet-es/tsconfig.json
+++ b/types/inspectlet-es/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/integer/tsconfig.json
+++ b/types/integer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/intercept-stdout/tsconfig.json
+++ b/types/intercept-stdout/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/intercom-client/tsconfig.json
+++ b/types/intercom-client/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],

--- a/types/intercom-web/tsconfig.json
+++ b/types/intercom-web/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/intercomjs/tsconfig.json
+++ b/types/intercomjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/internal-slot/tsconfig.json
+++ b/types/internal-slot/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["es5"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictFunctionTypes": true,
 		"strictNullChecks": true,
 		"baseUrl": "../",

--- a/types/intl-tel-input/v13/tsconfig.json
+++ b/types/intl-tel-input/v13/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/invariant/ts3.7/tsconfig.json
+++ b/types/invariant/ts3.7/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/invariant/tsconfig.json
+++ b/types/invariant/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/inversify-devtools/tsconfig.json
+++ b/types/inversify-devtools/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ion-rangeslider/tsconfig.json
+++ b/types/ion-rangeslider/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ion-rangeslider/v1/tsconfig.json
+++ b/types/ion-rangeslider/v1/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/iopipe__iopipe/tsconfig.json
+++ b/types/iopipe__iopipe/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ioredis/tsconfig.json
+++ b/types/ioredis/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ioredis/v3/tsconfig.json
+++ b/types/ioredis/v3/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/iost-contract/tsconfig.json
+++ b/types/iost-contract/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/iota.lib.js/tsconfig.json
+++ b/types/iota.lib.js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ip-subnet-calculator/tsconfig.json
+++ b/types/ip-subnet-calculator/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ip/tsconfig.json
+++ b/types/ip/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ipcheck/tsconfig.json
+++ b/types/ipcheck/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ipp/tsconfig.json
+++ b/types/ipp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/iri/tsconfig.json
+++ b/types/iri/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-absolute/tsconfig.json
+++ b/types/is-absolute/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-alphanumerical/tsconfig.json
+++ b/types/is-alphanumerical/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-array/tsconfig.json
+++ b/types/is-array/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-blank/tsconfig.json
+++ b/types/is-blank/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-callable/tsconfig.json
+++ b/types/is-callable/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-charging/tsconfig.json
+++ b/types/is-charging/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-ci/tsconfig.json
+++ b/types/is-ci/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-color/tsconfig.json
+++ b/types/is-color/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-date-object/tsconfig.json
+++ b/types/is-date-object/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/is-dotdir/tsconfig.json
+++ b/types/is-dotdir/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-dotfile/tsconfig.json
+++ b/types/is-dotfile/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-empty-object/tsconfig.json
+++ b/types/is-empty-object/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/is-empty/tsconfig.json
+++ b/types/is-empty/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-even/tsconfig.json
+++ b/types/is-even/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/is-finite/tsconfig.json
+++ b/types/is-finite/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-generator-function/tsconfig.json
+++ b/types/is-generator-function/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/is-generator/tsconfig.json
+++ b/types/is-generator/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/is-git-url/tsconfig.json
+++ b/types/is-git-url/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-glob/tsconfig.json
+++ b/types/is-glob/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-hotkey/tsconfig.json
+++ b/types/is-hotkey/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-integer/tsconfig.json
+++ b/types/is-integer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/is-natural-number/tsconfig.json
+++ b/types/is-natural-number/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/is-number-like/tsconfig.json
+++ b/types/is-number-like/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-object/tsconfig.json
+++ b/types/is-object/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-odd/tsconfig.json
+++ b/types/is-odd/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/is-progressive/tsconfig.json
+++ b/types/is-progressive/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-relative-path/tsconfig.json
+++ b/types/is-relative-path/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/is-relative/tsconfig.json
+++ b/types/is-relative/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-running/tsconfig.json
+++ b/types/is-running/tsconfig.json
@@ -6,6 +6,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/is-ssh/tsconfig.json
+++ b/types/is-ssh/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/is-touch-device/tsconfig.json
+++ b/types/is-touch-device/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-trademarked/tsconfig.json
+++ b/types/is-trademarked/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-typedarray/tsconfig.json
+++ b/types/is-typedarray/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-unc-path/tsconfig.json
+++ b/types/is-unc-path/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-uuid/tsconfig.json
+++ b/types/is-uuid/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/is-valid-glob/tsconfig.json
+++ b/types/is-valid-glob/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-valid-path/tsconfig.json
+++ b/types/is-valid-path/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/is-windows/tsconfig.json
+++ b/types/is-windows/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["es5"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictNullChecks": true,
 		"strictFunctionTypes": true,
 		"baseUrl": "../",

--- a/types/is/tsconfig.json
+++ b/types/is/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/isarray/tsconfig.json
+++ b/types/isarray/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/iscroll/tsconfig.json
+++ b/types/iscroll/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/iscroll/v4/tsconfig.json
+++ b/types/iscroll/v4/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/isexe/tsconfig.json
+++ b/types/isexe/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/iso8601-localizer/tsconfig.json
+++ b/types/iso8601-localizer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/isotope-layout/tsconfig.json
+++ b/types/isotope-layout/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/isstream/tsconfig.json
+++ b/types/isstream/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/issue-parser/tsconfig.json
+++ b/types/issue-parser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/istanbul-lib-coverage/tsconfig.json
+++ b/types/istanbul-lib-coverage/tsconfig.json
@@ -10,6 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/istanbul-lib-hook/tsconfig.json
+++ b/types/istanbul-lib-hook/tsconfig.json
@@ -10,6 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "esModuleInterop": true,

--- a/types/istanbul-lib-source-maps/tsconfig.json
+++ b/types/istanbul-lib-source-maps/tsconfig.json
@@ -10,6 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/istanbul-reports/tsconfig.json
+++ b/types/istanbul-reports/tsconfig.json
@@ -10,6 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/istextorbinary/tsconfig.json
+++ b/types/istextorbinary/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ityped/tsconfig.json
+++ b/types/ityped/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/iv-viewer/tsconfig.json
+++ b/types/iv-viewer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/ix.js/tsconfig.json
+++ b/types/ix.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jade/tsconfig.json
+++ b/types/jade/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jalaali-js/tsconfig.json
+++ b/types/jalaali-js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/japan-postal-code/tsconfig.json
+++ b/types/japan-postal-code/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "esModuleInterop": true,

--- a/types/jasmine-ajax/tsconfig.json
+++ b/types/jasmine-ajax/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": false,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jasmine-data-provider/tsconfig.json
+++ b/types/jasmine-data-provider/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jasmine-data_driven_tests/tsconfig.json
+++ b/types/jasmine-data_driven_tests/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jasmine-es6-promise-matchers/tsconfig.json
+++ b/types/jasmine-es6-promise-matchers/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jasmine-fixture/tsconfig.json
+++ b/types/jasmine-fixture/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jasmine-given/tsconfig.json
+++ b/types/jasmine-given/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jasmine-matchers/tsconfig.json
+++ b/types/jasmine-matchers/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jasmine-node/tsconfig.json
+++ b/types/jasmine-node/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jasmine-promise-matchers/tsconfig.json
+++ b/types/jasmine-promise-matchers/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jasmine/ts3.1/tsconfig.json
+++ b/types/jasmine/ts3.1/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": false,
         "baseUrl": "../../",

--- a/types/jasmine/v1/tsconfig.json
+++ b/types/jasmine/v1/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/jasmine_dom_matchers/tsconfig.json
+++ b/types/jasmine_dom_matchers/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jasminewd2/tsconfig.json
+++ b/types/jasminewd2/tsconfig.json
@@ -10,6 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/javascript-bignum/tsconfig.json
+++ b/types/javascript-bignum/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/javascript-time-ago/tsconfig.json
+++ b/types/javascript-time-ago/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],

--- a/types/jbinary/tsconfig.json
+++ b/types/jbinary/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jcanvas/tsconfig.json
+++ b/types/jcanvas/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jdataview/tsconfig.json
+++ b/types/jdataview/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jee-jsf/tsconfig.json
+++ b/types/jee-jsf/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jest-cucumber-fusion/tsconfig.json
+++ b/types/jest-cucumber-fusion/tsconfig.json
@@ -7,6 +7,7 @@
         "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jest-dev-server/tsconfig.json
+++ b/types/jest-dev-server/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jest-expect-message/tsconfig.json
+++ b/types/jest-expect-message/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jest-image-snapshot/tsconfig.json
+++ b/types/jest-image-snapshot/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jest-in-case/tsconfig.json
+++ b/types/jest-in-case/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jest-json-schema/tsconfig.json
+++ b/types/jest-json-schema/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jest-matcher-one-of/tsconfig.json
+++ b/types/jest-matcher-one-of/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jest-plugin-context/tsconfig.json
+++ b/types/jest-plugin-context/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jest-plugin-set/tsconfig.json
+++ b/types/jest-plugin-set/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jest-sinon/tsconfig.json
+++ b/types/jest-sinon/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jest-specific-snapshot/tsconfig.json
+++ b/types/jest-specific-snapshot/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jest-when/tsconfig.json
+++ b/types/jest-when/tsconfig.json
@@ -6,6 +6,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/jexl/tsconfig.json
+++ b/types/jexl/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jfp/tsconfig.json
+++ b/types/jfp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jju/tsconfig.json
+++ b/types/jju/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jjv/tsconfig.json
+++ b/types/jjv/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jjve/tsconfig.json
+++ b/types/jjve/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/josa/tsconfig.json
+++ b/types/josa/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jpeg-autorotate/tsconfig.json
+++ b/types/jpeg-autorotate/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jpegtran-bin/tsconfig.json
+++ b/types/jpegtran-bin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jqgrid/tsconfig.json
+++ b/types/jqgrid/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jqrangeslider/tsconfig.json
+++ b/types/jqrangeslider/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-ajax-chain/tsconfig.json
+++ b/types/jquery-ajax-chain/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-alertable/tsconfig.json
+++ b/types/jquery-alertable/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-animate-scroll/tsconfig.json
+++ b/types/jquery-animate-scroll/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-awesome-cursor/tsconfig.json
+++ b/types/jquery-awesome-cursor/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-backstretch/tsconfig.json
+++ b/types/jquery-backstretch/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-countdown/tsconfig.json
+++ b/types/jquery-countdown/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-countto/tsconfig.json
+++ b/types/jquery-countto/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-cropbox/tsconfig.json
+++ b/types/jquery-cropbox/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-cropper/tsconfig.json
+++ b/types/jquery-cropper/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-deferred/tsconfig.json
+++ b/types/jquery-deferred/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jquery-drawer/tsconfig.json
+++ b/types/jquery-drawer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-editable-select/tsconfig.json
+++ b/types/jquery-editable-select/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-focus-exit/tsconfig.json
+++ b/types/jquery-focus-exit/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-focusable/tsconfig.json
+++ b/types/jquery-focusable/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-formatdatetime/tsconfig.json
+++ b/types/jquery-formatdatetime/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-galleria/tsconfig.json
+++ b/types/jquery-galleria/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-gray/tsconfig.json
+++ b/types/jquery-gray/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-handsontable/tsconfig.json
+++ b/types/jquery-handsontable/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-jcrop/tsconfig.json
+++ b/types/jquery-jcrop/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-jsonrpcclient/tsconfig.json
+++ b/types/jquery-jsonrpcclient/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-knob/tsconfig.json
+++ b/types/jquery-knob/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-lazyload/tsconfig.json
+++ b/types/jquery-lazyload/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-loading-overlay/tsconfig.json
+++ b/types/jquery-loading-overlay/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-mask-plugin/tsconfig.json
+++ b/types/jquery-mask-plugin/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-maskmoney/tsconfig.json
+++ b/types/jquery-maskmoney/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-match-height/tsconfig.json
+++ b/types/jquery-match-height/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-migrate/tsconfig.json
+++ b/types/jquery-migrate/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jquery-mockjax/tsconfig.json
+++ b/types/jquery-mockjax/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-mouse-exit/tsconfig.json
+++ b/types/jquery-mouse-exit/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-mousewheel/tsconfig.json
+++ b/types/jquery-mousewheel/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-next-id/tsconfig.json
+++ b/types/jquery-next-id/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-slimscroll/tsconfig.json
+++ b/types/jquery-slimscroll/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-slugify/tsconfig.json
+++ b/types/jquery-slugify/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-sortable/tsconfig.json
+++ b/types/jquery-sortable/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-steps/tsconfig.json
+++ b/types/jquery-steps/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-sticky/tsconfig.json
+++ b/types/jquery-sticky/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-tags-input/tsconfig.json
+++ b/types/jquery-tags-input/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-timeentry/tsconfig.json
+++ b/types/jquery-timeentry/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-toast-plugin/tsconfig.json
+++ b/types/jquery-toast-plugin/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/jquery-toastmessage-plugin/tsconfig.json
+++ b/types/jquery-toastmessage-plugin/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "commonjs",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-truncate-html/tsconfig.json
+++ b/types/jquery-truncate-html/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-typeahead/tsconfig.json
+++ b/types/jquery-typeahead/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-urlparam/tsconfig.json
+++ b/types/jquery-urlparam/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery-validation-unobtrusive/tsconfig.json
+++ b/types/jquery-validation-unobtrusive/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.address/tsconfig.json
+++ b/types/jquery.address/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.appear/tsconfig.json
+++ b/types/jquery.appear/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.are-you-sure/tsconfig.json
+++ b/types/jquery.are-you-sure/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.autosize/tsconfig.json
+++ b/types/jquery.autosize/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.base64/tsconfig.json
+++ b/types/jquery.base64/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.blockui/tsconfig.json
+++ b/types/jquery.blockui/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.bootstrap.wizard/tsconfig.json
+++ b/types/jquery.bootstrap.wizard/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.browser/tsconfig.json
+++ b/types/jquery.browser/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.cleditor/tsconfig.json
+++ b/types/jquery.cleditor/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.clientsidelogging/tsconfig.json
+++ b/types/jquery.clientsidelogging/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.color/tsconfig.json
+++ b/types/jquery.color/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.colorbox/tsconfig.json
+++ b/types/jquery.colorbox/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.contextmenu/tsconfig.json
+++ b/types/jquery.contextmenu/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.cookie/tsconfig.json
+++ b/types/jquery.cookie/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.customselect/tsconfig.json
+++ b/types/jquery.customselect/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.cycle/tsconfig.json
+++ b/types/jquery.cycle/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.cycle2/tsconfig.json
+++ b/types/jquery.cycle2/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.dropotron/tsconfig.json
+++ b/types/jquery.dropotron/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.dynatree/tsconfig.json
+++ b/types/jquery.dynatree/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.elang/tsconfig.json
+++ b/types/jquery.elang/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.fancytree/tsconfig.json
+++ b/types/jquery.fancytree/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.fileupload/tsconfig.json
+++ b/types/jquery.fileupload/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.filtertable/tsconfig.json
+++ b/types/jquery.filtertable/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.finger/tsconfig.json
+++ b/types/jquery.finger/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.flagstrap/tsconfig.json
+++ b/types/jquery.flagstrap/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.form/tsconfig.json
+++ b/types/jquery.form/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.fullscreen/tsconfig.json
+++ b/types/jquery.fullscreen/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.growl/tsconfig.json
+++ b/types/jquery.growl/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.highlight-bartaz/tsconfig.json
+++ b/types/jquery.highlight-bartaz/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.jnotify/tsconfig.json
+++ b/types/jquery.jnotify/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": false,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.joyride/tsconfig.json
+++ b/types/jquery.joyride/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.jsignature/tsconfig.json
+++ b/types/jquery.jsignature/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.leanmodal/tsconfig.json
+++ b/types/jquery.leanmodal/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.menuaim/tsconfig.json
+++ b/types/jquery.menuaim/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.mmenu/tsconfig.json
+++ b/types/jquery.mmenu/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.nicescroll/tsconfig.json
+++ b/types/jquery.nicescroll/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.notify/tsconfig.json
+++ b/types/jquery.notify/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.notifybar/tsconfig.json
+++ b/types/jquery.notifybar/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.noty/tsconfig.json
+++ b/types/jquery.noty/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": false,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.payment/tsconfig.json
+++ b/types/jquery.payment/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.pin/tsconfig.json
+++ b/types/jquery.pin/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.pjax/tsconfig.json
+++ b/types/jquery.pjax/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.placeholder/tsconfig.json
+++ b/types/jquery.placeholder/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.postmessage/tsconfig.json
+++ b/types/jquery.postmessage/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.prettyphoto/tsconfig.json
+++ b/types/jquery.prettyphoto/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.qrcode/tsconfig.json
+++ b/types/jquery.qrcode/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.rateit/tsconfig.json
+++ b/types/jquery.rateit/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.rowgrid/tsconfig.json
+++ b/types/jquery.rowgrid/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.scrollto/tsconfig.json
+++ b/types/jquery.scrollto/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.simplemodal/tsconfig.json
+++ b/types/jquery.simplemodal/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.simplepagination/tsconfig.json
+++ b/types/jquery.simplepagination/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.simulate/tsconfig.json
+++ b/types/jquery.simulate/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.soap/tsconfig.json
+++ b/types/jquery.soap/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.sortelements/tsconfig.json
+++ b/types/jquery.sortelements/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.stickem/tsconfig.json
+++ b/types/jquery.stickem/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.superlink/tsconfig.json
+++ b/types/jquery.superlink/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.tagsmanager/tsconfig.json
+++ b/types/jquery.tagsmanager/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.tile/tsconfig.json
+++ b/types/jquery.tile/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.timeago/tsconfig.json
+++ b/types/jquery.timeago/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": false,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.timepicker/tsconfig.json
+++ b/types/jquery.timepicker/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.timer/tsconfig.json
+++ b/types/jquery.timer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.tinycarousel/tsconfig.json
+++ b/types/jquery.tinycarousel/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.tinyscrollbar/tsconfig.json
+++ b/types/jquery.tinyscrollbar/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.tipsy/tsconfig.json
+++ b/types/jquery.tipsy/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.tools/tsconfig.json
+++ b/types/jquery.tools/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.total-storage/tsconfig.json
+++ b/types/jquery.total-storage/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.ui.datetimepicker/tsconfig.json
+++ b/types/jquery.ui.datetimepicker/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.ui.layout/tsconfig.json
+++ b/types/jquery.ui.layout/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.uniform/tsconfig.json
+++ b/types/jquery.uniform/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.watermark/tsconfig.json
+++ b/types/jquery.watermark/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jquery.window/tsconfig.json
+++ b/types/jquery.window/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/js-base64/tsconfig.json
+++ b/types/js-base64/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/js-beautify/tsconfig.json
+++ b/types/js-beautify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/js-clipper/tsconfig.json
+++ b/types/js-clipper/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/js-data-angular/tsconfig.json
+++ b/types/js-data-angular/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/js-fixtures/tsconfig.json
+++ b/types/js-fixtures/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/js-git/tsconfig.json
+++ b/types/js-git/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/js-levenshtein/tsconfig.json
+++ b/types/js-levenshtein/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es6"],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/js-money/tsconfig.json
+++ b/types/js-money/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/js-nacl/tsconfig.json
+++ b/types/js-nacl/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/js-search/tsconfig.json
+++ b/types/js-search/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/js-string-escape/tsconfig.json
+++ b/types/js-string-escape/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/js-url/tsconfig.json
+++ b/types/js-url/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/js-yaml/tsconfig.json
+++ b/types/js-yaml/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["es6"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictNullChecks": true,
 		"strictFunctionTypes": true,
 		"baseUrl": "../",

--- a/types/jschannel/tsconfig.json
+++ b/types/jschannel/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jscrollpane/tsconfig.json
+++ b/types/jscrollpane/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsdeferred/tsconfig.json
+++ b/types/jsdeferred/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": false,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsdoc-to-markdown/tsconfig.json
+++ b/types/jsdoc-to-markdown/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/jsdoc-to-markdown/v4/tsconfig.json
+++ b/types/jsdoc-to-markdown/v4/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../../",

--- a/types/jsdom-global/tsconfig.json
+++ b/types/jsdom-global/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsdom/ts3.1/tsconfig.json
+++ b/types/jsdom/ts3.1/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["es2015", "dom"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictNullChecks": true,
 		"strictFunctionTypes": true,
 		"baseUrl": "../../",

--- a/types/jsdom/ts3.4/tsconfig.json
+++ b/types/jsdom/ts3.4/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["es2015", "dom"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictNullChecks": true,
 		"strictFunctionTypes": true,
 		"baseUrl": "../../",

--- a/types/jsdom/ts3.5/tsconfig.json
+++ b/types/jsdom/ts3.5/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["es2015", "dom"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictNullChecks": true,
 		"strictFunctionTypes": true,
 		"baseUrl": "../../",

--- a/types/jsdom/ts3.6/tsconfig.json
+++ b/types/jsdom/ts3.6/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["es2015", "dom"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictNullChecks": true,
 		"strictFunctionTypes": true,
 		"baseUrl": "../../",

--- a/types/jsesc/tsconfig.json
+++ b/types/jsesc/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsfl/tsconfig.json
+++ b/types/jsfl/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": false,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsftp/tsconfig.json
+++ b/types/jsftp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsmediatags/tsconfig.json
+++ b/types/jsmediatags/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/json-buffer/tsconfig.json
+++ b/types/json-buffer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/json-editor/tsconfig.json
+++ b/types/json-editor/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/json-file-plus/tsconfig.json
+++ b/types/json-file-plus/tsconfig.json
@@ -6,6 +6,7 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
+      "noUnusedLocals": true,
       "strictNullChecks": true,
       "strictFunctionTypes": true,
       "baseUrl": "../",

--- a/types/json-form-data/tsconfig.json
+++ b/types/json-form-data/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["dom", "es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/json-merge-patch/tsconfig.json
+++ b/types/json-merge-patch/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/json-parse-better-errors/tsconfig.json
+++ b/types/json-parse-better-errors/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/json-patch-gen/tsconfig.json
+++ b/types/json-patch-gen/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/json-schema-compare/tsconfig.json
+++ b/types/json-schema-compare/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/json-schema-merge-allof/tsconfig.json
+++ b/types/json-schema-merge-allof/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/json-schema-traverse/tsconfig.json
+++ b/types/json-schema-traverse/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/json-socket/tsconfig.json
+++ b/types/json-socket/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/json-stable-stringify/tsconfig.json
+++ b/types/json-stable-stringify/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/json-stringify-safe/tsconfig.json
+++ b/types/json-stringify-safe/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/json-to-ast/tsconfig.json
+++ b/types/json-to-ast/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["es5"],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictNullChecks": true,
 		"strictFunctionTypes": true,
 		"baseUrl": "../",

--- a/types/json3/tsconfig.json
+++ b/types/json3/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/json_ml/tsconfig.json
+++ b/types/json_ml/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsonabc/tsconfig.json
+++ b/types/jsonabc/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jsonapi-serializer/tsconfig.json
+++ b/types/jsonapi-serializer/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jsoneditor/tsconfig.json
+++ b/types/jsoneditor/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsoneditoronline/tsconfig.json
+++ b/types/jsoneditoronline/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsonfile/tsconfig.json
+++ b/types/jsonfile/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/jsonfile/v4/tsconfig.json
+++ b/types/jsonfile/v4/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../../",
         "typeRoots": [

--- a/types/jsonic/tsconfig.json
+++ b/types/jsonic/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsonnet/tsconfig.json
+++ b/types/jsonnet/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsonp/tsconfig.json
+++ b/types/jsonp/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsonpack/tsconfig.json
+++ b/types/jsonpack/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsonpointer/tsconfig.json
+++ b/types/jsonpointer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jsonquery/tsconfig.json
+++ b/types/jsonquery/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsontoxml/tsconfig.json
+++ b/types/jsontoxml/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "esModuleInterop": true,

--- a/types/jsonwebtoken-promisified/tsconfig.json
+++ b/types/jsonwebtoken-promisified/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsonwebtoken/tsconfig.json
+++ b/types/jsonwebtoken/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jspath/tsconfig.json
+++ b/types/jspath/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jsprintmanager/tsconfig.json
+++ b/types/jsprintmanager/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/jsqrcode/tsconfig.json
+++ b/types/jsqrcode/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,

--- a/types/jsqubits/tsconfig.json
+++ b/types/jsqubits/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jsreport-chrome-pdf/tsconfig.json
+++ b/types/jsreport-chrome-pdf/tsconfig.json
@@ -7,6 +7,7 @@
 		],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictNullChecks": true,
 		"baseUrl": "../",
 		"typeRoots": [

--- a/types/jsreport-core/tsconfig.json
+++ b/types/jsreport-core/tsconfig.json
@@ -7,6 +7,7 @@
         "strictFunctionTypes": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/jsreport-html-embedded-in-docx/tsconfig.json
+++ b/types/jsreport-html-embedded-in-docx/tsconfig.json
@@ -7,6 +7,7 @@
 		],
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictNullChecks": true,
 		"baseUrl": "../",
 		"typeRoots": [

--- a/types/jsreport-jsrender/tsconfig.json
+++ b/types/jsreport-jsrender/tsconfig.json
@@ -7,6 +7,7 @@
         "strictFunctionTypes": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/jsreport-phantom-pdf/tsconfig.json
+++ b/types/jsreport-phantom-pdf/tsconfig.json
@@ -7,6 +7,7 @@
         "strictFunctionTypes": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/jsrsasign/tsconfig.json
+++ b/types/jsrsasign/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jssip/tsconfig.json
+++ b/types/jssip/tsconfig.json
@@ -8,6 +8,7 @@
         "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsspec__jsspec/tsconfig.json
+++ b/types/jsspec__jsspec/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jstimezonedetect/tsconfig.json
+++ b/types/jstimezonedetect/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jstorage/tsconfig.json
+++ b/types/jstorage/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jstree/tsconfig.json
+++ b/types/jstree/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsuite/tsconfig.json
+++ b/types/jsuite/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jsum/tsconfig.json
+++ b/types/jsum/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jsurl/tsconfig.json
+++ b/types/jsurl/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jszip/tsconfig.json
+++ b/types/jszip/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jui-core/tsconfig.json
+++ b/types/jui-core/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jui/tsconfig.json
+++ b/types/jui/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jump.js/tsconfig.json
+++ b/types/jump.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/just-clone/tsconfig.json
+++ b/types/just-clone/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/just-extend/tsconfig.json
+++ b/types/just-extend/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/just-map-values/tsconfig.json
+++ b/types/just-map-values/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/just-pick/tsconfig.json
+++ b/types/just-pick/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/just-safe-get/tsconfig.json
+++ b/types/just-safe-get/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/just-safe-set/tsconfig.json
+++ b/types/just-safe-set/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/just-snake-case/tsconfig.json
+++ b/types/just-snake-case/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/just-throttle/tsconfig.json
+++ b/types/just-throttle/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jweixin/tsconfig.json
+++ b/types/jweixin/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jwk-to-pem/tsconfig.json
+++ b/types/jwk-to-pem/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jwplayer/tsconfig.json
+++ b/types/jwplayer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jwt-client/tsconfig.json
+++ b/types/jwt-client/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jwt-express/tsconfig.json
+++ b/types/jwt-express/tsconfig.json
@@ -7,6 +7,7 @@
         "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/jwt-simple/tsconfig.json
+++ b/types/jwt-simple/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/jxon/tsconfig.json
+++ b/types/jxon/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/kafka-node-avro/tsconfig.json
+++ b/types/kafka-node-avro/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/kamailio-kemi/tsconfig.json
+++ b/types/kamailio-kemi/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/karma-brief-reporter/tsconfig.json
+++ b/types/karma-brief-reporter/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/karma-browserify/tsconfig.json
+++ b/types/karma-browserify/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/karma-chai-sinon/tsconfig.json
+++ b/types/karma-chai-sinon/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/karma-chai/tsconfig.json
+++ b/types/karma-chai/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/karma-chrome-launcher/tsconfig.json
+++ b/types/karma-chrome-launcher/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/karma-coverage-istanbul-reporter/tsconfig.json
+++ b/types/karma-coverage-istanbul-reporter/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/karma-coverage/tsconfig.json
+++ b/types/karma-coverage/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/karma-detect-browsers/tsconfig.json
+++ b/types/karma-detect-browsers/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/karma-fixture/tsconfig.json
+++ b/types/karma-fixture/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/karma-jasmine-html-reporter/tsconfig.json
+++ b/types/karma-jasmine-html-reporter/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/karma-jasmine-spec-tags/tsconfig.json
+++ b/types/karma-jasmine-spec-tags/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/karma-jsdom-launcher/tsconfig.json
+++ b/types/karma-jsdom-launcher/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/karma-junit-reporter/tsconfig.json
+++ b/types/karma-junit-reporter/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/karma-material-reporter/tsconfig.json
+++ b/types/karma-material-reporter/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/karma-mocha-reporter/tsconfig.json
+++ b/types/karma-mocha-reporter/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/karma-remap-coverage/tsconfig.json
+++ b/types/karma-remap-coverage/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/karma-snapshot/tsconfig.json
+++ b/types/karma-snapshot/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/karma-summary-reporter/tsconfig.json
+++ b/types/karma-summary-reporter/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/karma-webpack/tsconfig.json
+++ b/types/karma-webpack/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/kcors/tsconfig.json
+++ b/types/kcors/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/kd-tree-javascript/tsconfig.json
+++ b/types/kd-tree-javascript/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/kdbush/tsconfig.json
+++ b/types/kdbush/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/kdbush/v1/tsconfig.json
+++ b/types/kdbush/v1/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/keccak/tsconfig.json
+++ b/types/keccak/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/keen-tracking/tsconfig.json
+++ b/types/keen-tracking/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/keyboardjs/tsconfig.json
+++ b/types/keyboardjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keymaster/tsconfig.json
+++ b/types/keymaster/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keymirror/tsconfig.json
+++ b/types/keymirror/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keypress.js/tsconfig.json
+++ b/types/keypress.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__adapter-knex/tsconfig.json
+++ b/types/keystonejs__adapter-knex/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__apollo-helpers/tsconfig.json
+++ b/types/keystonejs__apollo-helpers/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__app-admin-ui/tsconfig.json
+++ b/types/keystonejs__app-admin-ui/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__app-graphql/tsconfig.json
+++ b/types/keystonejs__app-graphql/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__app-next/tsconfig.json
+++ b/types/keystonejs__app-next/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__app-nuxt/tsconfig.json
+++ b/types/keystonejs__app-nuxt/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__app-static/tsconfig.json
+++ b/types/keystonejs__app-static/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__auth-passport/tsconfig.json
+++ b/types/keystonejs__auth-passport/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__auth-password/tsconfig.json
+++ b/types/keystonejs__auth-password/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__email/tsconfig.json
+++ b/types/keystonejs__email/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__fields/tsconfig.json
+++ b/types/keystonejs__fields/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__file-adapters/tsconfig.json
+++ b/types/keystonejs__file-adapters/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__keystone/tsconfig.json
+++ b/types/keystonejs__keystone/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__list-plugins/tsconfig.json
+++ b/types/keystonejs__list-plugins/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__logger/tsconfig.json
+++ b/types/keystonejs__logger/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__oembed-adapters/tsconfig.json
+++ b/types/keystonejs__oembed-adapters/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keystonejs__session/tsconfig.json
+++ b/types/keystonejs__session/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keyv/tsconfig.json
+++ b/types/keyv/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/keyv__mongo/tsconfig.json
+++ b/types/keyv__mongo/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keyv__mysql/tsconfig.json
+++ b/types/keyv__mysql/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keyv__postgres/tsconfig.json
+++ b/types/keyv__postgres/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keyv__redis/tsconfig.json
+++ b/types/keyv__redis/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/keyv__sqlite/tsconfig.json
+++ b/types/keyv__sqlite/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/kik-browser/tsconfig.json
+++ b/types/kik-browser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/kind-of/tsconfig.json
+++ b/types/kind-of/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/kineticjs/tsconfig.json
+++ b/types/kineticjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/kissfft-js/tsconfig.json
+++ b/types/kissfft-js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/klaw-sync/tsconfig.json
+++ b/types/klaw-sync/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/klaw/tsconfig.json
+++ b/types/klaw/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/klaw/v1/tsconfig.json
+++ b/types/klaw/v1/tsconfig.json
@@ -11,6 +11,7 @@
         },
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/kms-json/tsconfig.json
+++ b/types/kms-json/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knex-db-manager/tsconfig.json
+++ b/types/knex-db-manager/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/knex-postgis/tsconfig.json
+++ b/types/knex-postgis/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knockback/tsconfig.json
+++ b/types/knockback/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": false,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knockout-amd-helpers/tsconfig.json
+++ b/types/knockout-amd-helpers/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knockout-postbox/tsconfig.json
+++ b/types/knockout-postbox/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knockout.editables/tsconfig.json
+++ b/types/knockout.editables/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knockout.es5/tsconfig.json
+++ b/types/knockout.es5/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knockout.kogrid/tsconfig.json
+++ b/types/knockout.kogrid/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knockout.mapper/tsconfig.json
+++ b/types/knockout.mapper/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knockout.mapping/tsconfig.json
+++ b/types/knockout.mapping/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knockout.projections/tsconfig.json
+++ b/types/knockout.projections/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knockout.punches/tsconfig.json
+++ b/types/knockout.punches/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knockout.rx/tsconfig.json
+++ b/types/knockout.rx/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knockout.validation/tsconfig.json
+++ b/types/knockout.validation/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knockout.viewmodel/tsconfig.json
+++ b/types/knockout.viewmodel/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knockstrap/tsconfig.json
+++ b/types/knockstrap/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knuddels-userapps-api/tsconfig.json
+++ b/types/knuddels-userapps-api/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/knuth-shuffle/tsconfig.json
+++ b/types/knuth-shuffle/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/koa-basic-auth/tsconfig.json
+++ b/types/koa-basic-auth/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-bodyparser/tsconfig.json
+++ b/types/koa-bodyparser/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-bouncer/tsconfig.json
+++ b/types/koa-bouncer/tsconfig.json
@@ -10,6 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-bunyan-logger/tsconfig.json
+++ b/types/koa-bunyan-logger/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-cache-control/tsconfig.json
+++ b/types/koa-cache-control/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-compress/tsconfig.json
+++ b/types/koa-compress/tsconfig.json
@@ -10,6 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-conditional-get/tsconfig.json
+++ b/types/koa-conditional-get/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-convert/tsconfig.json
+++ b/types/koa-convert/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es6"],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/koa-cookie/tsconfig.json
+++ b/types/koa-cookie/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es6"],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "baseUrl": "../",

--- a/types/koa-cors/tsconfig.json
+++ b/types/koa-cors/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-csrf/tsconfig.json
+++ b/types/koa-csrf/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "strictFunctionTypes": true,

--- a/types/koa-docs/tsconfig.json
+++ b/types/koa-docs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/koa-ejs/tsconfig.json
+++ b/types/koa-ejs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-etag/tsconfig.json
+++ b/types/koa-etag/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-favicon/tsconfig.json
+++ b/types/koa-favicon/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-generic-session/tsconfig.json
+++ b/types/koa-generic-session/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-graphql/tsconfig.json
+++ b/types/koa-graphql/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/koa-hbs/tsconfig.json
+++ b/types/koa-hbs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-html-minifier/tsconfig.json
+++ b/types/koa-html-minifier/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-joi-router-docs/tsconfig.json
+++ b/types/koa-joi-router-docs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/koa-joi-router/tsconfig.json
+++ b/types/koa-joi-router/tsconfig.json
@@ -10,6 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-json-error/tsconfig.json
+++ b/types/koa-json-error/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-json/tsconfig.json
+++ b/types/koa-json/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-log/tsconfig.json
+++ b/types/koa-log/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-log4/tsconfig.json
+++ b/types/koa-log4/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes":true,
         "baseUrl": "../",

--- a/types/koa-logger-winston/tsconfig.json
+++ b/types/koa-logger-winston/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-logger/tsconfig.json
+++ b/types/koa-logger/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-morgan/tsconfig.json
+++ b/types/koa-morgan/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-mount/tsconfig.json
+++ b/types/koa-mount/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-pino-logger/tsconfig.json
+++ b/types/koa-pino-logger/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-proxies/tsconfig.json
+++ b/types/koa-proxies/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/koa-proxy/tsconfig.json
+++ b/types/koa-proxy/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "strictFunctionTypes": true,

--- a/types/koa-qs/tsconfig.json
+++ b/types/koa-qs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-range/tsconfig.json
+++ b/types/koa-range/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-ratelimit-lru/tsconfig.json
+++ b/types/koa-ratelimit-lru/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-ratelimit/tsconfig.json
+++ b/types/koa-ratelimit/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/koa-redis-cache/tsconfig.json
+++ b/types/koa-redis-cache/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-redis/tsconfig.json
+++ b/types/koa-redis/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-response-time/tsconfig.json
+++ b/types/koa-response-time/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-route/tsconfig.json
+++ b/types/koa-route/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-session-minimal/tsconfig.json
+++ b/types/koa-session-minimal/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-sslify/tsconfig.json
+++ b/types/koa-sslify/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-static-cache/tsconfig.json
+++ b/types/koa-static-cache/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-static-server/tsconfig.json
+++ b/types/koa-static-server/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-static/tsconfig.json
+++ b/types/koa-static/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-views/tsconfig.json
+++ b/types/koa-views/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-webpack/tsconfig.json
+++ b/types/koa-webpack/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-websocket/tsconfig.json
+++ b/types/koa-websocket/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa-xml-body/tsconfig.json
+++ b/types/koa-xml-body/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa2-cors/tsconfig.json
+++ b/types/koa2-cors/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "strictFunctionTypes": true,

--- a/types/koa2-session-redis/tsconfig.json
+++ b/types/koa2-session-redis/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/koa__cors/tsconfig.json
+++ b/types/koa__cors/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/kompression/tsconfig.json
+++ b/types/kompression/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/konami.js/tsconfig.json
+++ b/types/konami.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/kos-core/tsconfig.json
+++ b/types/kos-core/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/kraken-js/tsconfig.json
+++ b/types/kraken-js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/kue-ui-client/tsconfig.json
+++ b/types/kue-ui-client/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/kue/tsconfig.json
+++ b/types/kue/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/kurento-client/tsconfig.json
+++ b/types/kurento-client/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "esModuleInterop": true,

--- a/types/lab/tsconfig.json
+++ b/types/lab/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lambda-log/tsconfig.json
+++ b/types/lambda-log/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],

--- a/types/lambda-wrapper/tsconfig.json
+++ b/types/lambda-wrapper/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/lang.js/tsconfig.json
+++ b/types/lang.js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/langmap/tsconfig.json
+++ b/types/langmap/tsconfig.json
@@ -7,6 +7,7 @@
         "esModuleInterop": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/latinize/tsconfig.json
+++ b/types/latinize/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/launchpad/tsconfig.json
+++ b/types/launchpad/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,

--- a/types/layui-layer/tsconfig.json
+++ b/types/layui-layer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/lazy-property/tsconfig.json
+++ b/types/lazy-property/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/lazy.js/tsconfig.json
+++ b/types/lazy.js/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lazypipe/tsconfig.json
+++ b/types/lazypipe/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ldap-filters/tsconfig.json
+++ b/types/ldap-filters/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/ldapjs/tsconfig.json
+++ b/types/ldapjs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet-areaselect/tsconfig.json
+++ b/types/leaflet-areaselect/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet-curve/tsconfig.json
+++ b/types/leaflet-curve/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet-geocoder-mapzen/tsconfig.json
+++ b/types/leaflet-geocoder-mapzen/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet-groupedlayercontrol/tsconfig.json
+++ b/types/leaflet-groupedlayercontrol/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/leaflet-imageoverlay-rotated/tsconfig.json
+++ b/types/leaflet-imageoverlay-rotated/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet-mouse-position/tsconfig.json
+++ b/types/leaflet-mouse-position/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet-polylinedecorator/tsconfig.json
+++ b/types/leaflet-polylinedecorator/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet-providers/tsconfig.json
+++ b/types/leaflet-providers/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet-rastercoords/tsconfig.json
+++ b/types/leaflet-rastercoords/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet-responsive-popup/tsconfig.json
+++ b/types/leaflet-responsive-popup/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet-rotatedmarker/tsconfig.json
+++ b/types/leaflet-rotatedmarker/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/leaflet-routing-machine/tsconfig.json
+++ b/types/leaflet-routing-machine/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet.awesome-markers/tsconfig.json
+++ b/types/leaflet.awesome-markers/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet.awesome-markers/v0/tsconfig.json
+++ b/types/leaflet.awesome-markers/v0/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../../",

--- a/types/leaflet.fullscreen/tsconfig.json
+++ b/types/leaflet.fullscreen/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet.heat/tsconfig.json
+++ b/types/leaflet.heat/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet.pancontrol/tsconfig.json
+++ b/types/leaflet.pancontrol/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet.polylinemeasure/tsconfig.json
+++ b/types/leaflet.polylinemeasure/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet.utm/tsconfig.json
+++ b/types/leaflet.utm/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/leaflet/v0/tsconfig.json
+++ b/types/leaflet/v0/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": false,
         "baseUrl": "../../",

--- a/types/leapmotionts/tsconfig.json
+++ b/types/leapmotionts/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/legal-eagle/tsconfig.json
+++ b/types/legal-eagle/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lerna-get-packages/tsconfig.json
+++ b/types/lerna-get-packages/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/less-middleware/tsconfig.json
+++ b/types/less-middleware/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/level-codec/tsconfig.json
+++ b/types/level-codec/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/level-sublevel/tsconfig.json
+++ b/types/level-sublevel/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/level-ttl/tsconfig.json
+++ b/types/level-ttl/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "esModuleInterop": true,

--- a/types/levelup/tsconfig.json
+++ b/types/levelup/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lexicographic-integer/tsconfig.json
+++ b/types/lexicographic-integer/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/libnpmsearch/tsconfig.json
+++ b/types/libnpmsearch/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/librato-node/tsconfig.json
+++ b/types/librato-node/tsconfig.json
@@ -11,6 +11,7 @@
         "types": [],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noUnusedParameters": true,

--- a/types/license-checker-webpack-plugin/tsconfig.json
+++ b/types/license-checker-webpack-plugin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lifeomic__axios-fetch/tsconfig.json
+++ b/types/lifeomic__axios-fetch/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/liftoff/tsconfig.json
+++ b/types/liftoff/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lightpick/tsconfig.json
+++ b/types/lightpick/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/lightship/tsconfig.json
+++ b/types/lightship/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lil-uri/tsconfig.json
+++ b/types/lil-uri/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lil-uuid/tsconfig.json
+++ b/types/lil-uuid/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lime-js/tsconfig.json
+++ b/types/lime-js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/line-by-line/tsconfig.json
+++ b/types/line-by-line/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/line-column/tsconfig.json
+++ b/types/line-column/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/line-reader/tsconfig.json
+++ b/types/line-reader/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/linear-gradient/tsconfig.json
+++ b/types/linear-gradient/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "strictFunctionTypes": true,

--- a/types/list-git-remotes/tsconfig.json
+++ b/types/list-git-remotes/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/list-stream/tsconfig.json
+++ b/types/list-stream/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/list.js/tsconfig.json
+++ b/types/list.js/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "esModuleInterop": true,

--- a/types/little-loader/tsconfig.json
+++ b/types/little-loader/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es6", "dom"],
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedLocals": true,
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "baseUrl": "../",

--- a/types/loadable__component/tsconfig.json
+++ b/types/loadable__component/tsconfig.json
@@ -7,6 +7,7 @@
         "jsx": "react",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/loader-runner/tsconfig.json
+++ b/types/loader-runner/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/loadicons/tsconfig.json
+++ b/types/loadicons/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/loadjs/tsconfig.json
+++ b/types/loadjs/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lobibox/tsconfig.json
+++ b/types/lobibox/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/local-dynamo/tsconfig.json
+++ b/types/local-dynamo/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/local-storage/tsconfig.json
+++ b/types/local-storage/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/locale/tsconfig.json
+++ b/types/locale/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",

--- a/types/localized-countries/tsconfig.json
+++ b/types/localized-countries/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/localizejs-library/tsconfig.json
+++ b/types/localizejs-library/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lockr/tsconfig.json
+++ b/types/lockr/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.add/tsconfig.json
+++ b/types/lodash.add/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.after/tsconfig.json
+++ b/types/lodash.after/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.ary/tsconfig.json
+++ b/types/lodash.ary/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.assign/tsconfig.json
+++ b/types/lodash.assign/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.assignin/tsconfig.json
+++ b/types/lodash.assignin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.assigninwith/tsconfig.json
+++ b/types/lodash.assigninwith/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.assignwith/tsconfig.json
+++ b/types/lodash.assignwith/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.at/tsconfig.json
+++ b/types/lodash.at/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.attempt/tsconfig.json
+++ b/types/lodash.attempt/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.before/tsconfig.json
+++ b/types/lodash.before/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.bind/tsconfig.json
+++ b/types/lodash.bind/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.bindall/tsconfig.json
+++ b/types/lodash.bindall/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.bindkey/tsconfig.json
+++ b/types/lodash.bindkey/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.camelcase/tsconfig.json
+++ b/types/lodash.camelcase/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.capitalize/tsconfig.json
+++ b/types/lodash.capitalize/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.castarray/tsconfig.json
+++ b/types/lodash.castarray/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.ceil/tsconfig.json
+++ b/types/lodash.ceil/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.chunk/tsconfig.json
+++ b/types/lodash.chunk/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.clamp/tsconfig.json
+++ b/types/lodash.clamp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.clone/tsconfig.json
+++ b/types/lodash.clone/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.clonedeep/tsconfig.json
+++ b/types/lodash.clonedeep/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.clonedeepwith/tsconfig.json
+++ b/types/lodash.clonedeepwith/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.clonewith/tsconfig.json
+++ b/types/lodash.clonewith/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.compact/tsconfig.json
+++ b/types/lodash.compact/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.concat/tsconfig.json
+++ b/types/lodash.concat/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.cond/tsconfig.json
+++ b/types/lodash.cond/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.constant/tsconfig.json
+++ b/types/lodash.constant/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.countby/tsconfig.json
+++ b/types/lodash.countby/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.create/tsconfig.json
+++ b/types/lodash.create/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.curry/tsconfig.json
+++ b/types/lodash.curry/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.curryright/tsconfig.json
+++ b/types/lodash.curryright/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.debounce/tsconfig.json
+++ b/types/lodash.debounce/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.deburr/tsconfig.json
+++ b/types/lodash.deburr/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.defaults/tsconfig.json
+++ b/types/lodash.defaults/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.defaultsdeep/tsconfig.json
+++ b/types/lodash.defaultsdeep/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.defer/tsconfig.json
+++ b/types/lodash.defer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.delay/tsconfig.json
+++ b/types/lodash.delay/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.difference/tsconfig.json
+++ b/types/lodash.difference/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.differenceby/tsconfig.json
+++ b/types/lodash.differenceby/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.differencewith/tsconfig.json
+++ b/types/lodash.differencewith/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.divide/tsconfig.json
+++ b/types/lodash.divide/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.drop/tsconfig.json
+++ b/types/lodash.drop/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.dropright/tsconfig.json
+++ b/types/lodash.dropright/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.droprightwhile/tsconfig.json
+++ b/types/lodash.droprightwhile/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.dropwhile/tsconfig.json
+++ b/types/lodash.dropwhile/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.endswith/tsconfig.json
+++ b/types/lodash.endswith/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.eq/tsconfig.json
+++ b/types/lodash.eq/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.escape/tsconfig.json
+++ b/types/lodash.escape/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.escaperegexp/tsconfig.json
+++ b/types/lodash.escaperegexp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.every/tsconfig.json
+++ b/types/lodash.every/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.fill/tsconfig.json
+++ b/types/lodash.fill/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.filter/tsconfig.json
+++ b/types/lodash.filter/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.find/tsconfig.json
+++ b/types/lodash.find/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.findindex/tsconfig.json
+++ b/types/lodash.findindex/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.findkey/tsconfig.json
+++ b/types/lodash.findkey/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.findlast/tsconfig.json
+++ b/types/lodash.findlast/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.findlastindex/tsconfig.json
+++ b/types/lodash.findlastindex/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.findlastkey/tsconfig.json
+++ b/types/lodash.findlastkey/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.first/tsconfig.json
+++ b/types/lodash.first/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.flatmap/tsconfig.json
+++ b/types/lodash.flatmap/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.flatmapdeep/tsconfig.json
+++ b/types/lodash.flatmapdeep/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.flatmapdepth/tsconfig.json
+++ b/types/lodash.flatmapdepth/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.flatten/tsconfig.json
+++ b/types/lodash.flatten/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.flattendeep/tsconfig.json
+++ b/types/lodash.flattendeep/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.flattendepth/tsconfig.json
+++ b/types/lodash.flattendepth/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.flip/tsconfig.json
+++ b/types/lodash.flip/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.floor/tsconfig.json
+++ b/types/lodash.floor/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.flow/tsconfig.json
+++ b/types/lodash.flow/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.flowright/tsconfig.json
+++ b/types/lodash.flowright/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.foreach/tsconfig.json
+++ b/types/lodash.foreach/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.foreachright/tsconfig.json
+++ b/types/lodash.foreachright/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.forin/tsconfig.json
+++ b/types/lodash.forin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.forinright/tsconfig.json
+++ b/types/lodash.forinright/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.forown/tsconfig.json
+++ b/types/lodash.forown/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.forownright/tsconfig.json
+++ b/types/lodash.forownright/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.frompairs/tsconfig.json
+++ b/types/lodash.frompairs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.functions/tsconfig.json
+++ b/types/lodash.functions/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.functionsin/tsconfig.json
+++ b/types/lodash.functionsin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.get/tsconfig.json
+++ b/types/lodash.get/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.groupby/tsconfig.json
+++ b/types/lodash.groupby/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.gt/tsconfig.json
+++ b/types/lodash.gt/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.gte/tsconfig.json
+++ b/types/lodash.gte/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.has/tsconfig.json
+++ b/types/lodash.has/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.hasin/tsconfig.json
+++ b/types/lodash.hasin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.head/tsconfig.json
+++ b/types/lodash.head/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.identity/tsconfig.json
+++ b/types/lodash.identity/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.includes/tsconfig.json
+++ b/types/lodash.includes/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.indexof/tsconfig.json
+++ b/types/lodash.indexof/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.initial/tsconfig.json
+++ b/types/lodash.initial/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.inrange/tsconfig.json
+++ b/types/lodash.inrange/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.intersection/tsconfig.json
+++ b/types/lodash.intersection/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.intersectionby/tsconfig.json
+++ b/types/lodash.intersectionby/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.intersectionwith/tsconfig.json
+++ b/types/lodash.intersectionwith/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.invert/tsconfig.json
+++ b/types/lodash.invert/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.invertby/tsconfig.json
+++ b/types/lodash.invertby/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.invoke/tsconfig.json
+++ b/types/lodash.invoke/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.invokemap/tsconfig.json
+++ b/types/lodash.invokemap/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isarguments/tsconfig.json
+++ b/types/lodash.isarguments/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isarray/tsconfig.json
+++ b/types/lodash.isarray/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isarraybuffer/tsconfig.json
+++ b/types/lodash.isarraybuffer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isarraylike/tsconfig.json
+++ b/types/lodash.isarraylike/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isarraylikeobject/tsconfig.json
+++ b/types/lodash.isarraylikeobject/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isboolean/tsconfig.json
+++ b/types/lodash.isboolean/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isbuffer/tsconfig.json
+++ b/types/lodash.isbuffer/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isdate/tsconfig.json
+++ b/types/lodash.isdate/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.iselement/tsconfig.json
+++ b/types/lodash.iselement/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isempty/tsconfig.json
+++ b/types/lodash.isempty/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isequal/tsconfig.json
+++ b/types/lodash.isequal/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isequalwith/tsconfig.json
+++ b/types/lodash.isequalwith/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.iserror/tsconfig.json
+++ b/types/lodash.iserror/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isfinite/tsconfig.json
+++ b/types/lodash.isfinite/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isfunction/tsconfig.json
+++ b/types/lodash.isfunction/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isinteger/tsconfig.json
+++ b/types/lodash.isinteger/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.islength/tsconfig.json
+++ b/types/lodash.islength/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.ismap/tsconfig.json
+++ b/types/lodash.ismap/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.ismatch/tsconfig.json
+++ b/types/lodash.ismatch/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.ismatchwith/tsconfig.json
+++ b/types/lodash.ismatchwith/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isnan/tsconfig.json
+++ b/types/lodash.isnan/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isnative/tsconfig.json
+++ b/types/lodash.isnative/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isnil/tsconfig.json
+++ b/types/lodash.isnil/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isnull/tsconfig.json
+++ b/types/lodash.isnull/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isnumber/tsconfig.json
+++ b/types/lodash.isnumber/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isobject/tsconfig.json
+++ b/types/lodash.isobject/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isobjectlike/tsconfig.json
+++ b/types/lodash.isobjectlike/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isplainobject/tsconfig.json
+++ b/types/lodash.isplainobject/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isregexp/tsconfig.json
+++ b/types/lodash.isregexp/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.issafeinteger/tsconfig.json
+++ b/types/lodash.issafeinteger/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isset/tsconfig.json
+++ b/types/lodash.isset/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isstring/tsconfig.json
+++ b/types/lodash.isstring/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.issymbol/tsconfig.json
+++ b/types/lodash.issymbol/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.istypedarray/tsconfig.json
+++ b/types/lodash.istypedarray/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isundefined/tsconfig.json
+++ b/types/lodash.isundefined/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isweakmap/tsconfig.json
+++ b/types/lodash.isweakmap/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.isweakset/tsconfig.json
+++ b/types/lodash.isweakset/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.iteratee/tsconfig.json
+++ b/types/lodash.iteratee/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.join/tsconfig.json
+++ b/types/lodash.join/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.kebabcase/tsconfig.json
+++ b/types/lodash.kebabcase/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.keyby/tsconfig.json
+++ b/types/lodash.keyby/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.keys/tsconfig.json
+++ b/types/lodash.keys/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.keysin/tsconfig.json
+++ b/types/lodash.keysin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.last/tsconfig.json
+++ b/types/lodash.last/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.lastindexof/tsconfig.json
+++ b/types/lodash.lastindexof/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.lowercase/tsconfig.json
+++ b/types/lodash.lowercase/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.lowerfirst/tsconfig.json
+++ b/types/lodash.lowerfirst/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.lt/tsconfig.json
+++ b/types/lodash.lt/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.lte/tsconfig.json
+++ b/types/lodash.lte/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.mapkeys/tsconfig.json
+++ b/types/lodash.mapkeys/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.mapvalues/tsconfig.json
+++ b/types/lodash.mapvalues/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.matches/tsconfig.json
+++ b/types/lodash.matches/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.matchesproperty/tsconfig.json
+++ b/types/lodash.matchesproperty/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.max/tsconfig.json
+++ b/types/lodash.max/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.maxby/tsconfig.json
+++ b/types/lodash.maxby/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.mean/tsconfig.json
+++ b/types/lodash.mean/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.meanby/tsconfig.json
+++ b/types/lodash.meanby/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.memoize/tsconfig.json
+++ b/types/lodash.memoize/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.merge/tsconfig.json
+++ b/types/lodash.merge/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.mergewith/tsconfig.json
+++ b/types/lodash.mergewith/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.method/tsconfig.json
+++ b/types/lodash.method/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.methodof/tsconfig.json
+++ b/types/lodash.methodof/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.min/tsconfig.json
+++ b/types/lodash.min/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.minby/tsconfig.json
+++ b/types/lodash.minby/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.mixin/tsconfig.json
+++ b/types/lodash.mixin/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.multiply/tsconfig.json
+++ b/types/lodash.multiply/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.negate/tsconfig.json
+++ b/types/lodash.negate/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.noop/tsconfig.json
+++ b/types/lodash.noop/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.now/tsconfig.json
+++ b/types/lodash.now/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.nth/tsconfig.json
+++ b/types/lodash.nth/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.ntharg/tsconfig.json
+++ b/types/lodash.ntharg/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.omit/tsconfig.json
+++ b/types/lodash.omit/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.omitby/tsconfig.json
+++ b/types/lodash.omitby/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.once/tsconfig.json
+++ b/types/lodash.once/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.orderby/tsconfig.json
+++ b/types/lodash.orderby/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.over/tsconfig.json
+++ b/types/lodash.over/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.overargs/tsconfig.json
+++ b/types/lodash.overargs/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.overevery/tsconfig.json
+++ b/types/lodash.overevery/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/lodash.oversome/tsconfig.json
+++ b/types/lodash.oversome/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",


### PR DESCRIPTION
What do you think about enabling `noUnusedLocals`?

It would have caught e.g. #44213, thereby pruning a dependency.

Like #43637, `tsconfig.json` isn't distributed along with the types, so this only affects the automated tests, not the types themselves. It makes the tests slightly stricter.

Unlike `strictNullChecks` however, there isn't an [existing recommendation](https://github.com/DefinitelyTyped/DefinitelyTyped#some-packages-have-no-tslintjson-and-some-tsconfigjson-are-missing-noimplicitany-true-noimplicitthis-true-or-strictnullchecks-true) to enable `noUnusedLocals`. Are there practical/philosophical objections widespread enabling `noUnusedLocals`?

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).