### PR TITLE
[node-pdftk] fix: input function accepts also a Buffer

### DIFF
--- a/types/node-pdftk/index.d.ts
+++ b/types/node-pdftk/index.d.ts
@@ -255,5 +255,5 @@ export interface ConfigureOptions {
     tempDir: string;
 }
 
-export function input(file: string): PDFTK;
+export function input(file: string | Buffer): PDFTK;
 export function configure(opts: ConfigureOptions): void;

--- a/types/node-pdftk/node-pdftk-tests.ts
+++ b/types/node-pdftk/node-pdftk-tests.ts
@@ -7,13 +7,22 @@ PDFTK.configure({
     tempDir: './pdftk',
 });
 
-const pdftk = PDFTK.input('file'); // $ExpectType PDFTK
+[
+    {
+        input: 'string',
+    },
+    {
+        input: Buffer.from('buffer'),
+    },
+].forEach(scenario => {
+    const pdftk = PDFTK.input(scenario.input); // $ExpectType PDFTK
 
-pdftk.allow(['FillIn']).attachFiles(['./file1.pdf', './file2.pdf']); // $ExpectType PDFTK
+    pdftk.allow(['FillIn']).attachFiles(['./file1.pdf', './file2.pdf']); // $ExpectType PDFTK
 
-pdftk.allow(['FillIn']).compress().output('./fileoutput.pdf'); // $ExpectType Promise<Buffer>
-pdftk.allow(['FillIn']).compress().output('./fileoutput.pdf', './destination/folder'); // $ExpectType Promise<string>
-pdftk.allow(['FillIn']).compress().output(); // $ExpectType Promise<Buffer>
+    pdftk.allow(['FillIn']).compress().output('./fileoutput.pdf'); // $ExpectType Promise<Buffer>
+    pdftk.allow(['FillIn']).compress().output('./fileoutput.pdf', './destination/folder'); // $ExpectType Promise<string>
+    pdftk.allow(['FillIn']).compress().output(); // $ExpectType Promise<Buffer>
 
-PDFTK.input('file').flatten().ignoreWarnings().inputPw('password').burst('page_%02d.pdf'); // $ExpectType Promise<string>
-PDFTK.input('file').flatten().ignoreWarnings().inputPw('password').burst(); // $ExpectType Promise<Buffer>
+    PDFTK.input(scenario.input).flatten().ignoreWarnings().inputPw('password').burst('page_%02d.pdf'); // $ExpectType Promise<string>
+    PDFTK.input(scenario.input).flatten().ignoreWarnings().inputPw('password').burst(); // $ExpectType Promise<Buffer>
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [node-pdftk](https://github.com/jjwilly16/node-pdftk/blob/master/index.js#L88)
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
