### PR TITLE
Exempt swiper from npm-naming rule

### DIFF
--- a/types/swiper/tslint.json
+++ b/types/swiper/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
 }


### PR DESCRIPTION
Comments in index.d.ts indicate that it relies on non esm+bundler users to turn on esModuleInterop
