### PR TITLE
Fix flatMap types for Kefir

### DIFF
--- a/types/kefir/index.d.ts
+++ b/types/kefir/index.d.ts
@@ -104,16 +104,16 @@ export class Observable<T, S> {
     zip<U, V, W>(otherObs: Observable<U, V>, combinator?: (value: T, ...values: U[]) => W): Observable<W, S | V>;
     merge<U, V>(otherObs: Observable<U, V>): Observable<T | U, S | V>;
     concat<U, V>(otherObs: Observable<U, V>): Observable<T | U, S | V>;
-    flatMap<U, V>(transform: (value: T) => Observable<U, V>): Observable<U, V>;
+    flatMap<U, V>(transform: (value: T) => Observable<U, V>): Observable<U, V | S>;
     flatMap<X extends T & Property<T, any>>(): Observable<ValueOfAnObservable<X>, any>;
-    flatMapLatest<U, V>(fn: (value: T) => Observable<U, V>): Observable<U, V>;
+    flatMapLatest<U, V>(fn: (value: T) => Observable<U, V>): Observable<U, V | S>;
     flatMapLatest<X extends T & Property<T, any>>(): Observable<ValueOfAnObservable<X>, any>;
-    flatMapFirst<U, V>(fn: (value: T) => Observable<U, V>): Observable<U, V>;
+    flatMapFirst<U, V>(fn: (value: T) => Observable<U, V>): Observable<U, V | S>;
     flatMapFirst<X extends T & Property<T, any>>(): Observable<ValueOfAnObservable<X>, any>;
-    flatMapConcat<U, V>(fn: (value: T) => Observable<U, V>): Observable<U, V>;
+    flatMapConcat<U, V>(fn: (value: T) => Observable<U, V>): Observable<U, V | S>;
     flatMapConcat<X extends T & Property<T, any>>(): Observable<ValueOfAnObservable<X>, any>;
-    flatMapConcurLimit<U, V>(fn: (value: T) => Observable<U, V>, limit: number): Observable<U, V>;
-    flatMapErrors<U, V>(transform: (error: S) => Observable<U, V>): Observable<U, V>;
+    flatMapConcurLimit<U, V>(fn: (value: T) => Observable<U, V>, limit: number): Observable<U, V | S>;
+    flatMapErrors<U, V>(transform: (error: S) => Observable<U, V>): Observable<U | T, V>;
     // Combine two streams
     filterBy<U>(otherObs: Observable<boolean, U>): Observable<T, S>;
     sampledBy(otherObs: Observable<any, any>): Observable<T, S>;

--- a/types/kefir/kefir-tests.ts
+++ b/types/kefir/kefir-tests.ts
@@ -198,7 +198,18 @@ import { Observable, Pool, Stream, Property, Event, Emitter } from 'kefir';
     let observable08: Stream<number, void> = Kefir.sequentially(100, [1, 2, 3]).flatMapConcat(x => Kefir.interval(40, x).take(4));
     let observable09: Stream<number, void> = Kefir.sequentially(100, [1, 2, 3]).flatMapConcurLimit(x => Kefir.interval(40, x).take(6), 2);
     let observable10: Stream<number, void> = Kefir.sequentially(100, [1, 2]).valuesToErrors().flatMapErrors(x => Kefir.interval(40, x).take(2));
+
+    let observable11 = createObs()
+        .flatMap(num => num > 2 ? Kefir.constant(num) : Kefir.constantError('num too big'))
+        .flatMapErrors(err => {
+            if (err instanceof Error) {
+                return Kefir.constant(0);
+            }
+
+            return Kefir.constant(-1);
+        });
 }
+declare function createObs(): Stream<number, Error>;
 
 // Combine two observables
 {


### PR DESCRIPTION
The error type should get combined into the resulting Observable,
rather than being replaced as it is now. `merge` & `concat` do
this correctly already.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kefirjs/kefir/blob/master/kefir.js.flow#L129-L134
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.