### PR TITLE
Update js-beautify typings to v1.11.0

### DIFF
--- a/types/gulp-json-editor/index.d.ts
+++ b/types/gulp-json-editor/index.d.ts
@@ -9,7 +9,7 @@
 
 interface JEditor {
     (mergeWith: any | ((json: any) => any),
-        jsBeautifyOptions?: JsBeautifyOptions): NodeJS.ReadWriteStream;
+        jsBeautifyOptions?: JSBeautifyOptions): NodeJS.ReadWriteStream;
 }
 
 declare const jeditor: JEditor;

--- a/types/js-beautify/index.d.ts
+++ b/types/js-beautify/index.d.ts
@@ -1,81 +1,85 @@
-// Type definitions for js_beautify 1.8.3
+// Type definitions for js_beautify 1.11.0
 // Project: https://github.com/beautify-web/js-beautify/
 // Definitions by: Josh Goldberg <https://github.com/JoshuaKGoldberg>, Hans Windhoff <https://github.com/hansrwindhoff>, Gavin Rehkemper <https://github.com/gavinr/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface JsBeautifyOptions {
-  indent_size?: number;
-  indent_char?: string;
-  eol?: string;
-  indent_level?: number;
-  indent_with_tabs?: boolean;
-  preserve_newlines?: boolean;
-  max_preserve_newlines?: number;
-  jslint_happy?: boolean;
-  space_after_anon_function?: boolean;
-  brace_style?: 'collapse-preserve-inline' | 'collapse' | 'expand' | 'end-expand' | 'none';
-  keep_array_indentation?: boolean;
-  keep_function_indentation?: boolean;
-  space_before_conditional?: boolean;
-  space_in_empty_paren?: boolean;
-  break_chained_methods?: boolean;
-  eval_code?: boolean;
-  unescape_strings?: boolean;
-  wrap_line_length?: number;
-  wrap_attributes?: 'auto' | 'force';
-  wrap_attributes_indent_size?: number;
-  end_with_newline?: boolean;
-  e4x?: boolean;
+interface CoreBeautifyOptions {
+    disabled?: boolean;
+    eol?: string;
+    end_with_newline?: boolean;
+    indent_size?: number;
+    indent_char?: string;
+    indent_level?: number;
+    preserve_newlines?: boolean;
+    max_preserve_newlines?: number;
+    indent_with_tabs?: boolean;
+    wrap_line_length?: number;
+    indent_empty_lines?: boolean;
+    templating?: string[];
 }
 
-// See https://github.com/beautify-web/js-beautify/blob/v1.8.2/js/src/html/beautifier.js#L268-L330
-interface HTMLBeautifyOptions {
-  indent_inner_html?: boolean;
-  indent_body_inner_html?: boolean;
-  indent_head_inner_html?: boolean;
-  indent_size?: number;
-  indent_char?: string;
-  wrap_line_length?: number;
-  preserve_newlines?: boolean;
-  max_preserve_newlines?: number;
-  indent_handlebars?: boolean;
-  wrap_attributes?: 'auto' | 'force' | 'force-expand-multiline' | 'force-aligned' | 'aligned-multiple';
-  wrap_attributes_indent_size?: number;
-  end_with_newline?: boolean;
-  extra_liners?: string[];
-  eol?: string;
-  indent_with_tabs?: boolean;
-  disabled?: boolean;
-  inline?: string[];
-  void_elements?: string[];
-  unformatted?: string[];
-  content_unformatted?: string[];
-  indent_scripts?: 'keep' | 'separate';
+interface JSBeautifyOptions extends CoreBeautifyOptions {
+    brace_style?: 'collapse' | 'expand' | 'end-expand' | 'none' | 'preserve-inline';
+    unindent_chained_methods?: boolean;
+    break_chained_methods?: boolean;
+    space_in_paren?: boolean;
+    space_in_empty_paren?: boolean;
+    jslint_happy?: boolean;
+    space_after_anon_function?: boolean;
+    space_after_named_function?: boolean;
+    keep_array_indentation?: boolean;
+    space_before_conditional?: boolean;
+    unescape_strings?: boolean;
+    e4x?: boolean;
+    comma_first?: boolean;
+    operator_position?: 'before-newline' | 'after-newline' | 'preserve-newline';
+    test_output_raw?: boolean;
 }
 
-interface CSSBeautifyOptions {
-  indent_size?: number;
-  indent_char?: string;
-  indent_with_tabs?: boolean;
-  eol?: string;
-  end_with_newline?: boolean;
-  selector_separator_newline?: boolean;
-  newline_between_rules?: boolean;
+interface HTMLBeautifyOptions extends CoreBeautifyOptions {
+    templating?: string[];
+    indent_inner_html?: boolean;
+    indent_body_inner_html?: boolean;
+    indent_head_inner_html?: boolean;
+    indent_handlebars?: boolean;
+    wrap_attributes?:
+        | 'auto'
+        | 'force'
+        | 'force-aligned'
+        | 'force-expand-multiline'
+        | 'aligned-multiple'
+        | 'preserve'
+        | 'preserve-aligned';
+    wrap_attributes_indent_size?: number;
+    extra_liners?: string[];
+    inline?: string[];
+    void_elements?: string[];
+    unformatted?: string[];
+    content_unformatted?: string[];
+    unformatted_content_delimiter?: string;
+    indent_scripts?: 'normal' | 'keep' | 'separate';
+}
+
+interface CSSBeautifyOptions extends CoreBeautifyOptions {
+    selector_separator_newline?: boolean;
+    newline_between_rules?: boolean;
+    space_around_selector_separator?: boolean;
+    space_around_combinator?: boolean;
 }
 
 interface jsb {
-  (js_source_text: string, options?: JsBeautifyOptions): string;
-  js: (js_source_text: string, options?: JsBeautifyOptions) => string;
-  js_beautify: (js_source_text: string, options?: JsBeautifyOptions) => string;
+    (js_source_text: string, options?: JSBeautifyOptions): string;
+    js: (js_source_text: string, options?: JSBeautifyOptions) => string;
+    js_beautify: (js_source_text: string, options?: JSBeautifyOptions) => string;
 
-  css: (js_source_text: string, options?: CSSBeautifyOptions) => string;
-  css_beautify: (js_source_text: string, options?: CSSBeautifyOptions) => string;
+    css: (js_source_text: string, options?: CSSBeautifyOptions) => string;
+    css_beautify: (js_source_text: string, options?: CSSBeautifyOptions) => string;
 
-  html: (js_source_text: string, options?: HTMLBeautifyOptions) => string;
-  html_beautify: (js_source_text: string, options?: HTMLBeautifyOptions) => string;
+    html: (js_source_text: string, options?: HTMLBeautifyOptions) => string;
+    html_beautify: (js_source_text: string, options?: HTMLBeautifyOptions) => string;
 }
 
 declare var js_beautify: jsb;
-declare module "js-beautify" {
+declare module 'js-beautify' {
     export = js_beautify;
 }

--- a/types/js-beautify/js-beautify-tests.ts
+++ b/types/js-beautify/js-beautify-tests.ts
@@ -1,44 +1,68 @@
-let bCss = js_beautify.css("body{display:none;}");
-bCss = js_beautify.css_beautify("body{display:none;}");
+let bCSS = js_beautify.css('body{display:none;}');
+bCSS = js_beautify.css_beautify('body{display:none;}');
 
-let bHtml = js_beautify.html("<div/>");
-bHtml = js_beautify.html_beautify("<div/>");
+let bHTML = js_beautify.html('<div/>');
+bHTML = js_beautify.html_beautify('<div/>');
 
-let optHtml: HTMLBeautifyOptions = {};
-let optCss: CSSBeautifyOptions = {};
-let optjs: JsBeautifyOptions = {};
+let emptyHTMLOptions: HTMLBeautifyOptions = {};
+let emptyCSSOptions: CSSBeautifyOptions = {};
+let emptyJSOptions: JSBeautifyOptions = {};
 
 var simple: string = js_beautify("console.log('Hello world!');");
 
-var options: JsBeautifyOptions = {
-    "indent_size": 4,
-    "indent_char": " ",
-    "eol": "\n",
-    "indent_level": 0,
-    "indent_with_tabs": false,
-    "preserve_newlines": true,
-    "max_preserve_newlines": 10,
-    "jslint_happy": false,
-    "space_after_anon_function": false,
-    "brace_style": "collapse",
-    "keep_array_indentation": false,
-    "keep_function_indentation": false,
-    "space_before_conditional": true,
-    "space_in_empty_paren": true,
-    "break_chained_methods": false,
-    "eval_code": false,
-    "unescape_strings": false,
-    "wrap_line_length": 0,
-    "wrap_attributes": "auto",
-    "wrap_attributes_indent_size": 4,
-    "end_with_newline": false,
-    "e4x": false
+var JSoptions: JSBeautifyOptions = {
+    indent_size: 4,
+    indent_char: ' ',
+    eol: '\n',
+    indent_level: 0,
+    indent_with_tabs: false,
+    preserve_newlines: true,
+    max_preserve_newlines: 10,
+    jslint_happy: false,
+    space_after_anon_function: false,
+    brace_style: 'collapse',
+    keep_array_indentation: false,
+    space_before_conditional: true,
+    space_in_empty_paren: true,
+    break_chained_methods: false,
+    unescape_strings: false,
+    wrap_line_length: 0,
+    end_with_newline: false,
+    e4x: false,
+    unindent_chained_methods: true,
+    space_in_paren: true,
+    space_after_named_function: true,
+    comma_first: true,
+    operator_position: 'before-newline',
+    test_output_raw: true,
 };
 
-var full: string = js_beautify(
-    "console.log('Hello world!');",
-    options
-);
+var HTMLoptions: HTMLBeautifyOptions = {
+    indent_size: 4,
+    indent_char: ' ',
+    eol: '\n',
+    indent_level: 0,
+    indent_with_tabs: false,
+    preserve_newlines: true,
+    max_preserve_newlines: 10,
+    wrap_line_length: 0,
+    wrap_attributes: 'auto',
+    wrap_attributes_indent_size: 4,
+    end_with_newline: false,
+};
 
-var markup: string = js_beautify(
-    "function render(){return <div> <img src='.' /></div>}", { ...options, e4x: true });
+var CSSoptions: CSSBeautifyOptions = {
+    indent_size: 4,
+    indent_char: ' ',
+    eol: '\n',
+    indent_level: 0,
+    indent_with_tabs: false,
+    preserve_newlines: true,
+    max_preserve_newlines: 10,
+    wrap_line_length: 0,
+    end_with_newline: false,
+};
+
+var full: string = js_beautify("console.log('Hello world!');", JSoptions);
+
+var markup: string = js_beautify("function render(){return <div> <img src='.' /></div>}", { ...JSoptions, e4x: true });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/beautify-web/js-beautify/blob/master/js/src/css/options.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

