### PR TITLE
fix(express-http-proxy): correct `filter` method definition

### DIFF
--- a/types/express-http-proxy/express-http-proxy-tests.ts
+++ b/types/express-http-proxy/express-http-proxy-tests.ts
@@ -106,6 +106,13 @@ proxy("www.google.com", {
         return req.method === "GET";
     }
 });
+proxy("www.google.com", {
+    filter: (req, res) => {
+        return new Promise(resolve => {
+            resolve(req.method === 'GET');
+        });
+    }
+});
 
 proxy("www.google.com", {
     memoizeHost: true

--- a/types/express-http-proxy/index.d.ts
+++ b/types/express-http-proxy/index.d.ts
@@ -43,7 +43,11 @@ declare namespace proxy {
             userReq: Request,
             userRes: Response
         ) => Buffer | string | Promise<Buffer | string>;
-        filter?: (req: Request, res: Response) => boolean;
+        /**
+         * The filter option can be used to limit what requests are proxied.
+         * Return true to continue to execute proxy; return false-y to skip proxy for this request.
+         */
+        filter?: (req: Request, res: Response) => boolean | Promise<boolean>;
         skipToNextHandlerFilter?: (proxyRes: Response) => boolean;
         proxyReqBodyDecorator?: (bodyContent: any, srcReq: Request) => any;
         preserveHostHdr?: boolean;


### PR DESCRIPTION
This correct return type of the `filter` method to allow returning a
promise as per public documentation:

https://github.com/villadora/express-http-proxy#filter-supports-promises

/cc @ignaciocaff

Thanks!

Fixes #44550

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)