### PR TITLE
add optional scale argument to ToImgopts interface

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -178,6 +178,7 @@ export interface ToImgopts {
 	format: 'jpeg' | 'png' | 'webp' | 'svg';
 	width: number;
 	height: number;
+	scale?: number;
 }
 
 export interface DownloadImgopts {

--- a/types/plotly.js/test/core-tests.ts
+++ b/types/plotly.js/test/core-tests.ts
@@ -266,6 +266,17 @@ function rand() {
 //////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////
+// Plotly.toImage + scale parameter
+(() => {
+	// Plotly.toImage will turn the plot in the given div into a data URL string
+	// toImage takes the div as the first argument and an object specifying image properties as the other
+	Plotly.toImage(graphDiv, { format: 'png', width: 800, height: 600, scale: 2 }).then((dataUrl) => {
+		// use the dataUrl
+	});
+})();
+//////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////
 // Plotly.downloadImage
 (() => {
 	// downloadImage will accept the div as the first argument and an object specifying image properties as the other


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/plotly/plotly.js/blob/master/src/plot_api/to_image.js#L131
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

