### PR TITLE
Exempt scrollmagic from npm-naming

### DIFF
--- a/types/scrollmagic/tslint.json
+++ b/types/scrollmagic/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}


### PR DESCRIPTION
I can't tell from the source whether scrollmagic exports a callable object because all the documentation is for the global usage. However, the global usage is a namespace, not a function, so I suspect the module is the same.
