### PR TITLE
[React Native] Animated: add missing reset function, add documentation strings

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8538,6 +8538,15 @@ export namespace Animated {
          * start() takes a completion callback that will be called when the
          * animation is done or when the animation is done because stop() was
          * called on it before it could finish.
+         * 
+         * @param callback - Optional function that will be called
+         *      after the animation finished running normally or when the animation
+         *      is done because stop() was called on it before it could finish
+         * 
+         * @example
+         *   Animated.timing({}).start(({ finished }) => {
+         *    // completion callback
+         *   });
          */
         start: (callback?: EndCallback) => void;
         /**

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8538,11 +8538,11 @@ export namespace Animated {
          * start() takes a completion callback that will be called when the
          * animation is done or when the animation is done because stop() was
          * called on it before it could finish.
-         * 
+         *
          * @param callback - Optional function that will be called
          *      after the animation finished running normally or when the animation
          *      is done because stop() was called on it before it could finish
-         * 
+         *
          * @example
          *   Animated.timing({}).start(({ finished }) => {
          *    // completion callback

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8533,8 +8533,21 @@ export namespace Animated {
     type EndCallback = (result: EndResult) => void;
 
     export interface CompositeAnimation {
+        /**
+         * Animations are started by calling start() on your animation.
+         * start() takes a completion callback that will be called when the
+         * animation is done or when the animation is done because stop() was
+         * called on it before it could finish.
+         */
         start: (callback?: EndCallback) => void;
+        /**
+         * Stops any running animation.
+         */
         stop: () => void;
+        /**
+         * Stops any running animation and resets the value to its original.
+         */
+        reset: () => void;
     }
 
     interface AnimationConfig {

--- a/types/react-native/test/animated.tsx
+++ b/types/react-native/test/animated.tsx
@@ -91,6 +91,7 @@ function TestAnimatedAPI() {
 
     spring1.start();
     spring1.stop();
+    spring1.reset();
 
     Animated.parallel(
         [


### PR DESCRIPTION
This adds the missing `Animated.reset()` function and adds documentation strings for `Animated.start()` and `Animated.stop()`.

Reference:
- https://github.com/facebook/react-native/blob/master/Libraries/Animated/src/AnimatedImplementation.js#L43
- https://reactnative.dev/docs/animated#reset

---

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactnative.dev/docs/animated#reset
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.