### PR TITLE
node querystring: add readonly to input arrays

### DIFF
--- a/types/node/querystring.d.ts
+++ b/types/node/querystring.d.ts
@@ -10,7 +10,7 @@ declare module "querystring" {
 
     interface ParsedUrlQuery extends NodeJS.Dict<string | string[]> { }
 
-    interface ParsedUrlQueryInput extends NodeJS.Dict<string | number | boolean | string[] | number[] | boolean[] | null> {
+    interface ParsedUrlQueryInput extends NodeJS.Dict<string | number | boolean | readonly string[] | readonly number[] | readonly boolean[] | null> {
     }
 
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;

--- a/types/node/querystring.d.ts
+++ b/types/node/querystring.d.ts
@@ -10,7 +10,7 @@ declare module "querystring" {
 
     interface ParsedUrlQuery extends NodeJS.Dict<string | string[]> { }
 
-    interface ParsedUrlQueryInput extends NodeJS.Dict<string | number | boolean | readonly string[] | readonly number[] | readonly boolean[] | null> {
+    interface ParsedUrlQueryInput extends NodeJS.Dict<string | number | boolean | ReadonlyArray<string> | ReadonlyArray<number> | ReadonlyArray<boolean> | null> {
     }
 
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;

--- a/types/node/test/querystring.ts
+++ b/types/node/test/querystring.ts
@@ -27,6 +27,9 @@ interface SampleObject { [key: string]: string; }
         foo2: ['a', 'b'],
         bar2: [1, 2],
         baz2: [true, false],
+        rfoo2: ['a', 'b'] as ReadonlyArray<string>,
+        rbar2: [1, 2] as ReadonlyArray<number>,
+        rbaz2: [true, false] as ReadonlyArray<boolean>,
         a: undefined,
         b: null
     });

--- a/types/node/v12/querystring.d.ts
+++ b/types/node/v12/querystring.d.ts
@@ -11,7 +11,7 @@ declare module "querystring" {
     interface ParsedUrlQuery { [key: string]: string | string[]; }
 
     interface ParsedUrlQueryInput {
-        [key: string]: string | number | boolean | string[] | number[] | boolean[] | undefined | null;
+        [key: string]: string | number | boolean | readonly string[] | readonly number[] | readonly boolean[] | undefined | null;
     }
 
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;

--- a/types/node/v12/querystring.d.ts
+++ b/types/node/v12/querystring.d.ts
@@ -11,7 +11,7 @@ declare module "querystring" {
     interface ParsedUrlQuery { [key: string]: string | string[]; }
 
     interface ParsedUrlQueryInput {
-        [key: string]: string | number | boolean | readonly string[] | readonly number[] | readonly boolean[] | undefined | null;
+        [key: string]: string | number | boolean | ReadonlyArray<string> | ReadonlyArray<number> | ReadonlyArray<boolean> | undefined | null;
     }
 
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;

--- a/types/node/v12/test/querystring.ts
+++ b/types/node/v12/test/querystring.ts
@@ -27,6 +27,9 @@ interface SampleObject { [key: string]: string; }
         foo2: ['a', 'b'],
         bar2: [1, 2],
         baz2: [true, false],
+        rfoo2: ['a', 'b'] as ReadonlyArray<string>,
+        rbar2: [1, 2] as ReadonlyArray<number>,
+        rbaz2: [true, false] as ReadonlyArray<boolean>,
         a: undefined,
         b: null
     });


### PR DESCRIPTION
Minor update to allow more arrays passed to `querystring`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
