### PR TITLE
Webpack: Add getPath data contentHash and contentHashType

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1243,14 +1243,14 @@ declare namespace webpack {
             addEntry(context: any, entry: any, name: any, callback: Function): void;
 
             getPath(filename: string, data: {
-		    hash?: any,
-		    chunk?: any,
-		    filename?: string,
-		    basename?: string,
-		    query?: any,
-		    contentHashType?: string,
-		    contentHash?: string,
-	    }): string;
+                hash?: any,
+                chunk?: any,
+                filename?: string,
+                basename?: string,
+                query?: any,
+                contentHashType?: string,
+                contentHash?: string,
+            }): string;
 
             /**
              * @deprecated Compilation.applyPlugins is deprecated. Use new API on `.hooks` instead

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1241,7 +1241,17 @@ declare namespace webpack {
             addModule(module: CompilationModule, cacheGroup: any): any;
             // tslint:disable-next-line:ban-types
             addEntry(context: any, entry: any, name: any, callback: Function): void;
-            getPath(filename: string, data: {hash?: any, chunk?: any, filename?: string, basename?: string, query?: any}): string;
+
+            getPath(filename: string, data: {
+		    hash?: any,
+		    chunk?: any,
+		    filename?: string,
+		    basename?: string,
+		    query?: any,
+		    contentHashType?: string,
+		    contentHash?: string,
+	    }): string;
+
             /**
              * @deprecated Compilation.applyPlugins is deprecated. Use new API on `.hooks` instead
              */

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -918,9 +918,9 @@ class BannerPlugin extends webpack.Plugin {
                     for (const file of chunk.files) {
                         const pathA = compilation.getPath("", {});
                         const pathB = compilation.getPath("", {
-				contentHash: "abc",
-				contentHashType: "javascript",
-			});
+                            contentHash: "abc",
+                            contentHashType: "javascript",
+                        });
                     }
                 }
             });

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -916,7 +916,11 @@ class BannerPlugin extends webpack.Plugin {
                         continue;
                     }
                     for (const file of chunk.files) {
-                        compilation.getPath("", {});
+                        const pathA = compilation.getPath("", {});
+                        const pathB = compilation.getPath("", {
+				contentHash: "abc",
+				contentHashType: "javascript",
+			});
                     }
                 }
             });


### PR DESCRIPTION
Add missing `contentHash` and `contentHashType` properties to `compilation.getPath` data.

See implementation:
https://github.com/webpack/webpack/blob/28bb0c59c0d5a8d2d1192b4c19217f7ed59785f9/lib/Compilation.js#L187-L202
https://github.com/webpack/webpack/blob/28bb0c59c0d5a8d2d1192b4c19217f7ed59785f9/lib/Compilation.js#L2746-L2759


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/webpack/webpack/blob/28bb0c59c0d5a8d2d1192b4c19217f7ed59785f9/lib/Compilation.js#L187-L202
  - https://github.com/webpack/webpack/blob/28bb0c59c0d5a8d2d1192b4c19217f7ed59785f9/lib/Compilation.js#L2746-L2759
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.