### PR TITLE
feat(react-swipeable-views-core): Add types

### DIFF
--- a/types/react-swipeable-views-core/index.d.ts
+++ b/types/react-swipeable-views-core/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for react-swipeable-views-core 0.13
+// Project: https://github.com/oliviertassinari/react-swipeable-views#readme
+// Definitions by: kodai3 <https://github.com/kodai3>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { SwipeableViewsProps } from 'react-swipeable-views';
+
+export interface ComputeIndexParams {
+    children: SwipeableViewsProps['children'];
+    resistance: SwipeableViewsProps['resistance'];
+    startIndex: number;
+    startX: number;
+    pageX: number;
+    viewLength: number;
+}
+
+export const constant: {
+    RESISTANCE_COEF: number;
+    UNCERTAINTY_THRESHOLD: number;
+};
+export function mod(n: number, m: number): number;
+export function getDisplaySameSlide(props: SwipeableViewsProps, nextProps: SwipeableViewsProps): boolean;
+export function checkIndexBounds(props: SwipeableViewsProps): void;
+export function computeIndex(
+    params: ComputeIndexParams,
+): {
+    index: number;
+    startX: number;
+};

--- a/types/react-swipeable-views-core/react-swipeable-views-core-tests.ts
+++ b/types/react-swipeable-views-core/react-swipeable-views-core-tests.ts
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { SwipeableViewsProps } from 'react-swipeable-views';
+import { checkIndexBounds, computeIndex, constant, getDisplaySameSlide, mod } from 'react-swipeable-views-core';
+
+const oldProps: SwipeableViewsProps = {
+    index: 1,
+    children: [React.createElement('div'), React.createElement('div')],
+};
+
+const nextProps: SwipeableViewsProps = {
+    index: 2,
+    children: [React.createElement('div'), React.createElement('div')],
+};
+
+// $ExpectType number
+constant.RESISTANCE_COEF;
+// $ExpectType number
+constant.UNCERTAINTY_THRESHOLD;
+
+mod(); // $ExpectError
+mod(0); // $ExpectError
+mod(0, 4); // $ExpectType number
+mod(1, 4); // $ExpectType number
+mod(-1, 4); // $ExpectType number
+
+getDisplaySameSlide(); // $ExpectError
+getDisplaySameSlide(oldProps); // $ExpectError
+getDisplaySameSlide(oldProps, nextProps); // $ExpectType boolean
+
+checkIndexBounds(); // $ExpectError
+checkIndexBounds(oldProps); // $ExpectType void
+
+checkIndexBounds(); // $ExpectError
+computeIndex({
+    children: oldProps.children,
+    resistance: oldProps.resistance,
+    startIndex: 0,
+    startX: 50,
+    pageX: 10,
+    viewLength: 2,
+}); //  $ExpectType { index: number; startX: number; }

--- a/types/react-swipeable-views-core/tsconfig.json
+++ b/types/react-swipeable-views-core/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "react-swipeable-views-core-tests.ts"]
+}

--- a/types/react-swipeable-views-core/tslint.json
+++ b/types/react-swipeable-views-core/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
types for [react-swipeable-views-core](https://github.com/oliviertassinari/react-swipeable-views/tree/v0.13.3/packages/react-swipeable-views-core)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.