### PR TITLE
mui-datatables add missing information for customFilterListOptions

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -117,7 +117,7 @@ export interface MUIDataTableFilterOptions {
 
 export interface MUIDataTableCustomFilterListOptions {
     render?: (value: any) => string | string[];
-    update?: (...args: any) => string[];
+    update?: (...args: any[]) => string[];
 }
 
 export interface MUIDataTableColumnState extends MUIDataTableColumnOptions {

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -115,6 +115,11 @@ export interface MUIDataTableFilterOptions {
     logic?: (prop: string, filterValue: any[]) => boolean;
 }
 
+export interface MUIDataTableCustomFilterListOptions {
+    render?: (value: any) => string | string[];
+    update?: (...args: any) => string[];
+}
+
 export interface MUIDataTableColumnState extends MUIDataTableColumnOptions {
     name: string;
     label?: string;
@@ -124,6 +129,7 @@ export interface MUIDataTableColumnOptions {
     customBodyRender?: (value: any, tableMeta: MUIDataTableMeta, updateValue: (value: string) => void) => string | React.ReactNode;
     customHeadRender?: (columnMeta: MUIDataTableCustomHeadRenderer, updateDirection: (params: any) => any) => string | React.ReactNode;
     customFilterListRender?: (value: any) => string;
+    customFilterListOptions?: MUIDataTableCustomFilterListOptions;
     display?: 'true' | 'false' | 'excluded';
     download?: boolean;
     empty?: boolean;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -116,7 +116,7 @@ export interface MUIDataTableFilterOptions {
 }
 
 export interface MUIDataTableCustomFilterListOptions {
-    render?: (value: any) => string | string[];
+    render?: (value: any) => React.ReactNode;
     update?: (...args: any[]) => string[];
 }
 

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -34,6 +34,16 @@ const MuiCustomTable: React.FC<Props> = (props) => {
             }
         },
         {
+            name: 'color',
+            label: 'Color',
+            options: {
+                filter: true,
+                customFilterListOptions: {
+                    render: (value: string) => value.toUpperCase()
+                  },
+            }
+        },
+        {
             name: 'amount',
             label: 'Amount'
         }
@@ -128,11 +138,11 @@ const MuiCustomTable: React.FC<Props> = (props) => {
 };
 
 const TableFruits = [
-    { id: 1, name: "Apple", amount: 1 },
-    { id: 2, name: "Pear", amount: 2 },
-    { id: 3, name: "Strawberry", amount: 5 },
-    { id: 4, name: "Banana", amount: 7 },
-    { id: 5, name: "Orange", amount: 9 },
+    { id: 1, name: "Apple", color: "Red", amount: 1 },
+    { id: 2, name: "Pear", color: "Green", amount: 2 },
+    { id: 3, name: "Strawberry", color: "Red", amount: 5 },
+    { id: 4, name: "Banana", color: "Yellow", amount: 7 },
+    { id: 5, name: "Orange", color: "Orange", amount: 9 },
 ];
 
 const options: MUIDataTableOptions = {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gregnb/mui-datatables/blame/master/README.md#L236
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
