### PR TITLE
[@types/apidoc] Add apidoc typings

### DIFF
--- a/types/apidoc/apidoc-tests.ts
+++ b/types/apidoc/apidoc-tests.ts
@@ -1,6 +1,6 @@
-import apidoc from 'apidoc';
+import { createDoc } from 'apidoc';
 
-const apidocOutput = apidoc({
+const apidocOutput = createDoc({
     dest: '',
     template: '',
     templateSingleFile: '',

--- a/types/apidoc/apidoc-tests.ts
+++ b/types/apidoc/apidoc-tests.ts
@@ -1,0 +1,22 @@
+import apidoc from 'apidoc';
+
+const apidocOutput = apidoc({
+    dest: '',
+    template: '',
+    templateSingleFile: '',
+    debug: true,
+    single: true,
+    silent: true,
+    verbose: true,
+    simulate: true,
+    parse: true,
+    colorize: true,
+    markdown: true,
+    config: '',
+    apiprivate: true,
+    encoding: '',
+});
+
+if (typeof apidocOutput !== 'boolean') {
+    const { data, project } = apidocOutput;
+}

--- a/types/apidoc/index.d.ts
+++ b/types/apidoc/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for apidoc 0.22
+// Project: https://github.com/apidoc/apidoc
+// Definitions by: rigwild <https://github.com/rigwild>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface DocOptions {
+    dest?: string;
+    template?: string;
+    templateSingleFile?: string;
+    debug?: boolean;
+    single?: boolean;
+    silent?: boolean;
+    verbose?: boolean;
+    simulate?: boolean;
+    parse?: boolean;
+    colorize?: boolean;
+    markdown?: boolean;
+    config?: string;
+    apiprivate?: boolean;
+    encoding?: string;
+}
+
+export function createDoc(options: DocOptions): boolean | { data: Record<string, any>; project: Record<string, any> };

--- a/types/apidoc/tsconfig.json
+++ b/types/apidoc/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "apidoc-tests.ts"
+    ]
+}

--- a/types/apidoc/tslint.json
+++ b/types/apidoc/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.


___

See https://github.com/apidoc/apidoc/issues/875
Ping @NicolasCARPi