### PR TITLE
Pulsar client types: add AuthenticationToken, change AuthenticationTls to a class

### DIFF
--- a/types/pulsar-client/index.d.ts
+++ b/types/pulsar-client/index.d.ts
@@ -27,12 +27,14 @@ export type SubscriptionType =
     'Shared' |
     'Failover';
 
-export interface AuthenticationTls {
+export class AuthenticationTls {
+    constructor(authTlsOpts: { certificatePath: string; privateKeyPath: string });
     certificatePath: string;
     privateKeyPath: string;
 }
 
-export interface AuthenticationToken {
+export class AuthenticationToken {
+    constructor(authTokenOpts: { token: string });
     token: string;
 }
 

--- a/types/pulsar-client/index.d.ts
+++ b/types/pulsar-client/index.d.ts
@@ -32,6 +32,10 @@ export interface AuthenticationTls {
     privateKeyPath: string;
 }
 
+export interface AuthenticationToken {
+    token: string;
+}
+
 export interface ClientOpts {
     /**
      * The connection URL for the Pulsar cluster.
@@ -42,7 +46,7 @@ export interface ClientOpts {
      * Configure the authentication provider.
      * Default: No Authentication
      */
-    authentication?: AuthenticationTls;
+    authentication?: AuthenticationTls | AuthenticationToken;
 
     /**
      * The timeout for Node.js client operations (creating producers, subscribing to and unsubscribing from topics).


### PR DESCRIPTION
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

I have changed AuthenticationTls from an interface to a class and added a constructor; the documentation at https://pulsar.apache.org/docs/en/security-tls-authentication/ says it should be new-able.  I have also added an AuthenticationToken class.