### PR TITLE
add types for serverless.yml for AWS provider

### DIFF
--- a/types/serverless/classes/Plugin.d.ts
+++ b/types/serverless/classes/Plugin.d.ts
@@ -23,11 +23,13 @@ declare namespace Plugin {
     type VariableResolver = (variableSource: string) => Promise<any>;
 
     interface VariableResolvers {
-        [variablePrefix: string]: VariableResolver | {
-            resolver: VariableResolver,
-            isDisabledAtPrepopulation?: boolean,
-            serviceName?: string
-        };
+        [variablePrefix: string]:
+            | VariableResolver
+            | {
+                  resolver: VariableResolver;
+                  isDisabledAtPrepopulation?: boolean;
+                  serviceName?: string;
+              };
     }
 
     interface PluginStatic {

--- a/types/serverless/index.d.ts
+++ b/types/serverless/index.d.ts
@@ -4,6 +4,7 @@
 //                 Jonathan M. Wilbur <https://github.com/JonathanWilbur>
 //                 Alex Pavlenko <https://github.com/a-pavlenko>
 //                 Frédéric Barthelet <https://github.com/fredericbarthelet>
+//                 Bryan Hunter <https://github.com/bryan-hunter>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import Service = require('./classes/Service');
@@ -48,6 +49,8 @@ declare namespace Serverless {
         artifact?: string;
         individually?: boolean;
     }
+
+    type Aws = AwsProvider;
 }
 
 declare class Serverless {

--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -46,7 +46,7 @@ declare namespace Aws {
         alb?: Alb;
         httpApi?: HttpApi;
         usagePlan?: UsagePlan;
-        stackTags?: StackTags;
+        stackTags?: Tags;
         iamManagedPolicies?: string[];
         iamRoleStatements?: IamRoleStatement[];
         stackPolicy?: ResourcePolicy[];
@@ -164,14 +164,6 @@ declare namespace Aws {
     interface UsagePlan {
         quota?: Quota;
         throttle?: Throttle;
-    }
-
-    interface StackTags {
-        [key: string]: string;
-    }
-
-    interface Resource {
-        'Fn::Join': any[];
     }
 
     interface IamRoleStatement {

--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -1,5 +1,556 @@
 import Serverless = require('../../../index');
 
+declare namespace Aws {
+    /*
+        Types based on https://github.com/serverless/serverless/blob/master/docs/providers/aws/guide/serverless.yml.md
+    */
+    interface Serverless {
+        service: Service;
+        frameworkVersion: string;
+        provider: Provider;
+        package?: Package;
+        functions?: Functions;
+        layers?: Layers;
+        resources?: Resources;
+    }
+
+    interface Service {
+        name: string;
+        awsKmsKeyArn?: string;
+    }
+
+    interface Provider {
+        name: 'aws';
+        runtime: string;
+        stage?: string;
+        region?: string;
+        stackName?: string;
+        apiName?: string;
+        websocketsApiName?: string;
+        websocketsApiRouteSelectionExpression?: string;
+        profile?: string;
+        memorySize?: number | string;
+        reservedConcurrency?: number | string;
+        timeout?: number | string;
+        logRetentionInDays?: number | string;
+        deploymentBucket?: DeploymentBucket;
+        deploymentPrefix?: string;
+        role?: string;
+        rolePermissionsBoundary?: string;
+        cfnRole?: string;
+        versionFunctions?: boolean;
+        environment?: Environment;
+        endpointType?: string;
+        apiKeys?: string[];
+        apiGateway?: ApiGateway;
+        alb?: Alb;
+        httpApi?: HttpApi;
+        usagePlan?: UsagePlan;
+        stackTags?: StackTags;
+        iamManagedPolicies?: string[];
+        iamRoleStatements?: IamRoleStatement[];
+        stackPolicy?: ResourcePolicy[];
+        vpc?: Vpc;
+        notificationArns?: string[];
+        stackParameters?: StackParameters[];
+        resourcePolicy?: ResourcePolicy[];
+        rollbackConfiguration?: RollbackConfiguration;
+        tags?: Tags;
+        tracing?: Tracing;
+        logs?: Logs;
+    }
+
+    interface Tags {
+        [key: string]: string;
+    }
+
+    interface DeploymentBucket {
+        name?: string;
+        maxPreviousDeploymentArtifacts?: number | string;
+        blockPublicAccess?: boolean;
+        serverSideEncryption?: string;
+        sseKMSKeyId?: string;
+        sseCustomerAlgorithim?: string;
+        sseCustomerKey?: string;
+        sseCustomerKeyMD5?: string;
+        tags?: Tags;
+    }
+
+    interface Environment {
+        [key: string]: string;
+    }
+
+    interface ApiGateway {
+        restApiId?: string;
+        restApiRootResourceId?: string;
+        restApiResources?: {
+            [key: string]: string;
+        };
+        websocketApiId?: any;
+        apiKeySourceType?: string;
+        minimumCompressionSize?: number | string;
+        description?: string;
+        binaryMediaTypes?: string[];
+    }
+
+    interface CognitoAuthorizer {
+        type: 'cognito';
+        userPoolArn: string;
+        userPoolClientId: string;
+        userPoolDomain: string;
+        allowUnauthenticated?: boolean;
+        requestExtraParams?: {
+            prompt?: string;
+            redirect?: boolean;
+        };
+        scope?: string;
+        sessionCookieName?: string;
+        sessionTimeout?: number | string;
+    }
+
+    interface OidcAuthorizer {
+        type: 'oidc';
+        authorizationEndpoint: string;
+        clientId: string;
+        clientSecret?: string;
+        useExistingClientSecret?: boolean;
+        issuer: string;
+        tokenEndpoint: string;
+        userInfoEndpoint: string;
+        allowUnauthenticated?: boolean;
+        requestExtraParams?: {
+            prompt?: string;
+            redirect?: boolean;
+        };
+        scope?: string;
+        sessionCookieName?: string;
+        sessionTimeout?: number | string;
+    }
+
+    interface JwtAuthorizer {
+        identitySource: string;
+        issuerUrl: string;
+        audience: string[];
+    }
+
+    interface Authorizers {
+        [key: string]: CognitoAuthorizer | OidcAuthorizer | JwtAuthorizer;
+    }
+
+    interface Alb {
+        targetGroupPrefix?: string;
+        authorizers?: Authorizers;
+    }
+
+    interface HttpApi {
+        id?: string;
+        name?: string;
+        payload?: string;
+        cors?: boolean;
+        authorizers?: Authorizers;
+    }
+
+    interface Quota {
+        limit?: number | string;
+        offset?: number | string;
+        period?: string;
+    }
+
+    interface Throttle {
+        burstLimit?: number | string;
+        rateLimit?: number | string;
+    }
+
+    interface UsagePlan {
+        quota?: Quota;
+        throttle?: Throttle;
+    }
+
+    interface StackTags {
+        [key: string]: string;
+    }
+
+    interface Resource {
+        'Fn::Join': any[];
+    }
+
+    interface IamRoleStatement {
+        Effect: 'Allow' | 'Deny';
+        Sid?: string;
+        Condition?: {
+            [key: string]: any;
+        };
+        Action?: string | string[] | { [key: string]: any };
+        NotAction?: string | string[] | { [key: string]: any };
+        Resource?: string | string[] | { [key: string]: any };
+        NotResource?: string | string[] | { [key: string]: any };
+    }
+
+    interface ResourcePolicy {
+        Effect: 'Allow' | 'Deny';
+        Principal?: string | string[] | { [key: string]: any };
+        Action?: string | string[] | { [key: string]: any };
+        Resource?: string | string[] | { [key: string]: any };
+        Condition?: {
+            [key: string]: any;
+        };
+    }
+
+    interface Vpc {
+        securityGroupIds: string[];
+        subnetIds: string[];
+    }
+
+    interface StackParameters {
+        ParameterKey: string;
+        ParameterValue: string;
+    }
+
+    interface RollbackTrigger {
+        Arn: string;
+        Type: string;
+    }
+
+    interface RollbackConfiguration {
+        MonitoringTimeInMinutes: number | string;
+        RollbackTriggers: RollbackTrigger[];
+    }
+
+    interface Tracing {
+        apiGateway: boolean;
+        lambda?: boolean;
+    }
+
+    interface RestApiLogs {
+        accessLogging?: boolean;
+        format?: string;
+        executionLogging?: boolean;
+        level?: string;
+        fullExecutionData?: boolean;
+        role?: string;
+        roleManagedExternally?: boolean;
+    }
+
+    interface WebsocketLogs {
+        level?: string;
+    }
+
+    interface HttpApiLogs {
+        format?: string;
+    }
+
+    interface Logs {
+        restApi?: RestApiLogs;
+        websocket?: WebsocketLogs;
+        httpApi?: HttpApiLogs;
+        frameworkLambda?: boolean;
+    }
+
+    interface Package {
+        include?: string[];
+        exclude?: string[];
+        excludeDevDependencies?: boolean;
+        artifact?: string;
+        individually?: boolean;
+    }
+
+    interface Destinations {
+        onSuccess?: string;
+        onFailure?: string;
+    }
+
+    interface HttpAuthorizer {
+        name?: string;
+        arn?: string;
+        resultTtlInSeconds?: number | string;
+        identitySource?: string;
+        identityValidationExpression?: string;
+        type?: string;
+    }
+
+    interface Http {
+        path: string;
+        method: string;
+        cors?: boolean;
+        private?: boolean;
+        authorizer?: HttpAuthorizer;
+    }
+
+    interface HttpApiEventAuthorizer {
+        name: string;
+        scopes?: string[];
+    }
+
+    interface HttpApiEvent {
+        method: string;
+        path: string;
+        authorizer?: HttpApiEventAuthorizer;
+    }
+
+    interface WebsocketAuthorizer {
+        name?: string;
+        arn?: string;
+        identitySource?: string[];
+    }
+
+    interface Websocket {
+        route: string;
+        routeResponseSelectionExpression?: string;
+        authorizer?: WebsocketAuthorizer;
+    }
+
+    interface S3Rule {
+        prefix: string;
+        suffix: string;
+    }
+
+    interface S3 {
+        bucket: string;
+        event: string;
+        rules: S3Rule[];
+        existing?: boolean;
+    }
+
+    interface Input {
+        [key: string]: any;
+    }
+
+    interface InputTransformer {
+        inputPathsMap: { [key: string]: string };
+        inputTemplate: string;
+    }
+
+    interface Schedule {
+        name?: string;
+        description?: string;
+        rate: string;
+        enabled?: boolean;
+        input?: Input;
+        inputPath?: string;
+        inputTransformer?: InputTransformer;
+    }
+
+    interface FilterPolicy {
+        pet: string[];
+    }
+
+    interface DeadLetterTargetImport {
+        arn: string;
+        url: string;
+    }
+
+    interface RedrivePolicy {
+        deadLetterTargetArn?: string;
+        deadLetterTargetRef?: string;
+        deadLetterTargetImport?: DeadLetterTargetImport;
+    }
+
+    interface Sns {
+        topicName: string;
+        displayName?: string;
+        filterPolicy?: string[] | { [key: string]: string };
+        redrivePolicy?: RedrivePolicy;
+    }
+
+    interface Sqs {
+        arn: string;
+        batchSize?: number | string;
+        maximumRetryAttempts?: number | string;
+        enabled?: boolean;
+    }
+
+    interface Stream {
+        arn: string;
+        batchSize?: number | string;
+        startingPosition?: string;
+        enabled?: boolean;
+    }
+
+    interface AlexaSkill {
+        appId: string;
+        enabled?: boolean;
+    }
+
+    interface AlexaSmartHome {
+        appId: string;
+        enabled?: boolean;
+    }
+
+    interface Iot {
+        name: string;
+        description?: string;
+        enabled?: boolean;
+        sql: string;
+        sqlVersion: string;
+    }
+
+    interface Detail {
+        [key: string]: string[];
+    }
+
+    interface CloudwatchEventType {
+        source: string[];
+        'detail-type': string[];
+        detail: Detail;
+    }
+
+    interface CloudwatchEvent {
+        event: string;
+        name?: string;
+        description?: string;
+        enabled?: boolean;
+        input?: Input;
+        inputPath?: string;
+        inputTransformer?: InputTransformer;
+    }
+
+    interface CloudwatchLog {
+        logGroup: string;
+        filter: string;
+    }
+
+    interface CognitoUserPool {
+        pool: string;
+        trigger: string;
+        existing?: boolean;
+    }
+
+    interface AlbEvent {
+        listenerArn: string;
+        priority: number | string;
+        conditions: {
+            host: string;
+            path: string;
+        };
+    }
+
+    interface PatternExisting {
+        source: string[];
+    }
+
+    interface PatternInput {
+        source: string[];
+        'detail-type': string[];
+        detail: Detail;
+    }
+
+    interface EventBridge {
+        schedule?: string;
+        eventBus?: string;
+        pattern?: PatternExisting | PatternInput;
+        input?: Input;
+        inputPath?: string;
+        inputTransformer?: InputTransformer;
+    }
+
+    interface Origin {
+        DomainName: string;
+        OriginPath: string;
+        CustomOriginConfig: {
+            OriginProtocolPolicy: string;
+        };
+    }
+
+    interface CloudFront {
+        eventType: string;
+        includeBody: boolean;
+        pathPattern: string;
+        origin: Origin;
+    }
+
+    interface Event {
+        http: Http;
+        httpApi: HttpApiEvent;
+        websocket: Websocket;
+        s3: S3;
+        schedule: string | Schedule;
+        sns: Sns;
+        sqs: Sqs;
+        stream: Stream;
+        alexaSkill: AlexaSkill;
+        alexaSmartHome: AlexaSmartHome;
+        iot: Iot;
+        cloudwatchEvent: CloudwatchEvent;
+        cloudwatchLog: CloudwatchLog;
+        cognitoUserPool: CognitoUserPool;
+        alb: AlbEvent;
+        eventBridge: EventBridge;
+        cloudFront: CloudFront;
+    }
+
+    interface AwsFunction {
+        handler: string;
+        name?: string;
+        description?: string;
+        memorySize?: number | string;
+        reservedConcurrency?: number | string;
+        provisionedConcurrency?: number | string;
+        runtime?: string;
+        timeout?: number | string;
+        role?: string;
+        onError?: string;
+        awsKmsKeyArn?: string;
+        environment?: Environment;
+        tags?: Tags;
+        vpc?: Vpc;
+        package?: Package;
+        layers?: string[];
+        tracing?: string;
+        condition?: string;
+        dependsOn?: string[];
+        destinations?: Destinations;
+        events?: Event[];
+    }
+
+    interface Functions {
+        [key: string]: AwsFunction;
+    }
+
+    interface Layer {
+        path: string;
+        name?: string;
+        description?: string;
+        compatibleRuntimes?: string[];
+        licenseInfo?: string;
+        allowedAccounts?: string[];
+        retain?: boolean;
+    }
+
+    interface Layers {
+        [key: string]: Layer;
+    }
+
+    interface CloudFormationResource {
+        Type: string;
+        Properties: { [key: string]: any };
+        DependsOn?: string | { [key: string]: any };
+        DeletionPolicy?: string;
+    }
+
+    interface CloudFormationResources {
+        [key: string]: CloudFormationResource;
+    }
+
+    interface Output {
+        Description?: string;
+        Value: any;
+        Export?: {
+            Name: any;
+        };
+        Condition?: any;
+    }
+
+    interface Outputs {
+        [key: string]: Output;
+    }
+
+    interface Resources {
+        Resources: CloudFormationResources;
+        extensions: CloudFormationResources;
+        Outputs: Outputs;
+    }
+}
+
 declare class Aws {
     constructor(serverless: Serverless, options: Serverless.Options);
 

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -36,7 +36,7 @@ class CustomPlugin implements Plugin {
             'command:start': () => {},
         };
         this.variableResolvers = {
-            echo: async (source) => source.slice(5)
+            echo: async source => source.slice(5),
         };
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/serverless/serverless/blob/master/docs/providers/aws/guide/serverless.yml.md
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


This seemed like the best place to adding typings for https://github.com/serverless/serverless/blob/master/docs/providers/aws/guide/serverless.yml.md

I wanted to get some eyes on this from other contributors to see if it's beneficial to just add it here, or if we should standardize it a bit more and make it more closely match the folder structure within `serverless` repo.