### PR TITLE
Updates to forge-apis type definitions

### DIFF
--- a/types/forge-apis/forge-apis-tests.ts
+++ b/types/forge-apis/forge-apis-tests.ts
@@ -42,9 +42,7 @@ authClientThreeLegged.generateAuthUrl('');
 // $ExpectType Promise<AuthToken>
 authClientThreeLegged.getToken('');
 // $ExpectType Promise<AuthToken>
-authClientThreeLegged.refreshToken({
-    refresh_token: ''
-});
+authClientThreeLegged.refreshToken(authToken);
 
 // $ExpectType ActivitiesApi
 const activitiesApi = new ActivitiesApi();

--- a/types/forge-apis/forge-apis-tests.ts
+++ b/types/forge-apis/forge-apis-tests.ts
@@ -38,11 +38,13 @@ authClientTwoLegged.isAuthorized();
 // $ExpectType AuthClientThreeLegged
 const authClientThreeLegged = new AuthClientThreeLegged('', '', '', [], true);
 // $ExpectType string
-authClientThreeLegged.generateAuthUrl();
+authClientThreeLegged.generateAuthUrl('');
 // $ExpectType Promise<AuthToken>
 authClientThreeLegged.getToken('');
 // $ExpectType Promise<AuthToken>
-authClientThreeLegged.refreshToken(authToken);
+authClientThreeLegged.refreshToken({
+    refresh_token: ''
+});
 
 // $ExpectType ActivitiesApi
 const activitiesApi = new ActivitiesApi();

--- a/types/forge-apis/index.d.ts
+++ b/types/forge-apis/index.d.ts
@@ -88,7 +88,7 @@ export class AuthClientThreeLegged {
 
     generateAuthUrl(state: string): string;
     getToken(code: string): Promise<AuthToken>;
-    refreshToken(credentials: AuthToken): Promise<AuthToken>;
+    refreshToken({ refresh_token: any }): Promise<AuthToken>;
 }
 
 export type AuthClient = AuthClientTwoLegged | AuthClientThreeLegged;

--- a/types/forge-apis/index.d.ts
+++ b/types/forge-apis/index.d.ts
@@ -88,7 +88,7 @@ export class AuthClientThreeLegged {
 
     generateAuthUrl(state: string): string;
     getToken(code: string): Promise<AuthToken>;
-    refreshToken({ refresh_token: any }): Promise<AuthToken>;
+    refreshToken(credentials: { refresh_token?: string }, scope?: Scope[]): Promise<AuthToken>;
 }
 
 export type AuthClient = AuthClientTwoLegged | AuthClientThreeLegged;

--- a/types/forge-apis/index.d.ts
+++ b/types/forge-apis/index.d.ts
@@ -86,7 +86,7 @@ export class AuthClientTwoLegged {
 export class AuthClientThreeLegged {
     constructor(clientId: string, clientSecret: string, redirectUri: string, scopes: Scope[], autoRefresh: boolean);
 
-    generateAuthUrl(): string;
+    generateAuthUrl(state: string): string;
     getToken(code: string): Promise<AuthToken>;
     refreshToken(credentials: AuthToken): Promise<AuthToken>;
 }


### PR DESCRIPTION
- added missing state parameter to generateAuthUrl method
- refreshToken method doesn't require full credentials, only refresh_token is needed