### PR TITLE
[googlemaps] add AutocompletionRequest#origin

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -1,6 +1,6 @@
 // Test file for Google Maps JavaScript API Definition file
 
-const version = google.maps.version;  // $ExpectType string
+const version = google.maps.version; // $ExpectType string
 
 let mapOptions: google.maps.MapOptions = {
     backgroundColor: '#fff',
@@ -750,15 +750,9 @@ const placeResult = autocomplete.getPlace();
 placeResult.name; // $ExpectType string
 
 /***** google.maps.places.AutocompleteService *****/
-new google.maps.places.AutocompleteService()
-    .getPlacePredictions(
-        {input: 'Kyiv, Ukr'},
-        (result) => {
-            result[0]
-                .structured_formatting
-                .secondary_text_matched_substrings; // $ExpectType PredictionSubstring[] | undefined
-        }
-    );
+new google.maps.places.AutocompleteService().getPlacePredictions({ input: 'Kyiv, Ukr' }, result => {
+    result[0].structured_formatting.secondary_text_matched_substrings; // $ExpectType PredictionSubstring[] | undefined
+});
 
 /***** google.maps.ImageMapType *****/
 const imageMapType = new google.maps.ImageMapType({
@@ -810,27 +804,27 @@ const directionsWaypointStopover: google.maps.DirectionsWaypoint = {
 /***** google.maps.DirectionsService *****/
 let directionsService = new google.maps.DirectionsService();
 
-directionsService.route({
-    avoidFerries: true,
-    avoidHighways: true,
-    avoidTolls: true,
-    destination: 'destination',
-    origin: 'origin',
-    provideRouteAlternatives: true,
-    transitOptions: {
-        arrivalTime: new Date(),
-        departureTime: new Date(),
-        modes: [
-            google.maps.TransitMode.BUS,
-            google.maps.TransitMode.RAIL
-        ],
-        routingPreference: google.maps.TransitRoutePreference.FEWER_TRANSFERS
+directionsService.route(
+    {
+        avoidFerries: true,
+        avoidHighways: true,
+        avoidTolls: true,
+        destination: 'destination',
+        origin: 'origin',
+        provideRouteAlternatives: true,
+        transitOptions: {
+            arrivalTime: new Date(),
+            departureTime: new Date(),
+            modes: [google.maps.TransitMode.BUS, google.maps.TransitMode.RAIL],
+            routingPreference: google.maps.TransitRoutePreference.FEWER_TRANSFERS,
+        },
+        travelMode: google.maps.TravelMode.TRANSIT,
+        unitSystem: google.maps.UnitSystem.IMPERIAL,
     },
-    travelMode: google.maps.TravelMode.TRANSIT,
-    unitSystem: google.maps.UnitSystem.IMPERIAL
-}, (result: google.maps.DirectionsResult, status: google.maps.DirectionsStatus) => {
-    const routes = result.routes; // $ExpectType DirectionsRoute[]
-    const legs = routes[0].legs; // $ExpectType DirectionsLeg[]
-    const steps = legs[0].steps; // $ExpectType DirectionsStep[]
-    steps[0].steps; // $ExpectType BaseDirectionsStep[]
-});
+    (result: google.maps.DirectionsResult, status: google.maps.DirectionsStatus) => {
+        const routes = result.routes; // $ExpectType DirectionsRoute[]
+        const legs = routes[0].legs; // $ExpectType DirectionsLeg[]
+        const steps = legs[0].steps; // $ExpectType DirectionsStep[]
+        steps[0].steps; // $ExpectType BaseDirectionsStep[]
+    },
+);

--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -750,9 +750,13 @@ const placeResult = autocomplete.getPlace();
 placeResult.name; // $ExpectType string
 
 /***** google.maps.places.AutocompleteService *****/
-new google.maps.places.AutocompleteService().getPlacePredictions({ input: 'Kyiv, Ukr' }, result => {
-    result[0].structured_formatting.secondary_text_matched_substrings; // $ExpectType PredictionSubstring[] | undefined
-});
+new google.maps.places.AutocompleteService().getPlacePredictions(
+    { input: 'Kyiv, Ukr', origin: { lat: 50.4021368, lng: 30.252522 } },
+    result => {
+        result[0].distance_meters; // $ExpectType number | undefined
+        result[0].structured_formatting.secondary_text_matched_substrings; // $ExpectType PredictionSubstring[] | undefined
+    },
+);
 
 /***** google.maps.ImageMapType *****/
 const imageMapType = new google.maps.ImageMapType({

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -3547,6 +3547,13 @@ declare namespace google.maps {
 
         interface AutocompletePrediction {
             description: string;
+
+            /**
+             * The distance in meters of the place from the {@link AutocompletionRequest#origin}.
+             * @see {@link https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletePrediction.distance_meters Maps JavaScript API}
+             */
+            distance_meters?: number;
+
             id: string;
             matched_substrings: PredictionSubstring[];
             place_id: string;
@@ -3617,6 +3624,13 @@ declare namespace google.maps {
             input: string;
             location?: LatLng;
             offset?: number;
+
+            /**
+             * The location where {@link AutocompletePrediction#distance_meters} is calculated from.
+             * @see {@link https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest.origin Maps JavaScript API}
+             */
+            origin?: LatLng | LatLngLiteral;
+
             radius?: number;
             sessionToken?: AutocompleteSessionToken;
             types?: string[];


### PR DESCRIPTION
Closes #44330

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`AutocompletionRequest#origin`](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest.origin) & [`AutocompletePrediction#distance_meters`](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletePrediction.distance_meters)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
