### PR TITLE
[globalize] Add dateToPartsFormatter from 1.5.0

### DIFF
--- a/types/globalize/dist/globalize/date.d.ts
+++ b/types/globalize/dist/globalize/date.d.ts
@@ -32,6 +32,11 @@ declare module "../globalize" {
          */
         timeZone?: string;
     }
+    type DateFormatPartTypes = "day" | "dayperiod" | "era" | "hour" | "literal" | "minute" | "month" | "second" | "zone" | "weekday" | "year";
+    interface DateFormatPart {
+        type: DateFormatPartTypes;
+        value: string;
+    }
     interface Static {
         /**
          * Globalize.loadTimeZone ( ianaTzData, ... )
@@ -49,11 +54,22 @@ declare module "../globalize" {
          */
         dateFormatter(options?: DateFormatterOptions): (value: Date) => string;
 
+        /**
+         * .dateToPartsFormatter( options )
+         * @param {DateFormatterOptions} options see date/expand_pattern for more info.
+         * * @returns {Function} Return a function that formats a date into parts tokens according to the given options. The default formatting is numeric year, month, and day (i.e., `{ skeleton: "yMd" }`).
+         */
+        dateToPartsFormatter(options?: DateFormatterOptions): (value: Date) => DateFormatPart[];
+
         //Return a function that parses a string representing a date into a JavaScript Date object according to the given options. The default parsing assumes numeric year, month, and day (i.e., { skeleton: "yMd" }).
         dateParser(options?: DateFormatterOptions): (value: string) => Date;
 
         //Alias for .dateFormatter( [options] )( value ).
         formatDate(value: Date, options?: DateFormatterOptions): string;
+
+        //Alias for .dateToPartsFormatter( [options] )( value ).
+        formatDateToParts(value: Date, options?: DateFormatterOptions): DateFormatPart[];
+
         /**
          * Alias for .dateParser( [options] )( value ).
          * @param {string} value The object whose module id you wish to determine.

--- a/types/globalize/dist/globalize/date.d.ts
+++ b/types/globalize/dist/globalize/date.d.ts
@@ -57,7 +57,7 @@ declare module "../globalize" {
         /**
          * .dateToPartsFormatter( options )
          * @param {DateFormatterOptions} options see date/expand_pattern for more info.
-         * * @returns {Function} Return a function that formats a date into parts tokens according to the given options. The default formatting is numeric year, month, and day (i.e., `{ skeleton: "yMd" }`).
+         * @returns {Function} Return a function that formats a date into parts tokens according to the given options. The default formatting is numeric year, month, and day (i.e., `{ skeleton: "yMd" }`).
          */
         dateToPartsFormatter(options?: DateFormatterOptions): (value: Date) => DateFormatPart[];
 

--- a/types/globalize/globalize-tests.ts
+++ b/types/globalize/globalize-tests.ts
@@ -49,6 +49,11 @@ dateOutput = dateParser("");
 dateParser = Globalize.dateParser({});
 dateOutput = dateParser("");
 
+let dateToPartsFormatter = Globalize.dateToPartsFormatter({});
+let datePartsOutput: Globalize.DateFormatPart[];
+datePartsOutput = dateToPartsFormatter(new Date());
+datePartsOutput = Globalize.formatDateToParts(new Date(), {});
+
 strOutput = en.formatDate(new Date(), {});
 strOutput = Globalize.formatDate(new Date(), {});
 dateOutput = en.parseDate("", {});

--- a/types/globalize/index.d.ts
+++ b/types/globalize/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Globalize
+// Type definitions for Globalize 1.5
 // Project: https://github.com/jquery/globalize
 // Definitions by: Grégoire Castre <https://github.com/gcastre>
 //                 Aram Taieb <https://github.com/afromogli>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/globalizejs/globalize/releases/tag/1.5.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
