### PR TITLE
Add missing import for @types/google-map-react

### DIFF
--- a/types/google-map-react/OTHER_FILES.txt
+++ b/types/google-map-react/OTHER_FILES.txt
@@ -1,1 +1,0 @@
-utils.d.ts

--- a/types/google-map-react/google-map-react-tests.tsx
+++ b/types/google-map-react/google-map-react-tests.tsx
@@ -1,4 +1,8 @@
-import GoogleMapReact, { BootstrapURLKeys, MapOptions } from 'google-map-react';
+import GoogleMapReact, {
+    BootstrapURLKeys, MapOptions, NESWBounds,
+    Size
+} from 'google-map-react';
+import fitBounds from 'google-map-react/utils'
 import * as React from 'react';
 
 const center = { lat: 0, lng: 0 };
@@ -29,3 +33,18 @@ const options: MapOptions = {
 };
 
 <GoogleMapReact center={center} heatmapLibrary={true} zoom={3} bootstrapURLKeys={client} options={options} />;
+
+
+const bounds : NESWBounds = {
+    nw: {
+      lat: 50,
+      lng: 15,
+    }
+}
+
+const size : Size = {
+    width: 1280,
+    height: 640
+}
+
+fitBounds(bounds, size)

--- a/types/google-map-react/google-map-react-tests.tsx
+++ b/types/google-map-react/google-map-react-tests.tsx
@@ -2,7 +2,7 @@ import GoogleMapReact, {
     BootstrapURLKeys, MapOptions, NESWBounds,
     Size
 } from 'google-map-react';
-import fitBounds from 'google-map-react/utils'
+import { fitBounds } from 'google-map-react/utils'
 import * as React from 'react';
 
 const center = { lat: 0, lng: 0 };

--- a/types/google-map-react/google-map-react-tests.tsx
+++ b/types/google-map-react/google-map-react-tests.tsx
@@ -36,8 +36,12 @@ const options: MapOptions = {
 
 const bounds: NESWBounds = {
     ne: {
-      lat: 50,
-      lng: 15,
+      lat: 55,
+      lng: 10,
+    },
+    sw: {
+      lat: 45,
+      lng: 20,
     }
 };
 

--- a/types/google-map-react/google-map-react-tests.tsx
+++ b/types/google-map-react/google-map-react-tests.tsx
@@ -2,7 +2,7 @@ import GoogleMapReact, {
     BootstrapURLKeys, MapOptions, NESWBounds,
     Size
 } from 'google-map-react';
-import { fitBounds } from 'google-map-react/utils'
+import { fitBounds } from 'google-map-react/utils';
 import * as React from 'react';
 
 const center = { lat: 0, lng: 0 };
@@ -34,17 +34,16 @@ const options: MapOptions = {
 
 <GoogleMapReact center={center} heatmapLibrary={true} zoom={3} bootstrapURLKeys={client} options={options} />;
 
-
-const bounds : NESWBounds = {
-    nw: {
+const bounds: NESWBounds = {
+    ne: {
       lat: 50,
       lng: 15,
     }
-}
+};
 
-const size : Size = {
+const size: Size = {
     width: 1280,
     height: 640
-}
+};
 
-fitBounds(bounds, size)
+fitBounds(bounds, size);

--- a/types/google-map-react/utils.d.ts
+++ b/types/google-map-react/utils.d.ts
@@ -1,6 +1,6 @@
 import { Bounds, Coords, Point, Size, NESWBounds } from '.';
 
-interface Tile extends Point {
+export interface Tile extends Point {
     zoom: number;
 }
 

--- a/types/google-map-react/utils.d.ts
+++ b/types/google-map-react/utils.d.ts
@@ -1,4 +1,4 @@
-import { Bounds, Coords, Point, Size } from '.';
+import { Bounds, Coords, Point, Size, NESWBounds } from '.';
 
 interface Tile extends Point {
     zoom: number;


### PR DESCRIPTION
There are no new types or functionality added or removed in this PR. It is just a missing import fix.

There is missing reference causing tsc to fail in typescript projects calling the fitBounds method.

![image](https://user-images.githubusercontent.com/5519597/82879723-a6e3f480-9f3d-11ea-8dc2-267a635ff147.png)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/google-map-react/google-map-react/blob/master/API.md#fitbounds-func

