### PR TITLE
[globalize-compiler] Add array version of extracts option

### DIFF
--- a/types/globalize-compiler/globalize-compiler-tests.ts
+++ b/types/globalize-compiler/globalize-compiler-tests.ts
@@ -33,3 +33,6 @@ compileOutput = globalizeCompiler.compileExtracts({ extracts: extractOutput, def
 compileOutput = globalizeCompiler.compileExtracts({ extracts: extractOutput, defaultLocale: "en", cldr: {}, messages: {} });
 compileOutput = globalizeCompiler.compileExtracts({ extracts: extractOutput, defaultLocale: "en", cldr: {}, template: templateFunction });
 compileOutput = globalizeCompiler.compileExtracts({ extracts: extractOutput, defaultLocale: "en", cldr: {}, messages: {}, template: templateFunction });
+
+// Array extracts are also accepted
+compileOutput = globalizeCompiler.compileExtracts({ extracts: [extractOutput, extractOutput], defaultLocale: "en" });

--- a/types/globalize-compiler/index.d.ts
+++ b/types/globalize-compiler/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for globalize-compiler v0.2.0
-// Project: https://github.com/jquery-support/globalize-compiler
+// Project: https://github.com/globalizejs/globalize-compiler
 // Definitions by: Ian Clanton-Thuon <https://github.com/iclanton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/globalize-compiler/index.d.ts
+++ b/types/globalize-compiler/index.d.ts
@@ -42,7 +42,7 @@ interface CompileExtractsAttributes extends CompileOptions {
   /**
    * an Array of extracts obtained by @see{GlobalizeCompilerStatic.extract}
    */
-  extracts: ExtractFunction;
+  extracts: ExtractFunction | ExtractFunction[];
 
   /**
    * a locale to be used as Globalize.locale(defaultLocale) when generating the extracted formatters and parsers.


### PR DESCRIPTION
Also fixed the project homepage because the lint command recommended it.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/globalizejs/globalize-compiler#compileextracts-attributes-
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
