### PR TITLE
Additions to CodeMirror definitions

### DIFF
--- a/types/codemirror/addon/comment/comment.d.ts
+++ b/types/codemirror/addon/comment/comment.d.ts
@@ -7,10 +7,9 @@
 
 // Todo: add 'toggleComment' command, once command type definitions exist in main definitions
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
-
+declare module 'codemirror' {
     interface Editor {
         /** Tries to uncomment the current selection, and if that fails, line-comments it. */
         toggleComment(options?: CommentOptions): void;

--- a/types/codemirror/addon/display/autorefresh.d.ts
+++ b/types/codemirror/addon/display/autorefresh.d.ts
@@ -5,9 +5,9 @@
 
 // See docs https://codemirror.net/doc/manual.html#addon_autorefresh
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
+declare module 'codemirror' {
     interface EditorConfiguration {
         // if true, it will be refreshed the first time the editor becomes visible.
         // you can pass delay (msec) time as polling duration

--- a/types/codemirror/addon/display/panel.d.ts
+++ b/types/codemirror/addon/display/panel.d.ts
@@ -5,9 +5,9 @@
 
 // See docs https://codemirror.net/doc/manual.html#addon_panel
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
+declare module 'codemirror' {
     interface Panel {
         /**Removes the panel from the editor */
         clear(): void;
@@ -16,13 +16,13 @@ declare module "codemirror" {
     }
 
     interface ShowPanelOptions {
-        /**Controls the position of the newly added panel. The following values are recognized:  
-         * `top` (default): Adds the panel at the very top.  
-         *  `after-top`: Adds the panel at the bottom of the top panels.  
-         *  `bottom`: Adds the panel at the very bottom.  
-         *  `before-bottom`: Adds the panel at the top of the bottom panels.  
-        */
-        position?: "top" | "after-top" | "bottom" | "before-bottom";
+        /**Controls the position of the newly added panel. The following values are recognized:
+         * `top` (default): Adds the panel at the very top.
+         *  `after-top`: Adds the panel at the bottom of the top panels.
+         *  `bottom`: Adds the panel at the very bottom.
+         *  `before-bottom`: Adds the panel at the top of the bottom panels.
+         */
+        position?: 'top' | 'after-top' | 'bottom' | 'before-bottom';
         /**The new panel will be added before the given panel. */
         before?: Panel;
         /**The new panel will be added after the given panel. */
@@ -34,7 +34,6 @@ declare module "codemirror" {
     }
 
     interface Editor {
-
         /**
          * Places a DOM node above or below an editor and shrinks the editor to make room for the node.
          * When using the `after`, `before` or `replace` options, if the panel doesn't exists or has been removed, the value of the `position` option will be used as a fallback.
@@ -42,6 +41,5 @@ declare module "codemirror" {
          * @param options optional options object
          */
         addPanel(node: HTMLElement, options?: ShowPanelOptions): Panel;
-
     }
 }

--- a/types/codemirror/addon/display/placeholder.d.ts
+++ b/types/codemirror/addon/display/placeholder.d.ts
@@ -5,9 +5,9 @@
 
 // See docs https://codemirror.net/doc/manual.html#addon_placeholder
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
+declare module 'codemirror' {
     interface EditorConfiguration {
         /**
          * Adds a placeholder option that can be used to make content appear in the editor when it is empty and not focused.

--- a/types/codemirror/addon/edit/closebrackets.d.ts
+++ b/types/codemirror/addon/edit/closebrackets.d.ts
@@ -5,9 +5,9 @@
 
 // See docs https://codemirror.net/doc/manual.html#addon_closebrackets
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
+declare module 'codemirror' {
     interface AutoCloseBrackets {
         /**
          * String containing pairs of matching characters.

--- a/types/codemirror/addon/edit/closetag.d.ts
+++ b/types/codemirror/addon/edit/closetag.d.ts
@@ -5,9 +5,9 @@
 
 // See docs https://codemirror.net/doc/manual.html#addon_closetag
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
+declare module 'codemirror' {
     interface CommandActions {
         closeTag(cm: CodeMirror.Editor): void;
     }
@@ -34,7 +34,7 @@ declare module "codemirror" {
          * closing line to be indented. (default is block tags for HTML, none for XML)
          */
         indentTags?: Array<string>;
-        
+
         /**
          * An array of XML tag names that should be autoclosed with '/>'. (default is none)
          */

--- a/types/codemirror/addon/edit/matchbrackets.d.ts
+++ b/types/codemirror/addon/edit/matchbrackets.d.ts
@@ -5,9 +5,9 @@
 
 // See docs https://codemirror.net/doc/manual.html#addon_matchbrackets
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
+declare module 'codemirror' {
     interface MatchBrackets {
         /**
          * Only use the character after the start position, never the one before it.

--- a/types/codemirror/addon/edit/matchtags.d.ts
+++ b/types/codemirror/addon/edit/matchtags.d.ts
@@ -5,9 +5,9 @@
 
 // See docs https://codemirror.net/doc/manual.html#addon_matchtags
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
+declare module 'codemirror' {
     interface CommandActions {
         /**
          * You can bind a key to in order to jump to the tag matching the one under the cursor.

--- a/types/codemirror/addon/hint/show-hint.d.ts
+++ b/types/codemirror/addon/hint/show-hint.d.ts
@@ -7,9 +7,9 @@
 
 // See docs https://codemirror.net/doc/manual.html#addon_show-hint
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
+declare module 'codemirror' {
     /** Provides a framework for showing autocompletion hints. Defines editor.showHint, which takes an optional
     options object, and pops up a widget that allows the user to select a completion. Finding hints is done with
     a hinting functions (the hint option), which is a function that take an editor instance and options object,
@@ -61,8 +61,8 @@ declare module "codemirror" {
         closeOnUnfocus?: boolean;
         completeOnSingleClick?: boolean;
         container?: HTMLElement | null;
-        customKeys?: {[key: string]: ((editor: Editor, handle: Handle) => void) | string} | null;
-        extraKeys?: {[key: string]: ((editor: Editor, handle: Handle) => void) | string} | null;
+        customKeys?: { [key: string]: ((editor: Editor, handle: Handle) => void) | string } | null;
+        extraKeys?: { [key: string]: ((editor: Editor, handle: Handle) => void) | string } | null;
     }
 
     /** The Handle used to interact with the autocomplete dialog box.*/

--- a/types/codemirror/addon/merge/merge.d.ts
+++ b/types/codemirror/addon/merge/merge.d.ts
@@ -5,9 +5,9 @@
 
 // See docs https://github.com/codemirror/CodeMirror/blob/master/addon/merge/merge.js
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
+declare module 'codemirror' {
     interface CommandActions {
         /** Move cursor to the next diff */
         goNextDiff(cm: CodeMirror.Editor): void;

--- a/types/codemirror/addon/runmode/runmode.d.ts
+++ b/types/codemirror/addon/runmode/runmode.d.ts
@@ -5,10 +5,9 @@
 
 // See docs https://codemirror.net/doc/manual.html#addon_runmode
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
-
+declare module 'codemirror' {
     /**
      * Runs a CodeMirror mode over text without opening an editor instance.
      *
@@ -20,5 +19,12 @@ declare module "codemirror" {
      *               If it is a DOM node, the tokens will be converted to span elements as in an editor,
      *               and inserted into the node (through innerHTML).
      */
-    function runMode(text: string, mode: any, callback: (HTMLElement | ((text: string, style?: string | null, row?: number, column?: number, state?: any) => void)), options? : { tabSize?: number; state?: any; }): void;
+    function runMode(
+        text: string,
+        mode: any,
+        callback:
+            | HTMLElement
+            | ((text: string, style?: string | null, row?: number, column?: number, state?: any) => void),
+        options?: { tabSize?: number; state?: any },
+    ): void;
 }

--- a/types/codemirror/addon/scroll/scrollpastend.d.ts
+++ b/types/codemirror/addon/scroll/scrollpastend.d.ts
@@ -5,9 +5,9 @@
 
 // See docs https://github.com/codemirror/CodeMirror/blob/master/addon/scroll/scrollpastend.js
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
+declare module 'codemirror' {
     interface EditorConfiguration {
         /**
          * When the end of the file is reached it allows you to keep scrolling so that your last few lines of code are not stuck at the bottom of the editor.

--- a/types/codemirror/addon/search/match-highlighter.d.ts
+++ b/types/codemirror/addon/search/match-highlighter.d.ts
@@ -5,9 +5,9 @@
 
 // See docs https://codemirror.net/doc/manual.html#addon_match-highlighter
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
+declare module 'codemirror' {
     interface HighlightSelectionMatches {
         /**
          * Minimum amount of selected characters that triggers a highlight (default 2).
@@ -30,15 +30,15 @@ declare module "codemirror" {
         showToken?: boolean | RegExp;
 
         /**
-         * Used to specify how much time to wait, in milliseconds, before highlighting the matches. 
+         * Used to specify how much time to wait, in milliseconds, before highlighting the matches.
          */
-        delay: 100,
+        delay: 100;
 
         /**
          * If wordsOnly is enabled, the matches will be highlighted only if the selected text is a word.
          */
         wordsOnly?: boolean;
-        
+
         /**
          * If annotateScrollbar is enabled, the occurences will be highlighted on the scrollbar via the matchesonscrollbar addon.
          */

--- a/types/codemirror/addon/search/searchcursor.d.ts
+++ b/types/codemirror/addon/search/searchcursor.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: jacqt <https://github.com/jacqt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
+declare module 'codemirror' {
     interface Doc {
         /** This method can be used to implement search/replace functionality.
          *  `query`: This can be a regular * expression or a string (only strings will match across lines -
@@ -39,7 +39,6 @@ declare module "codemirror" {
         /** Only valid when the last call to find, findNext, or findPrevious did not return false. Returns {line, ch}
          * objects pointing the end of the match. */
         to(): Position;
-
 
         /** Replaces the currently found match with the given text and adjusts the cursor position to reflect the deplacement. */
         replace(text: string, origin?: string): void;

--- a/types/codemirror/addon/selection/active-line.d.ts
+++ b/types/codemirror/addon/selection/active-line.d.ts
@@ -5,9 +5,9 @@
 
 // See docs https://codemirror.net/doc/manual.html#active-line
 
-import * as CodeMirror from "codemirror";
+import * as CodeMirror from 'codemirror';
 
-declare module "codemirror" {
+declare module 'codemirror' {
     interface StyleActiveLine {
         /**
          * Controls whether single-line selections, or just cursor selections, are styled. Defaults to false (only cursor selections).

--- a/types/codemirror/addon/tern/tern.d.ts
+++ b/types/codemirror/addon/tern/tern.d.ts
@@ -6,25 +6,27 @@
 // See docs https://codemirror.net/doc/manual.html#addon_tern and https://codemirror.net/addon/tern/tern.js (comments in the beginning of the file)
 // Docs for tern itself might also be helpful: http://ternjs.net/doc/manual.html
 
-import * as CodeMirror from "codemirror";
-import * as Tern from "tern";
+import * as CodeMirror from 'codemirror';
+import * as Tern from 'tern';
 
-declare module "codemirror" {
-
+declare module 'codemirror' {
     interface TernServer {
         readonly options: TernOptions;
         readonly docs: {
             readonly [key: string]: {
-                doc: CodeMirror.Doc,
-                name: string,
+                doc: CodeMirror.Doc;
+                name: string;
                 changed?: {
-                    from: CodeMirror.Position | number,
-                    to: CodeMirror.Position | number
-                }
-            }
+                    from: CodeMirror.Position | number;
+                    to: CodeMirror.Position | number;
+                };
+            };
         };
         readonly server: Tern.Server;
-        addDoc(name: string, doc: CodeMirror.Doc): { doc: CodeMirror.Doc, name: string, changed: { from: number, to: number } | null };
+        addDoc(
+            name: string,
+            doc: CodeMirror.Doc,
+        ): { doc: CodeMirror.Doc; name: string; changed: { from: number; to: number } | null };
         delDoc(id: string | CodeMirror.Editor | CodeMirror.Doc): void;
         hideDoc(id: string | CodeMirror.Editor | CodeMirror.Doc): void;
         complete(cm: CodeMirror.Doc): void;
@@ -35,19 +37,29 @@ declare module "codemirror" {
         jumpBack(cm: CodeMirror.Doc): void;
         rename(cm: CodeMirror.Doc): void;
         selectName(cm: CodeMirror.Doc): void;
-        request<Q extends Tern.Query>(cm: CodeMirror.Doc, query: Q, callback: (error?: Error, data?: Tern.QueryRegistry[Q["type"]]["result"]) => void, pos?: CodeMirror.Position): void;
-        request<Q extends Tern.Query["type"]>(cm: CodeMirror.Doc, query: Q, callback: (error?: Error, data?: Tern.QueryRegistry[Q]["result"]) => void, pos?: CodeMirror.Position): void;
+        request<Q extends Tern.Query>(
+            cm: CodeMirror.Doc,
+            query: Q,
+            callback: (error?: Error, data?: Tern.QueryRegistry[Q['type']]['result']) => void,
+            pos?: CodeMirror.Position,
+        ): void;
+        request<Q extends Tern.Query['type']>(
+            cm: CodeMirror.Doc,
+            query: Q,
+            callback: (error?: Error, data?: Tern.QueryRegistry[Q]['result']) => void,
+            pos?: CodeMirror.Position,
+        ): void;
         destroy(): void;
     }
 
     interface TernConstructor {
-        new(options?: TernOptions): TernServer;
+        new (options?: TernOptions): TernServer;
     }
     export const TernServer: TernConstructor;
 
     interface TernOptions {
         /** An object mapping plugin names to configuration options. */
-        plugins?: Tern.ConstructorOptions["plugins"];
+        plugins?: Tern.ConstructorOptions['plugins'];
         /** An array of JSON definition data structures. */
         defs?: Tern.Def[];
         /**
@@ -75,7 +87,13 @@ declare module "codemirror" {
         /** Like completionTip, but for the tooltips shown for type queries. */
         typeTip?(data: Tern.TypeQueryResult): string | HTMLElement | null;
         /** This function will be applied to the Tern responses before treating them */
-        responseFilter?(doc: CodeMirror.Doc, query: Tern.Query, request: Tern.Document, error: Error | undefined, data: Tern.QueryRegistry[Tern.Query["type"]]["result"] | undefined): any;
+        responseFilter?(
+            doc: CodeMirror.Doc,
+            query: Tern.Query,
+            request: Tern.Document,
+            error: Error | undefined,
+            data: Tern.QueryRegistry[Tern.Query['type']]['result'] | undefined,
+        ): any;
         /**
          * Set to true to enable web worker mode. You'll probably
          * want to feature detect the actual value you use here, for example
@@ -92,5 +110,4 @@ declare module "codemirror" {
          */
         workerDeps?: string[];
     }
-
 }

--- a/types/codemirror/codemirror-tests.ts
+++ b/types/codemirror/codemirror-tests.ts
@@ -1,0 +1,7 @@
+import * as CodeMirror from 'codemirror';
+import 'codemirror/mode/meta';
+
+const a = CodeMirror.findModeByMIME('foo');
+const b = CodeMirror.findModeByExtension('foo');
+const c = CodeMirror.findModeByFileName('foo');
+const d = CodeMirror.findModeByName('foo');

--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -15,13 +15,16 @@ export = CodeMirror;
 export as namespace CodeMirror;
 
 declare function CodeMirror(host: HTMLElement, options?: CodeMirror.EditorConfiguration): CodeMirror.Editor;
-declare function CodeMirror(callback: (host: HTMLElement) => void , options?: CodeMirror.EditorConfiguration): CodeMirror.Editor;
+declare function CodeMirror(
+    callback: (host: HTMLElement) => void,
+    options?: CodeMirror.EditorConfiguration,
+): CodeMirror.Editor;
 
 declare namespace CodeMirror {
-    export var Doc : CodeMirror.DocConstructor;
+    export var Doc: CodeMirror.DocConstructor;
     export var Pos: CodeMirror.PositionConstructor;
     export var StringStream: CodeMirror.StringStreamConstructor;
-    export var Pass: {toString(): "CodeMirror.PASS"};
+    export var Pass: { toString(): 'CodeMirror.PASS' };
 
     /** Find the column position at a given string index using a given tabsize. */
     function countColumn(line: string, index: number | null, tabSize: number): number;
@@ -75,7 +78,7 @@ declare namespace CodeMirror {
     function registerHelper(namespace: string, name: string, helper: any): void;
 
     /** Given a state object, returns a {state, mode} object with the inner mode and its state for the current position. */
-    function innerMode(mode: Mode<any>, state: any): { state: any, mode: Mode<any> };
+    function innerMode(mode: Mode<any>, state: any): { state: any; mode: Mode<any> };
 
     /** Sometimes, it is useful to add or override mode object properties from external code.
     The CodeMirror.extendMode function can be used to add properties to mode objects produced for a specific mode.
@@ -88,55 +91,79 @@ declare namespace CodeMirror {
 
     /** Fired whenever a change occurs to the document. changeObj has a similar type as the object passed to the editor's "change" event,
     but it never has a next property, because document change events are not batched (whereas editor change events are). */
-    function on(doc: Doc, eventName: 'change', handler: (instance: Doc, changeObj: EditorChange) => void ): void;
-    function off(doc: Doc, eventName: 'change', handler: (instance: Doc, changeObj: EditorChange) => void ): void;
+    function on(doc: Doc, eventName: 'change', handler: (instance: Doc, changeObj: EditorChange) => void): void;
+    function off(doc: Doc, eventName: 'change', handler: (instance: Doc, changeObj: EditorChange) => void): void;
 
     /** See the description of the same event on editor instances. */
-    function on(doc: Doc, eventName: 'beforeChange', handler: (instance: Doc, change: EditorChangeCancellable) => void ): void;
-    function off(doc: Doc, eventName: 'beforeChange', handler: (instance: Doc, change: EditorChangeCancellable) => void ): void;
+    function on(
+        doc: Doc,
+        eventName: 'beforeChange',
+        handler: (instance: Doc, change: EditorChangeCancellable) => void,
+    ): void;
+    function off(
+        doc: Doc,
+        eventName: 'beforeChange',
+        handler: (instance: Doc, change: EditorChangeCancellable) => void,
+    ): void;
 
     /** Fired whenever the cursor or selection in this document changes. */
-    function on(doc: Doc, eventName: 'cursorActivity', handler: (instance: CodeMirror.Editor) => void ): void;
-    function off(doc: Doc, eventName: 'cursorActivity', handler: (instance: CodeMirror.Editor) => void ): void;
+    function on(doc: Doc, eventName: 'cursorActivity', handler: (instance: CodeMirror.Editor) => void): void;
+    function off(doc: Doc, eventName: 'cursorActivity', handler: (instance: CodeMirror.Editor) => void): void;
 
     /** Equivalent to the event by the same name as fired on editor instances. */
-    function on(doc: Doc, eventName: 'beforeSelectionChange', handler: (instance: CodeMirror.Editor, selection: { head: Position; anchor: Position; }) => void ): void;
-    function off(doc: Doc, eventName: 'beforeSelectionChange', handler: (instance: CodeMirror.Editor, selection: { head: Position; anchor: Position; }) => void ): void;
+    function on(
+        doc: Doc,
+        eventName: 'beforeSelectionChange',
+        handler: (instance: CodeMirror.Editor, selection: { head: Position; anchor: Position }) => void,
+    ): void;
+    function off(
+        doc: Doc,
+        eventName: 'beforeSelectionChange',
+        handler: (instance: CodeMirror.Editor, selection: { head: Position; anchor: Position }) => void,
+    ): void;
 
     /** Will be fired when the line object is deleted. A line object is associated with the start of the line.
     Mostly useful when you need to find out when your gutter markers on a given line are removed. */
-    function on(line: LineHandle, eventName: 'delete', handler: () => void ): void;
-    function off(line: LineHandle, eventName: 'delete', handler: () => void ): void;
+    function on(line: LineHandle, eventName: 'delete', handler: () => void): void;
+    function off(line: LineHandle, eventName: 'delete', handler: () => void): void;
 
     /** Fires when the line's text content is changed in any way (but the line is not deleted outright).
     The change object is similar to the one passed to change event on the editor object. */
-    function on(line: LineHandle, eventName: 'change', handler: (line: LineHandle, changeObj: EditorChange) => void ): void;
-    function off(line: LineHandle, eventName: 'change', handler: (line: LineHandle, changeObj: EditorChange) => void ): void;
+    function on(
+        line: LineHandle,
+        eventName: 'change',
+        handler: (line: LineHandle, changeObj: EditorChange) => void,
+    ): void;
+    function off(
+        line: LineHandle,
+        eventName: 'change',
+        handler: (line: LineHandle, changeObj: EditorChange) => void,
+    ): void;
 
     /** Fired when the cursor enters the marked range. From this event handler, the editor state may be inspected but not modified,
     with the exception that the range on which the event fires may be cleared. */
-    function on(marker: TextMarker, eventName: 'beforeCursorEnter', handler: () => void ): void;
-    function off(marker: TextMarker, eventName: 'beforeCursorEnter', handler: () => void ): void;
+    function on(marker: TextMarker, eventName: 'beforeCursorEnter', handler: () => void): void;
+    function off(marker: TextMarker, eventName: 'beforeCursorEnter', handler: () => void): void;
 
     /** Fired when the range is cleared, either through cursor movement in combination with clearOnEnter or through a call to its clear() method.
     Will only be fired once per handle. Note that deleting the range through text editing does not fire this event,
     because an undo action might bring the range back into existence. */
-    function on(marker: TextMarker, eventName: 'clear', handler: () => void ): void;
-    function off(marker: TextMarker, eventName: 'clear', handler: () => void ): void;
+    function on(marker: TextMarker, eventName: 'clear', handler: () => void): void;
+    function off(marker: TextMarker, eventName: 'clear', handler: () => void): void;
 
     /** Fired when the last part of the marker is removed from the document by editing operations. */
-    function on(marker: TextMarker, eventName: 'hide', handler: () => void ): void;
-    function off(marker: TextMarker, eventName: 'hide', handler: () => void ): void;
+    function on(marker: TextMarker, eventName: 'hide', handler: () => void): void;
+    function off(marker: TextMarker, eventName: 'hide', handler: () => void): void;
 
     /** Fired when, after the marker was removed by editing, a undo operation brought the marker back. */
-    function on(marker: TextMarker, eventName: 'unhide', handler: () => void ): void;
-    function off(marker: TextMarker, eventName: 'unhide', handler: () => void ): void;
+    function on(marker: TextMarker, eventName: 'unhide', handler: () => void): void;
+    function off(marker: TextMarker, eventName: 'unhide', handler: () => void): void;
 
     /** Fired whenever the editor re-adds the widget to the DOM. This will happen once right after the widget is added (if it is scrolled into view),
     and then again whenever it is scrolled out of view and back in again, or when changes to the editor options
     or the line the widget is on require the widget to be redrawn. */
-    function on(line: LineWidget, eventName: 'redraw', handler: () => void ): void;
-    function off(line: LineWidget, eventName: 'redraw', handler: () => void ): void;
+    function on(line: LineWidget, eventName: 'redraw', handler: () => void): void;
+    function off(line: LineWidget, eventName: 'redraw', handler: () => void): void;
 
     /** Various CodeMirror-related objects emit events, which allow client code to react to various situations.
     Handlers for such events can be registered with the on and off methods on the objects that the event fires on.
@@ -146,7 +173,22 @@ declare namespace CodeMirror {
     /** Modify a keymap to normalize modifier order and properly recognize multi-stroke bindings. */
     function normalizeKeyMap(km: KeyMap): KeyMap;
 
-    type DOMEvent = 'mousedown' | 'dblclick' | 'touchstart' | 'contextmenu' | 'keydown' | 'keypress' | 'keyup' | 'cut' | 'copy' | 'paste' | 'dragstart' | 'dragenter' | 'dragover' | 'dragleave' | 'drop';
+    type DOMEvent =
+        | 'mousedown'
+        | 'dblclick'
+        | 'touchstart'
+        | 'contextmenu'
+        | 'keydown'
+        | 'keypress'
+        | 'keyup'
+        | 'cut'
+        | 'copy'
+        | 'paste'
+        | 'dragstart'
+        | 'dragenter'
+        | 'dragover'
+        | 'dragleave'
+        | 'drop';
 
     type CoordsMode = 'window' | 'page' | 'local' | 'div';
 
@@ -170,7 +212,6 @@ declare namespace CodeMirror {
     /** Methods prefixed with doc. can, unless otherwise specified, be called both on CodeMirror (editor) instances and
     CodeMirror.Doc instances. Thus, the Editor interface extends Doc. **/
     interface Editor extends Doc {
-
         /** Tells you whether the editor currently has focus. */
         hasFocus(): boolean;
 
@@ -179,11 +220,20 @@ declare namespace CodeMirror {
         Will return a position that is produced by moving amount times the distance specified by unit.
         When visually is true , motion in right - to - left text will be visual rather than logical.
         When the motion was clipped by hitting the end or start of the document, the returned value will have a hitSide property set to true. */
-        findPosH(start: CodeMirror.Position, amount: number, unit: string, visually: boolean): { line: number; ch: number; hitSide?: boolean; };
+        findPosH(
+            start: CodeMirror.Position,
+            amount: number,
+            unit: string,
+            visually: boolean,
+        ): { line: number; ch: number; hitSide?: boolean };
 
         /** Similar to findPosH , but used for vertical motion.unit may be "line" or "page".
         The other arguments and the returned value have the same interpretation as they have in findPosH. */
-        findPosV(start: CodeMirror.Position, amount: number, unit: string): { line: number; ch: number; hitSide?: boolean; };
+        findPosV(
+            start: CodeMirror.Position,
+            amount: number,
+            unit: string,
+        ): { line: number; ch: number; hitSide?: boolean };
 
         /** Returns the start and end of the 'word' (the stretch of letters, whitespace, or punctuation) at the given position. */
         findWordAt(pos: CodeMirror.Position): CodeMirror.Range;
@@ -215,7 +265,6 @@ declare namespace CodeMirror {
         /** Pass this the exact argument passed for the mode parameter to addOverlay to remove an overlay again. */
         removeOverlay(mode: any): void;
 
-
         /** Retrieve the currently active document from an editor. */
         getDoc(): CodeMirror.Doc;
 
@@ -236,7 +285,11 @@ declare namespace CodeMirror {
         /** Set the cursor position. You can either pass a single {line, ch} object, or the line and the character as two separate parameters.
         Will replace all selections with a single, empty selection at the given position.
         The supported options are the same as for setSelection */
-        setCursor(pos: CodeMirror.Position | number, ch?: number, options?: { bias?: number, origin?: string, scroll?: boolean }): void;
+        setCursor(
+            pos: CodeMirror.Position | number,
+            ch?: number,
+            options?: { bias?: number; origin?: string; scroll?: boolean },
+        ): void;
 
         /** Sets the gutter marker for the given gutter (identified by its CSS class, see the gutters option) to the given value.
         Value can be either null, to clear the marker, or a DOM element, to set it. The DOM element will be shown in the specified gutter next to the specified line. */
@@ -268,7 +321,9 @@ declare namespace CodeMirror {
         heightAtLine(line: any, mode?: CoordsMode, includeWidgets?: boolean): number;
 
         /** Returns the line number, text content, and marker status of the given line, which can be either a number or a line handle. */
-        lineInfo(line: any): {
+        lineInfo(
+            line: any,
+        ): {
             line: any;
             handle: any;
             text: string;
@@ -292,7 +347,6 @@ declare namespace CodeMirror {
         Note that the widget node will become a descendant of nodes with CodeMirror-specific CSS classes, and those classes might in some cases affect it. */
         addLineWidget(line: any, node: HTMLElement, options?: CodeMirror.LineWidgetOptions): CodeMirror.LineWidget;
 
-
         /** Programatically set the size of the editor (overriding the applicable CSS rules).
         width and height height can be either numbers(interpreted as pixels) or CSS units ("100%", for example).
         You can pass null for either of them to indicate that that dimension should not be changed. */
@@ -311,39 +365,45 @@ declare namespace CodeMirror {
 
         /** Scrolls the given element into view. pos is a { left , top , right , bottom } object, in editor-local coordinates.
         The margin parameter is optional. When given, it indicates the amount of pixels around the given area that should be made visible as well. */
-        scrollIntoView(pos: { left: number; top: number; right: number; bottom: number; }, margin?: number): void;
+        scrollIntoView(pos: { left: number; top: number; right: number; bottom: number }, margin?: number): void;
 
         /** Scrolls the given element into view. pos is a { line, ch } object, in editor-local coordinates.
         The margin parameter is optional. When given, it indicates the amount of pixels around the given area that should be made visible as well. */
-        scrollIntoView(pos: { line: number, ch: number }, margin?: number): void;
+        scrollIntoView(pos: { line: number; ch: number }, margin?: number): void;
 
         /** Scrolls the given element into view. pos is a { from, to } object, in editor-local coordinates.
         The margin parameter is optional. When given, it indicates the amount of pixels around the given area that should be made visible as well. */
-        scrollIntoView(pos: { from: CodeMirror.Position, to: CodeMirror.Position }, margin?: number): void;
+        scrollIntoView(pos: { from: CodeMirror.Position; to: CodeMirror.Position }, margin?: number): void;
 
         /** Returns an { left , top , bottom } object containing the coordinates of the cursor position.
         If mode is "local", they will be relative to the top-left corner of the editable document.
         If it is "page" or not given, they are relative to the top-left corner of the page.
         where is a boolean indicating whether you want the start(true) or the end(false) of the selection. */
-        cursorCoords(where?: boolean, mode?: CoordsMode): { left: number; top: number; bottom: number; };
+        cursorCoords(where?: boolean, mode?: CoordsMode): { left: number; top: number; bottom: number };
 
         /** Returns an { left , top , bottom } object containing the coordinates of the cursor position.
         If mode is "local", they will be relative to the top-left corner of the editable document.
         If it is "page" or not given, they are relative to the top-left corner of the page.
         where specifies the precise position at which you want to measure. */
-        cursorCoords(where?: CodeMirror.Position | null, mode?: CoordsMode): { left: number; top: number; bottom: number; };
+        cursorCoords(
+            where?: CodeMirror.Position | null,
+            mode?: CoordsMode,
+        ): { left: number; top: number; bottom: number };
 
         /** Returns the position and dimensions of an arbitrary character. pos should be a { line , ch } object.
         If mode is "local", they will be relative to the top-left corner of the editable document.
         If it is "page" or not given, they are relative to the top-left corner of the page.
         This differs from cursorCoords in that it'll give the size of the whole character,
         rather than just the position that the cursor would have when it would sit at that position. */
-        charCoords(pos: CodeMirror.Position, mode?: CoordsMode): { left: number; right: number; top: number; bottom: number; };
+        charCoords(
+            pos: CodeMirror.Position,
+            mode?: CoordsMode,
+        ): { left: number; right: number; top: number; bottom: number };
 
         /** Given an { left , top } object , returns the { line , ch } position that corresponds to it.
         The optional mode parameter determines relative to what the coordinates are interpreted.
         It may be "window", "page" (the default), or "local". */
-        coordsChar(object: { left: number; top: number; }, mode?: CoordsMode): CodeMirror.Position;
+        coordsChar(object: { left: number; top: number }, mode?: CoordsMode): CodeMirror.Position;
 
         /** Returns the line height of the default font for the editor. */
         defaultTextHeight(): number;
@@ -384,7 +444,7 @@ declare namespace CodeMirror {
         If you need to perform a lot of operations on a CodeMirror instance, you can call this method with a function argument.
         It will call the function, buffering up all changes, and only doing the expensive update after the function returns.
         This can be a lot faster. The return value from this method will be the return value of your function. */
-        operation<T>(fn: ()=> T): T;
+        operation<T>(fn: () => T): T;
 
         /** In normal circumstances, use the above operation method. But if you want to buffer operations happening asynchronously, or that can't all be wrapped in a callback
         function, you can call startOperation to tell CodeMirror to start buffering changes, and endOperation to actually render all the updates. Be careful: if you use this
@@ -426,119 +486,181 @@ declare namespace CodeMirror {
         getGutterElement(): HTMLElement;
 
         /** Fires every time the content of the editor is changed. */
-        on(eventName: 'change', handler: (instance: CodeMirror.Editor, changeObj: CodeMirror.EditorChangeLinkedList) => void ): void;
-        off(eventName: 'change', handler: (instance: CodeMirror.Editor, changeObj: CodeMirror.EditorChangeLinkedList) => void ): void;
+        on(
+            eventName: 'change',
+            handler: (instance: CodeMirror.Editor, changeObj: CodeMirror.EditorChangeLinkedList) => void,
+        ): void;
+        off(
+            eventName: 'change',
+            handler: (instance: CodeMirror.Editor, changeObj: CodeMirror.EditorChangeLinkedList) => void,
+        ): void;
 
         /** Like the "change" event, but batched per operation, passing an
          * array containing all the changes that happened in the operation.
          * This event is fired after the operation finished, and display
          * changes it makes will trigger a new operation. */
-        on(eventName: 'changes', handler: (instance: CodeMirror.Editor, changes: CodeMirror.EditorChangeLinkedList[]) => void ): void;
-        off(eventName: 'changes', handler: (instance: CodeMirror.Editor, changes: CodeMirror.EditorChangeLinkedList[]) => void ): void;
+        on(
+            eventName: 'changes',
+            handler: (instance: CodeMirror.Editor, changes: CodeMirror.EditorChangeLinkedList[]) => void,
+        ): void;
+        off(
+            eventName: 'changes',
+            handler: (instance: CodeMirror.Editor, changes: CodeMirror.EditorChangeLinkedList[]) => void,
+        ): void;
 
         /** This event is fired before a change is applied, and its handler may choose to modify or cancel the change.
         The changeObj never has a next property, since this is fired for each individual change, and not batched per operation.
         Note: you may not do anything from a "beforeChange" handler that would cause changes to the document or its visualization.
         Doing so will, since this handler is called directly from the bowels of the CodeMirror implementation,
         probably cause the editor to become corrupted. */
-        on(eventName: 'beforeChange', handler: (instance: CodeMirror.Editor, changeObj: CodeMirror.EditorChangeCancellable) => void ): void;
-        off(eventName: 'beforeChange', handler: (instance: CodeMirror.Editor, changeObj: CodeMirror.EditorChangeCancellable) => void ): void;
+        on(
+            eventName: 'beforeChange',
+            handler: (instance: CodeMirror.Editor, changeObj: CodeMirror.EditorChangeCancellable) => void,
+        ): void;
+        off(
+            eventName: 'beforeChange',
+            handler: (instance: CodeMirror.Editor, changeObj: CodeMirror.EditorChangeCancellable) => void,
+        ): void;
 
         /** Will be fired when the cursor or selection moves, or any change is made to the editor content. */
-        on(eventName: 'cursorActivity', handler: (instance: CodeMirror.Editor) => void ): void;
-        off(eventName: 'cursorActivity', handler: (instance: CodeMirror.Editor) => void ): void;
+        on(eventName: 'cursorActivity', handler: (instance: CodeMirror.Editor) => void): void;
+        off(eventName: 'cursorActivity', handler: (instance: CodeMirror.Editor) => void): void;
 
         /** Fired after a key is handled through a key map. name is the name of the handled key (for example "Ctrl-X" or "'q'"), and event is the DOM keydown or keypress event. */
-        on(eventName: 'keyHandled', handler: (instance: CodeMirror.Editor, name: string, event: KeyboardEvent) => void ): void;
-        off(eventName: 'keyHandled', handler: (instance: CodeMirror.Editor, name: string, event: KeyboardEvent) => void ): void;
+        on(
+            eventName: 'keyHandled',
+            handler: (instance: CodeMirror.Editor, name: string, event: KeyboardEvent) => void,
+        ): void;
+        off(
+            eventName: 'keyHandled',
+            handler: (instance: CodeMirror.Editor, name: string, event: KeyboardEvent) => void,
+        ): void;
 
         /** Fired whenever new input is read from the hidden textarea (typed or pasted by the user). */
-        on(eventName: 'inputRead', handler: (instance: CodeMirror.Editor, changeObj: EditorChange) => void ): void;
-        off(eventName: 'inputRead', handler: (instance: CodeMirror.Editor, changeObj: EditorChange) => void ): void;
+        on(eventName: 'inputRead', handler: (instance: CodeMirror.Editor, changeObj: EditorChange) => void): void;
+        off(eventName: 'inputRead', handler: (instance: CodeMirror.Editor, changeObj: EditorChange) => void): void;
 
         /** Fired if text input matched the mode's electric patterns, and this caused the line's indentation to change. */
-        on(eventName: 'electricInput', handler: (instance: CodeMirror.Editor, line: number) => void ): void;
-        off(eventName: 'electricInput', handler: (instance: CodeMirror.Editor, line: number) => void ): void;
+        on(eventName: 'electricInput', handler: (instance: CodeMirror.Editor, line: number) => void): void;
+        off(eventName: 'electricInput', handler: (instance: CodeMirror.Editor, line: number) => void): void;
 
         /** This event is fired before the selection is moved. Its handler may modify the resulting selection head and anchor.
         Handlers for this event have the same restriction as "beforeChange" handlers they should not do anything to directly update the state of the editor. */
-        on(eventName: 'beforeSelectionChange', handler: (instance: CodeMirror.Editor, selection: { head: CodeMirror.Position; anchor: CodeMirror.Position; }) => void ): void;
-        off(eventName: 'beforeSelectionChange', handler: (instance: CodeMirror.Editor, selection: { head: CodeMirror.Position; anchor: CodeMirror.Position; }) => void ): void;
+        on(
+            eventName: 'beforeSelectionChange',
+            handler: (
+                instance: CodeMirror.Editor,
+                selection: { head: CodeMirror.Position; anchor: CodeMirror.Position },
+            ) => void,
+        ): void;
+        off(
+            eventName: 'beforeSelectionChange',
+            handler: (
+                instance: CodeMirror.Editor,
+                selection: { head: CodeMirror.Position; anchor: CodeMirror.Position },
+            ) => void,
+        ): void;
 
         /** Fires whenever the view port of the editor changes (due to scrolling, editing, or any other factor).
         The from and to arguments give the new start and end of the viewport. */
-        on(eventName: 'viewportChange', handler: (instance: CodeMirror.Editor, from: number, to: number) => void ): void;
-        off(eventName: 'viewportChange', handler: (instance: CodeMirror.Editor, from: number, to: number) => void ): void;
+        on(eventName: 'viewportChange', handler: (instance: CodeMirror.Editor, from: number, to: number) => void): void;
+        off(
+            eventName: 'viewportChange',
+            handler: (instance: CodeMirror.Editor, from: number, to: number) => void,
+        ): void;
 
         /** This is signalled when the editor's document is replaced using the swapDoc method. */
-        on(eventName: 'swapDoc', handler: (instance: CodeMirror.Editor, oldDoc: CodeMirror.Doc) => void ): void;
-        off(eventName: 'swapDoc', handler: (instance: CodeMirror.Editor, oldDoc: CodeMirror.Doc) => void ): void;
+        on(eventName: 'swapDoc', handler: (instance: CodeMirror.Editor, oldDoc: CodeMirror.Doc) => void): void;
+        off(eventName: 'swapDoc', handler: (instance: CodeMirror.Editor, oldDoc: CodeMirror.Doc) => void): void;
 
         /** Fires when the editor gutter (the line-number area) is clicked. Will pass the editor instance as first argument,
         the (zero-based) number of the line that was clicked as second argument, the CSS class of the gutter that was clicked as third argument,
         and the raw mousedown event object as fourth argument. */
-        on(eventName: 'gutterClick', handler: (instance: CodeMirror.Editor, line: number, gutter: string, clickEvent: MouseEvent) => void ): void;
-        off(eventName: 'gutterClick', handler: (instance: CodeMirror.Editor, line: number, gutter: string, clickEvent: MouseEvent) => void ): void;
+        on(
+            eventName: 'gutterClick',
+            handler: (instance: CodeMirror.Editor, line: number, gutter: string, clickEvent: MouseEvent) => void,
+        ): void;
+        off(
+            eventName: 'gutterClick',
+            handler: (instance: CodeMirror.Editor, line: number, gutter: string, clickEvent: MouseEvent) => void,
+        ): void;
 
         /** Fires when the editor gutter (the line-number area) receives a contextmenu event. Will pass the editor instance as first argument,
         the (zero-based) number of the line that was clicked as second argument, the CSS class of the gutter that was clicked as third argument,
         and the raw contextmenu mouse event object as fourth argument. You can preventDefault the event, to signal that CodeMirror should do no
         further handling. */
-        on(eventName: 'gutterContextMenu', handler: (instance: CodeMirror.Editor, line: number, gutter: string, contextMenu: MouseEvent) => void ): void;
-        off(eventName: 'gutterContextMenu', handler: (instance: CodeMirror.Editor, line: number, gutter: string, contextMenu: MouseEvent) => void ): void;
+        on(
+            eventName: 'gutterContextMenu',
+            handler: (instance: CodeMirror.Editor, line: number, gutter: string, contextMenu: MouseEvent) => void,
+        ): void;
+        off(
+            eventName: 'gutterContextMenu',
+            handler: (instance: CodeMirror.Editor, line: number, gutter: string, contextMenu: MouseEvent) => void,
+        ): void;
 
         /** Fires whenever the editor is focused. */
-        on(eventName: 'focus', handler: (instance: CodeMirror.Editor, event: FocusEvent) => void ): void;
-        off(eventName: 'focus', handler: (instance: CodeMirror.Editor, event: FocusEvent) => void ): void;
+        on(eventName: 'focus', handler: (instance: CodeMirror.Editor, event: FocusEvent) => void): void;
+        off(eventName: 'focus', handler: (instance: CodeMirror.Editor, event: FocusEvent) => void): void;
 
         /** Fires whenever the editor is unfocused. */
-        on(eventName: 'blur', handler: (instance: CodeMirror.Editor, event: FocusEvent) => void ): void;
-        off(eventName: 'blur', handler: (instance: CodeMirror.Editor, event: FocusEvent) => void ): void;
+        on(eventName: 'blur', handler: (instance: CodeMirror.Editor, event: FocusEvent) => void): void;
+        off(eventName: 'blur', handler: (instance: CodeMirror.Editor, event: FocusEvent) => void): void;
 
         /** Fires when the editor is scrolled. */
-        on(eventName: 'scroll', handler: (instance: CodeMirror.Editor) => void ): void;
-        off(eventName: 'scroll', handler: (instance: CodeMirror.Editor) => void ): void;
+        on(eventName: 'scroll', handler: (instance: CodeMirror.Editor) => void): void;
+        off(eventName: 'scroll', handler: (instance: CodeMirror.Editor) => void): void;
 
         /** Fires when the editor is refreshed or resized. Mostly useful to invalidate cached values that depend on the editor or character size. */
-        on(eventName: 'refresh', handler: (instance: CodeMirror.Editor) => void ): void;
-        off(eventName: 'refresh', handler: (instance: CodeMirror.Editor) => void ): void;
+        on(eventName: 'refresh', handler: (instance: CodeMirror.Editor) => void): void;
+        off(eventName: 'refresh', handler: (instance: CodeMirror.Editor) => void): void;
 
         /** Dispatched every time an option is changed with setOption. */
-        on(eventName: 'optionChange', handler: (instance: CodeMirror.Editor, option: string) => void ): void;
-        off(eventName: 'optionChange', handler: (instance: CodeMirror.Editor, option: string) => void ): void;
+        on(eventName: 'optionChange', handler: (instance: CodeMirror.Editor, option: string) => void): void;
+        off(eventName: 'optionChange', handler: (instance: CodeMirror.Editor, option: string) => void): void;
 
         /** Fires when the editor tries to scroll its cursor into view. Can be hooked into to take care of additional scrollable containers around the editor. When the event object has its preventDefault method called, CodeMirror will not itself try to scroll the window. */
-        on(eventName: 'scrollCursorIntoView', handler: (instance: CodeMirror.Editor, event: Event) => void ): void;
-        off(eventName: 'scrollCursorIntoView', handler: (instance: CodeMirror.Editor, event: Event) => void ): void;
+        on(eventName: 'scrollCursorIntoView', handler: (instance: CodeMirror.Editor, event: Event) => void): void;
+        off(eventName: 'scrollCursorIntoView', handler: (instance: CodeMirror.Editor, event: Event) => void): void;
 
         /** Will be fired whenever CodeMirror updates its DOM display. */
-        on(eventName: 'update', handler: (instance: CodeMirror.Editor) => void ): void;
-        off(eventName: 'update', handler: (instance: CodeMirror.Editor) => void ): void;
+        on(eventName: 'update', handler: (instance: CodeMirror.Editor) => void): void;
+        off(eventName: 'update', handler: (instance: CodeMirror.Editor) => void): void;
 
         /** Fired whenever a line is (re-)rendered to the DOM. Fired right after the DOM element is built, before it is added to the document.
         The handler may mess with the style of the resulting element, or add event handlers, but should not try to change the state of the editor. */
-        on(eventName: 'renderLine', handler: (instance: CodeMirror.Editor, line: CodeMirror.LineHandle, element: HTMLElement) => void ): void;
-        off(eventName: 'renderLine', handler: (instance: CodeMirror.Editor, line: CodeMirror.LineHandle, element: HTMLElement) => void ): void;
+        on(
+            eventName: 'renderLine',
+            handler: (instance: CodeMirror.Editor, line: CodeMirror.LineHandle, element: HTMLElement) => void,
+        ): void;
+        off(
+            eventName: 'renderLine',
+            handler: (instance: CodeMirror.Editor, line: CodeMirror.LineHandle, element: HTMLElement) => void,
+        ): void;
 
         /** Fires when one of the DOM events fires. */
-        on<K extends DOMEvent & keyof GlobalEventHandlersEventMap>(eventName: K, handler: (instance: CodeMirror.Editor, event: GlobalEventHandlersEventMap[K]) => void ): void;
-        off<K extends DOMEvent & keyof GlobalEventHandlersEventMap>(eventName: K, handler: (instance: CodeMirror.Editor, event: GlobalEventHandlersEventMap[K]) => void ): void;
+        on<K extends DOMEvent & keyof GlobalEventHandlersEventMap>(
+            eventName: K,
+            handler: (instance: CodeMirror.Editor, event: GlobalEventHandlersEventMap[K]) => void,
+        ): void;
+        off<K extends DOMEvent & keyof GlobalEventHandlersEventMap>(
+            eventName: K,
+            handler: (instance: CodeMirror.Editor, event: GlobalEventHandlersEventMap[K]) => void,
+        ): void;
 
         /** Fires when the overwrite flag is flipped. */
-        on(eventName: "overwriteToggle", handler: (instance: CodeMirror.Editor, overwrite: boolean) => void): void;
+        on(eventName: 'overwriteToggle', handler: (instance: CodeMirror.Editor, overwrite: boolean) => void): void;
 
         /** Events are registered with the on method (and removed with the off method).
         These are the events that fire on the instance object. The name of the event is followed by the arguments that will be passed to the handler.
         The instance argument always refers to the editor instance. */
-        on(eventName: string, handler: (instance: CodeMirror.Editor) => void ): void;
-        off(eventName: string, handler: (instance: CodeMirror.Editor) => void ): void;
+        on(eventName: string, handler: (instance: CodeMirror.Editor) => void): void;
+        off(eventName: string, handler: (instance: CodeMirror.Editor) => void): void;
 
         /** Expose the state object, so that the Editor.state.completionActive property is reachable*/
         state: any;
     }
 
     interface EditorFromTextArea extends Editor {
-
         /** Copy the content of the editor into the textarea. */
         save(): void;
 
@@ -597,12 +719,12 @@ declare namespace CodeMirror {
         /** Iterate over the whole document, and call f for each line, passing the line handle.
         This is a faster way to visit a range of line handlers than calling getLineHandle for each of them.
         Note that line handles have a text property containing the line's content (as a string). */
-        eachLine(f: (line: CodeMirror.LineHandle) => void ): void;
+        eachLine(f: (line: CodeMirror.LineHandle) => void): void;
 
         /** Iterate over the range from start up to (not including) end, and call f for each line, passing the line handle.
         This is a faster way to visit a range of line handlers than calling getLineHandle for each of them.
         Note that line handles have a text property containing the line's content (as a string). */
-        eachLine(start: number, end: number, f: (line: CodeMirror.LineHandle) => void ): void;
+        eachLine(start: number, end: number, f: (line: CodeMirror.LineHandle) => void): void;
 
         /** Set the editor content as 'clean', a flag that it will retain until it is edited, and which will be set again
         when such an edit is undone again. Useful to track whether the content needs to be saved. This function is deprecated
@@ -617,7 +739,6 @@ declare namespace CodeMirror {
         /** Returns whether the document is currently clean — not modified since initialization or the last call to markClean if
         no argument is passed, or since the matching call to changeGeneration if a generation value is given. */
         isClean(generation?: number): boolean;
-
 
         /** Get the currently selected code. */
         getSelection(): string;
@@ -644,16 +765,28 @@ declare namespace CodeMirror {
         /** Set the cursor position. You can either pass a single {line, ch} object, or the line and the character as two separate parameters.
         Will replace all selections with a single, empty selection at the given position.
         The supported options are the same as for setSelection */
-        setCursor(pos: CodeMirror.Position | number, ch?: number, options?: { bias?: number, origin?: string, scroll?: boolean }): void;
+        setCursor(
+            pos: CodeMirror.Position | number,
+            ch?: number,
+            options?: { bias?: number; origin?: string; scroll?: boolean },
+        ): void;
 
         /** Set a single selection range. anchor and head should be {line, ch} objects. head defaults to anchor when not given. */
-        setSelection(anchor: CodeMirror.Position, head?: CodeMirror.Position, options?: { bias?: number, origin?: string, scroll?: boolean }): void;
+        setSelection(
+            anchor: CodeMirror.Position,
+            head?: CodeMirror.Position,
+            options?: { bias?: number; origin?: string; scroll?: boolean },
+        ): void;
 
         /** Sets a new set of selections. There must be at least one selection in the given array. When primary is a
         number, it determines which selection is the primary one. When it is not given, the primary index is taken from
         the previous selection, or set to the last range if the previous selection had less ranges than the new one.
         Supports the same options as setSelection. */
-        setSelections(ranges: Array<{ anchor: CodeMirror.Position, head: CodeMirror.Position }>, primary?: number, options?: { bias?: number, origin?: string, scroll?: boolean }): void;
+        setSelections(
+            ranges: Array<{ anchor: CodeMirror.Position; head: CodeMirror.Position }>,
+            primary?: number,
+            options?: { bias?: number; origin?: string; scroll?: boolean },
+        ): void;
 
         /** Similar to setSelection , but will, if shift is held or the extending flag is set,
         move the head of the selection while leaving the anchor at its current place.
@@ -665,10 +798,8 @@ declare namespace CodeMirror {
         in that it will cause cursor movement and calls to extendSelection to leave the selection anchor in place. */
         setExtending(value: boolean): void;
 
-
         /** Retrieve the editor associated with a document. May return null. */
         getEditor(): CodeMirror.Editor | null;
-
 
         /** Create an identical copy of the given doc. When copyHistory is true , the history will also be copied.Can not be called directly on an editor. */
         copy(copyHistory: boolean): CodeMirror.Doc;
@@ -693,7 +824,7 @@ declare namespace CodeMirror {
 
         /** Will call the given function for all documents linked to the target document. It will be passed two arguments,
         the linked document and a boolean indicating whether that document shares history with the target. */
-        iterLinkedDocs(fn: (doc: CodeMirror.Doc, sharedHist: boolean) => void ): void;
+        iterLinkedDocs(fn: (doc: CodeMirror.Doc, sharedHist: boolean) => void): void;
 
         /** Undo one edit (if any undo events are stored). */
         undo(): void;
@@ -702,7 +833,7 @@ declare namespace CodeMirror {
         redo(): void;
 
         /** Returns an object with {undo, redo } properties , both of which hold integers , indicating the amount of stored undo and redo operations. */
-        historySize(): { undo: number; redo: number; };
+        historySize(): { undo: number; redo: number };
 
         /** Clears the editor's undo history. */
         clearHistory(): void;
@@ -714,21 +845,27 @@ declare namespace CodeMirror {
         Note that this will have entirely undefined results if the editor content isn't also the same as it was when getHistory was called. */
         setHistory(history: any): void;
 
-
         /** Can be used to mark a range of text with a specific CSS class name. from and to should be { line , ch } objects. */
-        markText(from: CodeMirror.Position, to: CodeMirror.Position, options?: CodeMirror.TextMarkerOptions): TextMarker;
+        markText(
+            from: CodeMirror.Position,
+            to: CodeMirror.Position,
+            options?: CodeMirror.TextMarkerOptions,
+        ): TextMarker;
 
         /** Inserts a bookmark, a handle that follows the text around it as it is being edited, at the given position.
         A bookmark has two methods find() and clear(). The first returns the current position of the bookmark, if it is still in the document,
         and the second explicitly removes the bookmark. */
-        setBookmark(pos: CodeMirror.Position, options?: {
-            /** Can be used to display a DOM node at the current location of the bookmark (analogous to the replacedWith option to markText). */
-            widget?: HTMLElement;
+        setBookmark(
+            pos: CodeMirror.Position,
+            options?: {
+                /** Can be used to display a DOM node at the current location of the bookmark (analogous to the replacedWith option to markText). */
+                widget?: HTMLElement;
 
-            /** By default, text typed when the cursor is on top of the bookmark will end up to the right of the bookmark.
+                /** By default, text typed when the cursor is on top of the bookmark will end up to the right of the bookmark.
             Set this option to true to make it go to the left instead. */
-            insertLeft?: boolean;
-        }): CodeMirror.TextMarker;
+                insertLeft?: boolean;
+            },
+        ): CodeMirror.TextMarker;
 
         /** Returns an array of all the bookmarks and marked ranges found between the given positions. */
         findMarks(from: CodeMirror.Position, to: CodeMirror.Position): TextMarker[];
@@ -782,7 +919,7 @@ declare namespace CodeMirror {
 
         /** Returns a {from, to} object (both holding document positions), indicating the current position of the marked range,
         or undefined if the marker is no longer in the document. */
-        find(): {from: CodeMirror.Position, to: CodeMirror.Position};
+        find(): { from: CodeMirror.Position; to: CodeMirror.Position };
 
         /**  Called when you've done something that might change the size of the marker and want to cheaply update the display*/
         changed(): void;
@@ -791,20 +928,20 @@ declare namespace CodeMirror {
         getOptions(copyWidget: boolean): CodeMirror.TextMarkerOptions;
 
         /** Fired when the cursor enters the marked range */
-        on(eventName: 'beforeCursorEnter', handler: () =>  void) : void;
-        off(eventName: 'beforeCursorEnter', handler: () => void) : void;
+        on(eventName: 'beforeCursorEnter', handler: () => void): void;
+        off(eventName: 'beforeCursorEnter', handler: () => void): void;
 
         /** Fired when the range is cleared, either through cursor movement in combination with clearOnEnter or through a call to its clear() method */
-        on(eventName: 'clear', handler: (from: Position, to: Position) => void) : void;
-        off(eventName: 'clear', handler: () => void) : void;
+        on(eventName: 'clear', handler: (from: Position, to: Position) => void): void;
+        off(eventName: 'clear', handler: () => void): void;
 
         /** Fired when the last part of the marker is removed from the document by editing operations */
-        on(eventName: 'hide', handler: () => void) : void;
-        off(eventname: 'hide', handler: () => void) : void;
+        on(eventName: 'hide', handler: () => void): void;
+        off(eventname: 'hide', handler: () => void): void;
 
         /** Fired when, after the marker was removed by editing, a undo operation brough the marker back */
-        on(eventName: 'unhide', handler: () => void) : void;
-        off(eventname: 'unhide', handler: () => void) : void;
+        on(eventName: 'unhide', handler: () => void): void;
+        off(eventname: 'unhide', handler: () => void): void;
     }
 
     interface LineWidget {
@@ -880,7 +1017,7 @@ declare namespace CodeMirror {
         sticky?: string;
     }
 
-    type InputStyle = "textarea" | "contenteditable";
+    type InputStyle = 'textarea' | 'contenteditable';
 
     interface EditorConfiguration {
         /** string| The starting value of the editor. Can be a string, or a document object. */
@@ -1047,7 +1184,7 @@ declare namespace CodeMirror {
         /** Indicates how quickly CodeMirror should poll its input textarea for changes(when focused).
         Most input is captured by events, but some things, like IME input on some browsers, don't generate events that allow CodeMirror to properly detect it.
         Thus, it polls. Default is 100 milliseconds. */
-        pollInterval?: number
+        pollInterval?: number;
 
         /** By default, CodeMirror will combine adjacent tokens into a single span if they have the same class.
         This will result in a simpler DOM tree, and thus perform better. With some kinds of styling(such as rounded corners),
@@ -1311,18 +1448,18 @@ declare namespace CodeMirror {
         /**
          * Trigger a reindent whenever one of the characters in the string is typed.
          */
-        electricChars?: string
+        electricChars?: string;
         /**
          * Trigger a reindent whenever the regex matches the part of the line before the cursor.
          */
-        electricinput?: RegExp
+        electricinput?: RegExp;
     }
 
     /**
      * A function that, given a CodeMirror configuration object and an optional mode configuration object, returns a mode object.
      */
     interface ModeFactory<T> {
-        (config: CodeMirror.EditorConfiguration, modeOptions?: any): Mode<T>
+        (config: CodeMirror.EditorConfiguration, modeOptions?: any): Mode<T>;
     }
 
     /**
@@ -1548,7 +1685,12 @@ declare namespace CodeMirror {
      * A function that calls the updateLintingCallback with any errors found during the linting process.
      */
     interface AsyncLinter {
-        (content: string, updateLintingCallback: UpdateLintingCallback, options: LintStateOptions, codeMirror: Editor): void;
+        (
+            content: string,
+            updateLintingCallback: UpdateLintingCallback,
+            options: LintStateOptions,
+            codeMirror: Editor,
+        ): void;
     }
 
     /**
@@ -1572,109 +1714,112 @@ declare namespace CodeMirror {
     /**
      * A function that calculates either a two-way or three-way merge between different sets of content.
      */
-    function MergeView(element: HTMLElement, options?: MergeView.MergeViewEditorConfiguration): MergeView.MergeViewEditor;
+    function MergeView(
+        element: HTMLElement,
+        options?: MergeView.MergeViewEditorConfiguration,
+    ): MergeView.MergeViewEditor;
 
     namespace MergeView {
-      /**
-       * Options available to MergeView.
-       */
-      interface MergeViewEditorConfiguration extends EditorConfiguration {
-          /**
-           * Determines whether the original editor allows editing. Defaults to false.
-           */
-          allowEditingOriginals?: boolean;
+        /**
+         * Options available to MergeView.
+         */
+        interface MergeViewEditorConfiguration extends EditorConfiguration {
+            /**
+             * Determines whether the original editor allows editing. Defaults to false.
+             */
+            allowEditingOriginals?: boolean;
 
-          /**
-           * When true stretches of unchanged text will be collapsed. When a number is given, this indicates the amount
-           * of lines to leave visible around such stretches (which defaults to 2). Defaults to false.
-           */
-          collapseIdentical?: boolean | number;
+            /**
+             * When true stretches of unchanged text will be collapsed. When a number is given, this indicates the amount
+             * of lines to leave visible around such stretches (which defaults to 2). Defaults to false.
+             */
+            collapseIdentical?: boolean | number;
 
-          /**
-           * Sets the style used to connect changed chunks of code. By default, connectors are drawn. When this is set to "align",
-           * the smaller chunk is padded to align with the bigger chunk instead.
-           */
-          connect?: string;
+            /**
+             * Sets the style used to connect changed chunks of code. By default, connectors are drawn. When this is set to "align",
+             * the smaller chunk is padded to align with the bigger chunk instead.
+             */
+            connect?: string;
 
-          /**
-           * Callback for when stretches of unchanged text are collapsed.
-           */
-          onCollapse?(mergeView: MergeViewEditor, line: number, size: number, mark: TextMarker): void;
+            /**
+             * Callback for when stretches of unchanged text are collapsed.
+             */
+            onCollapse?(mergeView: MergeViewEditor, line: number, size: number, mark: TextMarker): void;
 
-          /**
-           * Provides original version of the document to be shown on the right of the editor.
-           */
-          orig: any;
+            /**
+             * Provides original version of the document to be shown on the right of the editor.
+             */
+            orig: any;
 
-          /**
-           * Provides original version of the document to be shown on the left of the editor.
-           * To create a 2-way (as opposed to 3-way) merge view, provide only one of origLeft and origRight.
-           */
-          origLeft?: any;
+            /**
+             * Provides original version of the document to be shown on the left of the editor.
+             * To create a 2-way (as opposed to 3-way) merge view, provide only one of origLeft and origRight.
+             */
+            origLeft?: any;
 
-          /**
-           * Provides original version of document to be shown on the right of the editor.
-           * To create a 2-way (as opposed to 3-way) merge view, provide only one of origLeft and origRight.
-           */
-          origRight?: any;
+            /**
+             * Provides original version of document to be shown on the right of the editor.
+             * To create a 2-way (as opposed to 3-way) merge view, provide only one of origLeft and origRight.
+             */
+            origRight?: any;
 
-          /**
-           * Determines whether buttons that allow the user to revert changes are shown. Defaults to true.
-           */
-          revertButtons?: boolean;
+            /**
+             * Determines whether buttons that allow the user to revert changes are shown. Defaults to true.
+             */
+            revertButtons?: boolean;
 
-          /**
-           * When true, changed pieces of text are highlighted. Defaults to true.
-           */
-          showDifferences?: boolean;
-      }
+            /**
+             * When true, changed pieces of text are highlighted. Defaults to true.
+             */
+            showDifferences?: boolean;
+        }
 
-      interface MergeViewEditor extends Editor {
-          /**
-           * Returns the editor instance.
-           */
-          editor(): Editor;
+        interface MergeViewEditor extends Editor {
+            /**
+             * Returns the editor instance.
+             */
+            editor(): Editor;
 
-          /**
-           * Left side of the merge view.
-           */
-          left: DiffView;
-          leftChunks(): MergeViewDiffChunk[];
-          leftOriginal(): Editor;
+            /**
+             * Left side of the merge view.
+             */
+            left: DiffView;
+            leftChunks(): MergeViewDiffChunk[];
+            leftOriginal(): Editor;
 
-          /**
-           * Right side of the merge view.
-           */
-          right: DiffView;
-          rightChunks(): MergeViewDiffChunk[];
-          rightOriginal(): Editor;
+            /**
+             * Right side of the merge view.
+             */
+            right: DiffView;
+            rightChunks(): MergeViewDiffChunk[];
+            rightOriginal(): Editor;
 
-          /**
-           * Sets whether or not the merge view should show the differences between the editor views.
-           */
-          setShowDifferences(showDifferences: boolean): void;
-      }
+            /**
+             * Sets whether or not the merge view should show the differences between the editor views.
+             */
+            setShowDifferences(showDifferences: boolean): void;
+        }
 
-      /**
-       * Tracks changes in chunks from oroginal to new.
-       */
-      interface MergeViewDiffChunk {
-          editFrom: number;
-          editTo: number;
-          origFrom: number;
-          origTo: number;
-      }
+        /**
+         * Tracks changes in chunks from oroginal to new.
+         */
+        interface MergeViewDiffChunk {
+            editFrom: number;
+            editTo: number;
+            origFrom: number;
+            origTo: number;
+        }
 
-      interface DiffView {
-          /**
-           * Forces the view to reload.
-           */
-          forceUpdate(): (mode: string) => void;
+        interface DiffView {
+            /**
+             * Forces the view to reload.
+             */
+            forceUpdate(): (mode: string) => void;
 
-          /**
-           * Sets whether or not the merge view should show the differences between the editor views.
-           */
-          setShowDifferences(showDifferences: boolean): void;
-      }
+            /**
+             * Sets whether or not the merge view should show the differences between the editor views.
+             */
+            setShowDifferences(showDifferences: boolean): void;
+        }
     }
 }

--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -8,6 +8,7 @@
 //                 ysulyma <https://github.com/ysulyma>
 //                 azoson <https://github.com/azoson>
 //                 kylesferrazza <https://github.com/kylesferrazza>
+//                 koddsson <https://github.com/koddsson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 

--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -460,6 +460,9 @@ declare namespace CodeMirror {
         "subtract" Reduce the indentation of the line. */
         indentLine(line: number, dir?: string): void;
 
+        /** Indent a selection */
+        indentSelection(how: string): void;
+
         /** Tells you whether the editor's content can be edited by the user. */
         isReadOnly(): boolean;
 
@@ -677,6 +680,9 @@ declare namespace CodeMirror {
     }
 
     interface Doc {
+        /** Get the mode option **/
+        modeOption: any;
+
         /** Get the current editor content. You can pass it an optional argument to specify the string to be used to separate lines (defaults to "\n"). */
         getValue(seperator?: string): string;
 

--- a/types/codemirror/mode/meta.d.ts
+++ b/types/codemirror/mode/meta.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for codemirror
+// Project: https://github.com/marijnh/CodeMirror
+// Definitions by: koddsson <https://github.com/koddsson>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.2
+
+import * as CodeMirror from 'codemirror';
+
+interface MimeType {
+    name: string;
+    mime?: string;
+    mimes?: string;
+    mode: string;
+    file?: RegExp;
+    ext?: string[];
+    alias?: string[];
+}
+
+declare module 'codemirror' {
+    const modeInfo: MimeType[];
+    function findModeByMIME(mime: string): MimeType;
+    function findModeByExtension(ext: string): MimeType;
+    function findModeByFileName(filename: string): MimeType;
+    function findModeByName(name: string): MimeType;
+}

--- a/types/codemirror/test/addon/comment/comment.ts
+++ b/types/codemirror/test/addon/comment/comment.ts
@@ -1,17 +1,17 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/comment/comment";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/comment/comment';
 
 const editor = CodeMirror(document.body);
 const position: CodeMirror.Position = { ch: 0, line: 0 };
 const opt: CodeMirror.CommentOptions = {
-    blockCommentEnd: "*/",
-    blockCommentStart: "/*",
-    blockCommentLead: "*",
+    blockCommentEnd: '*/',
+    blockCommentStart: '/*',
+    blockCommentLead: '*',
     commentBlankLines: true,
     fullLines: true,
     indent: true,
-    lineComment: "//",
-    padding: " "
+    lineComment: '//',
+    padding: ' ',
 };
 editor.toggleComment(opt);
 editor.blockComment(position, position, opt);

--- a/types/codemirror/test/addon/display/autorefresh.ts
+++ b/types/codemirror/test/addon/display/autorefresh.ts
@@ -1,6 +1,6 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/display/autorefresh";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/display/autorefresh';
 
 const myCodeMirror: CodeMirror.Editor = CodeMirror(document.body, {
-    autoRefresh: true
+    autoRefresh: true,
 });

--- a/types/codemirror/test/addon/display/panel.ts
+++ b/types/codemirror/test/addon/display/panel.ts
@@ -1,16 +1,16 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/display/panel";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/display/panel';
 
 const cm: CodeMirror.Editor = CodeMirror(document.body);
 
 const panel1 = cm.addPanel(document.body);
 
 const panel2: CodeMirror.Panel = cm.addPanel(document.body, {
-    position: "top",
+    position: 'top',
     after: panel1,
     before: panel1,
     replace: panel1,
-    stable: true
+    stable: true,
 });
 
 panel2.changed();

--- a/types/codemirror/test/addon/display/placeholder.ts
+++ b/types/codemirror/test/addon/display/placeholder.ts
@@ -1,6 +1,6 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/display/placeholder";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/display/placeholder';
 
 const myCodeMirror: CodeMirror.Editor = CodeMirror(document.body, {
-    placeholder: "placeholder"
+    placeholder: 'placeholder',
 });

--- a/types/codemirror/test/addon/edit/closebrackets.ts
+++ b/types/codemirror/test/addon/edit/closebrackets.ts
@@ -1,10 +1,10 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/edit/closebrackets";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/edit/closebrackets';
 
 const myCodeMirror: CodeMirror.Editor = CodeMirror(document.body, {
-    autoCloseBrackets: "()[]{}''\"\""
+    autoCloseBrackets: '()[]{}\'\'""',
 });
 
 const myCodeMirror2: CodeMirror.Editor = CodeMirror(document.body, {
-    autoCloseBrackets: true
+    autoCloseBrackets: true,
 });

--- a/types/codemirror/test/addon/edit/closetag.ts
+++ b/types/codemirror/test/addon/edit/closetag.ts
@@ -1,6 +1,6 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/edit/closetag";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/edit/closetag';
 
 const myCodeMirror: CodeMirror.Editor = CodeMirror(document.body, {
-    autoCloseTags: true
+    autoCloseTags: true,
 });

--- a/types/codemirror/test/addon/edit/matchbrackets.ts
+++ b/types/codemirror/test/addon/edit/matchbrackets.ts
@@ -1,6 +1,6 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/edit/matchbrackets";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/edit/matchbrackets';
 
 const myCodeMirror: CodeMirror.Editor = CodeMirror(document.body, {
-    matchBrackets: true
+    matchBrackets: true,
 });

--- a/types/codemirror/test/addon/edit/matchtags.ts
+++ b/types/codemirror/test/addon/edit/matchtags.ts
@@ -1,6 +1,6 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/edit/matchtags";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/edit/matchtags';
 
 const myCodeMirror: CodeMirror.Editor = CodeMirror(document.body, {
-    matchTags: { bothTags: true}
+    matchTags: { bothTags: true },
 });

--- a/types/codemirror/test/addon/hint/show-hint.ts
+++ b/types/codemirror/test/addon/hint/show-hint.ts
@@ -1,14 +1,14 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/hint/show-hint";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/hint/show-hint';
 
-const cm = CodeMirror(document.body, {value: 'text'});
+const cm = CodeMirror(document.body, { value: 'text' });
 const pos = new CodeMirror.Pos(2, 3);
 CodeMirror.showHint(cm);
 CodeMirror.showHint(cm, function (cm) {
     return {
         from: pos,
-        list: ["one", "two"],
-        to: pos
+        list: ['one', 'two'],
+        to: pos,
     };
 });
 CodeMirror.showHint(cm, function (cm) {
@@ -16,33 +16,33 @@ CodeMirror.showHint(cm, function (cm) {
         from: pos,
         list: [
             {
-                text: "disp1",
-                render: function (el, self, data) {
-                    ;
-                }
+                text: 'disp1',
+                render: function (el, self, data) {},
             },
             {
-                className: "class2",
-                displayText: "disp2",
+                className: 'class2',
+                displayText: 'disp2',
                 from: pos,
                 to: pos,
-                text: "sometext"
-            }
+                text: 'sometext',
+            },
         ],
-        to: pos
+        to: pos,
     };
 });
-const asyncHintFunc : CodeMirror.AsyncHintFunction =
-    (cm: CodeMirror.Editor, callback: (hints: CodeMirror.Hints) => any) => {
-        callback({
-            from: pos,
-            list: ["one", "two"],
-            to: pos
-        });
-    };
+const asyncHintFunc: CodeMirror.AsyncHintFunction = (
+    cm: CodeMirror.Editor,
+    callback: (hints: CodeMirror.Hints) => any,
+) => {
+    callback({
+        from: pos,
+        list: ['one', 'two'],
+        to: pos,
+    });
+};
 asyncHintFunc.async = true;
 
 cm.showHint({
     completeSingle: false,
-    hint: asyncHintFunc
-})
+    hint: asyncHintFunc,
+});

--- a/types/codemirror/test/addon/runmode/runmode.ts
+++ b/types/codemirror/test/addon/runmode/runmode.ts
@@ -1,7 +1,7 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/runmode/runmode";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/runmode/runmode';
 
-const query = "SELECT * FROM Table";
+const query = 'SELECT * FROM Table';
 
-CodeMirror.runMode(query, "text/x-sql", document.body);
-CodeMirror.runMode(query, "text/x-sql", (text, style, row, column, state) => {});
+CodeMirror.runMode(query, 'text/x-sql', document.body);
+CodeMirror.runMode(query, 'text/x-sql', (text, style, row, column, state) => {});

--- a/types/codemirror/test/addon/scroll/scrollpastend.ts
+++ b/types/codemirror/test/addon/scroll/scrollpastend.ts
@@ -1,6 +1,6 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/scroll/scrollpastend";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/scroll/scrollpastend';
 
 const myCodeMirror: CodeMirror.Editor = CodeMirror(document.body, {
-    scrollPastEnd: true
+    scrollPastEnd: true,
 });

--- a/types/codemirror/test/addon/search/match-highlighter.ts
+++ b/types/codemirror/test/addon/search/match-highlighter.ts
@@ -1,6 +1,6 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/search/match-highlighter";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/search/match-highlighter';
 
 const myCodeMirror: CodeMirror.Editor = CodeMirror(document.body, {
-    highlightSelectionMatches: true
+    highlightSelectionMatches: true,
 });

--- a/types/codemirror/test/addon/search/searchcursor.ts
+++ b/types/codemirror/test/addon/search/searchcursor.ts
@@ -1,16 +1,15 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/search/searchcursor";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/search/searchcursor';
 
 const doc = new CodeMirror.Doc('text some string and another text match');
-let cursor = doc.getSearchCursor('text', new CodeMirror.Pos(0,0), false);
-cursor = doc.getSearchCursor('text', new CodeMirror.Pos(0,0));
+let cursor = doc.getSearchCursor('text', new CodeMirror.Pos(0, 0), false);
+cursor = doc.getSearchCursor('text', new CodeMirror.Pos(0, 0));
 cursor = doc.getSearchCursor('text');
-
 
 cursor.find(false);
 cursor.findNext();
 cursor.findPrevious();
 cursor.from();
 cursor.to();
-cursor.replace("blah");
-cursor.replace("text", "origin");
+cursor.replace('blah');
+cursor.replace('text', 'origin');

--- a/types/codemirror/test/addon/selection/active-line.ts
+++ b/types/codemirror/test/addon/selection/active-line.ts
@@ -1,6 +1,6 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/selection/active-line";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/selection/active-line';
 
 const myCodeMirror: CodeMirror.Editor = CodeMirror(document.body, {
-    styleActiveLine: true
+    styleActiveLine: true,
 });

--- a/types/codemirror/test/addon/tern/tern.ts
+++ b/types/codemirror/test/addon/tern/tern.ts
@@ -1,28 +1,31 @@
-import * as CodeMirror from "codemirror";
-import "codemirror/addon/tern/tern";
+import * as CodeMirror from 'codemirror';
+import 'codemirror/addon/tern/tern';
 
 const cm = CodeMirror(document.body);
 
 const options: CodeMirror.TernOptions = {
-
-    completionTip: (data) => {
+    completionTip: data => {
         const d = data.completions;
-        return "";
+        return '';
     },
 
     showError: (editor, message) => {
         alert(message);
-    }
-
+    },
 };
 
 const ts = new CodeMirror.TernServer(options);
 
-ts.request(cm.getDoc(), "completions", (_e, d) => {
-    if (d) {
-        const c = d.completions;
-    }
-}, { ch: 0, line: 0 });
+ts.request(
+    cm.getDoc(),
+    'completions',
+    (_e, d) => {
+        if (d) {
+            const c = d.completions;
+        }
+    },
+    { ch: 0, line: 0 },
+);
 
 ts.complete(cm.getDoc());
 

--- a/types/codemirror/test/index.ts
+++ b/types/codemirror/test/index.ts
@@ -3,19 +3,25 @@ import CodeMirror = require('codemirror');
 const myCodeMirror: CodeMirror.Editor = CodeMirror(document.body);
 
 const myCodeMirror2: CodeMirror.Editor = CodeMirror(document.body, {
-    value: "function myScript(){return 100;}\n",
-    mode: "javascript",
+    value: 'function myScript(){return 100;}\n',
+    mode: 'javascript',
     extraKeys: {
-        Enter: (cm) => { console.log("save"); },
-        Esc: (cm) => { return CodeMirror.Pass; }
-    }
+        Enter: cm => {
+            console.log('save');
+        },
+        Esc: cm => {
+            return CodeMirror.Pass;
+        },
+    },
 });
 
 // $ExpectError
 const myCodeMirror2_1: CodeMirror.Editor = CodeMirror(document.body, {
     extraKeys: {
-        "Shift-Enter": (cm) => { return 42; }  // not a valid return value
-    }
+        'Shift-Enter': cm => {
+            return 42;
+        }, // not a valid return value
+    },
 });
 
 const range = myCodeMirror2.findWordAt(CodeMirror.Pos(0, 2));
@@ -25,9 +31,12 @@ const from = range.from();
 const to = range.to();
 
 const myTextArea: HTMLTextAreaElement = undefined!;
-const myCodeMirror3: CodeMirror.Editor = CodeMirror(function (elt) {
-    myTextArea.parentNode!.replaceChild(elt, myTextArea);
-}, { value: myTextArea.value });
+const myCodeMirror3: CodeMirror.Editor = CodeMirror(
+    function (elt) {
+        myTextArea.parentNode!.replaceChild(elt, myTextArea);
+    },
+    { value: myTextArea.value },
+);
 
 const myCodeMirror4: CodeMirror.Editor = CodeMirror.fromTextArea(myTextArea);
 
@@ -36,62 +45,64 @@ const doc2: CodeMirror.Doc = CodeMirror(document.body).getDoc();
 
 const lintStateOptions: CodeMirror.LintStateOptions = {
     async: true,
-    hasGutters: true
+    hasGutters: true,
 };
 
 const asyncLintOptions: CodeMirror.LintOptions = {
     async: true,
     hasGutters: true,
-    getAnnotations: (content: string,
-                     updateLintingCallback: CodeMirror.UpdateLintingCallback,
-                     options: CodeMirror.LintStateOptions,
-                     codeMirror: CodeMirror.Editor) => {}
+    getAnnotations: (
+        content: string,
+        updateLintingCallback: CodeMirror.UpdateLintingCallback,
+        options: CodeMirror.LintStateOptions,
+        codeMirror: CodeMirror.Editor,
+    ) => {},
 };
 
 const syncLintOptions: CodeMirror.LintOptions = {
     async: false,
     hasGutters: true,
-    getAnnotations: (content: string,
-                     options: CodeMirror.LintStateOptions,
-                     codeMirror: CodeMirror.Editor): CodeMirror.Annotation[] => { return []; }
+    getAnnotations: (
+        content: string,
+        options: CodeMirror.LintStateOptions,
+        codeMirror: CodeMirror.Editor,
+    ): CodeMirror.Annotation[] => {
+        return [];
+    },
 };
 
-const updateLintingCallback: CodeMirror.UpdateLintingCallback = (codeMirror: CodeMirror.Editor,
-                                                               annotations: CodeMirror.Annotation[]) => {};
+const updateLintingCallback: CodeMirror.UpdateLintingCallback = (
+    codeMirror: CodeMirror.Editor,
+    annotations: CodeMirror.Annotation[],
+) => {};
 
 const annotation: CodeMirror.Annotation = {
     from: {
         ch: 0,
-        line: 0
+        line: 0,
     },
     to: CodeMirror.Pos(1),
-    message: "test",
-    severity: "warning"
+    message: 'test',
+    severity: 'warning',
 };
 
 myCodeMirror.getValue();
-myCodeMirror.getValue("foo")
-myCodeMirror.setValue("bar");
+myCodeMirror.getValue('foo');
+myCodeMirror.setValue('bar');
 
 myCodeMirror.getCursor();
 myCodeMirror.getCursor('from');
 myCodeMirror.setCursor({ ch: 1, line: 0 });
 
-myCodeMirror.on(
-  "renderLine",
-  (instance: CodeMirror.Editor, line: CodeMirror.LineHandle, element: HTMLElement) => { }
-);
+myCodeMirror.on('renderLine', (instance: CodeMirror.Editor, line: CodeMirror.LineHandle, element: HTMLElement) => {});
 
-myCodeMirror.on(
-  "beforeChange",
-  (instance: CodeMirror.Editor, change: CodeMirror.EditorChangeCancellable) => {
+myCodeMirror.on('beforeChange', (instance: CodeMirror.Editor, change: CodeMirror.EditorChangeCancellable) => {
     // $ExpectError
     change.update();
     if (change.update != null) change.update();
-  }
-);
+});
 
-CodeMirror.registerHelper("lint", "javascript", {});
+CodeMirror.registerHelper('lint', 'javascript', {});
 
 myCodeMirror.isReadOnly();
 myCodeMirror.execCommand('selectAll');
@@ -107,7 +118,7 @@ htmlElement2.remove();
 
 CodeMirror.commands.newlineAndIndent(myCodeMirror);
 
-let stringStream = new CodeMirror.StringStream("var myEditor;");
+let stringStream = new CodeMirror.StringStream('var myEditor;');
 
 // Call a method from the CodeMirror.Doc interface to confirm a CodeMirror.Editor extends it
 myCodeMirror.getCursor();

--- a/types/codemirror/tsconfig.json
+++ b/types/codemirror/tsconfig.json
@@ -35,6 +35,7 @@
         "test/addon/search/match-highlighter.ts",
         "test/addon/search/searchcursor.ts",
         "test/addon/selection/active-line.ts",
-        "test/addon/tern/tern.ts"
+        "test/addon/tern/tern.ts",
+        "codemirror-tests.ts"
     ]
 }


### PR DESCRIPTION
I ran `prettier` in order to get to a consistent codestyle and then I did my changes in seperate commits. It might be easier to read this PR commit by commit because of that.



- Add `modeOption` property:
  - https://github.com/codemirror/CodeMirror/blob/master/src/model/Doc.js#L37
- Add `indentSelection` function:
  - https://github.com/codemirror/CodeMirror/blob/master/src/edit/methods.js#L97
- Add defintions for `codemirror/mode/meta`
  - https://github.com/codemirror/CodeMirror/blob/master/mode/meta.js

I tried running the tests or linting but I just get errors? Not sure if I'm doing anything wrong there.