### PR TITLE
@types/dinero.js: change toJson -> toJSON

### DIFF
--- a/types/dinero.js/dinero.js-tests.ts
+++ b/types/dinero.js/dinero.js-tests.ts
@@ -88,7 +88,7 @@ number = dinero.toUnit();
 number = dinero.toRoundedUnit(1);
 number = dinero.toRoundedUnit(1, 'HALF_EVEN');
 dineroObject = dinero.toObject();
-dineroObject = dinero.toJson();
+dineroObject = dinero.toJSON();
 dineroArr = Dinero.normalizePrecision([
     Dinero({amount: 100, precision: 2}),
     Dinero({amount: 1000, precision: 3}),

--- a/types/dinero.js/index.d.ts
+++ b/types/dinero.js/index.d.ts
@@ -63,7 +63,7 @@ declare namespace DineroFactory {
         toUnit(): number;
         toRoundedUnit(digits: number, roundingMode?: RoundingMode): number;
         toObject(): DineroObject;
-        toJson(): DineroObject;
+        toJSON(): DineroObject;
     }
 
     type RoundingMode =


### PR DESCRIPTION
@BendingBender & @juandaco, the dinero.js method to convert objects to json in the source is spelled as ```toJSON```, but in the type definitions it's ```toJson```, which throws an error. It has been ```toJSON``` since v1.6 which is the version the type definitions were written against.  