### PR TITLE
update(copy-webpack-plugin): v6 migration

### DIFF
--- a/types/copy-webpack-plugin/copy-webpack-plugin-tests.ts
+++ b/types/copy-webpack-plugin/copy-webpack-plugin-tests.ts
@@ -1,99 +1,295 @@
-import { Configuration } from 'webpack'
-import CopyWebpackPlugin = require('copy-webpack-plugin');
+import { Configuration } from 'webpack';
+import CopyPlugin = require('copy-webpack-plugin');
+import path = require('path');
 
-const c: Configuration = {
+const _: Configuration = {
     plugins: [
-        new CopyWebpackPlugin([
-            // {output}/file.txt
-            { from: 'from/file.txt' },
-
-            // {output}/to/file.txt
-            { from: 'from/file.txt', to: 'to/file.txt' },
-
-            // {output}/to/directory/file.txt
-            { from: 'from/file.txt', to: 'to/directory' },
-
-            // Copy directory contents to {output}/
-            { from: 'from/directory' },
-
-            // Copy directory contents to {output}/to/directory/
-            { from: 'from/directory', to: 'to/directory' },
-
-            // Copy glob results to /absolute/path/
-            { from: 'from/directory/**/*', to: '/absolute/path' },
-
-            // Copy glob results (with dot files) to /absolute/path/
-            {
-                from: {
-                    glob:'from/directory/**/*',
-                    dot: true,
-                },
-                to: '/absolute/path'
-            },
-
-            // Copy glob results, relative to context
-            {
-                context: 'from/directory',
-                from: '**/*',
-                to: '/absolute/path'
-            },
-
-            // {output}/file/without/extension
-            {
-                from: 'path/to/file.txt',
-                to: 'file/without/extension',
-                toType: 'file'
-            },
-
-            // {output}/directory/with/extension.ext/file.txt
-            {
-                from: 'path/to/file.txt',
-                to: 'directory/with/extension.ext',
-                toType: 'dir'
-            },
-
-            // transform and cache (cache is always used with transform option).
-            {
-                from: 'src/*.png',
-                to: 'dest/',
-                transform: (content, path) => content,
-                cache: true
-            },
-
-            // Copy glob results (without dot files) to {output}/to/directory/
-            {
-                from: '**/*.png',
-                to: 'to/directory'
-            },
-
-            // Turns 1st and 2nd level directory names into file name seperated by a dash for png files
-            {
-                from: '*/*',
-                to: '[1]-[2].[hash].[ext]',
-                test: /([^/]+)\/(.+)\.png$/,
-            },
-        ], {
-            // Log only errors
-            logLevel: 'error',
-            
-            // All 'from' paths will be intepreted from this context
-            context: 'app/',
-
-            ignore: [
-                // Doesn't copy any files with a txt extension
-                '*.txt',
-
-                // Doesn't copy any file, even if they start with a dot
-                '**/*',
-
-                // Doesn't copy any file, except if they start with a dot
-                { glob: '**/*', dot: false }
+        // basic
+        new CopyPlugin({
+            patterns: [
+                { from: 'source', to: 'dest' },
+                { from: 'other', to: 'public' },
             ],
-
-            // By default, we only copy modified files during
-            // a watch or webpack-dev-server build. Setting this
-            // to `true` copies all files.
-            copyUnmodified: true,
-        })
-    ]
-}
+        }),
+        // basic options
+        new CopyPlugin({
+            patterns: [
+                { from: 'source', to: 'dest' },
+                { from: 'other', to: 'public' },
+            ],
+            options: {
+                concurrency: 100,
+            },
+        }),
+        // sample
+        new CopyPlugin({
+            patterns: [
+                'relative/path/to/file.ext',
+                'relative/path/to/dir',
+                path.resolve(__dirname, 'src', 'file.ext'),
+                path.resolve(__dirname, 'src', 'dir'),
+                '**/*',
+                {
+                    from: '**/*',
+                },
+                path.posix.join(path.resolve(__dirname, 'src').replace(/\\/g, '/'), '*.txt'),
+            ],
+        }),
+        // from
+        new CopyPlugin({
+            patterns: [
+                'relative/path/to/file.ext',
+                'relative/path/to/dir',
+                path.resolve(__dirname, 'src', 'file.ext'),
+                path.resolve(__dirname, 'src', 'dir'),
+                '**/*',
+                {
+                    from: '**/*',
+                },
+                // If absolute path is a `glob` we replace backslashes with forward slashes, because only forward slashes can be used in the `glob`
+                path.posix.join(path.resolve(__dirname, 'src').replace(/\\/g, '/'), '*.txt'),
+            ],
+        }),
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: path.resolve(__dirname, 'file.txt'),
+                },
+            ],
+        }),
+        new CopyPlugin({
+            patterns: [
+                {
+                    // If absolute path is a `glob` we replace backslashes with forward slashes, because only forward slashes can be used in the `glob`
+                    from: path.posix.join(path.resolve(__dirname, 'fixtures').replace(/\\/g, '/'), '*.txt'),
+                },
+            ],
+        }),
+        // to
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: '**/*',
+                    to: 'relative/path/to/dest/',
+                },
+                {
+                    from: '**/*',
+                    to: '/absolute/path/to/dest/',
+                },
+                {
+                    from: '**/*',
+                    to: '[path][name].[contenthash].[ext]',
+                },
+            ],
+        }),
+        // context
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'src/*.txt',
+                    to: 'dest/',
+                    context: 'app/',
+                },
+            ],
+        }),
+        // globOptions
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'public/**/*',
+                    globOptions: {
+                        dot: true,
+                        gitignore: true,
+                        ignore: ['**/file.*', '**/ignored-directory/**'],
+                    },
+                },
+            ],
+        }),
+        // toType
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'path/to/file.txt',
+                    to: 'directory/with/extension.ext',
+                    toType: 'dir',
+                },
+            ],
+        }),
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'path/to/file.txt',
+                    to: 'file/without/extension',
+                    toType: 'file',
+                },
+            ],
+        }),
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'src/',
+                    to: 'dest/[name].[hash].[ext]',
+                    toType: 'template',
+                },
+            ],
+        }),
+        // force
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'src/**/*',
+                    to: 'dest/',
+                    force: true,
+                },
+            ],
+        }),
+        // flatten
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'src/**/*',
+                    to: 'dest/',
+                    flatten: true,
+                },
+            ],
+        }),
+        // transform
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'src/*.png',
+                    to: 'dest/',
+                    transform(content, absoluteFrom) {
+                        return Promise.resolve('optimized content');
+                    },
+                },
+            ],
+        }),
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'src/*.png',
+                    to: 'dest/',
+                    transform(content, path) {
+                        return Promise.resolve('optimized content');
+                    },
+                },
+            ],
+        }),
+        // cacheTransform
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'src/*.png',
+                    to: 'dest/',
+                    transform(content, path) {
+                        return Promise.resolve('optimized content');
+                    },
+                    cacheTransform: true,
+                },
+            ],
+        }),
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'src/*.png',
+                    to: 'dest/',
+                    transform(content, path) {
+                        return Promise.resolve('optimized content');
+                    },
+                    cacheTransform: path.resolve(__dirname, 'cache-directory'),
+                },
+            ],
+        }),
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'src/*.png',
+                    to: 'dest/',
+                    transform(content, path) {
+                        return Promise.resolve('optimized content');
+                    },
+                    cacheTransform: {
+                        directory: path.resolve(__dirname, 'cache-directory'),
+                        keys: {
+                            key: 'value',
+                        },
+                    },
+                },
+            ],
+        }),
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'src/*.png',
+                    to: 'dest/',
+                    transform(content, path) {
+                        return Promise.resolve('optimized content');
+                    },
+                    cacheTransform: {
+                        directory: path.resolve(__dirname, 'cache-directory'),
+                        keys: (defaultCacheKeys: string[], absoluteFrom: string) => {
+                            const keys: string[] = [];
+                            return {
+                                ...defaultCacheKeys,
+                                keys,
+                            };
+                        },
+                    },
+                },
+            ],
+        }),
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'src/*.png',
+                    to: 'dest/',
+                    transform(content, path) {
+                        return Promise.resolve('optimized content');
+                    },
+                    cacheTransform: {
+                        directory: path.resolve(__dirname, 'cache-directory'),
+                        keys: async (defaultCacheKeys: string[], absoluteFrom: string) => {
+                            const keys: string[] = await Promise.resolve<string[]>([]);
+                            return {
+                                ...defaultCacheKeys,
+                                keys,
+                            };
+                        },
+                    },
+                },
+            ],
+        }),
+        // transformPath
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'src/*.png',
+                    to: 'dest/',
+                    transformPath(targetPath, absolutePath) {
+                        return 'newPath';
+                    },
+                },
+            ],
+        }),
+        // noErrorOnMissing
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: path.resolve(__dirname, 'missing-file.txt'),
+                    noErrorOnMissing: true,
+                },
+            ],
+        }),
+        // concurrency
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: 'src/*.png',
+                    to: 'dest/',
+                },
+            ],
+            options: { concurrency: 50 },
+        }),
+    ],
+};

--- a/types/copy-webpack-plugin/index.d.ts
+++ b/types/copy-webpack-plugin/index.d.ts
@@ -1,94 +1,117 @@
-// Type definitions for copy-webpack-plugin 5.0
+// Type definitions for copy-webpack-plugin 6.0
 // Project: https://github.com/webpack-contrib/copy-webpack-plugin
-// Definitions by:     flying-sheep <https://github.com/flying-sheep>
-//                     avin-kavish  <https://github.com/avin-kavish>
+// Definitions by: flying-sheep <https://github.com/flying-sheep>
+//                 avin-kavish  <https://github.com/avin-kavish>
+//                 Piotr Błażejewicz  <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 /// <reference types="node"/>
 
-import { Plugin, compiler } from 'webpack'
-import { IOptions } from 'minimatch'
+import { Plugin } from 'webpack';
 
-interface MiniMatchGlob extends IOptions {
-    glob: string
-}
+interface ObjectPattern {
+    /**
+     * File source path or glob
+     * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#from}
+     * @default undefined
+     */
+    from: string;
 
-interface MiniMatchOptions extends IOptions {
-    cwd?: string
-}
-
-interface CopyPattern {
-    /** File source path or glob */
-    from: string | MiniMatchGlob
     /**
      * Path or webpack file-loader patterns. defaults:
      * output root if `from` is file or dir.
      * resolved glob path if `from` is glob.
+     * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#to}
+     * @default compiler.options.output
      */
-    to?: string
-    /** A path that determines how to interpret the `from` path. 
-     * 
-     * (default: `options.context | compiler.options.context`) 
-     * */
-    context?: string
+    to?: string;
+
+    /**
+     * A path that determines how to interpret the `from` path.
+     * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#context}
+     * @default options.context | compiler.options.context
+     */
+    context?: string;
+
+    /**
+     * Allows to configure the glob pattern matching library used by the plugin.
+     * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#globoptions}
+     */
+    globOptions?: object;
+
     /**
      * How to interpret `to`. default: undefined
-     * 
      * `file` - if 'to' has extension or 'from' is file.
      * `dir` - if 'from' is directory, 'to' has no extension or ends in '/'.
      * `template` - if 'to' contains a template pattern.
+     * @default undefined
      */
-    toType?: 'file' | 'dir' | 'template'
-    /** 
-     * Pattern for extracting elements to be used in `to` templates. 
-     * 
-     * Defines a `RegExp` to match some parts of the file path. These capture groups can be reused in the name property using [N] 
-     * placeholder. Note that [0] will be replaced by the entire path of the file, whereas [1] will contain the first capturing 
-     * parenthesis of your RegExp and so on...
-     * 
-     * */
-    test?: RegExp
-    /** Overwrites files already in `compilation.assets` (usually added by other plugins; default: `false`) */
-    force?: boolean
-    /** Additional globs to ignore for this pattern. (default: `[]`) */
-    ignore?: Array<string | MiniMatchGlob>
+    toType?: 'file' | 'dir' | 'template';
+
+    /**
+     * Overwrites files already in `compilation.assets` (usually added by other plugins.
+     * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#force}
+     * @default false
+     */
+    force?: boolean;
+
     /**
      * Removes all directory references and only copies file names. (default: `false`)
-     *
-     * If files have the same name, the result is non-deterministic. 
+     * If files have the same name, the result is non-deterministic.
+     * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#flatten}
+     * @default false
      */
-    flatten?: boolean
-    /** Function that modifies file contents before writing to webpack. (default: `(content, path) => content`) */
-    transform?: (content: Buffer, path: string) => string | Buffer | Promise<string | Buffer>
-    /** 
-     * Enable transform caching.  (default: `false`)
-     * 
-     * You can use `{ key: 'my-cache-key' }` to invalidate the cache.  
-     * */
-    cache?: boolean | { key: string }
-    /** 
+    flatten?: boolean;
+
+    /**
+     * Function that modifies file contents before writing to webpack. (default: `(content, path) => content`)
+     * {@link https://webpack.js.org/plugins/copy-webpack-plugin/#transform}
+     * @default undefined
+     */
+    transform?: (content: Buffer, absoluteFrom: string) => string | Buffer | Promise<string | Buffer>;
+
+    /**
+     * Enable/disable and configure caching. Default path to cache directory: node_modules/.cache/copy-webpack-plugin.
+     * @default false
+     */
+    cacheTransform?: boolean | string | object;
+
+    /**
      * Allows to modify the writing path.
-     * 
-     *  Returns the new path or a promise that resolves into the new path
+     * Returns the new path or a promise that resolves into the new path
+     * @default undefined
      */
-    transformPath?: (targetPath: string, absolutePath: string) => string | Promise<string>
+    transformPath?: (targetPath: string, absolutePath: string) => string | Promise<string>;
+
+    /**
+     * Doesn't generate an error on missing file(s);
+     * @default false
+     */
+    noErrorOnMissing?: boolean;
 }
 
-interface CopyWebpackPluginConfiguration {
-    /** Level of messages that the module will log. (default: `'warn'`) */
-    logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
-    /** Array of globs to ignore. (applied to `from`; default: `[]`) */
-    ignore?: Array<string | MiniMatchGlob>
-    /** A path that determines how to interpret the from path, shared for all patterns. default: `'compiler.options.context'` */
-    context?: string
-    /** Copies files, regardless of modification when using `watch` or `webpack-dev-server`. All files are copied on first build, regardless of this option. (default: `false`) */
-    copyUnmodified?: boolean
+type StringPattern = string;
+
+interface Options {
+    /**
+     * Limits the number of simultaneous requests to fs
+     * @default 100
+     */
+    concurrency?: number;
 }
 
-interface CopyWebpackPlugin {
-    new (patterns?: (string | CopyPattern)[], options?: CopyWebpackPluginConfiguration): Plugin
+interface CopyPluginOptions {
+    patterns: ReadonlyArray<StringPattern | ObjectPattern>;
+    options?: Options;
 }
 
-declare const copyWebpackPlugin: CopyWebpackPlugin
-export = copyWebpackPlugin
+interface CopyPlugin {
+    new (options?: CopyPluginOptions): Plugin;
+}
+
+/**
+ * Copy files and directories with webpack
+ */
+declare const copyWebpackPlugin: CopyPlugin;
+
+export = copyWebpackPlugin;

--- a/types/copy-webpack-plugin/tslint.json
+++ b/types/copy-webpack-plugin/tslint.json
@@ -1,13 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "array-type": false,
-        "callable-types": false,
-        "jsdoc-format": false,
-        "no-redundant-jsdoc": false,
-        "no-trailing-whitespace": false,
-        "prefer-method-signature": false,
-        "semicolon": false,
-        "whitespace": false
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/copy-webpack-plugin/v5/copy-webpack-plugin-tests.ts
+++ b/types/copy-webpack-plugin/v5/copy-webpack-plugin-tests.ts
@@ -1,0 +1,99 @@
+import { Configuration } from 'webpack'
+import CopyWebpackPlugin = require('copy-webpack-plugin');
+
+const c: Configuration = {
+    plugins: [
+        new CopyWebpackPlugin([
+            // {output}/file.txt
+            { from: 'from/file.txt' },
+
+            // {output}/to/file.txt
+            { from: 'from/file.txt', to: 'to/file.txt' },
+
+            // {output}/to/directory/file.txt
+            { from: 'from/file.txt', to: 'to/directory' },
+
+            // Copy directory contents to {output}/
+            { from: 'from/directory' },
+
+            // Copy directory contents to {output}/to/directory/
+            { from: 'from/directory', to: 'to/directory' },
+
+            // Copy glob results to /absolute/path/
+            { from: 'from/directory/**/*', to: '/absolute/path' },
+
+            // Copy glob results (with dot files) to /absolute/path/
+            {
+                from: {
+                    glob:'from/directory/**/*',
+                    dot: true,
+                },
+                to: '/absolute/path'
+            },
+
+            // Copy glob results, relative to context
+            {
+                context: 'from/directory',
+                from: '**/*',
+                to: '/absolute/path'
+            },
+
+            // {output}/file/without/extension
+            {
+                from: 'path/to/file.txt',
+                to: 'file/without/extension',
+                toType: 'file'
+            },
+
+            // {output}/directory/with/extension.ext/file.txt
+            {
+                from: 'path/to/file.txt',
+                to: 'directory/with/extension.ext',
+                toType: 'dir'
+            },
+
+            // transform and cache (cache is always used with transform option).
+            {
+                from: 'src/*.png',
+                to: 'dest/',
+                transform: (content, path) => content,
+                cache: true
+            },
+
+            // Copy glob results (without dot files) to {output}/to/directory/
+            {
+                from: '**/*.png',
+                to: 'to/directory'
+            },
+
+            // Turns 1st and 2nd level directory names into file name seperated by a dash for png files
+            {
+                from: '*/*',
+                to: '[1]-[2].[hash].[ext]',
+                test: /([^/]+)\/(.+)\.png$/,
+            },
+        ], {
+            // Log only errors
+            logLevel: 'error',
+            
+            // All 'from' paths will be intepreted from this context
+            context: 'app/',
+
+            ignore: [
+                // Doesn't copy any files with a txt extension
+                '*.txt',
+
+                // Doesn't copy any file, even if they start with a dot
+                '**/*',
+
+                // Doesn't copy any file, except if they start with a dot
+                { glob: '**/*', dot: false }
+            ],
+
+            // By default, we only copy modified files during
+            // a watch or webpack-dev-server build. Setting this
+            // to `true` copies all files.
+            copyUnmodified: true,
+        })
+    ]
+}

--- a/types/copy-webpack-plugin/v5/index.d.ts
+++ b/types/copy-webpack-plugin/v5/index.d.ts
@@ -1,0 +1,94 @@
+// Type definitions for copy-webpack-plugin 5.0
+// Project: https://github.com/webpack-contrib/copy-webpack-plugin
+// Definitions by:     flying-sheep <https://github.com/flying-sheep>
+//                     avin-kavish  <https://github.com/avin-kavish>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node"/>
+
+import { Plugin, compiler } from 'webpack'
+import { IOptions } from 'minimatch'
+
+interface MiniMatchGlob extends IOptions {
+    glob: string
+}
+
+interface MiniMatchOptions extends IOptions {
+    cwd?: string
+}
+
+interface CopyPattern {
+    /** File source path or glob */
+    from: string | MiniMatchGlob
+    /**
+     * Path or webpack file-loader patterns. defaults:
+     * output root if `from` is file or dir.
+     * resolved glob path if `from` is glob.
+     */
+    to?: string
+    /** A path that determines how to interpret the `from` path. 
+     * 
+     * (default: `options.context | compiler.options.context`) 
+     * */
+    context?: string
+    /**
+     * How to interpret `to`. default: undefined
+     * 
+     * `file` - if 'to' has extension or 'from' is file.
+     * `dir` - if 'from' is directory, 'to' has no extension or ends in '/'.
+     * `template` - if 'to' contains a template pattern.
+     */
+    toType?: 'file' | 'dir' | 'template'
+    /** 
+     * Pattern for extracting elements to be used in `to` templates. 
+     * 
+     * Defines a `RegExp` to match some parts of the file path. These capture groups can be reused in the name property using [N] 
+     * placeholder. Note that [0] will be replaced by the entire path of the file, whereas [1] will contain the first capturing 
+     * parenthesis of your RegExp and so on...
+     * 
+     * */
+    test?: RegExp
+    /** Overwrites files already in `compilation.assets` (usually added by other plugins; default: `false`) */
+    force?: boolean
+    /** Additional globs to ignore for this pattern. (default: `[]`) */
+    ignore?: Array<string | MiniMatchGlob>
+    /**
+     * Removes all directory references and only copies file names. (default: `false`)
+     *
+     * If files have the same name, the result is non-deterministic. 
+     */
+    flatten?: boolean
+    /** Function that modifies file contents before writing to webpack. (default: `(content, path) => content`) */
+    transform?: (content: Buffer, path: string) => string | Buffer | Promise<string | Buffer>
+    /** 
+     * Enable transform caching.  (default: `false`)
+     * 
+     * You can use `{ key: 'my-cache-key' }` to invalidate the cache.  
+     * */
+    cache?: boolean | { key: string }
+    /** 
+     * Allows to modify the writing path.
+     * 
+     *  Returns the new path or a promise that resolves into the new path
+     */
+    transformPath?: (targetPath: string, absolutePath: string) => string | Promise<string>
+}
+
+interface CopyWebpackPluginConfiguration {
+    /** Level of messages that the module will log. (default: `'warn'`) */
+    logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
+    /** Array of globs to ignore. (applied to `from`; default: `[]`) */
+    ignore?: Array<string | MiniMatchGlob>
+    /** A path that determines how to interpret the from path, shared for all patterns. default: `'compiler.options.context'` */
+    context?: string
+    /** Copies files, regardless of modification when using `watch` or `webpack-dev-server`. All files are copied on first build, regardless of this option. (default: `false`) */
+    copyUnmodified?: boolean
+}
+
+interface CopyWebpackPlugin {
+    new (patterns?: (string | CopyPattern)[], options?: CopyWebpackPluginConfiguration): Plugin
+}
+
+declare const copyWebpackPlugin: CopyWebpackPlugin
+export = copyWebpackPlugin

--- a/types/copy-webpack-plugin/v5/tsconfig.json
+++ b/types/copy-webpack-plugin/v5/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "paths": {
+            "copy-webpack-plugin": [
+                "copy-webpack-plugin/v5"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "copy-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/copy-webpack-plugin/v5/tslint.json
+++ b/types/copy-webpack-plugin/v5/tslint.json
@@ -1,0 +1,13 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "array-type": false,
+        "callable-types": false,
+        "jsdoc-format": false,
+        "no-redundant-jsdoc": false,
+        "no-trailing-whitespace": false,
+        "prefer-method-signature": false,
+        "semicolon": false,
+        "whitespace": false
+    }
+}


### PR DESCRIPTION
- v5 created for backward compatiblity
- v6 created with migration applied
- types renamed to match current schema used by plugin
- tests amended
- maintainer added

https://github.com/webpack-contrib/copy-webpack-plugin/compare/v5.1.1...v6.0.0

/cc @hsimpson

Thanks!

Fixes #45008

Excerpt from changes:

```md
BREAKING CHANGES
minimum supported Node.js version is 10.13,
the plugin now accepts an object, you should change new CopyPlugin(patterns, options) to new CopyPlugin({ patterns, options })
migrate on compilation.additionalAssets hook
the ignore option was removed in favor globOptions.ignore
the test option was removed in favor the transformPath option
the cache option was renamed to the cacheTransform option, cacheTransform option should have only directory and keys properties when it is an object
global context and ignore options were removed in favor patten.context and pattern.globOptions.ignore options
the missing file error is now an error, before it was a warning
the from option now can only be a string, if you use { from: { glob: 'directory/**', dot: false } } changed it to { from: 'directory/**', globOptions: { dot: false } }
the copyUnmodified was removed without replacements
the 2 version of webpack-dev-server is not supported anymore
the logLever was removed in favor the infrastructureLogging.level option, please read the documentation
Features
implement the concurrency option (#466) (c176d7d)
implement the directory option for the cacheTransform option (29254e3)
implement the noErrorOnMissing option (#475) (e3803ce)
migrate on webpack built-in logger (#446) (5af02bc)
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.