### PR TITLE
[react-native] Remove accessibilityStates

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -2066,11 +2066,6 @@ export interface AccessibilityProps extends AccessibilityPropsAndroid, Accessibi
     accessibilityRole?: AccessibilityRole;
     /**
      * Accessibility State tells a person using either VoiceOver on iOS or TalkBack on Android the state of the element currently focused on.
-     * @deprecated: accessibilityState available in 0.60+
-     */
-    accessibilityStates?: AccessibilityStates[];
-    /**
-     * Accessibility State tells a person using either VoiceOver on iOS or TalkBack on Android the state of the element currently focused on.
      */
     accessibilityState?: AccessibilityState;
     /**
@@ -2100,11 +2095,11 @@ export type AccessibilityActionName =
      */
     | 'activate'
     /**
-     * Gererated when a screen reader user increments an adjustable component.
+     * Generated when a screen reader user increments an adjustable component.
      */
     | 'increment'
     /**
-     * Gererated when a screen reader user decrements an adjustable component.
+     * Generated when a screen reader user decrements an adjustable component.
      */
     | 'decrement'
     /**
@@ -2128,17 +2123,6 @@ export type AccessibilityActionEvent = NativeSyntheticEvent<
         actionName: string;
     }>
 >;
-
-// @deprecated: use AccessibilityState available in 0.60+
-export type AccessibilityStates =
-    | 'disabled'
-    | 'selected'
-    | 'checked'
-    | 'unchecked'
-    | 'busy'
-    | 'expanded'
-    | 'collapsed'
-    | 'hasPopup';
 
 export interface AccessibilityState {
     /**

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -866,7 +866,6 @@ class AccessibilityTest extends React.Component {
                 accessibilityTraits={'none'}
                 onAccessibilityTap={() => {}}
                 accessibilityRole="header"
-                accessibilityStates={['selected']}
                 accessibilityState={{ checked: true }}
                 accessibilityHint="Very importent header"
                 accessibilityValue={{ min: 60, max: 120, now: 80 }}
@@ -1095,10 +1094,10 @@ const VirtualizedListTest = () => {
     const DATA = [1, 2, 3];
 
     const getItem = (data: number[], index: number) => {
-        return  {
-            title: `Item ${data[index]}`
+        return {
+            title: `Item ${data[index]}`,
         };
-    }
+    };
 
     const getItemCount = (data: number[]) => data.length;
 
@@ -1111,7 +1110,7 @@ const VirtualizedListTest = () => {
             getItem={getItem}
         />
     );
-}
+};
 
 // DevSettings
 DevSettings.addMenuItem('alert', () => {


### PR DESCRIPTION
This was removed in v0.62:
https://github.com/facebook/react-native/commit/7b35f427fd66cb0f36921b992095fe5b3c14d8b9

cc @nickgerleman