### PR TITLE
[React-Native]: AccessibilityInfo type definition updates

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -6876,24 +6876,28 @@ export interface ShareStatic {
     dismissedAction: 'dismissedAction';
 }
 
-type AccessibilityEventName =
+type AccessibilityChangeEventName =
     | 'change' // deprecated, maps to screenReaderChanged
     | 'boldTextChanged' // iOS-only Event
     | 'grayscaleChanged' // iOS-only Event
     | 'invertColorsChanged' // iOS-only Event
     | 'reduceMotionChanged'
     | 'screenReaderChanged'
-    | 'reduceTransparencyChanged' // iOS-only Event
-    | 'announcementFinished'; // iOS-only Event
+    | 'reduceTransparencyChanged'; // iOS-only Event
 
 type AccessibilityChangeEvent = boolean;
 
-type AccessibilityAnnoucementFinishedEvent = {
+type AccessibilityChangeEventHandler = (event: AccessibilityChangeEvent) => void;
+
+type AccessibilityAnnouncementEventName =
+    | 'announcementFinished'; // iOS-only Event
+
+type AccessibilityAnnouncementFinishedEvent = {
     announcement: string;
     success: boolean;
 };
 
-type AccessibilityEvent = AccessibilityChangeEvent | AccessibilityAnnoucementFinishedEvent;
+type AccessibilityAnnouncementFinishedEventHandler = (event: AccessibilityAnnouncementFinishedEvent) => void;
 
 /**
  * @see https://facebook.github.io/react-native/docs/accessibilityinfo.html
@@ -6955,24 +6959,22 @@ export interface AccessibilityInfoStatic {
      *            The boolean is true when the related event's feature is enabled and false otherwise.
      *
      */
-    addEventListener: (eventName: AccessibilityEventName, handler: (event: AccessibilityEvent) => void) => void;
+    addEventListener(eventName: AccessibilityChangeEventName, handler: AccessibilityChangeEventHandler): void;
+    addEventListener(eventName: AccessibilityAnnouncementEventName, handler: AccessibilityAnnouncementFinishedEventHandler): void;
 
     /**
      * Remove an event handler.
      */
-    removeEventListener: (eventName: AccessibilityEventName, handler: (event: AccessibilityEvent) => void) => void;
+    removeEventListener(eventName: AccessibilityChangeEventName, handler: AccessibilityChangeEventHandler): void;
+    removeEventListener(eventName: AccessibilityAnnouncementEventName, handler: AccessibilityAnnouncementFinishedEventHandler): void;
 
     /**
-     * Set acessibility focus to a react component.
-     *
-     * @platform ios
+     * Set accessibility focus to a react component.
      */
     setAccessibilityFocus: (reactTag: number) => void;
 
     /**
      * Post a string to be announced by the screen reader.
-     *
-     * @platform ios
      */
     announceForAccessibility: (announcement: string) => void;
 }

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -886,6 +886,21 @@ const AccessibilityInfoFetchTest = AccessibilityInfo.fetch().then(isEnabled => {
     console.log(isEnabled);
 });
 
+AccessibilityInfo.isBoldTextEnabled().then(isEnabled => console.log(`AccessibilityInfo.isBoldTextEnabled => ${isEnabled}`));
+AccessibilityInfo.isGrayscaleEnabled().then(isEnabled => console.log(`AccessibilityInfo.isGrayscaleEnabled => ${isEnabled}`));
+AccessibilityInfo.isInvertColorsEnabled().then(isEnabled => console.log(`AccessibilityInfo.isInvertColorsEnabled => ${isEnabled}`));
+AccessibilityInfo.isReduceMotionEnabled().then(isEnabled => console.log(`AccessibilityInfo.isReduceMotionEnabled => ${isEnabled}`));
+AccessibilityInfo.isReduceTransparencyEnabled().then(isEnabled => console.log(`AccessibilityInfo.isReduceTransparencyEnabled => ${isEnabled}`));
+AccessibilityInfo.isScreenReaderEnabled().then(isEnabled => console.log(`AccessibilityInfo.isScreenReaderEnabled => ${isEnabled}`));
+
+AccessibilityInfo.addEventListener('announcementFinished', ({ announcement, success }) => console.log(`A11y Event: announcementFinished: ${announcement}, ${success}`))
+AccessibilityInfo.addEventListener('boldTextChanged', isEnabled => console.log(`AccessibilityInfo.isBoldTextEnabled => ${isEnabled}`))
+AccessibilityInfo.addEventListener('grayscaleChanged', isEnabled => console.log(`AccessibilityInfo.isGrayscaleEnabled => ${isEnabled}`));
+AccessibilityInfo.addEventListener('invertColorsChanged', isEnabled => console.log(`AccessibilityInfo.isInvertColorsEnabled => ${isEnabled}`));
+AccessibilityInfo.addEventListener('reduceMotionChanged', isEnabled => console.log(`AccessibilityInfo.isReduceMotionEnabled => ${isEnabled}`));
+AccessibilityInfo.addEventListener('reduceTransparencyChanged', isEnabled => console.log(`AccessibilityInfo.isReduceTransparencyEnabled => ${isEnabled}`));
+AccessibilityInfo.addEventListener('screenReaderChanged', isEnabled => console.log(`AccessibilityInfo.isScreenReaderEnabled => ${isEnabled}`));
+
 const KeyboardAvoidingViewTest = () => <KeyboardAvoidingView enabled />;
 
 const ModalTest = () => <Modal hardwareAccelerated />;


### PR DESCRIPTION
Updated a few typescript definitions for React Native's AccessibilityInfo API.
- removed `@platform ios` from `setAccessibilityFocus` and `announceForAccessibility`
- used function overloading for `addEventListener` and `removeEventListener` for better type safety across 'change' events and the 'announcedDidFinish' event.
- added tests

Checklist
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactnative.dev/docs/accessibilityinfo#__docusaurus
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)