### PR TITLE
@types/react-dates with moment 2.26

### DIFF
--- a/types/react-dates/package.json
+++ b/types/react-dates/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "moment": ">=2.17.1"
+        "moment": "^2.26.0"
     }
 }


### PR DESCRIPTION
Using `@types/react-dates` with `moment` 2.26+ gives me following error as the published package still installs the incompatible `moment` 2.25.3 as dep.

```
Type 'import("node_modules/@types/react-dates/node_modules/moment/ts3.1-
typings/moment").Moment | null' is not assignable to type 'moment.Moment | null'.

Property 'isoWeeksInISOWeekYear' is missing in type 'import("node_modules/@types/react-
dates/node_modules/moment/ts3.1-typings/moment").Moment' but required in type 
'moment.Moment'.
```

@ArturAmpilogov
@NathanNZ