### PR TITLE
feat: types for ellipsize ( npmjs.com/package/ellipsize) added

### DIFF
--- a/types/ellipsize/ellipsize-tests.ts
+++ b/types/ellipsize/ellipsize-tests.ts
@@ -1,4 +1,4 @@
-import ellipsize from 'ellipsize';
+import ellipsize = require('ellipsize');
 
 ellipsize('');
 // ''

--- a/types/ellipsize/ellipsize-tests.ts
+++ b/types/ellipsize/ellipsize-tests.ts
@@ -1,0 +1,25 @@
+import ellipsize from 'ellipsize';
+
+ellipsize('');
+// ''
+ellipsize(undefined);
+// ''
+ellipsize('one two three four', 8);
+// 'one two…'
+ellipsize('one two-three four', 8);
+// 'one two…'
+ellipsize('one two three four', 100);
+// 'one two three four'
+ellipsize('12345678910');
+// '1234567…'
+ellipsize('abc', 0);
+
+ellipsize('one two&three four', 8, { chars: [' ', '&'], ellipse: '→' });
+// 'one two→'
+
+ellipsize('123456789ABCDEF', 8, { truncate: false });
+// ''
+
+// its default settings
+ellipsize('123456789ABCDEF', 8, { truncate: true });
+// '1234567…'

--- a/types/ellipsize/index.d.ts
+++ b/types/ellipsize/index.d.ts
@@ -1,0 +1,57 @@
+// Type definitions for ellipsize 0.1
+// Project: https://github.com/mvhenten/ellipsize
+// Definitions by: Stefan Natter <https://github.com/natterstefan>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Ellipsizes a string near a word boundary.
+ *
+ * An ellipsized text looks much better if the ellipsize was added at the end of
+ * the last full word instead of somewhere in the middle - especially if there
+ * are very few characters remaining.
+ *
+ * @example
+ * ellipsize('one two three four', 8);
+ * // 'one two…'
+ *
+ * ellipsize('one two three four', 100);
+ * // 'one two three four'
+ *
+ * ellipsize('12345678910')
+ * // '1234567…'
+ *
+ * ellipsize( 'one two&three four', 8, { chars: [' ', '&'], ellipse: '→' });
+ * // 'one two→'
+ *
+ * // its default settings
+ * ellipsize( '123456789ABCDEF', 8, { truncate: true });
+ * // '1234567…'
+ */
+export default function ellipsize(
+    /**
+     * text to ellipsize.
+     */
+    text?: string,
+    /**
+     * maxLength of the text before it is ellipsized (default: 140)
+     */
+    maxLength?: number,
+    /**
+     * additional options to customize the result and rules
+     */
+    options?: {
+        /**
+         * after this char(s) the text can be ellipsized and the ellipse
+         * rendered. (default: [' ', '-'])
+         */
+        chars?: string[];
+        /**
+         * ellipse element (default: '...')
+         */
+        ellipse?: string;
+        /**
+         * truncate the text or not (default: true)
+         */
+        truncate?: boolean;
+    },
+): string;

--- a/types/ellipsize/index.d.ts
+++ b/types/ellipsize/index.d.ts
@@ -27,7 +27,7 @@
  * ellipsize( '123456789ABCDEF', 8, { truncate: true });
  * // '1234567…'
  */
-export default function ellipsize(
+declare function ellipsize(
     /**
      * text to ellipsize.
      */
@@ -55,3 +55,5 @@ export default function ellipsize(
         truncate?: boolean;
     },
 ): string;
+
+export = ellipsize;

--- a/types/ellipsize/tsconfig.json
+++ b/types/ellipsize/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ellipsize-tests.ts"
+    ]
+}

--- a/types/ellipsize/tslint.json
+++ b/types/ellipsize/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.