### PR TITLE
benchmark: switch to using Stats and Times interfaces.

### DIFF
--- a/types/benchmark/benchmark-tests.ts
+++ b/types/benchmark/benchmark-tests.ts
@@ -214,7 +214,7 @@ bench.on('cycle', (event: Benchmark.Event) => {
   target.stats.deviation;
   target.stats.mean;
   target.stats.sample;
-  target.stats.variances;
+  target.stats.variance;
   target.times;
   target.times.cycle;
   target.times.elapsed;

--- a/types/benchmark/index.d.ts
+++ b/types/benchmark/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://benchmarkjs.com
 // Definitions by: Asana <https://asana.com>
 //                 Charlie Fish <https://github.com/fishcharlie>
+//                 Blair Zajac <https://github.com/blair>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
@@ -149,21 +150,8 @@ declare namespace Benchmark {
         name?: string;
         fn?: Function;
         id: number;
-        stats?: {
-            moe?: number;
-            rme?: number;
-            sem?: number;
-            deviation?: number;
-            mean?: number;
-            sample?: any[];
-            variances?: number;
-        };
-        times?: {
-            cycle?: number;
-            elapsed?: number;
-            period?: number;
-            timeStamp?: number;
-        };
+        stats?: Stats;
+        times?: Times;
         running: boolean;
         count?: number;
         compiled?: Function;


### PR DESCRIPTION
This also fixes an issue with the previous `variances` property which
doesn't exist in the benchmark module source code.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
