### PR TITLE
Add new `react-transition-group` prop: `nodeRef`

### DIFF
--- a/types/react-transition-group/CSSTransition.d.ts
+++ b/types/react-transition-group/CSSTransition.d.ts
@@ -13,7 +13,7 @@ export interface CSSTransitionClassNames {
     exitDone?: string;
 }
 
-export type CSSTransitionProps = TransitionProps & {
+export type CSSTransitionProps<Ref extends undefined | HTMLElement = undefined> = TransitionProps<Ref> & {
     /**
      * The animation `classNames` applied to the component as it enters or exits.
      * A single name can be provided and it will be suffixed for each stage: e.g.
@@ -40,6 +40,6 @@ export type CSSTransitionProps = TransitionProps & {
     classNames?: string | CSSTransitionClassNames;
 };
 
-declare class CSSTransition extends Component<CSSTransitionProps> {}
+declare class CSSTransition<Ref extends undefined | HTMLElement> extends Component<CSSTransitionProps<Ref>> {}
 
 export default CSSTransition;

--- a/types/react-transition-group/Transition.d.ts
+++ b/types/react-transition-group/Transition.d.ts
@@ -1,8 +1,27 @@
-import { Component, ReactNode } from "react";
+import { Component, ReactNode } from 'react';
 
-export type EndHandler = (node: HTMLElement, done: () => void) => void;
-export type EnterHandler = (node: HTMLElement, isAppearing: boolean) => void;
-export type ExitHandler = (node: HTMLElement) => void;
+type RefHandler<
+    RefElement extends undefined | HTMLElement,
+    ImplicitRefHandler extends (node: HTMLElement, ...args: any[]) => void,
+    ExplicitRefHandler extends (...args: any[]) => void
+> = {
+    implicit: ImplicitRefHandler;
+    explicit: ExplicitRefHandler;
+}[RefElement extends undefined ? 'implicit' : 'explicit'];
+
+export type EndHandler<RefElement extends undefined | HTMLElement> = RefHandler<
+    RefElement,
+    (node: HTMLElement, done: () => void) => void,
+    (done: () => void) => void
+>;
+
+export type EnterHandler<RefElement extends undefined | HTMLElement> = RefHandler<
+    RefElement,
+    (node: HTMLElement, isAppearing: boolean) => void,
+    (isAppearing: boolean) => void
+>;
+
+export type ExitHandler<E extends undefined | HTMLElement> = RefHandler<E, (node: HTMLElement) => void, () => void>;
 
 export const UNMOUNTED = 'unmounted';
 export const EXITED = 'exited';
@@ -31,7 +50,7 @@ export interface TransitionActions {
     exit?: boolean;
 }
 
-interface BaseTransitionProps {
+interface BaseTransitionProps<RefElement extends undefined | HTMLElement> {
     /**
      * Show the component; triggers the enter or exit states
      */
@@ -58,36 +77,36 @@ interface BaseTransitionProps {
      * parameter `isAppearing` is supplied to indicate if the enter stage is
      * occurring on the initial mount
      */
-    onEnter?: EnterHandler;
+    onEnter?: EnterHandler<RefElement>;
 
     /**
      * Callback fired after the "entering" status is applied. An extra parameter
      * isAppearing is supplied to indicate if the enter stage is occurring on
      * the initial mount
      */
-    onEntering?: EnterHandler;
+    onEntering?: EnterHandler<RefElement>;
 
     /**
      * Callback fired after the "entered" status is applied. An extra parameter
      * isAppearing is supplied to indicate if the enter stage is occurring on
      * the initial mount
      */
-    onEntered?: EnterHandler;
+    onEntered?: EnterHandler<RefElement>;
 
     /**
      * Callback fired before the "exiting" status is applied.
      */
-    onExit?: ExitHandler;
+    onExit?: ExitHandler<RefElement>;
 
     /**
      * Callback fired after the "exiting" status is applied.
      */
-    onExiting?: ExitHandler;
+    onExiting?: ExitHandler<RefElement>;
 
     /**
      * Callback fired after the "exited" status is applied.
      */
-    onExited?: ExitHandler;
+    onExited?: ExitHandler<RefElement>;
 
     /**
      * A function child can be used instead of a React element. This function is
@@ -103,18 +122,22 @@ interface BaseTransitionProps {
      * ```
      */
     children?: TransitionChildren;
-    [ prop: string ]: any;
+
+    /**
+     * A React reference to DOM element that need to transition: https://stackoverflow.com/a/51127130/4671932
+     * When `nodeRef` prop is used, node is not passed to callback functions (e.g. onEnter) because user already has direct access to the node.
+     * When changing `key` prop of `Transition` in a `TransitionGroup` a new `nodeRef` need to be provided to `Transition` with changed `key`
+     * prop (@see https://github.com/reactjs/react-transition-group/blob/master/test/Transition-test.js).
+     */
+    nodeRef?: React.Ref<RefElement>;
+
+    [prop: string]: any;
 }
 
-export type TransitionStatus =
-    typeof ENTERING |
-    typeof ENTERED |
-    typeof EXITING |
-    typeof EXITED |
-    typeof UNMOUNTED;
+export type TransitionStatus = typeof ENTERING | typeof ENTERED | typeof EXITING | typeof EXITED | typeof UNMOUNTED;
 export type TransitionChildren = ReactNode | ((status: TransitionStatus) => ReactNode);
 
-interface TimeoutProps extends BaseTransitionProps {
+interface TimeoutProps<RefElement extends undefined | HTMLElement> extends BaseTransitionProps<RefElement> {
     /**
      * The duration of the transition, in milliseconds. Required unless addEndListener is provided.
      *
@@ -134,17 +157,17 @@ interface TimeoutProps extends BaseTransitionProps {
      * - enter defaults to `0`
      * - exit defaults to `0`
      */
-    timeout: number | { appear?: number, enter?: number, exit?: number };
+    timeout: number | { appear?: number; enter?: number; exit?: number };
 
     /**
      * Add a custom transition end trigger. Called with the transitioning DOM
      * node and a done callback. Allows for more fine grained transition end
      * logic. Note: Timeouts are still used as a fallback if provided.
      */
-    addEndListener?: EndHandler;
+    addEndListener?: EndHandler<RefElement>;
 }
 
-interface EndListenerProps extends BaseTransitionProps {
+interface EndListenerProps<Ref extends undefined | HTMLElement> extends BaseTransitionProps<Ref> {
     /**
      * The duration of the transition, in milliseconds. Required unless addEndListener is provided.
      *
@@ -164,16 +187,18 @@ interface EndListenerProps extends BaseTransitionProps {
      * - enter defaults to `0`
      * - exit defaults to `0`
      */
-    timeout?: number | { appear?: number, enter?: number, exit?: number };
+    timeout?: number | { appear?: number; enter?: number; exit?: number };
     /**
      * Add a custom transition end trigger. Called with the transitioning DOM
      * node and a done callback. Allows for more fine grained transition end
      * logic. Note: Timeouts are still used as a fallback if provided.
      */
-    addEndListener: EndHandler;
+    addEndListener: EndHandler<Ref>;
 }
 
-export type TransitionProps = TimeoutProps | EndListenerProps;
+export type TransitionProps<RefElement extends undefined | HTMLElement = undefined> =
+    | TimeoutProps<RefElement>
+    | EndListenerProps<RefElement>;
 
 /**
  * The Transition component lets you describe a transition from one component
@@ -216,6 +241,6 @@ export type TransitionProps = TimeoutProps | EndListenerProps;
  * ```
  *
  */
-declare class Transition extends Component<TransitionProps> {}
+declare class Transition<RefElement extends HTMLElement | undefined> extends Component<TransitionProps<RefElement>> {}
 
 export default Transition;

--- a/types/react-transition-group/TransitionGroup.d.ts
+++ b/types/react-transition-group/TransitionGroup.d.ts
@@ -1,5 +1,5 @@
-import { Component, ReactType, HTMLProps, ReactElement } from "react";
-import { TransitionActions, TransitionProps } from "./Transition";
+import { Component, ReactType, ReactElement } from 'react';
+import { TransitionActions, TransitionProps } from './Transition';
 
 export interface IntrinsicTransitionGroupProps<T extends keyof JSX.IntrinsicElements = 'div'>
     extends TransitionActions {

--- a/types/react-transition-group/TransitionGroup.d.ts
+++ b/types/react-transition-group/TransitionGroup.d.ts
@@ -13,7 +13,7 @@ export interface ComponentTransitionGroupProps<T extends ReactType> extends Tran
 export type TransitionGroupProps<T extends keyof JSX.IntrinsicElements = 'div', V extends ReactType = any> =
     | (IntrinsicTransitionGroupProps<T> & JSX.IntrinsicElements[T])
     | (ComponentTransitionGroupProps<V>) & {
-          children?: ReactElement<TransitionProps> | Array<ReactElement<TransitionProps>>;
+          children?: ReactElement<TransitionProps<any>> | Array<ReactElement<TransitionProps<any>>>;
           childFactory?(child: ReactElement): ReactElement;
           [prop: string]: any;
       };

--- a/types/react-transition-group/index.d.ts
+++ b/types/react-transition-group/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for react-transition-group 4.2
+// Type definitions for react-transition-group 4.4
 // Project: https://github.com/reactjs/react-transition-group
 // Definitions by: Karol Janyst <https://github.com/LKay>
 //                 Epskampie <https://github.com/Epskampie>
 //                 Masafumi Koba <https://github.com/ybiquitous>
 //                 tu4mo <https://github.com/tu4mo>
+//                 Ben Grynhaus <https://github.com/bengry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import { UNMOUNTED, EXITED, ENTERING, ENTERED, EXITING, TransitionStatus } from "react-transition-group/Transition";
-import { modes } from "react-transition-group/SwitchTransition";
-import { Transition, CSSTransition, TransitionGroup, SwitchTransition, config } from "react-transition-group";
+import * as React from 'react';
+import { UNMOUNTED, EXITED, ENTERING, ENTERED, EXITING, TransitionStatus } from 'react-transition-group/Transition';
+import { modes } from 'react-transition-group/SwitchTransition';
+import { Transition, CSSTransition, TransitionGroup, SwitchTransition, config } from 'react-transition-group';
 
 interface ContainerProps {
     theme: string;
@@ -9,20 +9,19 @@ interface ContainerProps {
 }
 
 const Container: React.StatelessComponent<ContainerProps> = (props: ContainerProps) => {
-    return (
-        <div data-theme={props.theme}>
-            {props.children}
-        </div>
-    );
+    return <div data-theme={props.theme}>{props.children}</div>;
 };
 
 const Test: React.StatelessComponent = () => {
+    const nodeRef = React.useRef<HTMLDivElement>(null);
+
     function handleEnter(node: HTMLElement, isAppearing: boolean) {}
+    function handleEnterNoNode(isAppearing: boolean) {}
 
     function handleExit(node: HTMLElement) {}
 
     function handleEndListener(node: HTMLElement, done: () => void) {
-        node.addEventListener("transitionend", done, false);
+        node.addEventListener('transitionend', done, false);
     }
 
     function statusAsArgument(status: TransitionStatus) {
@@ -46,16 +45,16 @@ const Test: React.StatelessComponent = () => {
                     appear
                     enter
                     exit
-                    timeout={ 500 }
-                    addEndListener={ handleEndListener }
-                    onEnter={ handleEnter }
-                    onEntering={ handleEnter }
-                    onEntered={ handleEnter }
-                    onExit={ handleExit }
-                    onExiting={ handleExit }
-                    onExited={ handleExit }
+                    timeout={500}
+                    addEndListener={handleEndListener}
+                    onEnter={handleEnter}
+                    onEntering={handleEnter}
+                    onEntered={handleEnter}
+                    onExit={handleExit}
+                    onExiting={handleExit}
+                    onExited={handleExit}
                 >
-                    <div>{ "test" }</div>
+                    <div>{'test'}</div>
                 </Transition>
             </SwitchTransition>
 
@@ -67,16 +66,16 @@ const Test: React.StatelessComponent = () => {
                     appear
                     enter
                     exit
-                    timeout={ 500 }
-                    addEndListener={ handleEndListener }
-                    onEnter={ handleEnter }
-                    onEntering={ handleEnter }
-                    onEntered={ handleEnter }
-                    onExit={ handleExit }
-                    onExiting={ handleExit }
-                    onExited={ handleExit }
+                    timeout={500}
+                    addEndListener={handleEndListener}
+                    onEnter={handleEnter}
+                    onEntering={handleEnter}
+                    onEntered={handleEnter}
+                    onExit={handleExit}
+                    onExiting={handleExit}
+                    onExited={handleExit}
                 >
-                    <div>{ "test" }</div>
+                    <div>{'test'}</div>
                 </Transition>
             </SwitchTransition>
 
@@ -88,16 +87,16 @@ const Test: React.StatelessComponent = () => {
                     appear
                     enter
                     exit
-                    timeout={ 500 }
-                    addEndListener={ handleEndListener }
-                    onEnter={ handleEnter }
-                    onEntering={ handleEnter }
-                    onEntered={ handleEnter }
-                    onExit={ handleExit }
-                    onExiting={ handleExit }
-                    onExited={ handleExit }
+                    timeout={500}
+                    addEndListener={handleEndListener}
+                    onEnter={handleEnter}
+                    onEntering={handleEnter}
+                    onEntered={handleEnter}
+                    onExit={handleExit}
+                    onExiting={handleExit}
+                    onExited={handleExit}
                 >
-                    <div>{ "test" }</div>
+                    <div>{'test'}</div>
                 </Transition>
             </SwitchTransition>
 
@@ -109,16 +108,16 @@ const Test: React.StatelessComponent = () => {
                     appear
                     enter
                     exit
-                    timeout={ 500 }
-                    addEndListener={ handleEndListener }
-                    onEnter={ handleEnter }
-                    onEntering={ handleEnter }
-                    onEntered={ handleEnter }
-                    onExit={ handleExit }
-                    onExiting={ handleExit }
-                    onExited={ handleExit }
+                    timeout={500}
+                    addEndListener={handleEndListener}
+                    onEnter={handleEnter}
+                    onEntering={handleEnter}
+                    onEntered={handleEnter}
+                    onExit={handleExit}
+                    onExiting={handleExit}
+                    onExited={handleExit}
                 >
-                    <div>{ "test" }</div>
+                    <div>{'test'}</div>
                 </Transition>
             </SwitchTransition>
 
@@ -126,7 +125,7 @@ const Test: React.StatelessComponent = () => {
                 component={Container}
                 theme="test"
                 className="animated-list"
-                childFactory={ (child: React.ReactElement) => child }
+                childFactory={(child: React.ReactElement) => child}
             >
                 <Transition
                     in
@@ -135,19 +134,19 @@ const Test: React.StatelessComponent = () => {
                     appear
                     enter
                     exit
-                    timeout={ 500 }
-                    addEndListener={ handleEndListener }
-                    onEnter={ handleEnter }
-                    onEntering={ handleEnter }
-                    onEntered={ handleEnter }
-                    onExit={ handleExit }
-                    onExiting={ handleExit }
-                    onExited={ handleExit }
+                    timeout={500}
+                    addEndListener={handleEndListener}
+                    onEnter={handleEnter}
+                    onEntering={handleEnter}
+                    onEntered={handleEnter}
+                    onExit={handleExit}
+                    onExiting={handleExit}
+                    onExited={handleExit}
                 >
-                    <div>{ "test" }</div>
+                    <div>{'test'}</div>
                 </Transition>
                 <Transition in timeout={500}>
-                    {(status) => {
+                    {status => {
                         switch (status) {
                             case ENTERING:
                             case ENTERED:
@@ -163,13 +162,11 @@ const Test: React.StatelessComponent = () => {
                     {statusAsArgument}
                 </Transition>
 
-                <Transition
-                    timeout={ { enter : 500, exit : 500 } }
-                >
-                    <div>{ "test" }</div>
+                <Transition timeout={{ enter: 500, exit: 500 }}>
+                    <div>{'test'}</div>
                 </Transition>
 
-                <Transition addEndListener={() => {}}/>
+                <Transition addEndListener={() => {}} />
 
                 <CSSTransition
                     in
@@ -178,38 +175,46 @@ const Test: React.StatelessComponent = () => {
                     appear
                     enter
                     exit
-                    timeout={ 500 }
-                    addEndListener={ handleEndListener }
-                    onEnter={ handleEnter }
-                    onEntering={ handleEnter }
-                    onEntered={ handleEnter }
-                    onExit={ handleExit }
-                    onExiting={ handleExit }
-                    onExited={ handleExit }
+                    timeout={500}
+                    addEndListener={handleEndListener}
+                    onEnter={handleEnter}
+                    onEntering={handleEnter}
+                    onEntered={handleEnter}
+                    onExit={handleExit}
+                    onExiting={handleExit}
+                    onExited={handleExit}
                     classNames="fade"
                 >
-                    <div>{ "test" }</div>
+                    <div>{'test'}</div>
                 </CSSTransition>
 
                 <CSSTransition
-                    timeout={ { enter : 500, exit : 500 } }
-                    classNames={ {
-                        appear: "fade-appear",
-                        appearActive: "fade-active-appear",
-                        appearDone: "fade-done-appear",
-                        enter: "fade-enter",
-                        enterActive: "fade-active-enter",
-                        enterDone: "fade-done-enter",
-                        exit: "fade-exit",
-                        exitActive: "fade-active-exit",
-                        exitDone: "fade-done-exit",
-                    } }
+                    timeout={{ enter: 500, exit: 500 }}
+                    classNames={{
+                        appear: 'fade-appear',
+                        appearActive: 'fade-active-appear',
+                        appearDone: 'fade-done-appear',
+                        enter: 'fade-enter',
+                        enterActive: 'fade-active-enter',
+                        enterDone: 'fade-done-enter',
+                        exit: 'fade-exit',
+                        exitActive: 'fade-active-exit',
+                        exitDone: 'fade-done-exit',
+                    }}
                 >
-                    <div>{ "test" }</div>
+                    <div>{'test'}</div>
                 </CSSTransition>
 
-                <CSSTransition timeout={ 100 }>
-                    <div>{ "test" }</div>
+                <CSSTransition timeout={100}>
+                    <div>{'test'}</div>
+                </CSSTransition>
+
+                <CSSTransition timeout={500} onEnter={handleEnter}>
+                    <div ref={nodeRef}>{'test'}</div>
+                </CSSTransition>
+
+                <CSSTransition timeout={500} nodeRef={nodeRef} onEnter={handleEnterNoNode}>
+                    <div ref={nodeRef}>{'test'}</div>
                 </CSSTransition>
             </TransitionGroup>
         </>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/react-transition-group/blob/v4.4.0/CHANGELOG.md and https://reactcommunity.org/react-transition-group/transition#Transition-prop-addEndListener (and other ones on the page) regarding the change in event handlers' types.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.