### PR TITLE
ffi-napi: First argument to 'Library' can be null

### DIFF
--- a/types/ffi-napi/ffi-napi-tests.ts
+++ b/types/ffi-napi/ffi-napi-tests.ts
@@ -104,3 +104,10 @@ import TArray = require('ref-array-di');
 {
     const refCharArr = TArray('char')([1, 3, 5], 2).ref();
 }
+{
+    // You can also access just functions in the current process by passing a null
+    const current = ffi.Library(null, {
+      atoi: [ 'int', [ 'string' ] ]
+    });
+    current.atoi('1234');
+}

--- a/types/ffi-napi/index.d.ts
+++ b/types/ffi-napi/index.d.ts
@@ -20,14 +20,14 @@ export interface Library {
      * @param funcs hash of [retType, [...argType], opts?: {abi?, async?, varargs?}]
      * @param lib hash that will be extended
      */
-    new (libFile: string, funcs?: {[key: string]: any[]}, lib?: object): any;
+    new (libFile: string | null, funcs?: {[key: string]: any[]}, lib?: object): any;
 
     /**
      * @param libFile name of library
      * @param funcs hash of [retType, [...argType], opts?: {abi?, async?, varargs?}]
      * @param lib hash that will be extended
      */
-    (libFile: string, funcs?: {[key: string]: any[]}, lib?: object): any;
+    (libFile: string | null, funcs?: {[key: string]: any[]}, lib?: object): any;
 }
 export const Library: Library;
 


### PR DESCRIPTION
Evidence: https://www.npmjs.com/package/ffi-napi#example

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see commit description above
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
