### PR TITLE
Exempt ndjson from npm-naming

### DIFF
--- a/types/ndjson/tslint.json
+++ b/types/ndjson/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}


### PR DESCRIPTION
It exports a function by default, but the existing exports are accurate so for now I'm just going to leave them.