### PR TITLE
[Auth0-js]feat: Add screen_hint to AuthorizeOptions to Allow Redirect Directly to Signup Page of the Universal Login

### DIFF
--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -948,6 +948,7 @@ export interface AuthorizeOptions {
     login_hint?: string;
     prompt?: string;
     mode?: "login" | "signUp";
+    screen_hint?: "signup";
     accessType?: string;
     approvalPrompt?: string;
     appState?: any;

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Auth0.js 9.12
+// Type definitions for Auth0.js 9.13.2
 // Project: https://github.com/auth0/auth0.js
 // Definitions by: Adrian Chia <https://github.com/adrianchia>
 //                 Matt Durrant <https://github.com/mdurrant>

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Auth0.js 9.13.2
+// Type definitions for Auth0.js 9.13
 // Project: https://github.com/auth0/auth0.js
 // Definitions by: Adrian Chia <https://github.com/adrianchia>
 //                 Matt Durrant <https://github.com/mdurrant>


### PR DESCRIPTION
Auth0-js now supports passing the screen_hint param via the authorize endpoint since this request was merged: https://github.com/auth0/auth0.js/pull/1093

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://auth0.com/docs/universal-login/new?_ga=2.197400687.1317054917.1589548420-83460548.1589195944 and pull request on auth0-js: https://github.com/auth0/auth0.js/pull/1093
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

