### PR TITLE
fix(later): overload schedule number of instance

### DIFF
--- a/types/later/index.d.ts
+++ b/types/later/index.d.ts
@@ -147,7 +147,7 @@ declare namespace later {
          * @param dateTo: The latest a valid instance can occur
          */
         next(numberOfInst: 1, dateFrom?: Date, dateTo?: Date): Date;
-        next(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[];
+        next(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[] | Date;
 
         /**
          * Finds the next valid range or ranges of the current schedule,
@@ -160,7 +160,7 @@ declare namespace later {
          * @param dateTo: The latest a valid range can occur
          */
         nextRange(numberOfInst: 1, dateFrom?: Date, dateTo?: Date): Date;
-        nextRange(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[];
+        nextRange(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[] | Date;
 
         /**
          * Finds the previous valid instance or instances of the current schedule,
@@ -173,7 +173,7 @@ declare namespace later {
          * @param dateTo: The latest a valid instance can occur
          */
         prev(numberOfInst: 1, dateFrom?: Date, dateTo?: Date): Date;
-        prev(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[];
+        prev(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[] | Date;
 
         /**
          * Finds the previous valid range or ranges of the current schedule,
@@ -186,7 +186,7 @@ declare namespace later {
          * @param dateTo: The latest a valid range can occur
          */
         prevRange(numberOfInst: 1, dateFrom?: Date, dateTo?: Date): Date;
-        prevRange(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[];
+        prevRange(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[] | Date;
     }
 
     interface RecurrenceBuilder extends ScheduleData {

--- a/types/later/index.d.ts
+++ b/types/later/index.d.ts
@@ -146,7 +146,8 @@ declare namespace later {
          * @param dateFrom: The earliest a valid instance can occur
          * @param dateTo: The latest a valid instance can occur
          */
-        next(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[] | Date;
+        next(numberOfInst: 1, dateFrom?: Date, dateTo?: Date): Date;
+        next(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[];
 
         /**
          * Finds the next valid range or ranges of the current schedule,
@@ -158,7 +159,8 @@ declare namespace later {
          * @param dateFrom: The earliest a valid range can occur
          * @param dateTo: The latest a valid range can occur
          */
-        nextRange(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[] | Date;
+        nextRange(numberOfInst: 1, dateFrom?: Date, dateTo?: Date): Date;
+        nextRange(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[];
 
         /**
          * Finds the previous valid instance or instances of the current schedule,
@@ -170,7 +172,8 @@ declare namespace later {
          * @param dateFrom: The earliest a valid instance can occur
          * @param dateTo: The latest a valid instance can occur
          */
-        prev(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[] | Date;
+        prev(numberOfInst: 1, dateFrom?: Date, dateTo?: Date): Date;
+        prev(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[];
 
         /**
          * Finds the previous valid range or ranges of the current schedule,
@@ -182,7 +185,8 @@ declare namespace later {
          * @param dateFrom: The earliest a valid range can occur
          * @param dateTo: The latest a valid range can occur
          */
-        prevRange(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[] | Date;
+        prevRange(numberOfInst: 1, dateFrom?: Date, dateTo?: Date): Date;
+        prevRange(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[];
     }
 
     interface RecurrenceBuilder extends ScheduleData {

--- a/types/later/later-tests.ts
+++ b/types/later/later-tests.ts
@@ -588,7 +588,6 @@ function LaterTest_GenerateRecurences() {
 }
 
 function LaterTest_CalculateOccurences() {
-
     // calculate the next 10 occurrences of a recur schedule
     const recurSched = later.parse.recur().last().dayOfMonth();
 

--- a/types/later/later-tests.ts
+++ b/types/later/later-tests.ts
@@ -588,18 +588,16 @@ function LaterTest_GenerateRecurences() {
 }
 
 function LaterTest_CalculateOccurences() {
-    // Initialise next variable.
-    let next: Date[] = [];
 
     // calculate the next 10 occurrences of a recur schedule
     const recurSched = later.parse.recur().last().dayOfMonth();
 
-    next = <Date[]> later.schedule(recurSched).next(10);
+    const nextMultiple: Date[] = later.schedule(recurSched).next(10);
 
     // calculate the previous occurrence starting from March 21, 2013
     const cronSched = later.parse.cron('0 0/5 14,18 * * ?');
 
-    next = <Date[]> later.schedule(cronSched).prev(1, new Date(2013, 2, 21));
+    const nextSingle: Date = later.schedule(cronSched).prev(1, new Date(2013, 2, 21));
 }
 
 function LaterTest_ExecuteCodeUsingSchedule() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://bunkat.github.io/later/occurrences.html#instances
  - https://github.com/bunkat/later/blob/master/src/core/schedule.js#L125

