### PR TITLE
[jscodeshift] export Collection as part of the core Namespace

### DIFF
--- a/types/jscodeshift/src/core.d.ts
+++ b/types/jscodeshift/src/core.d.ts
@@ -76,6 +76,7 @@ declare namespace core {
     }
 
     type JSCodeshift = Core & recast.NamedTypes & recast.Builders;
+    type Collection =  Collection.Collection<any>;
 
     interface API {
         j: JSCodeshift;


### PR DESCRIPTION
Export `Collection` as part of the `core` namespace.

This will allow people to:

```ts
updateAvatarProps(j: core.JSCodeshift,  source: core.Collection) {
 source.filter(blah);
}

export default function transformer(
  fileInfo: FileInfo,
  { jscodeshift: j }: API,
  options: Options,
) {
  const source = j(fileInfo.source);

  if (hasImportDeclaration(j, source, '@atlaskit/avatar')) {
    updateBorderWidthUsage(j, source);
    updateAvatarProps(j, source);
    updateAvatarItemProps(j, source);
  }

  return source.toSource(options.printOptions || { quote: 'single' });
}
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
