### PR TITLE
Add type definitions for css-global-variables

### DIFF
--- a/types/css-global-variables/css-global-variables-tests.ts
+++ b/types/css-global-variables/css-global-variables-tests.ts
@@ -1,0 +1,7 @@
+import { CSSGlobalVariables } from 'css-global-variables';
+
+export const CSSVars = new CSSGlobalVariables({
+    filter: '*',
+    autoprefix: false,
+    normalize: name => name.toUpperCase(),
+});

--- a/types/css-global-variables/index.d.ts
+++ b/types/css-global-variables/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for css-global-variables 3.0
+// Project: https://github.com/colxi/css-global-variables
+// Definitions by: M. Ege Ercan <https://github.com/eggei>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface CGVInterface {
+    [index: string]: string;
+}
+
+export const CSSGlobalVariables: {
+    new (config?: { filter?: string; autoprefix?: boolean; normalize?: (name: string) => string }): CGVInterface;
+};

--- a/types/css-global-variables/tsconfig.json
+++ b/types/css-global-variables/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "css-global-variables-tests.ts"
+    ]
+}

--- a/types/css-global-variables/tslint.json
+++ b/types/css-global-variables/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
**Note:**  I don't know how strict this suggestion is about `class` vs. `new-able constant`, but, even though I have read the suggestion in the common mistakes section about new-able constant, I haven't followed that since this library doesn't return a class instance but it returns a function that needs to be invoked with `new` keyword. I thought a new-able constant would represent this structure better. However, this is, of course, open to discussion.

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
