### PR TITLE
[yup] Add support for custom type-assertion tests that narrow the schema type

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -329,9 +329,9 @@ export interface TestMessageParams {
     label: string;
 }
 
-export interface TestOptions<P extends Record<string, any> = {}, R = any> {
+interface BaseTestOptions<P extends Record<string, any> = {}, R = any> {
     /**
-     * Unique name identifying the test
+     * Unique name identifying the test. Required for exclusive tests.
      */
     name?: string;
 
@@ -355,6 +355,18 @@ export interface TestOptions<P extends Record<string, any> = {}, R = any> {
      */
     exclusive?: boolean;
 }
+
+interface NonExclusiveTestOptions<P extends Record<string, any> = {}, R = any> extends BaseTestOptions<P, R> {
+    exclusive?: false;
+}
+
+interface ExclusiveTestOptions<P extends Record<string, any> = {}, R = any> extends BaseTestOptions<P, R> {
+    exclusive: true;
+    name: string;
+}
+
+export type TestOptions<P extends Record<string, any> = {}, R = any> =
+  NonExclusiveTestOptions<P, R> | ExclusiveTestOptions<P, R>;
 
 export interface SchemaFieldRefDescription {
     type: 'ref';

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -96,11 +96,12 @@ export interface MixedSchema<T = any> extends Schema<T> {
         message: TestOptionsMessage,
         test: AssertingTestFunction<U>
         ): MixedSchema<U>;
-        test(
-            name: string,
-            message: TestOptionsMessage,
-            test: TestFunction
-        ): this;
+    test(
+        name: string,
+        message: TestOptionsMessage,
+        test: TestFunction
+    ): this;
+    test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>>): MixedSchema<U>;
     test(options: TestOptions<Record<string, any>>): this;
 }
 
@@ -140,6 +141,7 @@ export interface StringSchema<T extends string | null | undefined = string> exte
         message: TestOptionsMessage,
         test: TestFunction
     ): this;
+    test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>>): StringSchema<U>;
     test(options: TestOptions<Record<string, any>>): this;
 }
 
@@ -173,6 +175,7 @@ export interface NumberSchema<T extends number | null | undefined = number> exte
         message: TestOptionsMessage,
         test: TestFunction
     ): this;
+    test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>>): NumberSchema<U>;
     test(options: TestOptions<Record<string, any>>): this;
 }
 
@@ -197,6 +200,7 @@ export interface BooleanSchema<T extends boolean | null | undefined = boolean> e
         message: TestOptionsMessage,
         test: TestFunction
     ): this;
+    test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>>): BooleanSchema<U>;
     test(options: TestOptions<Record<string, any>>): this;
 }
 
@@ -223,6 +227,7 @@ export interface DateSchema<T extends Date | null | undefined = Date> extends Sc
         message: TestOptionsMessage,
         test: TestFunction
     ): this;
+    test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>>): DateSchema<U>;
     test(options: TestOptions<Record<string, any>>): this;
 }
 
@@ -327,6 +332,7 @@ export interface ObjectSchema<T extends object | null | undefined = object> exte
         message: TestOptionsMessage,
         test: TestFunction
     ): this;
+    test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>>): ObjectSchema<U>;
     test(options: TestOptions<Record<string, any>>): this;
 }
 
@@ -429,8 +435,19 @@ interface ExclusiveTestOptions<P extends Record<string, any>> extends BaseTestOp
     name: string;
 }
 
+interface NonExclusiveAssertingTestOptions<U, P extends Record<string, any>> extends NonExclusiveTestOptions<P> {
+    test: AssertingTestFunction<U>;
+}
+
+interface ExclusiveAssertingTestOptions<U, P extends Record<string, any>> extends ExclusiveTestOptions<P> {
+    test: AssertingTestFunction<U>;
+}
+
 export type TestOptions<P extends Record<string, any> = {}> =
   NonExclusiveTestOptions<P> | ExclusiveTestOptions<P>;
+
+export type AssertingTestOptions<U, P extends Record<string, any> = {}> =
+  NonExclusiveAssertingTestOptions<U, P> | ExclusiveAssertingTestOptions<U, P>;
 
 export interface SchemaFieldRefDescription {
     type: 'ref';

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -76,8 +76,7 @@ export interface Schema<T> {
     test(
         name: string,
         message: TestOptionsMessage,
-        test: (this: TestContext, value?: any) => boolean | ValidationError | Promise<boolean | ValidationError>,
-        callbackStyleAsync?: boolean,
+        test: (this: TestContext, value?: any) => boolean | ValidationError | Promise<boolean | ValidationError>
     ): this;
     // tslint:disable-next-line:no-unnecessary-generics
     test<P>(options: TestOptions<P>): this;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -199,6 +199,14 @@ mixed.test({
     message: '${path} must be less than 5 characters',
     test: value => value == null || value.length <= 5,
 });
+// Name is required for exclusive tests:
+// $ExpectError
+mixed.test({
+    exclusive: true,
+    // tslint:disable-next-line:no-invalid-template-strings
+    message: '${path} must be less than 5 characters',
+    test: value => value == null || value.length <= 5,
+});
 mixed.test('with-promise', 'It contains invalid value', value => new Promise(resolve => true));
 const testContext = function(this: TestContext) {
     // $ExpectType string

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -206,8 +206,7 @@ mixed.test(
     "${path} is not a function",
     (value): value is Set<any> => value instanceof Set,
 );
-// Assertion functions don't narrow the type when used in test objects:
-// $ExpectType MixedSchema<any>
+// $ExpectType MixedSchema<Set<any>>
 mixed.test({
     name: 'is-function',
     exclusive: true,

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -199,6 +199,22 @@ mixed.test({
     message: '${path} must be less than 5 characters',
     test: value => value == null || value.length <= 5,
 });
+// $ExpectType MixedSchema<Set<any>>
+mixed.test(
+    'is-function',
+    // tslint:disable-next-line:no-invalid-template-strings
+    "${path} is not a function",
+    (value): value is Set<any> => value instanceof Set,
+);
+// Assertion functions don't narrow the type when used in test objects:
+// $ExpectType MixedSchema<any>
+mixed.test({
+    name: 'is-function',
+    exclusive: true,
+    // tslint:disable-next-line:no-invalid-template-strings
+    message: '${path} is not a function',
+    test: (value): value is Set<any> => value instanceof Set,
+});
 // Name is required for exclusive tests:
 // $ExpectError
 mixed.test({
@@ -207,7 +223,7 @@ mixed.test({
     message: '${path} must be less than 5 characters',
     test: value => value == null || value.length <= 5,
 });
-mixed.test('with-promise', 'It contains invalid value', value => new Promise(resolve => true));
+mixed.test('with-promise', 'It contains invalid value', value => new Promise<boolean>(resolve => resolve(true)));
 const testContext = function(this: TestContext) {
     // $ExpectType string
     this.path;
@@ -292,8 +308,8 @@ mixed = new ExtendsMixed2();
 /**
  * Creating new Types
  */
-class DateSchema extends yup.date {
-    isWednesday(message?: string): DateSchema {
+class CustomDateSchema extends yup.date {
+    isWednesday(message?: string): CustomDateSchema {
         return this.clone().test({
             name: 'Wednesday',
             // tslint:disable-next-line:no-invalid-template-strings
@@ -304,7 +320,7 @@ class DateSchema extends yup.date {
 }
 yup.object()
     .shape({
-        startDate: new DateSchema().isWednesday().required(),
+        startDate: new CustomDateSchema().isWednesday().required(),
     })
     .isValidSync({
         startDate: '2017-11-29',
@@ -783,6 +799,14 @@ const personSchema = yup.object({
         .nullable()
         .notRequired()
         .min(1),
+    friends: yup
+        .mixed()
+        .test(
+            "is-Set",
+            // tslint:disable-next-line:no-invalid-template-strings
+            "${path} must be a Set of strings",
+            (value): value is undefined | null | Set<string> =>
+                value === null || value === undefined || (value instanceof Set && Array.from(value.values()).every(el => typeof el === "string")))
 });
 
 type Person = yup.InferType<typeof personSchema>;
@@ -823,6 +847,7 @@ person.isAlive = true;
 person.isAlive = undefined;
 person.children = ['1', '2', '3'];
 person.children = undefined;
+person.friends = new Set(["Amy", "Beth"]);
 
 // $ExpectError
 person.gender = 1;
@@ -834,6 +859,10 @@ person.firstName = undefined;
 person.mustBeAString = null;
 // $ExpectError
 person.mustBeAString = undefined;
+// $ExpectError
+person.friends = new Set([1, 2, 3]);
+// $ExpectError
+person.friends = ["Amy", "Beth"];
 
 const castPerson = personSchema.cast({});
 castPerson.firstName = '';


### PR DESCRIPTION
This PR is not a change to fix a bug or reflect updates to the library. Instead it's  a proposal for a new feature in the typings for this library (Yup). 

Currently you can already use some built-in schema functions to modify the types of your Yup schemas. For example, `yup.string()` has type `StringSchema<string>` while `yup.string().nullable()` has the type `StringSchema<string | null>`.

However, there's no way to build your own modifier functions. You can create custom tests, but you can't use them to change the type of the schema, so if you use `InferType` to infer the type from the schema, you'll still only get the original type. For example:

```ts
const anySchema = yup.mixed(); // MixedSchema<any>

// We want to test that the recieved item is a Set of numbers:
const setSchema = anySchema.test(
  "is-set-of-numbers",
  "${path} must be an ES6 Set of numbers",
  (value): value is Set<number> =>
    value instanceof Set && Array.from(value.values()).every(el => typeof el === number)
);

// So now we know if we use that schema on an object, we'll be sure it's a set of numbers
// However, if we infer the type:
type OurSet = yup.InferType<typeof setSchema>; // any ❌ 
```

With this update, `test` is changed to a generic function that detects if the test function is of the form `(value): value is U` and narrows the schema down to `U`. 

**Caveats:**

This isn't perfect. If you use a type-assertion function for `test`, it will no longer return `this`, which only matters when you are making custom schema classes:
```
// Example from the test file:

class CustomDateSchema extends yup.date {
    // This function needs to return `CustomDateSchema`, NOT `DateSchema`
    isWednesday(message?: string): CustomDateSchema {
        // Therefore `test` cannot naively return `DateSchema` always - in this case it needs to return `this`
        return this.clone().test({
            name: 'Wednesday',
            message: message || '${path} must be Wednesday',
            test: value => true /* boring check that the day is Wednesday */,
        });
    }
}
```

This isn't that common of a case, but it does happen and if you were creating a class that extends a schema, you would almost certainly be using `test` to create custom tests.

~~To solve this problem, I provide two simple workarounds. First, if the function passed to `test` is not a type assertion function, then `test` returns `this`. Second, if an object is used ([see documentation](https://github.com/jquense/yup#mixedtestoptions-object-schema)), the type modifying behavior won't kick in at all, no matter what test function is used. This is both to provide a workaround for the above and because to make this work would be overcomplicating the types.~~

To solve this problem, I included function overloads such that if the test function isn't a type assertion function, the `test` call will return `this` instead of the refined type. Essentially, type-asserting tests won't work with subclassed schemas, but no functionality is lost.

The only other caveat is that this doesn't work at all on array schemas; due to the way they are defined, this would be much too complicated. Also, there's not really much point since you can write custom tests for the array members; when would you ever be able to use a type assertion test function on the array schema itself? 

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/yup#mixedtestname-string-message-string--function-test-function-schema
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.