### PR TITLE
react-fade-in v.0.1.8: add test for childClassName property

### DIFF
--- a/types/react-fade-in/index.d.ts
+++ b/types/react-fade-in/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-fade-in 0.1
+// Type definitions for react-fade-in 0.1.8
 // Project: github.com/gkaemmer/react-fade-in
 // Definitions by: Barry Michael Doyle <https://github.com/barrymichaeldoyle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -10,21 +10,27 @@ import { ComponentClass, ReactNode } from 'react';
  * Props for a FadeIn component.
  */
 export interface FadeInProps {
-    children?: ReactNode;
-    className?: string;
-    /**
-     * Default: 50. Delay between each child's animation in milliseconds.
-     */
-    delay?: number;
-    /**
-     * Default: 400. Duration of each child's animation in milliseconds.
-     */
-    transitionDuration?: number;
+  children?: ReactNode;
+  className?: string;
+  /**
+   * No default. Adds a `className` prop to each child div, allowing
+   * you to style the direct children of the `FadeIn` component.
+   */
+  childClassName?: string;
+  /**
+   * Default: 50. Delay between each child's animation in milliseconds.
+   */
+  delay?: number;
+  /**
+   * Default: 400. Duration of each child's animation in milliseconds.
+   */
+  transitionDuration?: number;
 }
 
 /**
  * Visually animates content on render with FadeIn.js
  */
 declare const FadeIn: ComponentClass<FadeInProps>;
+declare module 'react-fade-in';
 
 export default FadeIn;

--- a/types/react-fade-in/react-fade-in-tests.tsx
+++ b/types/react-fade-in/react-fade-in-tests.tsx
@@ -12,7 +12,7 @@ export const _ = () => (
             <div>Element 5</div>
             <div>Element 6</div>
         </FadeIn>
-        <FadeIn className="typescript">
+        <FadeIn className="container">
             <div>Element 1</div>
             <div>Element 2</div>
             <div>Element 3</div>
@@ -36,5 +36,22 @@ export const _ = () => (
             <div>Element 5</div>
             <div>Element 6</div>
         </FadeIn>
+        <FadeIn childClassName='child'>
+            <div>Element 1</div>
+            <div>Element 2</div>
+            <div>Element 3</div>
+            <div>Element 4</div>
+            <div>Element 5</div>
+            <div>Element 6</div>
+        </FadeIn>
+        
+        <style>{`
+           .container {
+             border: 1px solid blue;
+           }
+           .child {
+             color: red;
+           }
+         `}</style>
     </>
 );


### PR DESCRIPTION
Add test for `childClassName` property introduced in v.0.1.8
https://github.com/gkaemmer/react-fade-in/commit/a168810c9b3b49054a36220e0c7b20b4fe638889

Change `className` of previous example to match example at https://github.com/gkaemmer/react-fade-in/blob/a168810c9b3b49054a36220e0c7b20b4fe638889/example/FadeInTest.js

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.