### PR TITLE
[chrome] fix TtsVoice extensionId and documentation

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7876,16 +7876,17 @@ declare namespace chrome.tts {
         /**
          * Optional. This voice's gender.
          * One of: "male", or "female"
+         * @deprecated since Chrome 70. Gender is deprecated and will be ignored.
          */
         gender?: string;
         /** Optional. The name of the voice. */
         voiceName?: string;
-        /** The ID of the extension providing this voice. */
-        extensionsId?: string;
-        /** All of the callback event types that this voice is capable of sending. */
+        /** Optional. The ID of the extension providing this voice. */
+        extensionId?: string;
+        /** Optional. All of the callback event types that this voice is capable of sending. */
         eventTypes?: string[];
         /**
-         * If true, the synthesis engine is a remote network resource. It may be higher latency and may incur bandwidth costs.
+         * Optional. If true, the synthesis engine is a remote network resource. It may be higher latency and may incur bandwidth costs.
          * @since Chrome 33.
          */
         remote?: boolean;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -440,6 +440,17 @@ function testStorage() {
     });
 }
 
+// https://developer.chrome.com/apps/tts#type-TtsVoice
+function testTtsVoice() {
+    chrome.tts.getVoices(voices => voices.forEach(voice => {
+        console.log(voice.voiceName);
+        console.log("\tlang: " + voice.lang);
+        console.log("\tremote: " + voice.remote);
+        console.log("\textensionId: " + voice.extensionId);
+        console.log("\teventTypes: " + voice.eventTypes);
+    }));
+}
+
 chrome.devtools.network.onRequestFinished.addListener((request: chrome.devtools.network.Request) => {
     request; // $ExpectType Request
     console.log('request: ', request);


### PR DESCRIPTION
#### chrome `TtsVoice` fixes
1. `extensionsId` renamed to `extensionId` (singular *extension*) to match the documentation and the implementation.
1. fix comments to match documentation

Note: not sure about testing: `test/index.ts` seems like a set of functions that one can manually execute and verify. I added a testcase in a similar fashion.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/apps/tts#type-TtsVoice
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
