### PR TITLE
types/mysql: Fix lint warning

### DIFF
--- a/types/mysql/mysql-tests.ts
+++ b/types/mysql/mysql-tests.ts
@@ -121,12 +121,12 @@ sql = mysql.format(sql, inserts);
 
 connection.config.queryFormat = function(query, values) {
     if (!values) return query;
-    return query.replace(/\:(\w+)/g, function(txt: string, key: string) {
+    return query.replace(/\:(\w+)/g, (txt: string, key: string) => {
         if (values.hasOwnProperty(key)) {
             return this.escape(values[key]);
         }
         return txt;
-    }.bind(this));
+    });
 };
 
 connection.query("UPDATE posts SET title = :title", {title: "Hello MySQL"});


### PR DESCRIPTION
> ERROR: 124:38  unnecessary-bind  Don't bind `this` without arguments
> as a scope to a function. Use an arrow lambda instead.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- N/A: Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I just edited the test to fix a lint warning.  I didn't add/remove a declaration.