### PR TITLE
[react-lottie] Add the style prop to the Lottie component

### DIFF
--- a/types/react-lottie/index.d.ts
+++ b/types/react-lottie/index.d.ts
@@ -97,6 +97,7 @@ export interface LottieProps {
     ariaLabel?: string | 'animation';
     isClickToPauseDisabled?: boolean;
     title?: string;
+    style?: React.CSSProperties;
 }
 
 /**

--- a/types/react-lottie/react-lottie-tests.tsx
+++ b/types/react-lottie/react-lottie-tests.tsx
@@ -12,4 +12,13 @@ const LoadingIndicator = () => (
   />
 );
 
+const LoadingIndicatorStyled = () => (
+  <Lottie
+    options={{
+      animationData
+    }}
+    style={{margin: '0 0 30px'}}
+  />
+);
+
 export default LoadingIndicator;


### PR DESCRIPTION
The style prop was added a while back in the react-lottie library but is missing from the types validation.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/chenqingspring/react-lottie/blob/56f72845de2ed652f763b92978a06201d3333dd8/src/index.js#L150>
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/definitelytyped/definitelytyped/44602)
<!-- Reviewable:end -->
