### PR TITLE
Update `@babel/core`, `@babel/traverse` and `babel-plugin-macros`.

### DIFF
--- a/types/babel-plugin-macros/index.d.ts
+++ b/types/babel-plugin-macros/index.d.ts
@@ -11,25 +11,25 @@ import * as Babel from '@babel/core';
 export = babelPluginMacros;
 
 declare namespace babelPluginMacros {
-    export interface References {
+    interface References {
         [key: string]: Babel.NodePath[];
     }
 
-    export interface Options {
+    interface Options {
         configName?: string;
     }
 
-    export interface MacroParams {
+    interface MacroParams {
         references: { default: Babel.NodePath[] } & References;
         state: Babel.PluginPass;
         babel: typeof Babel;
     }
 
-    export type MacroHandler = (params: MacroParams) => void;
+    type MacroHandler = (params: MacroParams) => void;
 
-    export class MacroError extends Error {}
+    class MacroError extends Error {}
 
-    export function createMacro(handler: MacroHandler, options?: Options): any;
+    function createMacro(handler: MacroHandler, options?: Options): any;
 }
 
 declare function babelPluginMacros(babel: typeof Babel, options: any): Babel.PluginObj;

--- a/types/babel-plugin-macros/index.d.ts
+++ b/types/babel-plugin-macros/index.d.ts
@@ -2,27 +2,34 @@
 // Project: https://github.com/kentcdodds/babel-plugin-macros
 // Definitions by: Billy Kwok <https://github.com/billykwok>
 //                 Jake Runzer <https://github.com/coffee-cup>
+//                 Ifiok Jr. <https://github.com/ifiokjr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.4
 
 import * as Babel from '@babel/core';
 
-export interface References {
-    [key: string]: Babel.NodePath[];
+export = babelPluginMacros;
+
+declare namespace babelPluginMacros {
+    export interface References {
+        [key: string]: Babel.NodePath[];
+    }
+
+    export interface Options {
+        configName?: string;
+    }
+
+    export interface MacroParams {
+        references: { default: Babel.NodePath[] } & References;
+        state: Babel.PluginPass;
+        babel: typeof Babel;
+    }
+
+    export type MacroHandler = (params: MacroParams) => void;
+
+    export class MacroError extends Error {}
+
+    export function createMacro(handler: MacroHandler, options?: Options): any;
 }
 
-export interface Options {
-    configName?: string;
-}
-
-export interface MacroParams {
-    references: { default: Babel.NodePath[] } & References;
-    state: any;
-    babel: typeof Babel;
-}
-
-export type MacroHandler = (params: MacroParams) => void;
-
-export class MacroError extends Error {}
-
-export function createMacro(handler: MacroHandler, options?: Options): any;
+declare function babelPluginMacros(babel: typeof Babel, options: any): Babel.PluginObj;

--- a/types/babel__core/babel__core-tests.ts
+++ b/types/babel__core/babel__core-tests.ts
@@ -1,29 +1,29 @@
-import * as babel from "@babel/core";
+import * as babel from '@babel/core';
 
 const options: babel.TransformOptions = {
     ast: true,
-    sourceMaps: true
+    sourceMaps: true,
 };
 
-babel.transform("code();", options, (err, result) => {
+babel.transform('code();', options, (err, result) => {
     const { code, map, ast } = result!;
     const { body } = ast!.program;
 });
 
-const transformSyncResult = babel.transformSync("code();", options);
+const transformSyncResult = babel.transformSync('code();', options);
 if (transformSyncResult) {
     const { code, map, ast } = transformSyncResult;
     const { body } = ast!.program;
 }
 
-babel.transformFile("filename.js", options, (err, result) => {
+babel.transformFile('filename.js', options, (err, result) => {
     const { code, map, ast } = result!;
     const { body } = ast!.program;
 });
 
-babel.transformFileSync("filename.js", options)!.code;
+babel.transformFileSync('filename.js', options)!.code;
 
-const sourceCode = "if (true) return;";
+const sourceCode = 'if (true) return;';
 const parsedAst = babel.parse(sourceCode, options);
 
 babel.transformFromAst(parsedAst!, sourceCode, options, (err, result) => {
@@ -64,23 +64,23 @@ checkOptions({ exclude: 256 });
 checkOptions({ include: [/node_modules/, new RegExp('bower_components')] });
 // $ExpectError
 checkOptions({ include: [null] });
-checkOptions({ test: (fileName) => fileName ? fileName.endsWith('mjs') : false });
+checkOptions({ test: fileName => (fileName ? fileName.endsWith('mjs') : false) });
 // $ExpectError
-checkOptions({ test: (fileName) => fileName && fileName.endsWith('mjs') });
+checkOptions({ test: fileName => fileName && fileName.endsWith('mjs') });
 checkOptions({
     overrides: [
         {
             test: /^.*\.m?js$/,
             compact: true,
-        }
-    ]
+        },
+    ],
 });
 checkOptions({
     overrides: {
         // $ExpectError
         test: /^.*\.m?js$/,
         compact: true,
-    }
+    },
 });
 
 // $ExpectError
@@ -89,7 +89,7 @@ checkConfigFunction(() => {});
 checkConfigFunction(() => ({}));
 checkConfigFunction(api => {
     api.assertVersion(7);
-    api.assertVersion("^7.2");
+    api.assertVersion('^7.2');
 
     api.cache.forever();
     api.cache.never();
@@ -119,6 +119,10 @@ checkConfigFunction(api => {
             comment;
 
             return true;
-        }
+        },
     };
 });
+
+function withPluginPass(state: babel.PluginPass) {
+    state.file.hub.addHelper('something');
+}

--- a/types/babel__core/index.d.ts
+++ b/types/babel__core/index.d.ts
@@ -4,24 +4,17 @@
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
 //                 Melvin Groenhoff <https://github.com/mgroenhoff>
 //                 Jessica Franco <https://github.com/Jessidhia>
+//                 Ifiok Jr. <https://github.com/ifiokjr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.4
 
-import { GeneratorOptions } from "@babel/generator";
-import traverse, { Visitor, NodePath } from "@babel/traverse";
-import template from "@babel/template";
-import * as t from "@babel/types";
-import { ParserOptions } from "@babel/parser";
+import { GeneratorOptions } from '@babel/generator';
+import traverse, { Visitor, NodePath, Hub, Scope } from '@babel/traverse';
+import template from '@babel/template';
+import * as t from '@babel/types';
+import { ParserOptions } from '@babel/parser';
 
-export {
-    ParserOptions,
-    GeneratorOptions,
-    t as types,
-    template,
-    traverse,
-    NodePath,
-    Visitor
-};
+export { ParserOptions, GeneratorOptions, t as types, template, traverse, NodePath, Visitor };
 
 export type Node = t.Node;
 export type ParseResult = t.File | t.Program;
@@ -120,7 +113,7 @@ export interface TransformOptions {
      *
      * Default: `"auto"`
      */
-    compact?: boolean | "auto" | null;
+    compact?: boolean | 'auto' | null;
 
     /**
      * The working directory that Babel's programmatic options are loaded relative to.
@@ -143,7 +136,7 @@ export interface TransformOptions {
      *
      * Default: `{}`
      */
-    env?: { [index: string]: TransformOptions | null | undefined; } | null;
+    env?: { [index: string]: TransformOptions | null | undefined } | null;
 
     /**
      * A path to a `.babelrc` file to extend
@@ -296,7 +289,7 @@ export interface TransformOptions {
      *
      * Default: `false`
      */
-    sourceMaps?: boolean | "inline" | "both" | null;
+    sourceMaps?: boolean | 'inline' | 'both' | null;
 
     /**
      * The root from which all sources are relative
@@ -311,7 +304,7 @@ export interface TransformOptions {
      *
      * Default: `("module")`
      */
-    sourceType?: "script" | "module" | "unambiguous" | null;
+    sourceType?: 'script' | 'module' | 'unambiguous' | null;
 
     /**
      * If all patterns fail to match, the current configuration object is considered inactive and is ignored during config processing.
@@ -322,7 +315,13 @@ export interface TransformOptions {
      * An optional callback that can be used to wrap visitor methods. **NOTE**: This is useful for things like introspection, and not really needed for implementing anything. Called as
      * `wrapPluginVisitorMethod(pluginAlias, visitorType, callback)`.
      */
-    wrapPluginVisitorMethod?: ((pluginAlias: string, visitorType: "enter" | "exit", callback: (path: NodePath, state: any) => void) => (path: NodePath, state: any) => void) | null;
+    wrapPluginVisitorMethod?:
+        | ((
+              pluginAlias: string,
+              visitorType: 'enter' | 'exit',
+              callback: (path: NodePath, state: any) => void,
+          ) => (path: NodePath, state: any) => void)
+        | null;
 }
 
 export interface TransformCaller {
@@ -396,7 +395,12 @@ export function transformFromAst(ast: Node, code: string | undefined, callback: 
 /**
  * Given an AST, transform it.
  */
-export function transformFromAst(ast: Node, code: string | undefined, opts: TransformOptions | undefined, callback: FileResultCallback): void;
+export function transformFromAst(
+    ast: Node,
+    code: string | undefined,
+    opts: TransformOptions | undefined,
+    callback: FileResultCallback,
+): void;
 
 /**
  * Here for backward-compatibility. Ideally use ".transformSync" if you want a synchronous API.
@@ -406,19 +410,43 @@ export function transformFromAstSync(ast: Node, code?: string, opts?: TransformO
 /**
  * Given an AST, transform it.
  */
-export function transformFromAstAsync(ast: Node, code?: string, opts?: TransformOptions): Promise<BabelFileResult | null>;
+export function transformFromAstAsync(
+    ast: Node,
+    code?: string,
+    opts?: TransformOptions,
+): Promise<BabelFileResult | null>;
 
 // A babel plugin is a simple function which must return an object matching
 // the following interface. Babel will throw if it finds unknown properties.
 // The list of allowed plugin keys is here:
 // https://github.com/babel/babel/blob/4e50b2d9d9c376cee7a2cbf56553fe5b982ea53c/packages/babel-core/src/config/option-manager.js#L71
-export interface PluginObj<S = {}> {
+export interface PluginObj<S = PluginPass> {
     name?: string;
     manipulateOptions?(opts: any, parserOpts: any): void;
-    pre?(this: S, state: any): void;
+    pre?(this: S, state: S): void;
     visitor: Visitor<S>;
-    post?(this: S, state: any): void;
+    post?(this: S, state: S): void;
     inherits?: any;
+}
+
+export interface BabelFile {
+    ast: t.File;
+    opts: TransformOptions;
+    hub: Hub;
+    metadata: object;
+    path: NodePath;
+    scope: Scope;
+    inputMap: object | null;
+    code: string;
+}
+
+export interface PluginPass {
+    file: BabelFile;
+    key: string;
+    opts: PluginOptions;
+    cwd: string;
+    filename: string;
+    [key: string]: unknown;
 }
 
 export interface BabelFileResult {
@@ -571,14 +599,19 @@ export type PluginOptions = object | undefined | false;
 
 export type PluginTarget = string | object | ((...args: any[]) => any);
 
-export type PluginItem = ConfigItem | PluginObj<any> | PluginTarget | [PluginTarget, PluginOptions] | [PluginTarget, PluginOptions, string | undefined];
+export type PluginItem =
+    | ConfigItem
+    | PluginObj<any>
+    | PluginTarget
+    | [PluginTarget, PluginOptions]
+    | [PluginTarget, PluginOptions, string | undefined];
 
 export function resolvePlugin(name: string, dirname: string): string | null;
 export function resolvePreset(name: string, dirname: string): string | null;
 
 export interface CreateConfigItemOptions {
     dirname?: string;
-    type?: "preset" | "plugin";
+    type?: 'preset' | 'plugin';
 }
 
 /**
@@ -586,7 +619,10 @@ export interface CreateConfigItemOptions {
  * given plugin, Babel will call the plugin's function itself multiple times. If you have a clear set of expected
  * plugins and presets to inject, pre-constructing the config items would be recommended.
  */
-export function createConfigItem(value: PluginTarget | [PluginTarget, PluginOptions] | [PluginTarget, PluginOptions, string | undefined], options?: CreateConfigItemOptions): ConfigItem;
+export function createConfigItem(
+    value: PluginTarget | [PluginTarget, PluginOptions] | [PluginTarget, PluginOptions, string | undefined],
+    options?: CreateConfigItemOptions,
+): ConfigItem;
 
 // NOTE: the documentation says the ConfigAPI also exposes @babel/core's exports, but it actually doesn't
 /**

--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -1,4 +1,4 @@
-import traverse, { Visitor, NodePath } from '@babel/traverse';
+import traverse, { Visitor, NodePath, Hub } from '@babel/traverse';
 import * as t from '@babel/types';
 
 // Examples from: https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md
@@ -257,3 +257,7 @@ const VisitorAliasTest: Visitor = {
     Function() {},
     Expression() {},
 };
+
+const hub = new Hub('file', { options: '' });
+// $ExpectType string | undefined
+hub.getCode();

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -5,6 +5,7 @@
 //                 Ryan Petrich <https://github.com/rpetrich>
 //                 Melvin Groenhoff <https://github.com/mgroenhoff>
 //                 Dean L. <https://github.com/dlgrit>
+//                 Ifiok Jr. <https://github.com/ifiokjr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.4
 
@@ -841,10 +842,23 @@ export class NodePath<T = Node> {
     assertRegexLiteral(opts?: object): void;
 }
 
-export class Hub {
+type ErrorConstructor = typeof Error;
+
+export interface HubInterface {
+    getCode(): string | undefined;
+    getScope(): Scope | undefined;
+    addHelper(name: string): Object;
+    buildError(node: Object, msg: string, Error: ErrorConstructor): Error;
+}
+
+export class Hub implements HubInterface {
     constructor(file: any, options: any);
     file: any;
     options: any;
+    getCode(): string | undefined;
+    getScope(): Scope | undefined;
+    addHelper(name: string): Object;
+    buildError(node: Object, msg: string, Error: ErrorConstructor): Error;
 }
 
 export interface TraversalContext {

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -842,13 +842,11 @@ export class NodePath<T = Node> {
     assertRegexLiteral(opts?: object): void;
 }
 
-type ErrorConstructor = typeof Error;
-
 export interface HubInterface {
     getCode(): string | undefined;
     getScope(): Scope | undefined;
-    addHelper(name: string): Object;
-    buildError(node: Object, msg: string, Error: ErrorConstructor): Error;
+    addHelper(name: string): any;
+    buildError(node: any, msg: string, Error: ErrorConstructor): Error;
 }
 
 export class Hub implements HubInterface {
@@ -857,8 +855,8 @@ export class Hub implements HubInterface {
     options: any;
     getCode(): string | undefined;
     getScope(): Scope | undefined;
-    addHelper(name: string): Object;
-    buildError(node: Object, msg: string, Error: ErrorConstructor): Error;
+    addHelper(name: string): any;
+    buildError(node: any, msg: string, Constructor: typeof Error): Error;
 }
 
 export interface TraversalContext {


### PR DESCRIPTION
In testing out the babel plugins, I've noticed the state always points to the [`PluginPass`](https://github.com/babel/babel/blob/f6c7bf36cec81baaba8c37e572985bb59ca334b1/packages/babel-core/src/transformation/plugin-pass.js#L6-L54) class. 

I've added that as an export to the type definitions and set it as a default for the babel export. 

Please note, I'm not sure if this has other implications so I'm happy to hear your suggestions or push backs. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
