### PR TITLE
update(loader-utils): v2.0 migration

### DIFF
--- a/types/loader-utils/index.d.ts
+++ b/types/loader-utils/index.d.ts
@@ -1,32 +1,75 @@
-// Type definitions for loader-utils 1.1
+// Type definitions for loader-utils 2.0
 // Project: https://github.com/webpack/loader-utils#readme
 // Definitions by: Gyusun Yeom <https://github.com/Perlmint>
 //                 Totooria Hyperion <https://github.com/TotooriaHyperion>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 /// <reference types="node" />
 
 import { loader } from 'webpack';
+
+export type Readonly<T> = {
+    readonly [P in keyof T]: T[P];
+};
 
 export interface InterpolateOption {
     context?: string;
     content?: string | Buffer;
     regExp?: string | RegExp;
 }
-export interface OptionObject {
-    [key: string]: any;
-}
-export type HashType = "sha1" | "md5" | "sha256" | "sha512";
-export type DigestType = "hex" | "base26" | "base32" | "base36" | "base49" | "base52" | "base58" | "base62" | "base64";
 
-export function getOptions(loaderContext: loader.LoaderContext): OptionObject;
+export interface OptionObject {
+    [key: string]: null | false | true | string;
+}
+
+export type HashType = 'sha1' | 'md4' | 'md5' | 'sha256' | 'sha512';
+
+export type DigestType = 'hex' | 'base26' | 'base32' | 'base36' | 'base49' | 'base52' | 'base58' | 'base62' | 'base64';
+
+/**
+ * Recommended way to retrieve the options of a loader invocation
+ * {@link https://github.com/webpack/loader-utils#getoptions}
+ */
+export function getOptions(loaderContext: loader.LoaderContext): Readonly<OptionObject> | null;
+
+/**
+ * Parses a passed string (e.g. loaderContext.resourceQuery) as a query string, and returns an object.
+ * {@link https://github.com/webpack/loader-utils#parsequery}
+ */
 export function parseQuery(optionString: string): OptionObject;
+
+/**
+ * Turns a request into a string that can be used inside require() or import while avoiding absolute paths. Use it instead of JSON.stringify(...) if you're generating code inside a loader.
+ * {@link https://github.com/webpack/loader-utils#stringifyrequest}
+ */
 export function stringifyRequest(loaderContext: loader.LoaderContext, resource: string): string;
+
 export function getRemainingRequest(loaderContext: loader.LoaderContext): string;
+
 export function getCurrentRequest(loaderContext: loader.LoaderContext): string;
+
 export function isUrlRequest(url: string, root?: string): boolean;
+
 export function parseString(str: string): string;
+
+/**
+ * Converts some resource URL to a webpack module request.
+ * {@link https://github.com/webpack/loader-utils#urltorequest}
+ */
 export function urlToRequest(url: string, root?: string): string;
+
+/**
+ * Interpolates a filename template using multiple placeholders and/or a regular expression.
+ * The template and regular expression are set as query params called name and regExp on the current loader's context.
+ * {@link https://github.com/webpack/loader-utils#interpolatename}
+ */
 export function interpolateName(loaderContext: loader.LoaderContext, name: string, options?: any): string;
+
+/**
+ * @param buffer
+ * @param [hashType='md4']
+ * @param [digestType='hex']
+ * @param [maxLength=9999]
+ */
 export function getHashDigest(buffer: Buffer, hashType: HashType, digestType: DigestType, maxLength: number): string;

--- a/types/loader-utils/v1/index.d.ts
+++ b/types/loader-utils/v1/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for loader-utils 1.1
+// Project: https://github.com/webpack/loader-utils#readme
+// Definitions by: Gyusun Yeom <https://github.com/Perlmint>
+//                 Totooria Hyperion <https://github.com/TotooriaHyperion>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node" />
+
+import { loader } from 'webpack';
+
+export interface InterpolateOption {
+    context?: string;
+    content?: string | Buffer;
+    regExp?: string | RegExp;
+}
+export interface OptionObject {
+    [key: string]: any;
+}
+export type HashType = "sha1" | "md5" | "sha256" | "sha512";
+export type DigestType = "hex" | "base26" | "base32" | "base36" | "base49" | "base52" | "base58" | "base62" | "base64";
+
+export function getOptions(loaderContext: loader.LoaderContext): OptionObject;
+export function parseQuery(optionString: string): OptionObject;
+export function stringifyRequest(loaderContext: loader.LoaderContext, resource: string): string;
+export function getRemainingRequest(loaderContext: loader.LoaderContext): string;
+export function getCurrentRequest(loaderContext: loader.LoaderContext): string;
+export function isUrlRequest(url: string, root?: string): boolean;
+export function parseString(str: string): string;
+export function urlToRequest(url: string, root?: string): string;
+export function interpolateName(loaderContext: loader.LoaderContext, name: string, options?: any): string;
+export function getHashDigest(buffer: Buffer, hashType: HashType, digestType: DigestType, maxLength: number): string;

--- a/types/loader-utils/v1/loader-utils-tests.ts
+++ b/types/loader-utils/v1/loader-utils-tests.ts
@@ -23,11 +23,6 @@ jsonStr === parsed; // true
 function loader(this: loader.LoaderContext) {
     getOptions(this);
 
-    // get options readonly
-    const options = getOptions(this);
-    // $ExpectError
-    options.prop = {};
-
     getRemainingRequest(this);
 
     getCurrentRequest(this);

--- a/types/loader-utils/v1/tsconfig.json
+++ b/types/loader-utils/v1/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "paths": {
+            "loader-utils": [
+                "loader-utils/v1"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "loader-utils-tests.ts"
+    ]
+}

--- a/types/loader-utils/v1/tslint.json
+++ b/types/loader-utils/v1/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- v1 created
- v2 version bump
  - refined return object allowed values
  - 'md4' hahs type support (now default one in v2)
  - options returned are now read only as per v2 docs

https://github.com/webpack/loader-utils/releases/tag/v2.0.0
https://github.com/webpack/loader-utils/compare/v1.4.0...v2.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)