### PR TITLE
feat(parse5): Add `TreeAdapter.{get,set}NodeSourceCodeLocation(…)`

### DIFF
--- a/types/parse5/index.d.ts
+++ b/types/parse5/index.d.ts
@@ -1,34 +1,39 @@
 // Type definitions for parse5 5.0
 // Project: https://github.com/inikulin/parse5
 // Definitions by: Ivan Nikulin <https://github.com/inikulin>
+//                 ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
 export interface Location {
-    /**
-     * One-based line index of the first character
-     */
-    startLine: number;
-    /**
-     * One-based column index of the first character
-     */
-    startCol: number;
-    /**
-     * One-based line index of the last character
-     */
-    endLine: number;
     /**
      * One-based column index of the last character
      */
     endCol: number;
-    /**
-     * Zero-based first character index
-     */
-    startOffset: number;
+
     /**
      * Zero-based last character index
      */
     endOffset: number;
+
+    /**
+     * One-based line index of the last character
+     */
+    endLine: number;
+
+    /**
+     * One-based column index of the first character
+     */
+    startCol: number;
+
+    /**
+     * Zero-based first character index
+     */
+    startOffset: number;
+
+    /**
+     * One-based line index of the first character
+     */
+    startLine: number;
 }
 
 export interface AttributesLocation {
@@ -47,6 +52,7 @@ export interface ElementLocation extends StartTagLocation {
      * Element's start tag location info.
      */
     startTag: StartTagLocation;
+
     /**
      * Element's end tag location info.
      */
@@ -61,6 +67,7 @@ export interface ParserOptions {
      *  **Default:** `true`
      */
     scriptingEnabled?: boolean;
+
     /**
      * Enables source code location information. When enabled, each node (except the root node)
      * will have a `sourceCodeLocation` property. If the node is not an empty element, `sourceCodeLocation` will
@@ -72,6 +79,7 @@ export interface ParserOptions {
      * **Default:** `false`
      */
     sourceCodeLocationInfo?: boolean;
+
     /**
      * Specifies the resulting tree format.
      *
@@ -104,14 +112,17 @@ export interface Attribute {
      * The name of the attribute.
      */
     name: string;
+
     /**
      * The value of the attribute.
      */
     value: string;
+
     /**
      * The namespace of the attribute.
      */
     namespace?: string;
+
     /**
      * The namespace-related prefix of the attribute.
      */
@@ -156,14 +167,17 @@ export interface DefaultTreeDocumentType extends DefaultTreeNode {
      * The name of the node.
      */
     nodeName: "#documentType";
+
     /**
      * Document type name.
      */
     name: string;
+
     /**
      * Document type public identifier.
      */
     publicId: string;
+
     /**
      * Document type system identifier.
      */
@@ -178,6 +192,7 @@ export interface DefaultTreeDocument extends DefaultTreeParentNode {
      * The name of the node.
      */
     nodeName: "#document";
+
     /**
      * [Document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
      */
@@ -202,18 +217,22 @@ export interface DefaultTreeElement extends DefaultTreeChildNode, DefaultTreePar
      * The name of the node. Equals to element {@link tagName}.
      */
     nodeName: string;
+
     /**
      * Element tag name.
      */
     tagName: string;
+
     /**
      * Element namespace.
      */
     namespaceURI: string;
+
     /**
      * List of element attributes.
      */
     attrs: Attribute[];
+
     /**
      * Element source code location info. Available if location info is enabled via {@link ParserOptions}.
      */
@@ -228,10 +247,12 @@ export interface DefaultTreeCommentNode extends DefaultTreeChildNode {
      * The name of the node.
      */
     nodeName: "#comment";
+
     /**
      * Comment text.
      */
     data: string;
+
     /**
      * Comment source code location info. Available if location info is enabled via {@link ParserOptions}.
      */
@@ -246,57 +267,67 @@ export interface DefaultTreeTextNode extends DefaultTreeChildNode {
      * The name of the node.
      */
     nodeName: "#text";
+
     /**
      * Text content.
      */
     value: string;
+
     /**
      * Text node source code location info. Available if location info is enabled via {@link ParserOptions}.
      */
     sourceCodeLocation?: Location;
 }
 
-// Generic node intefaces
+// Generic node interfaces
 /**
  * Generic Node interface.
  * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeNode}) to get access to the properties.
  */
 export type Node = DefaultTreeNode | object;
+
 /**
  * Generic ChildNode interface.
  * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeChildNode}) to get access to the properties.
  */
 export type ChildNode = DefaultTreeChildNode | object;
+
 /**
  * Generic ParentNode interface.
  * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeParentNode}) to get access to the properties.
  */
 export type ParentNode = DefaultTreeParentNode | object;
+
 /**
  * Generic DocumentType interface.
  * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeDocumentType}) to get access to the properties.
  */
 export type DocumentType = DefaultTreeDocumentType | object;
+
 /**
  * Generic Document interface.
  * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeDocument}) to get access to the properties.
  */
 export type Document = DefaultTreeDocument | object;
+
 /**
  * Generic DocumentFragment interface.
  * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeDocumentFragment}) to get access to the properties.
  */
 export type DocumentFragment = DefaultTreeDocumentFragment | object;
+
 /**
  * Generic Element interface.
  * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeElement}) to get access to the properties.
  */
 export type Element = DefaultTreeElement | object;
+
 /**
  * Generic TextNode interface.
  * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeTextNode}) to get access to the properties.
  */
 export type TextNode = DefaultTreeTextNode | object;
+
 /**
  * Generic CommentNode interface.
  * Cast to the actual AST interface (e.g. {@link parse5.Default.CommentNode}) to get access to the properties.
@@ -308,17 +339,42 @@ export type CommentNode = DefaultTreeCommentNode | object;
  * Note that `TreeAdapter` is not designed to be a general purpose AST manipulation library. You can build such library
  * on top of existing `TreeAdapter` or use one of the existing libraries from npm.
  *
- * @see [default implementation](https://github.com/inikulin/parse5/blob/master/lib/tree_adapters/default.js)
+ * @see [default implementation](https://github.com/inikulin/parse5/blob/master/packages/parse5/lib/tree-adapters/default.js)
  */
 export interface TreeAdapter {
+    /**
+     * Copies attributes to the given element. Only attributes that are not yet present in the element are copied.
+     *
+     * @param recipient - Element to copy attributes into.
+     * @param attrs - Attributes to copy.
+     */
+    adoptAttributes(recipient: Element, attrs: Attribute[]): void;
+
+    /**
+     * Appends a child node to the given parent node.
+     *
+     * @param parentNode - Parent node.
+     * @param newNode -  Child node.
+     */
+    appendChild(parentNode: ParentNode, newNode: Node): void;
+
+    /**
+     * Creates a comment node.
+     *
+     * @param data - Comment text.
+     */
+    createCommentNode(data: string): CommentNode;
+
     /**
      * Creates a document node.
      */
     createDocument(): Document;
+
     /**
      * Creates a document fragment node.
      */
     createDocumentFragment(): DocumentFragment;
+
     /**
      * Creates an element node.
      *
@@ -331,19 +387,113 @@ export interface TreeAdapter {
         namespaceURI: string,
         attrs: Attribute[]
     ): Element;
+
     /**
-     * Creates a comment node.
+     * Removes a node from its parent.
      *
-     * @param data - Comment text.
+     * @param node - Node to remove.
      */
-    createCommentNode(data: string): CommentNode;
+    detachNode(node: Node): void;
+
     /**
-     * Appends a child node to the given parent node.
+     * Returns the given element's attributes in an array, in the form of name-value pairs.
+     * Foreign attributes may contain `namespace` and `prefix` fields as well.
      *
-     * @param parentNode - Parent node.
-     * @param newNode -  Child node.
+     * @param element - Element.
      */
-    appendChild(parentNode: ParentNode, newNode: Node): void;
+    getAttrList(element: Element): Attribute[];
+
+    /**
+     * Returns the given node's children in an array.
+     *
+     * @param node - Node.
+     */
+    getChildNodes(node: ParentNode): Node[];
+
+    /**
+     * Returns the given comment node's content.
+     *
+     * @param commentNode - Comment node.
+     */
+    getCommentNodeContent(commentNode: CommentNode): string;
+
+    /**
+     * Returns [document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
+     *
+     * @param document - Document node.
+     */
+    getDocumentMode(document: Document): DocumentMode;
+
+    /**
+     * Returns the given document type node's name.
+     *
+     * @param doctypeNode - Document type node.
+     */
+    getDocumentTypeNodeName(doctypeNode: DocumentType): string;
+
+    /**
+     * Returns the given document type node's public identifier.
+     *
+     * @param doctypeNode - Document type node.
+     */
+    getDocumentTypeNodePublicId(doctypeNode: DocumentType): string;
+
+    /**
+     * Returns the given document type node's system identifier.
+     *
+     * @param doctypeNode - Document type node.
+     */
+    getDocumentTypeNodeSystemId(doctypeNode: DocumentType): string;
+
+    /**
+     * Returns the first child of the given node.
+     *
+     * @param node - Node.
+     */
+    getFirstChild(node: ParentNode): Node;
+
+    /**
+     * Returns the given element's namespace.
+     *
+     * @param element - Element.
+     */
+    getNamespaceURI(element: Element): string;
+
+    /**
+     * Returns the given node's source code location information.
+     *
+     * @param node - Node.
+     */
+    getNodeSourceCodeLocation(node: Node): Location | StartTagLocation | ElementLocation;
+
+    /**
+     * Returns the given node's parent.
+     *
+     * @param node - Node.
+     */
+    getParentNode(node: ChildNode): ParentNode;
+
+    /**
+     * Returns the given element's tag name.
+     *
+     * @param element - Element.
+     */
+    getTagName(element: Element): string;
+
+    /**
+     * Returns the given text node's content.
+     *
+     * @param textNode - Text node.
+     */
+    getTextNodeContent(textNode: TextNode): string;
+
+    /**
+     * Returns the `<template>` element content element.
+     *
+     * @param templateElement - `<template>` element.
+     */
+    getTemplateContent(templateElement: Element): DocumentFragment;
+
     /**
      * Inserts a child node to the given parent node before the given reference node.
      *
@@ -356,22 +506,67 @@ export interface TreeAdapter {
         newNode: Node,
         referenceNode: Node
     ): void;
+
     /**
-     * Sets the `<template>` element content element.
+     * Inserts text into a node. If the last child of the node is a text node, the provided text will be appended to the
+     * text node content. Otherwise, inserts a new text node with the given text.
      *
-     * @param templateElement - `<template>` element.
-     * @param contentElement -  Content element.
+     * @param parentNode - Node to insert text into.
+     * @param text - Text to insert.
      */
-    setTemplateContent(
-        templateElement: Element,
-        contentElement: DocumentFragment
+    insertText(parentNode: ParentNode, text: string): void;
+
+    /**
+     * Inserts text into a sibling node that goes before the reference node. If this sibling node is the text node,
+     * the provided text will be appended to the text node content. Otherwise, inserts a new sibling text node with
+     * the given text before the reference node.
+     *
+     * @param parentNode - Node to insert text into.
+     * @param text - Text to insert.
+     * @param referenceNode - Node to insert text before.
+     */
+    insertTextBefore(
+        parentNode: ParentNode,
+        text: string,
+        referenceNode: Node
     ): void;
+
     /**
-     * Returns the `<template>` element content element.
+     * Determines if the given node is a comment node.
      *
-     * @param templateElement - `<template>` element.
+     * @param node - Node.
      */
-    getTemplateContent(templateElement: Element): DocumentFragment;
+    isCommentNode(node: Node): boolean;
+
+    /**
+     * Determines if the given node is a document type node.
+     *
+     * @param node - Node.
+     */
+    isDocumentTypeNode(node: Node): boolean;
+
+    /**
+     * Determines if the given node is an element.
+     *
+     * @param node - Node.
+     */
+    isElementNode(node: Node): boolean;
+
+    /**
+     * Determines if the given node is a text node.
+     *
+     * @param node - Node.
+     */
+    isTextNode(node: Node): boolean;
+
+    /**
+     * Sets the [document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
+     *
+     * @param document - Document node.
+     * @param mode - Document mode.
+     */
+    setDocumentMode(document: Document, mode: DocumentMode): void;
+
     /**
      * Sets the document type. If the `document` already contains a document type node, the `name`, `publicId` and `systemId`
      * properties of this node will be updated with the provided values. Otherwise, creates a new document type node
@@ -388,145 +583,24 @@ export interface TreeAdapter {
         publicId: string,
         systemId: string
     ): void;
+
     /**
-     * Sets the [document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
+     * Attaches source code location information to the node.
      *
-     * @param document - Document node.
-     * @param mode - Document mode.
+     * @param node - Node.
      */
-    setDocumentMode(document: Document, mode: DocumentMode): void;
+    setNodeSourceCodeLocation(node: Node, location: Location | StartTagLocation | ElementLocation): void;
+
     /**
-     * Returns [document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
+     * Sets the `<template>` element content element.
      *
-     * @param document - Document node.
+     * @param templateElement - `<template>` element.
+     * @param contentElement -  Content element.
      */
-    getDocumentMode(document: Document): DocumentMode;
-    /**
-     * Removes a node from its parent.
-     *
-     * @param node - Node to remove.
-     */
-    detachNode(node: Node): void;
-    /**
-     * Inserts text into a node. If the last child of the node is a text node, the provided text will be appended to the
-     * text node content. Otherwise, inserts a new text node with the given text.
-     *
-     * @param parentNode - Node to insert text into.
-     * @param text - Text to insert.
-     */
-    insertText(parentNode: ParentNode, text: string): void;
-    /**
-     * Inserts text into a sibling node that goes before the reference node. If this sibling node is the text node,
-     * the provided text will be appended to the text node content. Otherwise, inserts a new sibling text node with
-     * the given text before the reference node.
-     *
-     * @param parentNode - Node to insert text into.
-     * @param text - Text to insert.
-     * @param referenceNode - Node to insert text before.
-     */
-    insertTextBefore(
-        parentNode: ParentNode,
-        text: string,
-        referenceNode: Node
+    setTemplateContent(
+        templateElement: Element,
+        contentElement: DocumentFragment
     ): void;
-    /**
-     * Copies attributes to the given element. Only attributes that are not yet present in the element are copied.
-     *
-     * @param recipient - Element to copy attributes into.
-     * @param attrs - Attributes to copy.
-     */
-    adoptAttributes(recipient: Element, attrs: Attribute[]): void;
-    /**
-     * Returns the first child of the given node.
-     *
-     * @param node - Node.
-     */
-    getFirstChild(node: ParentNode): Node;
-    /**
-     * Returns the given node's children in an array.
-     *
-     * @param node - Node.
-     */
-    getChildNodes(node: ParentNode): Node[];
-    /**
-     * Returns the given node's parent.
-     *
-     * @param node - Node.
-     */
-    getParentNode(node: ChildNode): ParentNode;
-    /**
-     * Returns the given element's attributes in an array, in the form of name-value pairs.
-     * Foreign attributes may contain `namespace` and `prefix` fields as well.
-     *
-     * @param element - Element.
-     */
-    getAttrList(element: Element): Attribute[];
-    /**
-     * Returns the given element's tag name.
-     *
-     * @param element - Element.
-     */
-    getTagName(element: Element): string;
-    /**
-     * Returns the given element's namespace.
-     *
-     * @param element - Element.
-     */
-    getNamespaceURI(element: Element): string;
-    /**
-     * Returns the given text node's content.
-     *
-     * @param textNode - Text node.
-     */
-    getTextNodeContent(textNode: TextNode): string;
-    /**
-     * Returns the given comment node's content.
-     *
-     * @param commentNode - Comment node.
-     */
-    getCommentNodeContent(commentNode: CommentNode): string;
-    /**
-     * Returns the given document type node's name.
-     *
-     * @param doctypeNode - Document type node.
-     */
-    getDocumentTypeNodeName(doctypeNode: DocumentType): string;
-    /**
-     * Returns the given document type node's public identifier.
-     *
-     * @param doctypeNode - Document type node.
-     */
-    getDocumentTypeNodePublicId(doctypeNode: DocumentType): string;
-    /**
-     * Returns the given document type node's system identifier.
-     *
-     * @param doctypeNode - Document type node.
-     */
-    getDocumentTypeNodeSystemId(doctypeNode: DocumentType): string;
-    /**
-     * Determines if the given node is a text node.
-     *
-     * @param node - Node.
-     */
-    isTextNode(node: Node): boolean;
-    /**
-     * Determines if the given node is a comment node.
-     *
-     * @param node - Node.
-     */
-    isCommentNode(node: Node): boolean;
-    /**
-     * Determines if the given node is a document type node.
-     *
-     * @param node - Node.
-     */
-    isDocumentTypeNode(node: Node): boolean;
-    /**
-     * Determines if the given node is an element.
-     *
-     * @param node - Node.
-     */
-    isElementNode(node: Node): boolean;
 }
 
 /**

--- a/types/parse5/parse5-tests.ts
+++ b/types/parse5/parse5-tests.ts
@@ -2,17 +2,15 @@ import * as parse5 from "parse5";
 
 // Shorthands
 // parse
-const document = parse5.parse("<html>");
+declare const document: parse5.Document;
+declare const defaultAdapter: parse5.TreeAdapter;
 
-document; // $ExpectType Document
-
-const defaultAdapter = new Object() as parse5.TreeAdapter;
-
+parse5.parse("<html>"); // $ExpectType Document
 parse5.parse("<html>", {}); // $ExpectType Document
 parse5.parse("<html>", { sourceCodeLocationInfo: true }); // $ExpectType Document
 parse5.parse("<html>", { treeAdapter: defaultAdapter }); // $ExpectType Document
 
-let opt = {
+let opt: parse5.ParserOptions = {
     sourceCodeLocationInfo: true,
     scriptingEnabled: false,
     treeAdapter: defaultAdapter
@@ -104,24 +102,26 @@ loc.endTag.startOffset; // $ExpectType number
 loc.endTag.endOffset; // $ExpectType number
 
 // Default AST
-const defaultDocument = document as parse5.DefaultTreeDocument;
+declare const defaultDocument: parse5.DefaultTreeDocument;
 
+defaultDocument.childNodes; // $ExpectType DefaultTreeNode[]
 defaultDocument.nodeName; // $ExpectType "#document"
 defaultDocument.mode; // $ExpectType DocumentMode
 
-const defaultDoctype = document as parse5.DefaultTreeDocumentType;
+declare const defaultDoctype: parse5.DefaultTreeDocumentType;
 
 defaultDoctype.name; // $ExpectType string
 defaultDoctype.publicId; // $ExpectType string
 defaultDoctype.systemId; // $ExpectType string
 
-const defaultDocumentFragment = fragment as parse5.DefaultTreeDocumentFragment;
+declare const defaultDocumentFragment: parse5.DefaultTreeDocumentFragment;
 
+defaultDocumentFragment.childNodes; // $ExpectType DefaultTreeNode[]
 defaultDocumentFragment.nodeName; // $ExpectType "#document-fragment"
 
-const defaultElement = defaultDocument
-    .childNodes[0] as parse5.DefaultTreeElement;
+declare const defaultElement: parse5.DefaultTreeElement;
 
+defaultElement.childNodes; // $ExpectType DefaultTreeNode[]
 defaultElement.sourceCodeLocation!; // $ExpectType ElementLocation
 defaultElement.namespaceURI; // $ExpectType string
 defaultElement.nodeName; // $ExpectType string
@@ -129,6 +129,7 @@ defaultElement.tagName; // $ExpectType string
 defaultElement.parentNode; // $ExpectType DefaultTreeParentNode
 defaultElement.parentNode.nodeName; // $ExpectType string
 
+// $ExpectType Attribute
 const defaultAttr = defaultElement.attrs[0];
 
 defaultAttr.name; // $ExpectType string
@@ -136,8 +137,7 @@ defaultAttr.namespace!; // $ExpectType string
 defaultAttr.prefix!; // $ExpectType string
 defaultAttr.value; // $ExpectType string
 
-const defaultTextNode = defaultDocumentFragment
-    .childNodes[0] as parse5.DefaultTreeTextNode;
+declare const defaultTextNode: parse5.DefaultTreeTextNode;
 
 defaultTextNode.sourceCodeLocation!; // $ExpectType Location
 defaultTextNode.nodeName; // $ExpectType "#text"
@@ -145,8 +145,7 @@ defaultTextNode.value; // $ExpectType string
 defaultTextNode.parentNode; // $ExpectType DefaultTreeParentNode
 defaultTextNode.parentNode.nodeName; // $ExpectType string
 
-const defaultCommentNode = defaultDocumentFragment
-    .childNodes[0] as parse5.DefaultTreeCommentNode;
+declare const defaultCommentNode: parse5.DefaultTreeCommentNode;
 
 defaultCommentNode.sourceCodeLocation!; // $ExpectType Location
 defaultCommentNode.nodeName; // $ExpectType "#comment"
@@ -192,3 +191,8 @@ adapter.isTextNode(element); // $ExpectType boolean
 adapter.isCommentNode(element); // $ExpectType boolean
 adapter.isDocumentTypeNode(element); // $ExpectType boolean
 adapter.isElementNode(element); // $ExpectType boolean
+
+declare const location: parse5.ElementLocation | parse5.StartTagLocation | parse5.Location;
+
+adapter.setNodeSourceCodeLocation(defaultTextNode, location); // $ExpectType void
+adapter.getNodeSourceCodeLocation(defaultTextNode); // $ExpectType ElementLocation | StartTagLocation | Location

--- a/types/parse5/tsconfig.json
+++ b/types/parse5/tsconfig.json
@@ -1,17 +1,13 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
+        "lib": ["ES2015"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/inikulin/parse5/blob/v5.1.1/packages/parse5/docs/tree-adapter/interface.md>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

Extracted from <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44336>