### PR TITLE
fix(pino): remedy destination static method and add missing option prettifier

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -295,6 +295,11 @@ declare namespace P {
          */
         prettyPrint?: boolean | PrettyOptions;
         /**
+         * Allows to optionally define which prettifier module to use.
+         */
+        // TODO: use type definitions from 'pino-pretty' when available.
+        prettifier?: any;
+        /**
          * This function will be invoked during process shutdown when `extreme` is set to `true`. If you do not specify
          * a function, Pino will invoke `process.exit(0)` when no error has occurred, and `process.exit(1)` otherwise.
          * If you do specify a function, it is up to you to terminate the process; you must perform only synchronous

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -142,11 +142,24 @@ declare namespace P {
     };
 
     /**
+     * Equivalent of SonicBoom constructor options object
+     */
+    // TODO: use SonicBoom constructor options interface when available
+    interface DestinationObjectOptions {
+        fd?: string | number;
+        dest?: string;
+        minLength?: number;
+        sync?: boolean;
+    }
+
+    /**
      * Create a Pino Destination instance: a stream-like object with significantly more throughput (over 30%) than a standard Node.js stream.
-     * @param [fileDescriptor]: File path or numerical file descriptor, by default 1
+     * @param [dest]: The `destination` parameter, at a minimum must be an object with a `write` method. An ordinary Node.js
+     *                `stream` can be passed as the destination (such as the result of `fs.createWriteStream`) but for peak log
+     *                writing performance it is strongly recommended to use `pino.destination` to create the destination stream.
      * @returns A Sonic-Boom  stream to be used as destination for the pino function
      */
-    function destination(fileDescriptor?: string | number): SonicBoom;
+    function destination(dest?: string | number | DestinationObjectOptions | DestinationStream | NodeJS.WritableStream): SonicBoom;
 
     /**
      * Create an extreme mode destination. This yields an additional 60% performance boost.

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -205,3 +205,23 @@ const mappedHttpResponse: { res: pino.SerializedResponse } = pino.stdSerializers
 const serializedErr: pino.SerializedError = pino.stdSerializers.err(new Error());
 const serializedReq: pino.SerializedRequest = pino.stdSerializers.req(incomingMessage);
 const serializedRes: pino.SerializedResponse = pino.stdSerializers.res(serverResponse);
+
+/**
+ * Destination static method
+ */
+const destinationViaDefaultArgs = pino.destination();
+const destinationViaStrFileDescriptor = pino.destination('/log/path');
+const destinationViaNumFileDescriptor = pino.destination(2);
+const destinationViaStream = pino.destination(process.stdout);
+const destinationViaOptionsObject = pino.destination({ dest: '/log/path', sync: false });
+
+pino(destinationViaDefaultArgs);
+pino({ name: 'my-logger' }, destinationViaDefaultArgs);
+pino(destinationViaStrFileDescriptor);
+pino({ name: 'my-logger' }, destinationViaStrFileDescriptor);
+pino(destinationViaNumFileDescriptor);
+pino({ name: 'my-logger' }, destinationViaNumFileDescriptor);
+pino(destinationViaStream);
+pino({ name: 'my-logger' }, destinationViaStream);
+pino(destinationViaOptionsObject);
+pino({ name: 'my-logger' }, destinationViaOptionsObject);


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/pino/blob/v6.0.0/pino.js#L196
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

### PR Summary

* Fixes `destination` static method parameter to reflect `pino`’s documentation (https://getpino.io/#/docs/api?id=statics). This parameter should have already been typed this way for the current type version (v6.0.0), so no version change is required. As such, source code linked above refers to that version; no changes have been made to this portion of the API since then.
* Adds missing option `prettifier`. This was also available in current type version (v6.0.0).
