### PR TITLE
[tabulator-tables] Add sortValuesList on SharedSelectAutoCompleteEditorParams and update label on LinkParams

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -1310,7 +1310,7 @@ You can pass an optional additional property with sorter, sorterParams that shou
     interface LinkParams {
         // Link
         labelField?: string;
-        label?: string;
+        label?: string | ((cell: CellComponent) => string);
         urlPrefix?: string;
         urlField?: string;
         url?: string;

--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -1406,6 +1406,7 @@ You can pass an optional additional property with sorter, sorterParams that shou
 
     interface SharedSelectAutoCompleteEditorParams {
         defaultValue?: string;
+        sortValuesList?: 'asc' | 'desc';
     }
 
     interface SelectParams extends SharedEditorParams, SharedSelectAutoCompleteEditorParams {

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -249,7 +249,8 @@ let autoComplete: Tabulator.AutoCompleteParams = {
         // prefix all titles with the work "Mr"
         return 'Mr ' + title;
     },
-    values: true, // create list of values from all values contained in this column
+    values: true, // create list of values from all values contained in this column,
+    sortValuesList:'asc', // sort the values by ascending order,
 };
 colDef.editorParams = autoComplete;
 


### PR DESCRIPTION

In SharedSelectAutoCompleteEditorParams, missing : 

> sortValuesList - if values property is set to true this option can be used to set how the generated list should be sorted. if ommitted the list will be in the order of rows in the table, when used it can have a value of "asc" or "desc".

In label of LinkParams of the formatter, missing the function type :

> label - a string representing the lable, or a function which must return the string for the label, the function is passed the Cell Component as its first argument

 
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://tabulator.info/docs/4.6/format#format-builtin>>
<<http://tabulator.info/docs/4.6/edit#edit-builtin>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

