### PR TITLE
Fix toMatch argument for expect-puppeteer

### DIFF
--- a/types/expect-puppeteer/expect-puppeteer-tests.ts
+++ b/types/expect-puppeteer/expect-puppeteer-tests.ts
@@ -18,10 +18,14 @@ const testGlobal = async (instance: ElementHandle | Page) => {
     await expect(instance).toFillForm("selector", { foo: 'bar', baz: 123 });
     await expect(instance).toFillForm("selector", { foo: 'bar', baz: 123 }, { delay: 777 });
 
-    await expect(instance).toMatch("selector");
-    await expect(instance).toMatch("selector", { timeout: 777 });
-    await expect(instance).toMatch("selector", { polling: "raf", timeout: 777 });
-    await expect(instance).toMatch("selector", { polling: "mutation", timeout: 777 });
+    await expect(instance).toMatch("some_string");
+    await expect(instance).toMatch("some_string", { timeout: 777 });
+    await expect(instance).toMatch("some_string", { polling: "raf", timeout: 777 });
+    await expect(instance).toMatch("some_string", { polling: "mutation", timeout: 777 });
+    await expect(instance).toMatch(/some_regexp/);
+    await expect(instance).toMatch(/some_regexp/, { timeout: 777 });
+    await expect(instance).toMatch(/some_regexp/, { polling: "raf", timeout: 777 });
+    await expect(instance).toMatch(/some_regexp/, { polling: "mutation", timeout: 777 });
 
     await expect(instance).toMatchElement("selector");
     await expect(instance).toMatchElement("selector", { polling: "raf", timeout: 777 });

--- a/types/expect-puppeteer/index.d.ts
+++ b/types/expect-puppeteer/index.d.ts
@@ -84,7 +84,7 @@ declare global {
             toDisplayDialog(block: () => Promise<void>): Promise<Dialog>;
             toFill(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
             toFillForm(selector: string, value: { [key: string]: any}, options?: ExpectTimingActions): Promise<void>;
-            toMatch(selector: string, options?: ExpectTimingActions): Promise<void>;
+            toMatch(matcher: string | RegExp, options?: ExpectTimingActions): Promise<void>;
             toMatchElement(selector: string, options?: ExpectToClickOptions): Promise<ElementHandle>;
             toSelect(selector: string, valueOrText: string, options?: ExpectTimingActions): Promise<void>;
             toUploadFile(selector: string, filePath: string, options?: ExpectTimingActions): Promise<void>;


### PR DESCRIPTION
First argument takes a string or Regexp and isn't a [CSS] selector.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/smooth-code/jest-puppeteer/tree/69a0c3ee80ef4b6af08d45ff44229df6ced8b666/packages/expect-puppeteer#expectinstancetomatchmatcher-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
