### PR TITLE
Fix argument name of toMatch for expect-puppeteer

### DIFF
--- a/types/expect-puppeteer/index.d.ts
+++ b/types/expect-puppeteer/index.d.ts
@@ -84,7 +84,7 @@ declare global {
             toDisplayDialog(block: () => Promise<void>): Promise<Dialog>;
             toFill(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
             toFillForm(selector: string, value: { [key: string]: any}, options?: ExpectTimingActions): Promise<void>;
-            toMatch(selector: string, options?: ExpectTimingActions): Promise<void>;
+            toMatch(matcher: string, options?: ExpectTimingActions): Promise<void>;
             toMatchElement(selector: string, options?: ExpectToClickOptions): Promise<ElementHandle>;
             toSelect(selector: string, valueOrText: string, options?: ExpectTimingActions): Promise<void>;
             toUploadFile(selector: string, filePath: string, options?: ExpectTimingActions): Promise<void>;


### PR DESCRIPTION
`toMatch`'s first argument is a string/regex to match against. It is not a CSS selector.

https://github.com/smooth-code/jest-puppeteer/tree/69a0c3ee80ef4b6af08d45ff44229df6ced8b666/packages/expect-puppeteer#expectinstancetomatchmatcher-options

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/smooth-code/jest-puppeteer/tree/69a0c3ee80ef4b6af08d45ff44229df6ced8b666/packages/expect-puppeteer#expectinstancetomatchmatcher-options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

