### PR TITLE
Add types declaration for module Splashy

### DIFF
--- a/types/splashy/index.d.ts
+++ b/types/splashy/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for splashy 5.0
+// Project: https://nicedoc.io/microlinkhq/splashy
+// Definitions by: Valentin Dijkstra <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+type ImageSource = string | HTMLImageElement | Buffer;
+
+declare function splashy(source: ImageSource): Promise<string[]>;
+
+export = splashy;

--- a/types/splashy/index.d.ts
+++ b/types/splashy/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for splashy 5.0
-// Project: https://nicedoc.io/microlinkhq/splashy
-// Definitions by: Valentin Dijkstra <https://github.com/me>
+// Project: https://github.com/microlinkhq/splashy
+// Definitions by: Valentin Dijkstra <https://github.com/ValentinMumble>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -9,4 +9,4 @@ type ImageSource = string | HTMLImageElement | Buffer;
 
 declare function splashy(source: ImageSource): Promise<string[]>;
 
-export = splashy;
+export default splashy;

--- a/types/splashy/index.d.ts
+++ b/types/splashy/index.d.ts
@@ -9,4 +9,4 @@ type ImageSource = string | HTMLImageElement | Buffer;
 
 declare function splashy(source: ImageSource): Promise<string[]>;
 
-export default splashy;
+export = splashy;

--- a/types/splashy/splashy-tests.ts
+++ b/types/splashy/splashy-tests.ts
@@ -1,5 +1,18 @@
 import splashy from 'splashy';
 
-const url: string = 'https://kikobeats.com/images/avatar.jpg';
+const url = 'https://kikobeats.com/images/avatar.jpg';
+const image = new HTMLImageElement();
+const buffer = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+);
 
-const palette = await splashy(url);
+(async () => {
+    let palette = await splashy(url);
+    console.log(palette);
+
+    palette = await splashy(image);
+    console.log(palette);
+
+    palette = await splashy(buffer);
+    console.log(palette);
+})();

--- a/types/splashy/splashy-tests.ts
+++ b/types/splashy/splashy-tests.ts
@@ -1,0 +1,5 @@
+import splashy from 'splashy';
+
+const url: string = 'https://kikobeats.com/images/avatar.jpg';
+
+const palette = await splashy(url);

--- a/types/splashy/splashy-tests.ts
+++ b/types/splashy/splashy-tests.ts
@@ -1,4 +1,4 @@
-import splashy from 'splashy';
+import splashy = require('splashy');
 
 const url = 'https://kikobeats.com/images/avatar.jpg';
 const image = new HTMLImageElement();

--- a/types/splashy/tsconfig.json
+++ b/types/splashy/tsconfig.json
@@ -15,8 +15,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "esModuleInterop": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/splashy/tsconfig.json
+++ b/types/splashy/tsconfig.json
@@ -15,7 +15,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",

--- a/types/splashy/tsconfig.json
+++ b/types/splashy/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "splashy-tests.ts"
+    ]
+}

--- a/types/splashy/tsconfig.json
+++ b/types/splashy/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "lib": [
             "es6",
-            "DOM"
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/splashy/tslint.json
+++ b/types/splashy/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adding types declaration for module Slashy

https://github.com/microlinkhq/splashy
https://www.npmjs.com/package/splashy

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
