### PR TITLE
revision made optional in BulkGetOptions

### DIFF
--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -351,7 +351,7 @@ declare namespace PouchDB {
         }
 
         interface BulkGetOptions extends Options {
-            docs: Array<{ id: string; rev: RevisionId }>;
+            docs: Array<{ id: string; rev?: RevisionId }>;
             revs?: boolean;
             attachments?: boolean;
             binary?: boolean;


### PR DESCRIPTION
The "rev" parameter has been made optional in the BulkGetOptions interface.

As they write on PouchDB's website for the bulkGet operation:
"rev: Revision of the document to fetch. If this is not specified, all available revisions are fetched."
https://pouchdb.com/api.html#bulk_get
