### PR TITLE
[node] Mirror child_process encoding between execSync and spawnSync

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -436,6 +436,7 @@ declare module "child_process" {
         input?: string | NodeJS.ArrayBufferView;
         killSignal?: NodeJS.Signals | number;
         maxBuffer?: number;
+        encoding?: BufferEncoding | 'buffer' | null;
     }
     interface SpawnSyncOptionsWithStringEncoding extends SpawnSyncOptions {
         encoding: BufferEncoding;
@@ -466,6 +467,7 @@ declare module "child_process" {
         shell?: string;
         killSignal?: NodeJS.Signals | number;
         maxBuffer?: number;
+        encoding?: BufferEncoding | 'buffer' | null;
     }
     interface ExecSyncOptionsWithStringEncoding extends ExecSyncOptions {
         encoding: BufferEncoding;

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -436,13 +436,12 @@ declare module "child_process" {
         input?: string | NodeJS.ArrayBufferView;
         killSignal?: NodeJS.Signals | number;
         maxBuffer?: number;
-        encoding?: BufferEncoding;
     }
     interface SpawnSyncOptionsWithStringEncoding extends SpawnSyncOptions {
         encoding: BufferEncoding;
     }
     interface SpawnSyncOptionsWithBufferEncoding extends SpawnSyncOptions {
-        encoding: BufferEncoding; // specify `null`.
+        encoding?: 'buffer' | null;
     }
     interface SpawnSyncReturns<T> {
         pid: number;
@@ -467,13 +466,12 @@ declare module "child_process" {
         shell?: string;
         killSignal?: NodeJS.Signals | number;
         maxBuffer?: number;
-        encoding?: BufferEncoding;
     }
     interface ExecSyncOptionsWithStringEncoding extends ExecSyncOptions {
         encoding: BufferEncoding;
     }
     interface ExecSyncOptionsWithBufferEncoding extends ExecSyncOptions {
-        encoding: BufferEncoding; // specify `null`.
+        encoding?: 'buffer' | null;
     }
     function execSync(command: string): Buffer;
     function execSync(command: string, options?: ExecSyncOptionsWithStringEncoding): string;

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -18,6 +18,13 @@ import { Writable, Readable, Pipe } from 'stream';
     childProcess.spawnSync("echo test", {windowsVerbatimArguments: false, argv0: "echo-test"});
     childProcess.spawnSync("echo test", {input: new Uint8Array([])});
     childProcess.spawnSync("echo test", {input: new DataView(new ArrayBuffer(1))});
+    childProcess.spawnSync("echo test", { encoding: 'utf-8' });
+    childProcess.spawnSync("echo test", { encoding: 'buffer' });
+}
+
+{
+    childProcess.execSync("echo test", { encoding: 'utf-8' });
+    childProcess.execSync("echo test", { encoding: 'buffer' });
 }
 
 {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/child_process.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

I'm trying to get `child_process.spawnSync()` running without the `encoding` option, which makes it default to `'buffer'` encoding.

If I don't specify the encoding, the typings say I'll get a `string`, which (per the docs) is not Node's behavior.

I dug further into the code and found this:

```typescript
interface SpawnSyncOptions extends CommonSpawnOptions {
    input?: string | NodeJS.ArrayBufferView;
    killSignal?: NodeJS.Signals | number;
    maxBuffer?: number;
    encoding?: BufferEncoding;
}
interface SpawnSyncOptionsWithStringEncoding extends SpawnSyncOptions {
    encoding: BufferEncoding;
}
interface SpawnSyncOptionsWithBufferEncoding extends SpawnSyncOptions {
    encoding: BufferEncoding; // specify `null`.
}
```

First off, I don't see why `encoding` is defined in the supertype, as it's overridden in both subtypes.

Secondly, I'm not sure what's meant by "specify null". It suggests that I should be using `{ encoding: null }` but a) `BufferEncoding` doesn't allow that and b) Node doesn't require it.

As I understand it, `encoding` should be optional if you want buffer encoding, and any of the valid encodings if you want a string. With my limited knowledge of TypeScript, I believe this PR achieves that. I applied the same change to `execSync`, which should have the same behavior.

For clarity, I didn't update any of the versioned subdirectories. (I'm not even sure I'm supposed to.) I wanted to get clarification first, so please consider this an incomplete PR.