### PR TITLE
Clarification of parameter in sinon's getCall method

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -309,7 +309,7 @@ declare namespace Sinon {
         /**
          * Returns the nth call.
          * Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
-         * @param n
+         * @param n Index of the spy call. This is zero based, so use three if you want the fourth call.
          */
         getCall(n: number): SinonSpyCall;
         /**

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -309,7 +309,7 @@ declare namespace Sinon {
         /**
          * Returns the nth call.
          * Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
-         * @param n Index of the spy call. This is zero based, so use three if you want the fourth call.
+         * @param n Zero based index of the spy call.
          */
         getCall(n: number): SinonSpyCall;
         /**

--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -307,7 +307,7 @@ declare namespace Sinon {
         /**
          * Returns the nth call.
          * Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
-         * @param n Index of the spy call. This is zero based, so use three if you want the fourth call.
+         * @param n Zero based index of the spy call.
          */
         getCall(n: number): SinonSpyCall<TArgs, TReturnValue>;
         /**

--- a/types/sinon/ts3.1/index.d.ts
+++ b/types/sinon/ts3.1/index.d.ts
@@ -307,7 +307,7 @@ declare namespace Sinon {
         /**
          * Returns the nth call.
          * Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
-         * @param n
+         * @param n Index of the spy call. This is zero based, so use three if you want the fourth call.
          */
         getCall(n: number): SinonSpyCall<TArgs, TReturnValue>;
         /**


### PR DESCRIPTION
Only changed a documenting comment. No semantic or function changes.