### PR TITLE
[dropzone] Add displayExistingFile

### DIFF
--- a/types/dropzone/dropzone-tests.ts
+++ b/types/dropzone/dropzone-tests.ts
@@ -251,7 +251,7 @@ dropzone.createThumbnail(
     },
 );
 
-const mockFile: Dropzone.DropZoneMockFile = {
+const mockFile: Dropzone.DropzoneMockFile = {
     name: 'Mock File',
     size: 123456,
     customProperty: 'additional data',

--- a/types/dropzone/dropzone-tests.ts
+++ b/types/dropzone/dropzone-tests.ts
@@ -251,6 +251,41 @@ dropzone.createThumbnail(
     },
 );
 
+const mockFile: Dropzone.DropZoneMockFile = {
+    name: 'Mock File',
+    size: 123456,
+    customProperty: 'additional data',
+};
+dropzone.displayExistingFile(mockFile, 'https://example.com/original.jpeg');
+dropzone.displayExistingFile(mockFile, 'https://example.com/original.jpeg', () => {
+    console.log('displayExistingFile');
+});
+dropzone.displayExistingFile(
+    mockFile,
+    'https://example.com/original.jpeg',
+    () => {
+        console.log('displayExistingFile');
+    },
+    undefined,
+);
+dropzone.displayExistingFile(
+    mockFile,
+    'https://example.com/original.jpeg',
+    () => {
+        console.log('displayExistingFile');
+    },
+    'anonymous',
+);
+dropzone.displayExistingFile(
+    mockFile,
+    'https://example.com/original.jpeg',
+    () => {
+        console.log('displayExistingFile');
+    },
+    'anonymous',
+    false,
+);
+
 dropzone.createThumbnailFromUrl(firstFile);
 dropzone.createThumbnailFromUrl(firstFile, dropzone.defaultOptions.resizeWidth);
 dropzone.createThumbnailFromUrl(firstFile, dropzone.defaultOptions.resizeWidth, dropzone.defaultOptions.resizeHeight);

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -237,7 +237,7 @@ declare class Dropzone {
     displayExistingFile(
         mockFile: Dropzone.DropzoneMockFile,
         imageUrl: string,
-        callback?: (...args: any[]) => void,
+        callback?: () => void,
         crossOrigin?: 'anonymous' | 'use-credentials',
         resizeThumbnail?: boolean,
     ): any;

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -46,7 +46,7 @@ declare namespace Dropzone {
         upload?: DropzoneFileUpload;
     }
 
-    export interface DropZoneMockFile {
+    export interface DropzoneMockFile {
         name: string;
         size: number;
         [index: string]: any;
@@ -235,7 +235,7 @@ declare class Dropzone {
     ): any;
 
     displayExistingFile(
-        mockFile: Dropzone.DropZoneMockFile,
+        mockFile: Dropzone.DropzoneMockFile,
         imageUrl: string,
         callback?: (...args: any[]) => void,
         crossOrigin?: 'anonymous' | 'use-credentials',

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Dropzone 5.5.0
+// Type definitions for Dropzone 5.7.0
 // Project: http://www.dropzonejs.com/
 // Definitions by: Natan Vivo <https://github.com/nvivo>
 //                 Andy Hawkins <https://github.com/a904guy/,http://a904guy.com/,http://www.bmbsqd.com>
@@ -44,6 +44,12 @@ declare namespace Dropzone {
         accepted: boolean;
         xhr?: XMLHttpRequest;
         upload?: DropzoneFileUpload;
+    }
+
+    export interface DropZoneMockFile {
+        name: string;
+        size: number;
+        [index: string]: any;
     }
 
     export interface DropzoneDictFileSizeUnits {
@@ -226,6 +232,14 @@ declare class Dropzone {
         resizeMethod?: string,
         fixOrientation?: boolean,
         callback?: (...args: any[]) => void,
+    ): any;
+
+    displayExistingFile(
+        mockFile: Dropzone.DropZoneMockFile,
+        imageUrl: string,
+        callback?: (...args: any[]) => void,
+        crossOrigin?: 'anonymous' | 'use-credentials',
+        resizeThumbnail?: boolean,
     ): any;
 
     createThumbnailFromUrl(


### PR DESCRIPTION
This adds Dropzone definitions to version 5.7.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Official](https://www.dropzonejs.com/#dropzone-methods) [sources](https://gitlab.com/meno/dropzone/-/commit/f6ea2bc84b0227897aafe635ae92baf37dc5619b) [here](https://gitlab.com/meno/dropzone/-/wikis/FAQ#how-to-show-files-already-stored-on-server). Source for [`crossOrigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-crossorigin).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
