### PR TITLE
@types/node - Fix return type of process.kill

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -829,7 +829,7 @@ declare namespace NodeJS {
                 visibility: string;
             };
         };
-        kill(pid: number, signal?: string | number): void;
+        kill(pid: number, signal?: string | number): true;
         pid: number;
         ppid: number;
         title: string;

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -893,7 +893,7 @@ declare namespace NodeJS {
                 visibility: string;
             };
         };
-        kill(pid: number, signal?: string | number): boolean;
+        kill(pid: number, signal?: string | number): true;
         pid: number;
         ppid: number;
         title: string;

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -893,7 +893,7 @@ declare namespace NodeJS {
                 visibility: string;
             };
         };
-        kill(pid: number, signal?: string | number): void;
+        kill(pid: number, signal?: string | number): boolean;
         pid: number;
         ppid: number;
         title: string;


### PR DESCRIPTION
process.kill actually returns a boolean

Context for reasoning behind the change from `void` to `boolean` return type found here:
https://github.com/nodejs/node/blob/master/lib/internal/process/per_thread.js#L175

It always returns true or throws an error
