### PR TITLE
Add initial typings for 'wol' package

### DIFF
--- a/types/wol/index.d.ts
+++ b/types/wol/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for wol 1.0
+// Project: https://github.com/song940/wake-on-lan#readme
+// Definitions by: ulrichb <https://github.com/ulrichb>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface WakeOptions {
+    readonly address?: string;
+    readonly port?: number;
+}
+
+export function wake(mac: string, options?: WakeOptions): Promise<boolean>;
+export function wake(mac: string, callback: (err: unknown, result: boolean) => void): void;
+export function wake(mac: string, options: WakeOptions, callback: (err: unknown, result: boolean) => void): void;

--- a/types/wol/index.d.ts
+++ b/types/wol/index.d.ts
@@ -3,6 +3,10 @@
 // Definitions by: ulrichb <https://github.com/ulrichb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
+export function createMagicPacket(mac: string): Buffer;
+
 export interface WakeOptions {
     readonly address?: string;
     readonly port?: number;

--- a/types/wol/tsconfig.json
+++ b/types/wol/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "wol-tests.ts"
+    ]
+}

--- a/types/wol/tslint.json
+++ b/types/wol/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/wol/wol-tests.ts
+++ b/types/wol/wol-tests.ts
@@ -1,0 +1,10 @@
+import * as wol from "wol";
+
+wol.wake('20:DE:20:DE:20:DE'); // $ExpectType Promise<boolean>
+wol.wake('20:DE:20:DE:20:DE', (err, res) => { }); // $ExpectType void
+
+wol.wake('20:DE:20:DE:20:DE', {});
+wol.wake('20:DE:20:DE:20:DE', { address: "1.1.1.1" });
+wol.wake('20:DE:20:DE:20:DE', { port: 42 });
+
+wol.wake('20:DE:20:DE:20:DE', { port: 42 }, (err, res) => { }); // $ExpectType void

--- a/types/wol/wol-tests.ts
+++ b/types/wol/wol-tests.ts
@@ -1,5 +1,11 @@
 import * as wol from "wol";
 
+//
+
+wol.createMagicPacket('20:DE:20:DE:20:DE'); // $ExpectType Buffer
+
+//
+
 wol.wake('20:DE:20:DE:20:DE'); // $ExpectType Promise<boolean>
 wol.wake('20:DE:20:DE:20:DE', (err, res) => { }); // $ExpectType void
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

**! Note for reviewer !**
* For the promise return and the options see the source code: https://github.com/song940/wake-on-lan/blob/master/index.js#L32

