### PR TITLE
[cesium] Fix LabelGraphics property types

### DIFF
--- a/types/cesium/index.d.ts
+++ b/types/cesium/index.d.ts
@@ -2705,21 +2705,21 @@ declare namespace Cesium {
         definitionChanged: Event;
         text: Property;
         font: string;
-        style: LabelStyle | Property;
+        style: Property;
         fillColor: Color;
         outlineColor: Color;
         outlineWidth: number;
         horizontalOrigin: Property;
-        verticalOrigin: VerticalOrigin | Property;
+        verticalOrigin: Property;
         eyeOffset: Property;
-        pixelOffset: Cartesian2 | Property;
+        pixelOffset: Property;
         backgroundColor: Property;
         scale: Property;
         showBackground?: Property;
         show: Property;
         translucencyByDistance: Property;
         pixelOffsetScaleByDistance: Property;
-        distanceDisplayCondition?: DistanceDisplayCondition | Property;
+        distanceDisplayCondition?: Property;
         constructor(options?: {
             text?: Property | string;
             font?: string;


### PR DESCRIPTION
See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44648 for a full explanation of this change.

I wish there were a reasonable way to check that all the properties of `Graphics` objects remain of type `Property`, because this error has been made multiple times with no reasonable safeguard to catch it.

cc @fc 