### PR TITLE
[@types/simpl-schema] add missing argument to SimpleSchemaStatic.validator function

### DIFF
--- a/types/simpl-schema/index.d.ts
+++ b/types/simpl-schema/index.d.ts
@@ -4,6 +4,7 @@
 //                 Qkramer <https://github.com/Qkramer>
 //                 Deskoh <https://github.com/deskoh>
 //                 Nicusor Chiciuc <https://github.com/nicu-chiciuc>
+//                 Rafa Horo <https://github.com/rafahoro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface ValidationContext extends SimpleSchemaValidationContextStatic {
@@ -139,7 +140,7 @@ interface SimpleSchemaStatic {
   newContext(): ValidationContext;
   objectKeys(keyPrefix: any): any[];
   validate(obj: any, options?: ValidationOption): void;
-  validator(options?: ValidationOption): () => boolean;
+  validator(options?: ValidationOption): (obj: any) => boolean;
   extend(otherSchema: SimpleSchemaStatic): SimpleSchemaStatic;
   extendOptions(options: string[]): void;
   RegEx: {


### PR DESCRIPTION
Fixed the validator function definition
From:
The validator function returns a function that receives nothing and returns boolean
To:
The validator function returns a function that receives an object and returns boolean

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
https://github.com/aldeed/simple-schema-js/blob/master/package/lib/SimpleSchema.js#L673

