### PR TITLE
Add rawListeners field

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2544,6 +2544,7 @@ declare class TypedEventEmitter<Events> {
 
     emit<E extends keyof Events> (event: E, ...args: EventArguments<Events[E]>): boolean;
     eventNames (): Array<keyof Events>;
+    rawListeners<E extends keyof Events> (event: E): Function[];
     listeners<E extends keyof Events> (event: E): Function[];
     listenerCount<E extends keyof Events> (event: E): number;
 


### PR DESCRIPTION
Hi! There is [`rawListeners`](https://nodejs.org/api/events.html#events_emitter_rawlisteners_eventname) field in `EventEmitter` since Node.js v9.4.0. Typescript `globals.d.ts` definition:

```typescript
  rawListeners(event: string | symbol): Function[];
  listeners(event: string | symbol): Function[];
```

So I just duplicated the `listeners` field from the typings. PR in the `typed-emitter` package: https://github.com/andywer/typed-emitter/pull/6.

