### PR TITLE
Fix bad merge in redux-form

### DIFF
--- a/types/redux-form/lib/reduxForm.d.ts
+++ b/types/redux-form/lib/reduxForm.d.ts
@@ -110,7 +110,6 @@ export interface ConfigProps<FormData = {}, P = {}, ErrorType = string> {
     initialValues?: Partial<FormData>;
     keepDirtyOnReinitialize?: boolean;
     updateUnregisteredFields?: boolean;
-    submitAsSideEffect: boolean;
     keepValues?: boolean;
     onChange?(values: Partial<FormData>, dispatch: Dispatch<any>, props: DecoratedFormProps<FormData, P, ErrorType>, previousValues: Partial<FormData>): void;
     onSubmit?: FormSubmitHandler<FormData, P, ErrorType> | SubmitHandler<FormData, P, ErrorType>;


### PR DESCRIPTION
A recent PR had very old commits that conflicted with more recent commits. So there was a duplicate declaration of 'submitAsSideEffect'
