### PR TITLE
[node] Add missing properties to ChildProcess on Node v13

### DIFF
--- a/types/node/v13/child_process.d.ts
+++ b/types/node/v13/child_process.d.ts
@@ -21,6 +21,10 @@ declare module "child_process" {
         readonly killed: boolean;
         readonly pid: number;
         readonly connected: boolean;
+        readonly exitCode: number | null;
+        readonly signalCode: number | null;
+        readonly spawnargs: string[];
+        readonly spawnfile: string;
         kill(signal?: NodeJS.Signals | number): boolean;
         send(message: Serializable, callback?: (error: Error | null) => void): boolean;
         send(message: Serializable, sendHandle?: SendHandle, callback?: (error: Error | null) => void): boolean;

--- a/types/node/v13/test/child_process.ts
+++ b/types/node/v13/test/child_process.ts
@@ -70,6 +70,9 @@ async function testPromisify() {
     const _socket: net.Socket = net.createConnection(1);
     const _server: net.Server = net.createServer();
     let _boolean: boolean;
+    let _string: string;
+    let _stringArray: string[];
+    let _maybeNumber: number | null;
 
     _boolean = cp.send(1);
     _boolean = cp.send('one');
@@ -281,6 +284,17 @@ async function testPromisify() {
         const _message: any = message;
         const _sendHandle: net.Socket | net.Server = sendHandle;
     });
+
+    _boolean = cp.kill();
+    _boolean = cp.kill(9);
+    _boolean = cp.kill("SIGTERM");
+
+    _maybeNumber = cp.exitCode;
+    _maybeNumber = cp.signalCode;
+
+    _string = cp.spawnfile;
+
+    _stringArray = cp.spawnargs;
 
     function expectNonNull(cp: {
         readonly stdin: Writable;


### PR DESCRIPTION
Pull request #44307 already added these missing properties for Node v12 and v14, but #44097, which added v13, was merged afterwards.

<hr>

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v13.x/api/child_process.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.