### PR TITLE
Exempt material__drawer from npm-naming

### DIFF
--- a/types/material__drawer/tslint.json
+++ b/types/material__drawer/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}


### PR DESCRIPTION
The "must use export= for callable exports" rule mistakenly thinks that @material/drawer exports a function, when it actually exports an object with a default property that is callable.
