### PR TITLE
Fix returned promise generic types

### DIFF
--- a/types/rpi-gpio/index.d.ts
+++ b/types/rpi-gpio/index.d.ts
@@ -102,7 +102,7 @@ declare class Gpio extends EventEmitter {
          * @param edge
          * @returns Promise
          */
-        setup: (channel: number, direction: PinDirection, edge: EDGE) => Promise<unknown>;
+        setup: (channel: number, direction: PinDirection, edge?: EDGE) => Promise<boolean>;
         /**
          * @see {@link Gpio.write}
          * @param channel
@@ -115,7 +115,7 @@ declare class Gpio extends EventEmitter {
          * @param channel
          * @returns Promise
          */
-        read: (channel: number) => Promise<unknown>;
+        read: (channel: number) => Promise<boolean>;
         /**
          * @see {@link Gpio.destroy}
          * @returns Promise

--- a/types/rpi-gpio/rpi-gpio-tests.ts
+++ b/types/rpi-gpio/rpi-gpio-tests.ts
@@ -29,8 +29,9 @@ gpio.destroy(err => {});
 gpio.reset();
 
 async function asyncTest() {
-    await gpio.promise.setup(7, gpio.DIR_IN, gpio.EDGE_BOTH);
-    await gpio.promise.write(7, true);
-    await gpio.promise.read(7);
-    await gpio.promise.destroy();
+    const one = await gpio.promise.setup(7, gpio.DIR_IN, gpio.EDGE_BOTH);
+    const two = await gpio.promise.setup(7, gpio.DIR_IN);
+    const three = await gpio.promise.write(7, true);
+    const four = await gpio.promise.read(7);
+    const five = await gpio.promise.destroy();
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JamesBarwell/rpi-gpio.js/blob/master/rpi-gpio.js#L571 (promises just call underlying callback function so return type is the same)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

