### PR TITLE
Add definitions for edit-json-file 1.4

### DIFF
--- a/types/edit-json-file/edit-json-file-tests.ts
+++ b/types/edit-json-file/edit-json-file-tests.ts
@@ -1,13 +1,14 @@
 import * as editJsonFile from 'edit-json-file';
 
-const jsonEditor: editJsonFile.JsonEditor = editJsonFile('1.json');
+const jsonEditor: editJsonFile.JsonEditor = editJsonFile('1.json'); // $ExpectType JsonEditor
+jsonEditor.set('a', 2); // $ExpectType JsonEditor
+jsonEditor.set('b', []); // $ExpectType JsonEditor
+jsonEditor.unset('b'); // $ExpectType JsonEditor
+jsonEditor.get('a'); // $ExpectType any
 const options: editJsonFile.Options = { autosave: true };
-const jsonEditorWithOptions: editJsonFile.JsonEditor = editJsonFile('2.json', options);
-jsonEditorWithOptions.set('a', 2);
-jsonEditorWithOptions.set('b', []);
-jsonEditorWithOptions.unset('b');
-const a: number = jsonEditorWithOptions.get('a');
-jsonEditorWithOptions.write(`{"c":${a}}`);
-jsonEditorWithOptions.empty();
-jsonEditorWithOptions.save(err => console.log(err));
-const data: object = jsonEditorWithOptions.toObject();
+const jsonEditorWithOptions: editJsonFile.JsonEditor = editJsonFile('2.json', options); // $ExpectType JsonEditor
+jsonEditorWithOptions.read(); // $ExpectType object
+jsonEditorWithOptions.write(`{"c":7}`); // $ExpectType JsonEditor
+jsonEditorWithOptions.empty(); // $ExpectType JsonEditor
+jsonEditorWithOptions.save(err => console.log(err)); // $ExpectType JsonEditor
+jsonEditorWithOptions.toObject(); // $ExpectType object

--- a/types/edit-json-file/edit-json-file-tests.ts
+++ b/types/edit-json-file/edit-json-file-tests.ts
@@ -1,0 +1,13 @@
+import * as editJsonFile from 'edit-json-file';
+
+const jsonEditor: editJsonFile.JsonEditor = editJsonFile('1.json');
+const options: editJsonFile.Options = { autosave: true };
+const jsonEditorWithOptions: editJsonFile.JsonEditor = editJsonFile('2.json', options);
+jsonEditorWithOptions.set('a', 2);
+jsonEditorWithOptions.set('b', []);
+jsonEditorWithOptions.unset('b');
+const a: number = jsonEditorWithOptions.get('a');
+jsonEditorWithOptions.write(`{"c":${a}}`);
+jsonEditorWithOptions.empty();
+jsonEditorWithOptions.save(err => console.log(err));
+const data: object = jsonEditorWithOptions.toObject();

--- a/types/edit-json-file/index.d.ts
+++ b/types/edit-json-file/index.d.ts
@@ -17,8 +17,7 @@ declare namespace editJsonFile {
     }
 
     /** JSON file editor. */
-    class JsonEditor {
-        constructor(path: string, options?: Options);
+    interface JsonEditor {
         /** Get value at path. */
         get(path?: string): any;
         /** Set value at path. */

--- a/types/edit-json-file/index.d.ts
+++ b/types/edit-json-file/index.d.ts
@@ -19,22 +19,22 @@ declare namespace editJsonFile {
     /** JSON file editor. */
     class JsonEditor {
         constructor(path: string, options?: Options);
+        /** Get value at path. */
+        get(path: string): any;
         /** Set value at path. */
         set(path: string, value: any): JsonEditor;
         /** Unset value at path. */
         unset(path: string): JsonEditor;
-        /** Get value at path. */
-        get(path: string): any;
         /** Read the JSON file. */
-        read(cb: NoParamCallback): any;
+        read(cb?: NoParamCallback): object;
         /** Overwrite the JSON file. */
         write(content: string, cb?: NoParamCallback): JsonEditor;
         /** Empty the JSON file. */
         empty(cb?: NoParamCallback): JsonEditor;
         /** Save the JSON file back to disk. */
         save(cb?: NoParamCallback): JsonEditor;
-        /** Get f */
-        toObject(): any;
+        /** Get full object. */
+        toObject(): object;
     }
 }
 

--- a/types/edit-json-file/index.d.ts
+++ b/types/edit-json-file/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for edit-json-file 1.4
+// Project: https://github.com/IonicaBizau/edit-json-file#readme
+// Definitions by: Twixes <https://github.com/Twixes>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types= "node" />
+
+import { NoParamCallback } from 'fs';
+
+declare namespace editJsonFile {
+    /** JSON file editor options. */
+    interface Options {
+        stringify_width?: number;
+        stringify_fn?: (data: object) => string;
+        stringify_eol?: boolean;
+        autosave?: boolean;
+    }
+
+    /** JSON file editor. */
+    class JsonEditor {
+        constructor(path: string, options?: Options);
+        /** Set value at path. */
+        set(path: string, value: any): JsonEditor;
+        /** Unset value at path. */
+        unset(path: string): JsonEditor;
+        /** Get value at path. */
+        get(path: string): any;
+        /** Read the JSON file. */
+        read(cb: NoParamCallback): any;
+        /** Overwrite the JSON file. */
+        write(content: string, cb?: NoParamCallback): JsonEditor;
+        /** Empty the JSON file. */
+        empty(cb?: NoParamCallback): JsonEditor;
+        /** Save the JSON file back to disk. */
+        save(cb?: NoParamCallback): JsonEditor;
+        /** Get f */
+        toObject(): any;
+    }
+}
+
+/** Create a JSON file editor. */
+declare function editJsonFile(path: string, options?: editJsonFile.Options): editJsonFile.JsonEditor;
+
+export = editJsonFile;

--- a/types/edit-json-file/index.d.ts
+++ b/types/edit-json-file/index.d.ts
@@ -20,7 +20,7 @@ declare namespace editJsonFile {
     class JsonEditor {
         constructor(path: string, options?: Options);
         /** Get value at path. */
-        get(path: string): any;
+        get(path?: string): any;
         /** Set value at path. */
         set(path: string, value: any): JsonEditor;
         /** Unset value at path. */

--- a/types/edit-json-file/tsconfig.json
+++ b/types/edit-json-file/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "edit-json-file-tests.ts"
+    ]
+}

--- a/types/edit-json-file/tslint.json
+++ b/types/edit-json-file/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.