### PR TITLE
Fix typo of property name defaultEncoding

### DIFF
--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -124,7 +124,7 @@ declare module "stream" {
         interface WritableOptions {
             highWaterMark?: number;
             decodeStrings?: boolean;
-            defaultencoding?: BufferEncoding;
+            defaultEncoding?: BufferEncoding;
             objectMode?: boolean;
             emitClose?: boolean;
             write?(this: Writable, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;


### PR DESCRIPTION
A typo was introduced in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44097 that lowercased the `e` in `defaultEncoding`. 

See official docs at https://nodejs.org/api/stream.html#stream_constructor_new_stream_writable_options

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/stream.html#stream_constructor_new_stream_writable_options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
