### PR TITLE
Exempt auth0-js from npm-naming rule

### DIFF
--- a/types/auth0-js/tslint.json
+++ b/types/auth0-js/tslint.json
@@ -1,4 +1,7 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
 }
   


### PR DESCRIPTION
It incorrectly thinks that auth0-js exports a constructble object.