### PR TITLE
Make Vimeo request() generic to optionally type results

### DIFF
--- a/types/vimeo/index.d.ts
+++ b/types/vimeo/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: Matthew Leffler <https://github.com/mattleff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export type CompleteCallback<T = object> = (
+export type CompleteCallback = (
     err: string | undefined,
-    result: undefined | T,
+    result: any,
     statusCode?: number,
     headers?: object
 ) => void;
@@ -59,8 +59,7 @@ export class Vimeo {
      *                                  `host`, `port`, `query` or `headers`.
      * @param callback  Called when complete, `function (err, json)`.
      */
-    // tslint:disable-next-line no-unnecessary-generics
-    request<T>(url: string | RequestOptions, callback: CompleteCallback<T>): void;
+    request(url: string | RequestOptions, callback: CompleteCallback): void;
 
     /**
      * Set a user access token to be used with library requests.

--- a/types/vimeo/index.d.ts
+++ b/types/vimeo/index.d.ts
@@ -3,11 +3,11 @@
 // Definitions by: Matthew Leffler <https://github.com/mattleff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export type CompleteCallback = (
+export type CompleteCallback<T = object> = (
     err: string | undefined,
-    result: undefined | object,
+    result: undefined | T,
     statusCode?: number,
-    headers?: object,
+    headers?: object
 ) => void;
 
 export type ProgressCallback = (bytesUploaded: number, bytesTotal: number) => void;
@@ -59,7 +59,8 @@ export class Vimeo {
      *                                  `host`, `port`, `query` or `headers`.
      * @param callback  Called when complete, `function (err, json)`.
      */
-    request(url: string | RequestOptions, callback: CompleteCallback): void;
+    // tslint:disable-next-line no-unnecessary-generics
+    request<T>(url: string | RequestOptions, callback: CompleteCallback<T>): void;
 
     /**
      * Set a user access token to be used with library requests.

--- a/types/vimeo/tsconfig.json
+++ b/types/vimeo/tsconfig.json
@@ -17,6 +17,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "vimeo-tests.ts"
     ]
 }

--- a/types/vimeo/vimeo-tests.ts
+++ b/types/vimeo/vimeo-tests.ts
@@ -39,10 +39,10 @@ client.request('', completeHandler);
 client.request('', completeHandlerShort);
 
 // $ExpectType void
-client.request<string>('', (err: string | undefined, result: string | undefined) => {});
+client.request('', (err: string | undefined, result: string | undefined) => {});
 
 // $ExpectType void
-client.request<{ thing: string }>('', (err: string | undefined, result: { thing: string } | undefined) => {});
+client.request('', (err: string | undefined, result: { thing: string } | undefined) => {});
 
 const requestOptions: RequestOptions = {
     method: 'GET',
@@ -60,7 +60,7 @@ const requestOptionsFull: RequestOptions = {
 };
 
 // $ExpectType void
-client.request<string>(requestOptionsFull, (err: string | undefined, result: string | undefined) => {});
+client.request(requestOptionsFull, (err: string | undefined, result: string | undefined) => {});
 
 // $ExpectType Vimeo
 const clientWithoutAccessToken = new Vimeo('', '');

--- a/types/vimeo/vimeo-tests.ts
+++ b/types/vimeo/vimeo-tests.ts
@@ -1,0 +1,78 @@
+import { RequestOptions, Vimeo } from 'vimeo';
+
+const errorHandler = (e: string) => {};
+const uriHandler = (uri: string) => {};
+const progressHandler = (bytesUploaded: number, bytesTotal: number) => {};
+const completeHandler = (
+    err: string | undefined,
+    result: undefined | object,
+    statusCode?: number,
+    headers?: object,
+) => {};
+const completeHandlerShort = (err: string | undefined, result: undefined | object) => {};
+
+// $ExpectType Vimeo
+const client = new Vimeo('', '', '');
+
+// $ExpectType void
+client.upload('', {}, uriHandler, undefined, errorHandler);
+
+// $ExpectType void
+client.upload('', {}, uriHandler, progressHandler, errorHandler);
+
+// $ExpectType void
+client.upload('', uriHandler, undefined, errorHandler);
+
+// $ExpectType void
+client.upload('', uriHandler, progressHandler, errorHandler);
+
+// $ExpectType void
+client.replace('', '', {}, uriHandler, undefined, errorHandler);
+
+// $ExpectType void
+client.replace('', '', {}, uriHandler, progressHandler, errorHandler);
+
+// $ExpectType void
+client.request('', completeHandler);
+
+// $ExpectType void
+client.request('', completeHandlerShort);
+
+// $ExpectType void
+client.request<string>('', (err: string | undefined, result: string | undefined) => {});
+
+// $ExpectType void
+client.request<{ thing: string }>('', (err: string | undefined, result: { thing: string } | undefined) => {});
+
+const requestOptions: RequestOptions = {
+    method: 'GET',
+    path: '/videos/123',
+};
+
+// $ExpectType void
+client.request(requestOptions, completeHandler);
+
+const requestOptionsFull: RequestOptions = {
+    method: 'GET',
+    path: '/videos/123',
+    headers: {},
+    query: 'thing=thing2',
+};
+
+// $ExpectType void
+client.request<string>(requestOptionsFull, (err: string | undefined, result: string | undefined) => {});
+
+// $ExpectType Vimeo
+const clientWithoutAccessToken = new Vimeo('', '');
+
+// $ExpectType void
+clientWithoutAccessToken.setAccessToken('');
+
+// $ExpectType void
+clientWithoutAccessToken.accessToken('', '', completeHandler);
+
+// $ExpectType void
+clientWithoutAccessToken.buildAuthorizationEndpoint('', '', '');
+
+// $ExpectType void
+clientWithoutAccessToken.buildAuthorizationEndpoint('', [''], '');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
