### PR TITLE
add `initial` to FormState

### DIFF
--- a/types/redux-form/v7/lib/reducer.d.ts
+++ b/types/redux-form/v7/lib/reducer.d.ts
@@ -21,6 +21,7 @@ export interface FormState {
     registeredFields: RegisteredFieldState[];
     fields?: {[name: string]: FieldState};
     values?: { [fieldName: string]: any };
+    initial?: { [fieldName: string]: any };
     active?: string;
     anyTouched?: boolean;
     submitting?: boolean;


### PR DESCRIPTION
form is missing `initial` field. 

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://redux-form.com/7.4.2/docs/api/props.md/#-code-initialvalues-object-code-