### PR TITLE
fix(node): Writable.defaultEncoding option corrected

### DIFF
--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -124,7 +124,7 @@ declare module "stream" {
         interface WritableOptions {
             highWaterMark?: number;
             decodeStrings?: boolean;
-            defaultencoding?: BufferEncoding;
+            defaultEncoding?: BufferEncoding;
             objectMode?: boolean;
             emitClose?: boolean;
             write?(this: Writable, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -53,7 +53,8 @@ function simplified_stream_ctor_test() {
             this;
             // $ExpectType (error?: Error | null | undefined) => void
             cb;
-        }
+        },
+        defaultEncoding: 'utf8',
     });
 
     new Duplex({


### PR DESCRIPTION
This corrects obvious typo in property name.

/cc @SimonSchick @RAnders00

Thanks!

Fixes #44990

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)