### PR TITLE
[iltorb] Restrict the accepted arguments

### DIFF
--- a/types/iltorb/iltorb-tests.ts
+++ b/types/iltorb/iltorb-tests.ts
@@ -10,6 +10,12 @@ const opts: br.BrotliEncodeParams = {
     size_hint: 0
 };
 
+declare const mode: number;
+declare const quality: number;
+
+const myMode: br.BrotliMode = mode; // $ExpectError
+const myQuality: br.BrotliCompressionQuality = quality; // $ExpectError
+
 const onCompress = (err1: Error | null | undefined, compressed: Buffer) => {
     br.decompress(compressed, (err2: Error | null | undefined, decompressed: Buffer) => {
         console.log(decompressed.toString());

--- a/types/iltorb/index.d.ts
+++ b/types/iltorb/index.d.ts
@@ -9,12 +9,15 @@
 
 import { Transform } from 'stream';
 
+export type BrotliMode = 0 | 1 | 2;
+export type BrotliCompressionQuality = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
+
 export interface BrotliEncodeParams {
     disable_literal_context_modeling?: boolean;
     lgblock?: number;
     lgwin?: number;
-    mode?: number;
-    quality?: number;
+    mode?: BrotliMode;
+    quality?: BrotliCompressionQuality;
     size_hint?: number;
 }
 

--- a/types/iltorb/index.d.ts
+++ b/types/iltorb/index.d.ts
@@ -16,6 +16,7 @@ export interface BrotliEncodeParams {
     disable_literal_context_modeling?: boolean;
     lgblock?: number;
     lgwin?: number;
+    /** @default 0 */
     mode?: BrotliMode;
     quality?: BrotliCompressionQuality;
     size_hint?: number;

--- a/types/iltorb/index.d.ts
+++ b/types/iltorb/index.d.ts
@@ -18,6 +18,7 @@ export interface BrotliEncodeParams {
     lgwin?: number;
     /** @default 0 */
     mode?: BrotliMode;
+    /** @default 11 */
     quality?: BrotliCompressionQuality;
     size_hint?: number;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see below 👇
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

1. `iltorb` uses the `brotli` library under the hood. It's documented [here](https://github.com/nstepien/iltorb/blob/01907feaf696e630cf79eba85a61b186bf3c65b6/README.md#L133-L136).
1. The underlying library accepts [these values](https://github.com/google/brotli/blob/c6333e1e79fb62ea088443f192293f964409b04e/c/include/brotli/encode.h#L45-L57) for `mode` and [these values](https://github.com/google/brotli/blob/c6333e1e79fb62ea088443f192293f964409b04e/c/include/brotli/encode.h#L40-L42) for `quality`.
1. By restricting the values to number literals, we reduce the risk of confusing `mode` with `quality`.