### PR TITLE
Exempt final-form-set-field-data from npm-naming

### DIFF
--- a/types/final-form-set-field-data/tslint.json
+++ b/types/final-form-set-field-data/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}


### PR DESCRIPTION
It uses `export default` but the lint rule gets confused by an internal helper that assigns to `module.exports` and thinks it directly exports a function.