### PR TITLE
[@types/onesignal-cordova-plugin]: fix enum value of OSNotificationPermission

### DIFF
--- a/types/onesignal-cordova-plugin/index.d.ts
+++ b/types/onesignal-cordova-plugin/index.d.ts
@@ -395,8 +395,8 @@ declare namespace OneSignalCordovaPlugin {
      */
     const enum OSNotificationPermission {
         NotDetermined = 0,
-        Authorized = 1,
-        Denied = 2,
+        Denied = 1,
+        Authorized = 2,
     }
 
     /**


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://documentation.onesignal.com/v5.0/docs/cordova-sdk#permissionstatus
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


[See official documentation](https://documentation.onesignal.com/v5.0/docs/cordova-sdk#permissionstatus)
Denied and Authorized are inverted, which is pretty important.

