### PR TITLE
[redux-api-middleware] Fix return type of getJSON to be Promise<any>

### DIFF
--- a/types/redux-api-middleware/index.d.ts
+++ b/types/redux-api-middleware/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by:  Andrew Luca <https://github.com/iamandrewluca>
 //                  Craig S <https://github.com/Mrman>
 //                  Arturs Vonda <https://github.com/artursvonda>
+//                  Matthew M <https://github.com/magoogli>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -50,7 +51,7 @@ export class ApiError<T = any> extends Error {
     constructor(status: number, statusText: string, response: T);
 }
 
-export function getJSON(res: Response): Promise<any> | Promise<void>;
+export function getJSON(res: Response): Promise<any>;
 
 export function apiMiddleware(api: MiddlewareAPI): ReturnType<Middleware>;
 

--- a/types/redux-api-middleware/redux-api-middleware-tests.ts
+++ b/types/redux-api-middleware/redux-api-middleware-tests.ts
@@ -94,9 +94,10 @@ import {
 
 {
     // getJSON
-    getJSON(new Response()); // $ExpectType Promise<any> | Promise<void>
+    getJSON(new Response()); // $ExpectType Promise<any>
     getJSON(); // $ExpectError
     getJSON(0); // $ExpectError
+    getJSON(new Response()).then((value: any) => value); // $ExpectType Promise<any>
 }
 
 {


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
