### PR TITLE
[@types/qs] parse should not guarantee result

### DIFF
--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -55,7 +55,7 @@ declare namespace QueryString {
         interpretNumericEntities?: boolean;
     }
 
-    interface ParsedQs { [key: string]: string | string[] | ParsedQs | ParsedQs[] }
+    interface ParsedQs { [key: string]: undefined | string | string[] | ParsedQs | ParsedQs[] }
 
     // TODO: The value type here is a "poor man's `unknown`". When these types support TypeScript
     // 3.0+, we can replace this with `unknown`.

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -335,3 +335,11 @@ qs.parse('a=b&c=d', { delimiter: '&' });
 () => {
     assert.equal(qs.stringify({ a: { b: { c: 'd', e: 'f' } } }, { allowDots: true }), 'a.b.c=d&a.b.e=f');
 }
+
+declare const myQuery: { a: string; b?: string }
+const myQueryCopy: qs.ParsedQs = myQuery;
+
+interface MyQuery extends qs.ParsedQs {
+    a: string;
+    b?: string;
+}

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -10,7 +10,7 @@ qs.parse('a=b&c=d', { delimiter: '&' });
 () => {
     let obj = qs.parse('a=z&b[c]=z&d=z&d=z&e[][f]=z');
     obj; // $ExpectType ParsedQs
-    obj.a; // $ExpectType string | ParsedQs | string[] | ParsedQs[]
+    obj.a; // $ExpectType undefined | string | ParsedQs | string[] | ParsedQs[]
     assert.deepEqual(obj, { a: 'c' });
 
     var str = qs.stringify(obj);
@@ -191,12 +191,12 @@ qs.parse('a=b&c=d', { delimiter: '&' });
     var decoded = qs.parse('a=Number(12)&b=foo', {
         decoder: function (str, defaultDecoder, charset, type) {
             if (type !== 'key') {
-                var numberMatch = str.match(/^Number\((\d+)\)$/);            
+                var numberMatch = str.match(/^Number\((\d+)\)$/);
                 if (numberMatch) {
                     return +numberMatch[1];
                 }
             }
-        
+
             return defaultDecoder(str, defaultDecoder, charset);
         }
     });

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -10,7 +10,7 @@ qs.parse('a=b&c=d', { delimiter: '&' });
 () => {
     let obj = qs.parse('a=z&b[c]=z&d=z&d=z&e[][f]=z');
     obj; // $ExpectType ParsedQs
-    obj.a; // $ExpectType undefined | string | ParsedQs | string[] | ParsedQs[]
+    obj.a; // $ExpectType string | ParsedQs | string[] | ParsedQs[] | undefined
     assert.deepEqual(obj, { a: 'c' });
 
     var str = qs.stringify(obj);


### PR DESCRIPTION
The lack of `undefined` type in `interface ParsedQs` may introduce misleading problem since `parse` itself doesn't guarantee the return value to be existed. People may skip checking `undefined` if the compiler doesn't catch it for them.
```ts
const obj = qs.parse('a=c');
const { a } = obj;
if (a !== undefined) {
   // do something
}
```

But it is just my opinion. When I looked into other libs, there are 2 cases. If we are looking at how typescript handle list ...
```ts
const strList: string[] = [];
const s: string = strList[0];
```
But in case of `Map` ...
```ts
const myMap = new Map<string, string>();
myMap.set('a', 'a');
const a: string | undefined = myMap.get('a');
```
I think the result from `parse` function is more familiar to `Map` case.

Thank you.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
