### PR TITLE
[xml] export additional types already defined

### DIFF
--- a/types/xml/index.d.ts
+++ b/types/xml/index.d.ts
@@ -5,45 +5,58 @@
 
 /// <reference types="node" />
 
-interface Option {
-  /**
-   * String used for tab, defaults to no tabs (compressed)
-   */
-  indent?: string;
-  /**
-   * Return the result as a `stream` (default false)
-   */
-  stream?: boolean;
-  /**
-   * Add default xml declaration (default false)
-   */
-  declaration?: boolean | {
-    encoding?: string;
-    standalone?: string;
-  };
-}
+declare module 'xml' {
+    namespace xml {
+        export interface Option {
+            /**
+             * String used for tab, defaults to no tabs (compressed)
+             */
+            indent?: string;
+            /**
+             * Return the result as a `stream` (default false)
+             */
+            stream?: boolean;
+            /**
+             * Add default xml declaration (default false)
+             */
+            declaration?:
+                | boolean
+                | {
+                      encoding?: string;
+                      standalone?: string;
+                  };
+        }
 
-interface XmlAttrs {
-  [attr: string]: XmlAtom;
-}
-interface XmlDescArray {
-  [index: number]: { _attr: XmlAttrs } | XmlObject;
-}
-interface ElementObject {
-  push(xmlObject: XmlObject): void;
-  close(xmlObject?: XmlObject): void;
-}
+        export interface XmlAttrs {
+            [attr: string]: XmlAtom;
+        }
+        export interface XmlDescArray {
+            [index: number]: { _attr: XmlAttrs } | XmlObject;
+        }
+        export interface ElementObject {
+            push(xmlObject: XmlObject): void;
+            close(xmlObject?: XmlObject): void;
+        }
 
-type XmlAtom = string | number | boolean | null;
-type XmlDesc = { _attr: XmlAttrs } | { _cdata: string } | { _attr: XmlAttrs, _cdata: string } | XmlAtom | XmlAtom[] | XmlDescArray;
-type XmlObject = { [tag: string]: ElementObject | XmlDesc } | XmlDesc;
+        export type XmlAtom = string | number | boolean | null;
+        export type XmlDesc =
+            | { _attr: XmlAttrs }
+            | { _cdata: string }
+            | { _attr: XmlAttrs; _cdata: string }
+            | XmlAtom
+            | XmlAtom[]
+            | XmlDescArray;
+        export type XmlObject = { [tag: string]: ElementObject | XmlDesc } | XmlDesc;
 
-declare namespace xml {
-  function element(...xmlObjects: XmlObject[]): ElementObject;
-  function Element(...xmlObjects: XmlObject[]): ElementObject;
+        export function element(...xmlObjects: XmlObject[]): ElementObject;
+        export function Element(...xmlObjects: XmlObject[]): ElementObject;
+    }
+
+    function xml(
+        xmlObject: xml.XmlObject | xml.XmlObject[],
+        options: { stream: true; indent?: string },
+    ): NodeJS.ReadableStream;
+    function xml(xmlObject?: xml.XmlObject | xml.XmlObject[], options?: boolean | string | xml.Option): string;
+
+    export = xml;
 }
-
-declare function xml(xmlObject: XmlObject | XmlObject[], options: { stream: true, indent?: string }): NodeJS.ReadableStream;
-declare function xml(xmlObject?: XmlObject | XmlObject[], options?: boolean | string | Option): string;
-
-export = xml;

--- a/types/xml/index.d.ts
+++ b/types/xml/index.d.ts
@@ -5,58 +5,56 @@
 
 /// <reference types="node" />
 
-declare module 'xml' {
-    namespace xml {
-        export interface Option {
-            /**
-             * String used for tab, defaults to no tabs (compressed)
-             */
-            indent?: string;
-            /**
-             * Return the result as a `stream` (default false)
-             */
-            stream?: boolean;
-            /**
-             * Add default xml declaration (default false)
-             */
-            declaration?:
-                | boolean
-                | {
-                      encoding?: string;
-                      standalone?: string;
-                  };
-        }
-
-        export interface XmlAttrs {
-            [attr: string]: XmlAtom;
-        }
-        export interface XmlDescArray {
-            [index: number]: { _attr: XmlAttrs } | XmlObject;
-        }
-        export interface ElementObject {
-            push(xmlObject: XmlObject): void;
-            close(xmlObject?: XmlObject): void;
-        }
-
-        export type XmlAtom = string | number | boolean | null;
-        export type XmlDesc =
-            | { _attr: XmlAttrs }
-            | { _cdata: string }
-            | { _attr: XmlAttrs; _cdata: string }
-            | XmlAtom
-            | XmlAtom[]
-            | XmlDescArray;
-        export type XmlObject = { [tag: string]: ElementObject | XmlDesc } | XmlDesc;
-
-        export function element(...xmlObjects: XmlObject[]): ElementObject;
-        export function Element(...xmlObjects: XmlObject[]): ElementObject;
+declare namespace xml {
+    interface Option {
+        /**
+         * String used for tab, defaults to no tabs (compressed)
+         */
+        indent?: string;
+        /**
+         * Return the result as a `stream` (default false)
+         */
+        stream?: boolean;
+        /**
+         * Add default xml declaration (default false)
+         */
+        declaration?:
+            | boolean
+            | {
+                  encoding?: string;
+                  standalone?: string;
+              };
     }
 
-    function xml(
-        xmlObject: xml.XmlObject | xml.XmlObject[],
-        options: { stream: true; indent?: string },
-    ): NodeJS.ReadableStream;
-    function xml(xmlObject?: xml.XmlObject | xml.XmlObject[], options?: boolean | string | xml.Option): string;
+    interface XmlAttrs {
+        [attr: string]: XmlAtom;
+    }
+    interface XmlDescArray {
+        [index: number]: { _attr: XmlAttrs } | XmlObject;
+    }
+    interface ElementObject {
+        push(xmlObject: XmlObject): void;
+        close(xmlObject?: XmlObject): void;
+    }
 
-    export = xml;
+    type XmlAtom = string | number | boolean | null;
+    type XmlDesc =
+        | { _attr: XmlAttrs }
+        | { _cdata: string }
+        | { _attr: XmlAttrs; _cdata: string }
+        | XmlAtom
+        | XmlAtom[]
+        | XmlDescArray;
+    type XmlObject = { [tag: string]: ElementObject | XmlDesc } | XmlDesc;
+
+    function element(...xmlObjects: XmlObject[]): ElementObject;
+    function Element(...xmlObjects: XmlObject[]): ElementObject;
 }
+
+declare function xml(
+    xmlObject: xml.XmlObject | xml.XmlObject[],
+    options: { stream: true; indent?: string },
+): NodeJS.ReadableStream;
+declare function xml(xmlObject?: xml.XmlObject | xml.XmlObject[], options?: boolean | string | xml.Option): string;
+
+export = xml;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

<img src="https://user-images.githubusercontent.com/7195563/82575242-7c361c80-9b88-11ea-9816-24ae544abefd.png" width="400px">

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

I just used `declare module` so I can import types like `xml.XmlObject` in my own project and use it.