### PR TITLE
semantic-release: update type definitions for 17.0

### DIFF
--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for semantic-release 15.13
+// Type definitions for semantic-release 17.0
 // Project: https://github.com/semantic-release/semantic-release#readme
 // Definitions by: Leonardo Gatica <https://github.com/lgaticaq>
 //                 Daniel Cassidy <https://github.com/djcsdy>
@@ -16,29 +16,91 @@ declare namespace SemanticRelease {
 	 */
 	interface Options {
 		/**
-		 * The branch on which releases should happen.
+		 * List of modules or file paths containing a
+		 * [shareable configuration](https://semantic-release.gitbook.io/semantic-release/usage/shareable-configurations).
+		 * If multiple shareable configurations are set, they will be imported
+		 * in the order defined with each configuration option taking
+		 * precedence over the options defined in a previous shareable
+		 * configuration.
+		 * 
+		 * **Note**: Options defined via CLI arguments or in the configuration
+		 * file will take precedence over the ones defined in any shareable
+		 * configuration.
 		 */
-		branch?: string;
+		extends?: ReadonlyArray<string> | string;
 
 		/**
-		 * The Git repository URL, in any supported format.
+		 * The branches on which releases should happen. By default
+		 * **semantic-release** will release:
+		 * 
+		 *  * regular releases to the default distribution channel from the
+		 *    branch `master`
+		 *  * regular releases to a distribution channel matching the branch
+		 *    name from any existing branch with a name matching a maintenance
+		 *    release range (`N.N.x` or `N.x.x` or `N.x` with `N` being a
+		 *    number)
+		 *  * regular releases to the `next` distribution channel from the
+		 *    branch `next` if it exists
+		 *  * regular releases to the `next-major` distribution channel from
+		 *    the branch `next-major` if it exists.
+		 *  * prereleases to the `beta` distribution channel from the branch
+		 *    `beta` if it exists
+		 *  * prereleases to the `alpha` distribution channel from the branch
+		 *    `alpha` if it exists
+		 * 
+		 * **Note**: If your repository does not have a release branch, then
+		 * **semantic-release** will fail with an `ERELEASEBRANCHES` error
+		 * message. If you are using the default configuration, you can fix
+		 * this error by pushing a `master` branch.
+		 * 
+		 * **Note**: Once **semantic-release** is configured, any user with the
+		 * permission to push commits on one of those branches will be able to
+		 * publish a release. It is recommended to protect those branches, for
+		 * example with [GitHub protected branches](https://help.github.com/articles/about-protected-branches).
+		 * 
+		 * See [Workflow configuration](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#workflow-configuration)
+		 * for more details.
+		 */
+		branches?: ReadonlyArray<BranchSpec> | BranchSpec;
+
+		/**
+		 * The git repository URL.
+		 * 
+		 * Any valid git url format is supported (see
+		 * [git protocols](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols))
+		 * 
+		 * Default: `repository` property in `package.json`, or git origin url.
 		 */
 		repositoryUrl?: string;
 
 		/**
-		 * The Git tag format used by semantic-release to identify releases.
+		 * The git tag format used by **semantic-release** to identify
+		 * releases. The tag name is generated with [Lodash template](https://lodash.com/docs#template)
+		 * and will be compiled with the `version` variable.
+		 * 
+		 * **Note**: The `tagFormat` must contain the `version` variable
+		 * exactly once and compile to a
+		 * [valid git reference](https://git-scm.com/docs/git-check-ref-format#_description).
 		 */
 		tagFormat?: string;
 
 		/**
-		 * Specifies the list of plugins to use. Plugins will run in series, in
-		 * the order specified.
-		 *
-		 * If this option is not specified, then semantic-release will use a
-		 * default list of plugins.
-		 *
-		 * Configuration options for each plugin can be defined by wrapping the
-		 * name and an options object in an array.
+		 * Define the list of plugins to use. Plugins will run in series, in
+		 * the order defined, for each [step](https://semantic-release.gitbook.io/semantic-release/#release-steps)
+		 * if they implement it.
+		 * 
+		 * Plugins configuration can be defined by wrapping the name and an
+		 * options object in an array.
+		 * 
+		 * See [Plugins configuration](https://semantic-release.gitbook.io/semantic-release/usage/plugins#plugins)
+		 * for more details.
+		 * 
+		 * Default: `[
+		 *     "@semantic-release/commit-analyzer", 
+		 *     "@semantic-release/release-notes-generator",
+		 *     "@semantic-release/npm",
+		 *     "@semantic-release/github"
+		 * ]`
 		 */
 		plugins?: ReadonlyArray<PluginSpec>;
 
@@ -65,32 +127,165 @@ declare namespace SemanticRelease {
 	 */
 	interface GlobalConfig extends Options {
 		/**
-		 * The branch on which releases should happen.
+		 * The branches on which releases should happen. By default
+		 * **semantic-release** will release:
+		 * 
+		 *  * regular releases to the default distribution channel from the
+		 *    branch `master`
+		 *  * regular releases to a distribution channel matching the branch
+		 *    name from any existing branch with a name matching a maintenance
+		 *    release range (`N.N.x` or `N.x.x` or `N.x` with `N` being a
+		 *    number)
+		 *  * regular releases to the `next` distribution channel from the
+		 *    branch `next` if it exists
+		 *  * regular releases to the `next-major` distribution channel from
+		 *    the branch `next-major` if it exists.
+		 *  * prereleases to the `beta` distribution channel from the branch
+		 *    `beta` if it exists
+		 *  * prereleases to the `alpha` distribution channel from the branch
+		 *    `alpha` if it exists
+		 * 
+		 * **Note**: If your repository does not have a release branch, then
+		 * **semantic-release** will fail with an `ERELEASEBRANCHES` error
+		 * message. If you are using the default configuration, you can fix
+		 * this error by pushing a `master` branch.
+		 * 
+		 * **Note**: Once **semantic-release** is configured, any user with the
+		 * permission to push commits on one of those branches will be able to
+		 * publish a release. It is recommended to protect those branches, for
+		 * example with [GitHub protected branches](https://help.github.com/articles/about-protected-branches).
+		 * 
+		 * See [Workflow configuration](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#workflow-configuration)
+		 * for more details.
 		 */
-		branch: string;
+		branches: ReadonlyArray<BranchSpec> | BranchSpec;
 
 		/**
-		 * The Git repository URL, in any supported format.
+		 * The git repository URL.
+		 * 
+		 * Any valid git url format is supported (see
+		 * [git protocols](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols))
+		 * 
+		 * Default: `repository` property in `package.json`, or git origin url.
 		 */
 		repositoryUrl: string;
 
 		/**
-		 * The Git tag format used by semantic-release to identify releases.
+		 * The git tag format used by **semantic-release** to identify
+		 * releases. The tag name is generated with [Lodash template](https://lodash.com/docs#template)
+		 * and will be compiled with the `version` variable.
+		 * 
+		 * **Note**: The `tagFormat` must contain the `version` variable
+		 * exactly once and compile to a
+		 * [valid git reference](https://git-scm.com/docs/git-check-ref-format#_description).
 		 */
 		tagFormat: string;
 
 		/**
-		 * Specifies the list of plugins to use. Plugins will run in series, in
-		 * the order specified.
-		 *
-		 * If this option is not specified, then semantic-release will use a
-		 * default list of plugins.
-		 *
-		 * Configuration options for each plugin can be defined by wrapping the
-		 * name and an options object in an array.
+		 * Define the list of plugins to use. Plugins will run in series, in
+		 * the order defined, for each [step](https://semantic-release.gitbook.io/semantic-release/#release-steps)
+		 * if they implement it.
+		 * 
+		 * Plugins configuration can be defined by wrapping the name and an
+		 * options object in an array.
+		 * 
+		 * See [Plugins configuration](https://semantic-release.gitbook.io/semantic-release/usage/plugins#plugins)
+		 * for more details.
+		 * 
+		 * Default: `[
+		 *     "@semantic-release/commit-analyzer", 
+		 *     "@semantic-release/release-notes-generator",
+		 *     "@semantic-release/npm",
+		 *     "@semantic-release/github"
+		 * ]`
 		 */
 		plugins: ReadonlyArray<PluginSpec>;
 	}
+
+	/**
+	 * Specifies a git branch holding commits to analyze and code to release.
+	 * 
+	 * Each branch may be defined either by a string or an object. Specifying
+	 * a string is a shortcut for specifying that string as the `name` field,
+	 * for example `"master"` expands to `{name: "master"}`.
+	 */
+	type BranchSpec = string | {
+		/**
+		 * The name of git branch.
+		 * 
+		 * A `name` is required for all types of branch. It can be defined as a
+		 * [glob](https://github.com/micromatch/micromatch#matching-features)
+		 * in which case the definition will be expanded to one per matching
+		 * branch existing in the repository.
+		 * 
+		 * If `name` doesn't match any branch existing in the repository, the
+		 * definition will be ignored. For example, the default configuration
+		 * includes the definition `next` and `next-major` which will become
+		 * active only  when the branches `next` and/or `next-major` are
+		 * created in the repository.
+		 */
+		name: string;
+
+		/**
+		 * The distribution channel on which to publish releases from this
+		 * branch.
+		 * 
+		 * If this field is set to `false`, then the branch will be released
+		 * on the default distribution channel (for example the `@latest`
+		 * [dist-tag](https://docs.npmjs.com/cli/dist-tag) for npm). This is
+		 * also the default behavior for the first
+		 * [release branch](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#release-branches)
+		 * if the channel property is not set.
+		 * 
+		 * For all other branches, if the channel property is not set, then the
+		 * channel name will be the same as the branch name.
+		 * 
+		 * The value of `channel`, if defined as a string, is generated with
+		 * [Lodash template](https://lodash.com/docs#template) with the
+		 * variable `name` set to the branch name.
+		 * 
+		 * For example `{name: 'next', channel: 'channel-${name}'}` will be
+		 * expanded to `{name: 'next', channel: 'channel-next'}`.
+		 */
+		channel?: string | false;
+
+		/**
+		 * The range of [semantic versions](https://semver.org/) to support on
+		 * this branch.
+		 * 
+		 * A `range` only applies to maintenance branches and must be formatted
+		 * like `N.N.x` or `N.x` (`N` is a number). If no range is specified
+		 * but the `name` is formatted as a range, then the branch will be
+		 * considered a maintenance branch and the `name` value will be used
+		 * for the `range`.
+		 * 
+		 * Required for maintenance branches, unless `name` is formatted like
+		 * `N.N.x` or `N.x` (`N` is a number).
+		 */
+		range?: string;
+
+		/**
+		 * The pre-release identifier to append to [semantic versions](https://semver.org/)
+		 * released from this branch.
+		 * 
+		 * A `prerelease` property applies only to pre-release branches and
+		 * the `prerelease` value must be valid per the [Semantic Versioning
+		 * Specification](https://semver.org/#spec-item-9). It will determine
+		 * the name of versions. For example if `prerelease` is set to
+		 * `"beta"`, the version will be formatted like `2.0.0-beta.1`,
+		 * `2.0.0-beta.2`, etc.
+		 * 
+		 * The value of `prerelease`, if defined as a string, is generated with
+		 * [Lodash template](https://lodash.com/docs#template) with the
+		 * variable `name` set to the name of the branch.
+		 * 
+		 * If the `prerelease property is set to `true` then the name of the
+		 * branch is used as the pre-release identifier.
+		 * 
+		 * Required for pre-release branches.
+		 */
+		prerelease?: string;
+	};
 
 	/**
 	 * Specifies a plugin to use.

--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -22,7 +22,7 @@ declare namespace SemanticRelease {
 		 * in the order defined with each configuration option taking
 		 * precedence over the options defined in a previous shareable
 		 * configuration.
-		 * 
+		 *
 		 * **Note**: Options defined via CLI arguments or in the configuration
 		 * file will take precedence over the ones defined in any shareable
 		 * configuration.
@@ -32,7 +32,7 @@ declare namespace SemanticRelease {
 		/**
 		 * The branches on which releases should happen. By default
 		 * **semantic-release** will release:
-		 * 
+		 *
 		 *  * regular releases to the default distribution channel from the
 		 *    branch `master`
 		 *  * regular releases to a distribution channel matching the branch
@@ -47,17 +47,17 @@ declare namespace SemanticRelease {
 		 *    `beta` if it exists
 		 *  * prereleases to the `alpha` distribution channel from the branch
 		 *    `alpha` if it exists
-		 * 
+		 *
 		 * **Note**: If your repository does not have a release branch, then
 		 * **semantic-release** will fail with an `ERELEASEBRANCHES` error
 		 * message. If you are using the default configuration, you can fix
 		 * this error by pushing a `master` branch.
-		 * 
+		 *
 		 * **Note**: Once **semantic-release** is configured, any user with the
 		 * permission to push commits on one of those branches will be able to
 		 * publish a release. It is recommended to protect those branches, for
 		 * example with [GitHub protected branches](https://help.github.com/articles/about-protected-branches).
-		 * 
+		 *
 		 * See [Workflow configuration](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#workflow-configuration)
 		 * for more details.
 		 */
@@ -65,10 +65,10 @@ declare namespace SemanticRelease {
 
 		/**
 		 * The git repository URL.
-		 * 
+		 *
 		 * Any valid git url format is supported (see
 		 * [git protocols](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols))
-		 * 
+		 *
 		 * Default: `repository` property in `package.json`, or git origin url.
 		 */
 		repositoryUrl?: string;
@@ -77,7 +77,7 @@ declare namespace SemanticRelease {
 		 * The git tag format used by **semantic-release** to identify
 		 * releases. The tag name is generated with [Lodash template](https://lodash.com/docs#template)
 		 * and will be compiled with the `version` variable.
-		 * 
+		 *
 		 * **Note**: The `tagFormat` must contain the `version` variable
 		 * exactly once and compile to a
 		 * [valid git reference](https://git-scm.com/docs/git-check-ref-format#_description).
@@ -88,15 +88,15 @@ declare namespace SemanticRelease {
 		 * Define the list of plugins to use. Plugins will run in series, in
 		 * the order defined, for each [step](https://semantic-release.gitbook.io/semantic-release/#release-steps)
 		 * if they implement it.
-		 * 
+		 *
 		 * Plugins configuration can be defined by wrapping the name and an
 		 * options object in an array.
-		 * 
+		 *
 		 * See [Plugins configuration](https://semantic-release.gitbook.io/semantic-release/usage/plugins#plugins)
 		 * for more details.
-		 * 
+		 *
 		 * Default: `[
-		 *     "@semantic-release/commit-analyzer", 
+		 *     "@semantic-release/commit-analyzer",
 		 *     "@semantic-release/release-notes-generator",
 		 *     "@semantic-release/npm",
 		 *     "@semantic-release/github"
@@ -129,7 +129,7 @@ declare namespace SemanticRelease {
 		/**
 		 * The branches on which releases should happen. By default
 		 * **semantic-release** will release:
-		 * 
+		 *
 		 *  * regular releases to the default distribution channel from the
 		 *    branch `master`
 		 *  * regular releases to a distribution channel matching the branch
@@ -144,17 +144,17 @@ declare namespace SemanticRelease {
 		 *    `beta` if it exists
 		 *  * prereleases to the `alpha` distribution channel from the branch
 		 *    `alpha` if it exists
-		 * 
+		 *
 		 * **Note**: If your repository does not have a release branch, then
 		 * **semantic-release** will fail with an `ERELEASEBRANCHES` error
 		 * message. If you are using the default configuration, you can fix
 		 * this error by pushing a `master` branch.
-		 * 
+		 *
 		 * **Note**: Once **semantic-release** is configured, any user with the
 		 * permission to push commits on one of those branches will be able to
 		 * publish a release. It is recommended to protect those branches, for
 		 * example with [GitHub protected branches](https://help.github.com/articles/about-protected-branches).
-		 * 
+		 *
 		 * See [Workflow configuration](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#workflow-configuration)
 		 * for more details.
 		 */
@@ -162,10 +162,10 @@ declare namespace SemanticRelease {
 
 		/**
 		 * The git repository URL.
-		 * 
+		 *
 		 * Any valid git url format is supported (see
 		 * [git protocols](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols))
-		 * 
+		 *
 		 * Default: `repository` property in `package.json`, or git origin url.
 		 */
 		repositoryUrl: string;
@@ -174,7 +174,7 @@ declare namespace SemanticRelease {
 		 * The git tag format used by **semantic-release** to identify
 		 * releases. The tag name is generated with [Lodash template](https://lodash.com/docs#template)
 		 * and will be compiled with the `version` variable.
-		 * 
+		 *
 		 * **Note**: The `tagFormat` must contain the `version` variable
 		 * exactly once and compile to a
 		 * [valid git reference](https://git-scm.com/docs/git-check-ref-format#_description).
@@ -185,15 +185,15 @@ declare namespace SemanticRelease {
 		 * Define the list of plugins to use. Plugins will run in series, in
 		 * the order defined, for each [step](https://semantic-release.gitbook.io/semantic-release/#release-steps)
 		 * if they implement it.
-		 * 
+		 *
 		 * Plugins configuration can be defined by wrapping the name and an
 		 * options object in an array.
-		 * 
+		 *
 		 * See [Plugins configuration](https://semantic-release.gitbook.io/semantic-release/usage/plugins#plugins)
 		 * for more details.
-		 * 
+		 *
 		 * Default: `[
-		 *     "@semantic-release/commit-analyzer", 
+		 *     "@semantic-release/commit-analyzer",
 		 *     "@semantic-release/release-notes-generator",
 		 *     "@semantic-release/npm",
 		 *     "@semantic-release/github"
@@ -204,7 +204,7 @@ declare namespace SemanticRelease {
 
 	/**
 	 * Specifies a git branch holding commits to analyze and code to release.
-	 * 
+	 *
 	 * Each branch may be defined either by a string or an object. Specifying
 	 * a string is a shortcut for specifying that string as the `name` field,
 	 * for example `"master"` expands to `{name: "master"}`.
@@ -212,12 +212,12 @@ declare namespace SemanticRelease {
 	type BranchSpec = string | {
 		/**
 		 * The name of git branch.
-		 * 
+		 *
 		 * A `name` is required for all types of branch. It can be defined as a
 		 * [glob](https://github.com/micromatch/micromatch#matching-features)
 		 * in which case the definition will be expanded to one per matching
 		 * branch existing in the repository.
-		 * 
+		 *
 		 * If `name` doesn't match any branch existing in the repository, the
 		 * definition will be ignored. For example, the default configuration
 		 * includes the definition `next` and `next-major` which will become
@@ -229,21 +229,21 @@ declare namespace SemanticRelease {
 		/**
 		 * The distribution channel on which to publish releases from this
 		 * branch.
-		 * 
+		 *
 		 * If this field is set to `false`, then the branch will be released
 		 * on the default distribution channel (for example the `@latest`
 		 * [dist-tag](https://docs.npmjs.com/cli/dist-tag) for npm). This is
 		 * also the default behavior for the first
 		 * [release branch](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#release-branches)
 		 * if the channel property is not set.
-		 * 
+		 *
 		 * For all other branches, if the channel property is not set, then the
 		 * channel name will be the same as the branch name.
-		 * 
+		 *
 		 * The value of `channel`, if defined as a string, is generated with
 		 * [Lodash template](https://lodash.com/docs#template) with the
 		 * variable `name` set to the branch name.
-		 * 
+		 *
 		 * For example `{name: 'next', channel: 'channel-${name}'}` will be
 		 * expanded to `{name: 'next', channel: 'channel-next'}`.
 		 */
@@ -252,13 +252,13 @@ declare namespace SemanticRelease {
 		/**
 		 * The range of [semantic versions](https://semver.org/) to support on
 		 * this branch.
-		 * 
+		 *
 		 * A `range` only applies to maintenance branches and must be formatted
 		 * like `N.N.x` or `N.x` (`N` is a number). If no range is specified
 		 * but the `name` is formatted as a range, then the branch will be
 		 * considered a maintenance branch and the `name` value will be used
 		 * for the `range`.
-		 * 
+		 *
 		 * Required for maintenance branches, unless `name` is formatted like
 		 * `N.N.x` or `N.x` (`N` is a number).
 		 */
@@ -267,21 +267,21 @@ declare namespace SemanticRelease {
 		/**
 		 * The pre-release identifier to append to [semantic versions](https://semver.org/)
 		 * released from this branch.
-		 * 
+		 *
 		 * A `prerelease` property applies only to pre-release branches and
 		 * the `prerelease` value must be valid per the [Semantic Versioning
 		 * Specification](https://semver.org/#spec-item-9). It will determine
 		 * the name of versions. For example if `prerelease` is set to
 		 * `"beta"`, the version will be formatted like `2.0.0-beta.1`,
 		 * `2.0.0-beta.2`, etc.
-		 * 
+		 *
 		 * The value of `prerelease`, if defined as a string, is generated with
 		 * [Lodash template](https://lodash.com/docs#template) with the
 		 * variable `name` set to the name of the branch.
-		 * 
+		 *
 		 * If the `prerelease property is set to `true` then the name of the
 		 * branch is used as the pre-release identifier.
-		 * 
+		 *
 		 * Required for pre-release branches.
 		 */
 		prerelease?: string;

--- a/types/semantic-release/semantic-release-tests.ts
+++ b/types/semantic-release/semantic-release-tests.ts
@@ -13,7 +13,7 @@ function publish(pluginConfig: any, context: lib.Context) {
 }
 
 const options: lib.GlobalConfig = {
-    branch: "master",
+    branches: "master",
     repositoryUrl: "https://github.com/semantic-release/semantic-release.git",
     // Lint check disabled for the following line because this is the actual
     // format used by semantic-release. This is not a broken template string.
@@ -32,6 +32,21 @@ const options: lib.GlobalConfig = {
     assets: [
         {
             path: "app.zip"
+        }
+    ]
+};
+
+const options2: lib.Options = {
+    branches: [
+        "master",
+        {
+            name: "next",
+            channel: "next",
+            prerelease: "beta"
+        },
+        {
+            name: "legacy",
+            range: "1.x"
         }
     ]
 };
@@ -67,7 +82,9 @@ const config: lib.Config = {
 
 const result: Promise<lib.Result> = semanticRelease(options, config);
 
-const result2: lib.Result = {
+const result2: Promise<lib.Result> = semanticRelease(options2);
+
+const result3: lib.Result = {
     lastRelease: {
         version: "1.1.0",
         gitTag: "v1.1.0",


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://semantic-release.gitbook.io/semantic-release/usage/configuration
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.