### PR TITLE
Webpack: Add ExternalsFunctionCallback interface

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -408,7 +408,21 @@ declare namespace webpack {
         [key: string]: boolean | string | string[] | Record<string, string | string[]>;
     }
 
-    type ExternalsFunctionElement = (context: any, request: any, callback: (error: any, result: any) => void) => any;
+    interface ExternalsFunctionCallback {
+        /**
+         * Invoke with no arguments to not externalize
+         */
+        (): void;
+        /**
+         * Callback with an Error
+         */
+        (error: {}): void; /* tslint:disable-line */
+        /**
+         * Externalize the dependency
+         */
+        (error: null, result: string | string[] | ExternalsObjectElement, type?: string): void;
+    }
+    type ExternalsFunctionElement = (context: any, request: any, callback: ExternalsFunctionCallback) => any;
 
     interface Node {
         console?: boolean | 'mock';

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -111,14 +111,46 @@ configuration = {
         // Disable TSLint for allowing non-arrow functions
         /* tslint:disable-next-line */
         function(context, request, callback) {
-          if (/^yourregex$/.test(request)) {
-            // Disable TSLint for bypassing 'no-void-expression' to align with Webpack documentation
             /* tslint:disable-next-line */
-            return callback(null, 'commonjs ' + request);
-          }
-          callback({}, {});
-        }
-      ]
+            if (/^yourregex$/.test(request)) {
+                // Disable TSLint for allowing non-arrow functions
+                /* tslint:disable-next-line */
+                return callback(null, 'commonjs ' + request);
+            }
+            if (request === 'foo') {
+                // Disable TSLint for allowing non-arrow functions
+                /* tslint:disable-next-line */
+                return callback(null, ['path', 'to', 'external']);
+            }
+            if (request === 'bar') {
+                // Disable TSLint for allowing non-arrow functions
+                /* tslint:disable-next-line */
+                return callback(null, {}, 'commonjs');
+            }
+            if (request === 'baz') {
+                // Disable TSLint for allowing non-arrow functions
+                /* tslint:disable-next-line */
+                return callback(null, {});
+            }
+
+            // Callback can be invoked with an error
+            callback('An error');
+            callback(new Error('Boom!'));
+
+            // A null error should include external parameters
+            // $ExpectError
+            callback(null);
+
+            // An error should include no other parameters
+            // $ExpectError
+            callback('An error', 'externalName');
+
+            // Continue without externalizing the import
+            // Disable TSLint for allowing non-arrow functions
+            /* tslint:disable-next-line */
+            return callback();
+        },
+    ],
 };
 
 configuration = {
@@ -143,7 +175,7 @@ configuration = {
                 /* tslint:disable-next-line */
                 return callback(null, 'commonjs ' + request);
               }
-              callback({}, {});
+              callback(null, {});
             },
             // Regex
             /^(jquery|\$)$/i


### PR DESCRIPTION
Add an interface for the externals callback.

See webpack docs: https://webpack.js.org/configuration/externals/#function

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/configuration/externals/#function
- **Does not apply.** If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- **Does not apply.** If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.