### PR TITLE
Add alternative labeled tuple printback for parameter capture lists expected in tests

### DIFF
--- a/types/es-abstract/test/helpers/callBind.test.ts
+++ b/types/es-abstract/test/helpers/callBind.test.ts
@@ -8,5 +8,5 @@ callBind(Object.prototype.hasOwnProperty); // $ExpectType (thisArg: unknown, v: 
 callBind(Object.prototype.hasOwnProperty, any); // $ExpectType (v: string | number | symbol) => boolean
 
 applyBind(() => {}); // $ExpectType (thisArg: unknown, args: readonly []) => void
-applyBind(Object.prototype.hasOwnProperty); // $ExpectType (thisArg: unknown, args: readonly [string | number | symbol]) => boolean
-applyBind(Object.prototype.hasOwnProperty, any); // $ExpectType (args: readonly [string | number | symbol]) => boolean
+applyBind(Object.prototype.hasOwnProperty); // $ExpectType (thisArg: unknown, args: readonly [string | number | symbol]) => boolean || (thisArg: unknown, args: readonly [v: string | number | symbol]) => boolean
+applyBind(Object.prototype.hasOwnProperty, any); // $ExpectType (args: readonly [string | number | symbol]) => boolean || (args: readonly [v: string | number | symbol]) => boolean

--- a/types/es-abstract/test/helpers/callBind.test.ts
+++ b/types/es-abstract/test/helpers/callBind.test.ts
@@ -8,5 +8,7 @@ callBind(Object.prototype.hasOwnProperty); // $ExpectType (thisArg: unknown, v: 
 callBind(Object.prototype.hasOwnProperty, any); // $ExpectType (v: string | number | symbol) => boolean
 
 applyBind(() => {}); // $ExpectType (thisArg: unknown, args: readonly []) => void
-applyBind(Object.prototype.hasOwnProperty); // $ExpectType (thisArg: unknown, args: readonly [string | number | symbol]) => boolean || (thisArg: unknown, args: readonly [v: string | number | symbol]) => boolean
-applyBind(Object.prototype.hasOwnProperty, any); // $ExpectType (args: readonly [string | number | symbol]) => boolean || (args: readonly [v: string | number | symbol]) => boolean
+// $ExpectType (thisArg: unknown, args: readonly [string | number | symbol]) => boolean || (thisArg: unknown, args: readonly [v: string | number | symbol]) => boolean
+applyBind(Object.prototype.hasOwnProperty);
+// $ExpectType (args: readonly [string | number | symbol]) => boolean || (args: readonly [v: string | number | symbol]) => boolean
+applyBind(Object.prototype.hasOwnProperty, any);

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -1489,7 +1489,7 @@ describe('better typed spys', () => {
             spy.and.returnValue;
         });
         it('has a typed calls property', () => {
-            spy.calls.first().args; // $ExpectType [number, string]
+            spy.calls.first().args; // $ExpectType [num: number, str: string]
             spy.calls.first().returnValue; // $ExpectType string
         });
         it('has a typed callFake', () => {

--- a/types/jasmine/ts3.1/jasmine-tests.ts
+++ b/types/jasmine/ts3.1/jasmine-tests.ts
@@ -1489,7 +1489,7 @@ describe('better typed spys', () => {
             spy.and.returnValue;
         });
         it('has a typed calls property', () => {
-            spy.calls.first().args; // $ExpectType [num: number, str: string]
+            spy.calls.first().args; // $ExpectType [number, string] || [num: number, str: string]
             spy.calls.first().returnValue; // $ExpectType string
         });
         it('has a typed callFake', () => {

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -313,13 +313,13 @@ const mock3 = jest.fn(() => 'abc');
 const mock4 = jest.fn((): 'abc' => 'abc');
 // $ExpectType Mock<string, string[]>
 const mock5 = jest.fn((...args: string[]) => args.join(''));
-// $ExpectType Mock<{}, [{}]>
+// $ExpectType Mock<{}, [{}]> || Mock<{}, [arg: {}]>
 const mock6 = jest.fn((arg: {}) => arg);
-// $ExpectType Mock<number, [number]>
+// $ExpectType Mock<number, [number]> || Mock<number, [arg: number]>
 const mock7 = jest.fn((arg: number) => arg);
-// $ExpectType Mock<number, [number]>
+// $ExpectType Mock<number, [number]> || Mock<number, [arg: number]>
 const mock8: jest.Mock = jest.fn((arg: number) => arg);
-// $ExpectType Mock<Promise<boolean>, [number, string, {}, [], boolean]>
+// $ExpectType Mock<Promise<boolean>, [number, string, {}, [], boolean]> || Mock<Promise<boolean>, [a: number, _b: string, _c: {}, [], _makeItStop: boolean]>
 const mock9 = jest.fn((a: number, _b: string, _c: {}, _iReallyDontCare: [], _makeItStop: boolean) =>
     Promise.resolve(_makeItStop)
 );
@@ -327,12 +327,12 @@ const mock9 = jest.fn((a: number, _b: string, _c: {}, _iReallyDontCare: [], _mak
 const mock10 = jest.fn(() => {
     throw new Error();
 });
-// $ExpectType Mock<unknown, [unknown]>
+// $ExpectType Mock<unknown, [unknown]> || Mock<unknown, [arg: unknown]>
 const mock11 = jest.fn((arg: unknown) => arg);
 interface TestApi {
     test(x: number): string;
 }
-// $ExpectType Mock<string, [number]>
+// $ExpectType Mock<string, [number]> || Mock<string, [x: number]>
 const mock12 = jest.fn<ReturnType<TestApi['test']>, jest.ArgsType<TestApi['test']>>();
 
 // $ExpectType number
@@ -449,7 +449,7 @@ spy4.mockRestore();
 
 let spy5: jest.SpiedFunction<typeof spiedTarget.setValue>;
 
-// $ExpectType SpyInstance<void, [string]>
+// $ExpectType SpyInstance<void, [string]> || SpyInstance<void, [value: string]>
 spy5 = jest.spyOn(spiedTarget, 'setValue');
 // $ExpectError
 spy5 = jest.spyOn(spiedTarget, 'returnsString');
@@ -469,14 +469,14 @@ jest.spyOn(spyInterfaceImpl, 'method', 'get');
 jest.spyOn(spyInterfaceImpl, 'prop');
 // $ExpectType SpyInstance<number, []>
 jest.spyOn(spyInterfaceImpl, 'prop', 'get');
-// $ExpectType SpyInstance<void, [boolean]>
+// $ExpectType SpyInstance<void, [boolean]> || SpyInstance<void, [arg1: boolean]>
 jest.spyOn(spyInterfaceImpl, 'method');
 
 class SpyableClass {
     constructor(a: number, b: string) {}
     foo() {}
 }
-// $ExpectType SpyInstance<SpyableClass, [number, string]>
+// $ExpectType SpyInstance<SpyableClass, [number, string]> || SpyInstance<SpyableClass, [a: number, b: string]>
 jest.spyOn({ SpyableClass }, "SpyableClass");
 
 interface Type1 {
@@ -506,22 +506,22 @@ mocked.test1.mockImplementation(() => Promise.resolve({ a: 1 }));
 // $ExpectType (x: Type1) => Promise<Type1> | undefined
 mocked.test1.getMockImplementation();
 mocked.test1.mockReturnValue(Promise.resolve({ a: 1 }));
-// $ExpectType MockInstance<Promise<Type1>, [Type1]> & ((x: Type1) => Promise<Type1>)
+// $ExpectType MockInstance<Promise<Type1>, [Type1]> & ((x: Type1) => Promise<Type1>) || MockInstance<Promise<Type1>, [x: Type1]> & ((x: Type1) => Promise<Type1>)
 mocked.test1.mockResolvedValue({ a: 1 });
 mocked.test1.mockResolvedValueOnce({ a: 1 });
-// $ExpectType MockInstance<Promise<Type1>, [Type1]> & ((x: Type1) => Promise<Type1>)
+// $ExpectType MockInstance<Promise<Type1>, [Type1]> & ((x: Type1) => Promise<Type1>) || MockInstance<Promise<Type1>, [x: Type1]> & ((x: Type1) => Promise<Type1>)
 mocked.test1.mockResolvedValue(Promise.resolve({ a: 1 }));
 mocked.test1.mockResolvedValueOnce(Promise.resolve({ a: 1 }));
-// $ExpectType MockInstance<Promise<Type1>, [Promise<Type1>]> & ((x: Promise<Type1>) => Promise<Type1>)
+// $ExpectType MockInstance<Promise<Type1>, [Promise<Type1>]> & ((x: Promise<Type1>) => Promise<Type1>) || MockInstance<Promise<Type1>, [x: Promise<Type1>]> & ((x: Promise<Type1>) => Promise<Type1>)
 mocked.test2.mockResolvedValue({ a: 1 });
 mocked.test2.mockResolvedValueOnce({ a: 1 });
-// $ExpectType MockInstance<Promise<Type1>, [Promise<Type1>]> & ((x: Promise<Type1>) => Promise<Type1>)
+// $ExpectType MockInstance<Promise<Type1>, [Promise<Type1>]> & ((x: Promise<Type1>) => Promise<Type1>) || MockInstance<Promise<Type1>, [x: Promise<Type1>]> & ((x: Promise<Type1>) => Promise<Type1>)
 mocked.test2.mockResolvedValue(Promise.resolve({ a: 1 }));
 mocked.test2.mockResolvedValueOnce(Promise.resolve({ a: 1 }));
-// $ExpectType MockInstance<Promise<Type2>, [Promise<Type1>]> & ((x: Promise<Type1>) => Promise<Type2>)
+// $ExpectType MockInstance<Promise<Type2>, [Promise<Type1>]> & ((x: Promise<Type1>) => Promise<Type2>) || MockInstance<Promise<Type2>, [x: Promise<Type1>]> & ((x: Promise<Type1>) => Promise<Type2>)
 mocked.test3.mockResolvedValue({ b: 1 });
 mocked.test3.mockResolvedValueOnce({ b: 1 });
-// $ExpectType MockInstance<Promise<Type2>, [Promise<Type1>]> & ((x: Promise<Type1>) => Promise<Type2>)
+// $ExpectType MockInstance<Promise<Type2>, [Promise<Type1>]> & ((x: Promise<Type1>) => Promise<Type2>) || MockInstance<Promise<Type2>, [x: Promise<Type1>]> & ((x: Promise<Type1>) => Promise<Type2>)
 mocked.test3.mockResolvedValue(Promise.resolve({ b: 1 }));
 mocked.test3.mockResolvedValueOnce(Promise.resolve({ b: 1 }));
 mocked.test3.mockRejectedValue(new Error());

--- a/types/ospec/ospec-tests.ts
+++ b/types/ospec/ospec-tests.ts
@@ -145,13 +145,13 @@ o.spec('ospec typings', () => {
 
     const myFunc = (a: string, b?: boolean) => 42;
     const spiedFunc = o.spy(myFunc);
-    type SpiedFuncParams = Parameters<typeof spiedFunc>; // $ExpectType [string, (boolean | undefined)?]
+    type SpiedFuncParams = Parameters<typeof spiedFunc>; // $ExpectType [string, (boolean | undefined)?] || [a: string, b?: boolean | undefined]
     const _args1: SpiedFuncParams = ['hi', true];
     const _args2: SpiedFuncParams = ['hi'];
     spiedFunc(..._args1); // $ExpectType number
     spiedFunc(..._args2); // $ExpectType number
-    spiedFunc.args; // $ExpectType [string, (boolean | undefined)?]
-    spiedFunc.calls; // $ExpectType [string, (boolean | undefined)?][]
+    spiedFunc.args; // $ExpectType [string, (boolean | undefined)?] || [a: string, b?: boolean | undefined]
+    spiedFunc.calls; // $ExpectType [string, (boolean | undefined)?][] || [a: string, b?: boolean | undefined][]
 
     // ======================================================================
 

--- a/types/sinon/ts3.1/sinon-tests.ts
+++ b/types/sinon/ts3.1/sinon-tests.ts
@@ -419,7 +419,7 @@ function testSpy() {
     const methodSpy = sinon.spy(instance, 'foo'); // $ExpectType SinonSpy<[], void>
     methodSpy.wrappedMethod; // $ExpectType () => void
 
-    const methodSpy2 = sinon.spy(instance, 'foobar'); // $ExpectType SinonSpy<[(string | undefined)?], string | undefined>
+    const methodSpy2 = sinon.spy(instance, 'foobar'); // $ExpectType SinonSpy<[(string | undefined)?], string | undefined> || SinonSpy<[p1?: string | undefined], string | undefined>
     methodSpy2.wrappedMethod; // $ExpectType (p1?: string | undefined) => string | undefined
 
     methodSpy.calledBefore(methodSpy2);
@@ -443,10 +443,10 @@ function testSpy() {
     arr = spy.exceptions;
     arr = spy.returnValues;
 
-    const fnSpy = sinon.spy(fn); // $ExpectType SinonSpy<[string, number], boolean>
+    const fnSpy = sinon.spy(fn); // $ExpectType SinonSpy<[string, number], boolean> || SinonSpy<[arg: string, arg2: number], boolean>
     fn = fnSpy; // Should be assignable to original function
     fnSpy('a', 1); // $ExpectType boolean
-    fnSpy.args; // $ExpectType [string, number][]
+    fnSpy.args; // $ExpectType [string, number][] || [arg: string, arg2: number][]
     fnSpy.returnValues; // $ExpectType boolean[]
 
     spy(1, 2);


### PR DESCRIPTION
This should be all the changes https://github.com/microsoft/TypeScript/pull/38234 needs to be clean on DT.