### PR TITLE
@testing-library/jest dom - toHaveValue should allow null as a parameter

### DIFF
--- a/types/testing-library__jest-dom/index.d.ts
+++ b/types/testing-library__jest-dom/index.d.ts
@@ -355,7 +355,7 @@ declare namespace jest {
          * @see
          * [testing-library/jest-dom#tohavevalue](https:github.com/testing-library/jest-dom#tohavevalue)
          */
-        toHaveValue(value?: string | string[] | number): R;
+        toHaveValue(value?: string | string[] | number | null): R;
         /**
          * @description
          * Assert whether the given element is checked.

--- a/types/testing-library__jest-dom/test/testing-library__jest-dom-global-tests.ts
+++ b/types/testing-library__jest-dom/test/testing-library__jest-dom-global-tests.ts
@@ -31,6 +31,7 @@ expect(element).toHaveValue();
 expect(element).toHaveValue('str');
 expect(element).toHaveValue(['str1', 'str2']);
 expect(element).toHaveValue(1);
+expect(element).toHaveValue(null);
 expect(element).toBeChecked();
 
 expect(element).not.toBeInTheDOM();


### PR DESCRIPTION
This is my first time contributing so please accept my apologies if I have done anything wrong.

I created a bug report on @testing-library/jest-dom for this https://github.com/testing-library/jest-dom/issues/240.

You can see from the bug report that one of the contributors there @gnapse agrees with me it is a bug. Not sure if I need to create another bug report here as well.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/testing-library/jest-dom/issues/240>>
- [ ] N/A If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] N/A If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
