### PR TITLE
update(carbon-components-react): [7.10.x] Fix SideNav props not having children prop due to new ForwardRefReturn type alias.

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -29,7 +29,10 @@ import {
     FileUploaderItem,
     MultiSelect,
     Tabs,
-} from 'carbon-components-react';
+    SideNav,
+    SideNavItem,
+    SideNavItems,
+} from "carbon-components-react";
 import Link from 'carbon-components-react/lib/components/UIShell/Link';
 
 // AccordionItem
@@ -270,25 +273,21 @@ const uisHeaderContainerAnonRender = (
     />
 );
 
-const HeaderCompRender1: React.FC<{ someProp: number }> = () => <div/>;
-const HeaderCompRender2: React.FC<{ someProp?: number }> = () => <div/>;
+const HeaderCompRender1: React.FC<{ someProp: number }> = () => <div />;
+const HeaderCompRender2: React.FC<{ someProp?: number }> = () => <div />;
 
 /*
  * TODO: this should be a fail case but the priority is to correctly type the anonymous render as that's likely how it
  *  will be used.
  */
-const uisHeaderContainerCompRenderNotMatchingRequiredProps = (
-    <HeaderContainer render={HeaderCompRender1} />
-);
+const uisHeaderContainerCompRenderNotMatchingRequiredProps = <HeaderContainer render={HeaderCompRender1} />;
 
-const uisHeaderContainerCompRenderNotMatchingOptionalProps = (
-    <HeaderContainer render={HeaderCompRender2} />
-);
+const uisHeaderContainerCompRenderNotMatchingOptionalProps = <HeaderContainer render={HeaderCompRender2} />;
 
 // UI Shell - HeaderMenu
 const uisHeaderMenuAnonRender = (
-    <HeaderMenu menuLinkName="test" renderMenuContent={() => <div/>}>
-        <div/>
+    <HeaderMenu menuLinkName="test" renderMenuContent={() => <div />}>
+        <div />
     </HeaderMenu>
 );
 
@@ -471,14 +470,10 @@ const multiSelectFilterable = (
 
 // Grid
 
-const GridCustomRenderComp1: React.FC<{ someProp: number }> = () => <div/>;
+const GridCustomRenderComp1: React.FC<{ someProp: number }> = () => <div />;
 
 // Grid: Row
-const rowDefaultT1 = (
-    <Row onClick={(event: React.MouseEvent<HTMLDivElement>) => {}}>
-        Contents
-    </Row>
-);
+const rowDefaultT1 = <Row onClick={(event: React.MouseEvent<HTMLDivElement>) => {}}>Contents</Row>;
 
 const rowDefaultT2 = (
     <Row as={undefined} onClick={(event: React.MouseEvent<HTMLDivElement>) => {}}>
@@ -522,3 +517,12 @@ const columnCustomComp1 = (
         Content
     </Column>
 );
+
+// SideNav
+const sideNavChildren = (
+    <SideNav>
+        <SideNavItems>
+            <SideNavItem>Test</SideNavItem>
+        </SideNavItems>
+    </SideNav>
+)

--- a/types/carbon-components-react/lib/components/UIShell/SideNav.d.ts
+++ b/types/carbon-components-react/lib/components/UIShell/SideNav.d.ts
@@ -5,6 +5,7 @@ export type SideNavTranslationKey = "carbon.sidenav.state.closed" | "carbon.side
 interface InheritedProps extends InternationalProps<SideNavTranslationKey> {
     "aria-label"?: ReactAttr["aria-label"],
     "aria-labelledby"?: ReactAttr["aria-labelledby"],
+    children?: ReactAttr["children"],
     className?: ReactAttr["className"],
 }
 

--- a/types/carbon-components-react/lib/components/UIShell/SideNavSwitcher.d.ts
+++ b/types/carbon-components-react/lib/components/UIShell/SideNavSwitcher.d.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import { ReactAttr, ForwardRefReturn } from "../../../typings/shared";
 
 interface InheritedProps {
+    children?: ReactAttr["children"],
     className?: ReactAttr["className"],
     onChange?(event: React.ChangeEvent<HTMLSelectElement>): void,
 }

--- a/types/carbon-components-react/typings/shared.d.ts
+++ b/types/carbon-components-react/typings/shared.d.ts
@@ -89,6 +89,8 @@ export interface RefForwardingProps<T = HTMLElement> {
 // aliases for some React types that it doesn't export directly. They are needed to make sure we match the signatures
 // as close as possible
 export type FCReturn = ReturnType<React.FC>;
+// IMPORTANT: this type matches what react types has but you MUST add children prop to your prop interface or children
+// will be an unknown prop. This is typically not the case for a regular function component.
 export type ForwardRefReturn<T, P = {}> = React.ForwardRefExoticComponent<
     React.PropsWithoutRef<P> & React.RefAttributes<T>
 >;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x]  Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: check index.d.ts
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Fixes missing children prop on SideNav components due to usage of new type alias for ForwardRefReturn. I'm not adding children to that type because technically it matches the current signature in `@types/react` (return type of React.forwardRef).

