### PR TITLE
[react-dnd-multi-backend] Fixes and updates for version 6+

### DIFF
--- a/types/react-dnd-multi-backend/index.d.ts
+++ b/types/react-dnd-multi-backend/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-dnd-multi-backend 5.0
+// Type definitions for react-dnd-multi-backend 6.0
 // Project: https://github.com/LouisBrunner/react-dnd-multi-backend, https://louisbrunner.github.io/dnd-multi-backend/packages/react-dnd-multi-backend
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 //                 Adam Haglund <https://github.com/beeequeue>
@@ -6,7 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { CSSProperties, PureComponent } from "react";
+import { CSSProperties, FC, PureComponent } from "react";
 import { BackendFactory } from "dnd-core";
 
 /**
@@ -135,6 +135,15 @@ export const TouchTransition: Transition;
  * Pre-existing/default react-dnd-html5-backend transition available to use.
  */
 export const HTML5DragTransition: Transition;
+
+/**
+ * Multi-backend customized DndProvider implementation
+ */
+export const DndProvider: FC<{
+    context?: any;
+    debugMode?: boolean;
+    options: Backends;
+}>;
 
 /**
  * Primary BackendFactory for react-dnd-multi-backend.

--- a/types/react-dnd-multi-backend/index.d.ts
+++ b/types/react-dnd-multi-backend/index.d.ts
@@ -6,7 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { CSSProperties, FC, PureComponent } from "react";
+import { CSSProperties, FC, PureComponent, ReactNode } from "react";
 import { BackendFactory } from "dnd-core";
 
 /**
@@ -99,7 +99,7 @@ export interface PreviewGeneratorArg<T = any> {
     style: CSSProperties;
 }
 
-export type PreviewGenerator<T = any> = (arg: PreviewGeneratorArg<T>) => JSX.Element;
+export type PreviewGenerator<T = any> = (arg: PreviewGeneratorArg<T>) => ReactNode;
 
 /**
  * Properties for the Preview class

--- a/types/react-dnd-multi-backend/index.d.ts
+++ b/types/react-dnd-multi-backend/index.d.ts
@@ -81,20 +81,40 @@ export interface Backends {
     backends: BackendDeclaration[];
 }
 
+export interface PreviewGeneratorArg<T = any> {
+    /**
+     * The type of the item (monitor.getItemType())
+     */
+    itemType: string;
+
+    /**
+     * The item being dragged (monitor.getItem())
+     */
+    item: T;
+
+    /**
+     * An object representing the style to use for the item, it should be passed to
+     * your component's style property and is used for positioning
+     */
+    style: CSSProperties;
+}
+
+export type PreviewGenerator<T = any> = (arg: PreviewGeneratorArg<T>) => JSX.Element;
+
 /**
  * Properties for the Preview class
  */
-export interface PreviewProps {
+export interface PreviewProps<T = any> {
     /**
      * Callback function to generate a preview object when dragging. This preview will only be used
      * with backends that have the 'preview' flag set to true.
-     * @param type: the type of the item (monitor.getItemType())
-     * @param item: the item being dragged (monitor.getItem())
-     * @param style: an object representing the style to use for the item, it should be passed to
+     * @param arg.itemType: the type of the item (monitor.getItemType())
+     * @param arg.item: the item being dragged (monitor.getItem())
+     * @param arg.style: an object representing the style to use for the item, it should be passed to
      *               your component's style property and is used for positioning.
      * @returns The JSX element to display for the drag preview.
      */
-    generator(type: string, item: any, style: CSSProperties): JSX.Element;
+    generator: PreviewGenerator<T>;
 }
 
 /**

--- a/types/react-dnd-multi-backend/react-dnd-multi-backend-tests.tsx
+++ b/types/react-dnd-multi-backend/react-dnd-multi-backend-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DndProvider } from 'react-dnd';
-import MultiBackend, { createTransition, TouchTransition, Backends, Preview } from 'react-dnd-multi-backend';
+import MultiBackend, { createTransition, TouchTransition, Backends, Preview, PreviewGenerator } from 'react-dnd-multi-backend';
 import HTML5ToTouchEsm from 'react-dnd-multi-backend/dist/esm/HTML5toTouch';
 import HTML5ToTouchCjs from 'react-dnd-multi-backend/dist/cjs/HTML5toTouch';
 import TouchBackend from 'react-dnd-touch-backend';
@@ -49,8 +49,8 @@ const multiCustomBackendsComponent = (
  * Testing the Preview component.
  */
 class App extends React.Component {
-    generator = (type: string, item: any, style: React.CSSProperties) =>
-        (type === 'card')
+    generator: PreviewGenerator = ({item, itemType, style}) =>
+        (itemType === 'card')
             ? <div style={style}>{item.label}</div>
             : <div />
 


### PR DESCRIPTION
* Adjust type of preview generator to allow returning "anything react can render" rather than limiting it to a JSX.Element; see https://www.npmjs.com/package/react-dnd-preview#usage--example
* Apply changes to the ts definitions to match changes to the library; see https://github.com/LouisBrunner/dnd-multi-backend/tree/master/packages/react-dnd-multi-backend#migrating-from-4xx

#### Migrating from 4.x.x

Starting with 5.0.0, react-dnd-preview (which provides the Preview component) will start passing its arguments packed in one argument, an object {itemType, item, style}, instead of 3 different arguments (itemType, item and style). This means that will need to change your generator function to receive arguments correctly.

#### Migrating from 5.0.x

Starting with 5.1.0, react-dnd-multi-backend will export a new DndProvider which you can use instead of the one from react-dnd. You don't need to pass the backend prop to that component as it's implied you are using MultiBackend, however the major benefits is under the hood: