### PR TITLE
[generate-password] Add generate password types

### DIFF
--- a/types/generate-password/generate-password-tests.ts
+++ b/types/generate-password/generate-password-tests.ts
@@ -1,4 +1,4 @@
-import * as generator from 'generate-password';
+import generator = require('generate-password');
 
 generator.generate(); // $ExpectType string
 generator.generateMultiple(1); // $ExpectType string[]

--- a/types/generate-password/generate-password-tests.ts
+++ b/types/generate-password/generate-password-tests.ts
@@ -1,0 +1,7 @@
+import * as generator from 'generate-password';
+
+generator.generate(); // $ExpectType string
+generator.generateMultiple(1); // $ExpectType string[]
+
+// generateMultiple method called without required properties should error
+generator.generateMultiple(); // $ExpectError

--- a/types/generate-password/index.d.ts
+++ b/types/generate-password/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for generate-password 1.5
+// Project: https://github.com/brendanashworth/generate-password
+// Definitions by: Eddie CooRo <https://github.com/Eddie-Cooro>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface IGenerateOptions {
+    length?: number;
+    numbers?: boolean;
+    symbols?: boolean;
+    lowercase?: boolean;
+    uppercase?: boolean;
+    excludeSimilarCharacters?: boolean;
+    exclude?: string;
+    strict?: boolean;
+}
+
+export function generate(options?: IGenerateOptions): string;
+export function generateMultiple(count: number, options?: IGenerateOptions): string[];

--- a/types/generate-password/index.d.ts
+++ b/types/generate-password/index.d.ts
@@ -4,15 +4,53 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface GenerateOptions {
+    /**
+     * Length of the generated password.
+     * @default 10
+     */
     length?: number;
+    /**
+     * Should the password include numbers
+     * @default false
+     */
     numbers?: boolean;
+    /**
+     * Should the password include symbols
+     * @default false
+     */
     symbols?: boolean;
+    /**
+     * Should the password include lowercase characters
+     * @default true
+     */
     lowercase?: boolean;
+    /**
+     * Should the password include uppercase characters
+     * @default true
+     */
     uppercase?: boolean;
+    /**
+     * Should exclude visually similar characters like 'i' and 'I'
+     * @default false
+     */
     excludeSimilarCharacters?: boolean;
+    /**
+     * List of characters to be excluded from the password
+     * @default ""
+     */
     exclude?: string;
+    /**
+     * Password should include at least one character from each pool
+     * @default false
+     */
     strict?: boolean;
 }
 
+/**
+ * Generate one password with the given options.
+ */
 export function generate(options?: GenerateOptions): string;
+/**
+ * Bulk generate multiple passwords at once, with the same options for all.
+ */
 export function generateMultiple(count: number, options?: GenerateOptions): string[];

--- a/types/generate-password/index.d.ts
+++ b/types/generate-password/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Eddie CooRo <https://github.com/Eddie-Cooro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export interface IGenerateOptions {
+export interface GenerateOptions {
     length?: number;
     numbers?: boolean;
     symbols?: boolean;
@@ -14,5 +14,5 @@ export interface IGenerateOptions {
     strict?: boolean;
 }
 
-export function generate(options?: IGenerateOptions): string;
-export function generateMultiple(count: number, options?: IGenerateOptions): string[];
+export function generate(options?: GenerateOptions): string;
+export function generateMultiple(count: number, options?: GenerateOptions): string[];

--- a/types/generate-password/tsconfig.json
+++ b/types/generate-password/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "generate-password-tests.ts"
+    ]
+}

--- a/types/generate-password/tslint.json
+++ b/types/generate-password/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.) [link](https://codesandbox.io/s/compassionate-drake-z9v2k?file=/src/index.ts)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.