### PR TITLE
[tabulator-tables] getColumns should return an array of ColumnComponent

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -1879,7 +1879,7 @@ declare class Tabulator {
     /** To get an array of Column Components for the current table setup, call the getColumns function. This will only return actual data columns not column groups.
      ** To get a structured array of Column Components that includes column groups, pass a value of true as an argument.
      */
-    getColumns: (includeColumnGroups?: boolean) => Tabulator.ColumnComponent[] | Tabulator.GroupComponent[];
+    getColumns: (includeColumnGroups?: boolean) => Tabulator.ColumnComponent[];
     /** Using the getColumn function you can retrieve the Column Component  */
     getColumn: (column: Tabulator.ColumnLookup) => Tabulator.ColumnComponent;
     /** To get the current column definition array (including any changes made through user actions, such as resizing or re-ordering columns), call the getColumnDefinitions function. this will return the current columns definition array. */

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -751,3 +751,5 @@ table = new Tabulator('#example-table', {
 });
 const filterVal = table.getHeaderFilterValue('name');
 table.recalc();
+const columns = table.getColumns(true);
+columns.forEach(col => col.getDefinition());


### PR DESCRIPTION
As the documentation said, the getColumns from the tabulator should return an array of ColumnComponent.

> This will return an array of Column Components for the top level columns, whether they are columns or column groups.

The GroupComponent is dedicated for grouping rows, not for Columns.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://tabulator.info/docs/4.6/columns#get-component>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
