### PR TITLE
Allow to cast the type after projection in mongodb

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2261,7 +2261,7 @@ export class Cursor<T = Default> extends Readable {
     next(): Promise<T | null>;
     next(callback: MongoCallback<T | null>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#project */
-    project(value: object): Cursor<T>;
+    project<E = T>(value: object): Cursor<E>;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#read */
     read(size: number): string | Buffer | void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#next */


### PR DESCRIPTION
If you want to do something like this:

```ts
// is Cursor<User>
const cursor = 
  db.collection<User>('users')
    .find({ })
    .project({ 'avatar.small': 1 })

// but we want it to be Cursor<{ avatar: { small: string }}>
const cursor = 
  db.collection<User>('users')
    .find({ })
    .project<WithSmallAvatar>({ 'avatar.small': 1 })
```

~~Without this PR you have to cast to `as never as Cursor<WithSmallAvatar>`.~~