### PR TITLE
Update types for tmp to the latest version of the API

### DIFF
--- a/types/tmp/index.d.ts
+++ b/types/tmp/index.d.ts
@@ -1,28 +1,31 @@
-// Type definitions for tmp 0.1
+// Type definitions for tmp 0.2
 // Project: http://github.com/raszi/node-tmp
 // Definitions by: Jared Klopper <https://github.com/optical>
 //                 Gyusun Yeom <https://github.com/Perlmint>
 //                 Alan Plum <https://github.com/pluma>
+//                 Carsten Klein <https://github.com/silkentrance>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface TmpNameOptions {
-    prefix?: string;
-    postfix?: string;
-    template?: string;
     dir?: string;
+    name?: string;
+    postfix?: string;
+    prefix?: string;
+    template?: string;
+    tmpdir?: string;
     tries?: number;
 }
 
 export interface FileOptions extends TmpNameOptions {
-    mode?: number;
-    keep?: boolean;
-    discardDescriptor?: boolean;
     detachDescriptor?: boolean;
+    discardDescriptor?: boolean;
+    keep?: boolean;
+    mode?: number;
 }
 
 export interface DirOptions extends TmpNameOptions {
-    mode?: number;
     keep?: boolean;
+    mode?: number;
     unsafeCleanup?: boolean;
 }
 
@@ -38,19 +41,21 @@ export interface DirResult {
 }
 
 export type FileCallback = (
-    err: any,
+    err: Error|null,
     name: string,
     fd: number,
     removeCallback: () => void
 ) => void;
 
 export type DirCallback = (
-    err: any,
+    err: Error|null,
     name: string,
     removeCallback: () => void
 ) => void;
 
-export type TmpNameCallback = (err: any, name: string) => void;
+export type TmpNameCallback = (err: Error|null, name: string) => void;
+
+export const tmpdir: string;
 
 export function file(options: FileOptions, cb: FileCallback): void;
 export function file(cb: FileCallback): void;

--- a/types/tmp/tmp-tests.ts
+++ b/types/tmp/tmp-tests.ts
@@ -1,14 +1,19 @@
 import {
-    dir,
     DirResult,
+    FileResult,
+    tmpdir,
+    tmpName,
+    tmpNameSync,
+    dir,
     dirSync,
     file,
-    FileResult,
     fileSync,
-    setGracefulCleanup,
-    tmpName,
-    tmpNameSync
+    setGracefulCleanup
 } from "tmp";
+
+console.log(tmpdir);
+
+setGracefulCleanup();
 
 file((err, name, fd, removeCallback) => {
     if (err) throw err;
@@ -19,6 +24,13 @@ file((err, name, fd, removeCallback) => {
     removeCallback();
 });
 
+file({ mode: 644, prefix: "prefix-", postfix: ".txt" }, (err, name, fd) => {
+    if (err) throw err;
+
+    console.log("File name: ", name);
+    console.log("File descriptor: ", fd);
+});
+
 dir((err, name, removeCallback) => {
     if (err) throw err;
 
@@ -27,23 +39,16 @@ dir((err, name, removeCallback) => {
     removeCallback();
 });
 
-tmpName((err, name) => {
-    if (err) throw err;
-
-    console.log("Created temporary filename: ", name);
-});
-
-file({ mode: 644, prefix: "prefix-", postfix: ".txt" }, (err, name, fd) => {
-    if (err) throw err;
-
-    console.log("File name: ", name);
-    console.log("File descriptor: ", fd);
-});
-
 dir({ mode: 750, prefix: "myTmpDir_" }, (err, name) => {
     if (err) throw err;
 
     console.log("Dir name: ", name);
+});
+
+tmpName((err, name) => {
+    if (err) throw err;
+
+    console.log("Created temporary filename: ", name);
 });
 
 tmpName({ template: "/tmp/tmp-XXXXXX" }, (err, name) => {
@@ -52,26 +57,42 @@ tmpName({ template: "/tmp/tmp-XXXXXX" }, (err, name) => {
     console.log("Created temporary filename: ", name);
 });
 
-setGracefulCleanup();
+tmpName({ name: "fixed-name", dir: "relative" }, (err, name) => {
+    if (err) throw err;
+
+    console.log("Created temporary filename: ", name);
+});
+
+tmpName({ tmpdir: "/overridden/tmp/root" }, (err, name) => {
+    if (err) throw err;
+
+    console.log("Created temporary filename: ", name);
+});
+
+let tmpDir: DirResult = dirSync();
+console.log("Dir name: ", tmpDir.name);
+tmpDir.removeCallback();
+
+tmpDir = dirSync({ mode: 750, prefix: "myTmpDir_" });
+console.log("Dir: ", tmpDir.name);
 
 let tmpFile: FileResult = fileSync();
 console.log("File name: ", tmpFile.name);
 console.log("File descriptor: ", tmpFile.fd);
 tmpFile.removeCallback();
 
-let tmpDir: DirResult = dirSync();
-console.log("Dir name: ", tmpDir.name);
-tmpDir.removeCallback();
-
-let name: string = tmpNameSync();
-console.log("Created temporary filename: ", name);
-
 tmpFile = fileSync({ mode: 644, prefix: "prefix-", postfix: ".txt" });
 console.log("File name: ", tmpFile.name);
 console.log("File descriptor: ", tmpFile.fd);
 
-tmpDir = dirSync({ mode: 750, prefix: "myTmpDir_" });
-console.log("Dir: ", tmpDir.name);
+let name: string = tmpNameSync();
+console.log("Created temporary filename: ", name);
 
 name = tmpNameSync({ template: "/tmp/tmp-XXXXXX" });
+console.log("Created temporary filename: ", name);
+
+name = tmpNameSync({ name: "fixed-name", dir: "relative" });
+console.log("Created temporary filename: ", name);
+
+name = tmpNameSync({ tmpdir: "/overridden/tmp/root" });
 console.log("Created temporary filename: ", name);


### PR DESCRIPTION
See the changes documented in the [CHANGELOG](https://github.com/raszi/node-tmp/blob/master/CHANGELOG.md).

The version number in the header was updated to `0.2`.

Additional tests have been added.