### PR TITLE
[@types/webpack] add support for entry descriptor

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -162,8 +162,14 @@ declare namespace webpack {
         args: CliConfigOptions,
     ) => Configuration[] | Promise<Configuration[]>);
 
+    interface EntryDescriptor {
+        import: string | string[];
+        dependOn?: string | string[];
+        filename?: string;
+    }
+
     interface Entry {
-        [name: string]: string | string[];
+        [name: string]: string | string[] | EntryDescriptor;
     }
 
     type EntryFunc = () => (string | string[] | Entry | Promise<string | string[] | Entry>);

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -44,6 +44,57 @@ rule = {
 };
 
 //
+// https://webpack.js.org/configuration/entry-context/#entry-descriptor
+//
+
+configuration = {
+    entry: {
+        home: './home.js',
+        shared: ['react', 'react-dom', 'redux', 'react-redux'],
+        catalog: {
+            import: './catalog.js',
+            filename: 'pages/catalog.js',
+            dependOn: 'shared'
+        },
+        personal: {
+            import: './personal.js',
+            filename: 'pages/personal.js',
+            dependOn: 'shared'
+        }
+    }
+};
+
+//
+// https://webpack.js.org/configuration/entry-context/#output-filename
+//
+
+configuration = {
+    entry: {
+        app: './app.js',
+        home: { import: './contact.js', filename: 'pages/[name][ext]' },
+        about: { import: './about.js', filename: 'pages/[name][ext]' }
+    }
+};
+
+//
+// https://webpack.js.org/configuration/entry-context/#dependencies
+//
+
+configuration = {
+    entry: {
+        app: { import: './app.js', dependOn: 'react-vendors' },
+        'react-vendors': ['react', 'react-dom', 'prop-types']
+    }
+};
+
+configuration = {
+    entry: {
+        app: { import: ['./app.js', './app2.js'], dependOn: 'react-vendors' },
+        'react-vendors': ['react', 'react-dom', 'prop-types']
+    }
+};
+
+//
 // https://webpack.js.org/configuration/entry-context/#dynamic-entry
 //
 


### PR DESCRIPTION
https://webpack.js.org/configuration/entry-context/#entry-descriptor

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/configuration/entry-context/#entry-descriptor
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

