### PR TITLE
Updates Emscripten types with new MODULARIZE API

### DIFF
--- a/types/emscripten/emscripten-tests.ts
+++ b/types/emscripten/emscripten-tests.ts
@@ -10,6 +10,8 @@ interface EmscriptenModule {
     setValue: typeof setValue;
 }
 
+let Module: EmscriptenModule;
+
 /// Module
 function ModuleTest(): void {
     Module.environment = "WEB";
@@ -142,4 +144,25 @@ function StackAlloc() {
     const ptr = stackAlloc(42);
     const strPtr = allocateUTF8OnStack('testString');
     stackRestore(stack);
+}
+
+let createModule: EmscriptenModuleFactory;
+interface MyModule extends EmscriptenModule {
+    foo: string;
+}
+let createMyModule: EmscriptenModuleFactory<MyModule>;
+
+async function ModuleFactoryTest() {
+    const module1 = await createModule();
+    module1.print('🦆');
+    const module2 = await createModule({
+        print() {
+            console.log('testing passing overrides');
+        }
+    });
+    const myModule: MyModule = await createMyModule({
+        foo: 'bar',
+        locateFile: (url, dir) => '🌈',
+    });
+    myModule.foo;
 }

--- a/types/emscripten/emscripten-tests.ts
+++ b/types/emscripten/emscripten-tests.ts
@@ -14,25 +14,25 @@ let Module: EmscriptenModule;
 
 /// Module
 function ModuleTest(): void {
-    Module.environment = "WEB";
-    Module.environment = "NODE";
-    Module.environment = "WORKER";
+    Module.environment = 'WEB';
+    Module.environment = 'NODE';
+    Module.environment = 'WORKER';
     Module.noInitialRun = false;
     Module.logReadFiles = false;
-    Module.filePackagePrefixURL = "http://www.example.org/";
+    Module.filePackagePrefixURL = 'http://www.example.org/';
     Module.preinitializedWebGLContext = new WebGLRenderingContext();
-    Module.onAbort = (what) => console.log('abort');
+    Module.onAbort = what => console.log('abort');
     Module.onRuntimeInitialized = () => console.log('init');
 
-    const package: ArrayBuffer = Module.getPreloadedPackage("package-name", 100);
+    const package: ArrayBuffer = Module.getPreloadedPackage('package-name', 100);
     const exports: Emscripten.WebAssemblyExports = Module.instantiateWasm(
-        [{name: "func-name", kind: "function"}],
-        (module: WebAssembly.Module) => {}
+        [{ name: 'func-name', kind: 'function' }],
+        (module: WebAssembly.Module) => {},
     );
-    const memFile: string = Module.locateFile("file.mem", "http://www.example.org/");
-    Module.onCustomMessage(new MessageEvent("TestType"));
+    const memFile: string = Module.locateFile('file.mem', 'http://www.example.org/');
+    Module.onCustomMessage(new MessageEvent('TestType'));
 
-    Module.print = (text) => alert('stdout: ' + text);
+    Module.print = text => alert('stdout: ' + text);
 
     let int_sqrt = Module.cwrap('int_sqrt', 'number', ['number']);
     int_sqrt = Module.cwrap('int_sqrt', null, ['number']);
@@ -46,17 +46,21 @@ function ModuleTest(): void {
     Module.HEAPU8.set(myTypedArray, buf);
     Module.ccall('my_function', 'number', ['number'], [buf]);
     Module.ccall('my_function', null, ['number'], [buf]);
-    Module.ccall('my_function', null, ['number'], [buf], {async: true});
+    Module.ccall('my_function', null, ['number'], [buf], { async: true });
     Module.cwrap('my_function', 'string', ['number', 'boolean', 'array']);
     Module.cwrap('my_function', null, ['number']);
-    Module.cwrap('my_function', 'string', ['number', 'boolean', 'array'], {async: true});
+    Module.cwrap('my_function', 'string', ['number', 'boolean', 'array'], { async: true });
     Module._free(buf);
     Module.destroy({});
 }
 
 /// FS
 function FSTest(): void {
-    FS.init(() => null, _ => null, _ => null);
+    FS.init(
+        () => null,
+        _ => null,
+        _ => null,
+    );
     FS.init(null, null, null);
 
     FS.mkdir('/working');
@@ -66,13 +70,13 @@ function FSTest(): void {
         FS.mkdir('/data');
         FS.mount(IDBFS, {}, '/data');
 
-        FS.syncfs(true, (err) => {
+        FS.syncfs(true, err => {
             // handle callback
         });
     }
 
     function myAppShutdown() {
-        FS.syncfs((err) => {
+        FS.syncfs(err => {
             // handle callback
         });
     }
@@ -90,8 +94,8 @@ function FSTest(): void {
     FS.writeFile('file', 'foobar');
     FS.symlink('file', 'link');
 
-    FS.writeFile('forbidden', 'can\'t touch this');
-    FS.chmod('forbidden', parseInt("0000", 8));
+    FS.writeFile('forbidden', "can't touch this");
+    FS.chmod('forbidden', parseInt('0000', 8));
 
     FS.writeFile('file', 'foobar');
     FS.truncate('file', 3);
@@ -112,7 +116,7 @@ function FSTest(): void {
 
     FS.createDataFile('/', 'dummy2', data, true, true, true);
 
-    const lookup = FS.lookupPath("path", { parent: true });
+    const lookup = FS.lookupPath('path', { parent: true });
 }
 
 /// String conversions
@@ -158,7 +162,7 @@ async function ModuleFactoryTest() {
     const module2 = await createModule({
         print() {
             console.log('testing passing overrides');
-        }
+        },
     });
     const myModule: MyModule = await createMyModule({
         foo: 'bar',

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for Emscripten 1.39.5
-// Project: http://kripken.github.io/emscripten-site/index.html
+// Type definitions for Emscripten 1.39.16
+// Project: https://emscripten.org
 // Definitions by: Kensuke Matsuzaki <https://github.com/zakki>
 //                 Periklis Tsirakidis <https://github.com/periklis>
 //                 Bumsik Kim <https://github.com/kbumsik>
+//                 Louis DeScioli <https://github.com/lourd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -41,26 +42,6 @@ declare namespace Emscripten {
 }
 
 interface EmscriptenModule {
-    /**
-     * Initializes an EmscriptenModule object and returns it. The initialized
-     * obejct will be passed to then(). Works only when -s MODULARIZE=1 is
-     * enabled. This is default exported function when -s EXPORT_ES6=1 is
-     * enabled.
-     * https://emscripten.org/docs/getting_started/FAQ.html#how-can-i-tell-when-the-page-is-fully-loaded-and-it-is-safe-to-call-compiled-functions
-     * @param moduleOverrides Properties of an initialized module to override.
-     */
-    (moduleOverrides?: Partial<this>): this;
-    /**
-     * Promise-like then() inteface.
-     * WRANGING: Emscripten's then() is not really promise-based 'thenable'.
-     * Don't try to use it with Promise.resolve() or in an async function
-     * without deleting delete Module["then"] in the callback.
-     * https://github.com/kripken/emscripten/issues/5820
-     * Works only when -s MODULARIZE=1 is enabled.
-     * @param callback A callback chained from Module() with an Module instance.
-     */
-    then(callback: (module: this) => void): this;
-
     print(str: string): void;
     printErr(str: string): void;
     arguments: string[];
@@ -118,10 +99,20 @@ interface EmscriptenModule {
     _free(ptr: number): void;
 }
 
-// By default Emscripten emits a single global Module.  Users setting -s
-// MODULARIZE=1 -s EXPORT_NAME=MyMod should declare their own types, e.g.
-// declare var MyMod: EmscriptenModule;
-declare var Module: EmscriptenModule;
+/**
+ * A factory function is generated when setting the `MODULARIZE` build option
+ * to `1` in your Emscripten build. It return a Promise that resolves to an
+ * initialized, ready-to-call `EmscriptenModule` instance.
+ *
+ * By default, the factory function will be named `Module`. It's recommended to
+ * use the `EXPORT_ES6` option, in which the factory function will be the
+ * default export. If used without `EXPORT_ES6`, the factory function will be a
+ * global variable. You can rename the variable using the `EXPORT_NAME` build
+ * option. It's left to you to declare any global variables as needed in your
+ * application's types.
+ * @param moduleOverrides Default properties for the initialized module.
+ */
+type EmscriptenModuleFactory<T extends EmscriptenModule = EmscriptenModule> = (moduleOverrides?: Partial<T>) => Promise<T>;
 
 declare namespace FS {
     interface Lookup {

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -9,23 +9,22 @@
 
 /** Other WebAssembly declarations, for compatibility with older versions of Typescript */
 declare namespace WebAssembly {
-    interface Module { }
+    interface Module {}
 }
 
 declare namespace Emscripten {
-    interface FileSystemType {
-    }
-    type EnvironmentType = "WEB" | "NODE" | "SHELL" | "WORKER";
+    interface FileSystemType {}
+    type EnvironmentType = 'WEB' | 'NODE' | 'SHELL' | 'WORKER';
 
-    type JSType = "number" | "string" | "array" | "boolean";
+    type JSType = 'number' | 'string' | 'array' | 'boolean';
     type TypeCompatibleWithC = number | string | any[] | boolean;
 
     type CIntType = 'i8' | 'i16' | 'i32' | 'i64';
     type CFloatType = 'float' | 'double';
     type CPointerType = 'i8*' | 'i16*' | 'i32*' | 'i64*' | 'float*' | 'double*' | '*';
-    type CType =  CIntType | CFloatType | CPointerType;
+    type CType = CIntType | CFloatType | CPointerType;
 
-    type WebAssemblyImports =  Array<{
+    type WebAssemblyImports = Array<{
         name: string;
         kind: string;
     }>;
@@ -62,7 +61,7 @@ interface EmscriptenModule {
     getPreloadedPackage(remotePackageName: string, remotePackageSize: number): ArrayBuffer;
     instantiateWasm(
         imports: Emscripten.WebAssemblyImports,
-        successCallback: (module: WebAssembly.Module) => void
+        successCallback: (module: WebAssembly.Module) => void,
     ): Emscripten.WebAssemblyExports;
     locateFile(url: string, scriptDirectory: string): string;
     onCustomMessage(event: MessageEvent): void;
@@ -112,7 +111,9 @@ interface EmscriptenModule {
  * application's types.
  * @param moduleOverrides Default properties for the initialized module.
  */
-type EmscriptenModuleFactory<T extends EmscriptenModule = EmscriptenModule> = (moduleOverrides?: Partial<T>) => Promise<T>;
+type EmscriptenModuleFactory<T extends EmscriptenModule = EmscriptenModule> = (
+    moduleOverrides?: Partial<T>,
+) => Promise<T>;
 
 declare namespace FS {
     interface Lookup {
@@ -185,12 +186,27 @@ declare namespace FS {
     function close(stream: FSStream): void;
     function llseek(stream: FSStream, offset: number, whence: number): any;
     function read(stream: FSStream, buffer: ArrayBufferView, offset: number, length: number, position?: number): number;
-    function write(stream: FSStream, buffer: ArrayBufferView, offset: number, length: number, position?: number, canOwn?: boolean): number;
+    function write(
+        stream: FSStream,
+        buffer: ArrayBufferView,
+        offset: number,
+        length: number,
+        position?: number,
+        canOwn?: boolean,
+    ): number;
     function allocate(stream: FSStream, offset: number, length: number): void;
-    function mmap(stream: FSStream, buffer: ArrayBufferView, offset: number, length: number, position: number, prot: number, flags: number): any;
+    function mmap(
+        stream: FSStream,
+        buffer: ArrayBufferView,
+        offset: number,
+        length: number,
+        position: number,
+        prot: number,
+        flags: number,
+    ): any;
     function ioctl(stream: FSStream, cmd: any, arg: any): any;
-    function readFile(path: string, opts: { encoding: "binary", flags?: string }): Uint8Array;
-    function readFile(path: string, opts: { encoding: "utf8", flags?: string }): string;
+    function readFile(path: string, opts: { encoding: 'binary'; flags?: string }): Uint8Array;
+    function readFile(path: string, opts: { encoding: 'utf8'; flags?: string }): string;
     function readFile(path: string, opts?: { flags?: string }): Uint8Array;
     function writeFile(path: string, data: string | ArrayBufferView, opts?: { flags?: string }): void;
 
@@ -205,10 +221,32 @@ declare namespace FS {
         error: null | ((c: number) => any),
     ): void;
 
-    function createLazyFile(parent: string | FSNode, name: string, url: string, canRead: boolean, canWrite: boolean): FSNode;
-    function createPreloadedFile(parent: string | FSNode, name: string, url: string,
-        canRead: boolean, canWrite: boolean, onload?: () => void, onerror?: () => void, dontCreateFile?: boolean, canOwn?: boolean): void;
-    function createDataFile(parent: string | FSNode, name: string, data: ArrayBufferView, canRead: boolean, canWrite: boolean, canOwn: boolean): FSNode;
+    function createLazyFile(
+        parent: string | FSNode,
+        name: string,
+        url: string,
+        canRead: boolean,
+        canWrite: boolean,
+    ): FSNode;
+    function createPreloadedFile(
+        parent: string | FSNode,
+        name: string,
+        url: string,
+        canRead: boolean,
+        canWrite: boolean,
+        onload?: () => void,
+        onerror?: () => void,
+        dontCreateFile?: boolean,
+        canOwn?: boolean,
+    ): void;
+    function createDataFile(
+        parent: string | FSNode,
+        name: string,
+        data: ArrayBufferView,
+        canRead: boolean,
+        canWrite: boolean,
+        canOwn: boolean,
+    ): FSNode;
 }
 
 declare var MEMFS: Emscripten.FileSystemType;
@@ -229,13 +267,29 @@ declare var IDBFS: Emscripten.FileSystemType;
 //
 // See: https://emscripten.org/docs/getting_started/FAQ.html#why-do-i-get-typeerror-module-something-is-not-a-function
 
-declare function ccall(ident: string, returnType: Emscripten.JSType | null, argTypes: Emscripten.JSType[], args: Emscripten.TypeCompatibleWithC[], opts?: Emscripten.CCallOpts): any;
-declare function cwrap(ident: string, returnType: Emscripten.JSType | null, argTypes: Emscripten.JSType[], opts?: Emscripten.CCallOpts): (...args: any[]) => any;
+declare function ccall(
+    ident: string,
+    returnType: Emscripten.JSType | null,
+    argTypes: Emscripten.JSType[],
+    args: Emscripten.TypeCompatibleWithC[],
+    opts?: Emscripten.CCallOpts,
+): any;
+declare function cwrap(
+    ident: string,
+    returnType: Emscripten.JSType | null,
+    argTypes: Emscripten.JSType[],
+    opts?: Emscripten.CCallOpts,
+): (...args: any[]) => any;
 
 declare function setValue(ptr: number, value: any, type: Emscripten.CType, noSafe?: boolean): void;
 declare function getValue(ptr: number, type: Emscripten.CType, noSafe?: boolean): number;
 
-declare function allocate(slab: number[] | ArrayBufferView | number, types: Emscripten.CType | Emscripten.CType[], allocator: number, ptr?: number): number;
+declare function allocate(
+    slab: number[] | ArrayBufferView | number,
+    types: Emscripten.CType | Emscripten.CType[],
+    allocator: number,
+    ptr?: number,
+): number;
 
 declare function stackAlloc(size: number): number;
 declare function stackSave(): number;

--- a/types/sql.js/module.d.ts
+++ b/types/sql.js/module.d.ts
@@ -5,7 +5,7 @@ export namespace SqlJs {
     type ValueType = number | string | Uint8Array | null;
     type ParamsObject = Record<string, ValueType>;
     type ParamsCallback = (obj: ParamsObject) => void;
-    type Config = Partial<typeof Module>;
+    type Config = Partial<EmscriptenModule>;
 
     interface QueryResults {
         columns: string[];


### PR DESCRIPTION
**Don't merge until the new release of Emscripten has been cut**

---

This corresponds with the changes to Emscripten in emscripten-core/emscripten#10697,
creating a type for the new Promise-based API of the factory function
generated when using `MODULARIZE`.

Removes the obsolete `then` method from EmscriptenModule and separates
the type for the factory function generated when using the `MODULARIZE`
build option from the rest of the `EmscriptenModule` interface. This
will make it easier to extend the interface.

Also removes the global `Module` variable declaration as this is not
applicable for every application. This was not ideal as it left a very
generic variable name in the global scope for any application that used
Emscripten, regardless of whether there was actually a global variable.
This now leaves it up to the user to declare their module instance as
appropriate for them.

Fixes the reference in sql.js, using the EmscriptenModule interface
directly.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emscripten-core/emscripten/pull/10697
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)