### PR TITLE
Add type definitions for levenshtein-edit-distance

### DIFF
--- a/types/levenshtein-edit-distance/index.d.ts
+++ b/types/levenshtein-edit-distance/index.d.ts
@@ -1,0 +1,6 @@
+// Type definitions for levenshtein-edit-distance 2.0
+// Project: https://words.github.io/levenshtein-edit-distance/
+// Definitions by: Ryan Blackman <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function levenshtein(value: string, other: string, insensitive?: boolean): number;

--- a/types/levenshtein-edit-distance/index.d.ts
+++ b/types/levenshtein-edit-distance/index.d.ts
@@ -3,4 +3,6 @@
 // Definitions by: Ryan Blackman <https://github.com/me>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function levenshtein(value: string, other: string, insensitive?: boolean): number;
+declare function levenshtein(value: string, other: string, insensitive?: boolean): number;
+
+export = levenshtein;

--- a/types/levenshtein-edit-distance/levenshtein-edit-distance-tests.ts
+++ b/types/levenshtein-edit-distance/levenshtein-edit-distance-tests.ts
@@ -1,4 +1,4 @@
-import { levenshtein } from "levenshtein-edit-distance";
+import levenshtein = require("levenshtein-edit-distance");
 
 // $ExpectType number
 levenshtein("test", "tset");

--- a/types/levenshtein-edit-distance/levenshtein-edit-distance-tests.ts
+++ b/types/levenshtein-edit-distance/levenshtein-edit-distance-tests.ts
@@ -1,0 +1,12 @@
+import { levenshtein } from "levenshtein-edit-distance";
+
+// $ExpectType number
+levenshtein("test", "tset");
+// $ExpectType number
+levenshtein("test", "tset", true);
+// $ExpectType number
+levenshtein("test", "tset", false);
+// $ExpectError
+levenshtein("test");
+// $ExpectError
+levenshtein();

--- a/types/levenshtein-edit-distance/tsconfig.json
+++ b/types/levenshtein-edit-distance/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "levenshtein-edit-distance-tests.ts"
+    ]
+}

--- a/types/levenshtein-edit-distance/tslint.json
+++ b/types/levenshtein-edit-distance/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
