### PR TITLE
Exclude `npm pack` artifacts in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ yarn.lock
 shrinkwrap.yaml
 pnpm-lock.yaml
 pnpm-debug.log
+
+# Output of 'npm pack'
+*.tgz


### PR DESCRIPTION
This prevents accidental inclusion of common artifact in users PRs:

see:
https://github.com/github/gitignore/blob/master/Node.gitignore#L65
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44439#issuecomment-622962988

Thanks!

/cc @orta 