### PR TITLE
Add optional suffix argument to uniqid interface to sync types with uniqid v5.2

### DIFF
--- a/types/uniqid/index.d.ts
+++ b/types/uniqid/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for uniqid 4.1
+// Type definitions for uniqid 5.2
 // Project: http://github.com/adamhalasz/uniqid
-// Definitions by: idchlife <https://github.com/idchlife>
+// Definitions by: idchlife <https://github.com/idchlife>, onomatopoetry <https://github.com/onomatopoetry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/uniqid
 
 // Commmon function signature
-declare function f(prefix?: string): string;
+declare function f(prefix?: string, suffix?: string): string;
 
 // let x -> Workaround for ES6 imports
 // Combined type because of assigning to function object in original module

--- a/types/uniqid/uniqid-tests.ts
+++ b/types/uniqid/uniqid-tests.ts
@@ -1,7 +1,18 @@
 import uniqid = require("uniqid");
 
-const uniqueID = uniqid("123");
-const processString = uniqid.process("123");
-const timeString = uniqid.time("123");
+// $ExpectType string
+const uniqueID = uniqid();
+const processString = uniqid.process();
+const timeString = uniqid.time();
 
-if (uniqueID === "" && processString === "" && timeString === "") { /**/ }
+const uniqueIDPrefix = uniqid("123");
+const processStringPrefix = uniqid.process("123");
+const timeStringPrefix = uniqid.time("123");
+
+const uniqueIDSuffix = uniqid(undefined, "123");
+const processStringSuffix = uniqid.process(undefined, "123");
+const timeStringSuffix = uniqid.time(undefined, "123");
+
+const uniqueIDPrefixSuffix = uniqid("123", "456");
+const processStringPrefixSuffix = uniqid.process("123", "456");
+const timeStringPrefixSuffix = uniqid.time("123", "456");


### PR DESCRIPTION
Changing an existing definition for uniqid:
- Note the optional `suffix` argument added to `uniqid()`, `uniqid.process()` and `uniqid.time()` [here](https://www.npmjs.com/package/uniqid). Types have been added for these optional arguments
- Updated the version number in the header
- Updated tests to test calls to each function with with `prefix`, with `suffix`, with neither, and with both.
