### PR TITLE
mui-datatables: fixes to customBodyRender parameter types

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -44,7 +44,7 @@ export interface MUIDataTableState {
 }
 
 export interface MUIDataTableMeta {
-    columnData: MUIDataTableColumnOptions[];
+    columnData: MUIDataTableColumnState;
     columnIndex: number;
     rowData: any[];
     rowIndex: number;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for mui-datatables 2.13
+// Type definitions for mui-datatables 2.14
 // Project: https://github.com/gregnb/mui-datatables
 // Definitions by: Jeroen "Favna" Claassens <https://github.com/favna>
 //                 Ankith Konda <https://github.com/ankithkonda>
 //                 Herman "Von" Waters IV <https://github.com/hwatersiv>
 //                 souppower <https://github.com/souppower>
+//                 Byron "Byrekt" Mitchell <https://github.com/byrekt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
@@ -120,7 +121,7 @@ export interface MUIDataTableColumnState extends MUIDataTableColumnOptions {
 }
 
 export interface MUIDataTableColumnOptions {
-    customBodyRender?: (value: any, tableMeta: MUIDataTableMeta, updateValue: (s: any, c: any, p: any) => any) => string | React.ReactNode;
+    customBodyRender?: (value: any, tableMeta: MUIDataTableMeta, updateValue: (value: string) => void) => string | React.ReactNode;
     customHeadRender?: (columnMeta: MUIDataTableCustomHeadRenderer, updateDirection: (params: any) => any) => string | React.ReactNode;
     customFilterListRender?: (value: any) => string;
     display?: 'true' | 'false' | 'excluded';

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -20,7 +20,17 @@ const MuiCustomTable: React.FC<Props> = (props) => {
             label: 'Name',
             options: {
                 filterType: 'custom',
-                sortDirection: 'none'
+                sortDirection: 'none',
+                customBodyRender: (value, tableMeta, updateValue) => {
+                    return (
+                        <input
+                            type="text"
+                            value={value}
+                            name={`${tableMeta.columnData.name}-${tableMeta.rowIndex}`}
+                            onChange={event => updateValue(event.target.value)}
+                        />
+                    );
+                }
             }
         },
         {


### PR DESCRIPTION
I was trying to use the customBodyRender option for a column and noticed there were some discrepancies. 

The first discrepancy I noticed was that the type of the `columnData` property of the `tableMeta` parameter passed to `customBodyRender` would `MUIDataTableColumnOptions[]`. However, when actually checking the format of the object I noticed that it was actually just a single `MUIDataTableColumnState` object, which does extend `MUIDataTableColumnOptions` but is not an array. So I've updated this. I didn't see any other references to `MUIDataTableMeta` outside of `customBodyRender`. So I think this is 👍 .

The second discrepancy I noticed was that the `updateValue` callback that is a parameter to `customBodyRender` has 3 parameters. I think I understand why this was added like this, as the underlying function that is called in `mui-datatables` has 3 parameters (https://github.com/gregnb/mui-datatables/blob/4f836096a56be93ee1322f3c98cbaca485f0b064/src/MUIDataTable.js#L799) but if you look at the only reference to that function in the file you'll see that two of the parameters are being added by a `.bind` automatically. (https://github.com/gregnb/mui-datatables/blob/4f836096a56be93ee1322f3c98cbaca485f0b064/src/MUIDataTable.js#L711). So when actually using the `updateValue` callback all you should have to pass is a single argument.

Here is the code I used to test in my local app:
```
const columns: MUIDataTableColumn[] = [
        {
            name: 'id',
            label: 'id'
        },
        {
            name: 'name',
            label: 'Name',
            options: {
                filterType: 'custom',
                sortDirection: 'none',
                customBodyRender: (value, tableMeta, updateValue) => {
                    return (
                        <input
                            type="text"
                            value={value}
                            name={`${tableMeta.columnData.name}-${tableMeta.rowIndex}`}
                            onChange={event => updateValue(event.target.value)}
                        />
                    );
                }
            }
        },
        {
            name: 'amount',
            label: 'Amount'
        }
    ];
```

Notice above that I was correctly able to determine the name of the column because `tableMeta.columnData` is now correctly typed.