### PR TITLE
[callback-to-async-iterator] Fixes + allow usage of listener return value in onClose

### DIFF
--- a/types/callback-to-async-iterator/callback-to-async-iterator-tests.ts
+++ b/types/callback-to-async-iterator/callback-to-async-iterator-tests.ts
@@ -1,5 +1,9 @@
-import { callbackToAsyncIterator } from "callback-to-async-iterator";
+import callbackToAsyncIterator from "callback-to-async-iterator";
 
-callbackToAsyncIterator(() => {}); // $ExpectType AsyncIterator<unknown, any, undefined>
+callbackToAsyncIterator(async () => {}); // $ExpectType AsyncIterator<unknown, any, undefined>
 
-callbackToAsyncIterator<string>(() => {}); // $ExpectType AsyncIterator<string, any, undefined>
+callbackToAsyncIterator<string>(async () => {}); // $ExpectType AsyncIterator<string, any, undefined>
+
+callbackToAsyncIterator<string>(async () => {}, { onClose() {} }); // $ExpectType AsyncIterator<string, any, undefined>
+
+callbackToAsyncIterator<string, number>(async () => 1, { onClose(arg: number) {} });  // $ExpectType AsyncIterator<string, any, undefined>

--- a/types/callback-to-async-iterator/index.d.ts
+++ b/types/callback-to-async-iterator/index.d.ts
@@ -1,16 +1,17 @@
 // Type definitions for callback-to-async-iterator 1.1
 // Project: https://github.com/withspectrum/callback-to-async-iterator#readme
 // Definitions by: Zachary Svoboda <https://github.com/zacnomore>
+//                 Affan Shahid <https://github.com/affanshahid>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.6
 
-export interface AsyncifyOptions<T> {
-    onClose: () => void | T;
-    onError: () => Error;
-    buffering: boolean;
+export interface AsyncifyOptions<T, R> {
+    onClose?: (arg: R) => void | T;
+    onError?: () => Error;
+    buffering?: boolean;
 }
 
-export function callbackToAsyncIterator<T>(
-    listener: (callback: (message: T) => void) => void,
-    options?: AsyncifyOptions<T>,
+export default function callbackToAsyncIterator<T, R = void>(
+    listener: (callback: (message: T) => void) => Promise<R>,
+    options?: AsyncifyOptions<T, R>,
 ): AsyncIterator<T>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source](https://github.com/withspectrum/callback-to-async-iterator/blob/master/src/index.js)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (**see note at the end**)
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The previous types had some errors which are fixed in this PR. 
For one the previous types referred to a named export whereas the library has a [default export for its major function](https://github.com/withspectrum/callback-to-async-iterator/blob/c4f5c27a066aa1e5c1a0316e73c239cf52387302/src/index.js#L97) 

The previous types also lacked the typing to enforce that the listener argument had to return a promise as evident [here](https://github.com/withspectrum/callback-to-async-iterator/blob/c4f5c27a066aa1e5c1a0316e73c239cf52387302/src/index.js#L11) and [here](https://github.com/withspectrum/callback-to-async-iterator/blob/c4f5c27a066aa1e5c1a0316e73c239cf52387302/src/index.js#L26)

Finally I have also added type information to use the returned and resolved value of the listener in the `onClose()` callback. Seen [here](https://github.com/withspectrum/callback-to-async-iterator/blob/c4f5c27a066aa1e5c1a0316e73c239cf52387302/src/index.js#L57)

**Important**: This PR introduces *breaking type changes*. The library has not actually changed, its just that the previous types were slightly incorrect. Since the library hasn't changed I have left the version in the header as it was before, if that is not suitable and something else needs to be done about this please let me know.