### PR TITLE
[yarnpkg__lockfile] Fix `parse` return type. Add dependency.integrity

### DIFF
--- a/types/yarnpkg__lockfile/index.d.ts
+++ b/types/yarnpkg__lockfile/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for @yarnpkg/lockfile 1.0.2
 // Project: https://github.com/yarnpkg/yarn/tree/master/packages/lockfile
-// Definitions by: Eric Wang <https://github.com/fa93hws> - rigwild <https://github.com/rigwild>
+// Definitions by: Eric Wang <https://github.com/fa93hws>
+//                 rigwild <https://github.com/rigwild>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Dependency {

--- a/types/yarnpkg__lockfile/index.d.ts
+++ b/types/yarnpkg__lockfile/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for @yarnpkg/lockfile 1.1
+// Type definitions for @yarnpkg/lockfile 1.0.2
 // Project: https://github.com/yarnpkg/yarn/tree/master/packages/lockfile
-// Definitions by: Eric Wang <https://github.com/fa93hws>
+// Definitions by: Eric Wang <https://github.com/fa93hws> - rigwild <https://github.com/rigwild>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Dependency {
@@ -10,6 +10,7 @@ export interface Dependency {
 export interface FirstLevelDependency {
   version: string;
   resolved?: string;
+  integrity?: string;
   dependencies?: Dependency;
 }
 
@@ -19,14 +20,11 @@ export interface LockFileObject {
 
 export function parse(
   file: string,
-  fileLoc?: string,
-): {
-  type: 'success' | 'merge' | 'conflict';
-  object: any;
-};
+  fileLoc?: string
+): { type: 'success' | 'merge'; object: LockFileObject } | { type: 'conflict'; object: {} };
 
 export function stringify(
-  json: any,
+  json: LockFileObject,
   noHeader?: boolean,
   enableVersions?: boolean,
 ): string;

--- a/types/yarnpkg__lockfile/index.d.ts
+++ b/types/yarnpkg__lockfile/index.d.ts
@@ -1,31 +1,31 @@
-// Type definitions for @yarnpkg/lockfile 1.0.2
+// Type definitions for @yarnpkg/lockfile 1.1
 // Project: https://github.com/yarnpkg/yarn/tree/master/packages/lockfile
 // Definitions by: Eric Wang <https://github.com/fa93hws>
 //                 rigwild <https://github.com/rigwild>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Dependency {
-  [packageName: string]: string;
+    [packageName: string]: string;
 }
 
 export interface FirstLevelDependency {
-  version: string;
-  resolved?: string;
-  integrity?: string;
-  dependencies?: Dependency;
+    version: string;
+    resolved?: string;
+    integrity?: string;
+    dependencies?: Dependency;
 }
 
 export interface LockFileObject {
-  [packageName: string]: FirstLevelDependency;
+    [packageName: string]: FirstLevelDependency;
 }
 
 export function parse(
-  file: string,
-  fileLoc?: string
+    file: string,
+    fileLoc?: string
 ): { type: 'success' | 'merge'; object: LockFileObject } | { type: 'conflict'; object: {} };
 
 export function stringify(
-  json: LockFileObject,
-  noHeader?: boolean,
-  enableVersions?: boolean,
+    json: LockFileObject,
+    noHeader?: boolean,
+    enableVersions?: boolean,
 ): string;

--- a/types/yarnpkg__lockfile/tsconfig.json
+++ b/types/yarnpkg__lockfile/tsconfig.json
@@ -1,26 +1,26 @@
 {
-  "compilerOptions": {
-      "module": "commonjs",
-      "lib": [
-          "es6"
-      ],
-      "noImplicitAny": true,
-      "noImplicitThis": true,
-      "strictNullChecks": true,
-      "strictFunctionTypes": true,
-      "baseUrl": "../",
-      "typeRoots": [
-          "../"
-      ],
-      "types": [],
-      "noEmit": true,
-      "forceConsistentCasingInFileNames": true,
-      "paths": {
-          "@yarnpkg/lockfile": ["yarnpkg__lockfile"]
-      }
-  },
-  "files": [
-      "index.d.ts",
-      "yarnpkg__lockfile-tests.ts"
-  ]
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@yarnpkg/lockfile": ["yarnpkg__lockfile"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "yarnpkg__lockfile-tests.ts"
+    ]
 }

--- a/types/yarnpkg__lockfile/yarnpkg__lockfile-tests.ts
+++ b/types/yarnpkg__lockfile/yarnpkg__lockfile-tests.ts
@@ -6,11 +6,11 @@ function testFirstLevelDependency(obj: FirstLevelDependency) {}
 const file = '';
 const parseResult = parse(file);
 
-if (parseResult.type === 'conflict') testParseResultConflict(parseResult.object)
+if (parseResult.type === 'conflict') testParseResultConflict(parseResult.object);
 if (parseResult.type === 'success' || parseResult.type === 'merge') {
-  const fileAgain = stringify(parseResult.object);
-  fileAgain.toLowerCase();
+    const fileAgain = stringify(parseResult.object);
+    fileAgain.toLowerCase();
 }
 
 if (parseResult.type === 'merge' || parseResult.type === 'success')
-  Object.values(parseResult.object).forEach(v => testFirstLevelDependency(v));
+    Object.keys(parseResult.object).forEach(k => testFirstLevelDependency(parseResult.object[k]));

--- a/types/yarnpkg__lockfile/yarnpkg__lockfile-tests.ts
+++ b/types/yarnpkg__lockfile/yarnpkg__lockfile-tests.ts
@@ -1,15 +1,16 @@
 import { parse, stringify, FirstLevelDependency } from '@yarnpkg/lockfile';
 
+function testParseResultConflict(obj: {}) {}
 function testFirstLevelDependency(obj: FirstLevelDependency) {}
 
 const file = '';
 const parseResult = parse(file);
-const fileAgain = stringify(parseResult);
-fileAgain.toLowerCase();
 
-if (parseResult.type === 'merge' || parseResult.type === 'success') {
-  Object.keys(parseResult.object).forEach(k => {
-    const value = parseResult.object[k];
-    testFirstLevelDependency(value);
-  });
+if (parseResult.type === 'conflict') testParseResultConflict(parseResult.object)
+if (parseResult.type === 'success' || parseResult.type === 'merge') {
+  const fileAgain = stringify(parseResult.object);
+  fileAgain.toLowerCase();
 }
+
+if (parseResult.type === 'merge' || parseResult.type === 'success')
+  Object.values(parseResult.object).forEach(v => testFirstLevelDependency(v));


### PR DESCRIPTION
 - infer `parse` return type, See in [Yarn source](https://github.com/yarnpkg/yarn/blob/a75dbe36ca7f6d881d291a7231676d00d523bb39/src/lockfile/parse.js#L418-L421)
 - Add `FirstLevelDependency.integrity`
 - Update tests

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

