### PR TITLE
[react-relay] Add useMutation definition

### DIFF
--- a/types/react-relay/lib/hooks.d.ts
+++ b/types/react-relay/lib/hooks.d.ts
@@ -12,6 +12,7 @@ export { useBlockingPaginationFragment } from './relay-experimental/useBlockingP
 export { useFragment } from './relay-experimental/useFragment';
 export { useLazyLoadQuery } from './relay-experimental/useLazyLoadQuery';
 export { useLegacyPaginationFragment as usePaginationFragment } from './relay-experimental/useLegacyPaginationFragment';
+export { useMutation } from './relay-experimental/useMutation';
 export { usePreloadedQuery } from './relay-experimental/usePreloadedQuery';
 export { useRefetchableFragment } from './relay-experimental/useRefetchableFragment';
 export { useRelayEnvironment } from './relay-experimental/useRelayEnvironment';

--- a/types/react-relay/lib/relay-experimental/useMutation.d.ts
+++ b/types/react-relay/lib/relay-experimental/useMutation.d.ts
@@ -16,4 +16,7 @@ export interface UseMutationConfig<TMutation extends MutationParameters> {
 }
 
 // tslint:disable-next-line no-unnecessary-generics
-export function useMutation<TMutation extends MutationParameters>(mutation: GraphQLTaggedNode): [(config: UseMutationConfig<TMutation>) => Disposable, boolean];
+export function useMutation<TMutation extends MutationParameters>(
+    mutation: GraphQLTaggedNode, 
+    commitMutationFn?: (environment: IEnvironment, config: MutationConfig<TMutation>) => Disposable,
+): [(config: UseMutationConfig<TMutation>) => Disposable, boolean];

--- a/types/react-relay/lib/relay-experimental/useMutation.d.ts
+++ b/types/react-relay/lib/relay-experimental/useMutation.d.ts
@@ -1,4 +1,4 @@
-import { GraphQLTaggedNode, Disposable, MutationConfig, MutationParameters, PayloadError, DeclarativeMutationConfig, SelectorStoreUpdater, UploadableMap } from "relay-runtime";
+import { GraphQLTaggedNode, Disposable, MutationConfig, MutationParameters, IEnvironment, PayloadError, DeclarativeMutationConfig, SelectorStoreUpdater, UploadableMap } from "relay-runtime";
 
 export interface UseMutationConfig<TMutation extends MutationParameters> {
     configs?: DeclarativeMutationConfig[];
@@ -8,7 +8,7 @@ export interface UseMutationConfig<TMutation extends MutationParameters> {
         errors: PayloadError[],
     ) => void;
     onUnsubscribe?: () => void;
-    optimisticResponse?: TMutation["response"];
+    optimisticResponse?: TMutation["rawResponse"];
     optimisticUpdater?: SelectorStoreUpdater;
     updater?: SelectorStoreUpdater;
     uploadables?: UploadableMap;

--- a/types/react-relay/lib/relay-experimental/useMutation.d.ts
+++ b/types/react-relay/lib/relay-experimental/useMutation.d.ts
@@ -1,18 +1,19 @@
 import { GraphQLTaggedNode, Disposable, MutationConfig, MutationParameters, PayloadError, DeclarativeMutationConfig, SelectorStoreUpdater, UploadableMap } from "relay-runtime";
 
-export type UseMutationConfig<TMutation extends MutationParameters> = {
-    configs?: DeclarativeMutationConfig[],
-    onError?: (error: Error) => void,
+export interface UseMutationConfig<TMutation extends MutationParameters> {
+    configs?: DeclarativeMutationConfig[];
+    onError?: (error: Error) => void;
     onCompleted?: (
         response: TMutation["response"],
         errors: PayloadError[],
-    ) => void,
-    onUnsubscribe?: () => void,
-    optimisticResponse?: TMutation["response"],
-    optimisticUpdater?: SelectorStoreUpdater,
-    updater?: SelectorStoreUpdater,
-    uploadables?: UploadableMap,
-    variables: TMutation["variables"],
-};
+    ) => void;
+    onUnsubscribe?: () => void;
+    optimisticResponse?: TMutation["response"];
+    optimisticUpdater?: SelectorStoreUpdater;
+    updater?: SelectorStoreUpdater;
+    uploadables?: UploadableMap;
+    variables: TMutation["variables"];
+}
 
+// tslint:disable-next-line no-unnecessary-generics
 export function useMutation<TMutation extends MutationParameters>(mutation: GraphQLTaggedNode): [(config: UseMutationConfig<TMutation>) => Disposable, boolean];

--- a/types/react-relay/lib/relay-experimental/useMutation.d.ts
+++ b/types/react-relay/lib/relay-experimental/useMutation.d.ts
@@ -1,0 +1,18 @@
+import { GraphQLTaggedNode, Disposable, MutationConfig, MutationParameters, PayloadError, DeclarativeMutationConfig, SelectorStoreUpdater, UploadableMap } from "relay-runtime";
+
+export type UseMutationConfig<TMutation extends MutationParameters> = {
+    configs?: DeclarativeMutationConfig[],
+    onError?: (error: Error) => void,
+    onCompleted?: (
+        response: TMutation["response"],
+        errors: PayloadError[],
+    ) => void,
+    onUnsubscribe?: () => void,
+    optimisticResponse?: TMutation["response"],
+    optimisticUpdater?: SelectorStoreUpdater,
+    updater?: SelectorStoreUpdater,
+    uploadables?: UploadableMap,
+    variables: TMutation["variables"],
+};
+
+export function useMutation<TMutation extends MutationParameters>(mutation: GraphQLTaggedNode): [(config: UseMutationConfig<TMutation>) => Disposable, boolean];

--- a/types/react-relay/lib/relay-experimental/useMutation.d.ts
+++ b/types/react-relay/lib/relay-experimental/useMutation.d.ts
@@ -17,6 +17,6 @@ export interface UseMutationConfig<TMutation extends MutationParameters> {
 
 // tslint:disable-next-line no-unnecessary-generics
 export function useMutation<TMutation extends MutationParameters>(
-    mutation: GraphQLTaggedNode, 
+    mutation: GraphQLTaggedNode,
     commitMutationFn?: (environment: IEnvironment, config: MutationConfig<TMutation>) => Disposable,
 ): [(config: UseMutationConfig<TMutation>) => Disposable, boolean];

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -802,9 +802,14 @@ function Mutation() {
                         },
                         onCompleted(data) {
                             console.log(data);
-                            console.log(data.feedback_like?.feedback.id);
-                            console.log(data.feedback_like?.feedback?.like_count);
-                            console.log(data.feedback_like?.feedback?.viewer_does_like);
+
+                            if (data.feedback_like == null) {
+                                return;
+                            }
+
+                            console.log(data.feedback_like.feedback.id);
+                            console.log(data.feedback_like.feedback.like_count);
+                            console.log(data.feedback_like.feedback.viewer_does_like);
                         },
                         optimisticResponse: {
                             feedback_like: {

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -787,6 +787,9 @@ function Mutation() {
                         },
                         onCompleted(data) {
                             console.log(data);
+                            console.log(data.id);
+                            console.log(data.like_count);
+                            console.log(data.viewer_does_like);
                         },
                     });
                 }}

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -13,6 +13,7 @@ import {
     useRefetchableFragment,
     usePaginationFragment,
     useBlockingPaginationFragment,
+    useMutation
 } from 'react-relay/hooks';
 
 const source = new RecordSource();
@@ -732,6 +733,64 @@ function BlockingPaginationFragment_WithNonNullUserProp() {
 
                 <button onClick={() => loadNext(10)}>Load more friends</button>
             </>
+        );
+    };
+}
+
+/**
+ * Tests for useMutation
+ * see https://relay.dev/docs/en/experimental/api-reference#usemutation
+ */
+function Mutation() {
+    interface FeedbackLikeMutationResponse {
+        id: string;
+        viewer_does_like: boolean;
+        like_count: number;
+    }
+
+    interface FeedbackLikeMutationVariables {
+        input: {
+            id: string,
+            text: string;
+        };
+    }
+
+    interface FeedbackLikeMutation {
+        readonly response: FeedbackLikeMutationResponse;
+        readonly variables: FeedbackLikeMutationVariables;
+    }
+
+    return function LikeButton() {
+        const [commit, isInFlight] = useMutation<FeedbackLikeMutation>(graphql`
+            mutation FeedbackLikeMutation($input: FeedbackLikeData!) {
+                feedback_like(data: $input) {
+                    feedback {
+                        id
+                        viewer_does_like
+                        like_count
+                    }
+                }
+            }
+        `);
+        if (isInFlight) {
+          return <div>loading</div>;
+        }
+        return (
+            <button
+                onClick={() => {
+                    commit({
+                        variables: {
+                            input: {
+                                id: '123',
+                                text: 'text',
+                            },
+                        },
+                        onCompleted(data) {
+                            console.log(data);
+                        },
+                    });
+                }}
+            />
         );
     };
 }

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -742,10 +742,24 @@ function BlockingPaginationFragment_WithNonNullUserProp() {
  * see https://relay.dev/docs/en/experimental/api-reference#usemutation
  */
 function Mutation() {
+    interface FeedbackLikeMutationRawResponse {
+        readonly feedback_like: {
+            readonly feedback: {
+                readonly id: string;
+                readonly viewer_does_like?: boolean | null;
+                readonly like_count?: number | null;
+            }
+        } | null;
+    }
+
     interface FeedbackLikeMutationResponse {
-        id: string;
-        viewer_does_like: boolean;
-        like_count: number;
+        readonly feedback_like: {
+            readonly feedback: {
+                readonly id: string;
+                readonly viewer_does_like?: boolean | null;
+                readonly like_count?: number | null;
+            }
+        } | null;
     }
 
     interface FeedbackLikeMutationVariables {
@@ -756,13 +770,14 @@ function Mutation() {
     }
 
     interface FeedbackLikeMutation {
+        readonly rawResponse: FeedbackLikeMutationRawResponse;
         readonly response: FeedbackLikeMutationResponse;
         readonly variables: FeedbackLikeMutationVariables;
     }
 
     return function LikeButton() {
         const [commit, isInFlight] = useMutation<FeedbackLikeMutation>(graphql`
-            mutation FeedbackLikeMutation($input: FeedbackLikeData!) {
+            mutation FeedbackLikeMutation($input: FeedbackLikeData!) @raw_response_type {
                 feedback_like(data: $input) {
                     feedback {
                         id
@@ -787,10 +802,17 @@ function Mutation() {
                         },
                         onCompleted(data) {
                             console.log(data);
-                            console.log(data.id);
-                            console.log(data.like_count);
-                            console.log(data.viewer_does_like);
+                            console.log(data.feedback_like?.feedback.id);
+                            console.log(data.feedback_like?.feedback?.like_count);
+                            console.log(data.feedback_like?.feedback?.viewer_does_like);
                         },
+                        optimisticResponse: {
+                            feedback_like: {
+                                feedback: {
+                                    id: "1"
+                                }
+                            }
+                        }
                     });
                 }}
             />


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://relay.dev/docs/en/experimental/api-reference#usemutation
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
