### PR TITLE
react-router: Support a custom history/location

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -158,9 +158,9 @@ export function withRouter<P extends RouteComponentProps<any>, C extends React.C
 
 export const __RouterContext: React.Context<RouteComponentProps>;
 
-export function useHistory<HistoryLocationState = H.LocationState>(): H.History<HistoryLocationState>;
+export function useHistory<HistoryLocationState = H.LocationState, History = H.History<HistoryLocationState>>(): History;
 
-export function useLocation<S = H.LocationState>(): H.Location<S>;
+export function useLocation<S = H.LocationState, Location = H.Location<S>>(): Location;
 
 export function useParams<Params extends { [K in keyof Params]?: string } = {}>(): Params;
 


### PR DESCRIPTION
React Router supports passing your own history object when using the Router component (docs: https://reacttraining.com/react-router/web/api/Router/history-object ). This opens up the possibility of using custom history objects that might have their own location objects.

This PR updates the types of `useHistory`/`useLocation` to allow a developer to pass their own interface for a custom History and Location to these hooks.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
  - https://reacttraining.com/react-router/web/api/Router/history-object
  - https://github.com/jamesplease/query-history
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

I've held off on adding tests as I suspect this might create some discussion and may ultimately be rejected.

**tl;dr:** I wrote [a library](https://github.com/jamesplease/query-history) that allows you to more easily manage query params. It uses a modified history/location, taking advantage of the fact that `<Router/>` lets you pass in your own history. However, the current types in DefinitelyTyped don't allow passing in your own interface for History/Location.

#### Goals of this PR:

- Remain backwards compatible

#### Possible reasons to reject this PR:

- Custom history/location interfaces may go against the design philosophy of React Router

#### Todos:

- update other interfaces (i.e.; `Prompt`, `RouterChildContext`)

#### Possible todos:

- Tests?

What do folks think of this change? If you're against it in principle, then I understand and will add an override file to the README of the `query-history` library.

Thanks for reviewing!