### PR TITLE
add missing type for redux-sentry-middleware

### DIFF
--- a/types/redux-sentry-middleware/index.d.ts
+++ b/types/redux-sentry-middleware/index.d.ts
@@ -10,6 +10,7 @@ import * as Sentry from "@sentry/browser";
 declare namespace createSentryMiddleware {
     interface Options<T> {
         breadcrumbDataFromAction?: (action: Action) => any;
+        breadcrumbMessageFromAction?: (action: Action) => any;
         actionTransformer?: (action: Action) => any;
         stateTransformer?: (state: T) => any;
         breadcrumbCategory?: string;


### PR DESCRIPTION
- added breadcrumbMessageFromAction in createSentryMiddleware Options. The type should be the same as the other action types, but it is missing despite being an accepted ad working option (see https://www.npmjs.com/package/redux-sentry-middleware)

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.npmjs.com/package/redux-sentry-middleware>>