### PR TITLE
fix(parse5): `serialize(…)` uses a subset of `TreeAdapter`

### DIFF
--- a/types/parse5/index.d.ts
+++ b/types/parse5/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for parse5 5.0
 // Project: https://github.com/inikulin/parse5
 // Definitions by: Ivan Nikulin <https://github.com/inikulin>
+//                 ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -86,7 +87,7 @@ export interface SerializerOptions {
      *
      * **Default:** `treeAdapters.default`
      */
-    treeAdapter?: TreeAdapter;
+    treeAdapter?: SerializerTreeAdapter;
 }
 
 /**
@@ -310,7 +311,7 @@ export type CommentNode = DefaultTreeCommentNode | object;
  *
  * @see [default implementation](https://github.com/inikulin/parse5/blob/master/lib/tree_adapters/default.js)
  */
-export interface TreeAdapter {
+export interface TreeAdapter extends SerializerTreeAdapter {
     /**
      * Creates a document node.
      */
@@ -367,12 +368,6 @@ export interface TreeAdapter {
         contentElement: DocumentFragment
     ): void;
     /**
-     * Returns the `<template>` element content element.
-     *
-     * @param templateElement - `<template>` element.
-     */
-    getTemplateContent(templateElement: Element): DocumentFragment;
-    /**
      * Sets the document type. If the `document` already contains a document type node, the `name`, `publicId` and `systemId`
      * properties of this node will be updated with the provided values. Otherwise, creates a new document type node
      * with the given properties and inserts it into the `document`.
@@ -395,12 +390,6 @@ export interface TreeAdapter {
      * @param mode - Document mode.
      */
     setDocumentMode(document: Document, mode: DocumentMode): void;
-    /**
-     * Returns [document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
-     *
-     * @param document - Document node.
-     */
-    getDocumentMode(document: Document): DocumentMode;
     /**
      * Removes a node from its parent.
      *
@@ -436,6 +425,40 @@ export interface TreeAdapter {
      * @param attrs - Attributes to copy.
      */
     adoptAttributes(recipient: Element, attrs: Attribute[]): void;
+    /**
+     * Attaches source code location information to the node.
+     *
+     * @param node - Node.
+     */
+    setNodeSourceCodeLocation(node: Node, location: Location | StartTagLocation | ElementLocation): void;
+    /**
+     * Returns the given node's source code location information.
+     *
+     * @param node - Node.
+     */
+    getNodeSourceCodeLocation(node: Node): Location | StartTagLocation | ElementLocation;
+}
+
+/**
+ * Tree adapter is a set of utility functions that provides minimal required abstraction layer beetween parser and a specific AST format.
+ * Note that `TreeAdapter` is not designed to be a general purpose AST manipulation library. You can build such library
+ * on top of existing `TreeAdapter` or use one of the existing libraries from npm.
+ *
+ * @see [default implementation](https://github.com/inikulin/parse5/blob/master/lib/tree_adapters/default.js)
+ */
+export interface SerializerTreeAdapter {
+    /**
+     * Returns the `<template>` element content element.
+     *
+     * @param templateElement - `<template>` element.
+     */
+    getTemplateContent(templateElement: Element): DocumentFragment;
+    /**
+     * Returns [document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
+     *
+     * @param document - Document node.
+     */
+    getDocumentMode(document: Document): DocumentMode;
     /**
      * Returns the first child of the given node.
      *

--- a/types/parse5/parse5-tests.ts
+++ b/types/parse5/parse5-tests.ts
@@ -6,7 +6,8 @@ const document = parse5.parse("<html>");
 
 document; // $ExpectType Document
 
-const defaultAdapter = new Object() as parse5.TreeAdapter;
+declare const defaultAdapter: parse5.TreeAdapter;
+declare const defaultSerializerAdapter: parse5.SerializerTreeAdapter;
 
 parse5.parse("<html>", {}); // $ExpectType Document
 parse5.parse("<html>", { sourceCodeLocationInfo: true }); // $ExpectType Document
@@ -69,8 +70,8 @@ const html = parse5.serialize(element);
 
 html; // $ExpectType string
 
-parse5.serialize(element, { treeAdapter: defaultAdapter });
-parse5.serialize(element, { treeAdapter: defaultAdapter });
+parse5.serialize(element, { treeAdapter: defaultAdapter }); // $ExpectType string
+parse5.serialize(element, { treeAdapter: defaultSerializerAdapter }); // $ExpectType string
 
 // Location info
 const loc = (element as parse5.DefaultTreeElement).sourceCodeLocation!;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/inikulin/parse5/blob/master/docs/version-history.md#500>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

review?(@inikulin)