### PR TITLE
Flatbush uses export=

### DIFF
--- a/types/flatbush/flatbush-tests.ts
+++ b/types/flatbush/flatbush-tests.ts
@@ -1,4 +1,4 @@
-import Flatbush from 'flatbush';
+import Flatbush = require('flatbush');
 
 const from: Flatbush = Flatbush.from(new ArrayBuffer(0));
 

--- a/types/flatbush/index.d.ts
+++ b/types/flatbush/index.d.ts
@@ -53,7 +53,7 @@ declare class FlatbushClass {
      * Recreates a Flatbush index from raw ArrayBuffer data (that's exposed as index.data on a previously indexed Flatbush instance).
      * Very useful for transferring indices between threads or storing them in a file.
      */
-    static from(data: ArrayBuffer): Flatbush;
+    static from(data: ArrayBuffer): FlatbushClass;
 
     /**
      * array buffer that holds the index
@@ -95,6 +95,8 @@ declare class FlatbushClass {
     readonly IndexArrayType: TypedArrayConstructor;
 }
 
-export type Flatbush = FlatbushClass;
-// tslint:disable-next-line:npm-naming https://github.com/mourner/flatbush/blob/master/index.js#L11
-export default FlatbushClass;
+declare namespace FlatbushClass {
+    type Flatbush = FlatbushClass;
+}
+
+export = FlatbushClass;

--- a/types/geoflatbush/geoflatbush-tests.ts
+++ b/types/geoflatbush/geoflatbush-tests.ts
@@ -1,4 +1,4 @@
-import Flatbush from 'flatbush';
+import Flatbush = require('flatbush');
 import { around } from 'geoflatbush';
 
 const index = new Flatbush(1);


### PR DESCRIPTION
Previously, it incorrectly used `export default`.

[2869]