### PR TITLE
Exempt rox-browser from npm-naming

### DIFF
--- a/types/rox-browser/tslint.json
+++ b/types/rox-browser/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "file-name-casing": [true, "kebab-case"]
+        "file-name-casing": [true, "kebab-case"],
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }


### PR DESCRIPTION
The documentation uses default imports, although I can't tell from reading the npm-shipped code whether that's correct. I'm guessing that the npm-naming rule as it least as confused as I am when trying to analyse it, so I'm going to disable the rule.