### PR TITLE
Added definitons for react-notifications-component

### DIFF
--- a/types/react-notifications-component/index.d.ts
+++ b/types/react-notifications-component/index.d.ts
@@ -1,0 +1,56 @@
+// Type definitions for react-notifications-component 2.4
+// Project: https://www.npmjs.com/package/react-notifications-component
+// Definitions by: Sarhad Salam <https://github.com/SarhadSalam>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'react';
+
+export default class extends React.Component<ReactNotificationProps> {}
+
+export interface ReactNotificationProps {
+    isMobile?: boolean;
+    breakpoint?: number;
+    types?: string[];
+    className?: string;
+    id?: string;
+}
+
+export const store: {
+    addNotification: (options: ReactNotificationOptions) => string;
+    removeNotification: (id: string) => void;
+};
+
+export interface ReactNotificationOptions {
+    id?: string;
+    onRemoval?: (id: string, removedBy: any) => void;
+    title?: string | React.ReactNode | React.FunctionComponent;
+    message?: string | React.ReactNode | React.FunctionComponent;
+    content?: React.ComponentClass | React.FunctionComponent | React.ReactNode;
+    type?: 'success' | 'danger' | 'info' | 'default' | 'warning';
+    container: 'top-left' | 'top-right' | 'top-center' | 'center' | 'bottom-left' | 'bottom-right' | 'bottom-center';
+    insert?: 'top' | 'bottom';
+    dismiss?: DismissOptions;
+    animationIn?: string[];
+    animationOut?: string[];
+    slidingEnter?: TransitionOptions;
+    slidingExit?: TransitionOptions;
+    touchRevert?: TransitionOptions;
+    touchSlidingExit?: TransitionOptions;
+    width?: number;
+}
+
+export interface TransitionOptions {
+    duration?: number;
+    timingFunction?: 'ease' | 'linear' | 'ease-in' | 'ease-out' | 'ease-in-out' | 'step-start' | 'step-end';
+    delay?: number;
+}
+
+export interface DismissOptions {
+    duration?: number;
+    onScreen?: boolean;
+    pauseOnHover?: boolean;
+    waitForAnimation?: boolean;
+    click?: boolean;
+    touch?: boolean;
+    showIcon?: boolean;
+}

--- a/types/react-notifications-component/index.d.ts
+++ b/types/react-notifications-component/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for react-notifications-component 2.4
-// Project: https://www.npmjs.com/package/react-notifications-component
+// Project: https://github.com/teodosii/react-notifications-component
 // Definitions by: Sarhad Salam <https://github.com/SarhadSalam>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/react-notifications-component/react-notifications-component-tests.tsx
+++ b/types/react-notifications-component/react-notifications-component-tests.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import ReactNotification, { store } from 'react-notifications-component';
+
+const SampleNotification = () => {
+    store.addNotification({
+        title: 'Wonderful!',
+        message: 'Configurable',
+        type: 'success',
+        insert: 'top',
+        container: 'top-right',
+        animationIn: ['animated', 'fadeIn'],
+        animationOut: ['animated', 'fadeOut'],
+    });
+};
+
+const WrongSampleNotification = () => {
+    store.addNotification({
+        // $ExpectError
+        somethingRandom: 'Wonderful!',
+        animationOut: ['animated', 'fadeOut'],
+    });
+};
+
+const ComponentTest: React.SFC = () => {
+    return (
+        <div>
+            <ReactNotification />
+        </div>
+    );
+};
+
+const WrongPropTest: React.SFC = () => {
+    // $ExpectError
+    return <ReactNotification randomProp={false} />;
+};

--- a/types/react-notifications-component/tsconfig.json
+++ b/types/react-notifications-component/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "jsx": "react",
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-notifications-component-tests.tsx"
+    ]
+}

--- a/types/react-notifications-component/tslint.json
+++ b/types/react-notifications-component/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
