### PR TITLE
[reactstrap] allow toggle functions without args

### DIFF
--- a/types/reactstrap/lib/Alert.d.ts
+++ b/types/reactstrap/lib/Alert.d.ts
@@ -12,7 +12,7 @@ export interface UncontrolledAlertProps extends React.HTMLAttributes<HTMLElement
 }
 export interface AlertProps extends UncontrolledAlertProps {
     isOpen?: boolean;
-    toggle?: React.MouseEventHandler<any>;
+    toggle?: React.MouseEventHandler<any> | (() => void);
 }
 
 declare class Alert<T = {[key: string]: any}> extends React.Component<AlertProps> {}

--- a/types/reactstrap/lib/Dropdown.d.ts
+++ b/types/reactstrap/lib/Dropdown.d.ts
@@ -19,7 +19,7 @@ export interface DropdownProps extends React.HTMLAttributes<HTMLElement> {
   addonType?: boolean | 'prepend' | 'append';
   size?: string;
   tag?: string | React.ReactType;
-  toggle?: React.KeyboardEventHandler<any> | React.MouseEventHandler<any>;
+  toggle?: React.KeyboardEventHandler<any> | React.MouseEventHandler<any> | (() => void);
   children?: React.ReactNode;
   className?: string;
   cssModule?: CSSModule;

--- a/types/reactstrap/lib/Modal.d.ts
+++ b/types/reactstrap/lib/Modal.d.ts
@@ -7,7 +7,7 @@ export interface ModalProps extends React.HTMLAttributes<HTMLElement> {
     isOpen?: boolean;
     autoFocus?: boolean;
     size?: string;
-    toggle?: React.KeyboardEventHandler<any> | React.MouseEventHandler<any>;
+    toggle?: React.KeyboardEventHandler<any> | React.MouseEventHandler<any> | (() => void);
     keyboard?: boolean;
     backdrop?: boolean | 'static';
     scrollable?: boolean;

--- a/types/reactstrap/lib/ModalHeader.d.ts
+++ b/types/reactstrap/lib/ModalHeader.d.ts
@@ -7,7 +7,7 @@ export interface ModalHeaderProps extends React.HTMLAttributes<HTMLElement> {
     className?: string;
     cssModule?: CSSModule;
     wrapTag?: string | React.ReactType;
-    toggle?: React.MouseEventHandler<any>;
+    toggle?: React.MouseEventHandler<any> | (() => void);
 }
 
 declare class ModalHeader<T = {[key: string]: any}> extends React.Component<ModalHeaderProps> {}

--- a/types/reactstrap/lib/ToastHeader.d.ts
+++ b/types/reactstrap/lib/ToastHeader.d.ts
@@ -7,7 +7,7 @@ export interface ToastHeaderProps extends React.HTMLAttributes<HTMLElement> {
     className?: string;
     cssModule?: CSSModule;
     wrapTag?: string | React.ReactType;
-    toggle?: React.MouseEventHandler<any>;
+    toggle?: React.MouseEventHandler<any> | (() => void);
     icon?: string | React.ReactNode;
     close?: React.ReactNode;
     charCode?: string | number;


### PR DESCRIPTION
This loosens the `toggle` type for all components and allows them to be parameterless functions.

It undoes some of the strictness introduced in #38575