### PR TITLE
Fix return type of `thru` method in Kefir

### DIFF
--- a/types/kefir/index.d.ts
+++ b/types/kefir/index.d.ts
@@ -65,7 +65,7 @@ export class Observable<T, S> {
     setName(source: Observable<any, any>, selfName: string): this;
     setName(selfName: string): this;
 
-    thru<R>(cb: (obs: Observable<T, S>) => Observable<R, S>): Observable<R, S>;
+    thru<R>(cb: (obs: Observable<T, S>) => R): R;
     // Modify an stream
     map<U>(fn: (value: T) => U): Observable<U, S>;
     filter<U extends T>(fn: (value: T) => value is U): Observable<U, S>

--- a/types/kefir/kefir-tests.ts
+++ b/types/kefir/kefir-tests.ts
@@ -144,6 +144,9 @@ import { Observable, Pool, Stream, Property, Event, Emitter } from 'kefir';
     type First = 'first';
     type Second = 'second';
     let observable32: Stream<First, void> = Kefir.sequentially<First | Second>(100, ['first', 'second']).filter((value): value is First => value === 'first');
+
+    const thru = (a: Observable<string, never>) => 1;
+    let observable33: number = Kefir.constant('hello').thru(thru);
 }
 
 // Combine observables


### PR DESCRIPTION
This should just return the type of the callback–it doesn't have
to be an Observable.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kefirjs/kefir/blob/master/kefir.js.flow#L107
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

