### PR TITLE
prosemirror-keymap: set type for handler functions

### DIFF
--- a/types/prosemirror-keymap/index.d.ts
+++ b/types/prosemirror-keymap/index.d.ts
@@ -4,10 +4,12 @@
 //                 David Hahn <https://github.com/davidka>
 //                 Tim Baumann <https://github.com/timjb>
 //                 Patrick Simmelbauer <https://github.com/patsimm>
+//                 Mike Morearty <https://github.com/mmorearty>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
-import { Plugin } from 'prosemirror-state';
+import { Schema } from 'prosemirror-model';
+import { EditorState, Plugin, Transaction } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 
 /**
@@ -41,12 +43,23 @@ import { EditorView } from 'prosemirror-view';
  * which they appear determines their precedence (the ones early in
  * the array get to dispatch first).
  */
-export function keymap(bindings: { [key: string]: any }): Plugin;
+export function keymap<S extends Schema = any>(bindings: {
+  [key: string]: (
+    state: EditorState<S>,
+    dispatch: (tr: Transaction<S>) => void,
+    view: EditorView<S>
+  ) => boolean;
+}): Plugin;
+
 /**
  * Given a set of bindings (using the same format as
  * [`keymap`](#keymap.keymap), return a [keydown
  * handler](#view.EditorProps.handleKeyDown) handles them.
  */
-export function keydownHandler(bindings: {
-  [key: string]: any;
-}): (view: EditorView, event: Event) => boolean;
+export function keydownHandler<S extends Schema = any>(bindings: {
+  [key: string]: (
+      state: EditorState<S>,
+      dispatch: (tr: Transaction<S>) => void,
+      view: EditorView<S>
+    ) => boolean;
+}): (view: EditorView, event: KeyboardEvent) => boolean;

--- a/types/prosemirror-keymap/prosemirror-keymap-tests.ts
+++ b/types/prosemirror-keymap/prosemirror-keymap-tests.ts
@@ -1,3 +1,25 @@
 import * as keymap from 'prosemirror-keymap';
+import { Plugin } from 'prosemirror-state';
 
-keymap.keymap({});
+const plugin1: Plugin = keymap.keymap({
+    // Test that the argument types are correctly inferred
+    Enter: (state, dispatch, view) => {
+        dispatch(state.tr.insertText("hello"));
+        return true;
+    },
+});
+
+const plugin2 = new Plugin({
+    props: {
+        handleKeyDown: keymap.keydownHandler({
+            // Test that the argument types are correctly inferred
+            Enter: (state, dispatch, view) => {
+                dispatch(state.tr.insertText("hello"));
+                return true;
+            }
+        }),
+    },
+});
+
+// Handlers must return a boolean
+keymap.keydownHandler({ Enter: () => {} }); // $ExpectError


### PR DESCRIPTION
Handler functions were previously defined as `any`. This changes them to match the requirements, as specified in the [documentation](https://prosemirror.net/docs/ref/#keymap) and the [source code](https://github.com/ProseMirror/prosemirror-keymap/blob/master/src/keymap.js)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://prosemirror.net/docs/ref/#keymap> and <https://github.com/ProseMirror/prosemirror-keymap/blob/master/src/keymap.js>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
