### PR TITLE
Update RetryStrategy types to match docs

### DIFF
--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -13,6 +13,7 @@
 //                 Adebayo Opesanya <https://github.com/OpesanyaAdebayo>
 //                 Ryo Ota <https://github.com/nwtgck>
 //                 Thomas de Barochez <https://github.com/tdebarochez>
+//                 David Stephens <https://github.com/dwrss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Imported from: https://github.com/types/npm-redis

--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -29,7 +29,7 @@ export interface RetryStrategyOptions {
     attempt: number;
 }
 
-export type RetryStrategy = (options: RetryStrategyOptions) => number | Error;
+export type RetryStrategy = (options: RetryStrategyOptions) => number | Error | undefined;
 
 export interface ClientOpts {
     host?: string;

--- a/types/redis/redis-tests.ts
+++ b/types/redis/redis-tests.ts
@@ -39,11 +39,17 @@ function retryStrategyNumber(options: redis.RetryStrategyOptions): number {
 function retryStrategyError(options: redis.RetryStrategyOptions): Error {
   return new Error('Foo');
 }
+function retryStrategyUndefined(options: redis.RetryStrategyOptions): undefined {
+  return undefined;
+}
 client = redis.createClient({
   retry_strategy: retryStrategyNumber
 });
 client = redis.createClient({
   retry_strategy: retryStrategyError
+});
+client = redis.createClient({
+  retry_strategy: retryStrategyUndefined
 });
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 

--- a/types/redis/ts3.1/index.d.ts
+++ b/types/redis/ts3.1/index.d.ts
@@ -10,7 +10,7 @@ export interface RetryStrategyOptions {
     attempt: number;
 }
 
-export type RetryStrategy = (options: RetryStrategyOptions) => number | Error;
+export type RetryStrategy = (options: RetryStrategyOptions) => number | Error | unknown;
 
 export interface ClientOpts {
     host?: string;

--- a/types/redis/ts3.1/redis-tests.ts
+++ b/types/redis/ts3.1/redis-tests.ts
@@ -39,11 +39,17 @@ function retryStrategyNumber(options: redis.RetryStrategyOptions): number {
 function retryStrategyError(options: redis.RetryStrategyOptions): Error {
   return new Error('Foo');
 }
+function retryStrategyUndefined(options: redis.RetryStrategyOptions): undefined {
+  return undefined;
+}
 client = redis.createClient({
   retry_strategy: retryStrategyNumber
 });
 client = redis.createClient({
   retry_strategy: retryStrategyError
+});
+client = redis.createClient({
+  retry_strategy: retryStrategyUndefined
 });
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 


### PR DESCRIPTION
Please fill in this template.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/NodeRedis/node-redis#options-object-properties
- ~[ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- ~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed~.

Per the documentation, you can return any value from the `retry_strategy` function and that will cause the library to flush all offline commands with the standard error.

I've used `unknown` to represent this for ts3.1 but for 2.8 I've used `undefined`. This isn't technically correct, but I feel that it is more descriptive than widening the entire return type to `any`.