### PR TITLE
parse-numeric-range uses export=

### DIFF
--- a/types/parse-numeric-range/index.d.ts
+++ b/types/parse-numeric-range/index.d.ts
@@ -7,4 +7,5 @@
  * Parses expressions like `1-10,20-30`. Returns an energetic (as opposed to lazy) array.
  * @param expression a numeric range expression
  */
-export function parse(expression: string): number[];
+declare function parse(expression: string): number[];
+export = parse;

--- a/types/parse-numeric-range/parse-numeric-range-tests.ts
+++ b/types/parse-numeric-range/parse-numeric-range-tests.ts
@@ -1,4 +1,4 @@
-import { parse } from 'parse-numeric-range';
+import parse = require('parse-numeric-range');
 
 // $ExpectType number[]
 parse('');


### PR DESCRIPTION
The lint rules finally caught the error when parse-numeric-range@1.2 started shipping commonjs modules instead of es modules.

Previously parse-numeric-range assumed it would be consumed by a bundler that expected ES modules.