### PR TITLE
CodeMirror: removed method, options on marks

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -787,9 +787,6 @@ declare namespace CodeMirror {
         /**  Called when you've done something that might change the size of the marker and want to cheaply update the display*/
         changed(): void;
 
-        /**  Returns an object representing the options for the marker. If copyWidget is given true, it will clone the value of the replacedWith option, if any. */
-        getOptions(copyWidget: boolean): CodeMirror.TextMarkerOptions;
-
         /** Fired when the cursor enters the marked range */
         on(eventName: 'beforeCursorEnter', handler: () =>  void) : void;
         off(eventName: 'beforeCursorEnter', handler: () => void) : void;

--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -776,7 +776,7 @@ declare namespace CodeMirror {
         clientHeight: any;
     }
 
-    interface TextMarker {
+    interface TextMarker extends Partial<TextMarkerOptions> {
         /** Remove the mark. */
         clear(): void;
 

--- a/types/codemirror/test/index.ts
+++ b/types/codemirror/test/index.ts
@@ -111,3 +111,15 @@ let stringStream = new CodeMirror.StringStream("var myEditor;");
 
 // Call a method from the CodeMirror.Doc interface to confirm a CodeMirror.Editor extends it
 myCodeMirror.getCursor();
+
+// Ensure marks come back with option values
+myCodeMirror.markText(from, to, {
+  readOnly: true,
+  inclusiveLeft: true,
+  inclusiveRight: false,
+});
+
+const marks = myCodeMirror.getAllMarks();
+
+// $ExpectType TextMarker
+const mark = marks[0];


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - CodeMirror/codemirror@de9092bc99669da084fa99a16ad6ee010594dd92
  - https://github.com/codemirror/CodeMirror/blob/master/src/model/mark_text.js#L162
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.