### PR TITLE
[meteor] react-meteor-data: do not include container props in child component prop type.

### DIFF
--- a/types/meteor/index.d.ts
+++ b/types/meteor/index.d.ts
@@ -15,6 +15,7 @@
 //                 Nicusor Chiciuc <https://github.com/nicu-chiciuc>
 //                 Evan Broder <https://github.com/ebroder>
 //                 Radosław Miernik <https://github.com/radekmie>
+//                 Oliver Coleman <https://github.com/OliverColeman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.7
 

--- a/types/meteor/react-meteor-data.d.ts
+++ b/types/meteor/react-meteor-data.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 export function withTracker<TDataProps, TOwnProps>(
     options: (props: TOwnProps) => TDataProps | { getMeteorData: (props: TOwnProps) => TDataProps; pure?: boolean },
-): (reactComponent: React.ComponentType<TOwnProps & TDataProps>) => React.ComponentClass<TOwnProps>;
+): (reactComponent: React.ComponentType<TDataProps>) => React.ComponentClass<TOwnProps>;
 
 /**
  * Hooks (React 16.8 or later) version of tracker.

--- a/types/meteor/test/react-meteor-data-tests.tsx
+++ b/types/meteor/test/react-meteor-data-tests.tsx
@@ -10,7 +10,7 @@ interface DemoComponentData {
     result: string;
 }
 
-const DemoComponent: React.SFC<DemoComponentContainerProps & DemoComponentData> = props => <div>{props.data}</div>;
+const DemoComponent: React.SFC<DemoComponentData> = props => <div>{props.data}</div>;
 
 const DemoComponentContainer: React.ComponentClass<DemoComponentContainerProps> = withTracker<
     DemoComponentData,
@@ -25,7 +25,7 @@ const HooksDemoComponentContainer = (props: DemoComponentContainerProps) => {
         data: 'some data',
         result: 'success',
     }));
-    return <DemoComponent {...props} {...trackedProps} />;
+    return <DemoComponent {...trackedProps} />;
 };
 
 const RootComponent = () => (


### PR DESCRIPTION
See official documentation and example usage of `withTracker` and `useTracker`: https://guide.meteor.com/react.html#using-withTracker.
