### PR TITLE
[config] Add export for DeferredConfig class

### DIFF
--- a/types/config/defer.d.ts
+++ b/types/config/defer.d.ts
@@ -1,8 +1,15 @@
-type DeferFunction<T,R> = (this: any, origValue: T) => R;
-
 /*
  * Allows a config value to be deferred for later. The original config object is passed
  * into func as "this".
  * See: https://github.com/lorenwest/node-config/wiki/Special-features-for-JavaScript-configuration-files#deferred-values-in-javascript-configuration-files
  */
-export function deferConfig<T, R>(func: DeferFunction<T,R>): R;
+type DeferFunction<T,R> = (this: any, origValue: T) => R;
+
+import { IConfig } from '.';
+
+export class DeferredConfig<T, R> {
+    prepare(config: IConfig, prop: T, property: keyof T): this;
+    resolve(): R;
+}
+
+export function deferConfig<T, R>(func: DeferFunction<T,R>): DeferredConfig<T, R>;


### PR DESCRIPTION
The node-config package's `deferConfig` function returns an instance of
`DeferredConfig`. It later uses `instanceof DeferredConfig` to see if
the value needs to be resolved. This change adds an export for
`DeferredConfig` and also updates the `deferConfig` function to return
that instance.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lorenwest/node-config/blob/master/defer.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

