### PR TITLE
Exempt pdfjs-dist from npm-naming

### DIFF
--- a/types/pdfjs-dist/tslint.json
+++ b/types/pdfjs-dist/tslint.json
@@ -12,7 +12,7 @@
         "no-redundant-jsdoc": false,
         "no-redundant-jsdoc-2": false,
         "no-var-keyword": false,
-        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}],
         "object-literal-shorthand": false,
         "only-arrow-functions": false,
         "prefer-const": false,

--- a/types/pdfjs-dist/tslint.json
+++ b/types/pdfjs-dist/tslint.json
@@ -12,6 +12,7 @@
         "no-redundant-jsdoc": false,
         "no-redundant-jsdoc-2": false,
         "no-var-keyword": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
         "object-literal-shorthand": false,
         "only-arrow-functions": false,
         "prefer-const": false,


### PR DESCRIPTION
The rule incorrectly thinks the package exports a callable object.