### PR TITLE
Fixed incorrect typing for BoardConfig.onDrop()

### DIFF
--- a/types/chessboardjs/index.d.ts
+++ b/types/chessboardjs/index.d.ts
@@ -34,7 +34,7 @@ export type DropOffBoardType = 'snapback' | 'trash';
 export type Callback = () => void;
 
 export interface BoardConfig {
-    onDrop?: Callback;
+    onDrop?: Callback | () => 'snapback' | 'trash' | 'drop';
     draggable?: boolean;
     onChange?: Callback;
     onMoveEnd?: Callback;


### PR DESCRIPTION
In the original chessboardjs library, the onDrop() function accepts a function returning not only void but 'snapback', 'trash' and 'drop' as well.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.