### PR TITLE
[serverless] Add variableResolvers to plugin definition

### DIFF
--- a/types/serverless/classes/Plugin.d.ts
+++ b/types/serverless/classes/Plugin.d.ts
@@ -20,6 +20,16 @@ declare namespace Plugin {
         };
     }
 
+    type VariableResolver = (variableSource: string) => Promise<any>;
+
+    interface VariableResolvers {
+        [variablePrefix: string]: VariableResolver | {
+            resolver: VariableResolver,
+            isDisabledAtPrepopulation?: boolean,
+            serviceName?: string
+        };
+    }
+
     interface PluginStatic {
         new (serverless: Serverless, options: Serverless.Options): Plugin;
     }
@@ -28,6 +38,7 @@ declare namespace Plugin {
 interface Plugin {
     hooks: Plugin.Hooks;
     commands?: Plugin.Commands;
+    variableResolvers?: Plugin.VariableResolvers;
 }
 
 export = Plugin;

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -29,10 +29,14 @@ class CustomPlugin implements Plugin {
     customProp = {};
 
     hooks: Plugin.Hooks;
+    variableResolvers: Plugin.VariableResolvers;
 
     constructor(serverless: Serverless, options: Serverless.Options) {
         this.hooks = {
             'command:start': () => {},
+        };
+        this.variableResolvers = {
+            echo: async (source) => source.slice(5)
         };
     }
 }
@@ -49,6 +53,24 @@ manager.addPlugin(CustomPlugin);
 // Test adding a plugin with an incorrect constructor
 // prettier-ignore
 manager.addPlugin(BadPlugin); // $ExpectError
+
+// Test a plugin with bad arguments for a variable resolver
+class BadVariablePlugin1 implements Plugin {
+    hooks: Plugin.Hooks;
+    // $ExpectError
+    variableResolvers = {
+        badEchoArgs: async (badArg: number) => {},
+    };
+}
+
+// Test a plugin with non-async variable resolver
+class BadVariablePlugin implements Plugin {
+    hooks: Plugin.Hooks;
+    // $ExpectError
+    variableResolvers = {
+        badEchoNotAsync: (source: string) => {},
+    };
+}
 
 // Test provider's 'request' method
 const provider = serverless.getProvider('aws');


### PR DESCRIPTION
This adds support for optional custom variableResolvers in Serverless Framework plugin types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.serverless.com/framework/docs/providers/aws/guide/plugins#thisvariableresolvers-structure
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.