### PR TITLE
[@types/yup] Add defined() to interface MixedLocale

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -457,6 +457,7 @@ interface MixedLocale {
     oneOf?: TestOptionsMessage<{ values: any }>;
     notOneOf?: TestOptionsMessage<{ values: any }>;
     notType?: LocaleValue;
+    defined?: TestOptionsMessage;
 }
 
 interface StringLocale {


### PR DESCRIPTION
Added the missing function defined() to MixedLocale interface

defined function in mixed type from yup:
https://github.com/jquense/yup/blob/master/src/mixed.js#L544

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/yup/blob/master/src/mixed.js#L544
- [ x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.