### PR TITLE
[socket.io]: 2.1.1 adds inherited EventEmitter methods to Server

### DIFF
--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -14,6 +14,7 @@
 
 declare const SocketIO: SocketIOStatic;
 import engine = require('engine.io');
+import { EventEmitter } from 'events';
 export = SocketIO;
 /** @deprecated Available as a global for backwards-compatibility. */
 export as namespace SocketIO;
@@ -52,7 +53,7 @@ interface SocketIOStatic {
 }
 
 declare namespace SocketIO {
-    interface Server {
+    interface Server extends EventEmitter {
         engine: { ws: any };
 
         /**

--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -37,7 +37,7 @@ interface SocketIOStatic {
      * @param port A port to bind to, as a number, or a string
      * @param An optional parameters object
      */
-    (port: string|number, opts?: SocketIO.ServerOptions): SocketIO.Server;
+    (port: string | number, opts?: SocketIO.ServerOptions): SocketIO.Server;
 
     /**
      * Creates a new Server
@@ -53,13 +53,13 @@ interface SocketIOStatic {
 }
 
 declare namespace SocketIO {
-    interface Server extends EventEmitter {
+    interface Server {
         engine: { ws: any };
 
         /**
          * A dictionary of all the namespaces currently on this Server
          */
-        nsps: {[namespace: string]: Namespace};
+        nsps: { [namespace: string]: Namespace };
 
         /**
          * The default '/' Namespace
@@ -88,7 +88,7 @@ declare namespace SocketIO {
          * which will be null if there was no problem, and one parameter, success,
          * of type boolean
          */
-        checkRequest( req:any, fn:( err: any, success: boolean ) => void ):void;
+        checkRequest(req: any, fn: (err: any, success: boolean) => void): void;
 
         /**
          * Gets whether we're serving the client.js file or not
@@ -102,7 +102,7 @@ declare namespace SocketIO {
          * @default true
          * @return This Server
          */
-        serveClient( v: boolean ): Server;
+        serveClient(v: boolean): Server;
 
         /**
          * Gets the client serving path
@@ -116,7 +116,7 @@ declare namespace SocketIO {
          * @default '/socket.io'
          * @return This Server
          */
-        path( v: string ): Server;
+        path(v: string): Server;
 
         /**
          * Gets the adapter that we're going to use for handling rooms
@@ -130,13 +130,13 @@ declare namespace SocketIO {
          * @default typeof Adapter
          * @return This Server
          */
-        adapter( v: any ): Server;
+        adapter(v: any): Server;
 
         /**
          * Gets the allowed origins for requests
          * @default "*:*"
          */
-        origins(): string|string[];
+        origins(): string | string[];
 
         /**
          * Sets the allowed origins for requests
@@ -144,7 +144,7 @@ declare namespace SocketIO {
          * @default "*:*"
          * return This Server
          */
-        origins( v: string|string[] ): Server;
+        origins(v: string | string[]): Server;
 
         /**
          * Provides a function taking two arguments origin:String
@@ -155,7 +155,7 @@ declare namespace SocketIO {
          * @param fn The function that will be called to check the origin
          * return This Server
          */
-        origins( fn: ( origin: string, callback: ( error: string | null, success: boolean ) => void ) => void ): Server;
+        origins(fn: (origin: string, callback: (error: string | null, success: boolean) => void) => void): Server;
 
         /**
          * Attaches socket.io to a server
@@ -163,7 +163,7 @@ declare namespace SocketIO {
          * @param opts An optional parameters object
          * @return This Server
          */
-        attach( srv: any, opts?: ServerOptions ): Server;
+        attach(srv: any, opts?: ServerOptions): Server;
 
         /**
          * Attaches socket.io to a port
@@ -171,31 +171,31 @@ declare namespace SocketIO {
          * @param opts An optional parameters object
          * @return This Server
          */
-        attach( port: number, opts?: ServerOptions ): Server;
+        attach(port: number, opts?: ServerOptions): Server;
 
         /**
          * @see attach( srv, opts )
          */
-        listen( srv: any, opts?: ServerOptions ): Server;
+        listen(srv: any, opts?: ServerOptions): Server;
 
         /**
          * @see attach( port, opts )
          */
-        listen( port: number, opts?: ServerOptions ): Server;
+        listen(port: number, opts?: ServerOptions): Server;
 
         /**
          * Binds socket.io to an engine.io instance
          * @param src The Engine.io (or compatible) server to bind to
          * @return This Server
          */
-        bind( srv: any ): Server;
+        bind(srv: any): Server;
 
         /**
          * Called with each incoming connection
          * @param socket The Engine.io Socket
          * @return This Server
          */
-        onconnection( socket: any ): Server;
+        onconnection(socket: any): Server;
 
         /**
          * Looks up/creates a Namespace
@@ -203,12 +203,12 @@ declare namespace SocketIO {
          * with a '/'
          * @return The Namespace
          */
-        of( nsp: string | RegExp | Function ): Namespace;
+        of(nsp: string | RegExp | Function): Namespace;
 
         /**
          * Closes the server connection
          */
-        close( fn ?: () => void ):void;
+        close(fn?: () => void): void;
 
         /**
          * The event fired when we get a new connection
@@ -216,12 +216,12 @@ declare namespace SocketIO {
          * @param listener A listener that should take one parameter of type Socket
          * @return The default '/' Namespace
          */
-        on( event: 'connection', listener: ( socket: Socket ) => void ): Namespace;
+        on(event: 'connection', listener: (socket: Socket) => void): Namespace;
 
         /**
          * @see on( 'connection', listener )
          */
-        on( event: 'connect', listener: ( socket: Socket ) => void ): Namespace;
+        on(event: 'connect', listener: (socket: Socket) => void): Namespace;
 
         /**
          * Base 'on' method to add a listener for an event
@@ -230,19 +230,19 @@ declare namespace SocketIO {
          * for the callback depend on the event
          * @return The default '/' Namespace
          */
-        on( event: string, listener: Function ): Namespace;
+        on(event: string, listener: Function): Namespace;
 
         /**
          * Targets a room when emitting to the default '/' Namespace
          * @param room The name of the room that we're targeting
          * @return The default '/' Namespace
          */
-        to( room: string ): Namespace;
+        to(room: string): Namespace;
 
         /**
          * @see to( room )
          */
-        in( room: string ): Namespace;
+        in(room: string): Namespace;
 
         /**
          * Registers a middleware function, which is a function that gets executed
@@ -254,7 +254,7 @@ declare namespace SocketIO {
          * are sent as special 'error' packets to clients
          * @return The default '/' Namespace
          */
-        use( fn: ( socket:Socket, fn: ( err?: any ) => void ) =>void ): Namespace;
+        use(fn: (socket: Socket, fn: (err?: any) => void) => void): Namespace;
 
         /**
          * Emits an event to the default Namespace
@@ -264,38 +264,175 @@ declare namespace SocketIO {
          * take whatever data was sent with the packet
          * @return The default '/' Namespace
          */
-        emit( event: string, ...args: any[]): Namespace;
+        emit(event: string, ...args: any[]): Namespace;
 
         /**
          * Sends a 'message' event
          * @see emit( event, ...args )
          * @return The default '/' Namespace
          */
-        send( ...args: any[] ): Namespace;
+        send(...args: any[]): Namespace;
 
         /**
          * @see send( ...args )
          */
-        write( ...args: any[] ): Namespace;
+        write(...args: any[]): Namespace;
 
         /**
          * Gets a list of clients
          * @return The default '/' Namespace
          */
-        clients( ...args: any[] ): Namespace;
+        clients(...args: any[]): Namespace;
 
         /**
          * Sets the compress flag
          * @return The default '/' Namespace
          */
-        compress( ...args: any[] ): Namespace;
+        compress(...args: any[]): Namespace;
+
+        // Socket inherits the following methods from NodeJS.EventEmitter
+        // https://github.com/socketio/socket.io/blob/2.1.1/lib/socket.js#L81
+
+        /**
+         * Alias for `on`
+         * @param event The event that we want to add a listener for
+         * @param listener The callback to call when we get the event. The parameters
+         * for the callback depend on the event
+         * @return The default '/' Namespace
+         *
+         * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
+         */
+        addListener(event: string, listener: (...args: any[]) => void): Namespace;
+
+        /**
+         * Adds a one-time listener for an event
+         * @param event The event that we want to add a listener for
+         * @param listener The callback to call when we get the event. The parameters
+         * for the callback depend on the event
+         * @return The default '/' Namespace
+         *
+         * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
+         */
+        once(event: string, listener: (...args: any[]) => void): Namespace;
+
+        /**
+         * Removes a specific listener for an event
+         * @param event The event that we want to add a listener for
+         * @param listener The callback to remove from the event event. Must be
+         * the exact function reference that was added
+         * @return The default '/' Namespace
+         *
+         * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
+         */
+        removeListener(event: string, listener: (...args: any[]) => void): Namespace;
+
+        /**
+         * Alias for `removeListener`
+         * @param event The event that we want to add a listener for
+         * @param listener The callback to remove from the event event. Must be
+         * the exact function reference that was added
+         * @return The default '/' Namespace
+         *
+         * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
+         */
+        off(event: string, listener: (...args: any[]) => void): Namespace;
+
+        /**
+         * Removes all listeners, or those of the specified event
+         *
+         * @param event The event to remove all listeners for, if omitted
+         * all events will be removed
+         * @return The default '/' Namespace
+         *
+         * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
+         */
+        removeAllListeners(event?: string): Namespace;
+
+        /**
+         * Sets the max amount of event listeners
+         *
+         * @param n The max amount of allowed event listeners.
+         * @return The default '/' Namespace
+         *
+         * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
+         */
+        setMaxListeners(n: number): Namespace;
+
+        /**
+         * Gets the max amount of event listeners
+         *
+         * @return The max amount of allowed event listeners.
+         *
+         * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
+         */
+        getMaxListeners(): number;
+
+        /**
+         * Gets a copy of all listeners for an event.
+         *
+         * @param event The event to retrieve all listeners for
+         * @return A copy of the array of listeners for the event
+         *
+         * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
+         */
+        listeners(event: string): Function[];
+
+        /**
+         * Get a copy of all listeners for an event, including one-time events.
+         *
+         * @param event The event to retrieve all listeners for
+         * @return A copy of the array of listeners for the event,
+         * including any wrappers (such as those created by .once()).
+         *
+         * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
+         */
+        rawListeners(event: string): Function[];
+
+        /**
+         * Get a copy of all listeners for an event, including one-time events.
+         * @param event The event to retrieve all listeners for
+         * @return The number of listeners listening to the event
+         *
+         * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
+         */
+        listenerCount(type: string): number;
+
+        /**
+         * Adds the listener function to the _beginning_ of the listeners array for the event
+         * @param event The event that we want to add a listener for
+         * @param listener The callback to call when we get the event. The parameters
+         * for the callback depend on the event
+         * @return The default '/' Namespace
+         *
+         * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
+         */
+        prependListener(event: string, listener: (...args: any[]) => void): Namespace;
+
+        /**
+         * Adds a one-time listener function to the _beginning_ of the listeners array for the event
+         * @param event The event that we want to add a listener for
+         * @param listener The callback to call when we get the event. The parameters
+         * for the callback depend on the event
+         * @return The default '/' Namespace
+         *
+         * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
+         */
+        prependOnceListener(event: string, listener: (...args: any[]) => void): Namespace;
+
+        /**
+         * Gets an array of events for which listeners have been registered
+         * @param event The event that we want to add a listener for
+         * @return An array listing the events for which the emitter has registered listeners
+         *
+         * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
+         */
+        eventNames(): string[];
     }
 
     /**
      * Options to pass to our server when creating it
      */
     interface ServerOptions extends engine.ServerAttachOptions {
-
         /**
          * The path to server the client file to
          * @default '/socket.io'
@@ -319,7 +456,7 @@ declare namespace SocketIO {
          * Accepted origins
          * @default '*:*'
          */
-        origins?: string|string[];
+        origins?: string | string[];
     }
 
     /**
@@ -327,7 +464,6 @@ declare namespace SocketIO {
      * to a Namespace requires a new Socket
      */
     interface Namespace extends NodeJS.EventEmitter {
-
         /**
          * The name of the NameSpace
          */
@@ -370,31 +506,31 @@ declare namespace SocketIO {
          * are sent as special 'error' packets to clients
          * @return This Namespace
          */
-        use( fn: ( socket:Socket, fn: ( err?: any ) => void ) =>void ): Namespace;
+        use(fn: (socket: Socket, fn: (err?: any) => void) => void): Namespace;
 
         /**
          * Targets a room when emitting
          * @param room The name of the room that we're targeting
          * @return This Namespace
          */
-        to( room: string ): Namespace;
+        to(room: string): Namespace;
 
         /**
          * @see to( room )
          */
-        in( room: string ): Namespace;
+        in(room: string): Namespace;
 
         /**
          * Sends a 'message' event
          * @see emit( event, ...args )
          * @return This Namespace
          */
-        send( ...args: any[] ): Namespace;
+        send(...args: any[]): Namespace;
 
         /**
          * @see send( ...args )
          */
-        write( ...args: any[] ): Namespace;
+        write(...args: any[]): Namespace;
 
         /**
          * The event fired when we get a new connection
@@ -402,12 +538,12 @@ declare namespace SocketIO {
          * @param listener A listener that should take one parameter of type Socket
          * @return This Namespace
          */
-        on( event: 'connection', listener: ( socket: Socket ) => void ): this;
+        on(event: 'connection', listener: (socket: Socket) => void): this;
 
         /**
          * @see on( 'connection', listener )
          */
-        on( event: 'connect', listener: ( socket: Socket ) => void ): this;
+        on(event: 'connect', listener: (socket: Socket) => void): this;
 
         /**
          * Base 'on' method to add a listener for an event
@@ -416,20 +552,20 @@ declare namespace SocketIO {
          * for the callback depend on the event
          * @ This Namespace
          */
-        on( event: string, listener: Function ): this;
+        on(event: string, listener: Function): this;
 
         /**
          * Gets a list of clients.
          * @return This Namespace
          */
-        clients( fn: Function ): Namespace;
+        clients(fn: Function): Namespace;
 
         /**
          * Sets the compress flag.
          * @param compress If `true`, compresses the sending data
          * @return This Namespace
          */
-        compress( compress: boolean ): Namespace;
+        compress(compress: boolean): Namespace;
     }
 
     interface Packet extends Array<any> {
@@ -453,8 +589,7 @@ declare namespace SocketIO {
      * as we have a problem with the emit() event (as it's overridden with a
      * different return)
      */
-    interface Socket extends NodeJS.EventEmitter{
-
+    interface Socket extends NodeJS.EventEmitter {
         /**
          * The namespace that this socket is for
          */
@@ -536,30 +671,30 @@ declare namespace SocketIO {
          * @param room The name of the room that we're targeting
          * @return This Socket
          */
-        to( room: string ): Socket;
+        to(room: string): Socket;
 
         /**
          * @see to( room )
          */
-        in( room: string ): Socket;
+        in(room: string): Socket;
 
         /**
          * Registers a middleware, which is a function that gets executed for every incoming Packet and receives as parameter the packet and a function to optionally defer execution to the next registered middleware.
          *
          * Errors passed to middleware callbacks are sent as special error packets to clients.
          */
-        use( fn: ( packet: Packet, next: (err?: any) => void ) => void ): Socket;
+        use(fn: (packet: Packet, next: (err?: any) => void) => void): Socket;
 
         /**
          * Sends a 'message' event
          * @see emit( event, ...args )
          */
-        send( ...args: any[] ): Socket;
+        send(...args: any[]): Socket;
 
         /**
          * @see send( ...args )
          */
-        write( ...args: any[] ): Socket;
+        write(...args: any[]): Socket;
 
         /**
          * Joins a room. You can join multiple rooms, and by default, on connection,
@@ -569,7 +704,7 @@ declare namespace SocketIO {
          * take an optional parameter, err, of a possible error
          * @return This Socket
          */
-        join( name: string|string[], fn?: ( err?: any ) => void ): Socket;
+        join(name: string | string[], fn?: (err?: any) => void): Socket;
 
         /**
          * Leaves a room
@@ -577,7 +712,7 @@ declare namespace SocketIO {
          * @param fn An optional callback to call when we've left the room. It should
          * take on optional parameter, err, of a possible error
          */
-        leave( name: string, fn?: Function ): Socket;
+        leave(name: string, fn?: Function): Socket;
 
         /**
          * Leaves all the rooms that we've joined
@@ -589,21 +724,21 @@ declare namespace SocketIO {
          * @param close If true, also closes the underlying connection
          * @return This Socket
          */
-        disconnect( close?: boolean ): Socket;
+        disconnect(close?: boolean): Socket;
 
         /**
          * Returns all the callbacks for a particular event
          * @param event The event that we're looking for the callbacks of
          * @return An array of callback Functions, or an empty array if we don't have any
          */
-        listeners( event: string ):Function[];
+        listeners(event: string): Function[];
 
         /**
          * Sets the compress flag
          * @param compress If `true`, compresses the sending data
          * @return This Socket
          */
-        compress( compress: boolean ): Socket;
+        compress(compress: boolean): Socket;
 
         /**
          * Emits the error
@@ -659,7 +794,7 @@ declare namespace SocketIO {
      * The interface describing a room
      */
     interface Room {
-        sockets: {[id: string]: boolean };
+        sockets: { [id: string]: boolean };
         length: number;
     }
 
@@ -668,15 +803,14 @@ declare namespace SocketIO {
      * Where room is the name of the room
      */
 
-     interface Rooms {
+    interface Rooms {
         [room: string]: Room;
-     }
+    }
 
     /**
      * The interface used when dealing with rooms etc
      */
     interface Adapter extends NodeJS.EventEmitter {
-
         /**
          * The namespace that this adapter is for
          */
@@ -691,7 +825,7 @@ declare namespace SocketIO {
          * A dictionary of all the socket ids that we're dealing with, and all
          * the rooms that the socket is currently in
          */
-        sids: {[id: string]: {[room: string]: boolean}};
+        sids: { [id: string]: { [room: string]: boolean } };
 
         /**
          * Adds a socket to a room. If the room doesn't exist, it's created
@@ -700,7 +834,7 @@ declare namespace SocketIO {
          * @param callback An optional callback to call when the socket has been
          * added. It should take an optional parameter, error, if there was a problem
          */
-        add( id: string, room: string, callback?: ( err?: any ) => void ): void;
+        add(id: string, room: string, callback?: (err?: any) => void): void;
 
         /**
          * Removes a socket from a room. If there are no more sockets in the room,
@@ -710,13 +844,13 @@ declare namespace SocketIO {
          * @param callback An optional callback to call when the socket has been
          * removed. It should take on optional parameter, error, if there was a problem
          */
-        del( id: string, room: string, callback?: ( err?: any ) => void ): void;
+        del(id: string, room: string, callback?: (err?: any) => void): void;
 
         /**
          * Removes a socket from all the rooms that it's joined
          * @param id The ID of the socket that we're removing
          */
-        delAll( id: string ):void;
+        delAll(id: string): void;
 
         /**
          * Broadcasts a packet
@@ -726,7 +860,10 @@ declare namespace SocketIO {
          *     - except: A list of Socket IDs to exclude
          *     - flags: Any flags that we want to send along ('json', 'volatile', 'broadcast')
          */
-        broadcast( packet: any, opts: { rooms?: string[]; except?: string[]; flags?: {[flag: string]: boolean} } ):void;
+        broadcast(
+            packet: any,
+            opts: { rooms?: string[]; except?: string[]; flags?: { [flag: string]: boolean } },
+        ): void;
     }
 
     /**
@@ -758,13 +895,13 @@ declare namespace SocketIO {
          * The dictionary of sockets currently connect via this client (i.e. to different
          * namespaces) where the Socket ID is the key
          */
-        sockets: {[id: string]: Socket};
+        sockets: { [id: string]: Socket };
 
         /**
          * A dictionary of all the namespaces for this client, with the Socket that
          * deals with that namespace
          */
-        nsps: {[nsp: string]: Socket};
+        nsps: { [nsp: string]: Socket };
     }
 
     /**

--- a/types/socket.io/socket.io-tests.ts
+++ b/types/socket.io/socket.io-tests.ts
@@ -8,16 +8,15 @@ function testUsingWithNodeHTTPServer() {
     app.listen(80);
 
     function handler(req: any, res: any) {
-        fs.readFile(__dirname + '/index.html',
-            function (err: any, data: any) {
-                if (err) {
-                    res.writeHead(500);
-                    return res.end('Error loading index.html');
-                }
+        fs.readFile(__dirname + '/index.html', function (err: any, data: any) {
+            if (err) {
+                res.writeHead(500);
+                return res.end('Error loading index.html');
+            }
 
-                res.writeHead(200);
-                res.end(data);
-            });
+            res.writeHead(200);
+            res.end(data);
+        });
     }
 
     io.on('connection', function (socket) {
@@ -50,7 +49,7 @@ function testUsingWithExpress() {
 function testUsingWithOptions() {
     var app = require('express')();
     var server = require('http').Server(app);
-    var io = socketIO(server, {wsEngine: 'ws'});
+    var io = socketIO(server, { wsEngine: 'ws' });
 }
 
 function testUsingWithTheExpressFramework() {
@@ -89,33 +88,27 @@ function testSendingAndReceivingEvents() {
 
 function testRestrictingYourselfToANamespace() {
     var io = socketIO.listen(80);
-    var chat = io
-        .of('/chat')
-        .on('connection', function (socket) {
-            socket.emit('a message', {
-                that: 'only'
-                , '/chat': 'will get'
-            });
-            chat.emit('a message', {
-                everyone: 'in'
-                , '/chat': 'will get'
-            });
+    var chat = io.of('/chat').on('connection', function (socket) {
+        socket.emit('a message', {
+            that: 'only',
+            '/chat': 'will get',
         });
+        chat.emit('a message', {
+            everyone: 'in',
+            '/chat': 'will get',
+        });
+    });
 
-    var news = io
-        .of('/news')
-        .on('connection', function (socket) {
-            socket.emit('item', { news: 'item' });
-        });
+    var news = io.of('/news').on('connection', function (socket) {
+        socket.emit('item', { news: 'item' });
+    });
 }
 
 function testDynamicNamespace() {
     var io = socketIO.listen(80);
-    var dynamic = io
-        .of(/^\/dynamic-\d+$/)
-        .on('connection', function (socket) {
-            socket.emit('item', { dynamic: 'item' });
-        });
+    var dynamic = io.of(/^\/dynamic-\d+$/).on('connection', function (socket) {
+        socket.emit('item', { dynamic: 'item' });
+    });
 }
 
 function testSendingVolatileMessages() {
@@ -154,8 +147,8 @@ function testUsingItJustAsACrossBrowserWebSocket() {
     var io = socketIO.listen(80);
 
     io.sockets.on('connection', function (socket) {
-        socket.on('message', function () { });
-        socket.on('disconnect', function () { });
+        socket.on('message', function () {});
+        socket.on('disconnect', function () {});
     });
 }
 
@@ -169,16 +162,15 @@ function testSocketConnection() {
         console.log(socket.conn.upgraded);
         console.log(socket.conn.readyState);
 
-        socket.on('packet', function(message :string, ping :string){
+        socket.on('packet', function (message: string, ping: string) {
             console.log(message, ping);
-        });;
+        });
     });
 }
 
 function testClosingServerWithCallback() {
     var io = socketIO.listen(80);
-    io.close(function() {
-    });
+    io.close(function () {});
 }
 
 function testClosingServerWithoutCallback() {
@@ -198,9 +190,30 @@ function testVolatileServerMessages() {
 
 function testSocketUse() {
     var io = socketIO.listen(80);
-    io.on('connection', (socket) => {
+    io.on('connection', socket => {
         socket.use((packet, next) => {
             console.log(packet);
         });
     });
+}
+
+function testServerEventEmitter() {
+    var io = socketIO.listen(80);
+    const fn = () => {};
+    io.addListener('event', fn);
+    io.emit('event', 'payload');
+    io.eventNames();
+    io.getMaxListeners();
+    io.listenerCount('event');
+    io.listeners('event');
+    io.off('event', fn);
+    io.on('event', fn);
+    io.once('event', fn);
+    io.prependListener('event', fn);
+    io.prependOnceListener('event', fn);
+    io.removeAllListeners('event');
+    io.removeAllListeners();
+    io.removeListener('event', fn);
+    io.setMaxListeners(50);
+    io.rawListeners('event');
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/socketio/socket.io/blob/2.1.1/lib/socket.js#L81>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

## Context
I am getting type errors when trying to use `off` on the socket server listener. Example code that receives the type error:

```typescript
function example() {
  function listener() {}

  socket.on("cancel-job", listener);

  return () => {
    socket.off("cancel-job", listener); // Property 'off' does not exist on type 'Server'
  };
}
```
