### PR TITLE
Add type definitions for [plantuml-encoder] package

### DIFF
--- a/types/plantuml-encoder/index.d.ts
+++ b/types/plantuml-encoder/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for plantuml-encoder 1.4
+// Project: https://github.com/markushedvall/plantuml-encoder
+// Definitions by: Krisztián Balla <https://github.com/krisztianb>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+declare namespace PlantUmlEncoder {
+    /**
+     * Union type for possible typed arrays.
+     */
+    type TypedArray =
+        | Int8Array
+        | Uint8Array
+        | Uint8ClampedArray
+        | Int16Array
+        | Uint16Array
+        | Int32Array
+        | Uint32Array
+        | Float32Array
+        | Float64Array
+        | BigInt64Array
+        | BigUint64Array;
+}
+
+/**
+ * Wrapper object for the encode and decode functions.
+ */
+declare const PlantUmlEncoder: {
+    /**
+     * Encodes PlantUML code.
+     * @param puml The PlantUML code that should be encoded.
+     * @returns The encoded PlantUML code.
+     */
+    encode: (puml: Buffer | PlantUmlEncoder.TypedArray | DataView | ArrayBuffer | string) => string;
+
+    /**
+     * Decodes encoded PlantUML code.
+     * @param encodedPuml The encoded PlantUML code that should be decoded.
+     * @returns The decoded PlantUML code.
+     */
+    decode: (encodedPuml: string) => string;
+};
+
+export = PlantUmlEncoder;

--- a/types/plantuml-encoder/index.d.ts
+++ b/types/plantuml-encoder/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/markushedvall/plantuml-encoder
 // Definitions by: Krisztián Balla <https://github.com/krisztianb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.2
 
 /// <reference types="node" />
 

--- a/types/plantuml-encoder/index.d.ts
+++ b/types/plantuml-encoder/index.d.ts
@@ -33,7 +33,7 @@ declare const PlantUmlEncoder: {
      * @param puml The PlantUML code that should be encoded.
      * @returns The encoded PlantUML code.
      */
-    encode: (puml: Buffer | PlantUmlEncoder.TypedArray | DataView | ArrayBuffer | string) => string;
+    encode: (puml: string | Buffer | PlantUmlEncoder.TypedArray | DataView | ArrayBuffer) => string;
 
     /**
      * Decodes encoded PlantUML code.

--- a/types/plantuml-encoder/plantuml-encoder-tests.ts
+++ b/types/plantuml-encoder/plantuml-encoder-tests.ts
@@ -1,0 +1,9 @@
+import plantUmlEncoder = require('plantuml-encoder');
+
+if (plantUmlEncoder.encode('A -> B: Hello') !== 'SrJGjLDmibBmICt9oGS0') {
+    throw new Error('Test failed: encode');
+}
+
+if (plantUmlEncoder.decode('SrJGjLDmibBmICt9oGS0') !== 'A -> B: Hello') {
+    throw new Error('Test failed: decode');
+}

--- a/types/plantuml-encoder/tsconfig.json
+++ b/types/plantuml-encoder/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "strict": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "types": []
+    },
+    "files": [
+        "index.d.ts",
+        "plantuml-encoder-tests.ts"
+    ]
+}

--- a/types/plantuml-encoder/tslint.json
+++ b/types/plantuml-encoder/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
