### PR TITLE
react-d3-graph: Add onClickGraph GraphEventCallbacks interface

### DIFF
--- a/types/react-d3-graph/index.d.ts
+++ b/types/react-d3-graph/index.d.ts
@@ -114,6 +114,7 @@ export interface GraphData<N extends GraphNode, L extends GraphLink> {
 }
 
 export interface GraphEventCallbacks {
+    onClickGraph: (event: MouseEvent) => void;
     onClickNode: (nodeId: string) => void;
     onDoubleClickNode: (nodeId: string) => void;
     onRightClickNode: (event: MouseEvent, nodeId: string) => void;

--- a/types/react-d3-graph/react-d3-graph-tests.tsx
+++ b/types/react-d3-graph/react-d3-graph-tests.tsx
@@ -6,6 +6,7 @@ export class Example extends React.Component {
         return (
             <div>
                 <Graph
+                    onClickGraph={() => {}}
                     id="test"
                     data={{
                         nodes: [


### PR DESCRIPTION
Adding a missing function to the list of callbacks.

See https://goodguydaniel.com/react-d3-graph/docs/index.html#graph 