### PR TITLE
[@types/node]: Adds the `exitCode` field to ChildProcess in >= v12.

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -18,6 +18,7 @@ declare module "child_process" {
             Readable | Writable | null | undefined, // extra
             Readable | Writable | null | undefined // extra
         ];
+        readonly exitCode: number | null;
         readonly killed: boolean;
         readonly pid: number;
         readonly connected: boolean;

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -185,6 +185,8 @@ async function testPromisify() {
             const _err: Error | null = error;
         });
 
+    const _exitCode: number | null = cp.exitCode;
+
     const stdin: Writable | null = cp.stdio[0];
     const stdout: Readable | null = cp.stdio[1];
     const stderr: Readable | null = cp.stdio[2];

--- a/types/node/v12/child_process.d.ts
+++ b/types/node/v12/child_process.d.ts
@@ -15,6 +15,7 @@ declare module "child_process" {
             Readable | Writable | null | undefined, // extra
             Readable | Writable | null | undefined // extra
         ];
+        readonly exitCode: number | null;
         readonly killed: boolean;
         readonly pid: number;
         readonly connected: boolean;

--- a/types/node/v12/test/child_process.ts
+++ b/types/node/v12/test/child_process.ts
@@ -185,6 +185,8 @@ async function testPromisify() {
             const _err: Error | null = error;
         });
 
+    const _exitCode: number | null = cp.exitCode;
+
     const stdin: Writable | null = cp.stdio[0];
     const stdout: Readable | null = cp.stdio[1];
     const stderr: Readable | null = cp.stdio[2];


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v12.x/api/child_process.html#child_process_subprocess_exitcode
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.