### PR TITLE
blueimp-load-image uses export=

### DIFF
--- a/types/blueimp-load-image/blueimp-load-image-tests.ts
+++ b/types/blueimp-load-image/blueimp-load-image-tests.ts
@@ -1,4 +1,4 @@
-import loadImage, { MetaData } from 'blueimp-load-image';
+import loadImage = require('blueimp-load-image');
 
 // Test image taken from package tests: https://github.com/blueimp/JavaScript-Load-Image/blob/master/test/test.js
 
@@ -22,7 +22,7 @@ const b64DataJPEG =
   '2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwDAQACEQMRAD8A/v4ooooA/9k=';
 const imageUrlJPEG = 'data:image/jpeg;base64,' + b64DataJPEG;
 
-loadImage(imageUrlJPEG, (image: Event | HTMLCanvasElement | HTMLImageElement, data?: MetaData): void => {
+loadImage(imageUrlJPEG, (image: Event | HTMLCanvasElement | HTMLImageElement, data?: loadImage.MetaData): void => {
   const canvas = image as HTMLCanvasElement;
   console.log(data);
   canvas.toBlob((blob: Blob | null): void => {

--- a/types/blueimp-load-image/index.d.ts
+++ b/types/blueimp-load-image/index.d.ts
@@ -4,104 +4,105 @@
 //                 Konstantin Lukaschenko <https://github.com/KonstantinLukaschenko>
 //                 Saeid Rezaei <https://github.com/moeinio>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
 
 /// <reference types="node" />
 
-export type LoadImageCallback = (eventOrImage: Event | HTMLCanvasElement | HTMLImageElement, data?: MetaData) => void;
+declare namespace loadImage {
+    type LoadImageCallback = (eventOrImage: Event | HTMLCanvasElement | HTMLImageElement, data?: MetaData) => void;
 
-export type ParseMetaDataCallback = (data: ImageHead) => void;
+    type ParseMetaDataCallback = (data: ImageHead) => void;
 
-export interface Exif {
-    [tag: number]: number | string | string[];
+    interface Exif {
+        [tag: number]: number | string | string[];
+    }
+
+    interface Iptc {
+        [tag: number]: number | string | string[];
+    }
+
+    interface ImageHead {
+        imageHead?: ArrayBuffer | Uint8Array;
+    }
+
+    interface MetaData extends ImageHead {
+        originalWidth?: number;
+        originalHeight?: number;
+        exif?: Exif;
+        iptc?: Iptc;
+    }
+
+    interface BasicOptions {
+        maxWidth?: number;
+        maxHeight?: number;
+        minWidth?: number;
+        minHeight?: number;
+        contain?: boolean;
+        cover?: boolean;
+        crossOrigin?: string;
+        noRevoke?: boolean;
+    }
+
+    type Orientation = number | boolean;
+    type AspectRatio = number;
+
+    // Some options are only valid if 'canvas' is true.
+    // In addition, if 'crop' is true or 'orientation' is set,
+    // it automatically enables 'canvas' so in those cases,
+    // 'canvas' cannot be false
+    interface CanvasTrueOptions {
+        canvas: true;
+        sourceWidth?: number;
+        sourceHeight?: number;
+        top?: number;
+        right?: number;
+        bottom?: number;
+        left?: number;
+        pixelRatio?: number;
+        downsamplingRatio?: number;
+        orientation?: Orientation;
+        crop?: boolean;
+    }
+    interface CanvasFalseOptions {
+        canvas?: false;
+    }
+    type CanvasOptions = CanvasTrueOptions | CanvasFalseOptions;
+
+    // Setting 'aspectRatio' automatically enables 'crop', so setting 'crop' to
+    // 'false' in that case is not valid
+    interface CropTrueOptions {
+        crop?: true;
+        aspectRatio?: AspectRatio;
+    }
+    interface CropFalseOptions {
+        crop?: false;
+    }
+    type CropOptions = CropTrueOptions | CropFalseOptions;
+
+    // Setting 'orientation' automatically sets 'meta' to true
+    // so setting it to false is not valid in that case
+    interface MetaTrueOptions {
+        meta?: true;
+        orientation: Orientation;
+    }
+    interface MetaFalseOptions {
+        meta?: false;
+    }
+    type MetaOptions = MetaTrueOptions | MetaFalseOptions;
+
+    interface ParseOptions {
+        // Defines the maximum number of bytes to parse.
+        maxMetaDataSize?: number;
+
+        // Disables creating the imageHead property.
+        disableImageHead?: boolean;
+    }
+
+    type LoadImageOptions = BasicOptions & CanvasOptions & CropOptions & MetaOptions;
 }
-
-export interface Iptc {
-    [tag: number]: number | string | string[];
-}
-
-export interface ImageHead {
-    imageHead?: ArrayBuffer | Uint8Array;
-}
-
-export interface MetaData extends ImageHead {
-    originalWidth?: number;
-    originalHeight?: number;
-    exif?: Exif;
-    iptc?: Iptc;
-}
-
-export interface BasicOptions {
-    maxWidth?: number;
-    maxHeight?: number;
-    minWidth?: number;
-    minHeight?: number;
-    contain?: boolean;
-    cover?: boolean;
-    crossOrigin?: string;
-    noRevoke?: boolean;
-}
-
-export type Orientation = number | boolean;
-export type AspectRatio = number;
-
-// Some options are only valid if 'canvas' is true.
-// In addition, if 'crop' is true or 'orientation' is set,
-// it automatically enables 'canvas' so in those cases,
-// 'canvas' cannot be false
-export interface CanvasTrueOptions {
-    canvas: true;
-    sourceWidth?: number;
-    sourceHeight?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-    left?: number;
-    pixelRatio?: number;
-    downsamplingRatio?: number;
-    orientation?: Orientation;
-    crop?: boolean;
-}
-export interface CanvasFalseOptions {
-    canvas?: false;
-}
-export type CanvasOptions = CanvasTrueOptions | CanvasFalseOptions;
-
-// Setting 'aspectRatio' automatically enables 'crop', so setting 'crop' to
-// 'false' in that case is not valid
-export interface CropTrueOptions {
-    crop?: true;
-    aspectRatio?: AspectRatio;
-}
-export interface CropFalseOptions {
-    crop?: false;
-}
-export type CropOptions = CropTrueOptions | CropFalseOptions;
-
-// Setting 'orientation' automatically sets 'meta' to true
-// so setting it to false is not valid in that case
-export interface MetaTrueOptions {
-    meta?: true;
-    orientation: Orientation;
-}
-export interface MetaFalseOptions {
-    meta?: false;
-}
-export type MetaOptions = MetaTrueOptions | MetaFalseOptions;
-
-export interface ParseOptions {
-    // Defines the maximum number of bytes to parse.
-    maxMetaDataSize?: number;
-
-    // Disables creating the imageHead property.
-    disableImageHead?: boolean;
-}
-
-export type LoadImageOptions = BasicOptions & CanvasOptions & CropOptions & MetaOptions;
 
 // loadImage is implemented as a callable object.
 interface LoadImage  {
-    (file: File | Blob | string, callback: LoadImageCallback, options: LoadImageOptions):
+    (file: File | Blob | string, callback: loadImage.LoadImageCallback, options: loadImage.LoadImageOptions):
         | HTMLImageElement
         | FileReader
         | false;
@@ -109,9 +110,9 @@ interface LoadImage  {
     // Parses image meta data and calls the callback with the image head
     parseMetaData: (
         file: File | Blob | string,
-        callback: ParseMetaDataCallback,
-        options?: ParseOptions,
-        data?: ImageHead,
+        callback: loadImage.ParseMetaDataCallback,
+        options?: loadImage.ParseOptions,
+        data?: loadImage.ImageHead,
     ) => void;
 
     blobSlice: (this: Blob, start?: number, end?: number) => Blob;
@@ -119,4 +120,4 @@ interface LoadImage  {
 
 declare const loadImage: LoadImage;
 
-export default loadImage;
+export = loadImage;


### PR DESCRIPTION
Previously it incorrectly used export default, which requires consumers to have esModuleInterop turned on.

(Easier to review with whitespace ignored.)
