### PR TITLE
[mixpanel-browser] Add ignore_dnt to Config object

### DIFF
--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -73,6 +73,7 @@ export interface Config {
   opt_out_tracking_by_default: boolean;
   opt_out_tracking_persistence_type: Persistence;
   opt_out_tracking_cookie_prefix: string;
+  ignore_dnt: boolean;
 }
 
 export interface People {

--- a/types/mixpanel-browser/mixpanel-browser-tests.ts
+++ b/types/mixpanel-browser/mixpanel-browser-tests.ts
@@ -94,4 +94,4 @@ mixpanel.people.clear_charges();
 mixpanel.people.delete_user();
 mixpanel.init('YOUR PROJECT TOKEN', {
     ignore_dnt: true,
-})
+});

--- a/types/mixpanel-browser/mixpanel-browser-tests.ts
+++ b/types/mixpanel-browser/mixpanel-browser-tests.ts
@@ -92,3 +92,6 @@ mixpanel.people.track_charge(30.50, {
 });
 mixpanel.people.clear_charges();
 mixpanel.people.delete_user();
+mixpanel.init('YOUR PROJECT TOKEN', {
+    ignore_dnt: true,
+})


### PR DESCRIPTION
Adds the flag `ignore_dnt` to `mixpanel-browser`'s `Config`. This flag was added in Mixpanel 2.34: https://github.com/mixpanel/mixpanel-js/releases/tag/v2.34.0

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mixpanel/mixpanel-js/releases/tag/v2.34.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (N/A)
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. (N/A)

