### PR TITLE
types/mysql: query() first argument can be an object, whether or not 'values' is present

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -366,7 +366,7 @@ export interface QueryFunction {
 
     (options: string | QueryOptions, callback?: queryCallback): Query;
 
-    (options: string, values: any, callback?: queryCallback): Query;
+    (options: string | QueryOptions, values: any, callback?: queryCallback): Query;
 }
 
 export interface QueryOptions {

--- a/types/mysql/mysql-tests.ts
+++ b/types/mysql/mysql-tests.ts
@@ -133,6 +133,8 @@ connection.config.queryFormat = function(query, values) {
 connection.config.queryFormat("UPDATE posts SET title = :title", {title: "Hello MySQL"});
 
 connection.query("UPDATE posts SET title = :title", {title: "Hello MySQL"});
+connection.query({sql: "UPDATE posts SET title = :title"}, {title: "Hello MySQL"});
+connection.query({sql: "UPDATE posts SET title = :title"}, {title: "Hello MySQL"}, (err, result) => {});
 
 const s: stream.Readable = connection.query("UPDATE posts SET title = :title", {title: "Hello MySQL"}).stream({highWaterMark: 5});
 


### PR DESCRIPTION
Evidence: https://github.com/mysqljs/mysql/blob/v2.18.1/lib/Connection.js
- query(), line 180, passes all args to createQuery()
- createQuery(), line 25

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
    - The test has a pre-existing issue.  I fixed it in #44748.  I will rebase this PR on top of that once it lands.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see "Evidence" above
- [ ] (N/A) If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] (N/A) If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.