### PR TITLE
Update type definitions for airtable@0.8.1

### DIFF
--- a/types/airtable/index.d.ts
+++ b/types/airtable/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for airtable 0.5
+// Type definitions for airtable 0.8
 // Project: https://github.com/airtable/airtable.js
 // Definitions by: Brandon Valosek <https://github.com/bvalosek>
 //                 Max Chehab <https://github.com/maxchehab>
+//                 Evan Hahn <https://github.com/EvanHahn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -30,7 +31,6 @@ declare global {
             apiKey?: string;
             endpointUrl?: string;
             apiVersion?: string;
-            allowUnauthorizedSsl?: boolean;
             noRetryIfRateLimited?: boolean;
             requestTimeout?: number;
         }


### PR DESCRIPTION
This removes the `allowUnauthorizedSsl` option, which was [removed in Airtable.js v0.8.0][0]. Though its removal is technically a breaking change, it was insecure and shouldn't have been used. That's why I didn't make a separate version.

I didn't add tests for this because (1) it was previously untested (2) it felt unnecessary to test an option that doesn't exist. Let me know if I should add them.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I'm changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Airtable.js changelog][0]
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] ~Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)~
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

[0]: https://github.com/Airtable/airtable.js/blob/31fd0a089fee87832760f35c7270eae283972e35/CHANGELOG.md#v080