### PR TITLE
[react-relay] Fix data nullability for `useRefetchableFragment`

### DIFF
--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -9,6 +9,7 @@
 //                 Matt Krick <https://github.com/mattkrick>
 //                 Jared Kass <https://github.com/jdk243>
 //                 Renan Machado <https://github.com/renanmav>
+//                 Janic Duplessis <https://github.com/janicduplessis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.3
 

--- a/types/react-relay/lib/relay-experimental/useRefetchableFragment.d.ts
+++ b/types/react-relay/lib/relay-experimental/useRefetchableFragment.d.ts
@@ -1,18 +1,30 @@
 import { RefetchFnDynamic } from './useRefetchableFragmentNode';
 import { GraphQLTaggedNode, OperationType } from 'relay-runtime';
 
-export type $Call<Fn extends (...args: any[]) => any> = Fn extends (arg: any) => infer RT ? RT : never;
-
-export type NonNullableReturnType<T extends { readonly ' $data'?: unknown }> = (arg: T) => NonNullable<T[' $data']>;
-export type NullableReturnType<T extends { readonly ' $data'?: unknown | null }> = (arg: T) => T[' $data'] | null;
-
-export type ReturnType<TQuery extends OperationType, TKey extends { readonly ' $data'?: unknown | null }> = [
-    $Call<NonNullableReturnType<TKey> & NullableReturnType<TKey>>,
+export type ReturnType<TQuery extends OperationType, TKey, TFragmentData> = [
+    TFragmentData,
     RefetchFnDynamic<TQuery, TKey>,
 ];
 
+export type $Call<Fn extends (...args: any[]) => any> = Fn extends (arg: any) => infer RT ? RT : never;
+
+interface KeyType {
+    readonly ' $data'?: unknown;
+}
+
+type KeyReturnType<T extends KeyType> = (arg: T) => NonNullable<T[' $data']>;
+
 export function useRefetchableFragment<
     TQuery extends OperationType,
-    TKey extends { readonly ' $data'?: unknown | null }
+    TKey extends KeyType
     // tslint:disable-next-line:no-unnecessary-generics
->(fragmentInput: GraphQLTaggedNode, fragmentRef: TKey): ReturnType<TQuery, TKey>;
+>(fragmentInput: GraphQLTaggedNode, fragmentRef: TKey): ReturnType<TQuery, TKey, $Call<KeyReturnType<TKey>>>;
+
+export function useRefetchableFragment<
+    TQuery extends OperationType,
+    TKey extends KeyType
+    // tslint:disable-next-line:no-unnecessary-generics
+>(
+    fragmentInput: GraphQLTaggedNode,
+    fragmentRef: TKey | null,
+): ReturnType<TQuery, TKey, $Call<KeyReturnType<TKey>> | null>;

--- a/types/react-relay/lib/relay-experimental/useRefetchableFragment.d.ts
+++ b/types/react-relay/lib/relay-experimental/useRefetchableFragment.d.ts
@@ -28,3 +28,5 @@ export function useRefetchableFragment<
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey | null,
 ): ReturnType<TQuery, TKey, $Call<KeyReturnType<TKey>> | null>;
+
+export {};

--- a/types/react-relay/lib/relay-experimental/useRefetchableFragment.d.ts
+++ b/types/react-relay/lib/relay-experimental/useRefetchableFragment.d.ts
@@ -14,19 +14,16 @@ interface KeyType {
 
 type KeyReturnType<T extends KeyType> = (arg: T) => NonNullable<T[' $data']>;
 
-export function useRefetchableFragment<
-    TQuery extends OperationType,
-    TKey extends KeyType
-    // tslint:disable-next-line:no-unnecessary-generics
->(fragmentInput: GraphQLTaggedNode, fragmentRef: TKey): ReturnType<TQuery, TKey, $Call<KeyReturnType<TKey>>>;
+export function useRefetchableFragment<TQuery extends OperationType, TKey extends KeyType>(
+    fragmentInput: GraphQLTaggedNode,
+    fragmentRef: TKey,
+): // tslint:disable-next-line:no-unnecessary-generics
+ReturnType<TQuery, TKey, $Call<KeyReturnType<TKey>>>;
 
-export function useRefetchableFragment<
-    TQuery extends OperationType,
-    TKey extends KeyType
-    // tslint:disable-next-line:no-unnecessary-generics
->(
+export function useRefetchableFragment<TQuery extends OperationType, TKey extends KeyType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey | null,
-): ReturnType<TQuery, TKey, $Call<KeyReturnType<TKey>> | null>;
+): // tslint:disable-next-line:no-unnecessary-generics
+ReturnType<TQuery, TKey, $Call<KeyReturnType<TKey>> | null>;
 
 export {};

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -367,6 +367,7 @@ function RefetchableFragment() {
 
     interface Props {
         comment: CommentBody_comment$key;
+        commentNullable: CommentBody_comment$key | null;
     }
 
     return function CommentBody(props: Props) {
@@ -380,10 +381,21 @@ function RefetchableFragment() {
             `,
             props.comment,
         );
+        const [dataNullable] = useRefetchableFragment<CommentBodyRefetchQuery, CommentBody_comment$key>(
+            graphql`
+                fragment CommentBody_comment on Comment @refetchable(queryName: "CommentBodyRefetchQuery") {
+                    body(lang: $lang) {
+                        text
+                    }
+                }
+            `,
+            props.commentNullable,
+        );
 
         return (
             <>
-                <p>{data!.body!.text}</p>
+                <p>{data.body!.text}</p>
+                <p>{dataNullable!.body!.text}</p>
                 <button onClick={() => refetch({ lang: 'SPANISH' }, { fetchPolicy: 'store-or-network' })}>
                     Translate Comment
                 </button>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). Errors for some reason.

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This updates `useRefetchableFragment` to use the same logic as `useFragment` and `usePaginationFragment` so data has proper nullability based on the type of the ref key passed.