### PR TITLE
fix(mock-knex): Do not depend on Knex typings at all

### DIFF
--- a/types/mock-knex/index.d.ts
+++ b/types/mock-knex/index.d.ts
@@ -7,8 +7,23 @@
 
 /// <reference types="node" />
 
-import * as Knex from "knex";
 import { EventEmitter } from "events";
+
+interface Knex {
+    client: any;
+}
+
+declare namespace Knex {
+    interface Sql {
+        method: string;
+        options: any;
+        bindings: any;
+        sql: string;
+        toNative(): any;
+    }
+}
+
+export {};
 
 /**
  * Attaches mocked client to knex instance

--- a/types/mock-knex/mock-knex-tests.ts
+++ b/types/mock-knex/mock-knex-tests.ts
@@ -1,5 +1,16 @@
-import knex = require("knex");
 import * as mockDb from "mock-knex";
+
+interface Knex {
+    client: any;
+}
+
+interface KnexOptions {
+    client: string;
+}
+
+function knex(opt: KnexOptions): Knex {
+    return { client: {} };
+}
 
 const db = knex({
 	client: 'sqlite'

--- a/types/mock-knex/package.json
+++ b/types/mock-knex/package.json
@@ -1,6 +1,3 @@
 {
-    "private": true,
-    "dependencies": {
-        "knex": "> 0.8 < 1.0"
-    }
+    "private": true
 }


### PR DESCRIPTION
It's not necessary to have a dependency from knex at all. It's enough to satisfy some basic interface.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).