### PR TITLE
Add type definitions for svg2ttf

### DIFF
--- a/types/svg2ttf/index.d.ts
+++ b/types/svg2ttf/index.d.ts
@@ -11,9 +11,18 @@ declare function svg2ttf(svgFontString: string, options?: FontOptions): MicroBuf
 interface FontOptions {
     copyright?: string;
     description?: string;
+    /**
+     * Unix timestamp (in seconds) to override creation time
+     */
     ts?: number;
+    /**
+     * manufacturer url
+     */
     url?: string;
-    /** @default 'Version 1.0' */
+    /**
+     * font version string, can be Version x.y or x.y
+     * @default 'Version 1.0'
+     */
     version?: string;
 }
 

--- a/types/svg2ttf/index.d.ts
+++ b/types/svg2ttf/index.d.ts
@@ -3,34 +3,31 @@
 // Definitions by: Ewan Morrison <https://github.com/ewan-m>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// tslint:disable-next-line strict-export-declare-modifiers
 /** Converts SVG fonts to TTF format */
-declare function svg2ttf(svgFontString: string, options?: FontOptions): MicroBuffer;
+declare function svg2ttf(svgFontString: string, options?: svg2ttf.FontOptions): svg2ttf.MicroBuffer;
 
-// tslint:disable-next-line strict-export-declare-modifiers
-interface FontOptions {
-    copyright?: string;
-    description?: string;
-    /**
-     * @summary Unix timestamp (in seconds) to override creation time
-     */
-    ts?: number;
-    /**
-     * @summary manufacturer url
-     */
-    url?: string;
-    // tslint:disable:no-redundant-jsdoc-2
-    /**
-     * @summary font version string, can be Version x.y or x.y
-     * @default 'Version 1.0'
-     */
-    version?: string;
+declare namespace svg2ttf {
+    interface FontOptions {
+        copyright?: string;
+        description?: string;
+        /**
+         * Unix timestamp (in seconds) to override creation time
+         */
+        ts?: number;
+        /**
+         * manufacturer url
+         */
+        url?: string;
+        /**
+         * font version string, can be Version x.y or x.y
+         * @default 'Version 1.0'
+         */
+        version?: string;
+    }
+
+    interface MicroBuffer {
+        buffer: Uint8Array;
+    }
 }
 
-// tslint:disable-next-line strict-export-declare-modifiers
-interface MicroBuffer {
-    buffer: Uint8Array;
-}
-
-// tslint:disable-next-line strict-export-declare-modifiers
 export = svg2ttf;

--- a/types/svg2ttf/index.d.ts
+++ b/types/svg2ttf/index.d.ts
@@ -1,18 +1,18 @@
-declare module 'svg2ttf' {
-    function svg2ttf(svgFontString: string): MicroBuffer;
-    function svg2ttf(svgFontString: string, options: FontOptions): MicroBuffer;
+// Type definitions for svg2ttf 5.0
+// Project: https://github.com/fontello/svg2ttf
+// Definitions by: Ewan Morrison <https://github.com/ewan-m>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-    interface FontOptions {
-        copyright?: string;
-        description?: string;
-        ts?: number;
-        url?: string;
-        version: string;
-    }
+declare function svg2ttf(svgFontString: string, options?: FontOptions): MicroBuffer;
 
-    interface MicroBuffer {
-        buffer: Uint8Array;
-    }
+interface FontOptions {
+    copyright?: string;
+    description?: string;
+    ts?: number;
+    url?: string;
+    version: string;
+}
 
-    export = svg2ttf;
+interface MicroBuffer {
+    buffer: Uint8Array;
 }

--- a/types/svg2ttf/index.d.ts
+++ b/types/svg2ttf/index.d.ts
@@ -13,7 +13,8 @@ interface FontOptions {
     description?: string;
     ts?: number;
     url?: string;
-    version: string;
+    /** @default 'Version 1.0' */
+    version?: string;
 }
 
 interface MicroBuffer {

--- a/types/svg2ttf/index.d.ts
+++ b/types/svg2ttf/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Ewan Morrison <https://github.com/ewan-m>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+// tslint:disable:no-redundant-jsdoc-2
+
 /**
  * Converts SVG fonts to TTF format
  */

--- a/types/svg2ttf/index.d.ts
+++ b/types/svg2ttf/index.d.ts
@@ -20,3 +20,5 @@ interface FontOptions {
 interface MicroBuffer {
     buffer: Uint8Array;
 }
+
+export = svg2ttf;

--- a/types/svg2ttf/index.d.ts
+++ b/types/svg2ttf/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Ewan Morrison <https://github.com/ewan-m>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// tslint:disable:no-redundant-jsdoc-2
-
 /**
  * Converts SVG fonts to TTF format
  */
@@ -21,6 +19,7 @@ interface FontOptions {
      * manufacturer url
      */
     url?: string;
+    // tslint:disable:no-redundant-jsdoc-2
     /**
      * font version string, can be Version x.y or x.y
      * @default 'Version 1.0'

--- a/types/svg2ttf/index.d.ts
+++ b/types/svg2ttf/index.d.ts
@@ -3,6 +3,9 @@
 // Definitions by: Ewan Morrison <https://github.com/ewan-m>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/**
+ * Converts SVG fonts to TTF format
+ */
 declare function svg2ttf(svgFontString: string, options?: FontOptions): MicroBuffer;
 
 interface FontOptions {

--- a/types/svg2ttf/index.d.ts
+++ b/types/svg2ttf/index.d.ts
@@ -1,0 +1,18 @@
+declare module 'svg2ttf' {
+    function svg2ttf(svgFontString: string): MicroBuffer;
+    function svg2ttf(svgFontString: string, options: FontOptions): MicroBuffer;
+
+    interface FontOptions {
+        copyright?: string;
+        description?: string;
+        ts?: number;
+        url?: string;
+        version: string;
+    }
+
+    interface MicroBuffer {
+        buffer: Uint8Array;
+    }
+
+    export = svg2ttf;
+}

--- a/types/svg2ttf/index.d.ts
+++ b/types/svg2ttf/index.d.ts
@@ -3,9 +3,11 @@
 // Definitions by: Ewan Morrison <https://github.com/ewan-m>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+// tslint:disable-next-line strict-export-declare-modifiers
 /** Converts SVG fonts to TTF format */
 declare function svg2ttf(svgFontString: string, options?: FontOptions): MicroBuffer;
 
+// tslint:disable-next-line strict-export-declare-modifiers
 interface FontOptions {
     copyright?: string;
     description?: string;
@@ -25,8 +27,10 @@ interface FontOptions {
     version?: string;
 }
 
+// tslint:disable-next-line strict-export-declare-modifiers
 interface MicroBuffer {
     buffer: Uint8Array;
 }
 
+// tslint:disable-next-line strict-export-declare-modifiers
 export = svg2ttf;

--- a/types/svg2ttf/index.d.ts
+++ b/types/svg2ttf/index.d.ts
@@ -3,25 +3,23 @@
 // Definitions by: Ewan Morrison <https://github.com/ewan-m>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/**
- * Converts SVG fonts to TTF format
- */
+/** Converts SVG fonts to TTF format */
 declare function svg2ttf(svgFontString: string, options?: FontOptions): MicroBuffer;
 
 interface FontOptions {
     copyright?: string;
     description?: string;
     /**
-     * Unix timestamp (in seconds) to override creation time
+     * @summary Unix timestamp (in seconds) to override creation time
      */
     ts?: number;
     /**
-     * manufacturer url
+     * @summary manufacturer url
      */
     url?: string;
     // tslint:disable:no-redundant-jsdoc-2
     /**
-     * font version string, can be Version x.y or x.y
+     * @summary font version string, can be Version x.y or x.y
      * @default 'Version 1.0'
      */
     version?: string;

--- a/types/svg2ttf/svg2ttf-tests.ts
+++ b/types/svg2ttf/svg2ttf-tests.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 import fs = require('fs');
 import svg2ttf = require('svg2ttf');
+import { MicroBuffer, FontOptions } from 'svg2ttf';
 
 const ttf = svg2ttf(fs.readFileSync('myfont.svg', 'utf8'), {});
 

--- a/types/svg2ttf/svg2ttf-tests.ts
+++ b/types/svg2ttf/svg2ttf-tests.ts
@@ -1,22 +1,10 @@
-import  svg2ttf = require('svg2ttf');
+/// <reference types="node" />
+import fs = require('fs');
+import svg2ttf = require('svg2ttf');
 
-const dummySvgFontString = `
-<?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg">
-    <defs>
-        <font id="test" horiz-adv-x="200" >
-        <font-face font-family="test"
-            units-per-em="1000"
-            ascent="800"
-            descent="-200"
-            alphabetic="0"
-        />
-        <glyph unicode="." glyph-name="fullstop" horiz-adv-x="300" d="M0,0 L10,10 L20,10"/>
-        </font>
-    </defs>
-</svg>`;
+const ttf = svg2ttf(fs.readFileSync('myfont.svg', 'utf8'), {});
 
-svg2ttf(dummySvgFontString); // $ExpectType MicroBuffer
+ttf; // $ExpectType MicroBuffer
+ttf.buffer; // $ExpectType Uint8Array
 
-svg2ttf(dummySvgFontString).buffer; // $ExpectType Uint8Array
+fs.writeFileSync('myfont.ttf', new Buffer(ttf.buffer));

--- a/types/svg2ttf/svg2ttf-tests.ts
+++ b/types/svg2ttf/svg2ttf-tests.ts
@@ -1,6 +1,4 @@
-import svg2ttf from 'svg2ttf';
-
-const result = svg2ttf(`
+const dummySvgFontString = `
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg xmlns="http://www.w3.org/2000/svg">
@@ -15,6 +13,8 @@ const result = svg2ttf(`
         <glyph unicode="." glyph-name="fullstop" horiz-adv-x="300" d="M0,0 L10,10 L20,10"/>
         </font>
     </defs>
-</svg>`) // $ExpectType MicroBuffer;
+</svg>`;
 
-result.buffer // $ExpectType Uint8Array;
+svg2ttf(dummySvgFontString); // $ExpectType MicroBuffer
+
+svg2ttf(dummySvgFontString).buffer; // $ExpectType Uint8Array

--- a/types/svg2ttf/svg2ttf-tests.ts
+++ b/types/svg2ttf/svg2ttf-tests.ts
@@ -7,4 +7,14 @@ const ttf = svg2ttf(fs.readFileSync('myfont.svg', 'utf8'), {});
 ttf; // $ExpectType MicroBuffer
 ttf.buffer; // $ExpectType Uint8Array
 
+const ttfWithOptions = svg2ttf(fs.readFileSync('myfont.svg', 'utf8'), {
+    version: '1.2',
+    copyright: 'Yes',
+    ts: 1000,
+    description: 'A nice font',
+});
+
+ttfWithOptions; // $ExpectType MicroBuffer
+ttfWithOptions.buffer; // $ExpectType Uint8Array
+
 fs.writeFileSync('myfont.ttf', new Buffer(ttf.buffer));

--- a/types/svg2ttf/svg2ttf-tests.ts
+++ b/types/svg2ttf/svg2ttf-tests.ts
@@ -1,3 +1,5 @@
+import  svg2ttf = require('svg2ttf');
+
 const dummySvgFontString = `
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">

--- a/types/svg2ttf/svg2ttf-tests.ts
+++ b/types/svg2ttf/svg2ttf-tests.ts
@@ -1,0 +1,20 @@
+import svg2ttf from 'svg2ttf';
+
+const result = svg2ttf(`
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <font id="test" horiz-adv-x="200" >
+        <font-face font-family="test"
+            units-per-em="1000"
+            ascent="800"
+            descent="-200"
+            alphabetic="0"
+        />
+        <glyph unicode="." glyph-name="fullstop" horiz-adv-x="300" d="M0,0 L10,10 L20,10"/>
+        </font>
+    </defs>
+</svg>`);
+
+const buffer = result.buffer;

--- a/types/svg2ttf/svg2ttf-tests.ts
+++ b/types/svg2ttf/svg2ttf-tests.ts
@@ -15,6 +15,6 @@ const result = svg2ttf(`
         <glyph unicode="." glyph-name="fullstop" horiz-adv-x="300" d="M0,0 L10,10 L20,10"/>
         </font>
     </defs>
-</svg>`);
+</svg>`) // $ExpectType MicroBuffer;
 
-const buffer = result.buffer;
+result.buffer // $ExpectType Uint8Array;

--- a/types/svg2ttf/tsconfig.json
+++ b/types/svg2ttf/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "allowSyntheticDefaultImports": true
+    },
+    "files": [
+        "index.d.ts",
+        "svg2ttf-tests.ts"
+    ]
+}

--- a/types/svg2ttf/tslint.json
+++ b/types/svg2ttf/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with npm test.)
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] Run npm run lint package-name (or tsc if no tslint.json is present).
- [x] The package does not already provide its own types, or cannot have its .d.ts files generated via declaration
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with dts-gen --dt, not by basing it on an existing project.
- [x] Represents shape of module/library correctly
- [x] tslint.json should be present and it shouldn't have any additional or disabling of rules. Just content as { "extends": "dtslint/dt.json" }. If for reason the some rule need to be disabled, disable it for that line using // tslint:disable-next-line [ruleName] and not for whole package so that the need for disabling can be reviewed.
- [x] tsconfig.json should have noImplicitAny, noImplicitThis, strictNullChecks, and strictFunctionTypes set to true.