### PR TITLE
history: accept single ambiguous location parameter for History's `push` and `replace` methods

### DIFF
--- a/types/history/DOMUtils.d.ts
+++ b/types/history/DOMUtils.d.ts
@@ -7,7 +7,11 @@ declare global {
 
 export const isExtraneousPopstateEvent: boolean;
 export function addEventListener(node: EventTarget, event: string, listener: EventListener | EventListenerObject): void;
-export function removeEventListener(node: EventTarget, event: string, listener: EventListener | EventListenerObject): void;
+export function removeEventListener(
+    node: EventTarget,
+    event: string,
+    listener: EventListener | EventListenerObject,
+): void;
 export function getConfirmation(message: string, callback: (result: boolean) => void): void;
 export function supportsHistory(): boolean;
 export function supportsGoWithoutReloadUsingHash(): boolean;

--- a/types/history/LocationUtils.d.ts
+++ b/types/history/LocationUtils.d.ts
@@ -1,12 +1,9 @@
 import { Path, LocationState, LocationKey, Location, LocationDescriptor } from './index';
 
-export function locationsAreEqual<S = LocationState>(
-  lv: LocationDescriptor<S>,
-  rv: LocationDescriptor<S>,
-): boolean;
+export function locationsAreEqual<S = LocationState>(lv: LocationDescriptor<S>, rv: LocationDescriptor<S>): boolean;
 export function createLocation<S = LocationState>(
-  path: LocationDescriptor<S>,
-  state?: S,
-  key?: LocationKey,
-  currentLocation?: Location<S>,
+    path: LocationDescriptor<S>,
+    state?: S,
+    key?: LocationKey,
+    currentLocation?: Location<S>,
 ): Location<S>;

--- a/types/history/createBrowserHistory.d.ts
+++ b/types/history/createBrowserHistory.d.ts
@@ -2,12 +2,10 @@ import { History, LocationState } from './index';
 import { getConfirmation } from './DOMUtils';
 
 export interface BrowserHistoryBuildOptions {
-  basename?: string;
-  forceRefresh?: boolean;
-  getUserConfirmation?: typeof getConfirmation;
-  keyLength?: number;
+    basename?: string;
+    forceRefresh?: boolean;
+    getUserConfirmation?: typeof getConfirmation;
+    keyLength?: number;
 }
 
-export default function createBrowserHistory<S = LocationState>(
-  options?: BrowserHistoryBuildOptions,
-): History<S>;
+export default function createBrowserHistory<S = LocationState>(options?: BrowserHistoryBuildOptions): History<S>;

--- a/types/history/createHashHistory.d.ts
+++ b/types/history/createHashHistory.d.ts
@@ -4,11 +4,9 @@ import { getConfirmation } from './DOMUtils';
 export type HashType = 'hashbang' | 'noslash' | 'slash';
 
 export interface HashHistoryBuildOptions {
-  basename?: string;
-  hashType?: HashType;
-  getUserConfirmation?: typeof getConfirmation;
+    basename?: string;
+    hashType?: HashType;
+    getUserConfirmation?: typeof getConfirmation;
 }
 
-export default function createHashHistory<S = LocationState>(
-  options?: HashHistoryBuildOptions,
-): History<S>;
+export default function createHashHistory<S = LocationState>(options?: HashHistoryBuildOptions): History<S>;

--- a/types/history/createMemoryHistory.d.ts
+++ b/types/history/createMemoryHistory.d.ts
@@ -2,18 +2,16 @@ import { History, Location, LocationState } from './index';
 import { getConfirmation } from './DOMUtils';
 
 export interface MemoryHistoryBuildOptions {
-  getUserConfirmation?: typeof getConfirmation;
-  initialEntries?: string[];
-  initialIndex?: number;
-  keyLength?: number;
+    getUserConfirmation?: typeof getConfirmation;
+    initialEntries?: string[];
+    initialIndex?: number;
+    keyLength?: number;
 }
 
 export interface MemoryHistory<HistoryLocationState = LocationState> extends History<HistoryLocationState> {
-  index: number;
-  entries: Location<HistoryLocationState>[];
-  canGo(n: number): boolean;
+    index: number;
+    entries: Location<HistoryLocationState>[];
+    canGo(n: number): boolean;
 }
 
-export default function createMemoryHistory<S = LocationState>(
-  options?: MemoryHistoryBuildOptions,
-): MemoryHistory<S>;
+export default function createMemoryHistory<S = LocationState>(options?: MemoryHistoryBuildOptions): MemoryHistory<S>;

--- a/types/history/createTransitionManager.d.ts
+++ b/types/history/createTransitionManager.d.ts
@@ -1,31 +1,20 @@
-import {
-  Location,
-  Action,
-  LocationListener,
-  LocationState,
-  UnregisterCallback,
-} from './index';
+import { Location, Action, LocationListener, LocationState, UnregisterCallback } from './index';
 import { getConfirmation } from './DOMUtils';
 
-export type PromptFunction<S = LocationState> = (
-  location: Location<S>,
-  action: Action,
-) => any;
+export type PromptFunction<S = LocationState> = (location: Location<S>, action: Action) => any;
 
 export type Prompt<S = LocationState> = PromptFunction<S> | boolean;
 
 export interface TransitionManager<S = LocationState> {
-  setPrompt(nextPrompt?: Prompt<S>): UnregisterCallback;
-  appendListener(listener: LocationListener<S>): UnregisterCallback;
-  notifyListeners(location: Location<S>, action: Action): void;
-  confirmTransitionTo(
-    location: Location<S>,
-    action: Action,
-    getUserConfirmation: typeof getConfirmation,
-    callback: (result: boolean) => void,
-  ): void;
+    setPrompt(nextPrompt?: Prompt<S>): UnregisterCallback;
+    appendListener(listener: LocationListener<S>): UnregisterCallback;
+    notifyListeners(location: Location<S>, action: Action): void;
+    confirmTransitionTo(
+        location: Location<S>,
+        action: Action,
+        getUserConfirmation: typeof getConfirmation,
+        callback: (result: boolean) => void,
+    ): void;
 }
 
-export default function createTransitionManager<
-  S = LocationState
->(): TransitionManager<S>;
+export default function createTransitionManager<S = LocationState>(): TransitionManager<S>;

--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -1,18 +1,25 @@
-import { createBrowserHistory, createMemoryHistory, createHashHistory, createLocation, Location, History, MemoryHistory } from 'history';
+import {
+    createBrowserHistory,
+    createMemoryHistory,
+    createHashHistory,
+    createLocation,
+    Location,
+    History,
+    MemoryHistory,
+} from 'history';
 import * as LocationUtils from 'history/LocationUtils';
 import * as PathUtils from 'history/PathUtils';
 import * as DOMUtils from 'history/DOMUtils';
 import * as ExecutionEnvironment from 'history/ExecutionEnvironment';
 
-let input = { value: "" };
+let input = { value: '' };
 
 {
     let history = createBrowserHistory<{ some: 'state' }>();
 
     history.location.state; // $ExpectType { some: "state"; }
 
-    // Listen for changes to the current location. The
-    // listener is called once immediately.
+    // Listen for changes to the current location. The listener is called once immediately.
     let unlisten = history.listen(function (location) {
         console.log(location.pathname);
     });
@@ -30,7 +37,7 @@ let input = { value: "" };
     history.push({
         pathname: '/about',
         search: '?the=search',
-        state: { some: 'state' }
+        state: { some: 'state' },
     });
 
     // Change just the search on an existing location.
@@ -45,7 +52,7 @@ let input = { value: "" };
 }
 
 {
-    let history: MemoryHistory<{the: 'state'}> = createMemoryHistory();
+    let history: MemoryHistory<{ the: 'state' }> = createMemoryHistory();
 
     // Pushing a path string.
     history.push('/the/path');
@@ -72,7 +79,7 @@ let input = { value: "" };
 }
 
 {
-    let history = createHashHistory()
+    let history = createHashHistory();
     history.listen(function (location) {
         if (input.value !== '') {
             return 'Are you sure you want to leave this page?';
@@ -93,7 +100,7 @@ let input = { value: "" };
         forceRefresh: false,
         getUserConfirmation(message, callback) {
             callback(window.confirm(message)); // The default behavior
-        }
+        },
     });
 }
 
@@ -118,9 +125,13 @@ let input = { value: "" };
 {
     const anything: any = {};
     const eventTarget: EventTarget = anything;
-    DOMUtils.addEventListener(eventTarget, 'onload', function (event) { event.preventDefault(); });
-    DOMUtils.removeEventListener(eventTarget, 'onload', function (event) { event.preventDefault(); });
-    DOMUtils.getConfirmation('confirm?', (result) => console.log(result));
+    DOMUtils.addEventListener(eventTarget, 'onload', function (event) {
+        event.preventDefault();
+    });
+    DOMUtils.removeEventListener(eventTarget, 'onload', function (event) {
+        event.preventDefault();
+    });
+    DOMUtils.getConfirmation('confirm?', result => console.log(result));
     let booleanValues = DOMUtils.supportsGoWithoutReloadUsingHash() && DOMUtils.supportsHistory();
 }
 

--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -4,6 +4,7 @@ import {
     createHashHistory,
     createLocation,
     Location,
+    LocationDescriptor,
     History,
     MemoryHistory,
 } from 'history';
@@ -42,6 +43,15 @@ let input = { value: '' };
 
     // Change just the search on an existing location.
     history.push({ pathname: location.pathname, search: '?the=other+search' });
+
+    // Function parameter allows testing of ambiguous location type (i.e. either string or object)
+    (location: LocationDescriptor<{ some: 'state' }>) => {
+        // Push a new entry of ambiguous type
+        history.push(location);
+
+        // Replace the current entry with one of ambiguous type
+        history.replace(location);
+    };
 
     // Go back to the previous history entry. The following
     // two lines are synonymous.

--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -9,21 +9,19 @@ export type Action = 'PUSH' | 'POP' | 'REPLACE';
 export type UnregisterCallback = () => void;
 
 export interface History<HistoryLocationState = LocationState> {
-  length: number;
-  action: Action;
-  location: Location<HistoryLocationState>;
-  push(path: Path, state?: HistoryLocationState): void;
-  push(location: LocationDescriptorObject<HistoryLocationState>): void;
-  replace(path: Path, state?: HistoryLocationState): void;
-  replace(location: LocationDescriptorObject<HistoryLocationState>): void;
-  go(n: number): void;
-  goBack(): void;
-  goForward(): void;
-  block(
-    prompt?: boolean | string | TransitionPromptHook<HistoryLocationState>,
-  ): UnregisterCallback;
-  listen(listener: LocationListener<HistoryLocationState>): UnregisterCallback;
-  createHref(location: LocationDescriptorObject<HistoryLocationState>): Href;
+    length: number;
+    action: Action;
+    location: Location<HistoryLocationState>;
+    push(path: Path, state?: HistoryLocationState): void;
+    push(location: LocationDescriptorObject<HistoryLocationState>): void;
+    replace(path: Path, state?: HistoryLocationState): void;
+    replace(location: LocationDescriptorObject<HistoryLocationState>): void;
+    go(n: number): void;
+    goBack(): void;
+    goForward(): void;
+    block(prompt?: boolean | string | TransitionPromptHook<HistoryLocationState>): UnregisterCallback;
+    listen(listener: LocationListener<HistoryLocationState>): UnregisterCallback;
+    createHref(location: LocationDescriptorObject<HistoryLocationState>): Href;
 }
 
 export interface Location<S = LocationState> {
@@ -45,10 +43,7 @@ export interface LocationDescriptorObject<S = LocationState> {
 export namespace History {
     export type LocationDescriptor<S = LocationState> = Path | LocationDescriptorObject<S>;
     export type LocationKey = string;
-    export type LocationListener<S = LocationState> = (
-      location: Location<S>,
-      action: Action,
-    ) => void;
+    export type LocationListener<S = LocationState> = (location: Location<S>, action: Action) => void;
     // The value type here is a "poor man's `unknown`". When these types support TypeScript
     // 3.0+, we can replace this with `unknown`.
     type PoorMansUnknown = {} | null | undefined;
@@ -56,13 +51,10 @@ export namespace History {
     export type Path = string;
     export type Pathname = string;
     export type Search = string;
-    export type TransitionHook<S = LocationState> = (
-      location: Location<S>,
-      callback: (result: any) => void,
-    ) => any;
+    export type TransitionHook<S = LocationState> = (location: Location<S>, callback: (result: any) => void) => any;
     export type TransitionPromptHook<S = LocationState> = (
-      location: Location<S>,
-      action: Action,
+        location: Location<S>,
+        action: Action,
     ) => string | false | void;
     export type Hash = string;
     export type Href = string;
@@ -76,17 +68,15 @@ export type Path = History.Path;
 export type Pathname = History.Pathname;
 export type Search = History.Search;
 export type TransitionHook<S = LocationState> = History.TransitionHook<S>;
-export type TransitionPromptHook<
-  S = LocationState
-> = History.TransitionPromptHook<S>;
+export type TransitionPromptHook<S = LocationState> = History.TransitionPromptHook<S>;
 export type Hash = History.Hash;
 export type Href = History.Href;
 
-import { default as createBrowserHistory } from "./createBrowserHistory";
-import { default as createHashHistory } from "./createHashHistory";
-import { default as createMemoryHistory } from "./createMemoryHistory";
-import { createLocation, locationsAreEqual } from "./LocationUtils";
-import { parsePath, createPath } from "./PathUtils";
+import { default as createBrowserHistory } from './createBrowserHistory';
+import { default as createHashHistory } from './createHashHistory';
+import { default as createMemoryHistory } from './createMemoryHistory';
+import { createLocation, locationsAreEqual } from './LocationUtils';
+import { parsePath, createPath } from './PathUtils';
 
 // Global usage, without modules, needs the small trick, because lib.d.ts
 // already has `history` and `History` global definitions:
@@ -101,9 +91,9 @@ export interface Module {
     createPath: typeof createPath;
 }
 
-export * from "./createBrowserHistory";
-export * from "./createHashHistory";
-export * from "./createMemoryHistory";
-export { createLocation, locationsAreEqual } from "./LocationUtils";
-export { parsePath, createPath } from "./PathUtils";
+export * from './createBrowserHistory';
+export * from './createHashHistory';
+export * from './createMemoryHistory';
+export { createLocation, locationsAreEqual } from './LocationUtils';
+export { parsePath, createPath } from './PathUtils';
 export { createBrowserHistory, createHashHistory, createMemoryHistory };

--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -13,9 +13,9 @@ export interface History<HistoryLocationState = LocationState> {
     action: Action;
     location: Location<HistoryLocationState>;
     push(path: Path, state?: HistoryLocationState): void;
-    push(location: LocationDescriptorObject<HistoryLocationState>): void;
+    push(location: LocationDescriptor<HistoryLocationState>): void;
     replace(path: Path, state?: HistoryLocationState): void;
-    replace(location: LocationDescriptorObject<HistoryLocationState>): void;
+    replace(location: LocationDescriptor<HistoryLocationState>): void;
     go(n: number): void;
     goBack(): void;
     goForward(): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Playground Link](https://www.typescriptlang.org/play/?ssl=1&ssc=1&pln=28&pc=1#code/JYWwDg9gTgLgBAbwFB1XAxlApgQxlgISggHcBnLKACWDJmgE8AaFNGuxltOAGQnTzAIAOwAiWMpmBh6UFgF84AM2Ig4AcgAWtWQ3UBuJEnQi6cbRygMAXHHa64AXgzY8hYuUr3GACgCUhkhYAB6QsMoArsLoMELCGBFQ2MIwBFiaOABuQok+ADb8giK2fAKxIuKSUNKyfraZEMAAJoisqAD07XAA8pmUBTgt6InJMHkMcGQRYGEwZJPAwgDmeVhwYDhQOGrASnAA1sKk8fRwAEZrOJMw1cttcLtwPjAMYFgQewVlcU6Ozup0W5LdR+VrcbgWXQAOjAETImnyhXKwgC9whOkYUOwYDyOHQWER3xEqLRaGwMESwkM3HkRm4nR6fSgAyGIywKXGk2ms3mZEWKzWGy2Oz2h2OcFOFzgOHiEDOACssDF7pDMbD4YSiijqWhVVYsVgcXiCV8tajaUFQtB4EoojEfk0JMBsE00hlshBcqbkSUkXFKlIZNA6nAGs0wWgGQBlTSevItKYza0LZardabbZwEiadlwb0-WjSkBnYBLCKesgqjH69UI-PEnWoPUMA1G-Ga5HmpBAA)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing): [history-tests.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/e08c927d8ee1c5ce0d479cee3ddbfd3fdaab2f37#diff-526c75ef39bd4ee85e5ebc916570c0f2)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

Updates overload signatures for `History.pull` and `History.replace` either a single parameter of either `string` or `object`.

Note: ran `prettier` on the latest version of history package definitions only prior to making changes to those declarations in a separate commit.