### PR TITLE
[aframe] added core ECS props in line with v1.0

### DIFF
--- a/types/aframe/index.d.ts
+++ b/types/aframe/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for AFRAME 0.8
+// Type definitions for AFRAME 1.0
 // Project: https://aframe.io/
 // Definitions by: Paul Shannon <https://github.com/devpaul>
 //                 Roberto Ritger <https://github.com/bertoritger>
@@ -66,16 +66,19 @@ export interface Component<T extends object = any, S extends System = System> {
 	dependencies?: string[];
 	el: Entity;
 	id: string;
+	initialized: boolean;
 	multiple?: boolean;
 	name: string;
 	schema: Schema<T>;
 	system: S | undefined;
+	events?: any;
 
 	init(data?: T): void;
 	pause(): void;
 	play(): void;
 	remove(): void;
 	tick?(time: number, timeDelta: number): void;
+	tock?(time: number, timeDelta: number, camera: THREE.Camera): void;
 	update(oldData: T): void;
 	updateSchema?(): void;
 
@@ -120,11 +123,13 @@ export interface DefaultComponents {
 
 export interface Entity<C = ObjectMap<Component>> extends ANode {
 	components: C & DefaultComponents;
+	hasLoaded: boolean;
 	isPlaying: boolean;
 	object3D: THREE.Object3D;
 	object3DMap: ObjectMap<THREE.Object3D>;
 	sceneEl?: Scene;
 
+	destroy(): void;
 	addState(name: string): void;
 	flushToDOM(recursive?: boolean): void;
 	/**
@@ -175,6 +180,11 @@ export interface EntityEventMap {
 	componentchanged: DetailEvent<{
 		name: string;
 		id: string;
+	}>;
+	componentinitialized: DetailEvent<{
+		name: string;
+		id: string;
+		data: any;
 	}>;
 	componentremoved: DetailEvent<{
 		name: string;
@@ -239,6 +249,7 @@ export interface Scene extends Entity {
 	object3D: THREE.Scene;
 	renderer: THREE.WebGLRenderer;
 	renderStarted: boolean;
+	effect?: any; // THREE.VREffect
 	systems: ObjectMap<System>;
 	time: number;
 
@@ -293,6 +304,7 @@ export interface SinglePropertySchema<T> {
 export interface System<T extends object = any> {
 	data: T;
 	schema: Schema<T>;
+	el: Entity;
 	init(): void;
 	pause(): void;
 	play(): void;

--- a/types/aframe/test/aframe-tests.ts
+++ b/types/aframe/test/aframe-tests.ts
@@ -6,7 +6,8 @@ import {
 	SystemDefinition,
 	THREE,
 	Geometry,
-	registerComponent
+	registerComponent,
+	Scene
 } from 'aframe';
 
 // Global
@@ -75,11 +76,17 @@ const Component = registerComponent('test-component', {
 	},
 	init() {
 		this.data.num = 0;
-		this.el.setAttribute('custom-attribute', 'custom-value');
+		if (this.initialized && this.el.hasLoaded) {
+			this.el.setAttribute('custom-attribute', 'custom-value');
+		}
 	},
 	update() {},
 	tick() {},
-	remove() {},
+	tock() {},
+	remove() {
+		this.el.remove();
+		this.el.destroy();
+	},
 	pause() {},
 	play() {},
 
@@ -102,6 +109,7 @@ const testSystem: SystemDefinition = {
 
 	init() {
 		this.data.counter = 1;
+		((this.el as Entity).sceneEl as Scene).addEventListener('enter-vr', (e) => { });
 	}
 };
 

--- a/types/aframe/tslint.json
+++ b/types/aframe/tslint.json
@@ -1,6 +1,18 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "no-unnecessary-type-assertion": false
+        "no-unnecessary-type-assertion": false,
+        "npm-naming": [
+            true,
+            {
+                "mode": "code",
+                "errors": [
+                    [
+                        "NeedsExportEquals",
+                        false
+                    ]
+                ]
+            }
+        ]
     }
 }


### PR DESCRIPTION
This merge request partially updates the definitions from v0.8 to v1.0.4 -- I only updated the properties on the main classes (Entity, Component, System, Scene) -- there could be others that I missed.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [multiple sections in aframe docs](https://aframe.io/docs/1.0.0/core/entity.html#destroy)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
