### PR TITLE
Exempt 3 react packages from npm-naming

### DIFF
--- a/types/react-amplitude/tslint.json
+++ b/types/react-amplitude/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/react-avatar-editor/tslint.json
+++ b/types/react-avatar-editor/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+  "extends": "dtslint/dt.json",
+  "rules": {
+    "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+  }
+}

--- a/types/react-final-form-listeners/tslint.json
+++ b/types/react-final-form-listeners/tslint.json
@@ -1,3 +1,6 @@
 {
-  "extends": "dtslint/dt.json"
+  "extends": "dtslint/dt.json",
+  "rules": {
+    "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+  }
 }

--- a/types/react-inspector/tslint.json
+++ b/types/react-inspector/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}


### PR DESCRIPTION
The lint rule incorrectly thinks the packages export a callable object. Typescript is usually bad at understanding the output of react packages, so I think the best thing is to turn off the rule.
