### PR TITLE
[mongoose]: fix model properties not directly available on document

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -40,6 +40,7 @@
 //                 Cl3dson <https://github.com/cl3dson>
 //                 Richard Simko <https://github.com/richardsimko>
 //                 Marek Tuchalski <https://github.com/ith>
+//                 Jeremy Bensimon <https://github.com/jeremyben>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.2
 
@@ -2999,6 +3000,21 @@ declare module "mongoose" {
    */
   export var Model: Model<any>;
   interface Model<T extends Document, QueryHelpers = {}> extends NodeJS.EventEmitter, ModelProperties {
+    /** Base Mongoose instance the model uses. */
+    base: typeof mongoose;
+
+    /**
+     * If this is a discriminator model, baseModelName is the
+     * name of the base model.
+     */
+    baseModelName: string | undefined;
+
+    /** Registered discriminators for this model. */
+    discriminators: { [name: string]: Model<any> } | undefined;
+
+    /** The name of the model */
+    modelName: string;
+
     /**
      * Model constructor
      * Provides the interface to MongoDB collections as well as creates document instances.
@@ -3453,6 +3469,8 @@ declare module "mongoose" {
 
   class Document {}
   interface Document extends MongooseDocument, NodeJS.EventEmitter, ModelProperties {
+    constructor: Model<this>;
+
     /** Signal that we desire an increment of this documents version. */
     increment(): this;
 
@@ -3507,26 +3525,11 @@ declare module "mongoose" {
   }
 
   interface ModelProperties {
-    /** Base Mongoose instance the model uses. */
-    base: typeof mongoose;
-
-    /**
-     * If this is a discriminator model, baseModelName is the
-     * name of the base model.
-     */
-    baseModelName: string | undefined;
-
     /** Collection the model uses. */
     collection: Collection;
 
     /** Connection the model uses. */
     db: Connection;
-
-    /** Registered discriminators for this model. */
-    discriminators: any;
-
-    /** The name of the model */
-    modelName: string;
 
     /** Schema the model uses. */
     schema: Schema;

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -244,7 +244,7 @@ mongoModel.constructor.modelName;
 mongoModel.constructor.modelName.toLowerCase();
 MongoModel = mongoModel.constructor.base.model('new', mongoModel.schema);
 
-/* inherited properties */
+/* model inherited properties */
 MongoModel.collection;
 mongoModel.collection;
 mongoModel._id;

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -227,18 +227,24 @@ MongoModel.update({ age: { $gt: 18 } }, { oldEnough: true }, cb);
 MongoModel.update({ name: 'Tobi' }, { ferret: true }, { multi: true,  arrayFilters: [{ element: { $gte: 100 } }] }, cb);
 MongoModel.where('age').gte(21).lte(65).exec(cb);
 MongoModel.where('age').gte(21).lte(65).where('name', /^b/i);
-new (mongoModel.base.model(''))();
-mongoModel.baseModelName && mongoModel.baseModelName.toLowerCase();
+new (mongoModel.constructor.base.model(''))();
+// $ExpectError
+mongoModel.baseModelName;
+mongoModel.constructor.baseModelName && mongoModel.constructor.baseModelName.toLowerCase();
 mongoModel.collection.$format(99);
 mongoModel.collection.initializeOrderedBulkOp;
 mongoModel.collection.findOne;
 mongoModel.db.openUri('');
+// $ExpectError
 mongoModel.discriminators;
-mongoModel.modelName.toLowerCase();
-MongoModel = mongoModel.base.model('new', mongoModel.schema);
-/* inherited properties */
-MongoModel.modelName;
+mongoModel.constructor.discriminators;
+// $ExpectError
 mongoModel.modelName;
+mongoModel.constructor.modelName;
+mongoModel.constructor.modelName.toLowerCase();
+MongoModel = mongoModel.constructor.base.model('new', mongoModel.schema);
+
+/* inherited properties */
 MongoModel.collection;
 mongoModel.collection;
 mongoModel._id;


### PR DESCRIPTION
Some model properties are actually **not inherited** by the document.

`db` and `collection` are available on the document at runtime, but not `base`, `modelName`, `discriminators` or `baseModelName`. 
These properties are only available on the Model, which is accessible via the `constructor` of the document.

Another proof here: https://stackoverflow.com/questions/47040333/is-there-a-way-to-get-the-model-name-from-a-mongoose-model-instance

_See the code block below, tested at runtime._

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
```ts
const Foo = mongoose.model('Foo', new mongoose.Schema({ fooProp: String }))
const foo = new Foo({ fooProp: 'hello' })

foo.modelName // undefined
foo.constructor.modelName // 'Foo'

foo.base // undefined
foo.constructor.base // Mongoose {...}

const Bar = Foo.discriminator('Bar', new mongoose.Schema({ barProp: String }))

foo.discriminators // undefined
foo.constructor.discriminators // { Bar: Model { Bar } }

bar.baseModelName // undefined
bar.constructor.baseModelName // 'Foo'
```
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

