### PR TITLE
@types/yargs: yargs#showHelp accepts a callback

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -508,6 +508,12 @@ declare namespace yargs {
         showHelp(consoleLevel?: string): Argv<T>;
 
         /**
+         * Provide the usage data as a string.
+         * @param printCallback a function with a single argument.
+         */
+        showHelp(printCallback: (s: any) => void): Argv<T>;
+
+        /**
          * By default, yargs outputs a usage string if any error is detected.
          * Use the `.showHelpOnFail()` method to customize this behavior.
          * @param enable If `false`, the usage string is not output.

--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -511,7 +511,7 @@ declare namespace yargs {
          * Provide the usage data as a string.
          * @param printCallback a function with a single argument.
          */
-        showHelp(printCallback: (s: any) => void): Argv<T>;
+        showHelp(printCallback: (s: string) => void): Argv<T>;
 
         /**
          * By default, yargs outputs a usage string if any error is detected.

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -507,6 +507,13 @@ function Argv$showHelp() {
     yargs1.showHelp();
 }
 
+function Argv$showHelpWithCallback() {
+    const yargs1 = yargs.option('test', {
+        describe: "it's a test"
+    });
+    yargs1.showHelp(s => console.log(`Help! ${s}`));
+}
+
 function Argv$version() {
     const argv1 = yargs
         .version();


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/yargs/yargs/blob/master/docs/api.md#showhelpconsolelevel--printcallback>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

