### PR TITLE
feat: Add `has‑symbols`

### DIFF
--- a/types/has-symbols/has-symbols-tests.ts
+++ b/types/has-symbols/has-symbols-tests.ts
@@ -1,0 +1,5 @@
+import hasNativeSymbols = require('has-symbols');
+import hasSymbolSham = require('has-symbols/shams');
+
+hasNativeSymbols; // $ExpectType () => boolean
+hasSymbolSham; // $ExpectType () => boolean

--- a/types/has-symbols/has-symbols-tests.ts
+++ b/types/has-symbols/has-symbols-tests.ts
@@ -1,5 +1,5 @@
 import hasNativeSymbols = require('has-symbols');
 import hasSymbolSham = require('has-symbols/shams');
 
-hasNativeSymbols; // $ExpectType () => boolean
-hasSymbolSham; // $ExpectType () => boolean
+hasNativeSymbols(); // $ExpectType boolean
+hasSymbolSham(); // $ExpectType boolean

--- a/types/has-symbols/index.d.ts
+++ b/types/has-symbols/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for has-symbols 1.0
+// Project: https://github.com/ljharb/has-symbols#readme
+// Definitions by: Jordan Harband <https://github.com/ljharb>
+//                 ExE Boss <https://github.com/ExE-Boss>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Returns `true` only if the environment has native `Symbol` support.
+ *
+ * Not polyfillable, not forgeable.
+ */
+declare function hasNativeSymbols(): boolean;
+export = hasNativeSymbols;

--- a/types/has-symbols/shams.d.ts
+++ b/types/has-symbols/shams.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Returns `true` if the environment has a `Symbol` sham
+ * that mostly follows the spec.
+ */
+declare function hasSymbolSham(): boolean;
+export = hasSymbolSham;

--- a/types/has-symbols/tsconfig.json
+++ b/types/has-symbols/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["ES2015"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "has-symbols-tests.ts",
+        "index.d.ts"
+    ]
+}

--- a/types/has-symbols/tslint.json
+++ b/types/has-symbols/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
