### PR TITLE
[google.visualization] - change ChartWrapper.getChart() signature

### DIFF
--- a/types/google.visualization/google.visualization-tests.ts
+++ b/types/google.visualization/google.visualization-tests.ts
@@ -706,3 +706,38 @@ function test_addListeners() {
         chart.draw(data, {});
     }
 }
+
+function test_chartChart() {
+    var data = google.visualization.arrayToDataTable([
+        ['Year', 'Sales', 'Expenses'],
+        ['2004', 1000, 400],
+        ['2005', 1170, 460],
+        ['2006', 660, 1120],
+        ['2007', 1030, 540]
+    ]);
+
+    var options = {
+        title: 'Company Performance'
+    };
+
+    var container = document.getElementById('chart_div');
+    if (container) {
+        var chartWrapper = new google.visualization.ChartWrapper({
+            chartType: 'LineChart',
+            container,
+            options
+        });
+
+        var chart = chartWrapper.getChart();
+
+        function isClearable(baseChart: google.visualization.ChartBase): baseChart is google.visualization.ChartBaseClearable {
+            return 'clearChart' in baseChart;
+        }
+
+        if (chart) {
+            if (isClearable(chart)) {
+                chart.clearChart()
+            }
+        }
+    }
+}

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -20,7 +20,7 @@ declare namespace google {
 
         export function dataTableToCsv(data: DataTable | DataView): string;
         export function arrayToDataTable(data: any[], firstRowIsData?: boolean): DataTable;
-        
+
         export interface ChartSpecs {
             chartType: string;
             container?: HTMLElement;
@@ -51,7 +51,7 @@ declare namespace google {
             getDataTable(): DataTable;
             getChartType(): string;
             getChartName(): string;
-            getChart(): any;
+            getChart(): ChartBase | null;
             getContainerId(): string;
             getQuery(): string;
             getRefreshInterval(): number;
@@ -70,7 +70,7 @@ declare namespace google {
             setView(view_spec: string): void;
         }
         //#endregion
-        
+
         //#region data
         // https://developers.google.com/chart/interactive/docs/reference#google_visualization_data_group
         export interface GroupKeyOptions {
@@ -88,11 +88,11 @@ declare namespace google {
             label?: string;
             id?: string;
         }
-        
+
         export class data {
             // https://developers.google.com/chart/interactive/docs/reference#data_modifier_functions
             static month(value: Date): number;
-            
+
             // https://developers.google.com/chart/interactive/docs/reference#group
             static sum(values: number[] | string[] | Date[]): number;
             static avg(values: number[] | string[] | Date[]): number;
@@ -101,12 +101,12 @@ declare namespace google {
             static count(values: any[]): number;
 
             static group(data: DataTable | DataView, keys: (number | GroupKeyOptions)[], columns?: GroupColumnOptions[]): DataTable;
-                        
+
             // https://developers.google.com/chart/interactive/docs/reference#join
             static join(dataA: DataTable | DataView, dataB: DataTable | DataView, joinMethod: 'full' | 'inner' | 'left' | 'right', keys: number[][], columnsA: number[], columnsB: number[]): DataTable;
         }
         //#endregion
-        
+
         //#region DataTable
         // https://developers.google.com/chart/interactive/docs/reference#DataTable
         export class DataTable {
@@ -362,7 +362,7 @@ declare namespace google {
         }
 
         //#endregion
-        //#region Common        
+        //#region Common
         export interface ChartAnnotations {
             boxStyle?: ChartBoxStyle;
             textStyle?: ChartTextStyle;
@@ -455,9 +455,9 @@ declare namespace google {
 
         export type ChartOrientation = 'vertical' | 'horizontal';
         export type ChartAxisTitlesPosition = 'in' | 'out' | 'none';
-        
+
         export type ChartSelectionMode = 'single' | 'multiple';
-        
+
         export type ChartLegendPosition = 'bottom' | 'left' | 'in' | 'none' | 'right' | 'top';
         export type ChartLegendAlignment = 'start' | 'center' | 'end';
         export interface ChartLegend {
@@ -533,9 +533,9 @@ declare namespace google {
             colors?: string[];
             legend?: ChartLegend;
         }
-        
+
         export type ChartPointShape = 'circle' | 'triangle' | 'square' | 'diamond' | 'star' | 'polygon';
-        
+
         export interface ChartLayoutInterface {
             getBoundingBox(id: string): ChartBoundingBox;
             getChartAreaBoundingBox(): ChartBoundingBox;
@@ -559,11 +559,11 @@ declare namespace google {
             fallingColor?: ChartStrokeFill;
             risingColor?: ChartStrokeFill;
         }
-        
+
         export interface ChartSeriesOptionsBase {
             color?: string;
         }
-        
+
         // https://developers.google.com/chart/interactive/docs/gallery/trendlines
         export interface ChartTrendlineOptions {
             type?: 'linear' | 'exponential' | 'polynomial';
@@ -703,7 +703,7 @@ declare namespace google {
         export class LineChart extends CoreChartBase {
             draw(data: DataTable | DataView, options: LineChartOptions): void;
         }
-       
+
         export interface LineChartSeriesOptions extends ChartSeriesOptionsBase {
             annotations?: ChartAnnotations;
             curveType?: 'none' | 'function';
@@ -716,7 +716,7 @@ declare namespace google {
             labelInLegend?: string;
             targetAxisIndex?: number;
         }
-        
+
         // https://developers.google.com/chart/interactive/docs/gallery/linechart#Configuration_Options
         export interface LineChartOptions {
             aggregationTarget?: string;
@@ -1285,7 +1285,7 @@ declare namespace google {
 
         //#endregion
         //#region ControlWrapper
-        
+
         // https://developers.google.com/chart/interactive/docs/gallery/controls#controlwrapperobject
         export class ControlWrapper {
             constructor(opt_spec?: ControlWrapperOptions)
@@ -1307,7 +1307,7 @@ declare namespace google {
             setState(state_obj: Object): void;
         }
 
-        export interface ControlWrapperOptions {        
+        export interface ControlWrapperOptions {
             controlType: string;
             containerId: string;
             options?: Object;
@@ -1382,7 +1382,7 @@ declare namespace google {
             zoomLevel?: number;
         }
 
-        //#endregion         
+        //#endregion
         //#region Events
 
         namespace events {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/chart/interactive/docs/reference#methods_2 
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

**Summary**
According to [specs](https://developers.google.com/chart/interactive/docs/reference#methods_2 ), `getChart` might return null, if it is called before `.draw()` . That might cause a runtime exception if we do not explicitly return a nullable result. Obviously, this is a breaking change for those, who use `@types/google.visualization`, because they will have to check if `chart` exist or not. Moreover, users will have to cast `ChartBase` to proper type (or add custom type guards as I did), when needed. Nonetheless, I am wondering if it is considered a breaking change if I change `any` to something stricter.