### PR TITLE
jest: Update comparison methods to support BigInt

### DIFF
--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -3,5 +3,9 @@
     "dependencies": {
         "jest-diff": "^25.2.1",
         "pretty-format": "^25.2.1"
+    },
+    "types": "index",
+    "typesVersions": {
+        ">=3.2.0-0": { "*": ["ts3.2/*"] }
     }
 }

--- a/types/jest/ts3.2/index.d.ts
+++ b/types/jest/ts3.2/index.d.ts
@@ -1,0 +1,23 @@
+// tslint:disable-next-line:no-bad-reference
+/// <reference path="../index.d.ts" />
+
+declare namespace jest {
+    interface Matchers<R, T = {}> {
+        /**
+         * For comparing numbers or big integer values.
+         */
+        toBeGreaterThan(expected: number | bigint): R;
+        /**
+         * For comparing numbers or big integer values.
+         */
+        toBeGreaterThanOrEqual(expected: number | bigint): R;
+        /**
+         * For comparing numbers or big integer values.
+         */
+        toBeLessThan(expected: number | bigint): R;
+        /**
+         * For comparing numbers or big integer values.
+         */
+        toBeLessThanOrEqual(expected: number | bigint): R;
+    }
+}

--- a/types/jest/ts3.2/jest-tests.ts
+++ b/types/jest/ts3.2/jest-tests.ts
@@ -1,0 +1,13 @@
+/* Basic matchers */
+
+describe('', () => {
+    it('', () => {
+        expect(BigInt(0)).toBeGreaterThan(BigInt(1));
+
+        expect(BigInt(0)).toBeGreaterThanOrEqual(BigInt(1));
+
+        expect(BigInt(0)).toBeLessThan(BigInt(1));
+
+        expect(BigInt(0)).toBeLessThanOrEqual(BigInt(1));
+    });
+});

--- a/types/jest/ts3.2/tsconfig.json
+++ b/types/jest/ts3.2/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["dom", "es6", "esnext", "es2020"],
+        "noImplicitAny": true,
+        "noImplicitThis": false,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": ["../../"],
+        "target": "esnext",
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jest-tests.ts"
+    ]
+}

--- a/types/jest/ts3.2/tslint.json
+++ b/types/jest/ts3.2/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-unnecessary-generics": false
+    }
+}


### PR DESCRIPTION
As per https://github.com/facebook/jest/pull/8382

TypeScript 3.2+ supports BigInt with esnext target.
TypeScript 3.8+ supports it with es2020 target.

dtslint is very particular on how the `typesVersions`
should be handled, hence the code duplication.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jest/pull/8382
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.