### PR TITLE
Add definition types for 'ip6addr' npm package

### DIFF
--- a/types/ip6addr/index.d.ts
+++ b/types/ip6addr/index.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for ip6addr 0.2
+// Project: git@github.com:kryptoslogic/DefinitelyTyped.git
+// Definitions by: Vít Stanislav <https://github.com/slaweet>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+export interface ToStringOpts {
+  format?: 'auto' | 'v4' | 'v4-mapped' | 'v6';
+  zeroElide?: boolean;
+  zeroPad?: boolean;
+}
+
+export interface Addr {
+  kind: () => 'ipv4' | 'ipv6';
+  toString: (opts?: ToStringOpts) => string;
+  toBuffer: (buff?: Uint8Array) => Uint8Array;
+  toLong: () => number;
+  offset: (num: number) => Addr | null;
+  compare: (other: Addr) => number;
+}
+
+export interface AddrRange {
+  contains: (input: string) => boolean;
+  first: () => Addr;
+  last: () => Addr;
+}
+
+export interface CIDR {
+  contains: (input: string) => boolean;
+  first: () => Addr;
+  last: () => Addr;
+  broadcast: () => Addr;
+  compare: (other: CIDR) => number;
+  prefixLength: () => number;
+  address: () => Addr;
+  toString: (opts?: ToStringOpts) => string;
+}
+
+export function parse(cidr: string): Addr;
+
+export function createCIDR(cidr: string, plen?: number): CIDR;
+
+export function createAddrRange(first: string, last: string): AddrRange;
+
+export function compare(addr1: string, addr2: string): number;
+
+export function compareCIDR(cidr1: string, cidr2: string): number;

--- a/types/ip6addr/index.d.ts
+++ b/types/ip6addr/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for ip6addr 0.2
-// Project: git@github.com:kryptoslogic/DefinitelyTyped.git
+// Project: https://github.com/joyent/node-ip6addr
 // Definitions by: Vít Stanislav <https://github.com/slaweet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/ip6addr/index.d.ts
+++ b/types/ip6addr/index.d.ts
@@ -37,12 +37,12 @@ export interface CIDR {
   toString: (opts?: ToStringOpts) => string;
 }
 
-export function parse(cidr: string): Addr;
-
-export function createCIDR(cidr: string, plen?: number): CIDR;
-
-export function createAddrRange(first: string, last: string): AddrRange;
-
 export function compare(addr1: string, addr2: string): number;
 
 export function compareCIDR(cidr1: string, cidr2: string): number;
+
+export function createAddrRange(begin: string, end: string): AddrRange;
+
+export function createCIDR(addr: string, len?: number): CIDR;
+
+export function parse(input: string): Addr;

--- a/types/ip6addr/ip6addr-tests.ts
+++ b/types/ip6addr/ip6addr-tests.ts
@@ -1,0 +1,32 @@
+import ip6addr = require('ip6addr');
+
+const addr = ip6addr.parse('fd00::0123');
+addr.kind();
+addr.toString();
+addr.toString({ format: 'v6' });
+addr.toString({ format: 'v6', zeroElide: false, zeroPad: true });
+addr.toBuffer();
+addr.toLong();
+addr.offset(1);
+const addr2 = ip6addr.parse('fd20::5');
+addr.compare(addr2);
+
+const cidr = ip6addr.createCIDR('fe80::/10');
+const cidr2 = ip6addr.createCIDR('10.0.0.0', 8);
+cidr.toString();
+addr.toString({ format: 'v6' });
+addr.toString({ format: 'v6', zeroElide: false, zeroPad: true });
+cidr.contains('fe80::507f:baff:fe85:92eb');
+cidr.first().toString();
+cidr.last().toString();
+cidr.broadcast().toString();
+cidr.compare(cidr2);
+cidr.prefixLength();
+cidr.address();
+
+const range = ip6addr.createAddrRange('fd00::123', 'fd00::ea00');
+range.first().toString();
+range.last().toString();
+
+ip6addr.compare('10.0.1.76', '8.8.8.8');
+ip6addr.compareCIDR('192.168.0.0/24', '192.168.0.0/16');

--- a/types/ip6addr/tsconfig.json
+++ b/types/ip6addr/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ip6addr-tests.ts"
+    ]
+}

--- a/types/ip6addr/tslint.json
+++ b/types/ip6addr/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.


