### PR TITLE
[jsesc] Fix function signature

### DIFF
--- a/types/jsesc/index.d.ts
+++ b/types/jsesc/index.d.ts
@@ -2,11 +2,12 @@
 // Project: https://github.com/mathiasbynens/jsesc
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 //                 Lyanbin <https://github.com/Lyanbin>
+//                 Colin Reeder <https://github.com/vpzomtrrfrt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
 
-declare function jsesc(str: string, opts?: any): string;
+declare function jsesc(argument: any, opts?: jsesc.Opts): string;
 
 declare namespace jsesc {
     var version: string;

--- a/types/jsesc/jsesc-tests.ts
+++ b/types/jsesc/jsesc-tests.ts
@@ -6,6 +6,7 @@ import Opts = jsesc.Opts;
 
 var num: number;
 var str: string;
+var obj: object;
 var bool: boolean;
 var opts: Opts;
 var quotes: 'single' | 'double' | 'backtick';
@@ -57,3 +58,7 @@ opts = {
 
 str = jsesc(str);
 str = jsesc(str, opts);
+str = jsesc(num);
+str = jsesc(num, opts);
+str = jsesc(obj);
+str = jsesc(obj, opts);


### PR DESCRIPTION
The previous type definitions constrained the argument to string, but it seems to be intended to take any value.

I also changed the type of opts, since the interface was already defined but not used

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mathiasbynens/jsesc/blob/v2.5.2/src/jsesc.js#L137
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.