### PR TITLE
[tabulator-tables]Calculation function should be able to return anything

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -1226,7 +1226,7 @@ You can pass an optional additional property with sorter, sorterParams that shou
         | 'sum'
         | 'concat'
         | 'count'
-        | ((values: any[], data: any[], calcParams: {}) => number);
+        | ((values: any[], data: any[], calcParams: {}) => any);
     type ColumnCalcParams = (values: any, data: any) => any;
     type Formatter =
         | 'plaintext'

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -321,6 +321,15 @@ colDef.headerFilterFunc = (headerValue, rowValue, rowData, filterParams) => {
     return rowData.name === filterParams.name && rowValue < headerValue; // must return a boolean, true if it passes the filter.
 };
 
+// Calculation
+colDef.bottomCalc = (values, data, calcParams) => {
+    return {};
+};
+
+colDef.bottomCalcFormatter = (cell, formatterParams, onRendered) => {
+    return '';
+};
+
 // Cell Component
 
 let cell = <Tabulator.CellComponent>{};


### PR DESCRIPTION
This part is tricky because the documentation says nothing about the returned value of custom calculation function.
I think the type should not be restricted to number so we can combine it with a custom formatter. As a reference, the built-in function Concatenate return a string, not a number.

Example : I have a tabulator of items with a column for the color. I want 3 calculations : the number of black, the number of white and the number of colored. In JS I can use a custom calculation that return an object with the 3 results then use a custom formatter to show them. With the current Types I can't be cause I have to return a number in the calculation function.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://tabulator.info/docs/4.6/column-calcs#format>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
