### PR TITLE
Add type declarations for backblaze-b2

### DIFF
--- a/types/backblaze-b2/backblaze-b2-tests.ts
+++ b/types/backblaze-b2/backblaze-b2-tests.ts
@@ -1,4 +1,4 @@
-import BackBlazeB2 from 'backblaze-b2';
+import BackBlazeB2 =  require('backblaze-b2');
 
 const b2 = new BackBlazeB2({
     applicationKey: 'TEST',

--- a/types/backblaze-b2/backblaze-b2-tests.ts
+++ b/types/backblaze-b2/backblaze-b2-tests.ts
@@ -1,0 +1,344 @@
+import BackBlazeB2 from 'backblaze-b2';
+
+const b2 = new BackBlazeB2({
+    applicationKey: 'TEST',
+    applicationKeyId: 'TEST2',
+});
+
+const b2WithOptionalParams = new BackBlazeB2({
+    applicationKey: 'TEST',
+    applicationKeyId: 'TEST2',
+    axios: {
+        someAxiosConfig: true,
+    },
+    retry: {
+        retry: 3,
+    },
+});
+
+b2.authorize();
+
+b2.authorize({
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.createBucket({
+    bucketName: 'bucket-1',
+    bucketType: 'allPrivate',
+});
+
+b2.createBucket({
+    bucketName: 'bucket-1',
+    bucketType: 'allPrivate',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.deleteBucket({
+    bucketId: 'bucketId',
+});
+
+b2.deleteBucket({
+    bucketId: 'bucketId',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.listBuckets();
+
+b2.listBuckets({
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.getBucket({
+    bucketName: 'bucketName',
+    bucketId: 'bucketId',
+});
+
+b2.getBucket({
+    bucketName: 'bucketName',
+});
+
+b2.getBucket({
+    bucketName: 'bucketName',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.updateBucket({
+    bucketId: 'bucketId',
+    bucketType: 'allPublic',
+});
+
+b2.updateBucket({
+    bucketId: 'bucketId',
+    bucketType: 'allPublic',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.getUploadUrl({
+    bucketId: 'bucketId',
+});
+
+b2.getUploadUrl({
+    bucketId: 'bucketId',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+const buf1 = Buffer.alloc(10);
+b2.uploadFile({
+    uploadUrl: 'uploadUrl',
+    uploadAuthToken: 'uploadAuthToken',
+    fileName: 'fileName',
+    contentLength: 10,
+    mime: '',
+    data: buf1,
+    hash: 'sha1-hash',
+    info: {
+        key1: 'value',
+        key2: 'value',
+    },
+    onUploadProgress: event => {},
+});
+
+b2.uploadFile({
+    uploadUrl: 'uploadUrl',
+    uploadAuthToken: 'uploadAuthToken',
+    fileName: 'fileName',
+    data: buf1,
+    onUploadProgress: null,
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.listFileNames({
+    bucketId: 'bucketId',
+    startFileName: 'startFileName',
+    maxFileCount: 100,
+    delimiter: '',
+    prefix: '',
+});
+
+b2.listFileNames({
+    bucketId: 'bucketId',
+    startFileName: 'startFileName',
+    maxFileCount: 100,
+    delimiter: '',
+    prefix: '',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.listFileVersions({
+    bucketId: 'bucketId',
+    startFileName: 'startFileName',
+    startFileId: 'startFileId',
+    maxFileCount: 100,
+});
+
+b2.listFileVersions({
+    bucketId: 'bucketId',
+    startFileName: 'startFileName',
+    startFileId: 'startFileId',
+    maxFileCount: 100,
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.listParts({
+    fileId: 'fileId',
+    startPartNumber: 0,
+    maxPartCount: 100,
+});
+
+b2.listParts({
+    fileId: 'fileId',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.hideFile({
+    bucketId: 'bucketId',
+    fileName: 'fileName',
+});
+
+b2.hideFile({
+    bucketId: 'bucketId',
+    fileName: 'fileName',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.getFileInfo({
+    fileId: 'fileId',
+});
+
+b2.getFileInfo({
+    fileId: 'fileId',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.getDownloadAuthorization({
+    bucketId: 'bucketId',
+    fileNamePrefix: 'fileNamePrefix',
+    validDurationInSeconds: 230,
+    b2ContentDisposition: 'b2ContentDisposition',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.getDownloadAuthorization({
+    bucketId: 'bucketId',
+    fileNamePrefix: 'fileNamePrefix',
+    validDurationInSeconds: 230,
+    b2ContentDisposition: 'b2ContentDisposition',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.downloadFileByName({
+    bucketName: 'bucketName',
+    fileName: 'fileName',
+    responseType: 'document',
+    onDownloadProgress: null,
+});
+
+b2.downloadFileByName({
+    bucketName: 'bucketName',
+    fileName: 'fileName',
+    responseType: 'arraybuffer',
+    onDownloadProgress: event => {},
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.downloadFileById({
+    fileId: 'fileId',
+    responseType: 'arraybuffer',
+    onDownloadProgress: null,
+});
+
+b2.downloadFileById({
+    fileId: 'fileId',
+    responseType: 'arraybuffer',
+    onDownloadProgress: null,
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.deleteFileVersion({
+    fileId: 'fileId',
+    fileName: 'fileName',
+});
+
+b2.deleteFileVersion({
+    fileId: 'fileId',
+    fileName: 'fileName',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.startLargeFile({
+    bucketId: 'bucketId',
+    fileName: 'fileName',
+});
+
+b2.startLargeFile({
+    bucketId: 'bucketId',
+    fileName: 'fileName',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.getUploadPartUrl({
+    fileId: 'fileId',
+});
+
+b2.getUploadPartUrl({
+    fileId: 'fileId',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.uploadPart({
+    partNumber: 23,
+    uploadUrl: 'uploadUrl',
+    uploadAuthToken: 'uploadAuthToken',
+    data: buf1,
+});
+
+b2.uploadPart({
+    partNumber: 23,
+    uploadUrl: 'uploadUrl',
+    uploadAuthToken: 'uploadAuthToken',
+    data: buf1,
+    hash: 'sha1-hash',
+    onUploadProgress: null,
+    contentLength: 0,
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.finishLargeFile({
+    fileId: 'fileId',
+    partSha1Array: ['partSha1Array'],
+});
+
+b2.finishLargeFile({
+    fileId: 'fileId',
+    partSha1Array: ['partSha1Array'],
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.cancelLargeFile({
+    fileId: 'fileId',
+});
+
+b2.cancelLargeFile({
+    fileId: 'fileId',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.createKey({
+    capabilities: ['READ_FILES', 'DELETE_FILES'],
+    keyName: 'my-key-1',
+});
+
+b2.createKey({
+    capabilities: ['readFiles', 'DELETE_FILES'],
+    keyName: 'my-key-1', // letters, numbers, and '-' only, <=100 chars
+    validDurationInSeconds: 3600, // expire after duration (optional)
+    bucketId: 'bucketId', // restrict access to bucket (optional)
+    namePrefix: 'prefix_', // restrict access to file prefix (optional)
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.deleteKey({
+    applicationKeyId: 'applicationKeyId',
+});
+
+b2.deleteKey({
+    applicationKeyId: 'applicationKeyId',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});
+
+b2.listKeys({
+    maxKeyCount: 10,
+    startApplicationKeyId: '...',
+});
+
+b2.listKeys({
+    maxKeyCount: 10,
+    startApplicationKeyId: '...',
+    axios: { someAxiosConfig: true },
+    axiosOverride: { someOtherParam: '' },
+});

--- a/types/backblaze-b2/index.d.ts
+++ b/types/backblaze-b2/index.d.ts
@@ -62,7 +62,11 @@ interface UploadFileOpts extends CommonArgs {
      * @default 'b2/x-auto'
      */
     mime?: string;
-    hash?: string; // optional data hash, will use sha1(data) if not provided
+    /**
+     * data hash
+     * @default sha1(data)
+     */
+    hash?: string;
     // optional info headers, prepended with X-Bz-Info- when sent, throws error if more than 10 keys set
     // valid characters should be a-z, A-Z and '-', all other characters will cause an error to be thrown
     info?: Record<string, string>;

--- a/types/backblaze-b2/index.d.ts
+++ b/types/backblaze-b2/index.d.ts
@@ -67,8 +67,6 @@ interface UploadFileOpts extends CommonArgs {
      * @default sha1(data)
      */
     hash?: string;
-    // optional info headers, prepended with X-Bz-Info- when sent, throws error if more than 10 keys set
-    // valid characters should be a-z, A-Z and '-', all other characters will cause an error to be thrown
     /**
      * info headers, prepended with X-Bz-Info- when sent,
      * throws error if more than 10 keys set.

--- a/types/backblaze-b2/index.d.ts
+++ b/types/backblaze-b2/index.d.ts
@@ -52,7 +52,11 @@ interface UploadFileOpts extends CommonArgs {
     uploadAuthToken: string;
     fileName: string;
     data: Buffer;
-    contentLength?: number; // optional data length, will default to data.byteLength or data.length if not provided
+    /**
+     * data length
+     * @default  data.byteLength or data.length
+     */
+    contentLength?: number;
     mime?: string; // optional mime type, will default to 'b2/x-auto' if not provided
     hash?: string; // optional data hash, will use sha1(data) if not provided
     // optional info headers, prepended with X-Bz-Info- when sent, throws error if more than 10 keys set

--- a/types/backblaze-b2/index.d.ts
+++ b/types/backblaze-b2/index.d.ts
@@ -69,6 +69,12 @@ interface UploadFileOpts extends CommonArgs {
     hash?: string;
     // optional info headers, prepended with X-Bz-Info- when sent, throws error if more than 10 keys set
     // valid characters should be a-z, A-Z and '-', all other characters will cause an error to be thrown
+    /**
+     * info headers, prepended with X-Bz-Info- when sent,
+     * throws error if more than 10 keys set.
+     * valid characters should be a-z, A-Z and '-',
+     * all other characters will cause an error to be thrown
+     */
     info?: Record<string, string>;
     onUploadProgress?: UploadProgressFn | null;
 }

--- a/types/backblaze-b2/index.d.ts
+++ b/types/backblaze-b2/index.d.ts
@@ -95,15 +95,23 @@ interface ListFileVersionsOpts extends CommonArgs {
 interface ListPartsOpts extends CommonArgs {
     fileId: string;
     startPartNumber?: number;
-    maxPartCount?: number; //  (max: 1000)
+    /**
+     * maximum part count
+     * max value 100
+     */
+    maxPartCount?: number;
 }
 
 interface GetDownloadAuthorizationOpts extends CommonArgs {
     bucketId: string;
     fileNamePrefix: string;
-    validDurationInSeconds: number; // a number from 0 to 604800
+    /**
+     * Authorization validity : 0 to 604800
+     */
+    validDurationInSeconds: number;
     b2ContentDisposition: string;
 }
+
 interface DownloadFileOpts extends CommonArgs {
     responseType: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
     onDownloadProgress?: UploadProgressFn | null;
@@ -115,7 +123,10 @@ interface DownlaodFileByNameOpts extends DownloadFileOpts {
 }
 
 interface UploadPartOpts extends CommonArgs {
-    partNumber: number; // A number from 1 to 10000
+    /**
+     * part number: 1 to 10000
+     */
+    partNumber: number;
     uploadUrl: string;
     uploadAuthToken: string;
     data: Buffer;

--- a/types/backblaze-b2/index.d.ts
+++ b/types/backblaze-b2/index.d.ts
@@ -57,7 +57,11 @@ interface UploadFileOpts extends CommonArgs {
      * @default  data.byteLength or data.length
      */
     contentLength?: number;
-    mime?: string; // optional mime type, will default to 'b2/x-auto' if not provided
+    /**
+     * mime type
+     * @default 'b2/x-auto'
+     */
+    mime?: string;
     hash?: string; // optional data hash, will use sha1(data) if not provided
     // optional info headers, prepended with X-Bz-Info- when sent, throws error if more than 10 keys set
     // valid characters should be a-z, A-Z and '-', all other characters will cause an error to be thrown

--- a/types/backblaze-b2/index.d.ts
+++ b/types/backblaze-b2/index.d.ts
@@ -1,0 +1,150 @@
+// Type definitions for backblaze-b2 1.5
+// Project: https://github.com/yakovkhalinsky/backblaze-b2
+// Definitions by: Rohith Bhaskaran <https://github.com/rohithb>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+export as namespace BackBlazeB2;
+
+export = BackBlazeB2;
+
+interface B2InitOptions {
+    applicationKeyId: string;
+    applicationKey: string;
+    axios?: Record<string, any>;
+    retry?: Record<string, any>;
+}
+
+interface CommonArgs {
+    axios?: Record<string, any>;
+    axiosOverride?: Record<string, any>;
+}
+
+interface StandardApiResponse {
+    status: string;
+    statusText: string;
+    headers: any;
+    config: any;
+    request: any;
+    data: any;
+}
+type BucketType = 'allPublic' | 'allPrivate';
+
+interface CreateBucketOpts extends CommonArgs {
+    bucketName: string;
+    bucketType: BucketType;
+}
+interface GetBucketOpts extends CommonArgs {
+    bucketName: string;
+    bucketId?: string;
+}
+interface UpdateBucketOpts extends CommonArgs {
+    bucketId: string;
+    bucketType: BucketType;
+}
+interface UploadProgressFn {
+    (event: any): void;
+}
+
+interface UploadFileOpts extends CommonArgs {
+    uploadUrl: string;
+    uploadAuthToken: string;
+    fileName: string;
+    data: Buffer;
+    contentLength?: number; // optional data length, will default to data.byteLength or data.length if not provided
+    mime?: string; // optional mime type, will default to 'b2/x-auto' if not provided
+    hash?: string; // optional data hash, will use sha1(data) if not provided
+    // optional info headers, prepended with X-Bz-Info- when sent, throws error if more than 10 keys set
+    // valid characters should be a-z, A-Z and '-', all other characters will cause an error to be thrown
+    info?: Record<string, string>;
+    onUploadProgress?: UploadProgressFn | null;
+}
+
+interface ListFileNamesOpts extends CommonArgs {
+    bucketId: string;
+    startFileName: string;
+    maxFileCount: number;
+    delimiter: string;
+    prefix: string;
+}
+
+interface ListFileVersionsOpts extends CommonArgs {
+    bucketId: string;
+    startFileName: string;
+    startFileId: string;
+    maxFileCount: number;
+}
+
+interface ListPartsOpts extends CommonArgs {
+    fileId: string;
+    startPartNumber?: number;
+    maxPartCount?: number; //  (max: 1000)
+}
+
+interface GetDownloadAuthorizationOpts extends CommonArgs {
+    bucketId: string;
+    fileNamePrefix: string;
+    validDurationInSeconds: number; // a number from 0 to 604800
+    b2ContentDisposition: string;
+}
+interface DownloadFileOpts extends CommonArgs {
+    responseType: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
+    onDownloadProgress?: UploadProgressFn | null;
+}
+
+interface DownlaodFileByNameOpts extends DownloadFileOpts {
+    bucketName: string;
+    fileName: string;
+}
+
+interface UploadPartOpts extends CommonArgs {
+    partNumber: number; // A number from 1 to 10000
+    uploadUrl: string;
+    uploadAuthToken: string;
+    data: Buffer;
+    hash?: string;
+    onUploadProgress?: UploadProgressFn | null;
+    contentLength?: number;
+}
+
+interface CreateKeyOpts extends CommonArgs {
+    capabilities: string[];
+    keyName: string;
+    validDurationInSeconds?: number;
+    bucketId?: string;
+    namePrefix?: string;
+}
+
+declare class BackBlazeB2 {
+    constructor(options: B2InitOptions);
+    authorize(opts?: CommonArgs): Promise<StandardApiResponse>;
+
+    createBucket(opts: CreateBucketOpts): Promise<StandardApiResponse>;
+    deleteBucket(opts: { bucketId: string } & CommonArgs): Promise<StandardApiResponse>;
+    listBuckets(opts?: CommonArgs): Promise<StandardApiResponse>;
+    getBucket(opts: GetBucketOpts): Promise<StandardApiResponse>;
+    updateBucket(opts: UpdateBucketOpts): Promise<StandardApiResponse>;
+
+    getUploadUrl(opts: { bucketId: string } & CommonArgs): Promise<StandardApiResponse>;
+    uploadFile(opts: UploadFileOpts): Promise<StandardApiResponse>;
+    listFileNames(opts: ListFileNamesOpts): Promise<StandardApiResponse>;
+    listFileVersions(opts: ListFileVersionsOpts): Promise<StandardApiResponse>;
+
+    listParts(opts: ListPartsOpts): Promise<StandardApiResponse>;
+    hideFile(opts: { bucketId: string; fileName: string } & CommonArgs): Promise<StandardApiResponse>;
+    getFileInfo(opts: { fileId: string } & CommonArgs): Promise<StandardApiResponse>;
+    getDownloadAuthorization(opts: GetDownloadAuthorizationOpts): Promise<StandardApiResponse>;
+    downloadFileByName(opts: DownlaodFileByNameOpts): Promise<StandardApiResponse>;
+    downloadFileById(opts: { fileId: string } & DownloadFileOpts): Promise<StandardApiResponse>;
+    deleteFileVersion(opts: { fileId: string; fileName: string } & CommonArgs): Promise<StandardApiResponse>;
+    startLargeFile(opts: { bucketId: string; fileName: string } & CommonArgs): Promise<StandardApiResponse>;
+    getUploadPartUrl(opts: { fileId: string } & CommonArgs): Promise<StandardApiResponse>;
+    uploadPart(opts: UploadPartOpts): Promise<StandardApiResponse>;
+    finishLargeFile(opts: { fileId: string; partSha1Array: string[] } & CommonArgs): Promise<StandardApiResponse>;
+    cancelLargeFile(opts: { fileId: string } & CommonArgs): Promise<StandardApiResponse>;
+
+    createKey(opts: CreateKeyOpts): Promise<StandardApiResponse>;
+    deleteKey(opts: { applicationKeyId: string } & CommonArgs): Promise<StandardApiResponse>;
+    listKeys(opts: { maxKeyCount: number; startApplicationKeyId: string } & CommonArgs): Promise<StandardApiResponse>;
+}

--- a/types/backblaze-b2/tsconfig.json
+++ b/types/backblaze-b2/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "backblaze-b2-tests.ts"
+    ]
+}

--- a/types/backblaze-b2/tslint.json
+++ b/types/backblaze-b2/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.