### PR TITLE
fix(mailgun-js): wrong type on templateVariable

### DIFF
--- a/types/mailgun-js/index.d.ts
+++ b/types/mailgun-js/index.d.ts
@@ -117,7 +117,7 @@ declare namespace Mailgun {
 
         type SendTemplateData = SendData & {
             template: string;
-            [templateVariable: string]: string;
+            [templateVariable: string]: any;
         };
 
         interface BatchSendRecipientVars {

--- a/types/mailgun-js/mailgun-js-tests.ts
+++ b/types/mailgun-js/mailgun-js-tests.ts
@@ -72,6 +72,19 @@ const exampleSendDataWithTemplate: mailgunFactory.messages.SendTemplateData = {
     "v:template-variable": "foo",
   };
 
+const exampleSendDataWithTemplate2: mailgunFactory.messages.SendTemplateData = {
+    to: "someone@email.com",
+    template: "my-template",
+    "v:number": 123,
+    "v:boolean": true,
+    "v:string": "",
+    "v:undefined": undefined,
+    "v:complexObject": {
+        whatever: 123,
+        test: true
+    },
+  };
+
 const exampleSendDataTemplateResponse: Promise<mailgunFactory.messages.SendResponse> = mailgun.messages().send(exampleSendDataWithTemplate);
 
 let validationResultPromise: Promise<mailgunFactory.validation.ValidateResponse>;


### PR DESCRIPTION
There are multiple places in the code that show the usage of complex
types on template variables:
https://github.com/highlycaffeinated/mailgun-js/blob/339ea2a0613de9a5eb10ca82ecf400512ae7d685/test/messages.test.js#L405-L422

It also supports `undefined`:
https://github.com/highlycaffeinated/mailgun-js/blob/339ea2a0613de9a5eb10ca82ecf400512ae7d685/test/messages.test.js#L105

That is simply because the code is stringifying the variables before
sending:
https://github.com/highlycaffeinated/mailgun-js/blob/339ea2a0613de9a5eb10ca82ecf400512ae7d685/lib/request.js#L20


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (urls posted above - and part of the commit).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.