### PR TITLE
feat(webpack-clean): new type definition

### DIFF
--- a/types/webpack-clean/index.d.ts
+++ b/types/webpack-clean/index.d.ts
@@ -1,0 +1,43 @@
+// Type definitions for webpack-clean 1.2
+// Project: https://github.com/allexcd/webpack-clean#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Plugin } from 'webpack';
+
+declare namespace WebpackCleanPlugin {
+    interface Options {
+        /**
+         * directory to be resolved to
+         * @default null;
+         */
+        basePath?: string | null;
+        /**
+         * specify if the .map files should be automatically removed
+         * @default false
+         */
+        removeMaps?: boolean;
+        /**
+         * specify if the files should be force deleted in case of compile errors.
+         * If forceDelete is not enabled, the compile errors will be logged to stdout but the deletion of the files will not take place
+         * @default false
+         */
+        forceDelete?: boolean;
+    }
+}
+
+/**
+ * A webpack plugin to clean specified files after build
+ */
+declare class WebpackCleanPlugin extends Plugin {
+    /**
+     * @param files  array of files or string for a single file relative to the basePath
+     * or to the context of your config (if the basePath param is not specified)
+     */
+    constructor(files: string | string[], options?: WebpackCleanPlugin.Options);
+}
+
+/**
+ *  A webpack plugin to clean specified files after build
+ */
+export = WebpackCleanPlugin;

--- a/types/webpack-clean/tsconfig.json
+++ b/types/webpack-clean/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "webpack-clean-tests.ts"
+    ]
+}

--- a/types/webpack-clean/tslint.json
+++ b/types/webpack-clean/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webpack-clean/webpack-clean-tests.ts
+++ b/types/webpack-clean/webpack-clean-tests.ts
@@ -1,0 +1,38 @@
+/// <reference types="node" />
+
+import WebpackCleanPlugin = require('webpack-clean');
+import path = require('path');
+
+module.exports = {
+    context: path.join(__dirname, './'),
+    entry: './src/index.js',
+    output: {
+        filename: 'bundle.js',
+        path: path.resolve(__dirname, 'dist'),
+    },
+    plugins: [new WebpackCleanPlugin(['dist/test1.js', 'dist/test2.js'])],
+};
+
+module.exports = {
+    plugins: [new WebpackCleanPlugin('dist/fileA.js', { basePath: path.join(__dirname, './') })],
+};
+
+module.exports = {
+    plugins: [new WebpackCleanPlugin(['fileA.js', 'fileB.js'], { basePath: path.join(__dirname, 'dist') })],
+};
+
+module.exports = {
+    plugins: [
+        new WebpackCleanPlugin(['fileA.js', 'fileB.js'], { basePath: path.join(__dirname, 'dist'), removeMaps: true }),
+    ],
+};
+
+module.exports = {
+    plugins: [
+        new WebpackCleanPlugin(['fileA.js', 'fileB.js'], {
+            basePath: path.join(__dirname, 'dist'),
+            removeMaps: true,
+            forceDelete: true,
+        }),
+    ],
+};


### PR DESCRIPTION
- definition file for Webpack plugin
- tests

https://github.com/allexcd/webpack-clean
https://github.com/allexcd/webpack-clean#api

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](htps://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.