### PR TITLE
Added new type definition for react-gauge-chart

### DIFF
--- a/types/react-gauge-chart/index.d.ts
+++ b/types/react-gauge-chart/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for react-gauge-chart 0.2
+// Project: https://martin36.github.io/react-gauge-chart/
+// Definitions by: Meir Keller <https://github.com/meirkl>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'react';
+
+export interface GaugeChartProps {
+    id: string;
+    className?: string;
+    style?: React.CSSProperties;
+    marginInPercent?: number;
+    cornerRadius?: number;
+    nrOfLevels?: number;
+    percent?: number;
+    arcPadding?: number;
+    arcWidth?: number;
+    arcsLength?: number[];
+    colors?: string[];
+    textColor?: string;
+    needleColor?: string;
+    needleBaseColor?: string;
+    hideText?: boolean;
+    animate?: boolean;
+    animDelay?: number;
+    formatTextValue?: (value: string) => string;
+}
+
+export default function GaugeChart(props: GaugeChartProps): React.ReactElement;

--- a/types/react-gauge-chart/index.d.ts
+++ b/types/react-gauge-chart/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for react-gauge-chart 0.2
-// Project: https://martin36.github.io/react-gauge-chart/
+// Project: https://github.com/Martin36/react-gauge-chart
 // Definitions by: Meir Keller <https://github.com/meirkl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/react-gauge-chart/index.d.ts
+++ b/types/react-gauge-chart/index.d.ts
@@ -28,4 +28,3 @@ export interface GaugeChartProps {
 }
 
 export default function GaugeChart(props: GaugeChartProps): React.ReactElement;
-

--- a/types/react-gauge-chart/index.d.ts
+++ b/types/react-gauge-chart/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Meir Keller <https://github.com/meirkl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="react" />
-
 import * as React from 'react';
 
 export interface GaugeChartProps {

--- a/types/react-gauge-chart/index.d.ts
+++ b/types/react-gauge-chart/index.d.ts
@@ -28,3 +28,4 @@ export interface GaugeChartProps {
 }
 
 export default function GaugeChart(props: GaugeChartProps): React.ReactElement;
+

--- a/types/react-gauge-chart/index.d.ts
+++ b/types/react-gauge-chart/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Meir Keller <https://github.com/meirkl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="react" />
+
 import * as React from 'react';
 
 export interface GaugeChartProps {

--- a/types/react-gauge-chart/index.d.ts
+++ b/types/react-gauge-chart/index.d.ts
@@ -24,6 +24,7 @@ export interface GaugeChartProps {
     animate?: boolean;
     animDelay?: number;
     formatTextValue?: (value: string) => string;
+    fontSize?: string;
 }
 
 export default function GaugeChart(props: GaugeChartProps): React.ReactElement;

--- a/types/react-gauge-chart/react-gauge-chart-tests.tsx
+++ b/types/react-gauge-chart/react-gauge-chart-tests.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import GaugeChart from 'react-gauge-chart';
+
+const Gauge: React.ReactElement = <GaugeChart id="0" />;

--- a/types/react-gauge-chart/tsconfig.json
+++ b/types/react-gauge-chart/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "jsx": "react",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-gauge-chart-tests.tsx"
+    ]
+}

--- a/types/react-gauge-chart/tslint.json
+++ b/types/react-gauge-chart/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.