### PR TITLE
[@types/cytoscape] Fixed the Events style function for Nodes & Edges

### DIFF
--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -3558,8 +3558,8 @@ declare namespace cytoscape {
         /**
          * http://js.cytoscape.org/#style/node-body
          */
-        interface Node extends Partial<Overlay>, PaddingNode, Partial<Labels<NodeSingular>>,
-            BackgroundImage, Partial<Ghost>, Partial<Visibility<NodeSingular>>, Partial<PieChartBackground> {
+        interface Node extends Partial<Overlay>, PaddingNode, Partial<Labels<NodeSingular>>, BackgroundImage,
+            Partial<Ghost>, Partial<Visibility<NodeSingular>>, Partial<PieChartBackground>, Partial<Events<NodeSingular>> {
             /**
              * The CSS content field
              */
@@ -3755,8 +3755,9 @@ declare namespace cytoscape {
             "pie-i-background-opacity": PropertyValueNode<number>;
         }
 
-        interface Edge extends EdgeLine, EdgeArrow, Partial<Gradient>, Partial<Overlay>, Partial<BezierEdges>, Partial<UnbundledBezierEdges>,
-        Partial<HaystackEdges>, Partial<SegmentsEdges>, Partial<Visibility<EdgeSingular>>, Partial<Labels<EdgeSingular>> { }
+        interface Edge extends EdgeLine, EdgeArrow, Partial<Gradient>, Partial<Overlay>, Partial<BezierEdges>,
+            Partial<UnbundledBezierEdges>, Partial<HaystackEdges>, Partial<SegmentsEdges>, Partial<Visibility<EdgeSingular>>,
+            Partial<Labels<EdgeSingular>>, Partial<Events<NodeSingular>> { }
 
         /**
          * These properties affect the styling of an edge’s line:
@@ -4270,27 +4271,22 @@ declare namespace cytoscape {
              * it is guaranteed that the label will be shown at sizes equal to or greater than the value specified.
              */
             "min-zoomed-font-size": PropertyValue<SingularType, number>;
-            /**
-             * Whether events should occur on an element if the label receives an event.
-             * You may want a style applied to the text onactive so you know the text is activatable.
-             */
-            "text-events": PropertyValue<SingularType, "yes" | "no">;
         }
 
         /**
          * http://js.cytoscape.org/#style/events
          */
-        interface Events {
+        interface Events<SingularType extends NodeSingular | EdgeSingular> {
             /**
              * Whether events should occur on an element (e.g.tap, mouseover, etc.).
              *  * For "no", the element receives no events and events simply pass through to the core/viewport.
              */
-            "events": PropertyValueNode<"yes" | "no">;
+            "events": PropertyValue<SingularType, "yes" | "no">;
             /**
              *  Whether events should occur on an element if the label receives an event.
              * You may want a style applied to the text on active so you know the text is activatable.
              */
-            "text-events": PropertyValueNode<"yes" | "no">;
+            "text-events": PropertyValue<SingularType, "yes" | "no">;
         }
 
         /**


### PR DESCRIPTION
Greetings Maintainers!

I was browsing the issues and ran into [this issue](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44890) created by @jsphstls

I could recreate the issue and it's something I also needed fixed for my little project.

It's about the [events style](https://js.cytoscape.org/#style/events) not being implemented on nodes & edges. 
Had to remove the "text-events" propertyvalue from Labels to avoid duplicate code.

Have a very nice day!
