### PR TITLE
fix(lusca): missing CSRF 'header' base property

### DIFF
--- a/types/lusca/index.d.ts
+++ b/types/lusca/index.d.ts
@@ -1,8 +1,9 @@
 // Type definitions for lusca 1.6
 // Project: https://github.com/krakenjs/lusca#readme
-// Definitions by: Corbin Crutchley <https://github.com/crutchcorn>, Naoto Yokoyama <https://github.com/builtinnya>
+// Definitions by: Corbin Crutchley <https://github.com/crutchcorn>
+//                 Naoto Yokoyama <https://github.com/builtinnya>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 import express = require('express');
 
@@ -40,9 +41,24 @@ declare namespace lusca {
     type csrfOptions = csrfOptionsBase & csrfOptionsAngularOrNonAngular & csrfOptionsBlacklistOrWhitelist;
 
     interface csrfOptionsBase {
+        /**
+         * The name of the CSRF token in the model.
+         * @default '_csrf'
+         */
         key?: string;
+        /**
+         * @default '_csrfSecret'
+         */
         secret?: string;
+        /**
+         *  An object with create/validate methods for custom tokens
+         */
         impl?: () => any;
+        /**
+         * The name of the response header containing the CSRF token
+         * @default 'x-csrf-token'
+         */
+        header?: string;
     }
 
     interface csrfOptionsAngular {

--- a/types/lusca/lusca-tests.ts
+++ b/types/lusca/lusca-tests.ts
@@ -15,7 +15,7 @@ app.use(lusca({
 }));
 
 app.use(lusca.csrf());
-app.use(lusca.csrf({cookie: {name: 'csrf'}}));
+app.use(lusca.csrf({cookie: {name: 'csrf'}, header: 'x-csrf-token'}));
 app.use(lusca.csrf({cookie: 'csrf', angular: true}));
 app.use(lusca.csrf({blacklist: ['/blacklist']}));
 app.use(lusca.csrf({whitelist: ['/whitelist']}));


### PR DESCRIPTION
- `heaer` property added
- JSDoc comments added to the base options
- test amended

https://github.com/krakenjs/lusca/blob/0483eda77a6fcef08d9319369e1f2b6fd2a5dcba/lib/csrf.js#L49

/cc @shwao

Thanks!

Fixes #45040

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes