### PR TITLE
[dropzone] Add dataURL, element, listeners, previewsContainer, version

### DIFF
--- a/types/dropzone/dropzone-tests.ts
+++ b/types/dropzone/dropzone-tests.ts
@@ -210,6 +210,8 @@ dropzone.files.forEach(f => {
 });
 
 const firstFile = dropzone.files[0];
+firstFile.dataURL;
+
 dropzone.removeFile(firstFile);
 dropzone.addFile(firstFile);
 dropzone.enqueueFile(firstFile);

--- a/types/dropzone/dropzone-tests.ts
+++ b/types/dropzone/dropzone-tests.ts
@@ -181,12 +181,8 @@ dropzone.version;
 dropzone.listeners;
 dropzone.listeners[0].element;
 dropzone.listeners[0].events;
-dropzone.listeners[0].events.dragstart;
-dropzone.listeners[0].events.dragenter;
-dropzone.listeners[0].events.dragover;
-dropzone.listeners[0].events.dragleave;
-dropzone.listeners[0].events.drop;
-dropzone.listeners[0].events.dragend;
+dropzone.listeners[0].events.click(new MouseEvent('click'));
+dropzone.listeners[0].events.dragstart(new DragEvent('drag'));
 
 dropzone.options.clickable = true;
 if (!dropzone.options.headers) {

--- a/types/dropzone/dropzone-tests.ts
+++ b/types/dropzone/dropzone-tests.ts
@@ -177,6 +177,16 @@ const dropzone = new Dropzone('.test');
 dropzone.element;
 dropzone.previewsContainer;
 
+dropzone.listeners;
+dropzone.listeners[0].element;
+dropzone.listeners[0].events;
+dropzone.listeners[0].events.dragstart;
+dropzone.listeners[0].events.dragenter;
+dropzone.listeners[0].events.dragover;
+dropzone.listeners[0].events.dragleave;
+dropzone.listeners[0].events.drop;
+dropzone.listeners[0].events.dragend;
+
 dropzone.options.clickable = true;
 if (!dropzone.options.headers) {
     dropzone.options.headers = {};

--- a/types/dropzone/dropzone-tests.ts
+++ b/types/dropzone/dropzone-tests.ts
@@ -175,6 +175,7 @@ dropzoneWithOptionsVariations = new Dropzone('.test', {
 const dropzone = new Dropzone('.test');
 
 dropzone.element;
+dropzone.previewsContainer;
 
 dropzone.options.clickable = true;
 if (!dropzone.options.headers) {

--- a/types/dropzone/dropzone-tests.ts
+++ b/types/dropzone/dropzone-tests.ts
@@ -174,6 +174,8 @@ dropzoneWithOptionsVariations = new Dropzone('.test', {
 
 const dropzone = new Dropzone('.test');
 
+dropzone.element;
+
 dropzone.options.clickable = true;
 if (!dropzone.options.headers) {
     dropzone.options.headers = {};

--- a/types/dropzone/dropzone-tests.ts
+++ b/types/dropzone/dropzone-tests.ts
@@ -176,6 +176,7 @@ const dropzone = new Dropzone('.test');
 
 dropzone.element;
 dropzone.previewsContainer;
+dropzone.version;
 
 dropzone.listeners;
 dropzone.listeners[0].element;

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -187,6 +187,7 @@ declare class Dropzone {
     defaultOptions: Dropzone.DropzoneOptions;
     options: Dropzone.DropzoneOptions;
     previewsContainer: HTMLElement;
+    version: string;
 
     enable(): void;
 

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -148,6 +148,18 @@ declare namespace Dropzone {
 
         previewTemplate?: string;
     }
+
+    export interface DropzoneListeners {
+        element: HTMLElement;
+        events: {
+            dragstart: (e: DragEvent) => Dropzone;
+            dragenter: (e: DragEvent) => Dropzone;
+            dragover: (e: DragEvent) => Dropzone;
+            dragleave: (e: DragEvent) => Dropzone;
+            drop: (e: DragEvent) => Dropzone;
+            dragend: (e: DragEvent) => Dropzone;
+        };
+    }
 }
 
 declare class Dropzone {
@@ -171,6 +183,7 @@ declare class Dropzone {
 
     element: string | HTMLElement;
     files: Dropzone.DropzoneFile[];
+    listeners: Dropzone.DropzoneListeners[];
     defaultOptions: Dropzone.DropzoneOptions;
     options: Dropzone.DropzoneOptions;
     previewsContainer: HTMLElement;

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -173,6 +173,7 @@ declare class Dropzone {
     files: Dropzone.DropzoneFile[];
     defaultOptions: Dropzone.DropzoneOptions;
     options: Dropzone.DropzoneOptions;
+    previewsContainer: HTMLElement;
 
     enable(): void;
 

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -150,15 +150,10 @@ declare namespace Dropzone {
         previewTemplate?: string;
     }
 
-    export interface DropzoneListeners {
+    export interface DropzoneListener {
         element: HTMLElement;
         events: {
-            dragstart: (e: DragEvent) => Dropzone;
-            dragenter: (e: DragEvent) => Dropzone;
-            dragover: (e: DragEvent) => Dropzone;
-            dragleave: (e: DragEvent) => Dropzone;
-            drop: (e: DragEvent) => Dropzone;
-            dragend: (e: DragEvent) => Dropzone;
+            [key: string]: (e: Event) => any;
         };
     }
 }
@@ -184,7 +179,7 @@ declare class Dropzone {
 
     element: HTMLElement;
     files: Dropzone.DropzoneFile[];
-    listeners: Dropzone.DropzoneListeners[];
+    listeners: Dropzone.DropzoneListener[];
     defaultOptions: Dropzone.DropzoneOptions;
     options: Dropzone.DropzoneOptions;
     previewsContainer: HTMLElement;

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -182,7 +182,7 @@ declare class Dropzone {
     static ERROR: string;
     static SUCCESS: string;
 
-    element: string | HTMLElement;
+    element: HTMLElement;
     files: Dropzone.DropzoneFile[];
     listeners: Dropzone.DropzoneListeners[];
     defaultOptions: Dropzone.DropzoneOptions;

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -27,6 +27,7 @@ declare namespace Dropzone {
     }
 
     export interface DropzoneFile extends File {
+        dataURL?: string;
         previewElement: HTMLElement;
         previewTemplate: HTMLElement;
         previewsContainer: HTMLElement;

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -169,6 +169,7 @@ declare class Dropzone {
     static ERROR: string;
     static SUCCESS: string;
 
+    element: string | HTMLElement;
     files: Dropzone.DropzoneFile[];
     defaultOptions: Dropzone.DropzoneOptions;
     options: Dropzone.DropzoneOptions;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [element](https://gitlab.com/meno/dropzone/-/blob/6cef0c303a472468f8d3581c82062a6d31045666/src/dropzone.js#L926), [listeners](https://gitlab.com/meno/dropzone/-/blob/6cef0c303a472468f8d3581c82062a6d31045666/src/dropzone.js#L1149-1192), [previewsContainer](https://gitlab.com/meno/dropzone/-/blob/6cef0c303a472468f8d3581c82062a6d31045666/src/dropzone.js#L999-1006), [version](https://gitlab.com/meno/dropzone/-/blob/v5.5.0/src/dropzone.js#L2280), dataURL [1](https://gitlab.com/meno/dropzone/-/blob/v5.5.0/src/dropzone.js#L1652-1671), [2](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/result), [3](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
