### PR TITLE
pulsar-client negative acknowledge missing declarations

### DIFF
--- a/types/pulsar-client/index.d.ts
+++ b/types/pulsar-client/index.d.ts
@@ -384,6 +384,18 @@ export class Consumer {
     acknowledgeId(messageId: MessageId): void;
 
     /**
+     * Negatively acknowledges a message to the Pulsar broker by message object.
+     * @param message Message to acknowledge.
+     */
+    negativeAcknowledge(message: Message): void;
+
+    /**
+     * Negatively acknowledges a message to the Pulsar broker by message ID object.
+     * @param messageId Message ID to acknowledge.
+     */
+    negativeAcknowledgeId(messageId: MessageId): void;
+
+    /**
      * Acknowledges all the messages in the stream, up to and including the specified message.
      * The acknowledgeCumulative method will return void, and send the ack to the broker asynchronously.
      * After that, the messages will not be redelivered to the consumer. Cumulative acking can not be used with a shared subscription type.

--- a/types/pulsar-client/pulsar-client-tests.ts
+++ b/types/pulsar-client/pulsar-client-tests.ts
@@ -51,6 +51,8 @@ import Pulsar = require('pulsar-client');
 
     consumer.acknowledge(msg);
     consumer.acknowledgeId(msg.getMessageId());
+    consumer.negativeAcknowledge(msg);
+    consumer.negativeAcknowledgeId(msg.getMessageId());
     consumer.acknowledgeCumulative(msg);
     consumer.acknowledgeCumulativeId(msg.getMessageId());
 


### PR DESCRIPTION
`pulsar-client`: add missing negative acknowledge declarations.

`negativeAcknowledge` and `negativeAcknowledgeId` are missing from `Consumer` class in `@types/pulsar-client` despite the fact they are implemented in `pulsar-client-node`
https://github.com/apache/pulsar-client-node/blob/master/src/Consumer.h#L45
and used in corresponding tests
https://github.com/apache/pulsar-client-node/blob/master/tests/end_to_end.test.js#L102

I've added missing declarations.

(Also checked in my pet snippet - it works as expected. No awaiting for ack timeout before message redelivery.
```
            const msg = await this.consumer.receive();
            try {
                const msgData = JSON.parse(msg.getData().toString());
                await this.handler(msgData);
                this.consumer.acknowledge(msg);
            } catch (err) {
                console.log(`Error thrown `, err);
                this.consumer.negativeAcknowledge(msg);
            }
```
)


cc @bwalendz  (`@types/pulsar-client` author)