### PR TITLE
feat(write-file-encoding): add support for encoding option

### DIFF
--- a/types/write-file-atomic/index.d.ts
+++ b/types/write-file-atomic/index.d.ts
@@ -24,7 +24,7 @@ declare namespace writeFile {
         /**
          * @default 'utf8'
          */
-        encoding?: BufferEncoding | '';
+        encoding?: BufferEncoding;
         fsync?: boolean;
         mode?: number;
     }

--- a/types/write-file-atomic/index.d.ts
+++ b/types/write-file-atomic/index.d.ts
@@ -2,25 +2,29 @@
 // Project: https://github.com/npm/write-file-atomic
 // Definitions by: BendingBender <https://github.com/BendingBender>
 //                 Jay Rylan <https://github.com/jayrylan>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
 export = writeFile;
 
-declare function writeFile(filename: string, data: string | Buffer, options: writeFile.Options, callback: (error?: Error) => void): void;
+declare function writeFile(filename: string, data: string | Buffer, options: writeFile.Options | BufferEncoding, callback: (error?: Error) => void): void;
 declare function writeFile(filename: string, data: string | Buffer, callback: (error?: Error) => void): void;
-declare function writeFile(filename: string, data: string | Buffer, options?: writeFile.Options): Promise<void>;
+declare function writeFile(filename: string, data: string | Buffer, options?: writeFile.Options | BufferEncoding): Promise<void>;
 
 declare namespace writeFile {
-    function sync(filename: string, data: string | Buffer, options?: Options): void;
+    function sync(filename: string, data: string | Buffer, options?: Options | BufferEncoding): void;
 
     interface Options {
         chown?: {
             uid: number;
             gid: number;
         };
-        encoding?: string;
+        /**
+         * @default 'utf8'
+         */
+        encoding?: BufferEncoding | '';
         fsync?: boolean;
         mode?: number;
     }

--- a/types/write-file-atomic/write-file-atomic-tests.ts
+++ b/types/write-file-atomic/write-file-atomic-tests.ts
@@ -3,7 +3,6 @@ import writeFileAtomic = require('write-file-atomic');
 writeFileAtomic('message.txt', 'Hello Node', err => {});
 
 writeFileAtomic('message.txt', 'Hello Node', {chown: {uid: 100, gid: 50}}, err => {});
-writeFileAtomic('message.txt', 'Hello Node', {encoding: ''}, err => {});
 writeFileAtomic('message.txt', 'Hello Node', {fsync: false}, err => {});
 writeFileAtomic('message.txt', 'Hello Node', {mode: 123}, err => {});
 writeFileAtomic('message.txt', 'Hello Node', 'utf8', err => {});
@@ -15,7 +14,6 @@ writeFileAtomic('message.txt', 'Hello Node', 'utf8').then(() => {}).catch(() => 
 writeFileAtomic.sync('message.txt', 'Hello Node');
 
 writeFileAtomic.sync('message.txt', 'Hello Node', {chown: {uid: 100, gid: 50}});
-writeFileAtomic.sync('message.txt', 'Hello Node', {encoding: ''});
 writeFileAtomic.sync('message.txt', 'Hello Node', {fsync: false});
 writeFileAtomic.sync('message.txt', 'Hello Node', {mode: 123});
 writeFileAtomic.sync('message.txt', 'Hello Node', 'utf8');

--- a/types/write-file-atomic/write-file-atomic-tests.ts
+++ b/types/write-file-atomic/write-file-atomic-tests.ts
@@ -6,9 +6,11 @@ writeFileAtomic('message.txt', 'Hello Node', {chown: {uid: 100, gid: 50}}, err =
 writeFileAtomic('message.txt', 'Hello Node', {encoding: ''}, err => {});
 writeFileAtomic('message.txt', 'Hello Node', {fsync: false}, err => {});
 writeFileAtomic('message.txt', 'Hello Node', {mode: 123}, err => {});
+writeFileAtomic('message.txt', 'Hello Node', 'utf8', err => {});
 
 writeFileAtomic('message.txt', 'Hello Node').then(() => {}).catch(() => {});
 writeFileAtomic('message.txt', 'Hello Node', {mode: 123}).then(() => {}).catch(() => {});
+writeFileAtomic('message.txt', 'Hello Node', 'utf8').then(() => {}).catch(() => {});
 
 writeFileAtomic.sync('message.txt', 'Hello Node');
 
@@ -16,3 +18,4 @@ writeFileAtomic.sync('message.txt', 'Hello Node', {chown: {uid: 100, gid: 50}});
 writeFileAtomic.sync('message.txt', 'Hello Node', {encoding: ''});
 writeFileAtomic.sync('message.txt', 'Hello Node', {fsync: false});
 writeFileAtomic.sync('message.txt', 'Hello Node', {mode: 123});
+writeFileAtomic.sync('message.txt', 'Hello Node', 'utf8');


### PR DESCRIPTION
The api supports string as an option This string option is the encodign
of the data, defaulting to 'utf8'. As the Node types are referenced,
simply BufferEncoding is beign used instead of string or string aliases
to align with Node types.
For backward compatiblity options 'encoding' is defined as:
BufferEncoding | ''

https://github.com/npm/write-file-atomic#write-file-atomic

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)