### PR TITLE
[react-color] Fixed typings and added missing properties

### DIFF
--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -40,7 +40,7 @@ export type ColorChangeHandler = (color: ColorResult) => void;
 export interface ColorPickerProps<A> extends ClassAttributes<A> {
     color?: Color;
     className?: string;
-    styles?: Classes<any>;
+    styles?: Partial<Classes<any>>;
     onChange?: ColorChangeHandler;
     onChangeComplete?: ColorChangeHandler;
 }
@@ -49,7 +49,7 @@ export interface CustomPickerProps<A> extends ClassAttributes<A> {
     color?: Color;
     pointer?: ReactNode;
     className?: string;
-    styles?: Classes<any>;
+    styles?: Partial<Classes<any>>;
     onChange: ColorChangeHandler;
 }
 

--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -11,6 +11,7 @@
 // TypeScript Version: 2.8
 
 import { ComponentClass, ClassAttributes, StatelessComponent, ReactNode } from "react";
+import { Classes } from "reactcss";
 
 export interface HSLColor {
     a?: number;
@@ -45,6 +46,8 @@ export interface ColorPickerProps<A> extends ClassAttributes<A> {
 export interface CustomPickerProps<A> extends ClassAttributes<A> {
     color?: Color;
     pointer?: ReactNode;
+    className?: string;
+    styles?: Classes<any>;
     onChange: ColorChangeHandler;
 }
 

--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -39,6 +39,8 @@ export type ColorChangeHandler = (color: ColorResult) => void;
 
 export interface ColorPickerProps<A> extends ClassAttributes<A> {
     color?: Color;
+    className?: string;
+    styles?: Classes<any>;
     onChange?: ColorChangeHandler;
     onChangeComplete?: ColorChangeHandler;
 }

--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -10,7 +10,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { ComponentClass, ClassAttributes, StatelessComponent, ReactNode } from "react";
+import { ClassAttributes, ReactNode } from "react";
 import { Classes } from "reactcss";
 
 export interface HSLColor {

--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-color 2.18.1
+// Type definitions for react-color 3.0
 // Project: https://github.com/casesandberg/react-color/, http://casesandberg.github.io/react-color
 // Definitions by:  Karol Janyst <https://github.com/LKay>,
 //                  Marks Polakovs <https://github.com/markspolakovs>,

--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-color 3.0
+// Type definitions for react-color 2.18.1
 // Project: https://github.com/casesandberg/react-color/, http://casesandberg.github.io/react-color
 // Definitions by:  Karol Janyst <https://github.com/LKay>,
 //                  Marks Polakovs <https://github.com/markspolakovs>,
@@ -6,7 +6,8 @@
 //                  Nokogiri <https://github.com/nkgrnkgr>,
 //                  0815Strohhut <https://github.com/0815Strohhut>,
 //                  Daniel Fürst <https://github.com/dnlfrst>,
-//                  Erick Tamayo <https://github.com/ericktamayo>
+//                  Erick Tamayo <https://github.com/ericktamayo>,
+//                  Alexander P. Cerutti <https://github.com/alexandercerutti>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -36,7 +36,7 @@ export interface ColorResult {
     rgb: RGBColor;
 }
 
-export type ColorChangeHandler = (color: ColorResult) => void;
+export type ColorChangeHandler = (color: ColorResult, event: React.ChangeEvent<HTMLInputElement>) => void;
 
 export interface ColorPickerProps<A> extends ClassAttributes<A> {
     color?: Color;

--- a/types/react-color/lib/components/alpha/Alpha.d.ts
+++ b/types/react-color/lib/components/alpha/Alpha.d.ts
@@ -10,7 +10,7 @@ export interface AlphaPickerStylesProps {
 export interface AlphaPickerProps extends ColorPickerProps<AlphaPicker> {
     height?: string;
     width?: string;
-    styles?: Classes<AlphaPickerStylesProps>;
+    styles?: Partial<Classes<AlphaPickerStylesProps>>;
 }
 
 export default class AlphaPicker extends Component<AlphaPickerProps> { }

--- a/types/react-color/lib/components/alpha/Alpha.d.ts
+++ b/types/react-color/lib/components/alpha/Alpha.d.ts
@@ -1,9 +1,16 @@
-import { Component } from "react";
+import { Component, CSSProperties } from "react";
 import { ColorPickerProps } from "../../..";
+import { Classes } from "reactcss";
+
+export interface AlphaPickerStylesProps {
+    picker: CSSProperties;
+    alpha: CSSProperties;
+}
 
 export interface AlphaPickerProps extends ColorPickerProps<AlphaPicker> {
     height?: string;
     width?: string;
+    styles?: Classes<AlphaPickerStylesProps>;
 }
 
-export default class AlphaPicker extends Component<AlphaPickerProps> {}
+export default class AlphaPicker extends Component<AlphaPickerProps> { }

--- a/types/react-color/lib/components/block/Block.d.ts
+++ b/types/react-color/lib/components/block/Block.d.ts
@@ -15,7 +15,7 @@ export interface BlockPickerProps extends ColorPickerProps<BlockPicker> {
     colors?: string[];
     width?: string;
     triangle?: 'hide' | 'top';
-    styles?: Classes<BlockPickerStylesProps>;
+    styles?: Partial<Classes<BlockPickerStylesProps>>;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 

--- a/types/react-color/lib/components/block/Block.d.ts
+++ b/types/react-color/lib/components/block/Block.d.ts
@@ -1,11 +1,22 @@
-import { Component } from "react";
+import { Component, CSSProperties } from "react";
 import { ColorPickerProps, ColorResult } from "../../..";
+import { Classes } from "reactcss";
+
+export interface BlockPickerStylesProps {
+    card: CSSProperties;
+    head: CSSProperties;
+    body: CSSProperties;
+    label: CSSProperties;
+    triangle: CSSProperties;
+    input: CSSProperties;
+}
 
 export interface BlockPickerProps extends ColorPickerProps<BlockPicker> {
     colors?: string[];
     width?: string;
     triangle?: 'hide' | 'top';
+    styles?: Classes<BlockPickerStylesProps>;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 
-export default class BlockPicker extends Component<BlockPickerProps> {}
+export default class BlockPicker extends Component<BlockPickerProps> { }

--- a/types/react-color/lib/components/chrome/Chrome.d.ts
+++ b/types/react-color/lib/components/chrome/Chrome.d.ts
@@ -3,19 +3,19 @@ import { ColorPickerProps } from "../../..";
 import { Classes } from "reactcss";
 
 export interface ChromePickerStylesProps {
-    picker?: CSSProperties;
-    saturation?: CSSProperties;
-    Saturation?: CSSProperties;
-    body?: CSSProperties;
-    controls?: CSSProperties;
-    color?: CSSProperties;
-    swatch?: CSSProperties;
-    active?: CSSProperties;
-    toggles?: CSSProperties;
-    hue?: CSSProperties;
-    Hue?: CSSProperties;
-    alpha?: CSSProperties;
-    Alpha?: CSSProperties;
+    picker: CSSProperties;
+    saturation: CSSProperties;
+    Saturation: CSSProperties;
+    body: CSSProperties;
+    controls: CSSProperties;
+    color: CSSProperties;
+    swatch: CSSProperties;
+    active: CSSProperties;
+    toggles: CSSProperties;
+    hue: CSSProperties;
+    Hue: CSSProperties;
+    alpha: CSSProperties;
+    Alpha: CSSProperties;
 }
 
 export interface ChromePickerProps extends ColorPickerProps<ChromePicker> {

--- a/types/react-color/lib/components/chrome/Chrome.d.ts
+++ b/types/react-color/lib/components/chrome/Chrome.d.ts
@@ -20,7 +20,7 @@ export interface ChromePickerStylesProps {
 
 export interface ChromePickerProps extends ColorPickerProps<ChromePicker> {
     disableAlpha?: boolean;
-    styles?: Classes<ChromePickerStylesProps>;
+    styles?: Partial<Classes<ChromePickerStylesProps>>;
 }
 
 export default class ChromePicker extends Component<ChromePickerProps> { }

--- a/types/react-color/lib/components/chrome/Chrome.d.ts
+++ b/types/react-color/lib/components/chrome/Chrome.d.ts
@@ -1,7 +1,8 @@
 import { Component, CSSProperties } from "react";
 import { ColorPickerProps } from "../../..";
+import { Classes } from "reactcss";
 
-export interface ChromePickerDefaultStyles {
+export interface ChromePickerStylesProps {
     picker?: CSSProperties;
     saturation?: CSSProperties;
     Saturation?: CSSProperties;
@@ -17,21 +18,9 @@ export interface ChromePickerDefaultStyles {
     Alpha?: CSSProperties;
 }
 
-export interface ChromePickerDisableAlphaStyles {
-    color?: CSSProperties;
-    alpha?: CSSProperties;
-    hue?: CSSProperties;
-    swatch?: CSSProperties;
-}
-
-export interface ChromePickerStyles {
-    default?: ChromePickerDefaultStyles;
-    disableAlpha?: ChromePickerDisableAlphaStyles;
-}
-
 export interface ChromePickerProps extends ColorPickerProps<ChromePicker> {
     disableAlpha?: boolean;
-    styles?: ChromePickerStyles;
+    styles?: Classes<ChromePickerStylesProps>;
 }
 
-export default class ChromePicker extends Component<ChromePickerProps> {}
+export default class ChromePicker extends Component<ChromePickerProps> { }

--- a/types/react-color/lib/components/circle/Circle.d.ts
+++ b/types/react-color/lib/components/circle/Circle.d.ts
@@ -11,7 +11,7 @@ export interface CirclePickerProps extends ColorPickerProps<CirclePicker> {
     width?: string;
     circleSize?: number;
     circleSpacing?: number;
-    styles?: Classes<CirclePickerStylesProps>;
+    styles?: Partial<Classes<CirclePickerStylesProps>>;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 

--- a/types/react-color/lib/components/circle/Circle.d.ts
+++ b/types/react-color/lib/components/circle/Circle.d.ts
@@ -1,12 +1,18 @@
-import { Component } from "react";
+import { Component, CSSProperties } from "react";
 import { ColorPickerProps, ColorResult } from "../../..";
+import { Classes } from "reactcss";
+
+export interface CirclePickerStylesProps {
+    card: CSSProperties;
+}
 
 export interface CirclePickerProps extends ColorPickerProps<CirclePicker> {
     colors?: string[];
     width?: string;
     circleSize?: number;
     circleSpacing?: number;
+    styles?: Classes<CirclePickerStylesProps>;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 
-export default class CirclePicker extends Component<CirclePickerProps> {}
+export default class CirclePicker extends Component<CirclePickerProps> { }

--- a/types/react-color/lib/components/compact/Compact.d.ts
+++ b/types/react-color/lib/components/compact/Compact.d.ts
@@ -10,7 +10,7 @@ export interface CompactPickerStylesProps {
 
 export interface CompactPickerProps extends ColorPickerProps<CompactPicker> {
     colors?: string[];
-    styles?: Classes<CompactPickerStylesProps>;
+    styles?: Partial<Classes<CompactPickerStylesProps>>;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 

--- a/types/react-color/lib/components/compact/Compact.d.ts
+++ b/types/react-color/lib/components/compact/Compact.d.ts
@@ -1,9 +1,17 @@
-import { Component } from "react";
+import { Component, CSSProperties } from "react";
 import { ColorPickerProps, ColorResult } from "../../..";
+import { Classes } from "reactcss";
+
+export interface CompactPickerStylesProps {
+    Compact: CSSProperties;
+    compact: CSSProperties;
+    clear: CSSProperties;
+}
 
 export interface CompactPickerProps extends ColorPickerProps<CompactPicker> {
     colors?: string[];
+    styles?: Classes<CompactPickerStylesProps>;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 
-export default class CompactPicker extends Component<CompactPickerProps> {}
+export default class CompactPicker extends Component<CompactPickerProps> { }

--- a/types/react-color/lib/components/github/Github.d.ts
+++ b/types/react-color/lib/components/github/Github.d.ts
@@ -1,11 +1,19 @@
-import { Component } from "react";
+import { Component, CSSProperties } from "react";
 import { ColorPickerProps, ColorResult } from "../../..";
+import { Classes } from "reactcss";
+
+export interface GithubPickerStylesProps {
+    card: CSSProperties;
+    triangle: CSSProperties;
+    triangleShadow: CSSProperties;
+}
 
 export interface GithubPickerProps extends ColorPickerProps<GithubPicker> {
     colors?: string[];
     width?: string;
     triangle?: 'hide' | 'top-left' | 'top-right';
+    styles?: Classes<GithubPickerStylesProps>;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 
-export default class GithubPicker extends Component<GithubPickerProps> {}
+export default class GithubPicker extends Component<GithubPickerProps> { }

--- a/types/react-color/lib/components/github/Github.d.ts
+++ b/types/react-color/lib/components/github/Github.d.ts
@@ -12,7 +12,7 @@ export interface GithubPickerProps extends ColorPickerProps<GithubPicker> {
     colors?: string[];
     width?: string;
     triangle?: 'hide' | 'top-left' | 'top-right';
-    styles?: Classes<GithubPickerStylesProps>;
+    styles?: Partial<Classes<GithubPickerStylesProps>>;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 

--- a/types/react-color/lib/components/hue/Hue.d.ts
+++ b/types/react-color/lib/components/hue/Hue.d.ts
@@ -1,9 +1,16 @@
-import { Component } from "react";
+import { Component, CSSProperties } from "react";
 import { ColorPickerProps } from "../../..";
+import { Classes } from "reactcss";
+
+export interface HuePickerStylesProps {
+    picker: CSSProperties;
+    hue: CSSProperties;
+}
 
 export interface HuePickerProps extends ColorPickerProps<HuePicker> {
     height?: string;
     width?: string;
+    styles?: Classes<HuePickerStylesProps>;
 }
 
-export default class HuePicker extends Component<HuePickerProps> {}
+export default class HuePicker extends Component<HuePickerProps> { }

--- a/types/react-color/lib/components/hue/Hue.d.ts
+++ b/types/react-color/lib/components/hue/Hue.d.ts
@@ -10,7 +10,7 @@ export interface HuePickerStylesProps {
 export interface HuePickerProps extends ColorPickerProps<HuePicker> {
     height?: string;
     width?: string;
-    styles?: Classes<HuePickerStylesProps>;
+    styles?: Partial<Classes<HuePickerStylesProps>>;
 }
 
 export default class HuePicker extends Component<HuePickerProps> { }

--- a/types/react-color/lib/components/material/Material.d.ts
+++ b/types/react-color/lib/components/material/Material.d.ts
@@ -3,20 +3,20 @@ import { ColorPickerProps } from "../../..";
 import { Classes } from "reactcss";
 
 export interface MaterialPickerStylesProps {
-	material: CSSProperties;
-	HEXwrap: CSSProperties;
-	HEXinput: CSSProperties;
-	HEXlabel: CSSProperties;
-	Hex: CSSProperties;
-	RGBwrap: CSSProperties;
-	RGBinput: CSSProperties;
-	RGBlabel: CSSProperties;
-	split: CSSProperties;
-	third: CSSProperties;
+    material: CSSProperties;
+    HEXwrap: CSSProperties;
+    HEXinput: CSSProperties;
+    HEXlabel: CSSProperties;
+    Hex: CSSProperties;
+    RGBwrap: CSSProperties;
+    RGBinput: CSSProperties;
+    RGBlabel: CSSProperties;
+    split: CSSProperties;
+    third: CSSProperties;
 }
 
 export interface MaterialPickerProps extends ColorPickerProps<MaterialPicker> {
-	styles?: Partial<Classes<MaterialPickerStylesProps>>;
+    styles?: Partial<Classes<MaterialPickerStylesProps>>;
 }
 
 export default class MaterialPicker extends Component<MaterialPickerProps> { }

--- a/types/react-color/lib/components/material/Material.d.ts
+++ b/types/react-color/lib/components/material/Material.d.ts
@@ -16,7 +16,7 @@ export interface MaterialPickerStylesProps {
 }
 
 export interface MaterialPickerProps extends ColorPickerProps<MaterialPicker> {
-	styles?: Classes<MaterialPickerStylesProps>;
+	styles?: Partial<Classes<MaterialPickerStylesProps>>;
 }
 
 export default class MaterialPicker extends Component<MaterialPickerProps> { }

--- a/types/react-color/lib/components/material/Material.d.ts
+++ b/types/react-color/lib/components/material/Material.d.ts
@@ -1,6 +1,22 @@
-import { Component } from "react";
+import { Component, CSSProperties } from "react";
 import { ColorPickerProps } from "../../..";
+import { Classes } from "reactcss";
 
-export type MaterialPickerProps = ColorPickerProps<MaterialPicker>;
+export interface MaterialPickerStylesProps {
+	material: CSSProperties;
+	HEXwrap: CSSProperties;
+	HEXinput: CSSProperties;
+	HEXlabel: CSSProperties;
+	Hex: CSSProperties;
+	RGBwrap: CSSProperties;
+	RGBinput: CSSProperties;
+	RGBlabel: CSSProperties;
+	split: CSSProperties;
+	third: CSSProperties;
+}
 
-export default class MaterialPicker extends Component<MaterialPickerProps> {}
+export interface MaterialPickerProps extends ColorPickerProps<MaterialPicker> {
+	styles?: Classes<MaterialPickerStylesProps>;
+}
+
+export default class MaterialPicker extends Component<MaterialPickerProps> { }

--- a/types/react-color/lib/components/photoshop/Photoshop.d.ts
+++ b/types/react-color/lib/components/photoshop/Photoshop.d.ts
@@ -16,7 +16,7 @@ export interface PhotoshopPickerStylesProps {
 
 export interface PhotoshopPickerProps extends ColorPickerProps<PhotoshopPicker> {
     header?: string;
-    styles?: Classes<PhotoshopPickerStylesProps>;
+    styles?: Partial<Classes<PhotoshopPickerStylesProps>>;
     onAccept?: ColorChangeHandler;
     onCancel?: ColorChangeHandler;
 }

--- a/types/react-color/lib/components/photoshop/Photoshop.d.ts
+++ b/types/react-color/lib/components/photoshop/Photoshop.d.ts
@@ -1,10 +1,24 @@
-import { Component } from "react";
+import { Component, CSSProperties } from "react";
 import { ColorChangeHandler, ColorPickerProps } from "../../..";
+import { Classes } from "reactcss";
+
+export interface PhotoshopPickerStylesProps {
+    picker: CSSProperties;
+    head: CSSProperties;
+    body: CSSProperties;
+    saturation: CSSProperties;
+    hue: CSSProperties;
+    controls: CSSProperties;
+    top: CSSProperties;
+    previews: CSSProperties;
+    actions: CSSProperties;
+}
 
 export interface PhotoshopPickerProps extends ColorPickerProps<PhotoshopPicker> {
     header?: string;
+    styles?: Classes<PhotoshopPickerStylesProps>;
     onAccept?: ColorChangeHandler;
     onCancel?: ColorChangeHandler;
 }
 
-export default class PhotoshopPicker extends Component<PhotoshopPickerProps> {}
+export default class PhotoshopPicker extends Component<PhotoshopPickerProps> { }

--- a/types/react-color/lib/components/sketch/Sketch.d.ts
+++ b/types/react-color/lib/components/sketch/Sketch.d.ts
@@ -20,7 +20,7 @@ export interface SketchPickerProps extends ColorPickerProps<SketchPicker> {
     disableAlpha?: boolean;
     presetColors?: string[];
     width?: string;
-    styles?: Classes<SketchPickerStylesProps>;
+    styles?: Partial<Classes<SketchPickerStylesProps>>;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 

--- a/types/react-color/lib/components/sketch/Sketch.d.ts
+++ b/types/react-color/lib/components/sketch/Sketch.d.ts
@@ -1,11 +1,27 @@
-import { Component } from "react";
+import { Component, CSSProperties } from "react";
 import { ColorPickerProps, ColorResult } from "../../..";
+import { Classes } from "reactcss";
+
+export interface SketchPickerStylesProps {
+    picker: CSSProperties;
+    saturation: CSSProperties;
+    Saturation: CSSProperties;
+    controls: CSSProperties;
+    sliders: CSSProperties;
+    color: CSSProperties;
+    activeColor: CSSProperties;
+    hue: CSSProperties;
+    Hue: CSSProperties;
+    alpha: CSSProperties;
+    Alpha: CSSProperties;
+}
 
 export interface SketchPickerProps extends ColorPickerProps<SketchPicker> {
     disableAlpha?: boolean;
     presetColors?: string[];
     width?: string;
+    styles?: Classes<SketchPickerStylesProps>;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 
-export default class SketchPicker extends Component<SketchPickerProps> {}
+export default class SketchPicker extends Component<SketchPickerProps> { }

--- a/types/react-color/lib/components/slider/Slider.d.ts
+++ b/types/react-color/lib/components/slider/Slider.d.ts
@@ -8,7 +8,7 @@ export interface SliderPickerStylesProps {
 }
 
 export interface SliderPickerProps extends ColorPickerProps<SliderPicker> {
-	styles?: Classes<SliderPickerStylesProps>;
+	styles?: Partial<Classes<SliderPickerStylesProps>>;
 }
 
 export default class SliderPicker extends Component<SliderPickerProps> { }

--- a/types/react-color/lib/components/slider/Slider.d.ts
+++ b/types/react-color/lib/components/slider/Slider.d.ts
@@ -3,12 +3,12 @@ import { ColorPickerProps } from "../../..";
 import { Classes } from "reactcss";
 
 export interface SliderPickerStylesProps {
-	hue: CSSProperties;
-	Hue: CSSProperties;
+    hue: CSSProperties;
+    Hue: CSSProperties;
 }
 
 export interface SliderPickerProps extends ColorPickerProps<SliderPicker> {
-	styles?: Partial<Classes<SliderPickerStylesProps>>;
+    styles?: Partial<Classes<SliderPickerStylesProps>>;
 }
 
 export default class SliderPicker extends Component<SliderPickerProps> { }

--- a/types/react-color/lib/components/slider/Slider.d.ts
+++ b/types/react-color/lib/components/slider/Slider.d.ts
@@ -1,6 +1,14 @@
-import { Component } from "react";
+import { Component, CSSProperties } from "react";
 import { ColorPickerProps } from "../../..";
+import { Classes } from "reactcss";
 
-export type SliderPickerProps = ColorPickerProps<SliderPicker>;
+export interface SliderPickerStylesProps {
+	hue: CSSProperties;
+	Hue: CSSProperties;
+}
 
-export default class SliderPicker extends Component<SliderPickerProps> {}
+export interface SliderPickerProps extends ColorPickerProps<SliderPicker> {
+	styles?: Classes<SliderPickerStylesProps>;
+}
+
+export default class SliderPicker extends Component<SliderPickerProps> { }

--- a/types/react-color/lib/components/swatches/Swatches.d.ts
+++ b/types/react-color/lib/components/swatches/Swatches.d.ts
@@ -1,11 +1,20 @@
-import { Component } from "react";
+import { Component, CSSProperties } from "react";
 import { ColorPickerProps, ColorResult } from "../../..";
+import { Classes } from "reactcss";
+
+export interface SwatchesPickerStylesProps {
+    picker: CSSProperties;
+    overflow: CSSProperties;
+    body: CSSProperties;
+    clear: CSSProperties;
+}
 
 export interface SwatchesPickerProps extends ColorPickerProps<SwatchesPicker> {
     colors?: string[][];
     height?: number;
     width?: number;
+    styles?: Classes<SwatchesPickerStylesProps>;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 
-export default class SwatchesPicker extends Component<SwatchesPickerProps> {}
+export default class SwatchesPicker extends Component<SwatchesPickerProps> { }

--- a/types/react-color/lib/components/swatches/Swatches.d.ts
+++ b/types/react-color/lib/components/swatches/Swatches.d.ts
@@ -13,7 +13,7 @@ export interface SwatchesPickerProps extends ColorPickerProps<SwatchesPicker> {
     colors?: string[][];
     height?: number;
     width?: number;
-    styles?: Classes<SwatchesPickerStylesProps>;
+    styles?: Partial<Classes<SwatchesPickerStylesProps>>;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 

--- a/types/react-color/lib/components/twitter/Twitter.d.ts
+++ b/types/react-color/lib/components/twitter/Twitter.d.ts
@@ -1,11 +1,25 @@
-import { Component } from "react";
+import { Component, CSSProperties } from "react";
 import { ColorPickerProps, ColorResult } from "../../..";
+import { Classes } from "reactcss";
+
+export interface TwitterPickerStylesProps {
+    card: CSSProperties;
+    body: CSSProperties;
+    label: CSSProperties;
+    triangle: CSSProperties;
+    triangleShadow: CSSProperties;
+    hash: CSSProperties;
+    input: CSSProperties;
+    swatch: CSSProperties;
+    clear: CSSProperties;
+}
 
 export interface TwitterPickerProps extends ColorPickerProps<TwitterPicker> {
     colors?: string[];
     width?: string;
     triangle?: 'hide' | 'top-left' | 'top-right';
+    styles?: Classes<TwitterPickerStylesProps>;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 
-export default class TwitterPicker extends Component<TwitterPickerProps> {}
+export default class TwitterPicker extends Component<TwitterPickerProps> { }

--- a/types/react-color/lib/components/twitter/Twitter.d.ts
+++ b/types/react-color/lib/components/twitter/Twitter.d.ts
@@ -18,7 +18,7 @@ export interface TwitterPickerProps extends ColorPickerProps<TwitterPicker> {
     colors?: string[];
     width?: string;
     triangle?: 'hide' | 'top-left' | 'top-right';
-    styles?: Classes<TwitterPickerStylesProps>;
+    styles?: Partial<Classes<TwitterPickerStylesProps>>;
     onSwatchHover?(color: ColorResult, event: MouseEvent): void;
 }
 

--- a/types/react-color/react-color-tests.tsx
+++ b/types/react-color/react-color-tests.tsx
@@ -15,8 +15,8 @@ interface CustomProps extends InjectedColorProps {
 }
 
 const CustomComponent: StatelessComponent<CustomProps> = (props: CustomProps) => {
-    function onChange(color: ColorResult) {
-        console.log(color);
+    function onChange(color: ColorResult, event: React.ChangeEvent<HTMLInputElement>) {
+        console.log(color, event);
     }
 
     return (

--- a/types/react-color/react-color-tests.tsx
+++ b/types/react-color/react-color-tests.tsx
@@ -21,11 +21,11 @@ const CustomComponent: StatelessComponent<CustomProps> = (props: CustomProps) =>
 
     return (
         <div>
-            <Alpha color={ props.color } onChange={ onChange } />
-            <Checkboard size={ 10 } white="transparent" grey="#333" />
-            <EditableInput value={ props.color } label="Test" onChange={ onChange } />
-            <Hue color={ props.color } direction="horizontal" onChange={ onChange } />
-            <Saturation color={ props.color } onChange={ onChange } />
+            <Alpha color={props.color} onChange={onChange} />
+            <Checkboard size={10} white="transparent" grey="#333" />
+            <EditableInput value={props.color} label="Test" onChange={onChange} />
+            <Hue color={props.color} direction="horizontal" onChange={onChange} />
+            <Saturation color={props.color} onChange={onChange} />
         </div>
     );
 };
@@ -33,17 +33,17 @@ const Custom = CustomPicker(CustomComponent);
 
 const colors = ["#000", "#333"];
 
-render(<AlphaPicker height="100px" width="100px" />, document.getElementById("main"));
-render(<BlockPicker colors={ colors } width="100px" />, document.getElementById("main"));
-render(<ChromePicker disableAlpha styles={{ default: { picker: { width: 200 }}}} />, document.getElementById("main"));
-render(<CirclePicker colors={ colors } width="100px" />, document.getElementById("main"));
-render(<CompactPicker colors={ colors } />, document.getElementById("main"));
-render(<GithubPicker colors={ colors } width="100px" />, document.getElementById("main"));
-render(<HuePicker height="100px" width="100px" />, document.getElementById("main"));
-render(<MaterialPicker />, document.getElementById("main"));
-render(<PhotoshopPicker header="Test" />, document.getElementById("main"));
-render(<SketchPicker disableAlpha presetColors={ colors } />, document.getElementById("main"));
-render(<SliderPicker />, document.getElementById("main"));
-render(<SwatchesPicker colors={ [colors] } height={ 100 } width={ 100 } />, document.getElementById("main"));
-render(<TwitterPicker />, document.getElementById("main"));
+render(<AlphaPicker className="custom-cn" height="100px" width="100px" />, document.getElementById("main"));
+render(<BlockPicker className="custom-cn" colors={colors} width="100px" />, document.getElementById("main"));
+render(<ChromePicker className="custom-cn" disableAlpha styles={{ default: { picker: { width: 200 } } }} />, document.getElementById("main"));
+render(<CirclePicker className="custom-cn" colors={colors} width="100px" />, document.getElementById("main"));
+render(<CompactPicker className="custom-cn" colors={colors} />, document.getElementById("main"));
+render(<GithubPicker className="custom-cn" colors={colors} width="100px" />, document.getElementById("main"));
+render(<HuePicker className="custom-cn" height="100px" width="100px" />, document.getElementById("main"));
+render(<MaterialPicker className="custom-cn" />, document.getElementById("main"));
+render(<PhotoshopPicker className="custom-cn" header="Test" />, document.getElementById("main"));
+render(<SketchPicker className="custom-cn" disableAlpha presetColors={colors} />, document.getElementById("main"));
+render(<SliderPicker className="custom-cn" />, document.getElementById("main"));
+render(<SwatchesPicker className="custom-cn" colors={[colors]} height={100} width={100} />, document.getElementById("main"));
+render(<TwitterPicker className="custom-cn" />, document.getElementById("main"));
 render(<Custom />, document.getElementById("main"));

--- a/types/react-color/v2/lib/components/alpha/Alpha.d.ts
+++ b/types/react-color/v2/lib/components/alpha/Alpha.d.ts
@@ -1,5 +1,6 @@
-import { Component, ComponentType } from "react";
+import { Component, ComponentType, CSSProperties } from "react";
 import { RenderersProps, CustomPickerProps } from "../../..";
+import { Classes } from "reactcss";
 
 export interface AlphaPickerProps extends RenderersProps, CustomPickerProps {
     width?: string;
@@ -7,7 +8,13 @@ export interface AlphaPickerProps extends RenderersProps, CustomPickerProps {
     direction?: "horizontal" | "vertical";
     style?: any;
     pointer?: ComponentType;
+    styles?: Partial<Classes<AlphaPickerStylesProps>>;
     className?: string;
 }
 
-export default class AlphaPicker extends Component<AlphaPickerProps> {}
+export default class AlphaPicker extends Component<AlphaPickerProps> { }
+
+export interface AlphaPickerStylesProps {
+    picker: CSSProperties;
+    alpha: CSSProperties;
+}

--- a/types/react-color/v2/lib/components/block/Block.d.ts
+++ b/types/react-color/v2/lib/components/block/Block.d.ts
@@ -1,17 +1,14 @@
 import { Component, CSSProperties } from "react";
 import { CustomPickerProps, ColorState } from "../../..";
+import { Classes } from "reactcss";
 
-export interface BlockPickerDefaultStyles {
-    card?: CSSProperties;
-    head?: CSSProperties;
-    body?: CSSProperties;
-    label?: CSSProperties;
-    triangle?: CSSProperties;
-    input?: CSSProperties;
-}
-
-export interface BlockPickerStyles {
-    default?: BlockPickerDefaultStyles;
+export interface BlockPickerStylesProps {
+    card: CSSProperties;
+    head: CSSProperties;
+    body: CSSProperties;
+    label: CSSProperties;
+    triangle: CSSProperties;
+    input: CSSProperties;
 }
 
 export interface BlockPickerProps extends CustomPickerProps {
@@ -19,8 +16,8 @@ export interface BlockPickerProps extends CustomPickerProps {
     colors?: string[];
     width?: string;
     triangle?: "hide" | "top";
-    styles?: BlockPickerStyles;
+    styles?: Partial<Classes<BlockPickerStylesProps>>;
     className?: string;
 }
 
-export default class BlockPicker extends Component<BlockPickerProps> {}
+export default class BlockPicker extends Component<BlockPickerProps> { }

--- a/types/react-color/v2/lib/components/chrome/Chrome.d.ts
+++ b/types/react-color/v2/lib/components/chrome/Chrome.d.ts
@@ -1,20 +1,21 @@
 import { Component, CSSProperties } from "react";
 import { RenderersProps, CustomPickerProps } from "../../..";
+import { Classes } from "reactcss";
 
-export interface ChromePickerDefaultStyles {
-    picker?: CSSProperties;
-    saturation?: CSSProperties;
-    Saturation?: CSSProperties;
-    body?: CSSProperties;
-    controls?: CSSProperties;
-    color?: CSSProperties;
-    swatch?: CSSProperties;
-    active?: CSSProperties;
-    toggles?: CSSProperties;
-    hue?: CSSProperties;
-    Hue?: CSSProperties;
-    alpha?: CSSProperties;
-    Alpha?: CSSProperties;
+export interface ChromePickerStylesProps {
+    picker: CSSProperties;
+    saturation: CSSProperties;
+    Saturation: CSSProperties;
+    body: CSSProperties;
+    controls: CSSProperties;
+    color: CSSProperties;
+    swatch: CSSProperties;
+    active: CSSProperties;
+    toggles: CSSProperties;
+    hue: CSSProperties;
+    Hue: CSSProperties;
+    alpha: CSSProperties;
+    Alpha: CSSProperties;
 }
 
 export interface ChromePickerDisableAlphaStyles {
@@ -24,16 +25,11 @@ export interface ChromePickerDisableAlphaStyles {
     swatch?: CSSProperties;
 }
 
-export interface ChromePickerStyles {
-    default?: ChromePickerDefaultStyles;
-    disableAlpha?: ChromePickerDisableAlphaStyles;
-}
-
 export interface ChromePickerProps extends RenderersProps, CustomPickerProps {
     width?: string;
     disableAlpha?: boolean;
-    styles?: ChromePickerStyles;
+    styles?: Partial<Classes<ChromePickerStylesProps>>;
     className?: string;
 }
 
-export default class ChromePicker extends Component<ChromePickerProps> {}
+export default class ChromePicker extends Component<ChromePickerProps> { }

--- a/types/react-color/v2/lib/components/circle/Circle.d.ts
+++ b/types/react-color/v2/lib/components/circle/Circle.d.ts
@@ -1,12 +1,9 @@
 import { Component, CSSProperties } from "react";
 import { CustomPickerProps, ColorState } from "../../..";
+import { Classes } from "reactcss";
 
-export interface CirclePickerDefaultStyles {
-    card?: CSSProperties;
-}
-
-export interface CirclePickerStyles {
-    default?: CirclePickerDefaultStyles;
+export interface CirclePickerStylesProps {
+    card: CSSProperties;
 }
 
 export interface CirclePickerProps extends CustomPickerProps {
@@ -15,8 +12,7 @@ export interface CirclePickerProps extends CustomPickerProps {
     circleSize?: number;
     circleSpacing?: number;
     onSwatchHover?: (color: ColorState, event: MouseEvent) => void;
-    styles?: CirclePickerStyles;
-    className?: string;
+    styles?: Partial<Classes<CirclePickerStylesProps>>;
 }
 
-export default class CirclePicker extends Component<CirclePickerProps> {}
+export default class CirclePicker extends Component<CirclePickerProps> { }

--- a/types/react-color/v2/lib/components/common/ColorWrap.d.ts
+++ b/types/react-color/v2/lib/components/common/ColorWrap.d.ts
@@ -1,5 +1,6 @@
 import { ComponentType } from "react";
 import { Color, ColorState, ColorChangeHandler } from "../../..";
+import { Classes } from "reactcss";
 
 type SetDifference<A, B> = A extends B ? never : A;
 
@@ -13,6 +14,8 @@ export interface CustomPickerInjectedProps extends Partial<ColorState> {
 
 export interface CustomPickerProps {
     color?: Color;
+    className?: string;
+    styles?: Partial<Classes<any>>;
     onChange?: OnChangeHandler;
     onChangeComplete?: OnChangeHandler;
 }
@@ -21,4 +24,4 @@ export default function CustomPicker<A>(
     component: ComponentType<A & CustomPickerInjectedProps>
 ): ComponentType<Diff<A, CustomPickerProps> & CustomPickerProps>;
 
-export {};
+export { };

--- a/types/react-color/v2/lib/components/compact/Compact.d.ts
+++ b/types/react-color/v2/lib/components/compact/Compact.d.ts
@@ -1,20 +1,17 @@
 import { Component, CSSProperties } from "react";
 import { CustomPickerProps, ColorState } from "../../..";
+import { Classes } from "reactcss";
 
-export interface CompactPickerDefaultStyles {
+export interface CompactPickerStylesProps {
     Compact?: CSSProperties;
     compact?: CSSProperties;
     clear?: CSSProperties;
 }
-export interface CompactPickerStyles {
-    default?: CompactPickerDefaultStyles;
-}
 
 export interface CompactPickerProps extends CustomPickerProps {
     colors?: string[];
+    styles?: Partial<Classes<CompactPickerStylesProps>>;
     onSwatchHover?(color: ColorState, event: MouseEvent): void;
-    styles?: CompactPickerStyles;
-    className?: string;
 }
 
-export default class CompactPicker extends Component<CompactPickerProps> {}
+export default class CompactPicker extends Component<CompactPickerProps> { }

--- a/types/react-color/v2/lib/components/github/Github.d.ts
+++ b/types/react-color/v2/lib/components/github/Github.d.ts
@@ -1,27 +1,11 @@
 import { Component, CSSProperties } from "react";
 import { CustomPickerProps, ColorState } from "../../..";
+import { Classes } from "reactcss";
 
-export interface GithubPickerDefaultStyles {
-    card?: CSSProperties;
-    triangle?: CSSProperties;
-    triangleShadow?: CSSProperties;
-}
-
-export interface GithubPickerTriangleStyles {
-    triangle?: CSSProperties;
-    triangleShadow?: CSSProperties;
-}
-
-export interface GithubPickerHideTriangleStyles {
-    triangle?: CSSProperties;
-    "top-left-triangle"?: GithubPickerTriangleStyles;
-    "top-right-triangle"?: GithubPickerTriangleStyles;
-    "bottom-left-triangle"?: GithubPickerTriangleStyles;
-    "bottom-right-triangle"?: GithubPickerTriangleStyles;
-}
-
-export interface GithubPickerStyles {
-    default?: GithubPickerDefaultStyles;
+export interface GithubPickerStylesProps {
+    card: CSSProperties;
+    triangle: CSSProperties;
+    triangleShadow: CSSProperties;
 }
 
 export interface GithubPickerProps extends CustomPickerProps {
@@ -29,8 +13,7 @@ export interface GithubPickerProps extends CustomPickerProps {
     width?: string;
     triangle?: "hide" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
     onSwatchHover?(color: ColorState, event: MouseEvent): void;
-    className?: string;
-    styles?: GithubPickerStyles;
+    styles?: Partial<Classes<GithubPickerStylesProps>>;
 }
 
-export default class GithubPicker extends Component<GithubPickerProps> {}
+export default class GithubPicker extends Component<GithubPickerProps> { }

--- a/types/react-color/v2/lib/components/hue/Hue.d.ts
+++ b/types/react-color/v2/lib/components/hue/Hue.d.ts
@@ -1,13 +1,10 @@
 import { Component, ComponentType, CSSProperties } from "react";
 import { CustomPickerProps } from "../../..";
+import { Classes } from "reactcss";
 
-export interface HuePickerDefaultStyle {
-    picker?: CSSProperties;
-    hue?: CSSProperties;
-}
-
-export interface HuePickerStyle {
-    default?: HuePickerDefaultStyle;
+export interface HuePickerStylesProps {
+    picker: CSSProperties;
+    hue: CSSProperties;
 }
 
 export interface HuePickerProps extends CustomPickerProps {
@@ -15,8 +12,7 @@ export interface HuePickerProps extends CustomPickerProps {
     width?: string;
     direction?: "vertical" | "horizontal";
     pointer?: ComponentType;
-    styles?: HuePickerStyle;
-    className?: string;
+    styles?: Partial<Classes<HuePickerStylesProps>>;
 }
 
-export default class HuePicker extends Component<HuePickerProps> {}
+export default class HuePicker extends Component<HuePickerProps> { }

--- a/types/react-color/v2/lib/components/material/Material.d.ts
+++ b/types/react-color/v2/lib/components/material/Material.d.ts
@@ -1,26 +1,22 @@
 import { Component, CSSProperties } from "react";
 import { CustomPickerProps } from "../../..";
+import { Classes } from "reactcss";
 
-export interface MaterialPickerDefaultStyles {
-    material?: CSSProperties;
-    HEXwrap?: CSSProperties;
-    HEXinput?: CSSProperties;
-    HEXlabel?: CSSProperties;
-    Hex?: CSSProperties;
-    RGBwrap?: CSSProperties;
-    RGBinput?: CSSProperties;
-    RGBlabel?: CSSProperties;
-    split?: CSSProperties;
-    third?: CSSProperties;
-}
-
-export interface MaterialPickerStyles {
-    default?: MaterialPickerDefaultStyles;
+export interface MaterialPickerStylesProps {
+    material: CSSProperties;
+    HEXwrap: CSSProperties;
+    HEXinput: CSSProperties;
+    HEXlabel: CSSProperties;
+    Hex: CSSProperties;
+    RGBwrap: CSSProperties;
+    RGBinput: CSSProperties;
+    RGBlabel: CSSProperties;
+    split: CSSProperties;
+    third: CSSProperties;
 }
 
 export interface MaterialPickerProps extends CustomPickerProps {
-    styles?: MaterialPickerStyles;
-    className?: string;
+    styles?: Partial<Classes<MaterialPickerStylesProps>>;
 }
 
-export default class MaterialPicker extends Component<MaterialPickerProps> {}
+export default class MaterialPicker extends Component<MaterialPickerProps> { }

--- a/types/react-color/v2/lib/components/photoshop/Photoshop.d.ts
+++ b/types/react-color/v2/lib/components/photoshop/Photoshop.d.ts
@@ -1,28 +1,25 @@
 import { Component, MouseEvent, CSSProperties } from "react";
 import { CustomPickerProps } from "../../..";
+import { Classes } from "reactcss";
 
-export interface PhotoshopPickerDefaultStyles {
-    picker?: CSSProperties;
-    head?: CSSProperties;
-    body?: CSSProperties;
-    saturation?: CSSProperties;
-    hue?: CSSProperties;
-    controls?: CSSProperties;
-    top?: CSSProperties;
-    preview?: CSSProperties;
-    actions?: CSSProperties;
-}
-
-export interface PhotoshopPickerStyles {
-    default?: PhotoshopPickerDefaultStyles;
+export interface PhotoshopPickerStylesProps {
+    picker: CSSProperties;
+    head: CSSProperties;
+    body: CSSProperties;
+    saturation: CSSProperties;
+    hue: CSSProperties;
+    controls: CSSProperties;
+    top: CSSProperties;
+    preview: CSSProperties;
+    actions: CSSProperties;
 }
 
 export interface PhotoshopPickerProps extends CustomPickerProps {
     header?: string;
     onAccept?: (event: MouseEvent<HTMLDivElement, MouseEvent>) => void;
     onCancel?: (event: MouseEvent<HTMLDivElement, MouseEvent>) => void;
-    styles?: PhotoshopPickerStyles;
+    styles?: Partial<Classes<PhotoshopPickerStylesProps>>;
     className?: string;
 }
 
-export default class PhotoshopPicker extends Component<PhotoshopPickerProps> {}
+export default class PhotoshopPicker extends Component<PhotoshopPickerProps> { }

--- a/types/react-color/v2/lib/components/sketch/Sketch.d.ts
+++ b/types/react-color/v2/lib/components/sketch/Sketch.d.ts
@@ -1,23 +1,19 @@
 import { Component, CSSProperties } from "react";
-
 import { CustomPickerProps, ColorState, RenderersProps } from "../../..";
+import { Classes } from "reactcss";
 
-export interface SketchPickerDefaultStyles {
-    picker?: CSSProperties;
-    saturation?: CSSProperties;
-    Saturation?: CSSProperties;
-    controls?: CSSProperties;
-    sliders?: CSSProperties;
-    color?: CSSProperties;
-    activeColor?: CSSProperties;
-    hue?: CSSProperties;
-    Hue?: CSSProperties;
-    alpha?: CSSProperties;
-    Alpha?: CSSProperties;
-}
-
-export interface SketchPickerStyles {
-    default?: SketchPickerDefaultStyles;
+export interface SketchPickerStylesProps {
+    picker: CSSProperties;
+    saturation: CSSProperties;
+    Saturation: CSSProperties;
+    controls: CSSProperties;
+    sliders: CSSProperties;
+    color: CSSProperties;
+    activeColor: CSSProperties;
+    hue: CSSProperties;
+    Hue: CSSProperties;
+    alpha: CSSProperties;
+    Alpha: CSSProperties;
 }
 
 type PresetColor = { color: string; title: string } | string;
@@ -25,11 +21,10 @@ export interface SketchPickerProps extends RenderersProps, CustomPickerProps {
     disableAlpha?: boolean;
     presetColors?: PresetColor[];
     width?: string;
+    styles?: Partial<Classes<SketchPickerStylesProps>>;
     onSwatchHover?: (color: ColorState, event: MouseEvent) => void;
-    styles?: SketchPickerStyles;
-    className?: string;
 }
 
-export default class SketchPicker extends Component<SketchPickerProps> {}
+export default class SketchPicker extends Component<SketchPickerProps> { }
 
-export {};
+export { };

--- a/types/react-color/v2/lib/components/slider/Slider.d.ts
+++ b/types/react-color/v2/lib/components/slider/Slider.d.ts
@@ -1,19 +1,15 @@
 import { Component, ComponentType, CSSProperties } from "react";
 import { CustomPickerProps } from "../../..";
+import { Classes } from "reactcss";
 
-export interface SliderPickerDefaultStyles {
-    hue?: CSSProperties;
-    Hue?: CSSProperties;
-}
-
-export interface SliderPickerStyles {
-    default?: SliderPickerDefaultStyles;
+export interface SliderPickerStylesProps {
+    hue: CSSProperties;
+    Hue: CSSProperties;
 }
 
 export interface SliderPickerProps extends CustomPickerProps {
     pointer?: ComponentType;
-    styles?: SliderPickerStyles;
-    className?: string;
+    styles?: Partial<Classes<SliderPickerStylesProps>>;
 }
 
-export default class SliderPicker extends Component<SliderPickerProps> {}
+export default class SliderPicker extends Component<SliderPickerProps> { }

--- a/types/react-color/v2/lib/components/swatches/Swatches.d.ts
+++ b/types/react-color/v2/lib/components/swatches/Swatches.d.ts
@@ -1,15 +1,12 @@
 import { Component, CSSProperties } from "react";
 import { CustomPickerProps, ColorState } from "../../..";
+import { Classes } from "reactcss";
 
-export interface SwatchesPickerDefaultStyles {
+export interface SwatchesPickerStylesProps {
     picker?: CSSProperties;
     overflow?: CSSProperties;
     body?: CSSProperties;
     clear?: CSSProperties;
-}
-
-export interface SwatchesPickerStyles {
-    default?: SwatchesPickerDefaultStyles;
 }
 
 export interface SwatchesPickerProps extends CustomPickerProps {
@@ -17,8 +14,7 @@ export interface SwatchesPickerProps extends CustomPickerProps {
     height?: string;
     width?: string;
     onSwatchHover?(color: ColorState, event: MouseEvent): void;
-    styles?: SwatchesPickerStyles;
-    className?: string;
+    styles?: Partial<Classes<SwatchesPickerStylesProps>>;
 }
 
-export default class SwatchesPicker extends Component<SwatchesPickerProps> {}
+export default class SwatchesPicker extends Component<SwatchesPickerProps> { }

--- a/types/react-color/v2/lib/components/twitter/Twitter.d.ts
+++ b/types/react-color/v2/lib/components/twitter/Twitter.d.ts
@@ -1,7 +1,8 @@
 import { Component, CSSProperties } from "react";
 import { CustomPickerProps, ColorState } from "../../..";
+import { Classes } from "reactcss";
 
-export interface TwitterPickerDefaultStyle {
+export interface TwitterPickerStylesProps {
     card?: CSSProperties;
     body?: CSSProperties;
     label?: CSSProperties;
@@ -13,24 +14,12 @@ export interface TwitterPickerDefaultStyle {
     clear?: CSSProperties;
 }
 
-export interface TwitterPickerTriangleStyle {
-    triangle?: CSSProperties;
-    triangleShadow?: CSSProperties;
-}
-
-export interface TwitterPickerStyle {
-    default?: TwitterPickerDefaultStyle;
-    "top-left-triangle"?: TwitterPickerTriangleStyle;
-    "top-right-triangle"?: TwitterPickerTriangleStyle;
-}
-
 export interface TwitterPickerProps extends CustomPickerProps {
     colors?: string[];
     width?: string;
     triangle?: "hide" | "top-left" | "top-right";
+    styles?: Partial<Classes<TwitterPickerStylesProps>>;
     onSwatchHover?(color: ColorState, event: MouseEvent): void;
-    styles?: TwitterPickerStyle;
-    className?: string;
 }
 
-export default class TwitterPicker extends Component<TwitterPickerProps> {}
+export default class TwitterPicker extends Component<TwitterPickerProps> { }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

https://github.com/casesandberg/react-color/blob/master/src/components/twitter/Twitter.js#L11 This line is common for all the components. A component accepts two properties that were not available. `className`  and `styles`. `styles` follows the rules of [`reactcss`](https://github.com/casesandberg/reactcss), from the same package creator. `react-color` uses `lodash/merge` to merge the properties coming in `styles`. For this reason, I've type'd `styles` following the format provided by `reactcss`. `reactcss` has been added as dependency in code import. I'm not sure if it needs a `package.json` to be included.

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

It corrects the version number.

- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.