### PR TITLE
[prettier] feat: add name to SupportOption

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -44,6 +44,32 @@ export type BuiltInParserName =
     | 'yaml'
     | 'lwc';
 
+export type SupportOptionName =
+    | 'arrowParens'
+    | 'bracketSpacing'
+    | 'cursorOffset'
+    | 'endOfLine'
+    | 'filepath'
+    | 'htmlWhitespaceSensitivity'
+    | 'insertPragma'
+    | 'jsxBracketSameLine'
+    | 'jsxSingleQuote'
+    | 'parser'
+    | 'pluginSearchDirs'
+    | 'plugins'
+    | 'printWidth'
+    | 'proseWrap'
+    | 'quoteProps'
+    | 'rangeEnd'
+    | 'rangeStart'
+    | 'requirePragma'
+    | 'semi'
+    | 'singleQuote'
+    | 'tabWidth'
+    | 'trailingComma'
+    | 'useTabs'
+    | 'vueIndentScriptAndStyle'
+
 export type CustomParser = (text: string, parsers: Record<BuiltInParserName, BuiltInParser>, options: Options) => AST;
 
 export interface Options extends Partial<RequiredOptions> {}
@@ -324,6 +350,7 @@ export interface SupportOptionDefault {
 }
 
 export interface SupportOption {
+    name: SupportOptionName;
     since?: string;
     type: 'int' | 'boolean' | 'choice' | 'path';
     array?: boolean;

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -68,7 +68,7 @@ export type SupportOptionName =
     | 'tabWidth'
     | 'trailingComma'
     | 'useTabs'
-    | 'vueIndentScriptAndStyle'
+    | 'vueIndentScriptAndStyle';
 
 export type CustomParser = (text: string, parsers: Record<BuiltInParserName, BuiltInParser>, options: Options) => AST;
 

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -44,32 +44,6 @@ export type BuiltInParserName =
     | 'yaml'
     | 'lwc';
 
-export type SupportOptionName =
-    | 'arrowParens'
-    | 'bracketSpacing'
-    | 'cursorOffset'
-    | 'endOfLine'
-    | 'filepath'
-    | 'htmlWhitespaceSensitivity'
-    | 'insertPragma'
-    | 'jsxBracketSameLine'
-    | 'jsxSingleQuote'
-    | 'parser'
-    | 'pluginSearchDirs'
-    | 'plugins'
-    | 'printWidth'
-    | 'proseWrap'
-    | 'quoteProps'
-    | 'rangeEnd'
-    | 'rangeStart'
-    | 'requirePragma'
-    | 'semi'
-    | 'singleQuote'
-    | 'tabWidth'
-    | 'trailingComma'
-    | 'useTabs'
-    | 'vueIndentScriptAndStyle';
-
 export type CustomParser = (text: string, parsers: Record<BuiltInParserName, BuiltInParser>, options: Options) => AST;
 
 export interface Options extends Partial<RequiredOptions> {}
@@ -350,7 +324,7 @@ export interface SupportOptionDefault {
 }
 
 export interface SupportOption {
-    name: SupportOptionName;
+    name: string;
     since?: string;
     type: 'int' | 'boolean' | 'choice' | 'path';
     array?: boolean;


### PR DESCRIPTION
@ikatyang @ifiokjr @ffflorian and @sosukesuzuki 
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://prettier.io/docs/en/api.html#prettiergetsupportinfo>

```ts
import prettier from "prettier";
console.log(prettier.getSupportInfo().options.map((item: any) => item.name));
```

```bash
[
  'arrowParens',
  'bracketSpacing',
  'cursorOffset',
  'endOfLine',
  'filepath',
  'htmlWhitespaceSensitivity',
  'insertPragma',
  'jsxBracketSameLine',
  'jsxSingleQuote',
  'parser',
  'pluginSearchDirs',
  'plugins',
  'printWidth',
  'proseWrap',
  'quoteProps',
  'rangeEnd',
  'rangeStart',
  'requirePragma',
  'semi',
  'singleQuote',
  'tabWidth',
  'trailingComma',
  'useTabs',
  'vueIndentScriptAndStyle'
]
```