### PR TITLE
openpgp: Fix openpgp.wkd.WKD.lookup method parameter

### DIFF
--- a/types/openpgp/index.d.ts
+++ b/types/openpgp/index.d.ts
@@ -8,6 +8,7 @@
 //                 SardineFish <https://github.com/SardineFish>
 //                 Ryo Ota <https://github.com/nwtgck>
 //                 Sergey Bakulin <https://github.com/vansergen>
+//                 Wiktor Kwapisiewicz <https://metacode.biz/@wiktor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 import BN = require('bn.js');
@@ -4833,7 +4834,7 @@ export namespace wkd {
          * @param options.rawBytes Returns Uint8Array instead of parsed key.
          * @returns The public key.
          */
-        lookup(): Promise<Uint8Array | { keys: Array<key.Key>; err: Array<Error> | null }>;
+        lookup(options: { email: string; rawBytes?: boolean; }): Promise<Uint8Array | { keys: Array<key.Key>; err: Array<Error> | null }>;
     }
 }
 

--- a/types/openpgp/openpgp-tests.ts
+++ b/types/openpgp/openpgp-tests.ts
@@ -273,3 +273,6 @@ openpgp.util.print_debug_hexstr_dump('');
 openpgp.util.shiftRight(new Uint8Array([1, 0]), 1);
 openpgp.util.str_to_Uint8Array('');
 openpgp.util.Uint8Array_to_str(openpgp.util.str_to_Uint8Array(''));
+
+new openpgp.wkd.WKD().lookup({ email: 'test-wkd@metacode.biz', rawBytes: true });
+new openpgp.wkd.WKD().lookup({ email: 'test-wkd@metacode.biz' });

--- a/types/openpgp/ts3.2/index.d.ts
+++ b/types/openpgp/ts3.2/index.d.ts
@@ -8,6 +8,7 @@
 //                 SardineFish <https://github.com/SardineFish>
 //                 Ryo Ota <https://github.com/nwtgck>
 //                 Sergey Bakulin <https://github.com/vansergen>
+//                 Wiktor Kwapisiewicz <https://metacode.biz/@wiktor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import BN = require('bn.js');
@@ -4898,7 +4899,7 @@ export namespace wkd {
          * @param options.rawBytes Returns Uint8Array instead of parsed key.
          * @returns The public key.
          */
-        lookup(): Promise<Uint8Array | { keys: Array<key.Key>; err: Array<Error> | null }>;
+        lookup(options: { email: string; rawBytes?: boolean; }): Promise<Uint8Array | { keys: Array<key.Key>; err: Array<Error> | null }>;
     }
 }
 

--- a/types/openpgp/ts3.2/openpgp-tests.ts
+++ b/types/openpgp/ts3.2/openpgp-tests.ts
@@ -274,3 +274,6 @@ openpgp.util.print_debug_hexstr_dump('');
 openpgp.util.shiftRight(new Uint8Array([1, 0]), 1);
 openpgp.util.str_to_Uint8Array('');
 openpgp.util.Uint8Array_to_str(openpgp.util.str_to_Uint8Array(''));
+
+new openpgp.wkd.WKD().lookup({ email: 'test-wkd@metacode.biz', rawBytes: true });
+new openpgp.wkd.WKD().lookup({ email: 'test-wkd@metacode.biz' });


### PR DESCRIPTION
Previous declaration of `openpgp.wkd.WKD.lookup` omitted options parameter that made it practically useless (as `email` option parameter is mandatory).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://openpgpjs.org/openpgpjs/doc/wkd.js.html
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
