### PR TITLE
Rebass: add missed flexbox props to FlexProps

### DIFF
--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -7,6 +7,7 @@
 //                 angusfretwell <https://github.com/angusfretwell>
 //                 orzarchi <https://github.com/orzarchi>
 //                 ilaiwi <https://github.com/ilaiwi>
+//                 mrkosima <https://github.com/mrkosima>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
@@ -72,10 +73,16 @@ export const Card: React.FunctionComponent<BoxKnownProps>;
 
 interface FlexKnownProps
     extends BoxKnownProps,
+        StyledSystem.FlexGrowProps,
+        StyledSystem.FlexShrinkProps,
         StyledSystem.FlexWrapProps,
         StyledSystem.FlexDirectionProps,
         StyledSystem.AlignItemsProps,
-        StyledSystem.JustifyContentProps {}
+        StyledSystem.AlignContentProps,
+        StyledSystem.AlignSelfProps,
+        StyledSystem.JustifyItemsProps,
+        StyledSystem.JustifyContentProps,
+        StyledSystem.JustifySelfProps {}
 export interface FlexProps extends FlexKnownProps, Omit<React.HTMLProps<HTMLDivElement>, keyof FlexKnownProps> {}
 export const Flex: React.FunctionComponent<FlexProps>;
 

--- a/types/rebass/rebass-tests.tsx
+++ b/types/rebass/rebass-tests.tsx
@@ -31,7 +31,17 @@ const VariantBox = () => <Box tx="specialBoxes" />;
 
 export default () => (
     <Box width={1} css={{ height: '100vh' }} py={[1, 2, 3]} ml="1em" display="block">
-        <Flex width={1} alignItems="center" justifyContent="center">
+        <Flex
+            width={1}
+            flexGrow={1}
+            flexShrink={0}
+            alignItems="center"
+            alignContent="start"
+            alignSelf="stretch"
+            justifyItems="center"
+            justifyContent="start"
+            justifySelf="stretch"
+            >
             <Heading fontSize={5} fontWeight="bold">
                 Hi, I'm a heading.
             </Heading>


### PR DESCRIPTION
flexbox props added to `FlexProps`

- FlexGrowProps
- FlexShrinkProps
- AlignContentProps,
- AlignSelfProps,
- JustifyItemsProps,
- JustifyContentProps,
- JustifySelfProps

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
