### PR TITLE
[relay-runtime] Replace generic Variables with deduced variables type in GraphQLSubscriptionConfig

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -6,6 +6,7 @@
 //                 Renan Machado <https://github.com/renanmav>
 //                 Stephen Pittman <https://github.com/Stephen2>
 //                 Martin Zlámal <https://github.com/mrtnzlml>
+//                 Christian Ivicevic <https://github.com/ChristianIvicevic>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/relay-runtime/lib/subscription/requestSubscription.d.ts
+++ b/types/relay-runtime/lib/subscription/requestSubscription.d.ts
@@ -1,12 +1,12 @@
 import { DeclarativeMutationConfig } from '../mutations/RelayDeclarativeMutationConfig';
 import { GraphQLTaggedNode } from '../query/RelayModernGraphQLTag';
-import { Variables, Disposable, OperationType } from '../util/RelayRuntimeTypes';
+import { Disposable, OperationType } from '../util/RelayRuntimeTypes';
 import { SelectorStoreUpdater, Environment } from '../store/RelayStoreTypes';
 
 export interface GraphQLSubscriptionConfig<TSubscription extends OperationType> {
     configs?: ReadonlyArray<DeclarativeMutationConfig>;
     subscription: GraphQLTaggedNode;
-    variables: Variables;
+    variables: TSubscription["variables"];
     onCompleted?: () => void;
     onError?: (error: Error) => void;
     onNext?: (response: TSubscription['response'] | null | undefined) => void;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: refer to similar case here https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ecc77f83c0ba5a020a0afdf805fadcf7f44a4c8c/types/relay-runtime/lib/query/fetchQuery.d.ts#L8
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
