### PR TITLE
[mongoose]: fix regression with document constructor in queries

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -3477,8 +3477,6 @@ declare module "mongoose" {
 
   class Document {}
   interface Document extends MongooseDocument, NodeJS.EventEmitter, ModelProperties {
-    constructor: Model<this>;
-
     /** Signal that we desire an increment of this documents version. */
     increment(): this;
 

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -227,22 +227,22 @@ MongoModel.update({ age: { $gt: 18 } }, { oldEnough: true }, cb);
 MongoModel.update({ name: 'Tobi' }, { ferret: true }, { multi: true,  arrayFilters: [{ element: { $gte: 100 } }] }, cb);
 MongoModel.where('age').gte(21).lte(65).exec(cb);
 MongoModel.where('age').gte(21).lte(65).where('name', /^b/i);
-new (mongoModel.constructor.base.model(''))();
+new (MongoModel.base.model(''))();
 // $ExpectError
 mongoModel.baseModelName;
-mongoModel.constructor.baseModelName && mongoModel.constructor.baseModelName.toLowerCase();
+MongoModel.baseModelName && MongoModel.baseModelName.toLowerCase();
 mongoModel.collection.$format(99);
 mongoModel.collection.initializeOrderedBulkOp;
 mongoModel.collection.findOne;
 mongoModel.db.openUri('');
 // $ExpectError
 mongoModel.discriminators;
-mongoModel.constructor.discriminators;
+MongoModel.discriminators;
 // $ExpectError
 mongoModel.modelName;
-mongoModel.constructor.modelName;
-mongoModel.constructor.modelName.toLowerCase();
-MongoModel = mongoModel.constructor.base.model('new', mongoModel.schema);
+MongoModel.modelName;
+MongoModel.modelName.toLowerCase();
+MongoModel = MongoModel.base.model('new', mongoModel.schema);
 
 /* model inherited properties */
 MongoModel.collection;
@@ -270,6 +270,10 @@ MongoModel.find({
 .exec();
 
 /* practical example */
+interface Note extends mongoose.Document {
+    text: string
+}
+const noteSchema = new mongoose.Schema({ text: String })
 
 interface Location extends mongoose.Document {
   _id: mongodb.ObjectId;
@@ -280,6 +284,7 @@ interface Location extends mongoose.Document {
   coords: number[];
   openingTimes: any[];
   reviews: any[];
+  notes: Note[]
 };
 const locationSchema = new mongoose.Schema({
   name: { type: String, required: true },
@@ -288,7 +293,8 @@ const locationSchema = new mongoose.Schema({
   facilities: [String],
   coords: { type: [Number], index: "2dsphere" },
   openingTimes: [mongoose.Schema.Types.Mixed],
-  reviews: [mongoose.SchemaTypes.Mixed]
+  reviews: [mongoose.SchemaTypes.Mixed],
+  notes: [noteSchema]
 });
 
 var locDocument = <Location>{};
@@ -482,3 +488,10 @@ LocModel.updateMany({ name: 'foo' }, { name: 123 });
 LocModel.updateMany({ name: 'foo' }, { $pull: { facilities: 123 } });
 // $ExpectError
 LocModel.updateMany({ name: 'foo' }, { $push: { coords: 'bar' } });
+
+LocModel.findByIdAndUpdate('someId',
+  { $pull: { notes: { _id: ['someId'] } } }
+);
+LocModel.findByIdAndUpdate('someId',
+  { $pull: { notes: { _id: { $in: ['someId', 'someId'] } } } }
+)


### PR DESCRIPTION
I must revert part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44455

because of a regression in queries with subschemas: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44455#issuecomment-627515185

I couldn't find a way to adress this issue, since it touches mongodb own type definition, so I simply removed the faulty line and add tests to prevent future regressions.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44455#issuecomment-627515185
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
