### PR TITLE
Exempt even more packages from npm naming

### DIFF
--- a/types/blueimp-load-image/tslint.json
+++ b/types/blueimp-load-image/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/combine-reducers/tslint.json
+++ b/types/combine-reducers/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/db-migrate-base/tslint.json
+++ b/types/db-migrate-base/tslint.json
@@ -12,6 +12,7 @@
         "no-trailing-whitespace": false,
         "object-literal-key-quotes": false,
         "prefer-const": false,
-        "prefer-method-signature": false
+        "prefer-method-signature": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }

--- a/types/ethereumjs-abi/tslint.json
+++ b/types/ethereumjs-abi/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/fetch.io/tslint.json
+++ b/types/fetch.io/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/fluxible/tslint.json
+++ b/types/fluxible/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/formidable/tslint.json
+++ b/types/formidable/tslint.json
@@ -16,6 +16,7 @@
         "strict-export-declare-modifiers": false,
         "trim-file": false,
         "triple-equals": false,
-        "whitespace": false
+        "whitespace": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }

--- a/types/jsftp/tslint.json
+++ b/types/jsftp/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/jsoneditor/tslint.json
+++ b/types/jsoneditor/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
 }

--- a/types/jsonld/tslint.json
+++ b/types/jsonld/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/jspath/tslint.json
+++ b/types/jspath/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/keccak/tslint.json
+++ b/types/keccak/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/kue/tslint.json
+++ b/types/kue/tslint.json
@@ -15,6 +15,7 @@
         "semicolon": false,
         "space-before-function-paren": false,
         "space-within-parens": false,
-        "strict-export-declare-modifiers": false
+        "strict-export-declare-modifiers": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }

--- a/types/mapbox__mapbox-sdk/tslint.json
+++ b/types/mapbox__mapbox-sdk/tslint.json
@@ -1,3 +1,6 @@
 {
-  "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
 }

--- a/types/mongodb/tslint.json
+++ b/types/mongodb/tslint.json
@@ -15,6 +15,7 @@
         "object-literal-shorthand": false,
         "prefer-method-signature": false,
         "space-before-function-paren": false,
-        "unified-signatures": false
+        "unified-signatures": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }

--- a/types/mongoose-deep-populate/tslint.json
+++ b/types/mongoose-deep-populate/tslint.json
@@ -9,6 +9,7 @@
         "no-var-keyword": false,
         "prefer-const": false,
         "prefer-method-signature": false,
-        "space-before-function-paren": false
+        "space-before-function-paren": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }

--- a/types/mongorito/tslint.json
+++ b/types/mongorito/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
 }

--- a/types/node-mailjet/tslint.json
+++ b/types/node-mailjet/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/node-statsd/tslint.json
+++ b/types/node-statsd/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/node-xmpp-client/tslint.json
+++ b/types/node-xmpp-client/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/nodejs-license-file/tslint.json
+++ b/types/nodejs-license-file/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/object-mapper/tslint.json
+++ b/types/object-mapper/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/passport-anonymous/tslint.json
+++ b/types/passport-anonymous/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/passport-cognito/tslint.json
+++ b/types/passport-cognito/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
 }

--- a/types/passport-facebook/tslint.json
+++ b/types/passport-facebook/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
 }

--- a/types/passport-google-oauth20/tslint.json
+++ b/types/passport-google-oauth20/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "unified-signatures": false
+        "unified-signatures": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }

--- a/types/passport-instagram/tslint.json
+++ b/types/passport-instagram/tslint.json
@@ -2,6 +2,7 @@
     "extends": "dtslint/dt.json",
     "rules": {
         "no-void-expression": false,
-        "only-arrow-functions": false
+        "only-arrow-functions": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }

--- a/types/power-assert-formatter/tslint.json
+++ b/types/power-assert-formatter/tslint.json
@@ -10,6 +10,7 @@
         "strict-export-declare-modifiers": false,
         "trim-file": false,
         "typedef-whitespace": false,
-        "whitespace": false
+        "whitespace": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }

--- a/types/radium/tslint.json
+++ b/types/radium/tslint.json
@@ -12,6 +12,7 @@
         "prefer-method-signature": false,
         "semicolon": false,
         "strict-export-declare-modifiers": false,
-        "void-return": false
+        "void-return": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }

--- a/types/rbac-a/tslint.json
+++ b/types/rbac-a/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/rdf-data-model/tslint.json
+++ b/types/rdf-data-model/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "no-angle-bracket-type-assertion": false
+        "no-angle-bracket-type-assertion": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }

--- a/types/react-collapse/tslint.json
+++ b/types/react-collapse/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/react-howler/tslint.json
+++ b/types/react-howler/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/react-input-mask/tslint.json
+++ b/types/react-input-mask/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
 }

--- a/types/react-loadable-visibility/tslint.json
+++ b/types/react-loadable-visibility/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/react-motion-loop/tslint.json
+++ b/types/react-motion-loop/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "strict-export-declare-modifiers": false
+        "strict-export-declare-modifiers": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }

--- a/types/shipit-cli/tslint.json
+++ b/types/shipit-cli/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/sic-ecies/tslint.json
+++ b/types/sic-ecies/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/sqs-producer/tslint.json
+++ b/types/sqs-producer/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "dt-header": false
+        "dt-header": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }

--- a/types/svg-path-parser/tslint.json
+++ b/types/svg-path-parser/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}

--- a/types/weighted/tslint.json
+++ b/types/weighted/tslint.json
@@ -14,6 +14,7 @@
         "prefer-const": false,
         "prefer-method-signature": false,
         "space-before-function-paren": false,
-        "strict-export-declare-modifiers": false
+        "strict-export-declare-modifiers": false,
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
     }
 }


### PR DESCRIPTION
A change in typescript@next means that dts-critic now gets types for even more JS code, which means that it can discover problems with those new types.

This PR disables the errors for now; I'll come back and make changes for widely-used packages since they are the most likely to benefit from having correct exports.