### PR TITLE
fix(current-git-branch): narrow return type to `string | false`

### DIFF
--- a/types/current-git-branch/index.d.ts
+++ b/types/current-git-branch/index.d.ts
@@ -7,7 +7,7 @@
 
 declare namespace CurrentGitBranch {
     type CurrentGitBranchOptions = CurrentGitBranchOptionsObject | string[] | string;
-    type CurrentGitBranchResult = string | boolean;
+    type CurrentGitBranchResult = string | false;
 
     interface CurrentGitBranchOptionsObject {
         altPath?: string;


### PR DESCRIPTION
the `boolean` is less specific than the actual implementation, which just returns `false` as an error indicator: https://github.com/JPeer264/node-current-git-branch#usage

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
~~- [ ] Test the change in your own code. (Compile and run.)~~
~~- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)~~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
~~- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).~~

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JPeer264/node-current-git-branch#usage
~~- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
~~- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)~~
~~- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~