### PR TITLE
qs: add undefined to ParsedQs union type

### DIFF
--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -9,6 +9,7 @@
 //                 Dan Smith <https://github.com/dpsmith3>
 //                 Hunter Perrin <https://github.com/hperrin>
 //                 Jordan Harband <https://github.com/ljharb>
+//                 Paolo Scanferla <https://github.com/pscanf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = QueryString;
@@ -55,7 +56,9 @@ declare namespace QueryString {
         interpretNumericEntities?: boolean;
     }
 
-    interface ParsedQs { [key: string]: string | string[] | ParsedQs | ParsedQs[] }
+    interface ParsedQs {
+        [key: string]: string | string[] | ParsedQs | ParsedQs[] | undefined;
+    }
 
     // TODO: The value type here is a "poor man's `unknown`". When these types support TypeScript
     // 3.0+, we can replace this with `unknown`.

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -336,7 +336,10 @@ qs.parse('a=b&c=d', { delimiter: '&' });
     assert.equal(qs.stringify({ a: { b: { c: 'd', e: 'f' } } }, { allowDots: true }), 'a.b.c=d&a.b.e=f');
 }
 
-interface CustomQuery extends qs.ParsedQs {
-    requiredParam: string;
-    optionalParam?: string;
+declare const myQuery: { a: string; b?: string }
+const myQueryCopy: qs.ParsedQs = myQuery;
+
+interface MyQuery extends qs.ParsedQs {
+    a: string;
+    b?: string;
 }

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -10,7 +10,7 @@ qs.parse('a=b&c=d', { delimiter: '&' });
 () => {
     let obj = qs.parse('a=z&b[c]=z&d=z&d=z&e[][f]=z');
     obj; // $ExpectType ParsedQs
-    obj.a; // $ExpectType string | ParsedQs | string[] | ParsedQs[]
+    obj.a; // $ExpectType string | ParsedQs | string[] | ParsedQs[] | undefined
     assert.deepEqual(obj, { a: 'c' });
 
     var str = qs.stringify(obj);
@@ -191,12 +191,12 @@ qs.parse('a=b&c=d', { delimiter: '&' });
     var decoded = qs.parse('a=Number(12)&b=foo', {
         decoder: function (str, defaultDecoder, charset, type) {
             if (type !== 'key') {
-                var numberMatch = str.match(/^Number\((\d+)\)$/);            
+                var numberMatch = str.match(/^Number\((\d+)\)$/);
                 if (numberMatch) {
                     return +numberMatch[1];
                 }
             }
-        
+
             return defaultDecoder(str, defaultDecoder, charset);
         }
     });
@@ -334,4 +334,9 @@ qs.parse('a=b&c=d', { delimiter: '&' });
 
 () => {
     assert.equal(qs.stringify({ a: { b: { c: 'd', e: 'f' } } }, { allowDots: true }), 'a.b.c=d&a.b.e=f');
+}
+
+interface CustomQuery extends qs.ParsedQs {
+    requiredParam: string;
+    optionalParam?: string;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

