### PR TITLE
Add type definitions for wol

### DIFF
--- a/types/wol/index.d.ts
+++ b/types/wol/index.d.ts
@@ -7,10 +7,14 @@
 
 export as namespace wol
 
-export function wake(
-    mac: string,
-    options?: { address?: string, port?: number },
-    callback?: (error: Error) => void,
-): Promise<boolean>;
+export type WakeCallback = (error: Error | null, result?: boolean) => void;
+
+export interface WakeOptions {
+    address?: string;
+    port?: number;
+}
+
+export function wake(mac: string, callback: WakeCallback): Promise<boolean>;
+export function wake(mac: string, options?: WakeOptions, callback?: WakeCallback): Promise<boolean>;
 
 export function createMagicPacket(mac: string): Buffer;

--- a/types/wol/index.d.ts
+++ b/types/wol/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for wol 1.0
+// Project: https://github.com/song940/wake-on-lan#readme
+// Definitions by: Ovidiu Pruteanu <https://github.com/ovidiupruteanu>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+export as namespace wol
+
+export function wake(
+    mac: string,
+    options?: { address?: string, port?: number },
+    callback?: (error: Error) => void,
+): Promise<boolean>;
+
+export function createMagicPacket(mac: string): Buffer;

--- a/types/wol/tsconfig.json
+++ b/types/wol/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "wol-tests.ts"
+    ]
+}

--- a/types/wol/tslint.json
+++ b/types/wol/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/wol/wol-tests.ts
+++ b/types/wol/wol-tests.ts
@@ -1,0 +1,13 @@
+import wol = require('wol');
+
+// $ExpectType Promise<boolean>
+wol.wake('00:00:00:00:00:00');
+
+// $ExpectType Promise<boolean>
+wol.wake('00:00:00:00:00:00', {
+    address: '255.255.255.255',
+    port: 9,
+});
+
+// $ExpectType Buffer
+wol.createMagicPacket('00:00:00:00:00:00');

--- a/types/wol/wol-tests.ts
+++ b/types/wol/wol-tests.ts
@@ -1,12 +1,28 @@
 import wol = require('wol');
 
+const optionsAll: wol.WakeOptions = {address: '255.255.255.255', port: 9};
+const optionsAddress: wol.WakeOptions = {address: '255.255.255.255'};
+const optionsPort: wol.WakeOptions = {port: 9};
+const optionsNone: wol.WakeOptions = {};
+
+// $ExpectType Promise<boolean>
+wol.wake('00:00:00:00:00:00', (error: Error | null) => {
+    console.log(error);
+});
+// $ExpectType Promise<boolean>
+wol.wake('00:00:00:00:00:00', (error: Error | null, result: boolean | undefined) => {
+    console.log(error, result);
+});
+
 // $ExpectType Promise<boolean>
 wol.wake('00:00:00:00:00:00');
 
 // $ExpectType Promise<boolean>
-wol.wake('00:00:00:00:00:00', {
-    address: '255.255.255.255',
-    port: 9,
+wol.wake('00:00:00:00:00:00', optionsAll);
+
+// $ExpectType Promise<boolean>
+wol.wake('00:00:00:00:00:00', optionsAll, (error: Error | null, result: boolean | undefined) => {
+    console.log(error, result);
 });
 
 // $ExpectType Buffer


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
