### PR TITLE
Fix compass-vertical-rhythm types, returns and more tests

### DIFF
--- a/types/compass-vertical-rhythm/compass-vertical-rhythm-tests.ts
+++ b/types/compass-vertical-rhythm/compass-vertical-rhythm-tests.ts
@@ -1,4 +1,10 @@
 import compassVerticalRhythm = require('compass-vertical-rhythm');
+import { Options, VerticalRhythm, VerticalRhythmStyles } from 'compass-vertical-rhythm';
+
+// $ExpectType VerticalRhythm
+compassVerticalRhythm({});
+// $ExpectError
+compassVerticalRhythm();
 
 compassVerticalRhythm({ baseFontSize: '16px' });
 compassVerticalRhythm({ baseLineHeight: 1.5 });
@@ -26,6 +32,7 @@ compassVerticalRhythm({ defaultRhythmBorderStyle: 'outset' });
 compassVerticalRhythm({ roundToNearestHalfLine: true });
 compassVerticalRhythm({ minLinePadding: '2px' });
 
+// $ExpectType VerticalRhythm
 const cvr = compassVerticalRhythm({
     baseFontSize: '16px',
     baseLineHeight: 1.5,
@@ -45,14 +52,25 @@ cvr.rhythm(1, '16px');
 // $ExpectType number
 cvr.rhythm(1, '16px', 4);
 
+// $ExpectType VerticalRhythmStyles
+cvr.establishBaseline();
+// $ExpectType string
 cvr.establishBaseline().fontSize;
+// $ExpectType string
 cvr.establishBaseline().lineHeight;
 
+// $ExpectType number
 cvr.linesForFontSize('16px');
 
+// $ExpectType string
 cvr.adjustFontSizeTo('32px', 1, '16px').fontSize;
+// $ExpectType string
 cvr.adjustFontSizeTo('32px', 1, '16px').lineHeight;
+// $ExpectType VerticalRhythmStyles
 cvr.adjustFontSizeTo('32px', 'auto', '16px');
+// $ExpectType VerticalRhythmStyles
 cvr.adjustFontSizeTo('32px', null, '16px');
+// $ExpectType VerticalRhythmStyles
 cvr.adjustFontSizeTo('32px', 1);
+// $ExpectType VerticalRhythmStyles
 cvr.adjustFontSizeTo('32px');

--- a/types/compass-vertical-rhythm/compass-vertical-rhythm-tests.ts
+++ b/types/compass-vertical-rhythm/compass-vertical-rhythm-tests.ts
@@ -36,9 +36,13 @@ const cvr = compassVerticalRhythm({
     minLinePadding: '2px',
 });
 
+// $ExpectType number
 cvr.rhythm();
+// $ExpectType number
 cvr.rhythm(1);
+// $ExpectType number
 cvr.rhythm(1, '16px');
+// $ExpectType number
 cvr.rhythm(1, '16px', 4);
 
 cvr.establishBaseline().fontSize;

--- a/types/compass-vertical-rhythm/index.d.ts
+++ b/types/compass-vertical-rhythm/index.d.ts
@@ -6,36 +6,40 @@
 
 export = compassVerticalRhythm;
 
-interface Options {
-    baseFontSize?: string;
-    baseLineHeight?: number | string;
-    rhythmUnit?: '%' | 'em' | 'ex' | 'ch' | 'px' | 'rem' | 'vw' | 'vh' | 'vmin';
-    defaultRhythmBorderWidth?: string;
-    defaultRhythmBorderStyle?:
-        | 'solid'
-        | 'none'
-        | 'hidden'
-        | 'dashed'
-        | 'dotted'
-        | 'double'
-        | 'groove'
-        | 'ridge'
-        | 'inset'
-        | 'outset';
-    roundToNearestHalfLine?: boolean;
-    minLinePadding?: string;
+declare namespace compassVerticalRhythm {
+    interface Options {
+        baseFontSize?: string;
+        baseLineHeight?: number | string;
+        rhythmUnit?: '%' | 'em' | 'ex' | 'ch' | 'px' | 'rem' | 'vw' | 'vh' | 'vmin';
+        defaultRhythmBorderWidth?: string;
+        defaultRhythmBorderStyle?:
+            | 'solid'
+            | 'none'
+            | 'hidden'
+            | 'dashed'
+            | 'dotted'
+            | 'double'
+            | 'groove'
+            | 'ridge'
+            | 'inset'
+            | 'outset';
+        roundToNearestHalfLine?: boolean;
+        minLinePadding?: string;
+    }
+
+    interface VerticalRhythmStyles {
+        fontSize: string;
+        lineHeight: string;
+    }
+
+    interface VerticalRhythm {
+        rhythm(lines?: number, fontSize?: string, offset?: number): number;
+        establishBaseline(): VerticalRhythmStyles;
+        linesForFontSize(fontSize: string): number;
+        adjustFontSizeTo(toSize: string, lines?: number | 'auto' | null, fromSize?: string): VerticalRhythmStyles;
+    }
 }
 
-interface VerticalRhythmStyles {
-    fontSize: string;
-    lineHeight: string;
-}
-
-interface VerticalRhythm {
-    rhythm(lines?: number, fontSize?: string, offset?: number): number;
-    establishBaseline(): VerticalRhythmStyles;
-    linesForFontSize(fontSize: string): number;
-    adjustFontSizeTo(toSize: string, lines?: number | 'auto' | null, fromSize?: string): VerticalRhythmStyles;
-}
-
-declare function compassVerticalRhythm(options: Options): VerticalRhythm;
+declare function compassVerticalRhythm(
+    options: compassVerticalRhythm.Options
+): compassVerticalRhythm.VerticalRhythm;

--- a/types/compass-vertical-rhythm/index.d.ts
+++ b/types/compass-vertical-rhythm/index.d.ts
@@ -32,7 +32,7 @@ interface VerticalRhythmStyles {
 }
 
 interface VerticalRhythm {
-    rhythm(lines?: number, fontSize?: string, offset?: number): number;
+    rhythm(lines?: number, fontSize?: string, offset?: number): string;
     establishBaseline(): VerticalRhythmStyles;
     linesForFontSize(fontSize: string): number;
     adjustFontSizeTo(toSize: string, lines?: number | 'auto' | null, fromSize?: string): VerticalRhythmStyles;

--- a/types/compass-vertical-rhythm/index.d.ts
+++ b/types/compass-vertical-rhythm/index.d.ts
@@ -32,7 +32,7 @@ interface VerticalRhythmStyles {
 }
 
 interface VerticalRhythm {
-    rhythm(lines?: number, fontSize?: string, offset?: number): string;
+    rhythm(lines?: number, fontSize?: string, offset?: number): number;
     establishBaseline(): VerticalRhythmStyles;
     linesForFontSize(fontSize: string): number;
     adjustFontSizeTo(toSize: string, lines?: number | 'auto' | null, fromSize?: string): VerticalRhythmStyles;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
=> `rhythm()` return-type; always a string : https://github.com/KyleAMathews/compass-vertical-rhythm/blob/master/src/index.js#L46-L64
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
=> Not needed; same minor, just fixes and better type exposure
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.