### PR TITLE
Gestalt: changed Sticky zIndex to number

### DIFF
--- a/types/gestalt/gestalt-tests.tsx
+++ b/types/gestalt/gestalt-tests.tsx
@@ -77,7 +77,7 @@ const MasonryComponent = ({}) => {
 <SegmentedControl items={[]} selectedItemIndex={1} onChange={() => {}} />;
 <SelectList id="city" onChange={({ value }) => value} options={[]} />;
 <Spinner show={true} accessibilityLabel="Example spinner" />;
-<Sticky />;
+<Sticky dangerouslySetZIndex={ { __zIndex: 1 } } />;
 <Switch id="id" onChange={() => {}} />;
 <Tabs
     tabs={[

--- a/types/gestalt/index.d.ts
+++ b/types/gestalt/index.d.ts
@@ -731,7 +731,7 @@ https://pinterest.github.io/gestalt/#/Sticky
 export interface StickyProps {
     bottom?: number | string;
     children?: React.ReactNode;
-    dangerouslySetZIndex?: { __zIndex: string };
+    dangerouslySetZIndex?: { __zIndex: number };
     left?: number | string;
     right?: number | string;
     top?: number | string;

--- a/types/gestalt/index.d.ts
+++ b/types/gestalt/index.d.ts
@@ -5,6 +5,7 @@
 //                 Calvin Chhour <https://github.com/calvinchhour>
 //                 Muhammed Hafiz <https://github.com/zifahm>
 //                 Kyle Hensel <https://github.com/k-yle>
+//                 Francisco Jimenez <https://github.com/jimenezff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
Please fill in this template.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinterest/gestalt/blob/75056e67a322b7750810f196874663015024686b/packages/gestalt/src/Sticky.js#L23
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
