### PR TITLE
[socket.io] 2.1.1 - fixes copy mistake and format

### DIFF
--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -339,7 +339,6 @@ declare namespace SocketIO {
 
         /**
          * Removes all listeners, or those of the specified event
-         *
          * @param event The event to remove all listeners for, if omitted
          * all events will be removed
          * @return The default '/' Namespace
@@ -350,7 +349,6 @@ declare namespace SocketIO {
 
         /**
          * Sets the max amount of event listeners
-         *
          * @param n The max amount of allowed event listeners.
          * @return The default '/' Namespace
          *
@@ -360,7 +358,6 @@ declare namespace SocketIO {
 
         /**
          * Gets the max amount of event listeners
-         *
          * @return The max amount of allowed event listeners.
          *
          * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
@@ -369,7 +366,6 @@ declare namespace SocketIO {
 
         /**
          * Gets a copy of all listeners for an event.
-         *
          * @param event The event to retrieve all listeners for
          * @return A copy of the array of listeners for the event
          *
@@ -379,7 +375,6 @@ declare namespace SocketIO {
 
         /**
          * Get a copy of all listeners for an event, including one-time events.
-         *
          * @param event The event to retrieve all listeners for
          * @return A copy of the array of listeners for the event,
          * including any wrappers (such as those created by .once()).
@@ -389,9 +384,9 @@ declare namespace SocketIO {
         rawListeners(event: string): Function[];
 
         /**
-         * Get a copy of all listeners for an event, including one-time events.
-         * @param event The event to retrieve all listeners for
-         * @return The number of listeners listening to the event
+         * Gets the number of listeners listening to the event.
+         * @param event The event to retrieve the total listener count for
+         * @return The total number of listeners listening to the event
          *
          * _Inherited from EventEmitter - https://nodejs.org/api/events.html_
          */


### PR DESCRIPTION
I made a mistake with the JSDOC definition of the `listenerCount` method on #44925. This PR fixes that mistake and formats the JSDOC of the new methods to be consistent with the other types.

This change only affects JSDOC and not the actual type, because of this I did not do the following:
- Add / Edit Tests
- Run Tests
- Lint
- Provide a documentation url


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
