### PR TITLE
fix(mssql): correct return types for Transaction.begin

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -352,8 +352,13 @@ export declare class RequestError implements Error {
 export declare class Transaction extends events.EventEmitter {
     public isolationLevel: IIsolationLevel;
     public constructor(connection?: ConnectionPool);
-    public begin(isolationLevel?: IIsolationLevel): Promise<void>;
-    public begin(isolationLevel?: IIsolationLevel, callback?: (err?: any) => void): void;
+    /**
+     * Begin a transaction.
+     * @param [isolationLevel] - Controls the locking and row versioning behavior of TSQL statements issued by a connection.
+     * @param [callback] A callback which is called after transaction has began, or an error has occurred. If omited, method returns Promise.
+     */
+    public begin(isolationLevel?: IIsolationLevel): Promise<Transaction>;
+    public begin(isolationLevel?: IIsolationLevel, callback?: (err?: ConnectionError | TransactionError) => void): Transaction;
     public commit(): Promise<void>;
     public commit(callback: (err?: any) => void): void;
     public rollback(): Promise<void>;

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -176,8 +176,17 @@ function test_promise_returns() {
     preparedStatment.execute({ myValue: 1 }).then((recordSet) => { });
     preparedStatment.unprepare().then(() => { });
 
-    var transaction = new sql.Transaction(connection);
+    const transaction = new sql.Transaction(connection);
     transaction.begin().then(() => { });
+    transaction.begin(sql.ISOLATION_LEVEL.READ_COMMITTED).then(() => {}).catch(() => {});
+    transaction.begin(sql.ISOLATION_LEVEL.READ_COMMITTED).then(trans => {}).catch(err => {});
+    transaction.begin(undefined, err => {
+        err; // $ExpectType ConnectionError | TransactionError
+    });
+    (async () => {
+        await transaction.begin();
+        transaction.begin(sql.ISOLATION_LEVEL.READ_COMMITTED)
+    })();
     transaction.commit().then(() => { });
     transaction.rollback().then(() => { });
 


### PR DESCRIPTION
This changes definition of what Transaction.begin returns as per public
documentation:
https://github.com/tediousjs/node-mssql#begin-isolationlevel-callback
and code details:
https://github.com/tediousjs/node-mssql/blob/9140b365f19eff4bcfc0a2ee6ff2bf2b28d5d169/lib/base/transaction.js#L83-L89

/cc @aappddeevv

Thanks!

Fixes #44571

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)