### PR TITLE
FixedOffsetZone.utcInstance returns FixedOffsetZone, not string

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -530,7 +530,7 @@ export class IANAZone extends Zone {
 }
 
 export class FixedOffsetZone extends Zone {
-    static utcInstance: string;
+    static utcInstance: FixedOffsetZone;
     static instance(offset: number): FixedOffsetZone;
     static parseSpecifier(s: string): FixedOffsetZone;
 }

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -46,7 +46,7 @@ const ianaZoneTest = DateTime.fromObject({
     zone: ianaZone,
 });
 
-FixedOffsetZone.utcInstance;
+FixedOffsetZone.utcInstance.equals(FixedOffsetZone.instance(0));
 
 FixedOffsetZone.instance(60);
 FixedOffsetZone.parseSpecifier('UTC+6');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://moment.github.io/luxon/docs/class/src/zones/fixedOffsetZone.js~FixedOffsetZone.html#static-get-utcInstance>>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)