### PR TITLE
@types/async  update the function identify to fit package async:3.2.0

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -89,7 +89,8 @@ export interface AsyncPriorityQueue<T> {
     push<R, E = Error>(task: T | T[], priority: number, callback?: AsyncResultArrayCallback<R, E>): void;
     saturated: () => any;
     empty: () => any;
-    drain: () => any;
+    drain(): Promise<void>;
+    drain(handler: () => void): void;
     running(): number;
     idle(): boolean;
     pause(): void;
@@ -209,12 +210,12 @@ export function parallelLimit<T, E = Error>(tasks: Dictionary<AsyncFunction<T, E
 export function parallelLimit<T, R, E = Error>(tasks: Array<AsyncFunction<T, E>> | Dictionary<AsyncFunction<T, E>>, limit: number): Promise<R>;
 export function whilst<E = Error>(test: () => boolean, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
 export function whilst<R, E = Error>(test: () => boolean, fn: AsyncVoidFunction<E>): Promise<R>;
-export function doWhilst<T, E = Error>(fn: AsyncFunctionEx<T, E>, test: (...results: T[]) => boolean, callback: ErrorCallback<E>): void;
-export function doWhilst<T, R, E = Error>(fn: AsyncFunctionEx<T, E>, test: (...results: T[]) => boolean): Promise<R>;
+export function doWhilst<T, E = Error>(fn: AsyncFunctionEx<T, E>, test: (...results: T[]) => Promise<boolean>, callback: ErrorCallback<E>): void;
+export function doWhilst<T, R, E = Error>(fn: AsyncFunctionEx<T, E>, test: (...results: T[]) => Promise<boolean>): Promise<R>;
 export function until<E = Error>(test: () => boolean, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
 export function until<R, E = Error>(test: () => boolean, fn: AsyncVoidFunction<E>): Promise<R>;
-export function doUntil<T, E = Error>(fn: AsyncFunctionEx<T, E>, test: (...results: T[]) => boolean, callback: ErrorCallback<E>): void;
-export function doUntil<T, R, E = Error>(fn: AsyncFunctionEx<T, E>, test: (...results: T[]) => boolean): Promise<R>;
+export function doUntil<T, E = Error>(fn: AsyncFunctionEx<T, E>, test: (...results: T[]) => Promise<boolean>, callback: ErrorCallback<E>): void;
+export function doUntil<T, R, E = Error>(fn: AsyncFunctionEx<T, E>, test: (...results: T[]) => Promise<boolean>): Promise<R>;
 export function during<E = Error>(test: (testCallback: AsyncBooleanResultCallback<E>) => void, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
 export function doDuring<E = Error>(fn: AsyncVoidFunction<E>, test: (testCallback: AsyncBooleanResultCallback<E>) => void, callback: ErrorCallback<E>): void;
 export function forever<E = Error>(next: (next: ErrorCallback<E>) => void, errBack: ErrorCallback<E>): void;

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -155,7 +155,7 @@ function whileFn(callback: any) {
 }
 
 function whileTest() { return count < 5; }
-function doWhileTest(count: number) { return count < 5; }
+async function doWhileTest(count: number) { return count < 5; }
 
 let count = 0;
 async.whilst(whileTest, whileFn, err => { });


### PR DESCRIPTION
package @types/async 
version: 3.2.2
updates
- doWhilst
- doUntil
- AsyncPriorityQueue.drain

async package changes: https://github.com/caolan/async/blob/master/CHANGELOG.md
