### PR TITLE
Tape: Add node events emitted by interface Test

### DIFF
--- a/types/tape/index.d.ts
+++ b/types/tape/index.d.ts
@@ -242,10 +242,10 @@ declare namespace tape {
         /**
          * Tape emits some node events you can hook up to.
          */
-        on(event: 'prerun' | 'run'  | 'end', callback: () => any );
-        on(event: 'test', callback: (t: Test) => any);
-        on(event: 'result', callback: (result: string | Result) => any );
-        on(event: 'plan', callback: (n: number) => any );
+        on(event: 'prerun' | 'run'  | 'end', callback: () => void );
+        on(event: 'test', callback: (t: Test) => void);
+        on(event: 'result', callback: (result: string | Result) => void );
+        on(event: 'plan', callback: (n: number) => void );
     }
 
     interface Result {

--- a/types/tape/index.d.ts
+++ b/types/tape/index.d.ts
@@ -256,5 +256,13 @@ declare namespace tape {
         name: string;
         operator?: string;
         objectPrintDepth?: number;
+        actual?: any;
+        expected?: any;
+        error?: Error;
+        functionName?: string;
+        file?: string;
+        line?: number;
+        column?: number;
+        at?: string;
     }
 }

--- a/types/tape/index.d.ts
+++ b/types/tape/index.d.ts
@@ -246,6 +246,11 @@ declare namespace tape {
         on(event: 'test', callback: (t: Test) => void);
         on(event: 'result', callback: (result: string | Result) => void );
         on(event: 'plan', callback: (n: number) => void );
+    
+        once(event: 'prerun' | 'run'  | 'end', callback: () => void );
+        once(event: 'test', callback: (t: Test) => void);
+        once(event: 'result', callback: (result: string | Result) => void );
+        once(event: 'plan', callback: (n: number) => void );
     }
 
     interface Result {

--- a/types/tape/index.d.ts
+++ b/types/tape/index.d.ts
@@ -242,15 +242,15 @@ declare namespace tape {
         /**
          * Tape emits some node events you can hook up to.
          */
-        on(event: 'prerun' | 'run'  | 'end', callback: () => void );
-        on(event: 'test', callback: (t: Test) => void);
-        on(event: 'result', callback: (result: string | Result) => void );
-        on(event: 'plan', callback: (n: number) => void );
+        on(event: 'prerun' | 'run'  | 'end', callback: () => void ): void;
+        on(event: 'test', callback: (t: Test) => void): void;
+        on(event: 'result', callback: (result: string | Result) => void ): void;
+        on(event: 'plan', callback: (n: number) => void ): void;
     
-        once(event: 'prerun' | 'run'  | 'end', callback: () => void );
-        once(event: 'test', callback: (t: Test) => void);
-        once(event: 'result', callback: (result: string | Result) => void );
-        once(event: 'plan', callback: (n: number) => void );
+        once(event: 'prerun' | 'run'  | 'end', callback: () => void ): void;
+        once(event: 'test', callback: (t: Test) => void): void;
+        once(event: 'result', callback: (result: string | Result) => void ): void;
+        once(event: 'plan', callback: (n: number) => void ): void;
     }
 
     interface Result {

--- a/types/tape/index.d.ts
+++ b/types/tape/index.d.ts
@@ -238,5 +238,23 @@ declare namespace tape {
          * Assert that string does not match the RegExp regexp. Will throw (not just fail) when the first two arguments are the wrong type.
          */
         doesNotMatch(actual: string, expected: RegExp, msg?: string, extra?: AssertOptions): void;
+        
+        /**
+         * Tape emits some node events you can hook up to.
+         */
+        on(event: 'prerun' | 'run'  | 'end', callback: () => any );
+        on(event: 'test', callback: (t: Test) => any);
+        on(event: 'result', callback: (result: string | Result) => any );
+        on(event: 'plan', callback: (n: number) => any );
+    }
+
+    interface Result {
+        id: number;
+        ok: boolean;
+        skip?: boolean | string;
+        todo?: boolean | string;
+        name: string;
+        operator?: string;
+        objectPrintDepth?: number;
     }
 }


### PR DESCRIPTION
You can actually use the function `on` in node on every object that `emit` is called upon. Tape calls `emit` on itself quite a few times, you can find all those events by searching for `emit(` in the Tape source code.

I stumbled upon this porting a Tape test to TypeScript that depended on the test.on('end') event, in order to do a teardown after each test.

Unfortunately, I didn't understand exactly for all of these events at which stages they are emitted, that's why I documented none of them. But I could find out the argument types the events can possibly be emitted with, which alone was a whole lot of work.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

