### PR TITLE
[d3-brush] Added possibility of event.selection to be null

### DIFF
--- a/types/d3-brush/d3-brush-tests.ts
+++ b/types/d3-brush/d3-brush-tests.ts
@@ -183,5 +183,5 @@ const e: d3Brush.D3BrushEvent<BrushDatum> = event;
 
 const target: d3Brush.BrushBehavior<BrushDatum> = e.target;
 const type: 'start' | 'brush' | 'end' | string = e.type;
-const brushSelection: d3Brush.BrushSelection = e.selection;
+const brushSelection: d3Brush.BrushSelection | null = e.selection;
 const sourceEvent: any = e.sourceEvent;

--- a/types/d3-brush/index.d.ts
+++ b/types/d3-brush/index.d.ts
@@ -253,8 +253,9 @@ export interface D3BrushEvent<Datum> {
     type: 'start' | 'brush' | 'end' | string; // Leave failsafe string type for cases like 'brush.foo'
     /**
      * The current brush selection associated with the event.
+     * This is null when the selection is empty.
      */
-    selection: BrushSelection;
+    selection: BrushSelection | null;
     /**
      * The underlying input event, such as mousemove or touchmove.
      */


### PR DESCRIPTION
It is possible for `event.selection` to be `null` but the current type definitions do not reflect this.
This PR adds the possibility to be `null`.

In practice this happens when the user simply clicks without dragging.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-brush/blob/1159f87e63f6702b6d578df41f08ab9dd2b00765/src/brush.js#L476
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
