### PR TITLE
Add types for mute-stream

### DIFF
--- a/types/mute-stream/index.d.ts
+++ b/types/mute-stream/index.d.ts
@@ -1,37 +1,35 @@
 // Type definitions for mute-stream 0.0
 // Project: https://github.com/isaacs/mute-stream#readme
-// Definitions by: Adam Jarret <https://atj.me>
+// Definitions by: Adam Jarret <https://github.com/adamjarret>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
-declare module 'mute-stream' {
-    import { Duplex } from 'stream';
+import { Duplex } from 'stream';
 
-    namespace MuteStream {
-        interface Options {
-            /**
-             * Set to a string to replace each character with the specified string when muted.
-             * (So you can show **** instead of the password, for example.)
-             */
-            replace?: string;
+declare namespace MuteStream {
+    interface Options {
+        /**
+         * Set to a string to replace each character with the specified string when muted.
+         * (So you can show **** instead of the password, for example.)
+         */
+        replace?: string;
 
-            /**
-             * If you are using a replacement char, and also using a prompt with a readline stream
-             * (as for a Password: ***** input), then specify what the prompt is so that backspace
-             * will work properly. Otherwise, pressing backspace will overwrite the prompt with the
-             * replacement character, which is weird.
-             */
-            prompt?: string;
-        }
+        /**
+         * If you are using a replacement char, and also using a prompt with a readline stream
+         * (as for a Password: ***** input), then specify what the prompt is so that backspace
+         * will work properly. Otherwise, pressing backspace will overwrite the prompt with the
+         * replacement character, which is weird.
+         */
+        prompt?: string;
     }
-
-    class MuteStream extends Duplex {
-        constructor(options?: MuteStream.Options);
-        mute: () => void;
-        unmute: () => void;
-        isTTY: boolean;
-    }
-
-    export = MuteStream;
 }
+
+declare class MuteStream extends Duplex {
+    constructor(options?: MuteStream.Options);
+    mute: () => void;
+    unmute: () => void;
+    isTTY: boolean;
+}
+
+export = MuteStream;

--- a/types/mute-stream/index.d.ts
+++ b/types/mute-stream/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for mute-stream 0.0
+// Project: https://github.com/isaacs/mute-stream#readme
+// Definitions by: Adam Jarret <https://atj.me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+declare module 'mute-stream' {
+    import { Duplex } from 'stream';
+
+    namespace MuteStream {
+        interface Options {
+            /**
+             * Set to a string to replace each character with the specified string when muted.
+             * (So you can show **** instead of the password, for example.)
+             */
+            replace?: string;
+
+            /**
+             * If you are using a replacement char, and also using a prompt with a readline stream
+             * (as for a Password: ***** input), then specify what the prompt is so that backspace
+             * will work properly. Otherwise, pressing backspace will overwrite the prompt with the
+             * replacement character, which is weird.
+             */
+            prompt?: string;
+        }
+    }
+
+    class MuteStream extends Duplex {
+        constructor(options?: MuteStream.Options);
+        mute: () => void;
+        unmute: () => void;
+        isTTY: boolean;
+    }
+
+    export = MuteStream;
+}

--- a/types/mute-stream/mute-stream-tests.ts
+++ b/types/mute-stream/mute-stream-tests.ts
@@ -1,0 +1,14 @@
+import MuteStream = require('mute-stream');
+
+const output = new MuteStream();
+output.pipe(process.stdout);
+output.mute();
+output.unmute();
+output.isTTY;
+
+const options: MuteStream.Options = {};
+
+new MuteStream(options);
+new MuteStream({ replace: 'a' });
+new MuteStream({ replace: 'a', prompt: 'a' });
+new MuteStream({ prompt: 'a' });

--- a/types/mute-stream/tsconfig.json
+++ b/types/mute-stream/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mute-stream-tests.ts"
+    ]
+}

--- a/types/mute-stream/tslint.json
+++ b/types/mute-stream/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
