### PR TITLE
bulma-calendar uses export=

### DIFF
--- a/types/bulma-calendar/bulma-calendar-tests.ts
+++ b/types/bulma-calendar/bulma-calendar-tests.ts
@@ -1,4 +1,4 @@
-import BulmaCalendar from 'bulma-calendar';
+import BulmaCalendar = require('bulma-calendar');
 
 new BulmaCalendar('.selector');
 BulmaCalendar.attach('.selector');

--- a/types/bulma-calendar/index.d.ts
+++ b/types/bulma-calendar/index.d.ts
@@ -4,301 +4,303 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.6
 
-export interface BulmaCalendarOptions {
-    /**
-     * Component type
-     *
-     * @default 'datetime'
-     */
-    type?: 'date' | 'time' | 'datetime';
-
-    /**
-     * Picker dominant color
-     *
-     * @default 'primary'
-     */
-    color?: string;
-
-    /**
-     * Range capability (start and end date/time selection
-     *
-     * @default false
-     */
-    isRange?: boolean;
-
-    /**
-     * Possibility to select same date as start and end date in range mode
-     *
-     * @default true
-     */
-    allowSameDayRange?: boolean;
-
-    /**
-     * Display lang (from language supported by date-fns)
-     *
-     * @default navigator.language.substring(0, 2) || "en"
-     */
-    lang?: string;
-
-    /**
-     * Date format pattern
-     *
-     * @default 'MM/DD/YYYY'
-     */
-    dateFormat?: string;
-
-    /**
-     * Time format pattern
-     *
-     * @default 'HH:mm'
-     */
-    timeFormat?: string;
-
-    /**
-     * Display mode
-     *
-     * @default 'default'
-     */
-    displayMode?: 'default' | 'dialog' | 'inline';
-
-    /**
-     * @default 'auto'
-     */
-    position?: string;
-
-    /**
-     * Show/Hide header block (with current selection)
-     *
-     * @default true
-     */
-    showHeader?: boolean;
-
-    /**
-     * Header block position
-     *
-     * @default 'top'
-     */
-    headerPosition?: 'top' | 'bottom';
-
-    /**
-     * Show/Hide footer block
-     *
-     * @default true
-     */
-    showFooter?: boolean;
-
-    /**
-     * Show/Hide buttons
-     *
-     * @default true
-     */
-    showButtons?: boolean;
-
-    /**
-     * Show/Hide Today Button
-     *
-     * @default true
-     */
-    showTodayButton?: boolean;
-
-    /**
-     * Show/Hide Clear Button
-     *
-     * @default true
-     */
-    showClearButton?: boolean;
-
-    /**
-     * Cancel button label
-     *
-     * @default 'Cancel'
-     */
-    cancelLabel?: string;
-
-    /**
-     * Clear button label
-     *
-     * @default 'Clear'
-     */
-    clearLabel?: string;
-
-    /**
-     * Today button label
-     *
-     * @default 'Today'
-     */
-    todayLabel?: string;
-
-    /**
-     * Now button label
-     *
-     * @default 'Now'
-     */
-    nowLabel?: string;
-
-    /**
-     * Validate button label
-     *
-     * @default 'Validate'
-     */
-    validateLabel?: string;
-
-    /**
-     * Enable/disable month switch
-     *
-     * @default true
-     */
-    enableMonthSwitch?: boolean;
-
-    /**
-     * Enable/disable year switch
-     *
-     * @default true
-     */
-    enableYearSwitch?: boolean;
-
-    /**
-     * Pre-selected start date
-     */
-    startDate?: Date;
-
-    /**
-     * Pre-selected end date
-     */
-    endDate?: Date;
-
-    /**
-     * Minimum date allowed
-     */
-    minDate?: Date;
-
-    /**
-     * Maximum date allowed
-     */
-    maxDate?: Date;
-
-    /**
-     * List of disabled dates
-     */
-    disabledDates?: any[];
-
-    /**
-     * List of disabled week days
-     */
-    disabledWeekDays?: string | any[];
-
-    /**
-     * Default weekstart day number
-     *
-     * @default 0 // sunday
-     */
-    weekStart?: number;
-
-    /**
-     * Pre-selected start time
-     */
-    startTime?: Date;
-
-    /**
-     * Pre-selected end time
-     */
-    endTime?: Date;
-
-    /**
-     * Steps for minutes selector
-     *
-     * @default 5
-     */
-    minuteSteps?: number;
-
-    /**
-     * From label
-     */
-    labelFrom?: string;
-
-    /**
-     * To label
-     */
-    labelTo?: string;
-
-    /**
-     * Close picker on overlay click (only for dialog display style)
-     *
-     * @default true
-     */
-    closeOnOverlayClick?: boolean;
-
-    /**
-     * Automatically close the datePicker when date selected (or range date selected) - not available
-     * for inline display style. If set to False then a validate button will be displayed into the
-     * footer section.
-     *
-     * @default true
-     */
-    closeOnSelect?: boolean;
-
-    /**
-     * Automatically open datepicker when click into input element
-     *
-     * @default true
-     */
-    toggleOnInputClick?: boolean;
-
-    /**
-     * Callback to trigger once picker initiated
-     */
-    onReady?: () => void;
-    icons?: {
+declare namespace bulmaCalendar {
+    interface Options {
         /**
-         * Previous button icon
+         * Component type
+         *
+         * @default 'datetime'
          */
-        previous?: string;
+        type?: 'date' | 'time' | 'datetime';
 
         /**
-         * Next button icon
+         * Picker dominant color
+         *
+         * @default 'primary'
          */
-        next?: string;
+        color?: string;
 
         /**
-         * Time icon
+         * Range capability (start and end date/time selection
+         *
+         * @default false
          */
-        time?: string;
+        isRange?: boolean;
 
         /**
-         * Date icon
+         * Possibility to select same date as start and end date in range mode
+         *
+         * @default true
          */
-        date?: string;
-    };
+        allowSameDayRange?: boolean;
+
+        /**
+         * Display lang (from language supported by date-fns)
+         *
+         * @default navigator.language.substring(0, 2) || "en"
+         */
+        lang?: string;
+
+        /**
+         * Date format pattern
+         *
+         * @default 'MM/DD/YYYY'
+         */
+        dateFormat?: string;
+
+        /**
+         * Time format pattern
+         *
+         * @default 'HH:mm'
+         */
+        timeFormat?: string;
+
+        /**
+         * Display mode
+         *
+         * @default 'default'
+         */
+        displayMode?: 'default' | 'dialog' | 'inline';
+
+        /**
+         * @default 'auto'
+         */
+        position?: string;
+
+        /**
+         * Show/Hide header block (with current selection)
+         *
+         * @default true
+         */
+        showHeader?: boolean;
+
+        /**
+         * Header block position
+         *
+         * @default 'top'
+         */
+        headerPosition?: 'top' | 'bottom';
+
+        /**
+         * Show/Hide footer block
+         *
+         * @default true
+         */
+        showFooter?: boolean;
+
+        /**
+         * Show/Hide buttons
+         *
+         * @default true
+         */
+        showButtons?: boolean;
+
+        /**
+         * Show/Hide Today Button
+         *
+         * @default true
+         */
+        showTodayButton?: boolean;
+
+        /**
+         * Show/Hide Clear Button
+         *
+         * @default true
+         */
+        showClearButton?: boolean;
+
+        /**
+         * Cancel button label
+         *
+         * @default 'Cancel'
+         */
+        cancelLabel?: string;
+
+        /**
+         * Clear button label
+         *
+         * @default 'Clear'
+         */
+        clearLabel?: string;
+
+        /**
+         * Today button label
+         *
+         * @default 'Today'
+         */
+        todayLabel?: string;
+
+        /**
+         * Now button label
+         *
+         * @default 'Now'
+         */
+        nowLabel?: string;
+
+        /**
+         * Validate button label
+         *
+         * @default 'Validate'
+         */
+        validateLabel?: string;
+
+        /**
+         * Enable/disable month switch
+         *
+         * @default true
+         */
+        enableMonthSwitch?: boolean;
+
+        /**
+         * Enable/disable year switch
+         *
+         * @default true
+         */
+        enableYearSwitch?: boolean;
+
+        /**
+         * Pre-selected start date
+         */
+        startDate?: Date;
+
+        /**
+         * Pre-selected end date
+         */
+        endDate?: Date;
+
+        /**
+         * Minimum date allowed
+         */
+        minDate?: Date;
+
+        /**
+         * Maximum date allowed
+         */
+        maxDate?: Date;
+
+        /**
+         * List of disabled dates
+         */
+        disabledDates?: any[];
+
+        /**
+         * List of disabled week days
+         */
+        disabledWeekDays?: string | any[];
+
+        /**
+         * Default weekstart day number
+         *
+         * @default 0 // sunday
+         */
+        weekStart?: number;
+
+        /**
+         * Pre-selected start time
+         */
+        startTime?: Date;
+
+        /**
+         * Pre-selected end time
+         */
+        endTime?: Date;
+
+        /**
+         * Steps for minutes selector
+         *
+         * @default 5
+         */
+        minuteSteps?: number;
+
+        /**
+         * From label
+         */
+        labelFrom?: string;
+
+        /**
+         * To label
+         */
+        labelTo?: string;
+
+        /**
+         * Close picker on overlay click (only for dialog display style)
+         *
+         * @default true
+         */
+        closeOnOverlayClick?: boolean;
+
+        /**
+         * Automatically close the datePicker when date selected (or range date selected) - not available
+         * for inline display style. If set to False then a validate button will be displayed into the
+         * footer section.
+         *
+         * @default true
+         */
+        closeOnSelect?: boolean;
+
+        /**
+         * Automatically open datepicker when click into input element
+         *
+         * @default true
+         */
+        toggleOnInputClick?: boolean;
+
+        /**
+         * Callback to trigger once picker initiated
+         */
+        onReady?: () => void;
+        icons?: {
+            /**
+             * Previous button icon
+             */
+            previous?: string;
+
+            /**
+             * Next button icon
+             */
+            next?: string;
+
+            /**
+             * Time icon
+             */
+            time?: string;
+
+            /**
+             * Date icon
+             */
+            date?: string;
+        };
+    }
+
+    type EventType = 'show' | 'hide' | 'select' | 'select:start';
+
+    interface Event<T extends EventType = EventType> {
+        type: T;
+        timeStamp: number;
+        data: bulmaCalendar;
+    }
 }
 
-export type EventType = 'show' | 'hide' | 'select' | 'select:start';
-
-export interface Event<T extends EventType = EventType> {
-    type: T;
-    timeStamp: number;
-    data: bulmaCalendar;
-}
-
-export default class bulmaCalendar {
+declare class bulmaCalendar {
     // Custom EventEmitter implementation
-    listenerCount(eventName: EventType): void;
+    listenerCount(eventName: bulmaCalendar.EventType): void;
 
-    removeListeners(eventName: EventType, middleware?: boolean): void;
+    removeListeners(eventName: bulmaCalendar.EventType, middleware?: boolean): void;
 
-    middleware<T extends EventType>(eventName: T, fn: (event: Event<T>) => void): void;
+    middleware<T extends bulmaCalendar.EventType>(eventName: T, fn: (event: bulmaCalendar.Event<T>) => void): void;
 
-    removeMiddleware(eventName: EventType): void;
+    removeMiddleware(eventName: bulmaCalendar.EventType): void;
 
-    on<T extends EventType>(name: T, callback: (event: Event<T>) => void, once?: boolean): void;
+    on<T extends bulmaCalendar.EventType>(name: T, callback: (event: bulmaCalendar.Event<T>) => void, once?: boolean): void;
 
-    once<T extends EventType>(name: T, callback: (event: Event<T>) => void): void;
+    once<T extends bulmaCalendar.EventType>(name: T, callback: (event: bulmaCalendar.Event<T>) => void): void;
 
-    emit(name: EventType, data: bulmaCalendar, silent?: boolean): void;
+    emit(name: bulmaCalendar.EventType, data: bulmaCalendar, silent?: boolean): void;
 
     // Constructors
-    constructor(selector: string | HTMLElement, options?: BulmaCalendarOptions);
+    constructor(selector: string | HTMLElement, options?: bulmaCalendar.Options);
 
-    static attach(selector?: string | HTMLElement, options?: BulmaCalendarOptions): bulmaCalendar[];
+    static attach(selector?: string | HTMLElement, options?: bulmaCalendar.Options): bulmaCalendar[];
 
     // Methods
     /**
@@ -470,3 +472,5 @@ export default class bulmaCalendar {
      */
     set timeFormat(timeFormat: string);
 }
+
+export = bulmaCalendar;


### PR DESCRIPTION
It incorrectly used `export default` before.

This PR is much easier to view with whitespace diffing turned off.