### PR TITLE
[@types/lodash] Allow intersectionWith to be called with parameters of (destructured array, comparator)

### DIFF
--- a/types/lodash/common/array.d.ts
+++ b/types/lodash/common/array.d.ts
@@ -1341,7 +1341,7 @@ declare module "../index" {
          */
         intersectionWith<T>(
             array?: List<T> | null,
-            ...values: Array<List<T>>
+            ...values: Array<List<T> | Comparator2<T, never>>
         ): T[];
     }
 

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -701,6 +701,12 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType LoDashExplicitWrapper<number
         b; // $ExpectType AbcObject
         return true;
     });
+    // $ExpectType AbcObject[]
+    _.intersectionWith(...[list, list], (a, b) => {
+        a; // $ExpectType AbcObject
+        b; // $ExpectType never
+        return true;
+    });
 
     _(list).intersectionWith(list); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
     _(list).intersectionWith(list, list); // $ExpectType LoDashImplicitWrapper<AbcObject[]>

--- a/types/lodash/ts3.1/common/array.d.ts
+++ b/types/lodash/ts3.1/common/array.d.ts
@@ -771,7 +771,7 @@ declare module "../index" {
         /**
          * @see _.intersectionWith
          */
-        intersectionWith<T>(array?: List<T> | null, ...values: Array<List<T>>): T[];
+        intersectionWith<T>(array?: List<T> | null, ...values: Array<List<T> | Comparator2<T, never>>): T[];
     }
     interface Collection<T> {
         /**

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -709,6 +709,12 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
         b; // $ExpectType AbcObject
         return true;
     });
+    // $ExpectType AbcObject[]
+    _.intersectionWith(...[list, list], (a, b) => {
+        a; // $ExpectType AbcObject
+        b; // $ExpectType never
+        return true;
+    });
 
     _(list).intersectionWith(list); // $ExpectType Collection<AbcObject>
     _(list).intersectionWith(list, list); // $ExpectType Collection<AbcObject>


### PR DESCRIPTION
Fixes #44669

Adding the comparator as an allowed type in the value array lets the function be called with a destructured list as the first argument.

Thank you to @aj-r for the recommendation on how to resolve this issue.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
 - I had to add `"use-default-type-parameter": false` to `tslint.json` in order to have linting complete. This is also the case prior to my changes. Therefore, the issue is out of scope for this PR, and the PR contains no changes to `tslint.json`.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
