### PR TITLE
[codemirror] Add additional lint options

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -1230,7 +1230,7 @@ declare namespace CodeMirror {
         autocapitalize?: boolean;
 
         /** Optional lint configuration to be used in conjunction with CodeMirror's linter addon. */
-        lint?: boolean | LintOptions;
+        lint?: boolean | LintStateOptions | Linter | AsyncLinter;
     }
 
     interface TextMarkerOptions {
@@ -1669,30 +1669,46 @@ declare namespace CodeMirror {
      */
     var commands: CommandActions;
 
-    /**
-     * async specifies that the lint process runs asynchronously. hasGutters specifies that lint errors should be displayed in the CodeMirror
-     * gutter, note that you must use this in conjunction with [ "CodeMirror-lint-markers" ] as an element in the gutters argument on
-     * initialization of the CodeMirror instance.
-     */
     interface LintStateOptions {
+        /** specifies that the lint process runs asynchronously */
         async?: boolean;
-        hasGutters?: boolean;
-        onUpdateLinting?: (annotationsNotSorted: Annotation[], annotations: Annotation[], codeMirror: Editor) => void;
-    }
 
-    /**
-     * Adds the getAnnotations callback to LintStateOptions which may be overridden by the user if they choose use their own
-     * linter.
-     */
-    interface LintOptions extends LintStateOptions {
+        /** debounce delay before linting onChange */
+        delay?: number;
+
+        /** callback to modify an annotation before display */
+        formatAnnotation?: (annotation: Annotation) => Annotation
+
+        /** custom linting function provided by the user */
         getAnnotations?: Linter | AsyncLinter;
+
+        /** 
+         * specifies that lint errors should be displayed in the CodeMirror
+         * gutter, note that you must use this in conjunction with [ "CodeMirror-lint-markers" ] as an element in the gutters argument on
+         * initialization of the CodeMirror instance. */
+        hasGutters?: boolean;
+
+        /** whether to lint onChange event */
+        lintOnChange?: boolean;
+
+        /** callback after linter completes */
+        onUpdateLinting?: (annotationsNotSorted: Annotation[], annotations: Annotation[], codeMirror: Editor) => void;
+
+        /**
+         * Passing rules in `options` property prevents JSHint (and other linters) from complaining
+         * about unrecognized rules like `onUpdateLinting`, `delay`, `lintOnChange`, etc.
+         */
+        options?: any;
+
+        /** controls display of lint tooltips */
+        tooltips?: boolean | 'gutter'
     }
 
     /**
      * A function that return errors found during the linting process.
      */
     interface Linter {
-        (content: string, options: LintStateOptions, codeMirror: Editor): Annotation[] | PromiseLike<Annotation[]>;
+        (content: string, options: LintStateOptions | any, codeMirror: Editor): Annotation[] | PromiseLike<Annotation[]>;
     }
 
     /**
@@ -1702,7 +1718,7 @@ declare namespace CodeMirror {
         (
             content: string,
             updateLintingCallback: UpdateLintingCallback,
-            options: LintStateOptions,
+            options: LintStateOptions | any,
             codeMirror: Editor,
         ): void;
     }

--- a/types/codemirror/test/index.ts
+++ b/types/codemirror/test/index.ts
@@ -48,7 +48,7 @@ const lintStateOptions: CodeMirror.LintStateOptions = {
     hasGutters: true,
 };
 
-const asyncLintOptions: CodeMirror.LintOptions = {
+const asyncLintOptions: CodeMirror.LintStateOptions = {
     async: true,
     hasGutters: true,
     getAnnotations: (
@@ -59,12 +59,24 @@ const asyncLintOptions: CodeMirror.LintOptions = {
     ) => {},
 };
 
-const syncLintOptions: CodeMirror.LintOptions = {
+const syncLintOptions: CodeMirror.LintStateOptions = {
     async: false,
     hasGutters: true,
     getAnnotations: (
         content: string,
         options: CodeMirror.LintStateOptions,
+        codeMirror: CodeMirror.Editor,
+    ): CodeMirror.Annotation[] => {
+        return [];
+    },
+};
+
+const customLintOptions: CodeMirror.LintStateOptions = {
+    async: false,
+    options: {},
+    getAnnotations: (
+        content: string,
+        options: any,
         codeMirror: CodeMirror.Editor,
     ): CodeMirror.Annotation[] => {
         return [];


### PR DESCRIPTION
Add options found by reading the source of addon/lint/lint.js

This is particularly needed to pass options to JSHINT for the Javascript linter addon.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - lint options can be a linter function: https://github.com/codemirror/CodeMirror/blob/83978294fb8926aa923e77b696bf9ed5a03b5df4/addon/lint/lint.js#L71
  - delay option: https://github.com/codemirror/CodeMirror/blob/83978294fb8926aa923e77b696bf9ed5a03b5df4/addon/lint/lint.js#L202
  - formatAnnotation option: https://github.com/codemirror/CodeMirror/blob/83978294fb8926aa923e77b696bf9ed5a03b5df4/addon/lint/lint.js#L182
  - lintOnChange option: https://github.com/codemirror/CodeMirror/blob/83978294fb8926aa923e77b696bf9ed5a03b5df4/addon/lint/lint.js#L232
  - tooltips option: https://github.com/codemirror/CodeMirror/blob/83978294fb8926aa923e77b696bf9ed5a03b5df4/addon/lint/lint.js#L245
  - options option: https://github.com/codemirror/CodeMirror/blob/83978294fb8926aa923e77b696bf9ed5a03b5df4/addon/lint/lint.js#L148
  - options change to linter function signatures is a result of the custom options option
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
