### PR TITLE
Exempt deep-diff from npm-naming.

### DIFF
--- a/types/deep-diff/tslint.json
+++ b/types/deep-diff/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}


### PR DESCRIPTION
deep-diff actually makes its default function available via `import diff = require('deep-diff')`, but that's not currently in the typings. I added a lint exemption for this since it's not critical to export it that way.

The real fix is to put all the existing functions into a namespace named `deepDiff` and `export=` a function named `deepDiff`, so that the merged function/namespace will contain everything the package exports.