### PR TITLE
[slate]: Ensure setNodeByKey arguments are Partial

### DIFF
--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1798,7 +1798,7 @@ export class Editor implements Controller {
         properties: string | MarkProperties | MarkJSON | Mark,
         newProperties: string | Partial<MarkProperties> | Partial<MarkJSON> | Partial<Mark>
     ): Editor;
-    setNodeByKey(key: string, properties: string | BlockProperties | InlineProperties): Editor;
+    setNodeByKey(key: string, properties: string | Partial<BlockProperties> | Partial<InlineProperties>): Editor;
     setNodeByPath(path: Immutable.List<number>, newProperties: string | NodeProperties): Editor;
     setTextByKey(key: string, text: string, marks: Immutable.Set<Mark>): Editor;
     setTextByPath(path: Immutable.List<number>, text: string, marks: Immutable.Set<Mark>): Editor;

--- a/types/slate/slate-tests.ts
+++ b/types/slate/slate-tests.ts
@@ -403,6 +403,7 @@ editor
 .setInlinesAtRange(range, "paragraph")
 .setMarkByKey('a', 0, 2, { type: 'bold', data: { thing: 'value' } }, { data: { thing: false } })
 .setNodeByKey("a", "paragraph")
+.setNodeByKey("a", { data: Data.create({}) })
 .setNodeByPath(List([0]), "paragraph")
 .setReadOnly(true)
 .setValue(value)


### PR DESCRIPTION
The arguments to `Editor.setNodeByKey` were incorrectly set to `string | BlockProperties | InlineProperties`, and both of the latter options have a `type` key that is required. However, this function does not need to include all properties, and is used to merge new (partial) properties into those types. 

The author frequently uses it in that manner in the core codebase, passing an object without a `type` key:
https://github.com/ianstormtaylor/slate/blob/v0.47/packages/slate/src/plugins/schema.js#L234

This new test mirrors that usage, and failed prior to the fix:
https://github.com/jasonphillips/DefinitelyTyped/blob/53dd63e38f51cd81ad6fcafd35e4a792ee4a0cae/types/slate/slate-tests.ts#L406

Note that this is not for the latest version of Slate, but for the latest version that is here in `@typed`, because the versions that followed were converted fully to Typescript. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

