### PR TITLE
Update react-native-material-menu typings

### DIFF
--- a/types/react-native-material-menu/index.d.ts
+++ b/types/react-native-material-menu/index.d.ts
@@ -8,7 +8,7 @@ import { StyleProp, TextStyle, TextProps, ViewStyle } from 'react-native';
 
 export interface MenuProps {
     button?: ReactElement;
-    testID?: string; 
+    testID?: string;
     style?: StyleProp<ViewStyle>;
     onHidden?: () => void;
     animationDuration?: number;

--- a/types/react-native-material-menu/index.d.ts
+++ b/types/react-native-material-menu/index.d.ts
@@ -4,20 +4,22 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { ComponentClass, ReactElement, Component } from 'react';
-import { TextStyle, TextProps, ViewStyle } from 'react-native';
+import { StyleProp, TextStyle, TextProps, ViewStyle } from 'react-native';
 
 export interface MenuProps {
     button?: ReactElement;
-    style?: ViewStyle;
+    testID?: string; 
+    style?: StyleProp<ViewStyle>;
     onHidden?: () => void;
     animationDuration?: number;
 }
 export interface MenuItemProps {
     disabled?: boolean;
+    testID?: string;
     disabledTextColor?: string;
     ellipsizeMode?: TextProps["ellipsizeMode"];
     onPress?: () => void;
-    style?: ViewStyle;
+    style?: StyleProp<ViewStyle>;
     textStyle?: TextStyle;
     underlayColor?: string;
 }


### PR DESCRIPTION
- React native material menu handles passing `testID` and which will allow test runners to find the menu's
- Changing ViewStyle to StyleProp<ViewStyle> allows passing Viewstyle[]

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.