### PR TITLE
Add types for react-hexgrid

### DIFF
--- a/types/react-hexgrid/index.d.ts
+++ b/types/react-hexgrid/index.d.ts
@@ -69,7 +69,6 @@ export class HexUtils {
     static getId(hex: Hex): string;
 }
 
-// tslint:disable-next-line [no-unnecessary-class]
 export class GridGenerator {
     static getGenerator(name: string): (...args: any[]) => any;
     static ring(center: Hex, mapRadius: number): Hex[];

--- a/types/react-hexgrid/index.d.ts
+++ b/types/react-hexgrid/index.d.ts
@@ -1,0 +1,112 @@
+// Type definitions for react-hexgrid 1.0
+// Project: https://github.com/Hellenic/react-hexgrid
+// Definitions by: jsarihan <https://github.com/jsarihan/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from "react";
+
+export interface HexagonProps extends React.HTMLAttributes<Element> {
+    q: number;
+    r: number;
+    s: number;
+    fill?: string;
+    cellStyle?: any;
+    className?: string;
+    data?: any;
+}
+export interface HexagonState {
+    hex?: any;
+    pixel?: any;
+}
+export class Hexagon extends React.Component<HexagonProps, HexagonState> { }
+
+export interface TextProps extends React.HTMLAttributes<Element> {
+    x?: string | number;
+    y?: string | number;
+    className?: string;
+}
+export class Text extends React.Component<TextProps, any> { }
+export class Hex {
+    q: number;
+    r: number;
+    s: number;
+    constructor(q: number, r: number, s: number);
+}
+export class Orientation {
+    b0: number;
+    b1: number;
+    b2: number;
+    b3: number;
+    f0: number;
+    f1: number;
+    f2: number;
+    f3: number;
+    startAngle: number;
+    constructor(f0: number, f1: number, f2: number, f3: number, b0: number, b1: number, b2: number, b3: number, startAngle: number);
+}
+export class Point {
+    x: number;
+    y: number;
+    constructor(x: number, y: number);
+}
+
+export class HexUtils {
+    DIRECTIONS: Hex[];
+    static equals(a: Hex, b: Hex): boolean;
+    static add(a: Hex, b: Hex): number;
+    static subtract(a: Hex, b: Hex): number;
+    static multiply(a: Hex, b: number): Hex;
+    static lengths(hex: Hex): number;
+    static distance(a: Hex, b: Hex): number;
+    static direction(direction: number): Hex;
+    static neighbour(a: Hex, direction: number): Hex;
+    static neighbours(hex: Hex): Hex[];
+    static round(hex: Hex): Hex;
+    static hexToPixel(hex: Hex, layout: any): Point;
+    static pixelToHex(point: Point, layout: any): Hex;
+    static lerp(a: number, b: number, t: number): number;
+    static hexLerp(a: Hex, b: Hex, t: Hex): Hex;
+    static getId(hex: Hex): string;
+}
+
+// tslint:disable-next-line [no-unnecessary-class]
+export class GridGenerator {
+    static getGenerator(name: string): (...args: any[]) => any;
+    static ring(center: Hex, mapRadius: number): Hex[];
+    static spiral(center: Hex, mapRadius: number): Hex[];
+    static parallelogram(q1: number, q2: number, r1: number, r2: number): Hex[];
+    static triangle(mapSize: number): Hex[];
+    static hexagon(mapSize: number): Hex; static rectangle(mapWidth: number, mapHeight: number): Hex[];
+    static orientedRectangle(mapWidth: number, mapHeight: number): Hex[];
+}
+
+export interface HexGridProps extends React.HTMLAttributes<Element> {
+    width?: string | number;
+    height?: string | number;
+    viewBox?: string;
+}
+export class HexGrid extends React.Component<HexGridProps, any> { }
+
+export interface LayoutProps extends React.HTMLAttributes<Element> {
+    className?: string;
+    flat?: boolean;
+    origin?: Point;
+    size?: Point;
+    spacing?: number;
+    rest?: any;
+}
+export class Layout extends React.Component<LayoutProps, any> { }
+
+export interface PathProps extends React.HTMLAttributes<Element> {
+    start?: Hex;
+    end?: Hex;
+    layout?: any;
+}
+export class Path extends React.Component<PathProps, any> { }
+
+export interface PatternProps extends React.HTMLAttributes<Element> {
+    id: string;
+    link: string;
+    size?: any;
+}
+export class Pattern extends React.Component<PatternProps, any> { }

--- a/types/react-hexgrid/package.json
+++ b/types/react-hexgrid/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "csstype": "latest"
+    }
+}

--- a/types/react-hexgrid/react-hexgrid-tests.tsx
+++ b/types/react-hexgrid/react-hexgrid-tests.tsx
@@ -1,0 +1,37 @@
+import { HexGrid, Layout, Hexagon, Text, Pattern, Path, Hex } from 'react-hexgrid';
+import * as React from 'react';
+
+class App extends React.Component {
+    render() {
+        return (
+            <HexGrid width={1200} height={800} viewBox="-50 -50 100 100" >
+                {/* Grid with manually inserted hexagons */}
+                <Layout
+                    size={{ x: 10, y: 10 }}
+                    flat={true}
+                    spacing={1.1}
+                    origin={{ x: 0, y: 0 }}>
+                    <Hexagon q={0} r={0} s={0} />
+                    {/* Using pattern (defined below) to fill the hexagon */}
+                    <Hexagon q={0} r={- 1} s={1} fill="pat-1" />
+                    <Hexagon q={0} r={1} s={- 1} />
+                    <Hexagon q={1} r={- 1} s={0} >
+                        <Text>1, -1, 0 </Text>
+                    </Hexagon>
+                    <Hexagon q={1} r={0} s={- 1}>
+                        <Text>1, 0, -1 </Text>
+                    </Hexagon>
+                    {/* Pattern and text */}
+                    <Hexagon q={-1} r={1} s={0} fill="pat-2" >
+                        <Text>-1, 1, 0 </Text>
+                    </Hexagon>
+                    <Hexagon q={- 1} r={0} s={1} />
+                    <Hexagon q={-2} r={0} s={1} />
+                    <Path start={new Hex(0, 0, 0)} end={new Hex(-2, 0, 1)} />
+                </Layout>
+                <Pattern id="pat-1" link="http://cat-picture" />
+                <Pattern id="pat-2" link="http://cat-picture2" />
+            </HexGrid>
+        );
+    }
+}

--- a/types/react-hexgrid/tsconfig.json
+++ b/types/react-hexgrid/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "jsx": "react",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-hexgrid-tests.tsx"
+    ]
+}

--- a/types/react-hexgrid/tslint.json
+++ b/types/react-hexgrid/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/react-hexgrid/tslint.json
+++ b/types/react-hexgrid/tslint.json
@@ -1,3 +1,8 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-unnecessary-class": [
+            "allow-static-only"
+        ]
+    }
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.