### PR TITLE
Exempt more packages from npm-naming

### DIFF
--- a/types/symlink-or-copy/tslint.json
+++ b/types/symlink-or-copy/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/tdweb/tslint.json
+++ b/types/tdweb/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
 }

--- a/types/tinajs__tina/tslint.json
+++ b/types/tinajs__tina/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
 }

--- a/types/vis/tslint.json
+++ b/types/vis/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         "no-angle-bracket-type-assertion": false,
         "no-any-union": false,
-        "no-outside-dependencies": false
+        "no-outside-dependencies": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }


### PR DESCRIPTION
These either have webpack emit that Typescript can't understand, or appear to be targetting a non-node runtime.