### PR TITLE
Add types for react-svg-pan-zoom-loader

### DIFF
--- a/types/react-svg-pan-zoom-loader/index.d.ts
+++ b/types/react-svg-pan-zoom-loader/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for react-svg-pan-zoom-loader 1.4
+// Project: https://github.com/chrvadala/react-svg-pan-zoom-loader#readme
+// Definitions by: Rafal Witczak <https://github.com/rafw87>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'react';
+
+export interface ReactSvgPanZoomLoaderProps {
+    src: string;
+    render: (content: React.ReactNode) => React.ReactNode;
+    proxy?: React.ReactNode;
+}
+
+export const ReactSvgPanZoomLoader: React.ComponentType<ReactSvgPanZoomLoaderProps>;
+
+export interface SvgLoaderSelectElementProps {
+    selector: string;
+    children?: string;
+    [prop: string]: any;
+}
+
+export const SvgLoaderSelectElement: React.ComponentType<SvgLoaderSelectElementProps>;

--- a/types/react-svg-pan-zoom-loader/react-svg-pan-zoom-loader-tests.tsx
+++ b/types/react-svg-pan-zoom-loader/react-svg-pan-zoom-loader-tests.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { UncontrolledReactSVGPanZoom } from 'react-svg-pan-zoom';
+import { ReactSvgPanZoomLoader, SvgLoaderSelectElement } from 'react-svg-pan-zoom-loader';
+
+const Example1 = () => (
+    <ReactSvgPanZoomLoader
+        src="file/path/image.svg"
+        render={content => (
+            <UncontrolledReactSVGPanZoom width={500} height={500}>
+                <svg width={500} height={500}>
+                    {content}
+                </svg>
+            </UncontrolledReactSVGPanZoom>
+        )}
+    />
+);
+
+const Example2 = () => (
+    <ReactSvgPanZoomLoader
+        src="file/path/image.svg"
+        proxy={
+            <>
+                <SvgLoaderSelectElement selector="#tree" onClick={() => console.log('click')} stroke="#000" />
+            </>
+        }
+        render={content => (
+            <UncontrolledReactSVGPanZoom width={500} height={500}>
+                <svg width={500} height={500}>
+                    {content}
+                </svg>
+            </UncontrolledReactSVGPanZoom>
+        )}
+    />
+);

--- a/types/react-svg-pan-zoom-loader/tsconfig.json
+++ b/types/react-svg-pan-zoom-loader/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
+    },
+    "files": [
+        "index.d.ts",
+        "react-svg-pan-zoom-loader-tests.tsx"
+    ]
+}

--- a/types/react-svg-pan-zoom-loader/tslint.json
+++ b/types/react-svg-pan-zoom-loader/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
