### PR TITLE
[leaflet-draw] Properly extend Leaflet namespace for Leaflet Draw

### DIFF
--- a/types/leaflet-draw/index.d.ts
+++ b/types/leaflet-draw/index.d.ts
@@ -17,7 +17,7 @@ declare module 'leaflet' {
         touchExtend?: boolean;
     }
 
-    class DrawMap extends Map {
+    class DrawMap extends L.Map {
         mergeOptions(options?: MapOptions): void;
         addInitHook(): void;
     }

--- a/types/leaflet-draw/tslint.json
+++ b/types/leaflet-draw/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-unnecessary-qualifier": false
+    }
 }


### PR DESCRIPTION
Some times were not explicitly being extended from the Leaflet namespace. For example `DrawMap` accidentally extended the native `Map` language feature instead of the `Map` object from Leaflet itself.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Not applicable
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.