### PR TITLE
prosemirror-collab: add options argument to receiveTransaction()

### DIFF
--- a/types/prosemirror-collab/index.d.ts
+++ b/types/prosemirror-collab/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prosemirror-collab 1.1.0
+// Type definitions for prosemirror-collab 1.1
 // Project: https://github.com/ProseMirror/prosemirror-collab
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>

--- a/types/prosemirror-collab/index.d.ts
+++ b/types/prosemirror-collab/index.d.ts
@@ -1,11 +1,12 @@
-// Type definitions for prosemirror-collab 1.0
+// Type definitions for prosemirror-collab 1.1.0
 // Project: https://github.com/ProseMirror/prosemirror-collab
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>
 //                 Tim Baumann <https://github.com/timjb>
 //                 Patrick Simmelbauer <https://github.com/patsimm>
+//                 Mike Morearty <https://github.com/mmorearty>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.9
 
 import { Schema } from 'prosemirror-model';
 import { EditorState, Plugin, Transaction } from 'prosemirror-state';
@@ -14,21 +15,44 @@ import { Step } from 'prosemirror-transform';
 /**
  * Creates a plugin that enables the collaborative editing framework
  * for the editor.
+ *
+ *   config::- An optional set of options
+ *
+ *     version:: ?number
+ *     The starting version number of the collaborative editing.
+ *     Defaults to 0.
+ *
+ *     clientID:: ?union<number, string>
+ *     This client's ID, used to distinguish its changes from those of
+ *     other clients. Defaults to a random 32-bit number.
  */
 export function collab(config?: {
   version?: number | null;
   clientID?: number | string | null;
 }): Plugin;
+
 /**
  * Create a transaction that represents a set of new steps received from
  * the authority. Applying this transaction moves the state forward to
  * adjust to the authority's view of the document.
+ *
+ *   options::- Additional options.
+ *
+ *     mapSelectionBackward:: ?boolean
+ *     When enabled (the default is `false`), if the current selection
+ *     is a [text selection](#state.TextSelection), its sides are
+ *     mapped with a negative bias for this transaction, so that
+ *     content inserted at the cursor ends up after the cursor. Users
+ *     usually prefer this, but it isn't done by default for reasons
+ *     of backwards compatibility.
  */
 export function receiveTransaction<S extends Schema = any>(
   state: EditorState<S>,
   steps: Array<Step<S>>,
-  clientIDs: Array<number | string>
+  clientIDs: Array<number | string>,
+  options?: { mapSelectionBackward?: boolean }
 ): Transaction<S>;
+
 /**
  * Provides data describing the editor's unconfirmed steps, which need
  * to be sent to the central authority. Returns null when there is
@@ -48,6 +72,7 @@ export function sendableSteps<S extends Schema = any>(
   clientID: number | string;
   origins: Array<Transaction<S>>;
 } | null | undefined;
+
 /**
  * Get the version up to which the collab plugin has synced with the
  * central authority.

--- a/types/prosemirror-collab/prosemirror-collab-tests.ts
+++ b/types/prosemirror-collab/prosemirror-collab-tests.ts
@@ -1,5 +1,6 @@
 import * as collab from 'prosemirror-collab';
 import { EditorState } from 'prosemirror-state';
+import { Step } from 'prosemirror-transform';
 
 const state = new EditorState();
 const version = collab.getVersion(state);
@@ -11,3 +12,10 @@ plugin = collab.collab({ clientID: 1 });
 
 const sendableSteps = collab.sendableSteps(state);
 sendableSteps!.clientID;
+
+declare const steps: Step[];
+declare const clientIDs: Array<string | number>;
+collab.receiveTransaction(state, steps, clientIDs);
+collab.receiveTransaction(state, steps, clientIDs, {});
+collab.receiveTransaction(state, steps, clientIDs, { mapSelectionBackward: true });
+collab.receiveTransaction(state, steps, clientIDs, { invalidOption: true }); // $ExpectError


### PR DESCRIPTION
receiveTransaction() now accepts an optional `options` argument.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://prosemirror.net/docs/ref/#collab.receiveTransaction>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.