### PR TITLE
[ioredis] Remove param "callback" from Redis.Cluster::connect() method

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1395,7 +1395,7 @@ declare namespace IORedis {
     type Ok = 'OK';
 
     interface Cluster extends EventEmitter, Commander, Commands {
-        connect(callback: () => void): Promise<void>;
+        connect(): Promise<void>;
         disconnect(): void;
         nodes(role?: NodeRole): Redis[];
     }

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -526,11 +526,9 @@ cluster
     .then(result => console.log(result))
     .catch(reason => console.error(reason));
 cluster
-    .connect(() => {
-        console.log('connect');
-    })
+    .connect()
     .then(result => console.log(result))
-    .then(reason => console.error(reason));
+    .catch(reason => console.error(reason));
 
 cluster.setBuffer('key', '100', 'NX', 'EX', 10, (err, data) => {});
 cluster.getBuffer('key', (err, data) => {


### PR DESCRIPTION
I've fixed issue in mappings that forced to provide the `callback` parameter of `Cluster` instance while it's not even supported.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/luin/ioredis/blob/v4.16.2/lib/cluster/index.ts#L169](https://github.com/luin/ioredis/blob/v4.16.2/lib/cluster/index.ts#L169)
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
