### PR TITLE
fix(mongoose-delete): deleted should be optional

### DIFF
--- a/types/mongoose-delete/index.d.ts
+++ b/types/mongoose-delete/index.d.ts
@@ -75,7 +75,7 @@ declare namespace mongoose_delete {
     }
     interface SoftDeleteInterface {
         /** Soft deleted ? */
-        deleted: boolean;
+        deleted?: boolean;
         deleteAt?: Date;
         deletedBy?: mongoose.Types.ObjectId | string | mongoose.Document;
     }

--- a/types/mongoose-delete/mongoose-delete-tests.ts
+++ b/types/mongoose-delete/mongoose-delete-tests.ts
@@ -78,3 +78,6 @@ Pet.restore({ age: 10 }, (err, result) => {});
 // Restore multiple object, promise
 Pet.restore().exec((err, result) => {});
 Pet.restore({ age: 10 }).exec((err, result) => {});
+
+// $ExpectType boolean | undefined
+type deletedType = PetDocument["deleted"];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This PR is part of the changes needed to enable strong typed creation for mongoose. I'm making it separate here in hopes of making https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44619 easier to merge.

`deleted?` should be optional in the schema when inserting, otherwise it will always need to be specified.