### PR TITLE
update(luxon): v1.24

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for luxon 1.22
+// Type definitions for luxon 1.24
 // Project: https://github.com/moment/luxon#readme
 // Definitions by: Colby DeHart <https://github.com/colbydehart>
 //                 Hyeonseok Yang <https://github.com/FourwingsY>
@@ -11,7 +11,6 @@
 //                 Aitor Pérez Rodal <https://github.com/Aitor1995>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
 export type DateTimeFormatOptions = Intl.DateTimeFormatOptions;
 
@@ -67,10 +66,34 @@ export interface ToSQLOptions {
     includeZone?: boolean;
 }
 
+export type ToISOFormat = 'basic' | 'extended';
+
 export interface ToISOTimeOptions {
+    /**
+     * @default false
+     */
     suppressMilliseconds?: boolean;
+    /**
+     * @default false
+     */
     suppressSeconds?: boolean;
+    /**
+     * @default true
+     */
     includeOffset?: boolean;
+    /**
+     * choose between the basic and extended format
+     * @default 'extended'
+     */
+    format?: ToISOFormat;
+}
+
+export interface ToISODateOptions {
+    /**
+     * choose between the basic and extended format
+     * @default 'extended'
+     */
+    format?: ToISOFormat;
 }
 
 // alias for backwards compatibility
@@ -250,7 +273,8 @@ export class DateTime {
     toFormat(format: string, options?: DateTimeFormatOptions): string;
     toHTTP(): string;
     toISO(options?: ToISOTimeOptions): string;
-    toISODate(): string;
+    /** Returns an ISO 8601-compliant string representation of this DateTime's date component */
+    toISODate(options?: ToISODateOptions): string;
     toISOTime(options?: ToISOTimeOptions): string;
     toISOWeekDate(): string;
     toJSDate(): Date;

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -1,16 +1,14 @@
 import {
     DateTime,
     Duration,
-    Interval,
-    Info,
-    Settings,
-    InvalidZone,
-    LocalZone,
     FixedOffsetZone,
     IANAZone,
+    Info,
+    Interval,
+    Settings,
     Zone,
-    ZoneOffsetOptions,
     ZoneOffsetFormat,
+    ZoneOffsetOptions,
 } from 'luxon';
 
 /* DateTime */
@@ -71,9 +69,11 @@ getters.isInLeapYear;
 dt.toBSON(); // $ExpectType Date
 dt.toHTTP(); // $ExpectType string
 dt.toISO(); // $ExpectType string
-dt.toISO({ includeOffset: true }); // $ExpectType string
+dt.toISO({ includeOffset: true, format: 'extended' }); // $ExpectType string
 dt.toISODate(); // $ExpectType string
+dt.toISODate({ format: 'basic'}); // $ExpectType string
 dt.toISOTime(); // $ExpectType string
+dt.toISOTime({ format: 'basic' }); // $ExpectType string
 dt.toISOWeekDate(); // $ExpectType string
 dt.toJSDate(); // $ExpectType Date
 dt.toJSON(); // $ExpectType string


### PR DESCRIPTION
- `toISOTime` and `toISODate` support for `extended` and `basic` format
- defaults documented for relevant options changed
- tests amended
- minor cleanup (unused imports in tests)
- remove no-op TS version pragma for 2.2 version

https://github.com/moment/luxon/compare/1.22.0...1.24.1

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)