### PR TITLE
added the TextPropTypes and ImagePropTypes for the react native types…

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -9305,6 +9305,8 @@ export const ColorPropType: React.Validator<string>;
 export const EdgeInsetsPropType: React.Validator<Insets>;
 export const PointPropType: React.Validator<PointPropType>;
 export const ViewPropTypes: React.ValidationMap<ViewProps>;
+export const TextPropTypes: React.ValidationMap<TextProps>;
+export const ImagePropTypes: React.ValidationMap<ImageProps>;
 
 declare global {
     interface NodeRequire {


### PR DESCRIPTION
The types added allow for PropTypes prop validation when passing textStyles to a custom component, or to pass an imported image as a source for an image contained inside a custom component

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`