### PR TITLE
[react-relay] Add experimental useSubscription hook typing

### DIFF
--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -10,6 +10,7 @@
 //                 Jared Kass <https://github.com/jdk243>
 //                 Renan Machado <https://github.com/renanmav>
 //                 Janic Duplessis <https://github.com/janicduplessis>
+//                 Christian Ivicevic <https://github.com/ChristianIvicevic>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.3
 

--- a/types/react-relay/lib/hooks.d.ts
+++ b/types/react-relay/lib/hooks.d.ts
@@ -16,3 +16,4 @@ export { useMutation } from './relay-experimental/useMutation';
 export { usePreloadedQuery } from './relay-experimental/usePreloadedQuery';
 export { useRefetchableFragment } from './relay-experimental/useRefetchableFragment';
 export { useRelayEnvironment } from './relay-experimental/useRelayEnvironment';
+export { useSubscription } from './relay-experimental/useSubscription';

--- a/types/react-relay/lib/relay-experimental/useSubscription.d.ts
+++ b/types/react-relay/lib/relay-experimental/useSubscription.d.ts
@@ -1,7 +1,7 @@
 import { GraphQLSubscriptionConfig, OperationType, requestSubscription } from 'relay-runtime';
 
 // The actual subtype of OperationType is required to allow for type inferrence inside GraphQLSubscriptionConfig.
-// eslint-disable-next-line no-unnecessary-generics
+// tslint:disable-next-line:no-unnecessary-generics
 export function useSubscription<TSubscriptionPayload extends OperationType>(
     config: GraphQLSubscriptionConfig<TSubscriptionPayload>,
     requestSubscriptionFn?: typeof requestSubscription,

--- a/types/react-relay/lib/relay-experimental/useSubscription.d.ts
+++ b/types/react-relay/lib/relay-experimental/useSubscription.d.ts
@@ -1,8 +1,8 @@
 import { GraphQLSubscriptionConfig, OperationType, requestSubscription } from 'relay-runtime';
 
-// The actual subtype of OperationType is required to allow for type inferrence inside GraphQLSubscriptionConfig.
-// tslint:disable-next-line:no-unnecessary-generics
 export function useSubscription<TSubscriptionPayload extends OperationType>(
+    // The actual subtype of OperationType is required to allow for type inferrence inside GraphQLSubscriptionConfig.
+    // tslint:disable-next-line:no-unnecessary-generics
     config: GraphQLSubscriptionConfig<TSubscriptionPayload>,
     requestSubscriptionFn?: typeof requestSubscription,
 ): void;

--- a/types/react-relay/lib/relay-experimental/useSubscription.d.ts
+++ b/types/react-relay/lib/relay-experimental/useSubscription.d.ts
@@ -1,0 +1,6 @@
+import { GraphQLSubscriptionConfig, OperationType, requestSubscription } from 'relay-runtime';
+
+export function useSubscription<TSubscriptionPayload extends OperationType>(
+    config: GraphQLSubscriptionConfig<TSubscriptionPayload>,
+    requestSubscriptionFn?: typeof requestSubscription,
+): void;

--- a/types/react-relay/lib/relay-experimental/useSubscription.d.ts
+++ b/types/react-relay/lib/relay-experimental/useSubscription.d.ts
@@ -1,5 +1,7 @@
 import { GraphQLSubscriptionConfig, OperationType, requestSubscription } from 'relay-runtime';
 
+// The actual subtype of OperationType is required to allow for type inferrence inside GraphQLSubscriptionConfig.
+// eslint-disable-next-line no-unnecessary-generics
 export function useSubscription<TSubscriptionPayload extends OperationType>(
     config: GraphQLSubscriptionConfig<TSubscriptionPayload>,
     requestSubscriptionFn?: typeof requestSubscription,


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://relay.dev/docs/en/experimental/api-reference#usesubscription
  - https://github.com/facebook/relay/blob/relay-experimental/packages/relay-experimental/useSubscription.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

Quick note: I wasn't able to run the tests or linter since there were some arbitrary issues with unrelated packages along the React typings hierarchy with the Typescript 4.0 version. I hope that the CI tests will no fail as well.

Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44889