### PR TITLE
fix: optional parameter `type` missing in DateChangedCallback

### DIFF
--- a/types/react-native-calendar-picker/index.d.ts
+++ b/types/react-native-calendar-picker/index.d.ts
@@ -84,7 +84,7 @@ export interface CustomDateStyle {
     textStyle?: TextStyle;
 }
 
-export type DateChangedCallback = (date: Moment) => void;
+export type DateChangedCallback = (date: Moment, type?: 'START_DATE' | 'END_DATE') => void;
 
 export interface SwipeConfig {
     velocityThreshold?: number;


### PR DESCRIPTION
According to source code of `react-native-calendar-picker` package, onDateChange callback has optional parameter `type` of values `START_DATE | END_DATE`

[https://github.com/stephy/CalendarPicker/blob/c9087ee33c487eb81b17d3c6da6188f3a9d82742/CalendarPicker/index.js#L182](https://github.com/stephy/CalendarPicker/blob/c9087ee33c487eb81b17d3c6da6188f3a9d82742/CalendarPicker/index.js#L182)