### PR TITLE
[meteor] Fix declaration for Match.OneOf

### DIFF
--- a/types/meteor/check.d.ts
+++ b/types/meteor/check.d.ts
@@ -34,7 +34,7 @@ declare module "meteor/check" {
 
         function ObjectIncluding<T extends {[key: string]: Pattern}>(dico: T): Matcher<PatternMatch<T>>;
 
-        function OneOf<T extends Pattern>(...patterns: T[]): Matcher<PatternMatch<T>>;
+        function OneOf<T extends Pattern[]>(...patterns: T): Matcher<PatternMatch<T[number]>>;
 
         function Where(condition: (val: any) => boolean): Matcher<any>;
 

--- a/types/meteor/globals/check.d.ts
+++ b/types/meteor/globals/check.d.ts
@@ -33,7 +33,7 @@ declare module Match {
 
     function ObjectIncluding<T extends {[key: string]: Pattern}>(dico: T): Matcher<PatternMatch<T>>;
 
-    function OneOf<T extends Pattern>(...patterns: T[]): Matcher<PatternMatch<T>>;
+    function OneOf<T extends Pattern[]>(...patterns: T): Matcher<PatternMatch<T[number]>>;
 
     function Where(condition: (val: any) => boolean): Matcher<any>;
 

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -644,6 +644,30 @@ Meteor.methods({
 });
 
 /**
+ * From Match.test section
+ */
+
+var value2: unknown;
+
+// Will return true for `{ foo: 1, bar: 'hello' }` or similar.
+if (Match.test(value2, { foo: Match.Integer, bar: String })) {
+    // $ExpectType { foo: number; bar: string; }
+    value2;
+}
+
+// Will return true if `value` is a string.
+if (Match.test(value2, String)) {
+    // $ExpectType string
+    value2;
+}
+
+// Will return true if `value` is a string or an array of numbers.
+if (Match.test(value2, Match.OneOf(String, [Number]))) {
+    // $ExpectType string | number[]
+    value2;
+}
+
+/**
  * From Match patterns section
  */
 var pat = { name: Match.Optional('test') };

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -666,6 +666,30 @@ Meteor.methods({
 });
 
 /**
+ * From Match.test section
+ */
+
+var value2: unknown;
+
+// Will return true for `{ foo: 1, bar: 'hello' }` or similar.
+if (Match.test(value2, { foo: Match.Integer, bar: String })) {
+    // $ExpectType { foo: number; bar: string; }
+    value2;
+}
+
+// Will return true if `value` is a string.
+if (Match.test(value2, String)) {
+    // $ExpectType string
+    value2;
+}
+
+// Will return true if `value` is a string or an array of numbers.
+if (Match.test(value2, Match.OneOf(String, [Number]))) {
+    // $ExpectType string | number[]
+    value2;
+}
+
+/**
  * From Match patterns section
  */
 var pat = { name: Match.Optional('test') };


### PR DESCRIPTION
This corrects for an issue discovered by @afrokick in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41414#issuecomment-624894840

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.meteor.com/api/check.html#matchpatterns
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.