### PR TITLE
[koa-router] Fix: Param context type don't follows router context type

### DIFF
--- a/types/koa-router/index.d.ts
+++ b/types/koa-router/index.d.ts
@@ -6,6 +6,7 @@
 //                 Romain Faust <https://github.com/romain-faust>
 //                 Guillaume Mayer <https://github.com/Guillaume-Mayer>
 //                 Andrea Gueugnaut <https://github.com/falinor>
+//                 Yves Kaufmann <https://github.com/yveskaufmann>
 // Definitions: https://github.com/hellopao/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -69,8 +70,8 @@ declare namespace Router {
     export type IMiddleware<StateT = any, CustomT = {}> =
         Koa.Middleware<StateT, CustomT & IRouterParamContext<StateT, CustomT>>
 
-    export interface IParamMiddleware {
-        (param: string, ctx: RouterContext, next: () => Promise<any>): any;
+    export interface IParamMiddleware<STateT = any, CustomT = {}> {
+        (param: string, ctx: RouterContext<STateT, CustomT>, next: () => Promise<any>): any;
     }
 
     export interface IRouterAllowedMethodsOptions {
@@ -525,7 +526,7 @@ declare class Router<StateT = any, CustomT = {}> {
     /**
      * Run middleware for named route parameters. Useful for auto-loading or validation.
      */
-    param(param: string, middleware: Router.IParamMiddleware): Router<StateT, CustomT>;
+    param(param: string, middleware: Router.IParamMiddleware<StateT, CustomT>): Router<StateT, CustomT>;
 
     /**
      * Generate URL from url pattern and given `params`.

--- a/types/koa-router/koa-router-tests.ts
+++ b/types/koa-router/koa-router-tests.ts
@@ -4,7 +4,11 @@ import compose = require("koa-compose");
 import etag = require("koa-etag");
 import Router = require("koa-router");
 
-type MyState = {foo: string}
+type MyState = {
+    foo: string,
+    id: string
+}
+
 type MyContext = {bar: string}
 
 const app = new Koa<{}, {}>();
@@ -15,6 +19,8 @@ const router = new Router<MyState, MyContext>({
 
 router
     .param('id', function (id, ctx, next) {
+        ctx.state.id = id;
+        ctx.bar = 'bar';
         next();
     })
     .get('/', function (ctx, next) {


### PR DESCRIPTION
The context parameter of the param method,
don't takes the Context type of the router into account,
but it is always the default context.

This leads to type errors, if you try to access a custom properties from the context.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: npm run lint package-name
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

