### PR TITLE
tweezer.js uses export=

### DIFF
--- a/types/tweezer.js/index.d.ts
+++ b/types/tweezer.js/index.d.ts
@@ -21,4 +21,4 @@ declare class Tweezer {
   begin(): this;
 }
 
-export default Tweezer;
+export = Tweezer;

--- a/types/tweezer.js/tweezer.js-tests.ts
+++ b/types/tweezer.js/tweezer.js-tests.ts
@@ -1,4 +1,4 @@
-import Tweezer from 'tweezer.js';
+import Tweezer = require('tweezer.js');
 
 const tweezer = new Tweezer({
     start: 100,


### PR DESCRIPTION
previously it used `export default` which is incorrect.