### PR TITLE
Add types for react-image-magnifiers

### DIFF
--- a/types/react-image-magnifiers/index.d.ts
+++ b/types/react-image-magnifiers/index.d.ts
@@ -1,0 +1,148 @@
+// Type definitions for react-image-magnifiers 1.3
+// Project: https://github.com/adamrisberg/react-image-magnifiers
+// Definitions by: Rafal Witczak <https://github.com/rafw87>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'react';
+
+export type MouseActivation = 'click' | 'doubleClick';
+export type TouchActivation = 'tap' | 'doubleTap' | 'longTouch';
+
+export const MOUSE_ACTIVATION: {
+    CLICK: MouseActivation;
+    DOUBLE_CLICK: MouseActivation;
+};
+
+export const TOUCH_ACTIVATION: {
+    TAP: TouchActivation;
+    DOUBLE_TAP: TouchActivation;
+    LONG_TOUCH: TouchActivation;
+};
+
+export interface CommonProps {
+    imageSrc: string;
+    cursorStyle?: string;
+    largeImageSrc?: string;
+    imageAlt?: string;
+    style?: React.CSSProperties;
+    className?: string;
+    renderOverlay?: (state: boolean) => React.ReactNode;
+    onImageLoad?: (ev: React.SyntheticEvent) => void;
+    onLargeImageLoad?: (ev: React.SyntheticEvent) => void;
+    onZoomStart?: () => void;
+    onZoomEnd?: () => void;
+}
+
+export interface MagnifierProps extends CommonProps {
+    mouseActivation?: MouseActivation;
+    touchActivation?: TouchActivation;
+    cursorStyleActive?: string;
+    dragToMove?: boolean;
+    interactionSettings?: {
+        tapDurationInMs?: number;
+        doubleTapDurationInMs?: number;
+        longTouchDurationInMs?: number;
+        longTouchMoveLimit?: number;
+        clickMoveLimit?: number;
+    };
+}
+
+export const Magnifier: React.ComponentType<MagnifierProps>;
+
+export interface GlassMagnifierProps extends CommonProps {
+    allowOverflow?: boolean;
+    magnifierBorderColor?: string;
+    magnifierBorderSize?: number;
+    magnifierBackgroundColor?: string;
+    magnifierOffsetX?: number;
+    magnifierOffsetY?: number;
+    magnifierSize?: string | number;
+    square?: boolean;
+}
+
+export const GlassMagnifier: React.ComponentType<GlassMagnifierProps>;
+
+export interface PictureInPictureMagnifierProps extends CommonProps {
+    cursorStyleActive?: string;
+    previewHorizontalPos?: 'left' | 'right';
+    previewVerticalPos?: 'top' | 'bottom';
+    previewOpacity?: number;
+    previewOverlayBoxOpacity?: number;
+    previewOverlayBackgroundColor?: string;
+    previewOverlayBoxColor?: string;
+    previewOverlayBoxImage?: string;
+    previewOverlayBoxImageSize?: string;
+    previewOverlayOpacity?: number;
+    previewSizePercentage?: number;
+    shadow?: boolean;
+    shadowColor?: string;
+}
+
+export const PictureInPictureMagnifier: React.ComponentType<PictureInPictureMagnifierProps>;
+
+export interface SideBySideMagnifierProps extends CommonProps {
+    alwaysInPlace?: boolean;
+    switchSides?: boolean;
+    fillAvailableSpace?: boolean;
+    fillAlignTop?: boolean;
+    fillGapLeft?: number;
+    fillGapRight?: number;
+    fillGapTop?: number;
+    fillGapBottom?: number;
+    overlayBoxOpacity?: number;
+    overlayOpacity?: number;
+    overlayBackgroundColor?: string;
+    overlayBoxColor?: string;
+    overlayBoxImage?: string;
+    overlayBoxImageSize?: string;
+    zoomContainerBorder?: string;
+    zoomContainerBoxShadow?: string;
+    transitionSpeed?: number;
+    transitionSpeedInPlace?: number;
+    inPlaceMinBreakpoint?: number;
+}
+
+export const SideBySideMagnifier: React.ComponentType<SideBySideMagnifierProps>;
+
+export interface MagnifierContainerProps {
+    style?: string;
+    className?: string;
+    autoInPlace?: boolean;
+    inPlaceMinBreakpoint?: number;
+}
+
+export const MagnifierContainer: React.ComponentType<MagnifierContainerProps>;
+
+export interface MagnifierPreviewProps {
+    imageSrc: string;
+    largeImageSrc?: string;
+    imageAlt?: string;
+    style?: React.CSSProperties;
+    className?: string;
+    onImageLoad?: (ev: React.SyntheticEvent) => void;
+    onLargeImageLoad?: (ev: React.SyntheticEvent) => void;
+    cursorStyle?: string;
+    transitionSpeed?: number;
+    overlayBoxOpacity?: number;
+    overlayOpacity?: number;
+    overlayBackgroundColor?: number;
+    overlayBoxColor?: number;
+    overlayBoxImage?: number;
+    overlayBoxImageSize?: number;
+    renderOverlay?: (state: boolean) => React.ReactNode;
+    onZoomStart?: () => void;
+    onZoomEnd?: () => void;
+}
+
+export const MagnifierPreview: React.ComponentType<MagnifierPreviewProps>;
+
+export interface MagnifierZoomProps {
+    imageSrc: string;
+    imageAlt?: string;
+    style?: React.CSSProperties;
+    className?: string;
+    onImageLoad?: (ev: React.SyntheticEvent) => void;
+    transitionSpeed?: number;
+}
+
+export const MagnifierZoom: React.ComponentType<MagnifierZoomProps>;

--- a/types/react-image-magnifiers/react-image-magnifiers-tests.tsx
+++ b/types/react-image-magnifiers/react-image-magnifiers-tests.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+
+import {
+    Magnifier,
+    GlassMagnifier,
+    SideBySideMagnifier,
+    PictureInPictureMagnifier,
+    MagnifierContainer,
+    MagnifierPreview,
+    MagnifierZoom,
+    MOUSE_ACTIVATION,
+    TOUCH_ACTIVATION,
+} from 'react-image-magnifiers';
+
+export const MagnifierExample1 = () => <Magnifier imageSrc="./image.jpg" />;
+export const MagnifierExample2 = () => (
+    <Magnifier
+        imageSrc="./image.jpg"
+        imageAlt="Example"
+        largeImageSrc="./large-image.jpg" // Optional
+        mouseActivation={MOUSE_ACTIVATION.DOUBLE_CLICK} // Optional
+        touchActivation={TOUCH_ACTIVATION.DOUBLE_TAP} // Optional
+    />
+);
+
+export const MagnifierExample3 = () => (
+    <Magnifier
+        className="input-position"
+        imageSrc="./image.jpg"
+        largeImageSrc="./large-image.jpg"
+        mouseActivation={MOUSE_ACTIVATION.CLICK}
+        touchActivation={TOUCH_ACTIVATION.LONG_TOUCH}
+        dragToMove={true}
+    />
+);
+
+export const GlassMagnifierExample1 = () => <GlassMagnifier imageSrc="./image.jpg" />;
+
+export const GlassMagnifierExample2 = () => (
+    <GlassMagnifier
+        imageSrc="./image.jpg"
+        imageAlt="Example"
+        largeImageSrc="./large-image.jpg" // Optional
+    />
+);
+
+export const GlassMagnifierExample3 = () => (
+    <GlassMagnifier
+        className="input-position"
+        imageSrc="./image.jpg"
+        largeImageSrc="./large-image.jpg"
+        allowOverflow={true}
+        magnifierSize="30%"
+        magnifierBorderSize={5}
+        magnifierBorderColor="rgba(255, 255, 255, .5)"
+        square={false}
+    />
+);
+
+export const SideBySideMagnifierExample1 = () => <SideBySideMagnifier imageSrc="./image.jpg" />;
+
+export const SideBySideMagnifierExample2 = () => (
+    <SideBySideMagnifier
+        className="input-position"
+        style={{ order: 1 }}
+        imageSrc="./image.jpg"
+        largeImageSrc="./large-image.jpg"
+        alwaysInPlace={false}
+        overlayOpacity={0.6}
+        switchSides={false}
+        inPlaceMinBreakpoint={641}
+        fillAvailableSpace={false}
+        fillAlignTop={false}
+        fillGapTop={0}
+        fillGapRight={10}
+        fillGapBottom={10}
+        fillGapLeft={10}
+        zoomContainerBorder="1px solid #ccc"
+        zoomContainerBoxShadow="0 4px 8px rgba(0,0,0,.5)"
+    />
+);
+
+export const PictureInPictureMagnifierExample1 = () => <PictureInPictureMagnifier imageSrc="./image.jpg" />;
+
+export const PictureInPictureMagnifierExample2 = () => (
+    <PictureInPictureMagnifier
+        className="input-position"
+        imageSrc="./image.jpg"
+        largeImageSrc="./large-image.jpg"
+        previewHorizontalPos="left"
+        previewVerticalPos="bottom"
+        previewSizePercentage={35}
+        previewOpacity={1}
+        shadow={false}
+    />
+);
+
+export const CustomLayoutExample = () => (
+    <MagnifierContainer>
+        <div className="example-class">
+            <MagnifierPreview imageSrc="./image.jpg" />
+        </div>
+        <MagnifierZoom style={{ height: '400px' }} imageSrc="./image.jpg" />
+    </MagnifierContainer>
+);

--- a/types/react-image-magnifiers/tsconfig.json
+++ b/types/react-image-magnifiers/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
+    },
+    "files": [
+        "index.d.ts",
+        "react-image-magnifiers-tests.tsx"
+    ]
+}

--- a/types/react-image-magnifiers/tslint.json
+++ b/types/react-image-magnifiers/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adds types for react-image-magnifiers (https://github.com/adamrisberg/react-image-magnifiers)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

