### PR TITLE
[react-stickynode] Update types to match version 3.0.2

### DIFF
--- a/types/react-stickynode/index.d.ts
+++ b/types/react-stickynode/index.d.ts
@@ -68,7 +68,7 @@ declare namespace Sticky {
         activeClass?: string;
 
         /**
-         * 	Class name to be applied to the inner element ('' by default).
+         * Class name to be applied to the inner element ('' by default).
          */
         innerClass?: string;
 

--- a/types/react-stickynode/index.d.ts
+++ b/types/react-stickynode/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-stickynode 3.0.2
+// Type definitions for react-stickynode 3.0
 // Project: https://github.com/yahoo/react-stickynode
 // Definitions by: Tim Stirrat <https://github.com/tstirrat>
 //                 Kamil Socha <https://github.com/ksocha>

--- a/types/react-stickynode/index.d.ts
+++ b/types/react-stickynode/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for react-stickynode 2.1
+// Type definitions for react-stickynode 3.0.2
 // Project: https://github.com/yahoo/react-stickynode
 // Definitions by: Tim Stirrat <https://github.com/tstirrat>
 //                 Kamil Socha <https://github.com/ksocha>
+//                 Mirek Ciastek <https://github.com/mciastek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -40,16 +41,16 @@ declare namespace Sticky {
 
         /**
          * The offset from the top of window where the top of the element will
-         * be when sticky state is triggered(0 by default ).If it is a selector
-         * to a target(via `querySelector()`), the offset will be the height of
+         * be when sticky state is triggered(0 by default ). If it is a selector
+         * to a target (via `querySelector()`), the offset will be the height of
          * the target.
          */
         top?: number | string;
 
         /**
          * The offset from the top of document which release state will be
-         * triggered when the bottom of the element reaches at.If it is a
-         * selector to a target(via `querySelector()`), the offset will be the
+         * triggered when the bottom of the element reaches at. If it is a
+         * selector to a target (via `querySelector()`), the offset will be the
          * bottom of the target.
          */
         bottomBoundary?: number | string;
@@ -57,18 +58,23 @@ declare namespace Sticky {
         /** z-index of the sticky */
         innerZ?: number | string;
 
-        /** Enable the use of CSS3 transforms (true by default). */
+        /** Enable the use of CSS3 transforms (`true` by default). */
         enableTransforms?: boolean;
 
         /**
          * Class name to be applied to the element when the sticky state is
-         * active (active by default).
+         * active ('active' by default).
          */
         activeClass?: string;
 
         /**
+         * 	Class name to be applied to the inner element ('' by default).
+         */
+        innerClass?: string;
+
+        /**
          * Class name to be applied to the element when the sticky state is
-         * released (released by default).
+         * released ('released' by default).
          */
         releasedClass?: string;
 

--- a/types/react-stickynode/react-stickynode-tests.tsx
+++ b/types/react-stickynode/react-stickynode-tests.tsx
@@ -10,6 +10,7 @@ const StickyAllOptions: JSX.Element = (
         enableTransforms={true}
         activeClass="active"
         releasedClass="released"
+        innerClass="innerClass"
         onStateChange={s => s.status === Sticky.StatusCode.STATUS_ORIGINAL}
         shouldFreeze={() => false}
     >


### PR DESCRIPTION
This PR updates `react-stickynode` type definitions to match latest version ([3.0.2](https://github.com/yahoo/react-stickynode/releases/tag/v3.0.2))

Changes:
https://github.com/yahoo/react-stickynode/compare/v2.1.0...v3.0.2
