### PR TITLE
Fix typings for async.retryable

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -231,29 +231,28 @@ export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks
 export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>, callback?: AsyncResultCallback<R, E>): void;
 export function autoInject<E = Error>(tasks: any, callback?: AsyncResultCallback<any, E>): void;
 
+export interface RetryOptions {
+    times?: number;
+    interval?: number | ((retryCount: number) => number);
+    errorFilter?: (error: Error) => boolean;
+}
 export function retry<T, E = Error>(
-    opts?:
-        | number
-        | {
-              times?: number;
-              interval?: number | ((retryCount: number) => number);
-              errorFilter?: (error: Error) => boolean;
-          },
+    opts?: number | RetryOptions,
     task?: (callback: AsyncResultCallback<T, E>, results: any) => void,
 ): Promise<void>;
 export function retry<T, E = Error>(
-    opts?:
-        | number
-        | {
-              times?: number;
-              interval?: number | ((retryCount: number) => number);
-              errorFilter?: (error: Error) => boolean;
-          },
+    opts?: number | RetryOptions,
     task?: (callback: AsyncResultCallback<T, E>, results: any) => void,
     callback?: AsyncResultCallback<any, E>,
 ): void;
 
-export function retryable<T, E = Error>(opts: number | {times: number, interval: number}, task: AsyncFunction<T, E>): AsyncFunction<T, E>;
+export function retryable<T, E = Error>(task: AsyncFunction<T, E>): AsyncFunction<T, E>;
+export function retryable<T, E = Error>(
+    opts:
+        | number
+        | RetryOptions & {arity?: number},
+     task: AsyncFunction<T, E>
+): AsyncFunction<T, E>;
 export function apply<E = Error>(fn: Function, ...args: any[]): AsyncFunction<any, E>;
 export function nextTick(callback: Function, ...args: any[]): void;
 export const setImmediate: typeof nextTick;

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -338,6 +338,22 @@ async.retry(
     (err, result) => {},
 );
 
+async.retryable(
+    (callback) => {},
+);
+async.retryable(
+    3,
+    (callback) => {},
+);
+async.retryable(
+    { times: 3, interval: 200 },
+    (callback) => {},
+);
+async.retryable(
+    { times: 3, interval: retryCount => 200 * retryCount },
+    (callback) => {},
+);
+
 async.parallel([
         (callback: (err: Error, val: string) => void) => { },
         callback => { }


### PR DESCRIPTION
The typings for `async.retryable` were incorrect. This should fix them.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/caolan/async/blob/62cb8ea8ce3e3b4b66cf9abc66153d2d7255985b/lib/retryable.js#L35
https://caolan.github.io/async/v2/docs.html#retryable
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.