### PR TITLE
[iobroker] Expose return types of xyzAsync methods

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -716,7 +716,7 @@ declare global {
             getObject(id: string, callback: GetObjectCallback): void;
             getObject(id: string, options: unknown, callback: GetObjectCallback): void;
             /** Reads an object from the object db */
-            getObjectAsync(id: string, options?: unknown): Promise<CallbackReturnTypeOf<GetObjectCallback>>;
+            getObjectAsync(id: string, options?: unknown): GetObjectPromise;
             /** Creates or overwrites an object in the object db */
             setObject(id: string, obj: ioBroker.SettableObject, callback?: SetObjectCallback): void;
             setObject(id: string, obj: ioBroker.SettableObject, options: unknown, callback?: SetObjectCallback): void;
@@ -725,7 +725,7 @@ declare global {
                 id: string,
                 obj: ioBroker.SettableObject,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             /** Creates an object in the object db. Existing objects are not overwritten. */
             setObjectNotExists(id: string, obj: ioBroker.SettableObject, callback?: SetObjectCallback): void;
             setObjectNotExists(
@@ -739,7 +739,7 @@ declare global {
                 id: string,
                 obj: ioBroker.SettableObject,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             /** Get all states, channels and devices of this adapter */
             getAdapterObjects(callback: (objects: Record<string, ioBroker.Object>) => void): void;
             /** Get all states, channels and devices of this adapter */
@@ -752,7 +752,7 @@ declare global {
                 id: string,
                 objPart: PartialObject,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             /**
              * Deletes an object from the object db
              * @param id - The id of the object without namespace
@@ -772,7 +772,7 @@ declare global {
             getForeignObject(id: string, callback: GetObjectCallback): void;
             getForeignObject(id: string, options: unknown, callback: GetObjectCallback): void;
             /** Reads an object (which might not belong to this adapter) from the object db */
-            getForeignObjectAsync(id: string, options?: unknown): Promise<CallbackReturnTypeOf<GetObjectCallback>>;
+            getForeignObjectAsync(id: string, options?: unknown): GetObjectPromise;
             /** Get foreign objects by pattern, by specific type and resolve their enums. */
             // tslint:disable:unified-signatures
             getForeignObjects(pattern: string, callback: GetObjectsCallback): void;
@@ -792,18 +792,18 @@ declare global {
             getForeignObjectsAsync(
                 pattern: string,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<GetObjectsCallback>>;
+            ): GetObjectsPromise;
             getForeignObjectsAsync(
                 pattern: string,
                 type: ObjectType,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<GetObjectsCallback>>;
+            ): GetObjectsPromise;
             getForeignObjectsAsync(
                 pattern: string,
                 type: ObjectType,
                 enums: EnumList,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<GetObjectsCallback>>;
+            ): GetObjectsPromise;
             /** Creates or overwrites an object (which might not belong to this adapter) in the object db */
             setForeignObject(id: string, obj: ioBroker.SettableObject, callback?: SetObjectCallback): void;
             setForeignObject(
@@ -817,7 +817,7 @@ declare global {
                 id: string,
                 obj: ioBroker.SettableObject,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             /** Creates an object (which might not belong to this adapter) in the object db. Existing objects are not overwritten. */
             setForeignObjectNotExists(id: string, obj: ioBroker.SettableObject, callback?: SetObjectCallback): void;
             setForeignObjectNotExists(
@@ -831,7 +831,7 @@ declare global {
                 id: string,
                 obj: ioBroker.SettableObject,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             /** Extend an object (which might not belong to this adapter) and create it if it might not exist */
             extendForeignObject(id: string, objPart: PartialObject, callback?: SetObjectCallback): void;
             extendForeignObject(
@@ -845,7 +845,7 @@ declare global {
                 id: string,
                 objPart: PartialObject,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             /**
              * Finds an object by its ID or name
              * @param type - common.type of the state
@@ -906,7 +906,7 @@ declare global {
                 search: string,
                 params: GetObjectViewParams | null | undefined,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<GetObjectViewCallback>>;
+            ): GetObjectViewPromise;
 
             /**
              * Returns a list of objects with id between params.startkey and params.endkey
@@ -928,7 +928,7 @@ declare global {
             getObjectListAsync(
                 params: GetObjectListParams | null,
                 options?: { sorted?: boolean } | Record<string, any>,
-            ): Promise<NonNullCallbackReturnTypeOf<GetObjectListCallback>>;
+            ): GetObjectListPromise;
 
             // ==============================
             // states
@@ -965,18 +965,18 @@ declare global {
                 id: string,
                 state: string | number | boolean | State | SettableState | null,
                 ack?: boolean,
-            ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
+            ): SetStatePromise;
             setStateAsync(
                 id: string,
                 state: string | number | boolean | State | SettableState | null,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
+            ): SetStatePromise;
             setStateAsync(
                 id: string,
                 state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 options: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
+            ): SetStatePromise;
             /** Writes a value into the states DB only if it has changed. */
             setStateChanged(
                 id: string,
@@ -1007,18 +1007,18 @@ declare global {
                 id: string,
                 state: string | number | boolean | State | SettableState | null,
                 ack?: boolean,
-            ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
+            ): SetStateChangedPromise;
             setStateChangedAsync(
                 id: string,
                 state: string | number | boolean | State | SettableState | null,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
+            ): SetStateChangedPromise;
             setStateChangedAsync(
                 id: string,
                 state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 options: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
+            ): SetStateChangedPromise;
             /** Writes a value (which might not belong to this adapter) into the states DB. */
             setForeignState(
                 id: string,
@@ -1049,18 +1049,18 @@ declare global {
                 id: string,
                 state: string | number | boolean | State | SettableState | null,
                 ack?: boolean,
-            ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
+            ): SetStatePromise;
             setForeignStateAsync(
                 id: string,
                 state: string | number | boolean | State | SettableState | null,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
+            ): SetStatePromise;
             setForeignStateAsync(
                 id: string,
                 state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 options: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
+            ): SetStatePromise;
             /** Writes a value (which might not belong to this adapter) into the states DB only if it has changed. */
             setForeignStateChanged(
                 id: string,
@@ -1091,40 +1091,40 @@ declare global {
                 id: string,
                 state: string | number | boolean | State | SettableState | null,
                 ack?: boolean,
-            ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
+            ): SetStateChangedPromise;
             setForeignStateChangedAsync(
                 id: string,
                 state: string | number | boolean | State | SettableState | null,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
+            ): SetStateChangedPromise;
             setForeignStateChangedAsync(
                 id: string,
                 state: string | number | boolean | State | SettableState | null,
                 ack: boolean,
                 options: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
+            ): SetStateChangedPromise;
             // tslint:enable:unified-signatures
 
             /** Read a value from the states DB. */
             getState(id: string, callback: GetStateCallback): void;
             getState(id: string, options: unknown, callback: GetStateCallback): void;
             /** Read a value from the states DB. */
-            getStateAsync(id: string, options?: unknown): Promise<CallbackReturnTypeOf<GetStateCallback>>;
+            getStateAsync(id: string, options?: unknown): GetStatePromise;
             /** Read a value (which might not belong to this adapter) from the states DB. */
             getForeignState(id: string, callback: GetStateCallback): void;
             getForeignState(id: string, options: unknown, callback: GetStateCallback): void;
             /** Read a value (which might not belong to this adapter) from the states DB. */
-            getForeignStateAsync(id: string, options?: unknown): Promise<CallbackReturnTypeOf<GetStateCallback>>;
+            getForeignStateAsync(id: string, options?: unknown): GetStatePromise;
             /** Read all states of this adapter which match the given pattern */
             getStates(pattern: string, callback: GetStatesCallback): void;
             getStates(pattern: string, options: unknown, callback: GetStatesCallback): void;
             /** Read all states of this adapter which match the given pattern */
-            getStatesAsync(pattern: string, options?: unknown): Promise<CallbackReturnTypeOf<GetStatesCallback>>;
+            getStatesAsync(pattern: string, options?: unknown): GetStatesPromise;
             /** Read all states (which might not belong to this adapter) which match the given pattern */
             getForeignStates(pattern: string, callback: GetStatesCallback): void;
             getForeignStates(pattern: string, options: unknown, callback: GetStatesCallback): void;
             /** Read all states (which might not belong to this adapter) which match the given pattern */
-            getForeignStatesAsync(pattern: string, options?: unknown): Promise<CallbackReturnTypeOf<GetStatesCallback>>;
+            getForeignStatesAsync(pattern: string, options?: unknown): GetStatesPromise;
 
             /** Deletes a state from the states DB, but not the associated object. Consider using @link{deleteState} instead */
             delState(id: string, callback?: ErrorCallback): void;
@@ -1165,7 +1165,7 @@ declare global {
                 id: string,
                 binary: Buffer,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
+            ): SetStatePromise;
             /**
              * Reads a binary state from Redis
              * @param id The id of the state
@@ -1179,7 +1179,7 @@ declare global {
              * @param id The id of the state
              * @param options (optional) Some internal options.
              */
-            getBinaryStateAsync(id: string, options?: unknown): Promise<CallbackReturnTypeOf<GetBinaryStateCallback>>;
+            getBinaryStateAsync(id: string, options?: unknown): GetBinaryStatePromise;
 
             // ==============================
             // enums
@@ -1201,7 +1201,7 @@ declare global {
             getEnumsAsync(
                 enumList: EnumList,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<GetEnumsCallback>>;
+            ): GetEnumsPromise;
 
             addChannelToEnum(
                 enumName: string,
@@ -1382,18 +1382,18 @@ declare global {
             createDeviceAsync(
                 deviceName: string,
                 common?: Partial<ioBroker.ObjectCommon>,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             createDeviceAsync(
                 deviceName: string,
                 common: Partial<ioBroker.ObjectCommon>,
                 native?: Record<string, any>,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             createDeviceAsync(
                 deviceName: string,
                 common: Partial<ioBroker.ObjectCommon>,
                 native: Record<string, any>,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             /** deletes a device, its channels and states */
             deleteDevice(deviceName: string, callback?: ErrorCallback): void;
             deleteDevice(deviceName: string, options: unknown, callback?: ErrorCallback): void;
@@ -1428,20 +1428,20 @@ declare global {
                 parentDevice: string,
                 channelName: string,
                 roleOrCommon?: string | Partial<ioBroker.ChannelCommon>,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             createChannelAsync(
                 parentDevice: string,
                 channelName: string,
                 roleOrCommon: string | Partial<ioBroker.ChannelCommon>,
                 native?: Record<string, any>,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             createChannelAsync(
                 parentDevice: string,
                 channelName: string,
                 roleOrCommon: string | Partial<ioBroker.ChannelCommon>,
                 native: Record<string, any>,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             /** Deletes a channel and its states. It must have been created with `createChannel` */
             deleteChannel(channelName: string, options?: unknown, callback?: ErrorCallback): void;
             deleteChannel(parentDevice: string, channelName: string, options?: unknown, callback?: ErrorCallback): void;
@@ -1490,14 +1490,14 @@ declare global {
                 parentChannel: string,
                 stateName: string,
                 roleOrCommon?: string | Partial<ioBroker.StateCommon>,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             createStateAsync(
                 parentDevice: string,
                 parentChannel: string,
                 stateName: string,
                 roleOrCommon: string | Partial<ioBroker.StateCommon>,
                 native?: Record<string, any>,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             createStateAsync(
                 parentDevice: string,
                 parentChannel: string,
@@ -1505,7 +1505,7 @@ declare global {
                 roleOrCommon: string | Partial<ioBroker.StateCommon>,
                 native: Record<string, any>,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+            ): SetObjectPromise;
             /** Deletes a state. It must have been created with `createState` */
             deleteState(stateName: string, options?: unknown, callback?: ErrorCallback): void;
             deleteState(parentChannel: string, stateName: string, options?: unknown, callback?: ErrorCallback): void;
@@ -1615,7 +1615,7 @@ declare global {
                 adapterName: string | null,
                 path: string,
                 options?: unknown,
-            ): Promise<NonNullCallbackReturnTypeOf<ReadDirCallback>>;
+            ): ReadDirPromise;
 
             mkDir(adapterName: string | null, path: string, callback: ErrorCallback): void;
             mkDir(adapterName: string | null, path: string, options: unknown, callback: ErrorCallback): void;
@@ -1627,7 +1627,7 @@ declare global {
                 adapterName: string | null,
                 path: string,
                 options?: unknown,
-            ): Promise<{ file: string | Buffer; mimeType: string }>;
+            ): ReadFilePromise;
 
             writeFile(adapterName: string | null, path: string, data: Buffer | string, callback: ErrorCallback): void;
             // options see https://github.com/ioBroker/ioBroker.js-controller/blob/master/lib/objects/objectsInMemServer.js#L599
@@ -1762,7 +1762,11 @@ declare global {
         type MessageCallback = (response?: Message) => void;
 
         type SetObjectCallback = (err: string | null, obj?: { id: string }) => void;
+        type SetObjectPromise = Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
+
         type GetObjectCallback = (err: string | null, obj?: ioBroker.Object | null) => void;
+        type GetObjectPromise = Promise<CallbackReturnTypeOf<GetObjectCallback>>;
+
         type GetEnumCallback = (err: string | null, enums?: Record<string, Enum>, requestedEnum?: string) => void;
         type GetEnumsCallback = (
             err: string | null,
@@ -1770,7 +1774,10 @@ declare global {
                 [groupName: string]: Record<string, Enum>;
             },
         ) => void;
+        type GetEnumsPromise = Promise<NonNullCallbackReturnTypeOf<GetEnumsCallback>>;
+
         type GetObjectsCallback = (err: string | null, objects?: Record<string, ioBroker.Object>) => void;
+        type GetObjectsPromise = Promise<NonNullCallbackReturnTypeOf<GetObjectsCallback>>;
 
         type FindObjectCallback = (
             /** If an error happened, this contains the message */
@@ -1804,12 +1811,24 @@ declare global {
         >;
         /** Infers the return type from a callback-style API and and leaves null and undefined in */
         type CallbackReturnTypeOf<T extends (...args: any[]) => any> = SecondParameterOf<T>;
+
         type GetStateCallback = (err: string | null, state: State | null | undefined) => void;
+        type GetStatePromise = Promise<CallbackReturnTypeOf<GetStateCallback>>;
+
         type GetStatesCallback = (err: string | null, states: Record<string, State>) => void;
+        type GetStatesPromise = Promise<CallbackReturnTypeOf<GetStatesCallback>>;
+
         type GetBinaryStateCallback = (err: string | null, state?: Buffer) => void;
+        type GetBinaryStatePromise = Promise<CallbackReturnTypeOf<GetBinaryStateCallback>>;
+
         type SetStateCallback = (err: string | null, id?: string) => void;
+        type SetStatePromise = Promise<NonNullCallbackReturnTypeOf<SetStateCallback>>;
+
         type SetStateChangedCallback = (err: string | null, id: string, notChanged: boolean) => void;
+        type SetStateChangedPromise = Promise<NonNullCallbackReturnTypeOf<SetStateChangedCallback>>;
+
         type DeleteStateCallback = (err: string | null, id?: string) => void;
+
         type GetHistoryResult = Array<State & { id?: string }>;
         type GetHistoryCallback = (
             err: string | null,
@@ -1834,7 +1853,10 @@ declare global {
             createdAt?: number;
         }
         type ReadDirCallback = (err: string | null, entries?: ReadDirResult[]) => void;
+        type ReadDirPromise = Promise<NonNullCallbackReturnTypeOf<ReadDirCallback>>;
+
         type ReadFileCallback = (err: string | null, file?: Buffer | string, mimeType?: string) => void;
+        type ReadFilePromise = Promise<{ file: string | Buffer; mimeType: string }>;
 
         /** Contains the return values of chownFile */
         interface ChownFileResult {
@@ -1877,6 +1899,7 @@ declare global {
             value: ioBroker.Object | null;
         }
         type GetObjectViewCallback = (err: string | null, result?: { rows: GetObjectViewItem[] }) => void;
+        type GetObjectViewPromise = Promise<NonNullCallbackReturnTypeOf<GetObjectViewCallback>>;
 
         interface GetObjectListItem extends GetObjectViewItem {
             /** A copy of the object */
@@ -1885,6 +1908,7 @@ declare global {
             doc: ioBroker.Object;
         }
         type GetObjectListCallback = (err: string | null, result?: { rows: GetObjectListItem[] }) => void;
+        type GetObjectListPromise = Promise<NonNullCallbackReturnTypeOf<GetObjectListCallback>>;
 
         type ExtendObjectCallback = (
             err: string | null,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

No new functionality was added, I only made it less awkward to use existing return types for the `xyzAsync` methods.