### PR TITLE
Add types for react-switch-case

### DIFF
--- a/types/react-switch-case/index.d.ts
+++ b/types/react-switch-case/index.d.ts
@@ -14,7 +14,7 @@ interface CaseProps {
 }
 
 declare class Swtich extends React.Component<SwitchProps> {}
-export declare class Case extends React.Component<CaseProps> {}
-export declare class Default extends React.Component {}
+export class Case extends React.Component<CaseProps> {}
+export class Default extends React.Component {}
 
 export default Swtich;

--- a/types/react-switch-case/index.d.ts
+++ b/types/react-switch-case/index.d.ts
@@ -17,4 +17,4 @@ declare class Switch extends React.Component<SwitchProps> {}
 export class Case extends React.Component<CaseProps> {}
 export class Default extends React.Component {}
 
-export default Swtich;
+export default Switch;

--- a/types/react-switch-case/index.d.ts
+++ b/types/react-switch-case/index.d.ts
@@ -13,7 +13,7 @@ interface CaseProps {
     value: any;
 }
 
-declare class Swtich extends React.Component<SwitchProps> {}
+declare class Switch extends React.Component<SwitchProps> {}
 export class Case extends React.Component<CaseProps> {}
 export class Default extends React.Component {}
 

--- a/types/react-switch-case/index.d.ts
+++ b/types/react-switch-case/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for react-switch-case 1.5
+// Project: https://github.com/AlexSergey/react-switch-case
+// Definitions by: Fernando Falci <https://github.com/Falci>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../react/react.d.ts"/>
+
+import * as React from 'react';
+
+export interface SwitchProps {
+    condition: any;
+}
+
+interface CaseProps {
+    value: any;
+}
+
+declare class Swtich extends React.Component<SwitchProps> {}
+export declare class Case extends React.Component<CaseProps> {}
+export declare class Default extends React.Component {}
+
+export default Swtich;

--- a/types/react-switch-case/index.d.ts
+++ b/types/react-switch-case/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Fernando Falci <https://github.com/Falci>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../react/react.d.ts"/>
-
 import * as React from 'react';
 
 export interface SwitchProps {

--- a/types/react-switch-case/react-switch-case-tests.tsx
+++ b/types/react-switch-case/react-switch-case-tests.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Switch, { Case, Default } from 'react-switch-case';
+
+class Test extends React.Component {
+    render() {
+        const condition = 'component1';
+
+        return (
+            <Switch condition={condition}>
+                <Case value="component1">
+                    <span>Component 1</span>
+                </Case>
+                <Case value="component2">
+                    <span>Component 2</span>
+                </Case>
+                <Default>
+                    <span>Nothing!</span>
+                </Default>
+            </Switch>
+        );
+    }
+}

--- a/types/react-switch-case/tsconfig.json
+++ b/types/react-switch-case/tsconfig.json
@@ -10,7 +10,8 @@
         "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
     },
     "files": ["index.d.ts", "react-switch-case-tests.tsx"]
 }

--- a/types/react-switch-case/tsconfig.json
+++ b/types/react-switch-case/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "react-switch-case-tests.tsx"]
+}

--- a/types/react-switch-case/tslint.json
+++ b/types/react-switch-case/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
... removed

If removing a declaration:
... removed
