### PR TITLE
Add rpi-gpio types

### DIFF
--- a/types/rpi-gpio/index.d.ts
+++ b/types/rpi-gpio/index.d.ts
@@ -76,7 +76,7 @@ declare class Gpio extends EventEmitter {
     /**
      * Unexport any pins setup by this module
      *
-     * @param cb Optional callback
+     * @param [cb] callback
      */
     destroy(cb: ErrorCallback): void;
     /**

--- a/types/rpi-gpio/index.d.ts
+++ b/types/rpi-gpio/index.d.ts
@@ -48,7 +48,7 @@ declare class Gpio extends EventEmitter {
      *
      * @param channel The channel to write to
      * @param value   If true, turns the channel on, else turns off
-     * @param cb      Optional callback
+     * @param [cb]      callback
      */
     write(channel: number, value: boolean, cb?: ErrorCallback): void;
     /**

--- a/types/rpi-gpio/index.d.ts
+++ b/types/rpi-gpio/index.d.ts
@@ -83,7 +83,7 @@ declare class Gpio extends EventEmitter {
      * Reset the state of the module
      */
     reset(): void;
-    
+
     readonly promise: {
         DIR_IN: PinDirection;
         DIR_OUT: PinDirection;

--- a/types/rpi-gpio/index.d.ts
+++ b/types/rpi-gpio/index.d.ts
@@ -8,7 +8,7 @@
 import { EventEmitter } from 'events';
 
 type MODE = 'mode_rpi' | 'mode_bcm';
-type DIR = 'in' | 'out' | 'low' | 'high';
+type PinDirection = 'in' | 'out' | 'low' | 'high';
 type EDGE = 'none' | 'rising' | 'falling' | 'both';
 type ValueCallback<T> = (err?: Error | null, value?: T) => void;
 type ErrorCallback = (err?: Error | null) => void;

--- a/types/rpi-gpio/index.d.ts
+++ b/types/rpi-gpio/index.d.ts
@@ -1,0 +1,136 @@
+// Type definitions for rpi-gpio 2.1
+// Project: https://github.com/JamesBarwell/rpi-gpio.js#readme
+// Definitions by: Giles Roadnight <https://github.com/Roaders>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.0
+
+/// <reference types="node" />
+import { EventEmitter } from 'events';
+
+type MODE = 'mode_rpi' | 'mode_bcm';
+type DIR = 'in' | 'out' | 'low' | 'high';
+type EDGE = 'none' | 'rising' | 'falling' | 'both';
+type ValueCallback<T> = (err?: Error | null, value?: T) => void;
+type ErrorCallback = (err?: Error | null) => void;
+
+declare class Gpio extends EventEmitter {
+    constructor();
+
+    readonly DIR_IN: DIR;
+    readonly DIR_OUT: DIR;
+    readonly DIR_LOW: DIR;
+    readonly DIR_HIGH: DIR;
+    readonly MODE_RPI: MODE;
+    readonly MODE_BCM: MODE;
+    readonly EDGE_NONE: EDGE;
+    readonly EDGE_RISING: EDGE;
+    readonly EDGE_FALLING: EDGE;
+    readonly EDGE_BOTH: EDGE;
+    /**
+     * Set pin reference mode. Defaults to 'mode_rpi'.
+     *
+     * @param mode Pin reference mode, 'mode_rpi' or 'mode_bcm'
+     */
+    setMode(mode: MODE): void;
+    /**
+     * Setup a channel for use as an input or output
+     *
+     * @param  channel   Reference to the pin in the current mode's schema
+     * @param _direction The pin direction, either 'in' or 'out'
+     * @param _edge       edge Informs the GPIO chip if it needs to generate interrupts. Either 'none', 'rising', 'falling' or 'both'. Defaults to 'none'
+     * @param _onSetup  callback
+     */
+    setup(channel: number, onSetup?: ValueCallback<boolean>): void;
+    setup(channel: number, direction?: DIR, onSetup?: ValueCallback<boolean>): void;
+    setup(channel: number, direction?: DIR, edge?: EDGE, onSetup?: ValueCallback<boolean>): void;
+    /**
+     * Write a value to a channel
+     *
+     * @param channel The channel to write to
+     * @param value   If true, turns the channel on, else turns off
+     * @param cb      Optional callback
+     */
+    write(channel: number, value: boolean, cb?: ErrorCallback): void;
+    /**
+     * Write a value to a channel
+     *
+     * @param channel The channel to write to
+     * @param value   If true, turns the channel on, else turns off
+     * @param cb      Optional callback
+     */
+    output(channel: number, value: boolean, cb?: ErrorCallback): void;
+    /**
+     * Read a value from a channel
+     *
+     * @param channel The channel to read from
+     * @param cb      Callback which receives the channel's boolean value
+     */
+    read(channel: number, cb: ValueCallback<boolean>): void;
+    /**
+     * Read a value from a channel
+     *
+     * @param channel The channel to read from
+     * @param cb      Callback which receives the channel's boolean value
+     */
+    input(channel: number, cb: ValueCallback<boolean>): void;
+    /**
+     * Unexport any pins setup by this module
+     *
+     * @param cb Optional callback
+     */
+    destroy(cb?: ErrorCallback): void;
+    /**
+     * Reset the state of the module
+     */
+    reset(): void;
+    private setRaspberryVersion;
+    private getPinRpi;
+    private getPinBcm;
+    /**
+     * Listen for interrupts on a channel
+     *
+     * @param channel The channel to watch
+     * @param cb Callback which receives the channel's err
+     */
+    private listen;
+    readonly promise: {
+        DIR_IN: DIR;
+        DIR_OUT: DIR;
+        DIR_LOW: DIR;
+        DIR_HIGH: DIR;
+        MODE_RPI: MODE;
+        MODE_BCM: MODE;
+        EDGE_NONE: EDGE;
+        EDGE_RISING: EDGE;
+        EDGE_FALLING: EDGE;
+        EDGE_BOTH: EDGE;
+        /**
+         * @see {@link Gpio.setup}
+         * @param channel
+         * @param direction
+         * @param edge
+         * @returns Promise
+         */
+        setup: (channel: number, direction: DIR, edge: EDGE) => Promise<unknown>;
+        /**
+         * @see {@link Gpio.write}
+         * @param channel
+         * @param value
+         * @returns Promise
+         */
+        write: (channel: number, value: boolean) => Promise<unknown>;
+        /**
+         * @see {@link Gpio.read}
+         * @param channel
+         * @returns Promise
+         */
+        read: (channel: number) => Promise<unknown>;
+        /**
+         * @see {@link Gpio.destroy}
+         * @returns Promise
+         */
+        destroy: () => Promise<unknown>;
+    };
+}
+declare const GPIO: Gpio;
+export = GPIO;

--- a/types/rpi-gpio/index.d.ts
+++ b/types/rpi-gpio/index.d.ts
@@ -83,16 +83,6 @@ declare class Gpio extends EventEmitter {
      * Reset the state of the module
      */
     reset(): void;
-    private setRaspberryVersion;
-    private getPinRpi;
-    private getPinBcm;
-    /**
-     * Listen for interrupts on a channel
-     *
-     * @param channel The channel to watch
-     * @param cb Callback which receives the channel's err
-     */
-    private listen;
     readonly promise: {
         DIR_IN: DIR;
         DIR_OUT: DIR;

--- a/types/rpi-gpio/index.d.ts
+++ b/types/rpi-gpio/index.d.ts
@@ -78,7 +78,7 @@ declare class Gpio extends EventEmitter {
      *
      * @param cb Optional callback
      */
-    destroy(cb?: ErrorCallback): void;
+    destroy(cb: ErrorCallback): void;
     /**
      * Reset the state of the module
      */

--- a/types/rpi-gpio/index.d.ts
+++ b/types/rpi-gpio/index.d.ts
@@ -16,10 +16,10 @@ type ErrorCallback = (err?: Error | null) => void;
 declare class Gpio extends EventEmitter {
     constructor();
 
-    readonly DIR_IN: DIR;
-    readonly DIR_OUT: DIR;
-    readonly DIR_LOW: DIR;
-    readonly DIR_HIGH: DIR;
+    readonly DIR_IN: PinDirection;
+    readonly DIR_OUT: PinDirection;
+    readonly DIR_LOW: PinDirection;
+    readonly DIR_HIGH: PinDirection;
     readonly MODE_RPI: MODE;
     readonly MODE_BCM: MODE;
     readonly EDGE_NONE: EDGE;
@@ -35,20 +35,20 @@ declare class Gpio extends EventEmitter {
     /**
      * Setup a channel for use as an input or output
      *
-     * @param  channel   Reference to the pin in the current mode's schema
-     * @param _direction The pin direction, either 'in' or 'out'
-     * @param _edge       edge Informs the GPIO chip if it needs to generate interrupts. Either 'none', 'rising', 'falling' or 'both'. Defaults to 'none'
-     * @param _onSetup  callback
+     * @param channel   Reference to the pin in the current mode's schema
+     * @param direction The pin direction, either 'in' or 'out'
+     * @param edge       edge Informs the GPIO chip if it needs to generate interrupts. Either 'none', 'rising', 'falling' or 'both'. Defaults to 'none'
+     * @param onSetup  callback
      */
     setup(channel: number, onSetup?: ValueCallback<boolean>): void;
-    setup(channel: number, direction?: DIR, onSetup?: ValueCallback<boolean>): void;
-    setup(channel: number, direction?: DIR, edge?: EDGE, onSetup?: ValueCallback<boolean>): void;
+    setup(channel: number, direction?: PinDirection, onSetup?: ValueCallback<boolean>): void;
+    setup(channel: number, direction?: PinDirection, edge?: EDGE, onSetup?: ValueCallback<boolean>): void;
     /**
      * Write a value to a channel
      *
      * @param channel The channel to write to
      * @param value   If true, turns the channel on, else turns off
-     * @param [cb]      callback
+     * @param [cb]      Optional callback
      */
     write(channel: number, value: boolean, cb?: ErrorCallback): void;
     /**
@@ -56,7 +56,7 @@ declare class Gpio extends EventEmitter {
      *
      * @param channel The channel to write to
      * @param value   If true, turns the channel on, else turns off
-     * @param cb      Optional callback
+     * @param [cb]      Optional callback
      */
     output(channel: number, value: boolean, cb?: ErrorCallback): void;
     /**
@@ -83,11 +83,12 @@ declare class Gpio extends EventEmitter {
      * Reset the state of the module
      */
     reset(): void;
+    
     readonly promise: {
-        DIR_IN: DIR;
-        DIR_OUT: DIR;
-        DIR_LOW: DIR;
-        DIR_HIGH: DIR;
+        DIR_IN: PinDirection;
+        DIR_OUT: PinDirection;
+        DIR_LOW: PinDirection;
+        DIR_HIGH: PinDirection;
         MODE_RPI: MODE;
         MODE_BCM: MODE;
         EDGE_NONE: EDGE;
@@ -101,7 +102,7 @@ declare class Gpio extends EventEmitter {
          * @param edge
          * @returns Promise
          */
-        setup: (channel: number, direction: DIR, edge: EDGE) => Promise<unknown>;
+        setup: (channel: number, direction: PinDirection, edge: EDGE) => Promise<unknown>;
         /**
          * @see {@link Gpio.write}
          * @param channel

--- a/types/rpi-gpio/rpi-gpio-tests.ts
+++ b/types/rpi-gpio/rpi-gpio-tests.ts
@@ -1,4 +1,4 @@
-import gpio from "rpi-gpio";
+import gpio = require('rpi-gpio');
 
 gpio.setMode("mode_bcm");
 gpio.setMode("mode_rpi");

--- a/types/rpi-gpio/rpi-gpio-tests.ts
+++ b/types/rpi-gpio/rpi-gpio-tests.ts
@@ -1,0 +1,37 @@
+import gpio from "rpi-gpio";
+
+gpio.setMode("mode_bcm");
+gpio.setMode("mode_rpi");
+
+gpio.setup(1);
+gpio.setup(1, () => {});
+
+gpio.setup(1, gpio.DIR_IN);
+gpio.setup(1, "in");
+gpio.setup(1, "in", () => {});
+
+gpio.setup(1, gpio.DIR_IN, gpio.EDGE_BOTH);
+gpio.setup(1, gpio.DIR_IN, "both");
+gpio.setup(1, gpio.DIR_IN, "both", () => {});
+
+gpio.write(7, true);
+gpio.write(7, true, err => {});
+
+gpio.output(7, true);
+gpio.output(7, true, err => {});
+
+gpio.read(7, (err, value) => {});
+
+gpio.input(7, (err, value) => {});
+
+gpio.destroy();
+gpio.destroy(err => {});
+
+gpio.reset();
+
+async function asyncTest() {
+    await gpio.promise.setup(7, gpio.DIR_IN, gpio.EDGE_BOTH);
+    await gpio.promise.write(7, true);
+    await gpio.promise.read(7);
+    await gpio.promise.destroy();
+}

--- a/types/rpi-gpio/rpi-gpio-tests.ts
+++ b/types/rpi-gpio/rpi-gpio-tests.ts
@@ -24,7 +24,6 @@ gpio.read(7, (err, value) => {});
 
 gpio.input(7, (err, value) => {});
 
-gpio.destroy();
 gpio.destroy(err => {});
 
 gpio.reset();

--- a/types/rpi-gpio/tsconfig.json
+++ b/types/rpi-gpio/tsconfig.json
@@ -14,8 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "esModuleInterop": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/rpi-gpio/tsconfig.json
+++ b/types/rpi-gpio/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "rpi-gpio-tests.ts"
+    ]
+}

--- a/types/rpi-gpio/tslint.json
+++ b/types/rpi-gpio/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

