### PR TITLE
[yup] Add missing aliases, defined(), and fix array innerType

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -96,6 +96,7 @@ export interface MixedSchema<T = any> extends Schema<T> {
     nullable(isNullable: false): MixedSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): MixedSchema<T>;
     required(message?: TestOptionsMessage): MixedSchema<Exclude<T, undefined>>;
+    defined(): MixedSchema<Exclude<T, undefined>>;
     notRequired(): MixedSchema<T | undefined>;
     concat(schema: this): this;
     concat<U>(schema: MixedSchema<U>): MixedSchema<T | U>;
@@ -126,6 +127,7 @@ export interface StringSchema<T extends string | null | undefined = string> exte
     nullable(isNullable: false): StringSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): StringSchema<T>;
     required(message?: TestOptionsMessage): StringSchema<Exclude<T, undefined>>;
+    defined(): StringSchema<Exclude<T, undefined>>;
     notRequired(): StringSchema<T | undefined>;
 }
 
@@ -148,6 +150,7 @@ export interface NumberSchema<T extends number | null | undefined = number> exte
     nullable(isNullable: false): NumberSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): NumberSchema<T>;
     required(message?: TestOptionsMessage): NumberSchema<Exclude<T, undefined>>;
+    defined(): NumberSchema<Exclude<T, undefined>>;
     notRequired(): NumberSchema<T | undefined>;
 }
 
@@ -161,6 +164,7 @@ export interface BooleanSchema<T extends boolean | null | undefined = boolean> e
     nullable(isNullable: false): BooleanSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): BooleanSchema<T>;
     required(message?: TestOptionsMessage): BooleanSchema<Exclude<T, undefined>>;
+    defined(): BooleanSchema<Exclude<T, undefined>>;
     notRequired(): BooleanSchema<T | undefined>;
 }
 
@@ -176,6 +180,7 @@ export interface DateSchema<T extends Date | null | undefined = Date> extends Sc
     nullable(isNullable: false): DateSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): DateSchema<T>;
     required(message?: TestOptionsMessage): DateSchema<Exclude<T, undefined>>;
+    defined(): DateSchema<Exclude<T, undefined>>;
     notRequired(): DateSchema<T | undefined>;
 }
 
@@ -200,6 +205,7 @@ export interface NotRequiredNullableArraySchema<T> extends BasicArraySchema<T, T
     nullable(isNullable: false): NotRequiredArraySchema<T>;
     nullable(isNullable?: boolean): ArraySchema<T>;
     required(message?: TestOptionsMessage): NullableArraySchema<T>;
+    defined(): NullableArraySchema<T>;
     notRequired(): NotRequiredNullableArraySchema<T>;
 }
 
@@ -209,6 +215,7 @@ export interface NullableArraySchema<T> extends BasicArraySchema<T, T[] | null> 
     nullable(isNullable: false): ArraySchema<T>;
     nullable(isNullable?: boolean): ArraySchema<T>;
     required(message?: TestOptionsMessage): NullableArraySchema<T>;
+    defined(): NullableArraySchema<T>;
     notRequired(): NotRequiredNullableArraySchema<T>;
 }
 
@@ -218,6 +225,7 @@ export interface NotRequiredArraySchema<T> extends BasicArraySchema<T, T[] | und
     nullable(isNullable: false): NotRequiredArraySchema<T>;
     nullable(isNullable: boolean): ArraySchema<T>;
     required(message?: TestOptionsMessage): ArraySchema<T>;
+    defined(): ArraySchema<T>;
     notRequired(): NotRequiredArraySchema<T>;
 }
 
@@ -226,6 +234,7 @@ export interface ArraySchema<T> extends BasicArraySchema<T, T[]> {
     nullable(isNullable?: true): NullableArraySchema<T>;
     nullable(isNullable: false | boolean): ArraySchema<T>;
     required(message?: TestOptionsMessage): ArraySchema<T>;
+    defined(): ArraySchema<T>;
     notRequired(): NotRequiredArraySchema<T>;
 }
 
@@ -265,6 +274,7 @@ export interface ObjectSchema<T extends object | null | undefined = object> exte
     nullable(isNullable: false): ObjectSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): ObjectSchema<T>;
     required(message?: TestOptionsMessage): ObjectSchema<Exclude<T, undefined>>;
+    defined(): ObjectSchema<Exclude<T, undefined>>;
     notRequired(): ObjectSchema<T | undefined>;
     concat(schema: this): this;
     concat<U extends object>(schema: ObjectSchema<U>): ObjectSchema<T & U>;

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -98,6 +98,7 @@ export interface MixedSchema<T = any> extends Schema<T> {
     required(message?: TestOptionsMessage): MixedSchema<Exclude<T, undefined>>;
     defined(): MixedSchema<Exclude<T, undefined>>;
     notRequired(): MixedSchema<T | undefined>;
+    optional(): MixedSchema<T | undefined>;
     concat(schema: this): this;
     concat<U>(schema: MixedSchema<U>): MixedSchema<T | U>;
 }
@@ -129,6 +130,7 @@ export interface StringSchema<T extends string | null | undefined = string> exte
     required(message?: TestOptionsMessage): StringSchema<Exclude<T, undefined>>;
     defined(): StringSchema<Exclude<T, undefined>>;
     notRequired(): StringSchema<T | undefined>;
+    optional(): StringSchema<T | undefined>;
 }
 
 export interface NumberSchemaConstructor {
@@ -152,6 +154,7 @@ export interface NumberSchema<T extends number | null | undefined = number> exte
     required(message?: TestOptionsMessage): NumberSchema<Exclude<T, undefined>>;
     defined(): NumberSchema<Exclude<T, undefined>>;
     notRequired(): NumberSchema<T | undefined>;
+    optional(): NumberSchema<T | undefined>;
 }
 
 export interface BooleanSchemaConstructor {
@@ -166,6 +169,7 @@ export interface BooleanSchema<T extends boolean | null | undefined = boolean> e
     required(message?: TestOptionsMessage): BooleanSchema<Exclude<T, undefined>>;
     defined(): BooleanSchema<Exclude<T, undefined>>;
     notRequired(): BooleanSchema<T | undefined>;
+    optional(): BooleanSchema<T | undefined>;
 }
 
 export interface DateSchemaConstructor {
@@ -182,6 +186,7 @@ export interface DateSchema<T extends Date | null | undefined = Date> extends Sc
     required(message?: TestOptionsMessage): DateSchema<Exclude<T, undefined>>;
     defined(): DateSchema<Exclude<T, undefined>>;
     notRequired(): DateSchema<T | undefined>;
+    optional(): DateSchema<T | undefined>;
 }
 
 export interface ArraySchemaConstructor {
@@ -207,6 +212,7 @@ export interface NotRequiredNullableArraySchema<T> extends BasicArraySchema<T, T
     required(message?: TestOptionsMessage): NullableArraySchema<T>;
     defined(): NullableArraySchema<T>;
     notRequired(): NotRequiredNullableArraySchema<T>;
+    optional(): NotRequiredNullableArraySchema<T>;
 }
 
 export interface NullableArraySchema<T> extends BasicArraySchema<T, T[] | null> {
@@ -217,6 +223,7 @@ export interface NullableArraySchema<T> extends BasicArraySchema<T, T[] | null> 
     required(message?: TestOptionsMessage): NullableArraySchema<T>;
     defined(): NullableArraySchema<T>;
     notRequired(): NotRequiredNullableArraySchema<T>;
+    optional(): NotRequiredNullableArraySchema<T>;
 }
 
 export interface NotRequiredArraySchema<T> extends BasicArraySchema<T, T[] | undefined> {
@@ -227,6 +234,7 @@ export interface NotRequiredArraySchema<T> extends BasicArraySchema<T, T[] | und
     required(message?: TestOptionsMessage): ArraySchema<T>;
     defined(): ArraySchema<T>;
     notRequired(): NotRequiredArraySchema<T>;
+    optional(): NotRequiredArraySchema<T>;
 }
 
 export interface ArraySchema<T> extends BasicArraySchema<T, T[]> {
@@ -236,6 +244,7 @@ export interface ArraySchema<T> extends BasicArraySchema<T, T[]> {
     required(message?: TestOptionsMessage): ArraySchema<T>;
     defined(): ArraySchema<T>;
     notRequired(): NotRequiredArraySchema<T>;
+    optional(): NotRequiredArraySchema<T>;
 }
 
 export type ObjectSchemaDefinition<T extends object | null | undefined> = {
@@ -276,6 +285,7 @@ export interface ObjectSchema<T extends object | null | undefined = object> exte
     required(message?: TestOptionsMessage): ObjectSchema<Exclude<T, undefined>>;
     defined(): ObjectSchema<Exclude<T, undefined>>;
     notRequired(): ObjectSchema<T | undefined>;
+    optional(): ObjectSchema<T | undefined>;
     concat(schema: this): this;
     concat<U extends object>(schema: ObjectSchema<U>): ObjectSchema<T & U>;
 }

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -275,6 +275,7 @@ export interface ObjectSchema<T extends object | null | undefined = object> exte
     ): ObjectSchema<Shape<T, U>>;
     from(fromKey: string, toKey: string, alias?: boolean): ObjectSchema<T>;
     noUnknown(onlyKnownKeys?: boolean, message?: ObjectLocale['noUnknown']): ObjectSchema<T>;
+    unknown(allow?: boolean, message?: ObjectLocale['noUnknown']): ObjectSchema<T>;
     transformKeys(callback: (key: any) => any): void;
     camelCase(): ObjectSchema<T>;
     snakeCase(): ObjectSchema<T>;

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -184,16 +184,17 @@ export interface ArraySchemaConstructor {
     new (): ArraySchema<{}>;
 }
 
-interface BasicArraySchema<T extends any[] | null | undefined> extends Schema<T> {
+interface BasicArraySchema<E, T extends E[] | null | undefined> extends Schema<T> {
     min(limit: number | Ref, message?: ArrayLocale['min']): this;
     max(limit: number | Ref, message?: ArrayLocale['max']): this;
     ensure(): this;
     compact(
         rejector?: (value: InferredArrayType<T>, index: number, array: Array<InferredArrayType<T>>) => boolean,
     ): this;
+    innerType: Schema<E>;
 }
 
-export interface NotRequiredNullableArraySchema<T> extends BasicArraySchema<T[] | null | undefined> {
+export interface NotRequiredNullableArraySchema<T> extends BasicArraySchema<T, T[] | null | undefined> {
     of<U>(type: Schema<U>): NotRequiredNullableArraySchema<U>;
     nullable(isNullable?: true): NotRequiredNullableArraySchema<T>;
     nullable(isNullable: false): NotRequiredArraySchema<T>;
@@ -202,7 +203,7 @@ export interface NotRequiredNullableArraySchema<T> extends BasicArraySchema<T[] 
     notRequired(): NotRequiredNullableArraySchema<T>;
 }
 
-export interface NullableArraySchema<T> extends BasicArraySchema<T[] | null> {
+export interface NullableArraySchema<T> extends BasicArraySchema<T, T[] | null> {
     of<U>(type: Schema<U>): NullableArraySchema<U>;
     nullable(isNullable?: true): NullableArraySchema<T>;
     nullable(isNullable: false): ArraySchema<T>;
@@ -211,7 +212,7 @@ export interface NullableArraySchema<T> extends BasicArraySchema<T[] | null> {
     notRequired(): NotRequiredNullableArraySchema<T>;
 }
 
-export interface NotRequiredArraySchema<T> extends BasicArraySchema<T[] | undefined> {
+export interface NotRequiredArraySchema<T> extends BasicArraySchema<T, T[] | undefined> {
     of<U>(type: Schema<U>): NotRequiredArraySchema<U>;
     nullable(isNullable?: true): NotRequiredNullableArraySchema<T>;
     nullable(isNullable: false): NotRequiredArraySchema<T>;
@@ -220,8 +221,7 @@ export interface NotRequiredArraySchema<T> extends BasicArraySchema<T[] | undefi
     notRequired(): NotRequiredArraySchema<T>;
 }
 
-export interface ArraySchema<T> extends BasicArraySchema<T[]> {
-    innerType: Schema<T>;
+export interface ArraySchema<T> extends BasicArraySchema<T, T[]> {
     of<U>(type: Schema<U>): ArraySchema<U>;
     nullable(isNullable?: true): NullableArraySchema<T>;
     nullable(isNullable: false | boolean): ArraySchema<T>;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -1,21 +1,7 @@
 import * as yup from 'yup';
-
 // tslint:disable-next-line:no-duplicate-imports
-import {
-    reach,
-    isSchema,
-    date,
-    Schema,
-    ObjectSchema,
-    ValidationError,
-    MixedSchema,
-    SchemaDescription,
-    TestOptions,
-    ValidateOptions,
-    NumberSchema,
-    TestContext,
-    LocaleObject,
-} from 'yup';
+import {isSchema, LocaleObject, MixedSchema, NumberSchema, ObjectSchema, reach, Schema, SchemaDescription, TestContext, TestOptions, ValidateOptions, ValidationError} from 'yup';
+
 
 // reach function
 const schema1 = yup.object().shape({
@@ -158,6 +144,7 @@ mixed.nullable();
 mixed.required();
 mixed.required('Foo');
 mixed.required(() => 'Foo');
+mixed.defined();
 mixed.notRequired(); // $ExpectType MixedSchema<any>
 mixed.typeError('type error');
 mixed.typeError(() => 'type error');
@@ -346,6 +333,7 @@ function strSchemaTests(strSchema: yup.StringSchema) {
     strSchema.uppercase();
     strSchema.uppercase('upper');
     strSchema.uppercase(() => 'upper');
+    strSchema.defined();
 }
 
 const strSchema = yup.string(); // $ExpectType StringSchema<string>
@@ -394,11 +382,13 @@ numSchema
     .validate(5, { strict: true })
     .then(value => value)
     .catch(err => err);
+numSchema.defined();
 
 // Boolean Schema
 const boolSchema = yup.boolean();
 boolSchema.type;
 boolSchema.isValid(true); // => true
+boolSchema.defined();
 
 // Date Schema
 const dateSchema = yup.date();
@@ -436,6 +426,7 @@ arrSchema.min(5);
 arrSchema.min(5, 'min');
 arrSchema.min(5, () => 'min');
 arrSchema.compact((value, index, array) => value === array[index]);
+arrSchema.defined();
 
 const arrOfObjSchema = yup.array().of(
     yup.object().shape({
@@ -481,6 +472,7 @@ objSchema.transformKeys(key => key.toUpperCase());
 objSchema.camelCase();
 objSchema.snakeCase();
 objSchema.constantCase();
+objSchema.defined();
 
 const description: SchemaDescription = {
     type: 'type',

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -146,6 +146,7 @@ mixed.required('Foo');
 mixed.required(() => 'Foo');
 mixed.defined();
 mixed.notRequired(); // $ExpectType MixedSchema<any>
+mixed.optional(); // $ExpectType MixedSchema<any>
 mixed.typeError('type error');
 mixed.typeError(() => 'type error');
 mixed.oneOf(['hello', 'world'], 'message');
@@ -410,8 +411,10 @@ const arrSchema = yup.array().of(yup.number().min(2));
 arrSchema.type;
 arrSchema.innerType;
 arrSchema.notRequired().innerType;
+arrSchema.optional().innerType;
 arrSchema.nullable().innerType;
 arrSchema.notRequired().nullable().innerType;
+arrSchema.optional().nullable().innerType;
 arrSchema.innerType.type;
 arrSchema.isValid([2, 3]); // => true
 arrSchema.isValid([1, -24]); // => false

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -1,7 +1,6 @@
 import * as yup from 'yup';
 // tslint:disable-next-line:no-duplicate-imports
-import {isSchema, LocaleObject, MixedSchema, NumberSchema, ObjectSchema, reach, Schema, SchemaDescription, TestContext, TestOptions, ValidateOptions, ValidationError} from 'yup';
-
+import { isSchema, LocaleObject, MixedSchema, NumberSchema, ObjectSchema, reach, Schema, SchemaDescription, TestContext, TestOptions, ValidateOptions, ValidationError } from 'yup';
 
 // reach function
 const schema1 = yup.object().shape({

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -471,6 +471,7 @@ objSchema.noUnknown();
 objSchema.noUnknown(true);
 objSchema.noUnknown(true, 'message');
 objSchema.noUnknown(true, () => 'message');
+objSchema.unknown();
 objSchema.transformKeys(key => key.toUpperCase());
 objSchema.camelCase();
 objSchema.snakeCase();

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -419,6 +419,9 @@ dateSchema.max('2017-11-12', () => 'message');
 const arrSchema = yup.array().of(yup.number().min(2));
 arrSchema.type;
 arrSchema.innerType;
+arrSchema.notRequired().innerType;
+arrSchema.nullable().innerType;
+arrSchema.notRequired().nullable().innerType;
 arrSchema.innerType.type;
 arrSchema.isValid([2, 3]); // => true
 arrSchema.isValid([1, -24]); // => false


### PR DESCRIPTION
1. Adds missing function aliases: `object().unknown()` (alias for inverse of `noUnknown`) and `mixed().optional()` (alias for `notRequired`). Reference: https://github.com/jquense/yup/pull/460
2. Adds missing `defined()` function, which was never described in changelog. Reference: https://github.com/jquense/yup#mixeddefined-schema
3. Extends the `innerType` property to all array schema forms. Before this, `array().nullable().innerType` would not be allowed. Reference: https://github.com/jquense/yup/commit/8f00d50

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see above.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
