### PR TITLE
[react-relay] useRefetchableFragment refetch function should accept partial vars

### DIFF
--- a/types/react-relay/lib/relay-experimental/useRefetchableFragmentNode.d.ts
+++ b/types/react-relay/lib/relay-experimental/useRefetchableFragmentNode.d.ts
@@ -31,7 +31,7 @@ export type RefetchFnExact<TQuery extends OperationType, TOptions = Options> = R
     TOptions
 >;
 export type RefetchFnInexact<TQuery extends OperationType, TOptions = Options> = RefetchFnBase<
-    TQuery['variables'],
+    Partial<TQuery['variables']>,
     TOptions
 >;
 

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -339,8 +339,8 @@ function ArrayOfNullableFragment() {
  */
 function RefetchableFragment() {
     interface CommentBodyRefetchQueryVariables {
-        lang?: string | null;
-        id?: string | null;
+        lang: string;
+        id: string;
     }
     interface CommentBodyRefetchQueryResponse {
         readonly node: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). Errors for some reason.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/blob/master/packages/relay-experimental/useRefetchableFragmentNode.js#L112
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The refetch function returned by `useRefetchableContainer` should accept partial variables, it will reuse initial values for variables not provided.

This also tests it works by making variables in the `RefetchableFragment` example non nullable and passing only one in the `refetch` call.