### PR TITLE
lyric-parser uses export=

### DIFF
--- a/types/lyric-parser/index.d.ts
+++ b/types/lyric-parser/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Wang KaiLing <https://github.com/wkl007>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export default class Lyric {
+declare class Lyric {
     constructor(lrc: string, handler: (params: { lineNum: number; txt: string }) => void);
 
     lrc: string;
@@ -21,3 +21,5 @@ export default class Lyric {
 
     seek(offset: number): void;
 }
+
+export = Lyric;

--- a/types/lyric-parser/lyric-parser-tests.ts
+++ b/types/lyric-parser/lyric-parser-tests.ts
@@ -1,4 +1,4 @@
-import Lyric from 'lyric-parser';
+import Lyric = require('lyric-parser');
 
 const lyricStr =
     'W3RpOuiKkuenjV0NClthcjrpn7PpmJnor5flkKwv6LW15pa55amnXQ0KW2FsOuiKkuenjV0NCltieTpdDQpbb2Zmc2V0OjBdDQpbMDA6MDAuMDBd6IqS56eNIC0g6Z+z6ZiZ6K+X5ZCsL';


### PR DESCRIPTION
Previously, it incorrectly used export default.

[802]