### PR TITLE
[@types/expect-puppeteer] Add setDefaultConfig and getDefaultConfig exports

### DIFF
--- a/types/expect-puppeteer/expect-puppeteer-tests.ts
+++ b/types/expect-puppeteer/expect-puppeteer-tests.ts
@@ -1,4 +1,5 @@
 import { ElementHandle, Page } from "puppeteer";
+import { getDefaultOptions, setDefaultOptions } from 'expect-puppeteer';
 
 const testGlobal = async (instance: ElementHandle | Page) => {
     await expect(instance).toClick("selector");
@@ -32,6 +33,9 @@ const testGlobal = async (instance: ElementHandle | Page) => {
 
     await expect(instance).toUploadFile("selector", "filePath");
     await expect(instance).toUploadFile("selector", "filePath", { timeout: 777 });
+
+    setDefaultOptions({ polling: "mutation", timeout: 5000 });
+    const { polling, timeout } = getDefaultOptions();
 };
 
 const testImported = async (instance: ElementHandle | Page) => {

--- a/types/expect-puppeteer/index.d.ts
+++ b/types/expect-puppeteer/index.d.ts
@@ -16,9 +16,9 @@ import { ElementHandle, Page, Dialog } from "puppeteer";
 type ExpectPolling = number | "mutation" | "raf";
 
 /**
- * Configures how to poll for an element.
+ * Default options that apply to all expectations and can be set globally
  */
-interface ExpectTimingActions {
+interface ExpectDefaultOptions {
     /**
      * An interval at which the pageFunction is executed. Defaults to "raf".
      */
@@ -28,7 +28,12 @@ interface ExpectTimingActions {
      * Maximum time to wait for in milliseconds. Defaults to 500.
      */
     timeout?: number;
+}
 
+/**
+ * Configures how to poll for an element.
+ */
+interface ExpectTimingActions extends ExpectDefaultOptions {
     /**
      * delay to pass to the puppeteer element.type API
      */
@@ -93,4 +98,10 @@ declare global {
 }
 
 declare function expectPuppeteer(instance: ElementHandle | Page): ExpectPuppeteer;
+
+declare namespace expectPuppeteer {
+    function setDefaultOptions(options: ExpectDefaultOptions): void;
+    function getDefaultOptions(): ExpectDefaultOptions;
+}
+
 export = expectPuppeteer;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/smooth-code/jest-puppeteer/blob/master/packages/expect-puppeteer/README.md#configure-default-options
- [ ] (N/A) If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] (N/A) If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
