### PR TITLE
fix(node): add missing util.types.isArrayBufferView

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -43,6 +43,7 @@
 //                 ExE Boss <https://github.com/ExE-Boss>
 //                 Surasak Chaisurin <https://github.com/Ryan-Willpower>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 Anna Henningsen <https://github.com/addaleax>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // NOTE: These definitions support NodeJS and TypeScript 3.5.

--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -178,6 +178,12 @@ import { readFile } from 'fs';
     b = util.types.isBigUint64Array(15);
     b = util.types.isModuleNamespaceObject(15);
 
+    const f = (v: any) => {
+        if (util.types.isArrayBufferView(v)) {
+            const abv: ArrayBufferView  = v;
+        }
+    };
+
     // tslint:disable-next-line:no-construct ban-types
     const maybeBoxed: number | Number = new Number(1);
     if (util.types.isBoxedPrimitive(maybeBoxed)) {

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -123,6 +123,7 @@ declare module "util" {
         function isAnyArrayBuffer(object: any): boolean;
         function isArgumentsObject(object: any): object is IArguments;
         function isArrayBuffer(object: any): object is ArrayBuffer;
+        function isArrayBufferView(object: any): object is ArrayBufferView;
         function isAsyncFunction(object: any): boolean;
         function isBooleanObject(object: any): object is Boolean;
         function isBoxedPrimitive(object: any): object is (Number | Boolean | String | Symbol /* | Object(BigInt) | Object(Symbol) */);

--- a/types/node/v10/util.d.ts
+++ b/types/node/v10/util.d.ts
@@ -112,6 +112,7 @@ declare module "util" {
         function isAnyArrayBuffer(object: any): boolean;
         function isArgumentsObject(object: any): object is IArguments;
         function isArrayBuffer(object: any): object is ArrayBuffer;
+        function isArrayBufferView(object: any): object is ArrayBufferView;
         function isAsyncFunction(object: any): boolean;
         function isBooleanObject(object: any): object is Boolean;
         function isBoxedPrimitive(object: any): object is (Number | Boolean | String | Symbol /* | Object(BigInt) | Object(Symbol) */);

--- a/types/node/v11/test/util.ts
+++ b/types/node/v11/test/util.ts
@@ -168,6 +168,12 @@ import { readFile } from 'fs';
     b = util.types.isBigUint64Array(15);
     b = util.types.isModuleNamespaceObject(15);
 
+    const f = (v: any) => {
+        if (util.types.isArrayBufferView(v)) {
+            const abv: ArrayBufferView  = v;
+        }
+    };
+
     // tslint:disable-next-line:no-construct ban-types
     const maybeBoxed: number | Number = new Number(1);
     if (util.types.isBoxedPrimitive(maybeBoxed)) {

--- a/types/node/v11/util.d.ts
+++ b/types/node/v11/util.d.ts
@@ -116,6 +116,7 @@ declare module "util" {
         function isAnyArrayBuffer(object: any): boolean;
         function isArgumentsObject(object: any): object is IArguments;
         function isArrayBuffer(object: any): object is ArrayBuffer;
+        function isArrayBufferView(object: any): object is ArrayBufferView;
         function isAsyncFunction(object: any): boolean;
         function isBooleanObject(object: any): object is Boolean;
         function isBoxedPrimitive(object: any): object is (Number | Boolean | String | Symbol /* | Object(BigInt) | Object(Symbol) */);

--- a/types/node/v12/test/util.ts
+++ b/types/node/v12/test/util.ts
@@ -173,6 +173,12 @@ import { readFile } from 'fs';
     b = util.types.isBigUint64Array(15);
     b = util.types.isModuleNamespaceObject(15);
 
+    const f = (v: any) => {
+        if (util.types.isArrayBufferView(v)) {
+            const abv: ArrayBufferView  = v;
+        }
+    };
+
     // tslint:disable-next-line:no-construct ban-types
     const maybeBoxed: number | Number = new Number(1);
     if (util.types.isBoxedPrimitive(maybeBoxed)) {

--- a/types/node/v12/util.d.ts
+++ b/types/node/v12/util.d.ts
@@ -110,6 +110,7 @@ declare module "util" {
         function isAnyArrayBuffer(object: any): boolean;
         function isArgumentsObject(object: any): object is IArguments;
         function isArrayBuffer(object: any): object is ArrayBuffer;
+        function isArrayBufferView(object: any): object is ArrayBufferView;
         function isAsyncFunction(object: any): boolean;
         function isBooleanObject(object: any): object is Boolean;
         function isBoxedPrimitive(object: any): object is (Number | Boolean | String | Symbol /* | Object(BigInt) | Object(Symbol) */);

--- a/types/node/v13/test/util.ts
+++ b/types/node/v13/test/util.ts
@@ -178,6 +178,12 @@ import { readFile } from 'fs';
     b = util.types.isBigUint64Array(15);
     b = util.types.isModuleNamespaceObject(15);
 
+    const f = (v: any) => {
+        if (util.types.isArrayBufferView(v)) {
+            const abv: ArrayBufferView  = v;
+        }
+    };
+
     // tslint:disable-next-line:no-construct ban-types
     const maybeBoxed: number | Number = new Number(1);
     if (util.types.isBoxedPrimitive(maybeBoxed)) {

--- a/types/node/v13/util.d.ts
+++ b/types/node/v13/util.d.ts
@@ -123,6 +123,7 @@ declare module "util" {
         function isAnyArrayBuffer(object: any): boolean;
         function isArgumentsObject(object: any): object is IArguments;
         function isArrayBuffer(object: any): object is ArrayBuffer;
+        function isArrayBufferView(object: any): object is ArrayBufferView;
         function isAsyncFunction(object: any): boolean;
         function isBooleanObject(object: any): object is Boolean;
         function isBoxedPrimitive(object: any): object is (Number | Boolean | String | Symbol /* | Object(BigInt) | Object(Symbol) */);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/util.html#util_util_types_isanyarraybuffer_value
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
