### PR TITLE
[mapbox-gl] Extend map.setFilter second param to accept boolean

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -307,7 +307,7 @@ declare namespace mapboxgl {
 
         getLayer(id: string): mapboxgl.Layer;
 
-        setFilter(layer: string, filter?: any[] | null): this;
+        setFilter(layer: string, filter?: any[] | boolean | null): this;
 
         setLayerZoomRange(layerId: string, minzoom: number, maxzoom: number): this;
 

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -801,6 +801,9 @@ map.setPadding({ top: 10, bottom: 20, left: 30, right: 40 }, { myData: 'MY DATA'
 map.showPadding;
 map.showPadding = false;
 
+expectType<mapboxgl.Map>(map.setFilter('layerId', true));
+expectType<mapboxgl.Map>(map.setFilter('layerId', true));
+
 /*
  * Map Events
  */

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -802,7 +802,7 @@ map.showPadding;
 map.showPadding = false;
 
 expectType<mapboxgl.Map>(map.setFilter('layerId', true));
-expectType<mapboxgl.Map>(map.setFilter('layerId', true));
+expectType<mapboxgl.Map>(map.setFilter('layerId', false));
 
 /*
  * Map Events


### PR DESCRIPTION
To easily clear all filters it's possible to set second `setFilter` parameter to `true`.
To filter out all the features we can use `false`.

Therefore `boolean` type is missing in the definition.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mapbox/mapbox-gl-js/issues/7759#issuecomment-453034895
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

