### PR TITLE
MySql: Pool `end` method takes optional err object

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -10,8 +10,8 @@
 
 /// <reference types="node" />
 
-import stream = require('stream');
-import tls = require('tls');
+import stream = require("stream");
+import tls = require("tls");
 
 export interface EscapeFunctions {
     /**
@@ -191,10 +191,7 @@ export interface Pool extends EscapeFunctions {
 
     getConnection(callback: (err: MysqlError, connection: PoolConnection) => void): void;
 
-    acquireConnection(
-        connection: PoolConnection,
-        callback: (err: MysqlError, connection: PoolConnection) => void,
-    ): void;
+    acquireConnection(connection: PoolConnection, callback: (err: MysqlError, connection: PoolConnection) => void): void;
 
     releaseConnection(connection: PoolConnection): void;
 
@@ -273,11 +270,7 @@ export interface PoolCluster {
 
     getConnection(pattern: string, callback: (err: MysqlError, connection: PoolConnection) => void): void;
 
-    getConnection(
-        pattern: string,
-        selector: string,
-        callback: (err: MysqlError, connection: PoolConnection) => void,
-    ): void;
+    getConnection(pattern: string, selector: string, callback: (err: MysqlError, connection: PoolConnection) => void): void;
 
     /**
      * Set handler to be run on a certain event.
@@ -355,23 +348,15 @@ export interface Query {
     on(ev: 'end', callback: () => void): Query;
 }
 
-export interface GeometryType extends Array<{ x: number; y: number } | GeometryType> {
+export interface GeometryType extends Array<{ x: number, y: number } | GeometryType> {
     x: number;
     y: number;
 }
 
-export type TypeCast =
-    | boolean
-    | ((
-          field: UntypedFieldInfo & {
-              type: string;
-              length: number;
-              string(): string;
-              buffer(): Buffer;
-              geometry(): null | GeometryType;
-          },
-          next: () => void,
-      ) => any);
+export type TypeCast = boolean | (
+    (field: UntypedFieldInfo
+        & { type: string, length: number, string(): string, buffer(): Buffer, geometry(): null | GeometryType },
+        next: () => void) => any);
 
 export type queryCallback = (err: MysqlError | null, results?: any, fields?: FieldInfo[]) => void;
 

--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -10,8 +10,8 @@
 
 /// <reference types="node" />
 
-import stream = require("stream");
-import tls = require("tls");
+import stream = require('stream');
+import tls = require('tls');
 
 export interface EscapeFunctions {
     /**
@@ -122,8 +122,8 @@ export interface Connection extends EscapeFunctions {
      * there are any fatal errors, the connection will be immediately closed.
      * @param callback Handler for any fatal error
      */
-    end(callback?: (err: MysqlError, ...args: any[]) => void): void;
-    end(options: any, callback: (err: MysqlError, ...args: any[]) => void): void;
+    end(callback?: (err: MysqlError | undefined, ...args: any[]) => void): void;
+    end(options: any, callback: (err: MysqlError | undefined, ...args: any[]) => void): void;
 
     /**
      * Close the connection immediately, without waiting for any queued data (eg
@@ -191,7 +191,10 @@ export interface Pool extends EscapeFunctions {
 
     getConnection(callback: (err: MysqlError, connection: PoolConnection) => void): void;
 
-    acquireConnection(connection: PoolConnection, callback: (err: MysqlError, connection: PoolConnection) => void): void;
+    acquireConnection(
+        connection: PoolConnection,
+        callback: (err: MysqlError, connection: PoolConnection) => void,
+    ): void;
 
     releaseConnection(connection: PoolConnection): void;
 
@@ -270,7 +273,11 @@ export interface PoolCluster {
 
     getConnection(pattern: string, callback: (err: MysqlError, connection: PoolConnection) => void): void;
 
-    getConnection(pattern: string, selector: string, callback: (err: MysqlError, connection: PoolConnection) => void): void;
+    getConnection(
+        pattern: string,
+        selector: string,
+        callback: (err: MysqlError, connection: PoolConnection) => void,
+    ): void;
 
     /**
      * Set handler to be run on a certain event.
@@ -348,15 +355,23 @@ export interface Query {
     on(ev: 'end', callback: () => void): Query;
 }
 
-export interface GeometryType extends Array<{ x: number, y: number } | GeometryType> {
+export interface GeometryType extends Array<{ x: number; y: number } | GeometryType> {
     x: number;
     y: number;
 }
 
-export type TypeCast = boolean | (
-    (field: UntypedFieldInfo
-        & { type: string, length: number, string(): string, buffer(): Buffer, geometry(): null | GeometryType },
-        next: () => void) => any);
+export type TypeCast =
+    | boolean
+    | ((
+          field: UntypedFieldInfo & {
+              type: string;
+              length: number;
+              string(): string;
+              buffer(): Buffer;
+              geometry(): null | GeometryType;
+          },
+          next: () => void,
+      ) => any);
 
 export type queryCallback = (err: MysqlError | null, results?: any, fields?: FieldInfo[]) => void;
 

--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -122,8 +122,8 @@ export interface Connection extends EscapeFunctions {
      * there are any fatal errors, the connection will be immediately closed.
      * @param callback Handler for any fatal error
      */
-    end(callback?: (err: MysqlError | undefined, ...args: any[]) => void): void;
-    end(options: any, callback: (err: MysqlError | undefined, ...args: any[]) => void): void;
+    end(callback?: (err: MysqlError | undefined) => void): void;
+    end(options: any, callback: (err: MysqlError | undefined) => void): void;
 
     /**
      * Close the connection immediately, without waiting for any queued data (eg

--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -10,8 +10,8 @@
 
 /// <reference types="node" />
 
-import stream = require("stream");
-import tls = require("tls");
+import stream = require('stream');
+import tls = require('tls');
 
 export interface EscapeFunctions {
     /**
@@ -122,8 +122,8 @@ export interface Connection extends EscapeFunctions {
      * there are any fatal errors, the connection will be immediately closed.
      * @param callback Handler for any fatal error
      */
-    end(callback?: (err: MysqlError | undefined) => void): void;
-    end(options: any, callback: (err: MysqlError | undefined) => void): void;
+    end(callback?: (err?: MysqlError) => void): void;
+    end(options: any, callback: (err?: MysqlError) => void): void;
 
     /**
      * Close the connection immediately, without waiting for any queued data (eg
@@ -191,7 +191,10 @@ export interface Pool extends EscapeFunctions {
 
     getConnection(callback: (err: MysqlError, connection: PoolConnection) => void): void;
 
-    acquireConnection(connection: PoolConnection, callback: (err: MysqlError, connection: PoolConnection) => void): void;
+    acquireConnection(
+        connection: PoolConnection,
+        callback: (err: MysqlError, connection: PoolConnection) => void,
+    ): void;
 
     releaseConnection(connection: PoolConnection): void;
 
@@ -270,7 +273,11 @@ export interface PoolCluster {
 
     getConnection(pattern: string, callback: (err: MysqlError, connection: PoolConnection) => void): void;
 
-    getConnection(pattern: string, selector: string, callback: (err: MysqlError, connection: PoolConnection) => void): void;
+    getConnection(
+        pattern: string,
+        selector: string,
+        callback: (err: MysqlError, connection: PoolConnection) => void,
+    ): void;
 
     /**
      * Set handler to be run on a certain event.
@@ -348,15 +355,23 @@ export interface Query {
     on(ev: 'end', callback: () => void): Query;
 }
 
-export interface GeometryType extends Array<{ x: number, y: number } | GeometryType> {
+export interface GeometryType extends Array<{ x: number; y: number } | GeometryType> {
     x: number;
     y: number;
 }
 
-export type TypeCast = boolean | (
-    (field: UntypedFieldInfo
-        & { type: string, length: number, string(): string, buffer(): Buffer, geometry(): null | GeometryType },
-        next: () => void) => any);
+export type TypeCast =
+    | boolean
+    | ((
+          field: UntypedFieldInfo & {
+              type: string;
+              length: number;
+              string(): string;
+              buffer(): Buffer;
+              geometry(): null | GeometryType;
+          },
+          next: () => void,
+      ) => any);
 
 export type queryCallback = (err: MysqlError | null, results?: any, fields?: FieldInfo[]) => void;
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mysqljs/mysql/blob/283425b44bc7a310bf6613d0e112d89080516e55/lib/Pool.js#L165

The callback method on Pool.end takes an optional error object. Since this is marked as non-optional in the existing @types its very difficult to know that the pool isn't ended before the callback has been called.