### PR TITLE
ember__test-helpers - update SettledState definition

### DIFF
--- a/types/ember__test-helpers/ember__test-helpers-tests.ts
+++ b/types/ember__test-helpers/ember__test-helpers-tests.ts
@@ -90,6 +90,7 @@ test('wait helpers', async (assert) => {
     const {
         hasPendingRequests,
         hasPendingTimers,
+        hasPendingTransitions,
         hasPendingWaiters,
         hasRunLoop,
         pendingRequestCount

--- a/types/ember__test-helpers/index.d.ts
+++ b/types/ember__test-helpers/index.d.ts
@@ -177,6 +177,7 @@ declare module '@ember/test-helpers/settled' {
         hasPendingTimers: boolean;
         hasPendingWaiters: boolean;
         hasPendingRequests: boolean;
+        hasPendingTransitions: boolean | null;
         pendingRequestCount: number;
     }
 


### PR DESCRIPTION
Add hasPendingTransitions flag to SettledState because it was missing.

The original interface can be reviewed [here](https://github.com/emberjs/ember-test-helpers/blob/9d6dc6c35b167650edaf0700ba9d1704e24d14b8/addon-test-support/%40ember/test-helpers/settled.ts#L152)
