### PR TITLE
Exempt complex.js from npm naming export=

### DIFF
--- a/types/complex.js/tslint.json
+++ b/types/complex.js/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
 }


### PR DESCRIPTION
It technically should use export= but also has a default export, so I'm not going to change the code.
I'm just going to disable the rule. 

The real fix is to switch to `export =` and add a property named `default` so that `import x = require('complex.js')` will work in addition to `import x from 'complex.js'`.