### PR TITLE
node: add errorMonitor on EventEmitter

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -43,6 +43,16 @@ declare module "events" {
             /** @deprecated since v4.0.0 */
             static listenerCount(emitter: EventEmitter, event: string | symbol): number;
             static defaultMaxListeners: number;
+            /**
+             * This symbol shall be used to install a listener for only monitoring `'error'`
+             * events. Listeners installed using this symbol are called before the regular
+             * `'error'` listeners are called.
+             *
+             * Installing a listener using this symbol does not change the behavior once an
+             * `'error'` event is emitted, therefore the process will still crash if no
+             * regular `'error'` listener is installed.
+             */
+            static readonly errorMonitor: unique symbol;
         }
     }
 

--- a/types/node/test/events.ts
+++ b/types/node/test/events.ts
@@ -84,3 +84,8 @@ async function test() {
         console.log(e);
     }
 }
+
+{
+    emitter.on(events.errorMonitor, listener);
+    emitter.on(events.EventEmitter.errorMonitor, listener);
+}


### PR DESCRIPTION
The property `errorMonitor` is a static property on class `EventEmitter`.
This avoid the need to import `errorMonitor` separate of `EventEmitter`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v14.x/docs/api/events.html#events_eventemitter_errormonitor
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
