### PR TITLE
Update SingleSpaReact export

### DIFF
--- a/types/single-spa-react/index.d.ts
+++ b/types/single-spa-react/index.d.ts
@@ -9,8 +9,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-export = SingleSpaReact;
-declare function SingleSpaReact(
+export default function SingleSpaReact(
     opts: SingleSpaReact.Options
 ): SingleSpaReact.Lifecycles;
 


### PR DESCRIPTION
Refactored to default export because declaring module using 'export =' requires default import when using the 'esModuleInterop' flag with Typescript.
