### PR TITLE
fix(react-facebook-login): correct `callback` parameter types

### DIFF
--- a/types/react-facebook-login/index.d.ts
+++ b/types/react-facebook-login/index.d.ts
@@ -8,7 +8,7 @@ import * as React from "react";
 
 export interface ReactFacebookLoginProps {
     appId: string;
-    callback(userInfo: ReactFacebookLoginInfo): void;
+    callback(userInfo: ReactFacebookLoginInfo | ReactFacebookFailureResponse): void;
     onFailure?(response: ReactFacebookFailureResponse): void;
 
     autoLoad?: boolean;

--- a/types/react-facebook-login/react-facebook-login-tests.tsx
+++ b/types/react-facebook-login/react-facebook-login-tests.tsx
@@ -10,6 +10,10 @@ const failureResponseFacebook = (response: ReactFacebookFailureResponse) => {
     console.log(response);
 };
 
+const loginInfoOrFailureResponse = (response: ReactFacebookLoginInfo | ReactFacebookLoginInfo) => {
+    console.log(response);
+};
+
 const componentClicked = () => {
     console.log("component clicked");
 };
@@ -21,6 +25,16 @@ ReactDOM.render(
         fields="name,email,picture"
         onClick={componentClicked}
         callback={responseFacebook} />,
+    document.getElementById('demo')
+);
+
+ReactDOM.render(
+    <FacebookLogin
+        appId="1088597931155576"
+        autoLoad={true}
+        fields="name,email,picture"
+        onClick={componentClicked}
+        callback={loginInfoOrFailureResponse} />,
     document.getElementById('demo')
 );
 


### PR DESCRIPTION
- `callback` is used in the source as general loopback for both success
  and failure in most cases when `onFailure` was not defined.
https://github.com/keppelen/react-facebook-login/blob/207389377577b291743a8218bdb8e921b34d52c0/src/facebook.js#L153

/cc @WojtekKr

Thanks!

Fixes #44482

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)