### PR TITLE
build: format changed files in pre-commit and require changed files to be formatted in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: node_js
 node_js:
-  - 10
+    - 10
 
 notifications:
-  email: false
+    email: false
 
 script:
- - npm run test
- - if [[ $TRAVIS_EVENT_TYPE == "cron" ]]; then npm run update-codeowners || travis_terminate 1; fi
+    - node_modules/.bin/prettier --list-different $(if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then git diff --name-only HEAD~; else git diff --name-only $TRAVIS_BRANCH; fi)
+    - npm run test
+    - if [[ $TRAVIS_EVENT_TYPE == "cron" ]]; then npm run update-codeowners || travis_terminate 1; fi

--- a/package.json
+++ b/package.json
@@ -20,18 +20,22 @@
         "update-codeowners": "node scripts/update-codeowners.js",
         "test": "node node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed",
         "lint": "dtslint types",
-        "prettier": "prettier"
+        "prettier": "prettier --write '*.{js,json,md,ts,yml}' '{scripts,types,docs}/**/*.{js,json,md,ts,yml}'"
     },
     "devDependencies": {
         "dtslint": "latest",
+        "husky": "^4.2.5",
+        "lint-staged": "^10.1.7",
         "prettier": "^2.0.2",
         "types-publisher": "github:Microsoft/types-publisher#production"
     },
     "husky": {
         "hooks": {
-            "_comment": "This will remove husky from when we started migrating to use prettier",
-            "pre-commit": "npm uninstall husky"
+            "pre-commit": "lint-staged"
         }
+    },
+    "lint-staged": {
+        "*.{js,ts,json,md,yml}": ["prettier --write"]
     },
     "dependencies": {}
 }


### PR DESCRIPTION
Please enforce the prettier formatting settings so that contributors' time doesn't get wasted
if they have a prettier IDE extension format something on save.  This is  a n n o y i n g  and
no programmers should have to kill brain cells with tedium like undoing formatting these days.