### PR TITLE
feat(react-svg-map,svg-maps__usa): add new declarations

### DIFF
--- a/types/react-svg-map/index.d.ts
+++ b/types/react-svg-map/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-svg-map 2.1.0
+// Type definitions for react-svg-map 2.1
 // Project: https://github.com/VictorCazanave/react-svg-map
 // Definitions by: Nick Glazer <https://github.com/nickglazer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-svg-map/index.d.ts
+++ b/types/react-svg-map/index.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for react-svg-map 2.1.0
+// Project: https://github.com/VictorCazanave/react-svg-map
+// Definitions by: Nick Glazer <https://github.com/nickglazer>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from "react";
+
+export interface Location {
+    path: string;
+    id: string;
+    name?: string;
+}
+
+export interface Map {
+    viewBox: string;
+    locations: Location[];
+    label?: string;
+}
+
+export interface BaseMapProps {
+    map: Map;
+    className?: string;
+    locationClassName?: string | ((...args: any[]) => any);
+    onLocationMouseOver?: (...args: any[]) => any;
+    onLocationMouseOut?: (...args: any[]) => any;
+    onLocationMouseMove?: (...args: any[]) => any;
+    onLocationFocus?: (...args: any[]) => any;
+    onLocationBlur?: (...args: any[]) => any;
+    childrenBefore?: React.ReactElement;
+    childrenAfter?: React.ReactElement;
+}
+
+export interface SVGMapProps extends BaseMapProps {
+    role?: string;
+    locationTabIndex?: string | ((...args: any[]) => any);
+    locationRole?: string;
+    onLocationClick?: (...args: any[]) => any;
+    onLocationKeyDown?: (...args: any[]) => any;
+    isLocationSelected?: (...args: any[]) => any;
+}
+
+export interface OnChangeMapProps extends BaseMapProps {
+    onChange?: (...args: any[]) => any;
+}
+
+export class CheckboxSVGMap extends React.Component<OnChangeMapProps> {}
+export class RadioSVGMap extends React.Component<OnChangeMapProps> {}
+export const SVGMap: React.SFC<SVGMapProps>;

--- a/types/react-svg-map/react-svg-map-tests.ts
+++ b/types/react-svg-map/react-svg-map-tests.ts
@@ -1,0 +1,40 @@
+import { SVGMap } from 'react-svg-map';
+import * as React from 'react';
+
+const mockFunction = () => null;
+
+const SVGMapContainer: JSX.Element = React.createElement(SVGMap, {
+  map: {
+    viewBox: 'viewBox',
+    locations: [{
+        path: 'path',
+        id: 'id',
+        name: 'name'
+    }],
+    label: 'label',
+  },
+  className: 'className',
+  role: 'role',
+  locationClassName: 'locationClassName',
+  locationTabIndex: 'locationTabIndex',
+  locationRole: 'locationRole',
+  onLocationMouseOver: mockFunction,
+  onLocationMouseOut: mockFunction,
+  onLocationMouseMove: mockFunction,
+  onLocationClick: mockFunction,
+  onLocationKeyDown: mockFunction,
+  onLocationFocus: mockFunction,
+  onLocationBlur: mockFunction,
+  isLocationSelected: mockFunction,
+});
+
+const SVGMapContainerNoOptional: JSX.Element = React.createElement(SVGMap, {
+  map: {
+    viewBox: 'viewBox',
+    locations: [{
+        path: 'path',
+        id: 'id',
+    }],
+    label: 'label',
+  },
+});

--- a/types/react-svg-map/tsconfig.json
+++ b/types/react-svg-map/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-svg-map-tests.ts"
+    ]
+}

--- a/types/react-svg-map/tslint.json
+++ b/types/react-svg-map/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/svg-maps__usa/index.d.ts
+++ b/types/svg-maps__usa/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for svg-maps__usa 1.1
+// Project: https://github.com/VictorCazanave/svg-maps/tree/master/packages/usa
+// Definitions by: Nick Glazer <https://github.com/nickglazer>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// tslint:disable-next-line no-single-declare-module
+declare module '@svg-maps/usa' {
+    export interface Location {
+        path: string;
+        id: string;
+        name?: string;
+    }
+
+    export interface Map {
+        viewBox: string;
+        locations: Location[];
+        label?: string;
+    }
+
+    const USA: Map;
+    export default USA;
+}

--- a/types/svg-maps__usa/svg-maps__usa-tests.ts
+++ b/types/svg-maps__usa/svg-maps__usa-tests.ts
@@ -1,0 +1,21 @@
+import USA, { Map } from '@svg-maps/usa';
+
+const map: Map = USA;
+
+const SVGMapContainer: Map = {
+  viewBox: 'viewBox',
+  locations: [{
+    path: 'path',
+    id: 'id',
+    name: 'name'
+  }],
+  label: 'label'
+};
+
+const SVGMapContainerNoOptional: Map = {
+  viewBox: 'vieweBox',
+  locations: [{
+  path: 'path',
+  id: 'id',
+  }],
+};

--- a/types/svg-maps__usa/tsconfig.json
+++ b/types/svg-maps__usa/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "svg-maps__usa-tests.ts"
+    ]
+}

--- a/types/svg-maps__usa/tslint.json
+++ b/types/svg-maps__usa/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
