### PR TITLE
Add JSDoc from jest to jest-expect-message

### DIFF
--- a/types/jest-expect-message/index.d.ts
+++ b/types/jest-expect-message/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for jest-expect-message 1.0
 // Project: https://github.com/mattphillips/jest-expect-message#readme
 // Definitions by: Mike Davydov <https://github.com/mike-d-davydov>
+//                 Michael Bashurov <https://github.com/saitonakamura>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.4
 
@@ -8,6 +9,13 @@
 
 declare namespace jest {
     interface Expect {
+        /**
+         * The `expect` function is used every time you want to test a value.
+         * You will rarely call `expect` by itself.
+         *
+         * @param actual The value to apply matchers against.
+         * @param message Clarification message
+         */
         <T = any>(actual: T, message: string): JestMatchers<T>;
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [jest expect jsdoc](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jest/index.d.ts#L590)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

`npm run list jest-expect-message` fails with
```
~/code/DefinitelyTyped % npm run lint jest-expect-message

> definitely-typed@0.0.3 lint /Users/saitonakamura/code/DefinitelyTyped
> dtslint types "jest-expect-message"

Error: Errors in typescript@3.9 for external dependencies:
../jest/index.d.ts(486,51): error TS2307: Cannot find module 'jest-diff' or its corresponding type declarations.
../jest/index.d.ts(540,44): error TS2307: Cannot find module 'pretty-format' or its corresponding type declarations.

    at /Users/saitonakamura/code/DefinitelyTyped/node_modules/dtslint/bin/index.js:195:19
    at Generator.next (<anonymous>)
    at fulfilled (/Users/saitonakamura/code/DefinitelyTyped/node_modules/dtslint/bin/index.js:6:58)
```

But that's no my PR that triggers