### PR TITLE
fix(webidl2): Add `extAttrs` property to `IDLTypeDescription`

### DIFF
--- a/types/webidl2/index.d.ts
+++ b/types/webidl2/index.d.ts
@@ -83,6 +83,8 @@ export interface SingleTypeDescription {
      * the eventual value of the promise, etc.
      */
     idlType: string;
+    /** A list of extended attributes. */
+    extAttrs: ExtendedAttribute[];
 }
 
 export interface UnionTypeDescription {
@@ -103,6 +105,8 @@ export interface UnionTypeDescription {
      * the eventual value of the promise, etc.
      */
     idlType: IDLTypeDescription[];
+    /** A list of extended attributes. */
+    extAttrs: ExtendedAttribute[];
 }
 
 export interface InterfaceType {
@@ -304,13 +308,19 @@ export interface ExtendedAttribute {
 }
 
 export type ExtendedAttributeRightHandSide =
+    | ExtendedAttributeRightHandSideBase
+    | ExtendedAttributeRightHandSideList;
+
+export type ExtendedAttributeRightHandSideBase =
     | ExtendedAttributeRightHandSideIdentifier
-    | ExtendedAttributeRightHandSideIdentifierList
     | ExtendedAttributeRightHandSideString
-    | ExtendedAttributeRightHandSideStringList
     | ExtendedAttributeRightHandSideDecimal
+    | ExtendedAttributeRightHandSideInteger;
+
+export type ExtendedAttributeRightHandSideList =
+    | ExtendedAttributeRightHandSideIdentifierList
+    | ExtendedAttributeRightHandSideStringList
     | ExtendedAttributeRightHandSideDecimalList
-    | ExtendedAttributeRightHandSideInteger
     | ExtendedAttributeRightHandSideIntegerList;
 
 export interface ExtendedAttributeRightHandSideIdentifier {

--- a/types/webidl2/webidl2-tests.ts
+++ b/types/webidl2/webidl2-tests.ts
@@ -148,6 +148,7 @@ function logExtAttr(extAttr: webidl2.ExtendedAttribute) {
             case "string":
             case "decimal":
             case "integer":
+                rhs.value; // $ExpectType string
                 logExtAttrRHS(rhs);
                 break;
             case "identifier-list":
@@ -163,25 +164,14 @@ function logExtAttr(extAttr: webidl2.ExtendedAttribute) {
     }
 }
 
-function logExtAttrRHSList(
-    rhsList:
-        | webidl2.ExtendedAttributeRightHandSideIdentifierList
-        | webidl2.ExtendedAttributeRightHandSideStringList
-        | webidl2.ExtendedAttributeRightHandSideDecimalList
-        | webidl2.ExtendedAttributeRightHandSideIntegerList
-) {
+function logExtAttrRHSList(rhsList: webidl2.ExtendedAttributeRightHandSideList) {
     for (const rhs of rhsList.value) {
         logExtAttrRHS(rhs);
     }
 }
 
-function logExtAttrRHS(
-    rhs:
-        | webidl2.ExtendedAttributeRightHandSideIdentifier
-        | webidl2.ExtendedAttributeRightHandSideString
-        | webidl2.ExtendedAttributeRightHandSideDecimal
-        | webidl2.ExtendedAttributeRightHandSideInteger
-) {
+function logExtAttrRHS(rhs: webidl2.ExtendedAttributeRightHandSideBase) {
+    rhs.value; // $ExpectType string
     console.log(rhs.type, rhs.value);
 }
 
@@ -210,6 +200,7 @@ function logIdlType(idlType: webidl2.IDLTypeDescription) {
         idlType; // $ExpectType SingleTypeDescription
         console.log(idlType);
     }
+    logExtAttrs(idlType.extAttrs);
 }
 
 function logValueDescription(valueDesc: webidl2.ValueDescription) {


### PR DESCRIPTION
I’ve also added the convenience `ExtendedAttributeRightHandSideBase` and `ExtendedAttributeRightHandSideList` union type aliases.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/w3c/webidl2.js/blob/gh-pages/README.md#idl-type>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
