### PR TITLE
[fabric] Support StaticCanvas constructor with null as well

### DIFF
--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -1185,7 +1185,7 @@ export class StaticCanvas {
      * @param {Object} [options] Options object
      * @return {Object} thisArg
      */
-    constructor(element: HTMLCanvasElement | string, options?: ICanvasOptions);
+    constructor(element: HTMLCanvasElement | string | null, options?: ICanvasOptions);
 
     _activeObject?: Object | Group;
 


### PR DESCRIPTION
This is a follow-up to #44953. I'd tested my changes locally, but then I made the mistake of copying them over manually, and naturally, I missed one.

This PR also updates the overloaded constructor with the ability to not pass in an HTML canvas, which is the API I'm actually using.

(This time, I linked rather than copying.)