### PR TITLE
[socker.io] initialization options inherit from engine.io

### DIFF
--- a/types/engine.io/index.d.ts
+++ b/types/engine.io/index.d.ts
@@ -82,7 +82,7 @@ declare namespace engine {
          * conform to the ws interface (see ws module api docs). Default value is ws.
          * An alternative c++ addon is also available by installing uws module.
          */
-        wsEngine?: "ws"|"uws"|string;
+        wsEngine?: "ws"|"uws";
         /**
          * an optional packet which will be concatenated to the handshake packet emitted by Engine.IO.
          */

--- a/types/engine.io/index.d.ts
+++ b/types/engine.io/index.d.ts
@@ -82,7 +82,7 @@ declare namespace engine {
          * conform to the ws interface (see ws module api docs). Default value is ws.
          * An alternative c++ addon is also available by installing uws module.
          */
-        wsEngine?: "ws"|"uws";
+        wsEngine?: "ws"|"uws"|string;
         /**
          * an optional packet which will be concatenated to the handshake packet emitted by Engine.IO.
          */

--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -13,6 +13,7 @@
 ///<reference types="node" />
 
 declare const SocketIO: SocketIOStatic;
+import engine = require('engine.io');
 export = SocketIO;
 /** @deprecated Available as a global for backwards-compatibility. */
 export as namespace SocketIO;
@@ -292,7 +293,7 @@ declare namespace SocketIO {
     /**
      * Options to pass to our server when creating it
      */
-    interface ServerOptions {
+    interface ServerOptions extends engine.ServerAttachOptions {
 
         /**
          * The path to server the client file to
@@ -318,75 +319,6 @@ declare namespace SocketIO {
          * @default '*:*'
          */
         origins?: string|string[];
-
-        /**
-         * How many milliseconds without a pong packed to consider the connection closed (engine.io)
-         * @default 60000
-         */
-        pingTimeout?: number;
-
-        /**
-         * How many milliseconds before sending a new ping packet (keep-alive) (engine.io)
-         * @default 25000
-         */
-        pingInterval?: number;
-
-        /**
-         * How many bytes or characters a message can be when polling, before closing the session
-         * (to avoid Dos) (engine.io)
-         * @default 10E7
-         */
-        maxHttpBufferSize?: number;
-
-        /**
-         * A function that receives a given handshake or upgrade request as its first parameter,
-         * and can decide whether to continue or not. The second argument is a function that needs
-         * to be called with the decided information: fn( err, success ), where success is a boolean
-         * value where false means that the request is rejected, and err is an error code (engine.io)
-         * @default null
-         */
-        allowRequest?: (request:any, callback: (err: number, success: boolean) => void) => void;
-
-        /**
-         * Transports to allow connections to (engine.io)
-         * @default ['polling','websocket']
-         */
-        transports?: string[];
-
-        /**
-         * Whether to allow transport upgrades (engine.io)
-         * @default true
-         */
-        allowUpgrades?: boolean;
-
-        /**
-         * parameters of the WebSocket permessage-deflate extension (see ws module).
-         * Set to false to disable (engine.io)
-         * @default true
-         */
-        perMessageDeflate?: Object|boolean;
-
-        /**
-         * Parameters of the http compression for the polling transports (see zlib).
-         * Set to false to disable, or set an object with parameter "threshold:number"
-         * to only compress data if the byte size is above this value (1024) (engine.io)
-         * @default true|1024
-         */
-        httpCompression?: Object|boolean;
-
-        /**
-         * Name of the HTTP cookie that contains the client sid to send as part of
-         * handshake response headers. Set to false to not send one (engine.io)
-         * @default "io"
-         */
-        cookie?: string|boolean;
-
-        /**
-         * Whether to let engine.io handle the OPTIONS requests.
-         * You can also pass a custom function to handle the requests
-         * @default true
-         */
-        handlePreflightRequest?: ((req: any, res: any) => void) | boolean;
     }
 
     /**

--- a/types/socket.io/socket.io-tests.ts
+++ b/types/socket.io/socket.io-tests.ts
@@ -47,6 +47,12 @@ function testUsingWithExpress() {
     });
 }
 
+function testUsingWithOptions() {
+    var app = require('express')();
+    var server = require('http').Server(app);
+    var io = socketIO(server, {wsEngine: 'ws'});
+}
+
 function testUsingWithTheExpressFramework() {
     var app = require('express').createServer();
     var io = socketIO(app);


### PR DESCRIPTION
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  
  * https://github.com/socketio/socket.io/blob/master/docs/API.md#new-serverhttpserver-options
    > The same options passed to socket.io are always passed to the engine.io Server that gets created. See engine.io options as reference.
  * https://github.com/socketio/socket.io/blob/2.2.0/lib/index.js#L310
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This improvement include fix of #44788