### PR TITLE
fix(koa-generic-session): add null maxAge on cookie opts

### DIFF
--- a/types/koa-generic-session/index.d.ts
+++ b/types/koa-generic-session/index.d.ts
@@ -34,7 +34,7 @@ declare namespace koaSession {
             path?: string;
             rewrite?: boolean;
             signed?: boolean;
-            maxAge?: number;
+            maxAge?: number | null;
             secure?: boolean;
             httpOnly?: boolean;
             sameSite?: boolean | "lax" | "none" | "strict";


### PR DESCRIPTION
According to https://github.com/koajs/generic-session#options, allow using null on maxAge for setting a session cookie.