### PR TITLE
feat(node): add typesafety to EventEmitter events via generics (proposal)

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -35,8 +35,9 @@ declare module "events" {
          */
         let captureRejections: boolean;
 
-        interface EventEmitter extends NodeJS.EventEmitter {
-        }
+        type Events = Record<string | symbol, (...args: any[]) => void>;
+
+        interface EventEmitter<E extends Events = Events> extends NodeJS.EventEmitter<E> {}
 
         class EventEmitter {
             constructor(options?: EventEmitterOptions);

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -549,23 +549,25 @@ declare namespace NodeJS {
         stack?: string;
     }
 
-    interface EventEmitter {
-        addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        on(event: string | symbol, listener: (...args: any[]) => void): this;
-        once(event: string | symbol, listener: (...args: any[]) => void): this;
-        removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        off(event: string | symbol, listener: (...args: any[]) => void): this;
-        removeAllListeners(event?: string | symbol): this;
-        setMaxListeners(n: number): this;
+    type Events = Record<string | symbol, (...args: any[]) => void>
+
+    interface EventEmitter<E extends Events> {
+        addListener<K extends keyof E>(event: K, listener: E[K]): this;
+        on<K extends keyof E>(event: K, listener: E[K]): this;
+        once<K extends keyof E>(event: K, listener: E[K]): this;
+        removeListener<K extends keyof E>(event: K, listener: E[K]): this;
+        off<K extends keyof E>(event: K, listener: E[K]): this;
+        removeAllListeners<K extends keyof E>(event?: K): this;
+        setMaxListeners(maxListeners: number): this;
         getMaxListeners(): number;
-        listeners(event: string | symbol): Function[];
-        rawListeners(event: string | symbol): Function[];
-        emit(event: string | symbol, ...args: any[]): boolean;
-        listenerCount(type: string | symbol): number;
+        listeners<K extends keyof E>(event: K): E[K][];
+        rawListeners<K extends keyof E>(event: K): E[K][];
+        emit<K extends keyof E>(event: K, ...args: Parameters<E[K]>): boolean;
+        listenerCount<K extends keyof E>(event: K): number;
         // Added in Node 6...
-        prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        eventNames(): Array<string | symbol>;
+        prependListener<K extends keyof E>(event: K, listener: E[K]): this;
+        prependOnceListener<K extends keyof E>(event: K, listener: E[K]): this;
+        eventNames<K extends keyof E>(): K[];
     }
 
     interface ReadableStream extends EventEmitter {
@@ -599,12 +601,6 @@ declare namespace NodeJS {
         remove(emitter: EventEmitter | Timer): void;
         bind<T extends Function>(cb: T): T;
         intercept<T extends Function>(cb: T): T;
-
-        addListener(event: string, listener: (...args: any[]) => void): this;
-        on(event: string, listener: (...args: any[]) => void): this;
-        once(event: string, listener: (...args: any[]) => void): this;
-        removeListener(event: string, listener: (...args: any[]) => void): this;
-        removeAllListeners(event?: string): this;
     }
 
     interface MemoryUsage {
@@ -766,7 +762,22 @@ declare namespace NodeJS {
         voluntaryContextSwitches: number;
     }
 
-    interface Process extends EventEmitter {
+    type ProcessEvents = {
+        "beforeExit": BeforeExitListener,
+        "disconnect": DisconnectListener,
+        "exit": ExitListener,
+        "rejectionHandled": RejectionHandledListener,
+        "uncaughtException": UncaughtExceptionListener,
+        "uncaughtExceptionMonitor": UncaughtExceptionListener,
+        "unhandledRejection": UnhandledRejectionListener,
+        "warning": WarningListener,
+        "message": MessageListener,
+        "newListener": NewListenerListener,
+        "removeListener": RemoveListenerListener,
+        "multipleResolves": MultipleResolveListener,
+    } & Record<Signals, SignalsListener>
+
+    interface Process extends EventEmitter<ProcessEvents> {
         /**
          * Can also be a tty.WriteStream, not typed due to limitations.
          */
@@ -875,106 +886,6 @@ declare namespace NodeJS {
         report?: ProcessReport;
 
         resourceUsage(): ResourceUsage;
-
-        /* EventEmitter */
-        addListener(event: "beforeExit", listener: BeforeExitListener): this;
-        addListener(event: "disconnect", listener: DisconnectListener): this;
-        addListener(event: "exit", listener: ExitListener): this;
-        addListener(event: "rejectionHandled", listener: RejectionHandledListener): this;
-        addListener(event: "uncaughtException", listener: UncaughtExceptionListener): this;
-        addListener(event: "uncaughtExceptionMonitor", listener: UncaughtExceptionListener): this;
-        addListener(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
-        addListener(event: "warning", listener: WarningListener): this;
-        addListener(event: "message", listener: MessageListener): this;
-        addListener(event: Signals, listener: SignalsListener): this;
-        addListener(event: "newListener", listener: NewListenerListener): this;
-        addListener(event: "removeListener", listener: RemoveListenerListener): this;
-        addListener(event: "multipleResolves", listener: MultipleResolveListener): this;
-
-        emit(event: "beforeExit", code: number): boolean;
-        emit(event: "disconnect"): boolean;
-        emit(event: "exit", code: number): boolean;
-        emit(event: "rejectionHandled", promise: Promise<any>): boolean;
-        emit(event: "uncaughtException", error: Error): boolean;
-        emit(event: "uncaughtExceptionMonitor", error: Error): boolean;
-        emit(event: "unhandledRejection", reason: any, promise: Promise<any>): boolean;
-        emit(event: "warning", warning: Error): boolean;
-        emit(event: "message", message: any, sendHandle: any): this;
-        emit(event: Signals, signal: Signals): boolean;
-        emit(event: "newListener", eventName: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "removeListener", eventName: string, listener: (...args: any[]) => void): this;
-        emit(event: "multipleResolves", listener: MultipleResolveListener): this;
-
-        on(event: "beforeExit", listener: BeforeExitListener): this;
-        on(event: "disconnect", listener: DisconnectListener): this;
-        on(event: "exit", listener: ExitListener): this;
-        on(event: "rejectionHandled", listener: RejectionHandledListener): this;
-        on(event: "uncaughtException", listener: UncaughtExceptionListener): this;
-        on(event: "uncaughtExceptionMonitor", listener: UncaughtExceptionListener): this;
-        on(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
-        on(event: "warning", listener: WarningListener): this;
-        on(event: "message", listener: MessageListener): this;
-        on(event: Signals, listener: SignalsListener): this;
-        on(event: "newListener", listener: NewListenerListener): this;
-        on(event: "removeListener", listener: RemoveListenerListener): this;
-        on(event: "multipleResolves", listener: MultipleResolveListener): this;
-        on(event: string | symbol, listener: (...args: any[]) => void): this;
-
-        once(event: "beforeExit", listener: BeforeExitListener): this;
-        once(event: "disconnect", listener: DisconnectListener): this;
-        once(event: "exit", listener: ExitListener): this;
-        once(event: "rejectionHandled", listener: RejectionHandledListener): this;
-        once(event: "uncaughtException", listener: UncaughtExceptionListener): this;
-        once(event: "uncaughtExceptionMonitor", listener: UncaughtExceptionListener): this;
-        once(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
-        once(event: "warning", listener: WarningListener): this;
-        once(event: "message", listener: MessageListener): this;
-        once(event: Signals, listener: SignalsListener): this;
-        once(event: "newListener", listener: NewListenerListener): this;
-        once(event: "removeListener", listener: RemoveListenerListener): this;
-        once(event: "multipleResolves", listener: MultipleResolveListener): this;
-
-        prependListener(event: "beforeExit", listener: BeforeExitListener): this;
-        prependListener(event: "disconnect", listener: DisconnectListener): this;
-        prependListener(event: "exit", listener: ExitListener): this;
-        prependListener(event: "rejectionHandled", listener: RejectionHandledListener): this;
-        prependListener(event: "uncaughtException", listener: UncaughtExceptionListener): this;
-        prependListener(event: "uncaughtExceptionMonitor", listener: UncaughtExceptionListener): this;
-        prependListener(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
-        prependListener(event: "warning", listener: WarningListener): this;
-        prependListener(event: "message", listener: MessageListener): this;
-        prependListener(event: Signals, listener: SignalsListener): this;
-        prependListener(event: "newListener", listener: NewListenerListener): this;
-        prependListener(event: "removeListener", listener: RemoveListenerListener): this;
-        prependListener(event: "multipleResolves", listener: MultipleResolveListener): this;
-
-        prependOnceListener(event: "beforeExit", listener: BeforeExitListener): this;
-        prependOnceListener(event: "disconnect", listener: DisconnectListener): this;
-        prependOnceListener(event: "exit", listener: ExitListener): this;
-        prependOnceListener(event: "rejectionHandled", listener: RejectionHandledListener): this;
-        prependOnceListener(event: "uncaughtException", listener: UncaughtExceptionListener): this;
-        prependOnceListener(event: "uncaughtExceptionMonitor", listener: UncaughtExceptionListener): this;
-        prependOnceListener(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
-        prependOnceListener(event: "warning", listener: WarningListener): this;
-        prependOnceListener(event: "message", listener: MessageListener): this;
-        prependOnceListener(event: Signals, listener: SignalsListener): this;
-        prependOnceListener(event: "newListener", listener: NewListenerListener): this;
-        prependOnceListener(event: "removeListener", listener: RemoveListenerListener): this;
-        prependOnceListener(event: "multipleResolves", listener: MultipleResolveListener): this;
-
-        listeners(event: "beforeExit"): BeforeExitListener[];
-        listeners(event: "disconnect"): DisconnectListener[];
-        listeners(event: "exit"): ExitListener[];
-        listeners(event: "rejectionHandled"): RejectionHandledListener[];
-        listeners(event: "uncaughtException"): UncaughtExceptionListener[];
-        listeners(event: "uncaughtExceptionMonitor"): UncaughtExceptionListener[];
-        listeners(event: "unhandledRejection"): UnhandledRejectionListener[];
-        listeners(event: "warning"): WarningListener[];
-        listeners(event: "message"): MessageListener[];
-        listeners(event: Signals): SignalsListener[];
-        listeners(event: "newListener"): NewListenerListener[];
-        listeners(event: "removeListener"): RemoveListenerListener[];
-        listeners(event: "multipleResolves"): MultipleResolveListener[];
     }
 
     interface Global {

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -549,25 +549,26 @@ declare namespace NodeJS {
         stack?: string;
     }
 
-    type Events = Record<string | symbol, (...args: any[]) => void>
+    type Events = Record<string | symbol, (...args: any[]) => void>;
+    type Arguments<T> = [T] extends [(...args: infer U) => any] ? U : [T] extends [] ? [] : [T];
 
-    interface EventEmitter<E extends Events> {
+    interface EventEmitter<E extends Events = Events> {
         addListener<K extends keyof E>(event: K, listener: E[K]): this;
         on<K extends keyof E>(event: K, listener: E[K]): this;
         once<K extends keyof E>(event: K, listener: E[K]): this;
         removeListener<K extends keyof E>(event: K, listener: E[K]): this;
         off<K extends keyof E>(event: K, listener: E[K]): this;
-        removeAllListeners<K extends keyof E>(event?: K): this;
+        removeAllListeners(event?: keyof E): this;
         setMaxListeners(maxListeners: number): this;
         getMaxListeners(): number;
-        listeners<K extends keyof E>(event: K): E[K][];
-        rawListeners<K extends keyof E>(event: K): E[K][];
-        emit<K extends keyof E>(event: K, ...args: Parameters<E[K]>): boolean;
-        listenerCount<K extends keyof E>(event: K): number;
+        listeners<K extends keyof E>(event: K): Array<E[K]>;
+        rawListeners<K extends keyof E>(event: K): Array<E[K]>;
+        emit<K extends keyof E>(event: K, ...args: Arguments<E[K]>): boolean;
+        listenerCount(event: keyof E): number;
         // Added in Node 6...
         prependListener<K extends keyof E>(event: K, listener: E[K]): this;
         prependOnceListener<K extends keyof E>(event: K, listener: E[K]): this;
-        eventNames<K extends keyof E>(): K[];
+        eventNames(): Array<keyof E>;
     }
 
     interface ReadableStream extends EventEmitter {
@@ -763,19 +764,19 @@ declare namespace NodeJS {
     }
 
     type ProcessEvents = {
-        "beforeExit": BeforeExitListener,
-        "disconnect": DisconnectListener,
-        "exit": ExitListener,
-        "rejectionHandled": RejectionHandledListener,
-        "uncaughtException": UncaughtExceptionListener,
-        "uncaughtExceptionMonitor": UncaughtExceptionListener,
-        "unhandledRejection": UnhandledRejectionListener,
-        "warning": WarningListener,
-        "message": MessageListener,
-        "newListener": NewListenerListener,
-        "removeListener": RemoveListenerListener,
-        "multipleResolves": MultipleResolveListener,
-    } & Record<Signals, SignalsListener>
+        beforeExit: BeforeExitListener;
+        disconnect: DisconnectListener;
+        exit: ExitListener;
+        rejectionHandled: RejectionHandledListener;
+        uncaughtException: UncaughtExceptionListener;
+        uncaughtExceptionMonitor: UncaughtExceptionListener;
+        unhandledRejection: UnhandledRejectionListener;
+        warning: WarningListener;
+        message: MessageListener;
+        newListener: NewListenerListener;
+        removeListener: RemoveListenerListener;
+        multipleResolves: MultipleResolveListener;
+    } & Record<Signals, SignalsListener>;
 
     interface Process extends EventEmitter<ProcessEvents> {
         /**

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -776,7 +776,8 @@ declare namespace NodeJS {
         newListener: NewListenerListener;
         removeListener: RemoveListenerListener;
         multipleResolves: MultipleResolveListener;
-    } & Record<Signals, SignalsListener>;
+    } & Record<Signals, SignalsListener> &
+        Record<string | symbol, (...args: any[]) => void>;
 
     interface Process extends EventEmitter<ProcessEvents> {
         /**


### PR DESCRIPTION
Heavily inspired by: [`typed-emitter`](https://github.com/andywer/typed-emitter)

It seems we need to figure out a compatibility path here, as there's quite a good amount of tests failing. Maybe widening the default types so we can migrate.

There's a lot of core code which can benefit from easier-to-add event typings 😄 

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
