### PR TITLE
sharedb – Fix missing & incorrect types

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -53,9 +53,7 @@ declare class sharedb {
         action: A,
         fn: (context: sharedb.middleware.ActionContextMap[A], callback: (err?: any) => void) => void,
     ): void;
-    static types: {
-        register: (type: { name?: string, uri?: string, [key: string]: any}) => void;
-    };
+    static types: ShareDB.Types;
 }
 
 declare namespace sharedb {

--- a/types/sharedb/lib/client.d.ts
+++ b/types/sharedb/lib/client.d.ts
@@ -32,3 +32,5 @@ export type SubtypeOp = ShareDB.SubtypeOp;
 
 export type Path = ShareDB.Path;
 export type ShareDBSourceOptions = ShareDB.ShareDBSourceOptions;
+
+export const types: ShareDB.Types;

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from 'events';
 
+import { Connection } from './client';
+
 export type JSONValue = string | number | boolean | null | JSONObject | JSONArray;
 export interface JSONObject {
   [name: string]: JSONValue;
@@ -75,9 +77,13 @@ export type Callback = (err: Error) => any;
 export type DocEvent = 'load' | 'create' | 'before op' | 'op' | 'del' | 'error' | 'no write pending' | 'nothing pending';
 
 export class Doc extends EventEmitter {
+    connection: Connection;
     type: Type | null;
     id: string;
+    collection: string;
     data: any;
+    version: number | null;
+
     fetch: (callback: (err: Error) => void) => void;
     subscribe: (callback: (err: Error) => void) => void;
 

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -75,7 +75,7 @@ export type Callback = (err: Error) => any;
 export type DocEvent = 'load' | 'create' | 'before op' | 'op' | 'del' | 'error' | 'no write pending' | 'nothing pending';
 
 export class Doc extends EventEmitter {
-    type: string;
+    type: Type | null;
     id: string;
     data: any;
     fetch: (callback: (err: Error) => void) => void;

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -51,16 +51,25 @@ export interface RawOp {
     c: string;
     d: string;
 }
-export type OTType = 'ot-text' | 'ot-json0' | 'ot-text-tp2' | 'rich-text';
+export type OTType = 'ot-text' | 'ot-json0' | 'ot-json1' | 'ot-text-tp2' | 'rich-text';
 
 export interface Type {
-  name?: string;
-  uri?: string;
-  [key: string]: any;
+    name?: string;
+    uri?: string;
+    create(initialData?: any): any;
+    apply(snapshot: any, op: any): any;
+    transform(op1: any, op2: any, side: 'left' | 'right'): any;
+    compose(op1: any, op2: any): any;
+    invert?(op: any): any;
+    normalize?(op: any): any;
+    transformCursor?(cursor: any, op: any, isOwnOp: boolean): any;
+    serialize?(snapshot: any): any;
+    deserialize?(data: any): any;
+    [key: string]: any;
 }
 export interface Types {
-  register: (type: Type) => void;
-  map: { [key: string]: Type };
+    register: (type: Type) => void;
+    map: { [key: string]: Type };
 }
 
 export interface Error {

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -50,6 +50,17 @@ export interface RawOp {
     d: string;
 }
 export type OTType = 'ot-text' | 'ot-json0' | 'ot-text-tp2' | 'rich-text';
+
+export interface Type {
+  name?: string;
+  uri?: string;
+  [key: string]: any;
+}
+export interface Types {
+  register: (type: Type) => void;
+  map: { [key: string]: Type };
+}
+
 export interface Error {
     code: number;
     message: string;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -223,4 +223,8 @@ function startClient(callback) {
     connection.createSubscribeQuery('examples', 'numClicks >= 5', null, (err, results) => {
         console.log(err, results);
     });
+
+    if (doc.type !== null) {
+      console.log(doc.type.name);
+    }
 }

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -224,7 +224,12 @@ function startClient(callback) {
         console.log(err, results);
     });
 
-    if (doc.type !== null) {
-      console.log(doc.type.name);
+    const anotherDoc = doc.connection.get('examples', 'another-counter');
+    console.log(anotherDoc.collection);
+    if (anotherDoc.type !== null) {
+      console.log(anotherDoc.type.name);
+    }
+    if (anotherDoc.version !== null) {
+      Math.round(anotherDoc.version);
     }
 }

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -198,14 +198,24 @@ function startServer() {
     });
 }
 
-ShareDBClient.types.register({
+const richTextType = {
   name: 'rich-text',
-  uri: 'http://sharejs.org/types/rich-text/v1'
-});
+  uri: 'http://sharejs.org/types/rich-text/v1',
+  create() {},
+  apply() {},
+  transform() {},
+  compose() {},
+};
+
+ShareDBClient.types.register(richTextType);
 
 console.log(ShareDBClient.types.map);
 console.log(ShareDBClient.types.map['rich-text'].name);
 console.log(ShareDBClient.types.map['rich-text'].uri);
+
+const op1 = [{ insert: 'Hello' }];
+const op2 = [{ retain: 5 }, { insert: ' world!' }];
+const op3 = ShareDBClient.types.map['rich-text'].compose(op1, op2);
 
 function startClient(callback) {
     const socket = new WebSocket('ws://localhost:8080');

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -198,6 +198,15 @@ function startServer() {
     });
 }
 
+ShareDBClient.types.register({
+  name: 'rich-text',
+  uri: 'http://sharejs.org/types/rich-text/v1'
+});
+
+console.log(ShareDBClient.types.map);
+console.log(ShareDBClient.types.map['rich-text'].name);
+console.log(ShareDBClient.types.map['rich-text'].uri);
+
 function startClient(callback) {
     const socket = new WebSocket('ws://localhost:8080');
     const connection = new ShareDBClient.Connection(socket);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See below
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

---

This pull request adds a few missing type declaration inside a `ShareDB.Doc`:
- [`doc.connection`](https://github.com/share/sharedb/blob/master/lib/client/doc.js#L55)
- [`doc.collection`](https://github.com/share/sharedb/blob/master/lib/client/doc.js#L57)
- [`doc.version`](https://github.com/share/sharedb/blob/master/lib/client/doc.js#L60)

It also fix the `doc.types` which should not be a string, but rather a proper ShareDB type interface: https://github.com/share/sharedb/blob/master/lib/client/doc.js#L132-L152

Finally, it adds the missing `types` object on ShareDB client library: https://github.com/share/sharedb/blob/master/lib/client/index.js#L5