### PR TITLE
Exempt uikit from npm-naming

### DIFF
--- a/types/uikit/tslint.json
+++ b/types/uikit/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}


### PR DESCRIPTION
The instructions for node usage apparently only work with webkit, so I think it's fine to leave the `export default` even if it's not technically correct.
