### PR TITLE
Add types for motion-sensors-polyfill

### DIFF
--- a/types/motion-sensors-polyfill/index.d.ts
+++ b/types/motion-sensors-polyfill/index.d.ts
@@ -1,0 +1,71 @@
+type EventHandler = (event: Event) => void;
+
+declare class Sensor extends EventTarget {
+    readonly activated: boolean;
+    readonly hasReading: boolean;
+    readonly timestamp?: DOMHighResTimeStamp;
+    start(): void;
+    stop(): void;
+    onreading: EventHandler;
+    onactivate: EventHandler;
+    onerror: EventHandler;
+}
+
+interface SensorOptions {
+    frequency?: number
+}
+
+type AccelerometerLocalCoordinateSystem = "device" | "screen";
+
+interface AccelerometerSensorOptions extends SensorOptions {
+  referenceFrame?: AccelerometerLocalCoordinateSystem // defaults to "device". IDK how to type this
+}
+
+export declare class Accelerometer extends Sensor {
+    constructor(options?: AccelerometerSensorOptions);
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+}
+
+export declare class LinearAccelerationSensor extends Accelerometer {
+    constructor (options?: AccelerometerSensorOptions);
+}
+
+export declare class GravitySensor extends Accelerometer {
+    constructor (options?: AccelerometerSensorOptions);
+}
+
+interface GyroscopeSensorOptions {
+    referenceFrame?: GyroscopeLocalCoordinateSystem // defauts to "device"
+}
+
+type GyroscopeLocalCoordinateSystem = "device" | "screen";
+
+export declare class Gyroscope extends Sensor {
+    constructor (options: GyroscopeSensorOptions);
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+}
+
+type OrientationSensorLocalCoordinateSystem = "device" | "screen"
+
+interface OrientationSensorOptions extends SensorOptions {
+    referenceFrame?: OrientationSensorLocalCoordinateSystem; // defaults to "device"
+}
+
+type RotationMatrixType = Float32Array | Float64Array | DOMMatrix;
+
+declare class OrientationSensor extends Sensor {
+    readonly quaternion: [ number, number, number, number ]
+    populateMatrix(matrix: RotationMatrixType): void
+}
+
+export declare class RelativeOrientationSensor extends OrientationSensor {
+    constructor(options?: OrientationSensorOptions);
+}
+
+export declare class AbsoluteOrientationSensor extends OrientationSensor {
+    constructor (options?: OrientationSensorOptions);
+}

--- a/types/motion-sensors-polyfill/index.d.ts
+++ b/types/motion-sensors-polyfill/index.d.ts
@@ -1,6 +1,13 @@
+// Type definitions for motion-sensors-polyfill 0.3
+// Project: https://github.com/kenchris/lit-element
+// Definitions by: Kevin Wylder <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export {};
+
 type EventHandler = (event: Event) => void;
 
-declare class Sensor extends EventTarget {
+export class Sensor extends EventTarget {
     readonly activated: boolean;
     readonly hasReading: boolean;
     readonly timestamp?: DOMHighResTimeStamp;
@@ -12,44 +19,44 @@ declare class Sensor extends EventTarget {
 }
 
 interface SensorOptions {
-    frequency?: number
+    frequency?: number;
 }
 
 type AccelerometerLocalCoordinateSystem = "device" | "screen";
 
 interface AccelerometerSensorOptions extends SensorOptions {
-  referenceFrame?: AccelerometerLocalCoordinateSystem // defaults to "device". IDK how to type this
+  referenceFrame?: AccelerometerLocalCoordinateSystem; // defaults to "device". IDK how to type this
 }
 
-export declare class Accelerometer extends Sensor {
+export class Accelerometer extends Sensor {
     constructor(options?: AccelerometerSensorOptions);
     readonly x: number;
     readonly y: number;
     readonly z: number;
 }
 
-export declare class LinearAccelerationSensor extends Accelerometer {
-    constructor (options?: AccelerometerSensorOptions);
+export class LinearAccelerationSensor extends Accelerometer {
+    constructor(options?: AccelerometerSensorOptions);
 }
 
-export declare class GravitySensor extends Accelerometer {
-    constructor (options?: AccelerometerSensorOptions);
+export class GravitySensor extends Accelerometer {
+    constructor(options?: AccelerometerSensorOptions);
 }
 
 interface GyroscopeSensorOptions {
-    referenceFrame?: GyroscopeLocalCoordinateSystem // defauts to "device"
+    referenceFrame?: GyroscopeLocalCoordinateSystem; // defauts to "device"
 }
 
 type GyroscopeLocalCoordinateSystem = "device" | "screen";
 
-export declare class Gyroscope extends Sensor {
-    constructor (options: GyroscopeSensorOptions);
+export class Gyroscope extends Sensor {
+    constructor(options?: GyroscopeSensorOptions);
     readonly x: number;
     readonly y: number;
     readonly z: number;
 }
 
-type OrientationSensorLocalCoordinateSystem = "device" | "screen"
+type OrientationSensorLocalCoordinateSystem = "device" | "screen";
 
 interface OrientationSensorOptions extends SensorOptions {
     referenceFrame?: OrientationSensorLocalCoordinateSystem; // defaults to "device"
@@ -57,15 +64,15 @@ interface OrientationSensorOptions extends SensorOptions {
 
 type RotationMatrixType = Float32Array | Float64Array | DOMMatrix;
 
-declare class OrientationSensor extends Sensor {
-    readonly quaternion: [ number, number, number, number ]
-    populateMatrix(matrix: RotationMatrixType): void
+export class OrientationSensor extends Sensor {
+    readonly quaternion: [ number, number, number, number ];
+    populateMatrix(matrix: RotationMatrixType): void;
 }
 
-export declare class RelativeOrientationSensor extends OrientationSensor {
+export class RelativeOrientationSensor extends OrientationSensor {
     constructor(options?: OrientationSensorOptions);
 }
 
-export declare class AbsoluteOrientationSensor extends OrientationSensor {
-    constructor (options?: OrientationSensorOptions);
+export class AbsoluteOrientationSensor extends OrientationSensor {
+    constructor(options?: OrientationSensorOptions);
 }

--- a/types/motion-sensors-polyfill/motion-sensors-polyfill-tests.ts
+++ b/types/motion-sensors-polyfill/motion-sensors-polyfill-tests.ts
@@ -1,0 +1,53 @@
+import {
+    Accelerometer,
+    LinearAccelerationSensor,
+    GravitySensor,
+    Gyroscope,
+    AbsoluteOrientationSensor,
+    RelativeOrientationSensor,
+    // Magnetometer,
+    // GeolocationSensor,
+} from 'motion-sensors-polyfill';
+
+const accelerometer = new Accelerometer();
+accelerometer.timestamp;
+accelerometer.x;
+accelerometer.y;
+accelerometer.z;
+
+const linearAccelerationSensor = new LinearAccelerationSensor();
+linearAccelerationSensor.timestamp;
+linearAccelerationSensor.x;
+linearAccelerationSensor.y;
+linearAccelerationSensor.z;
+
+const gravitySensor = new GravitySensor();
+gravitySensor.timestamp;
+gravitySensor.x;
+gravitySensor.y;
+gravitySensor.z;
+
+const gyroscope = new Gyroscope();
+gyroscope.x;
+gyroscope.y;
+gyroscope.z;
+
+const absoluteOrientation = new AbsoluteOrientationSensor();
+absoluteOrientation.timestamp;
+absoluteOrientation.quaternion;
+
+const relativeOrientation = new RelativeOrientationSensor();
+relativeOrientation.timestamp;
+relativeOrientation.quaternion;
+
+// Missing Properties
+/*
+const properties = {
+    'Magnetometer' : ['timestamp', 'x', 'y', 'z'],
+    'GeolocationSensor' : [
+      'timestamp',
+      'latitude',
+      'longitude'
+    ]
+  };
+*/

--- a/types/motion-sensors-polyfill/tsconfig.json
+++ b/types/motion-sensors-polyfill/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "files": [
+        "index.d.ts"
+    ]
+}

--- a/types/motion-sensors-polyfill/tsconfig.json
+++ b/types/motion-sensors-polyfill/tsconfig.json
@@ -1,5 +1,24 @@
 {
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "motion-sensors-polyfill-tests.ts"
     ]
 }

--- a/types/motion-sensors-polyfill/tslint.json
+++ b/types/motion-sensors-polyfill/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.