### PR TITLE
fix: Fix Yup array type inference

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -642,8 +642,9 @@ type Id<T> = { [K in keyof T]: T[K] };
 type RequiredProps<T> = Pick<T, Exclude<keyof T, KeyOfUndefined<T>>>;
 type NotRequiredProps<T> = Partial<Pick<T, KeyOfUndefined<T>>>;
 type InnerInferType<T> =
-    | (T extends Array<infer T> ? T[] : Id<NotRequiredProps<T> & RequiredProps<T>>)
+    | (T extends Array<infer T> ? InnerInferTypeArray<T> : Id<NotRequiredProps<T> & RequiredProps<T>>)
     | PreserveOptionals<T>;
+interface InnerInferTypeArray<T> extends Array<InnerInferType<T>> {}
 type InferredArrayType<T> = T extends Array<infer U> ? U : T;
 /** If `T` is optional, returns optional `U`. */
 type MaintainOptionality<T, U> = T extends undefined ? U | undefined : U;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -958,3 +958,8 @@ const nestedArrayNullable = yup.object().shape({
 const nestedArrayNullableExample: yup.InferType<typeof nestedArrayNullable> = {
     foo: null
 };
+
+const arrayOfOptional = yup.array().of(
+  yup.object({ bar: yup.string() }),
+).defined();
+const arrayOfOptionalExample: yup.InferType<typeof arrayOfOptional> = [{}];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
