### PR TITLE
Add types for nodemailer-sendgrid

### DIFF
--- a/types/nodemailer-sendgrid/index.d.ts
+++ b/types/nodemailer-sendgrid/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for nodemailer-sendgrid 1.0
+// Project: https://github.com/nodemailer/nodemailer-sendgrid
+// Definitions by: Luke Jones <https://github.com/luke-j>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.3
+
+import { Transport } from 'nodemailer';
+
+declare namespace nodemailerSendgrid {
+    interface SendgridOptions {
+        apiKey: string;
+    }
+}
+
+declare function nodemailerSendgrid(options: nodemailerSendgrid.SendgridOptions): Transport;
+
+export = nodemailerSendgrid;

--- a/types/nodemailer-sendgrid/nodemailer-sendgrid-tests.ts
+++ b/types/nodemailer-sendgrid/nodemailer-sendgrid-tests.ts
@@ -1,0 +1,16 @@
+import nodemailerSendgrid = require('nodemailer-sendgrid');
+import nodemailer = require('nodemailer');
+
+const opts: nodemailerSendgrid.SendgridOptions = { apiKey: 'XXXXXXXXXXXXXXXX' };
+const transport: nodemailer.Transporter = nodemailer.createTransport(nodemailerSendgrid(opts));
+const mailOptions: nodemailer.SendMailOptions = {
+    from: 'Foo Bar ✔ <foo@bar.com>',
+    to: 'foo@baz.com, foo@baz.com',
+    subject: 'Hello world ✔',
+    text: 'Hello world ✔',
+    html: '<b>Hello world ✔</b>',
+};
+
+transport.sendMail(mailOptions, (error: Error | null, info: nodemailer.SentMessageInfo): void => {
+    // nothing
+});

--- a/types/nodemailer-sendgrid/tsconfig.json
+++ b/types/nodemailer-sendgrid/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "nodemailer-sendgrid-tests.ts"
+    ]
+}

--- a/types/nodemailer-sendgrid/tslint.json
+++ b/types/nodemailer-sendgrid/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.