### PR TITLE
Update passport-saml tests

### DIFF
--- a/types/passport-saml/passport-saml-tests.ts
+++ b/types/passport-saml/passport-saml-tests.ts
@@ -22,7 +22,7 @@ const samlStrategy = new SamlStrategy.Strategy(
                 // key removed, null if no key is removed
             }
         },
-        cert: fs.readFileSync('/path/to/cert.crt', 'UTF8')
+        cert: fs.readFileSync('/path/to/cert.crt', 'utf8')
     },
     (profile: {}, done: (err: Error | null, user: {}, info?: {}) => void) => {
         const user = {};


### PR DESCRIPTION
fs.readFileSync requires lowercase 'utf8', not "UTF8", and node types now enforce that. I updated passport-saml tests to match.
