### PR TITLE
[cesium] Fix member variables on graphics types

### DIFF
--- a/types/cesium/index.d.ts
+++ b/types/cesium/index.d.ts
@@ -2134,7 +2134,7 @@ declare namespace Cesium {
         height?: Property;
         scaleByDistance?: Property;
         translucencyByDistance?: Property;
-        disableDepthTestDistance?: Property | number;
+        disableDepthTestDistance?: Property;
         pixelOffsetScaleByDistance?: Property;
         heightReference?: Property;
         constructor(options?: { image?: Property;
@@ -2424,8 +2424,8 @@ declare namespace Cesium {
 
     class EllipseGraphics {
         definitionChanged: Event;
-        semiMajorAxis: Property | number;
-        semiMinorAxis: Property | number;
+        semiMajorAxis: Property;
+        semiMinorAxis: Property;
         rotation: Property;
         show: Property;
         material: MaterialProperty | Color;
@@ -2702,7 +2702,7 @@ declare namespace Cesium {
 
     class LabelGraphics {
         definitionChanged: Event;
-        text: Property | string;
+        text: Property;
         font: string;
         style: Property;
         fillColor: Color;
@@ -2877,8 +2877,8 @@ declare namespace Cesium {
         definitionChanged: Event;
         distanceDisplayCondition: Property;
         show: Property;
-        material: MaterialProperty | Color;
-        hierarchy: Property | Cartesian3[] | PolygonHierarchy;
+        material: MaterialProperty;
+        hierarchy: Property;
         height: Property;
         heightReference: Property;
         extrudedHeight: Property;
@@ -2954,8 +2954,8 @@ declare namespace Cesium {
         granularity: Property;
         shadows: Property;
         show: Property;
-        material: MaterialProperty | Color;
-        positions: Property | Cartesian3[];
+        material: MaterialProperty;
+        positions: Property;
         width: Property | number;
         zIndex: ConstantProperty;
         constructor(options?: {

--- a/types/cesium/test/cesium-global.test.ts
+++ b/types/cesium/test/cesium-global.test.ts
@@ -96,4 +96,30 @@ const options = {
     maximumScreenSpaceError: 2
 };
 
- const tilesetModel = new Cesium.Cesium3DTilesetGraphics(options);
+const tilesetModel = new Cesium.Cesium3DTilesetGraphics(options);
+
+const polygonGraphics = new Cesium.PolygonGraphics({
+    hierarchy: Cesium.Cartesian3.fromDegreesArray([
+        -108.0,
+        42.0,
+        -100.0,
+        42.0,
+        -104.0,
+        40.0,
+    ]),
+});
+
+const polygonHierarchyProperty: Cesium.Property = polygonGraphics.hierarchy;
+
+const polylineGraphics = new Cesium.PolylineGraphics({
+    positions: Cesium.Cartesian3.fromDegreesArrayHeights([
+        -75,
+        42,
+        250000,
+        -125,
+        42,
+        250000,
+    ]),
+});
+
+const polylinePositionsProperty: Cesium.Property = polylineGraphics.positions;

--- a/types/cesium/test/cesium-module.test.ts
+++ b/types/cesium/test/cesium-module.test.ts
@@ -98,4 +98,30 @@ const options = {
     maximumScreenSpaceError: 2
 };
 
- const tilesetModel = new Cesium.Cesium3DTilesetGraphics(options);
+const tilesetModel = new Cesium.Cesium3DTilesetGraphics(options);
+
+const polygonGraphics = new Cesium.PolygonGraphics({
+    hierarchy: Cesium.Cartesian3.fromDegreesArray([
+        -108.0,
+        42.0,
+        -100.0,
+        42.0,
+        -104.0,
+        40.0,
+    ]),
+});
+
+const polygonHierarchyProperty: Cesium.Property = polygonGraphics.hierarchy;
+
+const polylineGraphics = new Cesium.PolylineGraphics({
+    positions: Cesium.Cartesian3.fromDegreesArrayHeights([
+        -75,
+        42,
+        250000,
+        -125,
+        42,
+        250000,
+    ]),
+});
+
+const polylinePositionsProperty: Cesium.Property = polylineGraphics.positions;


### PR DESCRIPTION
A previous change introduced union types for various member variables on `Graphics` types (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44143). This change is incorrect, as I commented here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44143#discussion_r413747367. Unfortunately I did not realize that if I suggest changes, the author makes an unrelated change, and then I don't do anything, a maintainer will come along and merge their PR anyway. It was my mistake to not re-request changes and keep the PR updated.

To reiterate what is in that comment: member variables on `Graphics` types can be set using raw types like `boolean` and `number` but **they are converted to `Property` once set**. The member variables have different `get` and `set` types, which is a convenience feature we can't yet express in the typings (https://github.com/microsoft/TypeScript/issues/2521). To prevent incorrect access of these variables, we have to restrict our type to the narrower of the two types. In this case, that type is `Property`. Otherwise, it's permissible by the types to write the following:

```
// set positions using an array of Cartesian3
myPolygonGraphics.hierarchy = [myPosition1, myPosition2];

// attempt to read out something from that array
const numPolygonPoints = myPolygonGraphics.hierarchy.length;
```

This will compile fine but will throw on usage, because the `positions` is no longer a `Cartesian3[]`, but is instead a `ConstantProperty` wrapping around the originally passed positions. The conversion happens here in the Cesium source: https://github.com/CesiumGS/cesium/blob/bb9f245cef5659b2d7020ce70cf072b9f6add92e/Source/DataSources/createPropertyDescriptor.js#L17. The function here, `createPropertyDescriptor`, is used for every property on every `Graphics` object type.

cc @anotherhale 