### PR TITLE
react-native: Implement refs for AnimatedComponents

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -36,6 +36,7 @@
 //                 André Krüger <https://github.com/akrger>
 //                 Jérémy Barbet <https://github.com/jeremybarbet>
 //                 Christian Ost <https://github.com/ca057>
+//                 David Sheldrick <https://github.com/ds300>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -8314,11 +8315,17 @@ export interface EasingStatic {
     inOut(easing: EasingFunction): EasingFunction;
 }
 
+// We need to alias these views so we can reference them in the Animated
+// namespace where their names are shadowed.
+declare const _View: typeof View;
+declare const _Image: typeof Image;
+declare const _Text: typeof Text;
+declare const _ScrollView: typeof ScrollView;
+declare const _FlatList: typeof FlatList;
+declare const _SectionList: typeof SectionList;
 export namespace Animated {
     type AnimatedValue = Value;
     type AnimatedValueXY = ValueXY;
-
-    type Base = Animated;
 
     class Animated {
         // Internal class, no public API.
@@ -8637,6 +8644,8 @@ export namespace Animated {
 
     export type ComponentProps<T> = T extends React.ComponentType<infer P> | React.Component<infer P> ? P : never;
 
+    export type LegacyRef<C> = { getNode(): C };
+
     export interface WithAnimatedValue<T>
         extends ThisType<
             T extends object
@@ -8646,31 +8655,31 @@ export namespace Animated {
                 : T | Value | AnimatedInterpolation
         > {}
 
-    export type AnimatedProps<T> = { [key in keyof T]: WithAnimatedValue<T[key]> };
+    export type AnimatedProps<T> = { [key in keyof T]: WithAnimatedValue<T[key]> } &
+        (T extends {
+            ref?: React.Ref<infer R>;
+        }
+            ? { ref?: React.Ref<R | { getNode(): R }> }
+            : {});
 
-    export interface AnimatedComponent<
-        T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>
-    > extends React.FC<AnimatedProps<ComponentProps<T>>> {
-        getNode: () => T;
-    }
+    export interface AnimatedComponent<T extends React.ComponentType<any>>
+        extends React.FC<AnimatedProps<React.ComponentPropsWithRef<T>>> {}
 
     /**
      * Make any React component Animatable.  Used to create `Animated.View`, etc.
      */
-    export function createAnimatedComponent<
-        T extends React.ComponentType<ComponentProps<T>> | React.Component<ComponentProps<T>>
-    >(component: T): AnimatedComponent<T extends React.ComponentClass<ComponentProps<T>> ? InstanceType<T> : T>;
+    export function createAnimatedComponent<T extends React.ComponentType<any>>(component: T): AnimatedComponent<T>;
 
     /**
      * Animated variants of the basic native views. Accepts Animated.Value for
      * props and style.
      */
-    export const View: AnimatedComponent<View>;
-    export const Image: AnimatedComponent<Image>;
-    export const Text: AnimatedComponent<Text>;
-    export const ScrollView: AnimatedComponent<ScrollView>;
-    export const FlatList: AnimatedComponent<FlatList>;
-    export const SectionList: AnimatedComponent<SectionList>;
+    export const View: AnimatedComponent<typeof _View>;
+    export const Image: AnimatedComponent<typeof _Image>;
+    export const Text: AnimatedComponent<typeof _Text>;
+    export const ScrollView: AnimatedComponent<typeof _ScrollView>;
+    export const FlatList: AnimatedComponent<typeof _FlatList>;
+    export const SectionList: AnimatedComponent<typeof _SectionList>;
 }
 
 // tslint:disable-next-line:interface-name

--- a/types/react-native/test/animated.tsx
+++ b/types/react-native/test/animated.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 
 import { Animated, View, NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
 
+const AnimatedView = Animated.createAnimatedComponent(View);
+
 function TestAnimatedAPI() {
     // Value
     const v1 = new Animated.Value(0);
@@ -88,9 +90,13 @@ function TestAnimatedAPI() {
 
     Animated.event([{ nativeEvent: { contentOffset: { y: v1 } } }], { useNativeDriver: true, listener });
 
+    const ref = React.useRef<View>(null);
+    const legacyRef = React.useRef<Animated.LegacyRef<View>>(null);
+
     return (
-        <View>
+        <View ref={ref}>
             <Animated.View
+                ref={ref}
                 style={[
                     position.getLayout(),
                     {
@@ -98,6 +104,14 @@ function TestAnimatedAPI() {
                     },
                 ]}
             />
+
+            <AnimatedView ref={ref} style={{ top: 3 }}>
+                i has children
+            </AnimatedView>
+
+            <Animated.View ref={legacyRef} />
+
+            <AnimatedView ref={legacyRef} />
 
             <Animated.Image style={position.getTranslateTransform()} source={{ uri: 'https://picsum.photos/200' }} />
         </View>

--- a/types/react-native/test/animated.tsx
+++ b/types/react-native/test/animated.tsx
@@ -159,7 +159,6 @@ function TestAnimatedAPI() {
 
             <AnimatedView ref={legacyRef} />
 
-
             <AnimatedComp ref={AnimatedCompRef} width={v1} />
             <ForwardComp ref={ForwardCompRef} width={1} />
             <AnimatedForwardComp ref={AnimatedForwardCompRef} width={10} />

--- a/types/react-native/test/animated.tsx
+++ b/types/react-native/test/animated.tsx
@@ -2,12 +2,57 @@ import * as React from 'react';
 
 import { Animated, View, NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
 
-const AnimatedView = Animated.createAnimatedComponent(View);
+interface CompProps {
+    width: number;
+}
+
+class Comp extends React.Component<CompProps> {
+    f1: () => boolean = () => true;
+
+    render() {
+        const { width } = this.props;
+        return <View style={{ width }} />;
+    }
+}
+
+const ForwardComp = React.forwardRef<View, CompProps>(({ width }, ref) => {
+    function f1(): boolean {
+        return true;
+    }
+
+    return <View ref={ref} style={{ width }} />;
+});
+
+type X = React.PropsWithoutRef<React.ComponentProps<typeof ForwardComp>>;
 
 function TestAnimatedAPI() {
     // Value
     const v1 = new Animated.Value(0);
     const v2 = new Animated.Value(0);
+
+    // Ref
+    const AnimatedViewRef = React.useRef<View>(null);
+
+    AnimatedViewRef.current &&
+        AnimatedViewRef.current.measure(() => {
+            return;
+        });
+
+    const AnimatedComp = Animated.createAnimatedComponent(Comp);
+
+    const AnimatedCompRef = React.useRef<Comp>(null);
+
+    AnimatedCompRef.current && AnimatedCompRef.current.f1();
+
+    const AnimatedForwardComp = Animated.createAnimatedComponent(ForwardComp);
+
+    const AnimatedForwardCompRef = React.useRef<React.ElementRef<typeof ForwardComp>>(null);
+    const ForwardCompRef = React.useRef<View>(null);
+
+    AnimatedForwardCompRef.current &&
+        AnimatedForwardCompRef.current.measure(() => {
+            return;
+        });
 
     v1.setValue(0.1);
 
@@ -90,6 +135,7 @@ function TestAnimatedAPI() {
 
     Animated.event([{ nativeEvent: { contentOffset: { y: v1 } } }], { useNativeDriver: true, listener });
 
+    const AnimatedView = Animated.createAnimatedComponent(View);
     const ref = React.useRef<View>(null);
     const legacyRef = React.useRef<Animated.LegacyRef<View>>(null);
 
@@ -113,6 +159,10 @@ function TestAnimatedAPI() {
 
             <AnimatedView ref={legacyRef} />
 
+
+            <AnimatedComp ref={AnimatedCompRef} width={v1} />
+            <ForwardComp ref={ForwardCompRef} width={1} />
+            <AnimatedForwardComp ref={AnimatedForwardCompRef} width={10} />
             <Animated.Image style={position.getTranslateTransform()} source={{ uri: 'https://picsum.photos/200' }} />
         </View>
     );


### PR DESCRIPTION
Fixes #42806.
This PR replaces #43484 

Typings for the `ref` prop on animated components were not previously implemented.

There was a static `getNode` method added to `AnimatedComponent` types which implies that an attempt had been made to give a type for the `ref` prop, since `ref` is the only place `getNode` appears. I've removed it from the static method position and added it in the correct place.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/commit/66e72bb4e00aafbcb9f450ed5db261d98f99f82a
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
