### PR TITLE
[@types/react-big-calendar] Add custom day layout algorithm functions.

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -16,6 +16,7 @@
 //                 Paito Anderson <https://github.com/PaitoAnderson>
 //                 Jan Michalak <https://github.com/michalak111>
 //                 Felix Hessenberger <https://github.com/fhessenberger>
+//                 Tom Price <https://github.com/tomtom5152>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import { Validator } from 'prop-types';
@@ -35,6 +36,12 @@ export type ViewsProps = View[] | {
     month?: boolean | React.ComponentType<any> & ViewStatic,
     week?: boolean | React.ComponentType<any> & ViewStatic
 };
+export type DayLayoutFunction<TEvent extends object = Event> = (_: {
+    events: TEvent[],
+    minimumStartDifference: number,
+    slotMetrics: any,
+    accessors: any,
+}) => Array<{ event: TEvent, style: React.CSSProperties }>;
 export type DayLayoutAlgorithm = 'overlap' | 'no-overlap';
 export type NavigateAction = 'PREV' | 'NEXT' | 'TODAY' | 'DATE';
 export interface Event {
@@ -297,7 +304,7 @@ export interface CalendarProps<TEvent extends object = Event, TResource extends 
     formats?: Formats;
     components?: Components<TEvent>;
     messages?: Messages;
-    dayLayoutAlgorithm?: DayLayoutAlgorithm;
+    dayLayoutAlgorithm?: DayLayoutAlgorithm | DayLayoutFunction<TEvent>;
     titleAccessor?: keyof TEvent | ((event: TEvent) => string);
     tooltipAccessor?: keyof TEvent | ((event: TEvent) => string);
     allDayAccessor?: keyof TEvent | ((event: TEvent) => boolean);

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -17,8 +17,8 @@ import {
     EventProps,
     EventWrapperProps,
     NavigateAction,
-    Culture
-} from "react-big-calendar";
+    Culture, DayLayoutAlgorithm, DayLayoutFunction,
+} from 'react-big-calendar';
 import withDragAndDrop from "react-big-calendar/lib/addons/dragAndDrop";
 
 // Don't want to add this as a dependency, because it is only used for tests.
@@ -198,7 +198,7 @@ class CalendarResource {
                         const end = slotInfo.end;
                         return true;
                     }}
-                    dayLayoutAlgorithm="overlap"
+                    dayLayoutAlgorithm={customLayoutAlgorithm}
                     views={['day']}
                     toolbar={true}
                     popup={true}
@@ -332,6 +332,18 @@ const customGroupSlotPropGetter = () => {
     return {
         className: 'slot-group'
     };
+};
+
+const customLayoutAlgorithm: DayLayoutFunction<CalendarEvent> = (args: {
+    events: CalendarEvent[],
+    minimumStartDifference: any,
+    slotMetrics: any,
+    accessors: any,
+}) => {
+    // This is where the events would get styled in an actual algorithm, but for TS test we just want to confirm it returns
+    return args.events.map(e => {
+        return { event: e, style: {} };
+    });
 };
 
 function Event(props: EventProps<CalendarEvent>) {

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import {
     Calendar,
     CalendarProps,
@@ -19,7 +19,7 @@ import {
     NavigateAction,
     Culture, DayLayoutAlgorithm, DayLayoutFunction,
 } from 'react-big-calendar';
-import withDragAndDrop from "react-big-calendar/lib/addons/dragAndDrop";
+import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
 
 // Don't want to add this as a dependency, because it is only used for tests.
 declare const globalize: any;


### PR DESCRIPTION
react-big-calendar allows the user to change the layout algorithm using the `dayLayoutAlgorithm` prop. This currently is required to be one of the inbuilt algorithms reference by a name string. Implementers may choose to provide their own function matching the signature of the exiting algorithms.

This change adds the function type definition using a generic, and allows a function of that type to be used in place of a named algorithm. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [existing function definition](https://github.com/jquense/react-big-calendar/blob/v0.24.6/src/utils/layout-algorithms/overlap.js#L131), [usage showing function allowed](https://github.com/jquense/react-big-calendar/blob/v0.24.6/src/utils/DayEventLayout.js#L16)
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

