### PR TITLE
[lowdb] Memory adapter needs zero args

### DIFF
--- a/types/lowdb/adapters/Memory.d.ts
+++ b/types/lowdb/adapters/Memory.d.ts
@@ -1,3 +1,3 @@
 import { AdapterSync } from "../index";
-declare const FileSync: AdapterSync;
-export = FileSync;
+declare const Memory: AdapterSync;
+export = Memory;

--- a/types/lowdb/index.d.ts
+++ b/types/lowdb/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/typicode/lowdb
 // Definitions by: typicode <https://github.com/typicode>
 //                 Bazyli Brzóska <https://github.com/niieani>
+//                 Austin Cawley-Edwards <https://github.com/austince>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
@@ -48,7 +49,7 @@ declare namespace Lowdb {
 
   interface AdapterSync<SchemaT = any> extends BaseAdapter<SchemaT> {
     new <SchemaT = any>(
-      source: string,
+      source?: string,
       options?: AdapterOptions<SchemaT>
     ): AdapterSync<SchemaT>;
     write(state: object): void;

--- a/types/lowdb/lowdb-tests.ts
+++ b/types/lowdb/lowdb-tests.ts
@@ -3,9 +3,11 @@ import * as lowfp from "lowdb/lib/fp";
 import * as Base from "lowdb/adapters/Base";
 import * as FileSync from "lowdb/adapters/FileSync";
 import * as FileAsync from "lowdb/adapters/FileAsync";
+import * as Memory from "lowdb/adapaters/Memory";
 import * as LocalStorage from "lowdb/adapters/LocalStorage";
 import { find, filter, random, concat, sortBy, take, set } from "lodash/fp";
 
+const adapterMemory = new Memory();
 const adapterSync = new FileSync<DbSchema>("db.json");
 const adapterAsync = new FileAsync<DbSchema>("db.json");
 const db = low(adapterSync);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I can't figure out how the files are linked, but getting this error on TS v4:
```
ERROR: 6:25  expect  TypeScript@4.0 compile error: 
Cannot find module 'lowdb/adapaters/Memory' or its corresponding type declarations.
```

I've made these changes to the files in node_modules in my project and everything is happy, but using TS v3.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/typicode/lowdb/tree/master/examples#in-memory
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
