### PR TITLE
fix(pino-multi-stream): add prettyStream and align stream with pino

### DIFF
--- a/types/pino-multi-stream/index.d.ts
+++ b/types/pino-multi-stream/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pino-multi-stream 3.1
+// Type definitions for pino-multi-stream 5.0
 // Project: https://github.com/pinojs/pino-multi-stream#readme
 // Definitions by: Jake Ginnivan <https://github.com/JakeGinnivan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -7,18 +7,29 @@ import {
     LoggerOptions as PinoLoggerOptions,
     Logger as PinoLogger,
     Level as PinoLevel,
+    DestinationStream as PinoDestinationStream,
     stdSerializers as pinoStdSerializers
 } from 'pino';
 import stream = require('stream');
 
 declare namespace pinoms {
-    type Streams = Array<{ stream: NodeJS.WritableStream; level?: Level }>;
+    type Streams = Array<{ stream: PinoDestinationStream | NodeJS.WritableStream; level?: Level }>;
     interface LoggerOptions extends PinoLoggerOptions {
         streams?: Streams;
     }
+    interface PrettyStreamOptions extends Pick<PinoLoggerOptions, 'prettyPrint'> {
+        /**
+         * Allows to optionally define which prettifier module to use
+         */
+        // TODO: use type definitions from 'pino-pretty' when available.
+        prettifier?: any;
+        dest?: PinoDestinationStream | NodeJS.WritableStream;
+    }
+
     const stdSerializers: typeof pinoStdSerializers;
 
     function multistream(streams: Streams): stream.Writable;
+    function prettyStream(opts?: PrettyStreamOptions): PinoDestinationStream;
     type Level = PinoLevel;
     type Logger = PinoLogger;
 }

--- a/types/pino-multi-stream/pino-multi-stream-tests.ts
+++ b/types/pino-multi-stream/pino-multi-stream-tests.ts
@@ -6,14 +6,19 @@ const streams: pinoms.Streams = [
     { stream: process.stdout }, // an "info" level destination stream
     { level: 'error', stream: process.stderr }, // an "error" level destination stream
     { stream: fs.createWriteStream('/tmp/info.stream.out') },
-    { level: 'fatal', stream: fs.createWriteStream('/tmp/fatal.stream.out') }
+    { level: 'fatal', stream: fs.createWriteStream('/tmp/fatal.stream.out') },
+    { stream: pino.destination() },
+    { stream: pinoms.prettyStream() },
+    { stream: pinoms.prettyStream({ prettyPrint: { colorize: true } }) }
 ];
 const logger = pinoms({
     level: 'warn',
     streams
 });
 
-const log = pino({
-    level: 'debug' // this MUST be set at the lowest level of the
-                   // destinations
-}, pinoms.multistream(streams));
+const log = pino(
+    {
+        level: 'debug',
+    },
+    pinoms.multistream(streams)
+);


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/pino-multi-stream/blob/v5.0.0/index.js#L81
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

### PR Summary

Adds `prettyStream` method with API settled as of [v4.3.0](https://github.com/pinojs/pino-multi-stream/releases/tag/v4.3.0), and aligns stream type strictness with `pino`’s type definitions. See https://github.com/DefinitelyTyped/DefinitelyTyped/commit/2388e7ca03a9a8afeb7374c532477dc97c4d718b for reasoning.