### PR TITLE
chrome-apps: fixed DisplayPropertiesInfo optional key boundsOriginY

### DIFF
--- a/types/chrome-apps/index.d.ts
+++ b/types/chrome-apps/index.d.ts
@@ -9460,7 +9460,7 @@ declare namespace chrome {
              * If set, updates the display's logical bounds origin along y-axis.
              * @see[See documentation for boundsOriginX parameter.]
              */
-            boundsOriginY: integer;
+            boundsOriginY?: integer;
 
             /**
              * If set, updates the display mode to the mode matching this value.


### PR DESCRIPTION
Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/apps/system_display#method-setDisplayProperties
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

boundsOriginY is an optional key in the setDisplayProperties method for chrome-apps as stated here
https://developer.chrome.com/apps/system_display#method-setDisplayProperties

updated the definition to match the definition from Chrome as there are times where you do not need to set boundsOriginY when modifying the display settings (such as setting rotation)
