### PR TITLE
[@types/cytoscape] Added in missing NodeShapes.

### DIFF
--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -3536,10 +3536,11 @@ declare namespace cytoscape {
          * 'polygon' is a custom polygon specified via shape-polygon-points.
          */
         type NodeShape = 'rectangle' | 'roundrectangle' | 'ellipse' | 'triangle'
-            | "pentagon" | "hexagon" | "heptagon" | "octagon" | "star"
-            | "diamond" | "vee" | "rhomboid" | "polygon" | "round-rectangle"
+            | "pentagon" | "hexagon" | "heptagon" | "octagon" | "star" | "barrel"
+            | "diamond" | "vee" | "rhomboid" | "polygon" | "tag" | "round-rectangle"
             | "round-triangle" | "round-diamond" | "round-pentagon" | "round-hexagon"
-            | "round-heptagon" | "round-octagon" | "round-tag";
+            | "round-heptagon" | "round-octagon" | "round-tag"
+            | "cut-rectangle"| "bottom-round-rectangle" | "concave-hexagon";
 
         /**
          * A space-separated list of numbers ranging on [-1, 1],


### PR DESCRIPTION
Hello Maintainers!

I'm using Cytoscapes Types for a project and I wanted to use a one of the node shapes from the demo in the docs: https://js.cytoscape.org/demos/node-types/
Then I noticed some shapes where not included in the type definition, so I want to add them in!

Have a nice day!