### PR TITLE
[Bootstrap-3-Typeahead] Add missing detail to definitions

### DIFF
--- a/types/bootstrap-3-typeahead/index.d.ts
+++ b/types/bootstrap-3-typeahead/index.d.ts
@@ -16,7 +16,7 @@ declare namespace Bootstrap3Typeahead {
         /**
          * The max number of items to display in the dropdown
          */
-        items?: number;
+        items?: number | 'all';
 
         /**
          * The minimum character length needed before triggering autocomplete suggestions
@@ -66,7 +66,7 @@ declare namespace Bootstrap3Typeahead {
         /**
          * Call back function to execute after selected an item
          */
-        afterSelect?: (item: string|object) => void;
+        afterSelect?: (this: Typeahead, item: string|object) => void;
 
         /**
          * Adds a delay between lookups
@@ -88,7 +88,13 @@ declare namespace Bootstrap3Typeahead {
          */
         addItem?: object;
     }
+
+	interface Typeahead {
+		$element: JQuery;
+		options: Options;
+	}
 }
+
 interface JQuery {
     /**
      * Initialize or destroy Typeahead


### PR DESCRIPTION
Change Options.items to allow setting to 'all' and set scope of Options.afterSelect function to Typeahead instance

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/bassjobsen/Bootstrap-3-Typeahead#options>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
