### PR TITLE
fix(intercom-client): expose 'useRequestOpts' method

### DIFF
--- a/types/intercom-client/index.d.ts
+++ b/types/intercom-client/index.d.ts
@@ -20,6 +20,7 @@ import { Scroll } from './Scroll';
 import { IntercomError } from './IntercomError';
 
 import { IncomingMessage } from 'http';
+import request = require('request');
 
 export { IntercomError };
 
@@ -44,6 +45,12 @@ export class Client {
     leads: Leads;
     visitors: Visitors;
     messages: Messages;
+
+    /**
+     * client library also supports passing in `request` options
+     * Note that certain request options (such as `json`, and certain `headers` names cannot be overridden).
+     */
+    useRequestOpts(options?: request.CoreOptions): this;
 }
 
 export class ApiResponse<T> extends IncomingMessage {

--- a/types/intercom-client/intercom-client-tests.ts
+++ b/types/intercom-client/intercom-client-tests.ts
@@ -1,3 +1,13 @@
-import * as intercom from "intercom-client";
+import Intercom = require('intercom-client');
+import { IdentityVerification } from 'intercom-client';
 
-intercom.IdentityVerification.userHash({ secretKey: "", identifier: "" }); // $ExpectType string
+IdentityVerification.userHash({ secretKey: '', identifier: '' }); // $ExpectType string
+
+const client = new Intercom.Client({ token: 'my_token' });
+client.useRequestOpts({
+    baseUrl: 'http://local.test-server.com',
+    headers: {
+        'Intercom-Version': 1.2,
+    },
+    forever: true,
+});


### PR DESCRIPTION
This adds direct types from `request` to support passing optional
options to configure client, as per API description here:

https://github.com/intercom/intercom-node#request-options

/cc @zeuslawyer

Thanks!

Fixes #44367

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)