### PR TITLE
[youtube-player] Adding string width/height definition

### DIFF
--- a/types/youtube-player/dist/types.d.ts
+++ b/types/youtube-player/dist/types.d.ts
@@ -6,8 +6,8 @@ export interface EmitterType {
 }
 
 export interface Options {
-    width?: number;
-    height?: number;
+    width?: number | string;
+    height?: number | string;
     videoId?: string;
     playerVars?: {
         autoplay?: 0 | 1,


### PR DESCRIPTION
The api documentation from the youtube player API never declares that it accepts only number for width and height. Moreover, providing "100%" to both attributes is accepted by the API in practice, even though never written inside the documentation. It seems the correct behavior since this allows the iframe to be responsive without refreshing the attributes manually through computed properties/variables.
Besides it came to me that the documentation examples use most of the time a string representation for the two attributes: 
* (https://developers.google.com/youtube/iframe_api_reference#Loading_a_Video_Player)
* (https://developers.google.com/youtube/iframe_api_reference#Getting_Started)
* (https://developers.google.com/youtube/player_parameters#IFrame_Player_API)
Since the javascript API does allow string value for these attributes, it seems better to translate the possibility inside the typescript definition.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
* (https://developers.google.com/youtube/iframe_api_reference#Loading_a_Video_Player)
* (https://developers.google.com/youtube/iframe_api_reference#Getting_Started)
* (https://developers.google.com/youtube/player_parameters#IFrame_Player_API)