### PR TITLE
fix(convict): add optional second parameter

### DIFF
--- a/types/convict/convict-tests.ts
+++ b/types/convict/convict-tests.ts
@@ -176,7 +176,7 @@ const conf2 = convict(
     },
     {
         env: {
-            PORT: 12345
+            PORT: '12345'
         },
         args: []
     }

--- a/types/convict/convict-tests.ts
+++ b/types/convict/convict-tests.ts
@@ -164,4 +164,27 @@ conf.getProperties();
 conf.getSchemaString();
 conf.toString();
 
+const conf2 = convict(
+    {
+        port: {
+            doc: 'The port to bind.',
+            format: 'port',
+            default: 0,
+            env: 'PORT',
+            arg: 'port',
+        }
+    },
+    {
+        env: {
+            PORT: 12345
+        },
+        args: []
+    }
+);
+
+const port2 = conf2.get('port');
+if (port2 !== 12345) {
+    throw new Error(`Test failed. Expected injected environment variable to be reflected in config.`);
+}
+
 // vim:et:sw=2:ts=2

--- a/types/convict/index.d.ts
+++ b/types/convict/index.d.ts
@@ -9,6 +9,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
+/// <reference types="node" />
+
 declare namespace convict {
     // Taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
     type Overwrite<T, U> = { [P in Exclude<keyof T, keyof U>]: T[P] } & U;
@@ -90,6 +92,11 @@ declare namespace convict {
         properties: {
             [K in keyof T]: T[K] extends object ? InternalSchema<T[K]> : { default: T[K] }
         };
+    }
+
+    interface Options {
+        env?: NodeJS.ProcessEnv;
+        args?: string[];
     }
 
     interface Config<T> {
@@ -200,7 +207,7 @@ interface convict {
     addFormat(format: convict.Format): void;
     addFormats(formats: { [name: string]: convict.Format }): void;
     addParser(parsers: convict.Parser | convict.Parser[]): void;
-    <T>(config: convict.Schema<T> | string, options?: { env?: any, args?: string[] }): convict.Config<T>;
+    <T>(config: convict.Schema<T> | string, opts?: convict.Options): convict.Config<T>;
 }
 declare var convict: convict;
 export = convict;

--- a/types/convict/index.d.ts
+++ b/types/convict/index.d.ts
@@ -5,6 +5,7 @@
 //                 Eli Young <https://github.com/elyscape>
 //                 Suntharesan Mohan <https://github.com/vanthiyathevan>
 //                 Igor Strebezhev <https://github.com/xamgore>
+//                 Peter Somogyvari <https://github.com/petermetz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -199,7 +200,7 @@ interface convict {
     addFormat(format: convict.Format): void;
     addFormats(formats: { [name: string]: convict.Format }): void;
     addParser(parsers: convict.Parser | convict.Parser[]): void;
-    <T>(config: convict.Schema<T> | string): convict.Config<T>;
+    <T>(config: convict.Schema<T> | string, options?: { env?: any, args?: string[] }): convict.Config<T>;
 }
 declare var convict: convict;
 export = convict;


### PR DESCRIPTION
Needed for injecting custom process.env or process.args parameters to be used by convict which is sorely needed when testing code that uses convict for it's configuration parsing.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mozilla/node-convict/blob/9d9070966f3dc9dc269895b09d5b4a4777a44ccb/packages/convict/src/main.js#L454
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
