### PR TITLE
add definitions for once() to noble

### DIFF
--- a/types/noble/index.d.ts
+++ b/types/noble/index.d.ts
@@ -25,6 +25,12 @@ export declare function on(event: "scanStop", listener: () => void): events.Even
 export declare function on(event: "discover", listener: (peripheral: Peripheral) => void): events.EventEmitter;
 export declare function on(event: string, listener: Function): events.EventEmitter;
 
+export declare function once(event: "stateChange", listener: (state: string) => void): events.EventEmitter;
+export declare function once(event: "scanStart", listener: () => void): events.EventEmitter;
+export declare function once(event: "scanStop", listener: () => void): events.EventEmitter;
+export declare function once(event: "discover", listener: (peripheral: Peripheral) => void): events.EventEmitter;
+export declare function once(event: string, listener: Function): events.EventEmitter;
+
 export declare function removeListener(event: "stateChange", listener: (state: string) => void): events.EventEmitter;
 export declare function removeListener(event: "scanStart", listener: () => void): events.EventEmitter;
 export declare function removeListener(event: "scanStop", listener: () => void): events.EventEmitter;
@@ -60,8 +66,14 @@ export declare class Peripheral extends events.EventEmitter {
     on(event: "connect", listener: (error: string) => void): this;
     on(event: "disconnect", listener: (error: string) => void): this;
     on(event: "rssiUpdate", listener: (rssi: number) => void): this;
-	on(event: "servicesDiscover", listener: (services: Service[]) => void): this;
-	on(event: string, listener: Function): this;
+    on(event: "servicesDiscover", listener: (services: Service[]) => void): this;
+    on(event: string, listener: Function): this;
+
+    once(event: "connect", listener: (error: string) => void): this;
+    once(event: "disconnect", listener: (error: string) => void): this;
+    once(event: "rssiUpdate", listener: (rssi: number) => void): this;
+    once(event: "servicesDiscover", listener: (services: Service[]) => void): this;
+    once(event: string, listener: Function): this;
 }
 
 export interface Advertisement {
@@ -87,8 +99,12 @@ export declare class Service extends events.EventEmitter {
     toString(): string;
 
     on(event: "includedServicesDiscover", listener: (includedServiceUuids: string[]) => void): this;
-	on(event: "characteristicsDiscover", listener: (characteristics: Characteristic[]) => void): this;
-	on(event: string, listener: Function): this;
+    on(event: "characteristicsDiscover", listener: (characteristics: Characteristic[]) => void): this;
+    on(event: string, listener: Function): this;
+
+    once(event: "includedServicesDiscover", listener: (includedServiceUuids: string[]) => void): this;
+    once(event: "characteristicsDiscover", listener: (characteristics: Characteristic[]) => void): this;
+    once(event: string, listener: Function): this;
 }
 
 export declare class Characteristic extends events.EventEmitter {
@@ -111,9 +127,17 @@ export declare class Characteristic extends events.EventEmitter {
     on(event: "write", withoutResponse: boolean, listener: (error: string) => void): this;
     on(event: "broadcast", listener: (state: string) => void): this;
     on(event: "notify", listener: (state: string) => void): this;
-	on(event: "descriptorsDiscover", listener: (descriptors: Descriptor[]) => void): this;
-	on(event: string, listener: Function): this;
+    on(event: "descriptorsDiscover", listener: (descriptors: Descriptor[]) => void): this;
+    on(event: string, listener: Function): this;
     on(event: string, option: boolean, listener: Function): this;
+
+    once(event: "read", listener: (data: Buffer, isNotification: boolean) => void): this;
+    once(event: "write", withoutResponse: boolean, listener: (error: string) => void): this;
+    once(event: "broadcast", listener: (state: string) => void): this;
+    once(event: "notify", listener: (state: string) => void): this;
+    once(event: "descriptorsDiscover", listener: (descriptors: Descriptor[]) => void): this;
+    once(event: string, listener: Function): this;
+    once(event: string, option: boolean, listener: Function): this;
 }
 
 export declare class Descriptor extends events.EventEmitter {
@@ -126,6 +150,10 @@ export declare class Descriptor extends events.EventEmitter {
     toString(): string;
 
     on(event: "valueRead", listener: (error: string, data: Buffer) => void): this;
-	on(event: "valueWrite", listener: (error: string) => void): this;
-	on(event: string, listener: Function): this;
+    on(event: "valueWrite", listener: (error: string) => void): this;
+    on(event: string, listener: Function): this;
+
+    once(event: "valueRead", listener: (error: string, data: Buffer) => void): this;
+    once(event: "valueWrite", listener: (error: string) => void): this;
+    once(event: string, listener: Function): this;
 }

--- a/types/noble/noble-tests.ts
+++ b/types/noble/noble-tests.ts
@@ -27,6 +27,14 @@ noble.on("discover", (peripheral: noble.Peripheral): void => {
     peripheral.disconnect((): void => {});
 });
 
+noble.once("stateChange", (state: string): void => {});
+noble.once("scanStart", (): void => {});
+noble.once("scanStop", (): void => {});
+noble.once("discover", (peripheral: noble.Peripheral): void => {
+    peripheral.connect((error: string): void => {});
+    peripheral.disconnect((): void => {});
+});
+
 noble.removeListener("stateChange", (state: string): void => {});
 noble.removeListener("scanStart", (): void => {});
 noble.removeListener("scanStop", (): void => {});
@@ -71,6 +79,10 @@ peripheral.on("connect", (error: string): void => {});
 peripheral.on("disconnect", (error: string): void => {});
 peripheral.on("rssiUpdate", (rssi: number): void => {});
 peripheral.on("servicesDiscover", (services: noble.Service[]): void => {});
+peripheral.once("connect", (error: string): void => {});
+peripheral.once("disconnect", (error: string): void => {});
+peripheral.once("rssiUpdate", (rssi: number): void => {});
+peripheral.once("servicesDiscover", (services: noble.Service[]): void => {});
 
 var service: noble.Service = new noble.Service();
 service.uuid = "180a";
@@ -83,6 +95,8 @@ service.discoverCharacteristics(["2a38"]);
 service.discoverCharacteristics(["2a38"], (error: string, characteristics: noble.Characteristic[]): void => {});
 service.on("includedServicesDiscover", (includedServiceUuids: string[]): void => {});
 service.on("characteristicsDiscover", (characteristics: noble.Characteristic[]): void => {});
+service.once("includedServicesDiscover", (includedServiceUuids: string[]): void => {});
+service.once("characteristicsDiscover", (characteristics: noble.Characteristic[]): void => {});
 
 var characteristic: noble.Characteristic = new noble.Characteristic();
 characteristic.uuid = "2a37";
@@ -104,6 +118,11 @@ characteristic.on("write", true, (error: string): void => {});
 characteristic.on("broadcast", (state: string): void => {});
 characteristic.on("notify", (state: string): void => {});
 characteristic.on("descriptorsDiscover", (descriptors: noble.Descriptor[]): void => {});
+characteristic.once("read", (data: Buffer, isNotification: boolean): void => {});
+characteristic.once("write", true, (error: string): void => {});
+characteristic.once("broadcast", (state: string): void => {});
+characteristic.once("notify", (state: string): void => {});
+characteristic.once("descriptorsDiscover", (descriptors: noble.Descriptor[]): void => {});
 characteristic.subscribe();
 characteristic.subscribe((error: string) => {});
 characteristic.unsubscribe();
@@ -119,4 +138,5 @@ descriptor.writeValue(new Buffer(1));
 descriptor.writeValue(new Buffer(1), (error: string): void => {});
 descriptor.on("valueRead", (error: string, data: Buffer): void => {});
 descriptor.on("valueWrite", (error: string): void => {});
-
+descriptor.once("valueRead", (error: string, data: Buffer): void => {});
+descriptor.once("valueWrite", (error: string): void => {});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ x Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/events.html#events_handling_events_only_once
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.