### PR TITLE
Create @types/aws-elasticsearch-connector

### DIFF
--- a/types/aws-elasticsearch-connector/aws-elasticsearch-connector-tests.ts
+++ b/types/aws-elasticsearch-connector/aws-elasticsearch-connector-tests.ts
@@ -1,0 +1,5 @@
+import { Connection, Transport } from '@elastic/elasticsearch';
+import { AmazonConnection, AmazonTransport } from 'aws-elasticsearch-connector';
+
+AmazonConnection; // $ExpectType Connection
+AmazonTransport; // $ExpectType Transport

--- a/types/aws-elasticsearch-connector/index.d.ts
+++ b/types/aws-elasticsearch-connector/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for aws-elasticsearch-connector 8.2
+// Project: https://github.com/compwright/aws-elasticsearch-connector#readme
+// Definitions by: Paul Draper <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Connection, Transport } from '@elastic/elasticsearch';
+
+class AmazonConnection extends Connection {}
+class AmazonTransport extends Transport {}
+
+export const AmazonConnection: AmazonConnection;
+export const AmazonTransport: AmazonTransport;

--- a/types/aws-elasticsearch-connector/package.json
+++ b/types/aws-elasticsearch-connector/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@elastic/elasticsearch": ">=7.0"
+    }
+}

--- a/types/aws-elasticsearch-connector/tsconfig.json
+++ b/types/aws-elasticsearch-connector/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "aws-elasticsearch-connector-tests.ts"
+    ]
+}

--- a/types/aws-elasticsearch-connector/tslint.json
+++ b/types/aws-elasticsearch-connector/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.