### PR TITLE
[fabric] Support StaticCanvas constructor without canvas and with dimensions

### DIFF
--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -1887,6 +1887,20 @@ interface ICanvasOptions extends IStaticCanvasOptions {
      * @default
      */
     targets?: Object[];
+
+    /**
+     * Canvas width
+     * @type number
+     * @default
+     */
+    width?: number;
+
+    /**
+     * Canvas height
+     * @type number
+     * @default
+     */
+    height?: number;
 }
 export interface Canvas extends StaticCanvas { }
 export interface Canvas extends ICanvasOptions { }
@@ -1896,7 +1910,7 @@ export class Canvas {
      * @param element <canvas> element to initialize instance on
      * @param [options] Options object
      */
-    constructor(element: HTMLCanvasElement | string, options?: ICanvasOptions);
+    constructor(element: HTMLCanvasElement | string | null, options?: ICanvasOptions);
 
     /**
      * When true, target detection is skipped when hovering over canvas. This can be used to improve performance.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://fabricjs.com/docs/fabric.StaticCanvas.html#StaticCanvas
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

I'm successfully using the following in code that rasterizes an SVG image:

```typescript
const canvas = new fabric.StaticCanvas(null, { width, height })
```

But the typings neither allow `null` as the canvas, nor do they accept `width` and `height` options. This is an attempt to fix that.