### PR TITLE
fix react-native-pull-to-refresh callback signature

### DIFF
--- a/types/react-native-pull-to-refresh/index.d.ts
+++ b/types/react-native-pull-to-refresh/index.d.ts
@@ -6,7 +6,7 @@
 import * as React from 'react';
 
 export interface PTRViewProps {
-    onRefresh?: (params?: any) => Promise<any>;
+    onRefresh?: () => any;
     delay?: number; // default O
     style?: object;
 


### PR DESCRIPTION
Mistake in the callback signature: onRefresh can't take any param, and can return anything. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/euZebe/DefinitelyTyped/commit/08871dee3973c62218c790f61d5eed4bc1a1a7c3#commitcomment-39184394>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
