### PR TITLE
[slate-html-serializer]:  defaultBlock argument accepts string

### DIFF
--- a/types/slate-html-serializer/index.d.ts
+++ b/types/slate-html-serializer/index.d.ts
@@ -13,7 +13,7 @@ export interface Rule {
 
 export interface HtmlOptions {
     rules?: Rule[];
-    defaultBlock?: BlockProperties;
+    defaultBlock?: BlockProperties | string;
     parseHtml?: (html: string) => HTMLElement;
 }
 

--- a/types/slate-html-serializer/slate-html-serializer-tests.ts
+++ b/types/slate-html-serializer/slate-html-serializer-tests.ts
@@ -8,3 +8,8 @@ const myRule: Rule = {
 const serializer = new Html({
     rules: [myRule]
 });
+
+const serializerWithDefaultBlock = new Html({
+    rules: [myRule],
+    defaultBlock: 'unstyled'
+})

--- a/types/slate-html-serializer/slate-html-serializer-tests.ts
+++ b/types/slate-html-serializer/slate-html-serializer-tests.ts
@@ -12,4 +12,4 @@ const serializer = new Html({
 const serializerWithDefaultBlock = new Html({
     rules: [myRule],
     defaultBlock: 'unstyled'
-})
+});


### PR DESCRIPTION
`slate-html-serializer` should accept a string for the argument `defaultBlock`. 

See the annotations in the original code:
https://github.com/ianstormtaylor/slate/blob/v0.47/packages/slate-html-serializer/src/index.js#L89

Which ultimately passes it to this function in the core lib:
https://github.com/ianstormtaylor/slate/blob/9e8f27eeb0e533cb4d6f8e5bdaa19ee7756a8ec9/packages/slate/src/models/node.js#L107

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

