### PR TITLE
[@types/react-table] Update groupByID property

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -594,7 +594,7 @@ export interface UseGroupByColumnProps<D extends object> {
 
 export interface UseGroupByRowProps<D extends object> {
     isGrouped: boolean;
-    groupById: IdType<D>;
+    groupByID: IdType<D>;
     groupByVal: string;
     values: Record<IdType<D>, AggregatedValue>;
     subRows: Array<Row<D>>;


### PR DESCRIPTION
I believe this is a typo and it should be uppercase ID this is the line the type is referring about 


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tannerlinsley/react-table/blob/master/src/plugin-hooks/useGroupBy.js#L311
