### PR TITLE
[react-select] Added removeValue field to ActionMeta

### DIFF
--- a/types/react-select/src/styles.d.ts
+++ b/types/react-select/src/styles.d.ts
@@ -31,11 +31,6 @@ import { CSSProperties } from 'react';
 
 export interface Props { [key: string]: any; }
 
-/**
- * @param base -- the component's default style
- * @param state -- the component's current state e.g. `isFocused`
- * @returns
- */
 export type styleFn = (base: CSSProperties, state: any) => CSSProperties;
 
 export interface Styles {

--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -70,6 +70,7 @@ export interface ActionMeta<OptionType extends OptionTypeBase> {
   action: ActionTypes;
   name?: string;
   option?: OptionType;
+  removedValue?: OptionType;
 }
 
 export type InputActionTypes =


### PR DESCRIPTION
When the `remove-value` or `pop-value` action is performed, then the _removedValue_ field in the action meta will contain the option that was removed.  This PR adds the _removedValue_ field to the ActionMeta type definition.

This PR also removed redundant JSDocs that was causing lint to fail due to the no-redundant-jsdoc rule.

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/react-select/blob/master/packages/react-select/CHANGELOG.md#v200-beta6--2018-05-23
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
