### PR TITLE
libxslt: fix callback type signatures, errors can be null

### DIFF
--- a/types/libxslt/index.d.ts
+++ b/types/libxslt/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for node-libxslt 0.7
+// Type definitions for node-libxslt 0.9
 // Project: https://github.com/albanm/node-libxslt
 // Definitions by: Alejandro Sánchez <https://github.com/alejo90>
+//                 Daniel Pedersen <https://github.com/daniel-pedersen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -8,30 +9,38 @@ import * as xmljs from 'libxmljs';
 
 import {
     ApplyCallback,
-    ApplyResult,
     ApplyStringCallback,
-    OutputFormat,
+    ApplyDocumentCallback,
     ParseCallback
 } from './internal-types';
 export const libxmljs: typeof xmljs;
 
 export interface ApplyOptions {
-    outputFormat?: OutputFormat;
+    outputFormat: 'string' | 'document';
     noWrapParams?: boolean;
 }
 
 export interface Stylesheet {
     apply(source: string, params?: object): string;
-    apply(source: string|xmljs.Document, params: object, options: ApplyOptions): ApplyResult;
-    apply(source: string|xmljs.Document, params: object, options: ApplyOptions, callback: ApplyCallback): void;
-    apply(source: string|xmljs.Document, callback: ApplyStringCallback): void;
     apply(source: xmljs.Document, params?: object): xmljs.Document;
+    apply(source: string | xmljs.Document, params: object, options: { outputFormat: 'string', noWrapParams?: boolean }): string;
+    apply(source: string | xmljs.Document, params: object, options: { outputFormat: 'document', noWrapParams?: boolean }): xmljs.Document;
+    apply(source: string | xmljs.Document, params?: object, options?: ApplyOptions): string | xmljs.Document;
 
-    applyToFile(sourcePath: string, params: object, options: ApplyOptions, callback: ApplyStringCallback): void;
+    apply(source: string, callback: ApplyStringCallback): void;
+    apply(source: xmljs.Document, callback: ApplyDocumentCallback): void;
+    apply(source: string, params: object, callback: ApplyStringCallback): void;
+    apply(source: xmljs.Document, params: object, callback: ApplyDocumentCallback): void;
+    apply(source: string | xmljs.Document, params: object, options: { outputFormat: 'string', noWrapParams?: boolean }, callback: ApplyStringCallback): void;
+    apply(source: string | xmljs.Document, params: object, options: { outputFormat: 'document', noWrapParams?: boolean }, callback: ApplyDocumentCallback): void;
+    apply(source: string | xmljs.Document, params: object, options: ApplyOptions, callback: ApplyCallback): void;
+
     applyToFile(sourcePath: string, callback: ApplyStringCallback): void;
+    applyToFile(sourcePath: string, params: object, callback: ApplyStringCallback): void;
+    applyToFile(sourcePath: string, params: object, options: ApplyOptions, callback: ApplyStringCallback): void;
 }
 
-export function parse(source: string|xmljs.Document): Stylesheet;
-export function parse(source: string|xmljs.Document, callback: ParseCallback): void;
+export function parse(source: string | xmljs.Document): Stylesheet;
+export function parse(source: string | xmljs.Document, callback: ParseCallback): void;
 
 export function parseFile(sourcePath: string, callback: ParseCallback): void;

--- a/types/libxslt/internal-types.d.ts
+++ b/types/libxslt/internal-types.d.ts
@@ -1,11 +1,8 @@
 import * as xmljs from 'libxmljs';
 import { Stylesheet } from './index';
 
-export type OutputFormat = 'document' | 'string';
+export type ApplyCallback = (err: Error | null, result: string | xmljs.Document) => void;
+export type ApplyStringCallback = (err: Error | null, result: string) => void;
+export type ApplyDocumentCallback = (err: Error | null, result: xmljs.Document) => void;
 
-export type ApplyResult = string | xmljs.Document;
-export type ApplyCallback = (err: Error, result: ApplyResult) => void;
-export type ApplyStringCallback = (err: Error, result: string) => void;
-export type ApplyDocumentCallback = (err: Error, result: xmljs.Document) => void;
-
-export type ParseCallback = (err: Error, stylesheet: Stylesheet) => void;
+export type ParseCallback = (err: Error | null, stylesheet: Stylesheet) => void;

--- a/types/libxslt/libxslt-tests.ts
+++ b/types/libxslt/libxslt-tests.ts
@@ -27,10 +27,8 @@ libxslt.parseFile('/path/to/file', (err, result) => {
     }
 });
 
-let applyOptions: libxslt.ApplyOptions = {};
-
-applyOptions = {
-    outputFormat: 'string',
+const applyOptions: libxslt.ApplyOptions = {
+    outputFormat: 'document',
     noWrapParams: true
 };
 


### PR DESCRIPTION
The type signatures for the callbacks for libxslt were wrong, the callback `error` parameter can be null.

I also added furhter overloads for `Stylesheet.apply`, including mapping the `outputFormat` option to their proper type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
