### PR TITLE
added definitions for redux-subscriber

### DIFF
--- a/types/redux-subscriber/index.d.ts
+++ b/types/redux-subscriber/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for redux-subscriber 1.1
 // Project: https://github.com/ivantsov/redux-subscriber#readme
-// Definitions by: thisissami\n <https://github.com/thisissami>
+// Definitions by: thisissami <https://github.com/thisissami>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export type Unsubscribe = () => void;

--- a/types/redux-subscriber/index.d.ts
+++ b/types/redux-subscriber/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for redux-subscriber 1.1
+// Project: https://github.com/ivantsov/redux-subscriber#readme
+// Definitions by: thisissami\n <https://github.com/thisissami>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export type Unsubscribe = () => void;
+export type Subscribe = (key: string, cb: (state: any) => void) => Unsubscribe;
+
+export default function(store: any): Subscribe;
+
+export const subscribe: Subscribe;

--- a/types/redux-subscriber/redux-subscriber-tests.ts
+++ b/types/redux-subscriber/redux-subscriber-tests.ts
@@ -1,0 +1,5 @@
+import initSubscriber, { subscribe, Subscribe, Unsubscribe } from 'redux-subscriber';
+
+const subscribe2: Subscribe = initSubscriber({});
+const unsubscribe: Unsubscribe = subscribe('', state => {});
+const unsubscribe2: Unsubscribe = subscribe2('', state => {});

--- a/types/redux-subscriber/redux-subscriber-tests.ts
+++ b/types/redux-subscriber/redux-subscriber-tests.ts
@@ -3,3 +3,6 @@ import initSubscriber, { subscribe, Subscribe, Unsubscribe } from 'redux-subscri
 const subscribe2: Subscribe = initSubscriber({});
 const unsubscribe: Unsubscribe = subscribe('', state => {});
 const unsubscribe2: Unsubscribe = subscribe2('', state => {});
+
+unsubscribe();
+unsubscribe2();

--- a/types/redux-subscriber/tsconfig.json
+++ b/types/redux-subscriber/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "redux-subscriber-tests.ts"
+    ]
+}

--- a/types/redux-subscriber/tslint.json
+++ b/types/redux-subscriber/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
