### PR TITLE
Fix DT 2020-05-27

### DIFF
--- a/types/openseadragon/index.d.ts
+++ b/types/openseadragon/index.d.ts
@@ -366,7 +366,7 @@ declare namespace OpenSeadragon {
         previousButton?: string;
         nextButton?: string;
         sequenceMode?: boolean;
-        /** 
+        /**
          * If sequenceMode is true, display this page initially.
          * @default 0
          */

--- a/types/skatejs/index.d.ts
+++ b/types/skatejs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/skatejs/skatejs
 // Definitions by: Martin Hochel <https://github.com/Hotell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.6
 
 export as namespace skate;
 

--- a/types/skatejs/types.d.ts
+++ b/types/skatejs/types.d.ts
@@ -51,8 +51,8 @@ export declare class WithContext<C = Mixed> extends HTMLElement {
 }
 
 export declare class WithRenderer<O = Mixed | null> extends HTMLElement implements Renderer<O> {
-  // getter for turning of ShadowDOM
-  readonly renderRoot?: this | Mixed;
+  // getter for turning off ShadowDOM
+  get renderRoot(): this | Mixed;
 
   updated(props?: Mixed, state?: Mixed): void;
   // called before render


### PR DESCRIPTION
Couple of small fixes from the overnight run:

1. Trailing space lint. Not sure how this got in. 
2. skatejs is now required to use `get` accessor syntax in types.d.ts because in TS 4.0 it will be an error to override an accessor with a property.
