### PR TITLE
update(stringify-object): v3.3 update

### DIFF
--- a/types/stringify-object/index.d.ts
+++ b/types/stringify-object/index.d.ts
@@ -1,17 +1,36 @@
-// Type definitions for stringify-object 3.2
+// Type definitions for stringify-object 3.3
 // Project: https://github.com/yeoman/stringify-object
 // Definitions by: Chris Khoo <https://github.com/khoomeister>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
 declare namespace stringifyObject { }
 
-declare function stringifyObject(o: any, options?: {
+declare function stringifyObject(input: any, options?: {
+    /**
+     * Preferred indentation
+     * @default '\t'
+     */
     indent?: string,
+    /**
+     * Set to false to get double-quoted strings
+     * @default true
+     */
     singleQuotes?: boolean,
-    filter?(o: any, prop: string | symbol): boolean,
+    /**
+     * Expected to return a boolean of whether to include the property property of the object object in the output.
+     */
+    filter?(input: any, prop: string | symbol): boolean,
+    /**
+     * When set, will inline values up to inlineCharacterLimit length for the sake of more terse output.
+     */
     inlineCharacterLimit?: number,
-    transform?: (val: any[] | object, i: number | string | symbol, value: string) => string,
-}): string;
+    /**
+     * Expected to return a string that transforms the string that resulted from stringifying object[property].
+     * This can be used to detect special types of objects that need to be stringified in a particular way.
+     * The transform function might return an alternate string in this case, otherwise returning the originalResult.
+     */
+    transform?: (input: any[] | object, prop: number | string | symbol, originalResult: string) => string,
+}, pad?: string): string;
 
 export = stringifyObject;

--- a/types/stringify-object/stringify-object-tests.ts
+++ b/types/stringify-object/stringify-object-tests.ts
@@ -28,3 +28,8 @@ stringifyObject([1, 2, 3], {
 stringifyObject([1, 2, 3], {
     transform: (val, key, value) => value
 });
+
+/** pad */
+stringifyObject([1, 2, 3], {
+    indent: '  ',
+}, ' ');


### PR DESCRIPTION
- minor changes in param names to align with documented usage
(input/prop/etc)
- defaults documentation added
- add public, non-documented `pad` parameter
- remove TS vresion pragma which is now no-op (DT defaults to 2.8 or
newer by default)
- maintainer added

https://github.com/yeoman/stringify-object/releases/tag/v3.3.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)