### PR TITLE
[ioredis] Update types to match version 4.17.1 of the ioredis library

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -16,6 +16,7 @@
 //                 Demian Rodriguez <https://github.com/demian85>
 //                 Andrew Lavers <https://github.com/alavers>
 //                 Claudiu Ceia <https://github.com/ClaudiuCeia>
+//                 Asyrique <https://github.com/asyrique>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -697,7 +698,9 @@ declare namespace IORedis {
         dbsize(): Promise<number>;
 
         auth(password: string, callback: Callback<string>): void;
+        auth(username: string, password: string, callback: Callback<string>): void;
         auth(password: string): Promise<string>;
+        auth(username: string, password: string): Promise<string>;
 
         ping(callback: Callback<string>): void;
         ping(message: string, callback: Callback<string>): void;
@@ -1223,6 +1226,7 @@ declare namespace IORedis {
         dbsize(callback?: Callback<number>): Pipeline;
 
         auth(password: string, callback?: Callback<string>): Pipeline;
+        auth(username: string, password: string, callback?: Callback<string>): Pipeline;
 
         ping(callback?: Callback<string>): Pipeline;
         ping(message: string, callback?: Callback<string>): Pipeline;
@@ -1413,6 +1417,10 @@ declare namespace IORedis {
         keepAlive?: number;
         connectionName?: string;
         /**
+         * If set, client will send AUTH command with the value of this option as the first argument when connected. The `password` option must be set too. Username should only be set for Redis >=6.
+         */
+        username?: string;
+        /**
          * If set, client will send AUTH command with the value of this option when connected.
          */
         password?: string;
@@ -1482,6 +1490,7 @@ declare namespace IORedis {
          * default: null.
          */
         name?: string;
+        sentinelUsername?: string;
         sentinelPassword?: string;
         sentinels?: Array<{ host: string; port: number }>;
         /**

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ioredis 4.16
+// Type definitions for ioredis 4.17
 // Project: https://github.com/luin/ioredis
 // Definitions by: York Yao <https://github.com/plantain-00>
 //                 Christopher Eck <https://github.com/chrisleck>

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -699,8 +699,9 @@ declare namespace IORedis {
 
         auth(username: string, password: string, callback: Callback<string>): void;
         auth(password: string, callback: Callback<string>): void;
-        auth(username: string, password?: string): Promise<string>;
-        // auth(password: string): Promise<string>;
+        // tslint:disable-next-line unified-signatures
+        auth(username: string, password: string): Promise<string>;
+        auth(password: string): Promise<string>;
 
         ping(callback: Callback<string>): void;
         ping(message: string, callback: Callback<string>): void;

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -697,10 +697,10 @@ declare namespace IORedis {
         dbsize(callback: Callback<number>): void;
         dbsize(): Promise<number>;
 
-        auth(password: string, callback: Callback<string>): void;
         auth(username: string, password: string, callback: Callback<string>): void;
+        auth(password: string, callback: Callback<string>): void;
+        auth(username: string, password?: string): Promise<string>;
         auth(password: string): Promise<string>;
-        auth(username: string, password: string): Promise<string>;
 
         ping(callback: Callback<string>): void;
         ping(message: string, callback: Callback<string>): void;

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -700,7 +700,7 @@ declare namespace IORedis {
         auth(username: string, password: string, callback: Callback<string>): void;
         auth(password: string, callback: Callback<string>): void;
         auth(username: string, password?: string): Promise<string>;
-        auth(password: string): Promise<string>;
+        // auth(password: string): Promise<string>;
 
         ping(callback: Callback<string>): void;
         ping(message: string, callback: Callback<string>): void;

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -268,6 +268,7 @@ new Redis({
     port: 6379, // Redis port
     host: '127.0.0.1', // Redis host
     family: 4, // 4 (IPv4) or 6 (IPv6)
+    username: 'user',
     password: 'auth',
     db: 0,
     retryStrategy() {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/luin/ioredis/commit/ad5b45587b2e378c15fa879cc72580c391c3c18d
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

Opening this PR because I need a second pair of eyes and some assistance. When I run `npm run lint ioredis`, I keep getting this error.
```
ERROR: 703:32  unified-signatures  This overload and the one on line 702 can be combined into one signature with an optional parameter.
```

Looking at the relevant lines:
```typescript
auth(password: string): Promise<string>;
auth(username: string, password: string): Promise<string>;
```
I'm not sure how to combine them, as what has happened is the library update introduced a new optional parameter `username` which should be passed as the first argument, and `password` should be passed either as the first argument when no username is passed, or as the second one when `username` is passed.

adding `?` to the username argument raises another Typescript error, which is that a required parameter cannot follow an optional one in arguments.

I'm a bit stumped here, as I can't think of any way these 2 lines can be combined, but Typescript somehow thinks it can, and would appreciate any suggestions on how to proceed, as right now, the lint run is erroring out.

Thanks.