### PR TITLE
fix(mongodb): correct GridFSBucketWriteStream.abort callback

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2439,10 +2439,8 @@ export interface GridFSBucketOptions {
     readPreference?: ReadPreferenceOrMode;
 }
 
-/** http://mongodb.github.io/node-mongodb-native/3.1/api/GridFSBucket.html#~errorCallback */
-export interface GridFSBucketErrorCallback {
-    (err?: MongoError): void;
-}
+/** http://mongodb.github.io/node-mongodb-native/3.6/api/GridFSBucket.html#~errorCallback */
+export interface GridFSBucketErrorCallback extends MongoCallback<void> {}
 
 /** http://mongodb.github.io/node-mongodb-native/3.1/api/GridFSBucket.html#find */
 export interface GridFSBucketFindOptions {
@@ -2487,7 +2485,7 @@ export class GridFSBucketWriteStream extends Writable {
      * @param [callback] called when chunks are successfully removed or error occurred
      * @see {@link https://mongodb.github.io/node-mongodb-native/3.6/api/GridFSBucketWriteStream.html#abort}
      */
-    abort(callback?: () => void): void;
+    abort(callback?: GridFSBucketErrorCallback): void;
 }
 
 /** https://mongodb.github.io/node-mongodb-native/3.1/api/GridFSBucketWriteStream.html */

--- a/types/mongodb/test/index.ts
+++ b/types/mongodb/test/index.ts
@@ -89,10 +89,14 @@ const gridFSBucketTests = (bucket: mongodb.GridFSBucket) => {
     const openUploadStream  = bucket.openUploadStream('file.dat');
     openUploadStream.on('close', () => {});
     openUploadStream.on('end', () => {});
+    openUploadStream.abort(); // $ExpectType void
     openUploadStream.abort(() => {
         openUploadStream.removeAllListeners();
     });
-    openUploadStream.abort();
+    openUploadStream.abort((error) => {
+        error; // $ExpectType MongoError
+    });
+    openUploadStream.abort((error, result) => {});
 };
 
 // Compression


### PR DESCRIPTION
This fixes callback method definition to match documentation:
https://mongodb.github.io/node-mongodb-native/3.6/api/GridFSBucket.html#~errorCallback

Also this error callback now has the same shape as default
MongoCallback, hence the extend.

/cc @alexy4744

Fixes #44549

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)