### PR TITLE
json-stream-stringify uses export=

### DIFF
--- a/types/json-stream-stringify/index.d.ts
+++ b/types/json-stream-stringify/index.d.ts
@@ -6,7 +6,8 @@
 /// <reference types="node" />
 import { Readable } from "stream";
 
-export default class JsonStreamStringify extends Readable {
+declare class JsonStreamStringify extends Readable {
     constructor(value: any, replacer?: ((key: any, value: any) => any) | any[], spaces?: string | number, cycle?: boolean);
     path(): [string, number];
 }
+export = JsonStreamStringify;

--- a/types/json-stream-stringify/json-stream-stringify-tests.ts
+++ b/types/json-stream-stringify/json-stream-stringify-tests.ts
@@ -1,4 +1,4 @@
-import JsonStreamStringify from 'json-stream-stringify';
+import JsonStreamStringify = require('json-stream-stringify');
 import { Readable } from 'stream';
 
 function ReadableStream(...args: any[]) {


### PR DESCRIPTION
Previously, it incorrectly used `export default`.

[729]