### PR TITLE
[crypto-js] Revert most of #43932

### DIFF
--- a/types/crypto-js/crypto-js-tests.ts
+++ b/types/crypto-js/crypto-js-tests.ts
@@ -20,6 +20,9 @@ FR.onloadend = () => {
 
 var randomWordArrayEncoded = CryptoJS.lib.WordArray.random(16).toString(CryptoJS.enc.Hex);
 
+const libWordArray: CryptoJS.LibWordArray = CryptoJS.lib.WordArray.create("Message");
+const encKey = CryptoJS.AES.encrypt(libWordArray, "Key");
+
 // Ciphers
 var encrypted: CryptoJS.WordArray;
 var decrypted: CryptoJS.DecryptedMessage;

--- a/types/crypto-js/index.d.ts
+++ b/types/crypto-js/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/evanvosberg/crypto-js
 // Definitions by: Michael Zabka <https://github.com/misak113>
 //                 Max Lysenko <https://github.com/maximlysenko>
+//                 Brendan Early <https://github.com/mymindstorm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = CryptoJS;
@@ -30,7 +31,7 @@ declare namespace CryptoJS {
     interface StreamCipher extends Cipher {}
 
     interface CipherHelper {
-        encrypt(message: string | WordArray, secretPassphrase: string | WordArray, option?: CipherOption): WordArray;
+        encrypt(message: string | LibWordArray, secretPassphrase: string | WordArray, option?: CipherOption): WordArray;
         decrypt(encryptedMessage: string | WordArray, secretPassphrase: string | WordArray, option?: CipherOption): DecryptedMessage;
     }
     interface Encryptor {
@@ -57,7 +58,7 @@ declare namespace CryptoJS {
         toString(encoder?: Encoder): string;
     };
     interface CipherOption {
-        iv?: string | WordArray;
+        iv?: string | LibWordArray;
         mode?: Mode;
         padding?: Padding;
         [option: string]: any;
@@ -147,7 +148,7 @@ declare namespace CryptoJS {
         lib: {
             WordArray: {
                 create: (v: any) => LibWordArray;
-                random: (v: number) => WordArray;
+                random: (v: number) => LibWordArray;
             };
         };
         mode: {


### PR DESCRIPTION
This reverts commit 844962b6f6bfd3d9bbb377a914d28ae1a17b0eb2 (#43932)

#43932 broke my builds and some others (https://github.com/brix/crypto-js/issues/279). `libWordArray` does not exist in crypto-js's source and was intentionally different from `WordArray` and should not have been changed.

cc @QuentinFombaron

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A