### PR TITLE
(slate) fix insertText

### DIFF
--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1527,7 +1527,7 @@ export class Editor implements Controller {
     insertBlock(block: string | Block | BlockProperties | BlockJSON): Editor;
     insertFragment(fragment: Document): Editor;
     insertInline(inline: string | Inline | InlineProperties | InlineJSON): Editor;
-    insertText(text: string): Editor;
+    insertText(text: string, marks?: Immutable.Set<string | MarkProperties | MarkJSON | Mark> | Array<string | MarkProperties | MarkJSON | Mark>): Editor;
     setBlocks(properties: string | Block | BlockProperties | BlockJSON): Editor;
     setInlines(properties: string | Inline | InlineProperties): Editor;
     splitBlock(depth?: number): Editor;

--- a/types/slate/slate-tests.ts
+++ b/types/slate/slate-tests.ts
@@ -20,7 +20,7 @@ import {
     Decoration,
     Annotation
 } from "slate";
-import { List } from "immutable";
+import { List, Set } from "immutable";
 
 const data = Data.create({ foo: "bar " });
 
@@ -240,6 +240,7 @@ editor
 .insertNodeByKey("a", 0, inline)
 .insertNodeByPath(List([0]), 0, inline)
 .insertText("A bit of rich text, followed by...")
+.insertText("A bit of marked text", Set.of(Mark.create('bold')))
 .insertTextAtRange(range, "More text")
 .insertTextByKey("a", 0, "text")
 .insertTextByPath(List([0]), 0, "text")


### PR DESCRIPTION
The Editor command `insertText` did not include the optional Marks parameter, defined here: 

https://github.com/ianstormtaylor/slate/blob/v0.47/packages/slate/src/commands/with-intent.js#L317) 

and used in package tests here:
https://github.com/ianstormtaylor/slate/blob/v0.47/packages/slate/test/models/text/insert/from-middle/marked-text-in-middle-of-marked-text.js#L14

Also added myself to the list for this package.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/ianstormtaylor/slate/blob/v0.47/packages/slate/src/commands/with-intent.js#L317>>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

