### PR TITLE
[knex-db-manager] Fix populatePathPattern config parameter and populateDb method

### DIFF
--- a/types/knex-db-manager/index.d.ts
+++ b/types/knex-db-manager/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for knex-db-manager 0.5
+// Type definitions for knex-db-manager 0.6.1
 // Project: https://github.com/Vincit/knex-db-manager#readme
 // Definitions by: Dmitrii Solovev <https://github.com/dimonnwc3>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/knex-db-manager/index.d.ts
+++ b/types/knex-db-manager/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for knex-db-manager 0.6.1
+// Type definitions for knex-db-manager 0.6
 // Project: https://github.com/Vincit/knex-db-manager#readme
 // Definitions by: Dmitrii Solovev <https://github.com/dimonnwc3>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/knex-db-manager/index.d.ts
+++ b/types/knex-db-manager/index.d.ts
@@ -13,7 +13,7 @@ export interface KnexDbManager {
     close(): Promise<void>;
     closeKnex(): Promise<void>;
     dbVersion(): Promise<string>;
-    populateDb(glob: string): Promise<void>;
+    populateDb(glob?: string): Promise<void>;
     copyDb(fromDbName?: string, toDbName?: string): Promise<void>;
     truncateDb(ignoreTables?: [string]): Promise<void>;
     knexInstance(): QueryBuilder;
@@ -23,6 +23,7 @@ export interface DbManagerConfig {
     collate?: string[];
     superUser?: string;
     superPassword?: string;
+    populatePathPattern?: string;
 }
 
 export interface DbanagerFactoryConfig {


### PR DESCRIPTION
As per documentation:
`populatePathPattern` in config
https://github.com/Vincit/knex-db-manager#api--usage
`populateDb()` without glob string parameter
https://github.com/Vincit/knex-db-manager#populatedbglob-string-promisevoid

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/Vincit/knex-db-manager#populatedbglob-string-promisevoid
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.