### PR TITLE
Add circle-to-polygon typings

### DIFF
--- a/types/circle-to-polygon/circle-to-polygon-tests.ts
+++ b/types/circle-to-polygon/circle-to-polygon-tests.ts
@@ -1,0 +1,4 @@
+import circleToPolygon = require("circle-to-polygon");
+
+circleToPolygon([0, 0], 10); // $ExpectType Polygon
+circleToPolygon([0, 0], 10, 10); // $ExpectType Polygon

--- a/types/circle-to-polygon/index.d.ts
+++ b/types/circle-to-polygon/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for circle-to-polygon 2.0
+// Project: https://github.com/gabzim/circle-to-polygon
+// Definitions by: Jan Zak <https://github.com/zakjan>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as GeoJSON from "geojson";
+
+declare function circleToPolygon(center: GeoJSON.Position, radius: number, numberOfSegments?: number): GeoJSON.Polygon;
+
+export = circleToPolygon;

--- a/types/circle-to-polygon/tsconfig.json
+++ b/types/circle-to-polygon/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "circle-to-polygon-tests.ts"
+    ]
+}

--- a/types/circle-to-polygon/tslint.json
+++ b/types/circle-to-polygon/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
