### PR TITLE
[cache-manager] Add missing cache reset functions to Cache type definitions

### DIFF
--- a/types/cache-manager/cache-manager-tests.ts
+++ b/types/cache-manager/cache-manager-tests.ts
@@ -55,6 +55,13 @@ if (memoryCache.store.keys) {
     });
 }
 
+memoryCache.reset().then(() => {
+    // console.log('reset with promise');
+});
+memoryCache.reset(() => {
+    // console.log('reset with callback');
+});
+
 const multiCache = cacheManager.multiCaching([memoryCache]);
 
 multiCache.set('foo', 'bar', { ttl: ttl }, (err) => {
@@ -71,4 +78,8 @@ multiCache.set('foo', 'bar', { ttl: ttl }, (err) => {
         });
 
     });
+});
+
+multiCache.reset(() => {
+    // console.log('multiCache reset');
 });

--- a/types/cache-manager/index.d.ts
+++ b/types/cache-manager/index.d.ts
@@ -72,6 +72,9 @@ export interface Cache {
     del(key: string, callback: (error: any) => void): void;
     del(key: string): Promise<any>;
 
+    reset(): Promise<void>;
+    reset(cb: () => void): void;
+
     store: Store;
 }
 
@@ -95,6 +98,8 @@ export interface MultiCache {
 
     del(key: string, callback: (error: any) => void): void;
     del(key: string): Promise<any>;
+
+    reset(cb: () => void): void;
 }
 
 export function caching(IConfig: StoreConfig & CacheOptions): Cache;


### PR DESCRIPTION
- [./] Use a meaningful title for the pull request. Include the name of the package modified.
- [./] Test the change in your own code. (Compile and run.)
- [./] Add or edit tests to reflect the change. (Run with `npm test`.)
- [./] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [./] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [./] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [./] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/BryanDonovan/node-cache-manager/blob/master/lib/caching.js#L355 and https://github.com/BryanDonovan/node-cache-manager/blob/master/lib/multi_caching.js#L644 define the reset function in the implementation.
- [./] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [./] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [./] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

