### PR TITLE
fix(mongodb): missing 'abort' method on GridFSBucketWriteStream

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2471,6 +2471,14 @@ export interface GridFSBucketReadStreamOptions {
 export class GridFSBucketWriteStream extends Writable {
     id: GridFSBucketWriteStreamId;
     constructor(bucket: GridFSBucket, filename: string, options?: GridFSBucketWriteStreamOptions);
+
+    /**
+     * Places this write stream into an aborted state (all future writes fail)
+     * and deletes all chunks that have already been written.
+     * @param [callback] called when chunks are successfully removed or error occurred
+     * @see {@link https://mongodb.github.io/node-mongodb-native/3.6/api/GridFSBucketWriteStream.html#abort}
+     */
+    abort(callback?: () => void): void;
 }
 
 /** https://mongodb.github.io/node-mongodb-native/3.1/api/GridFSBucketWriteStream.html */

--- a/types/mongodb/test/index.ts
+++ b/types/mongodb/test/index.ts
@@ -83,3 +83,14 @@ const client = new mongodb.MongoClient(url, {
 // Test other error classes
 new mongodb.MongoNetworkError('network error');
 new mongodb.MongoParseError('parse error');
+
+// Streams
+const gridFSBucketTests = (bucket: mongodb.GridFSBucket) => {
+    const openUploadStream  = bucket.openUploadStream('file.dat');
+    openUploadStream.on('close', () => {});
+    openUploadStream.on('end', () => {});
+    openUploadStream.abort(() => {
+        openUploadStream.removeAllListeners();
+    });
+    openUploadStream.abort();
+};


### PR DESCRIPTION
- add missing method from write stream
- tests amended

https://mongodb.github.io/node-mongodb-native/3.6/api/GridFSBucketWriteStream.html#abort

/cc @alexy4744

Thanks!

fixes #44360

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)