### PR TITLE
[clean-css] move semicolonAfterLastProperty to FormatOptions

### DIFF
--- a/types/clean-css/clean-css-tests.ts
+++ b/types/clean-css/clean-css-tests.ts
@@ -96,3 +96,15 @@ CleanCssOptions = { returnPromise: false };
 new CleanCSS(CleanCssOptions).minify(source, (error: any, minified: CleanCSS.Output): void => {
     console.log(minified.styles);
 });
+
+// test clean-css semicolonAfterLastProperty option works as expected
+source = 'a{font-weight:bold;}';
+CleanCssOptions = {
+    format: {
+        semicolonAfterLastProperty: true
+    }
+};
+
+new CleanCSS(CleanCssOptions).minify(source, (error: any, minified: CleanCSS.Output): void => {
+    console.log(minified.styles);
+});

--- a/types/clean-css/clean-css-tests.ts
+++ b/types/clean-css/clean-css-tests.ts
@@ -99,12 +99,12 @@ new CleanCSS(CleanCssOptions).minify(source, (error: any, minified: CleanCSS.Out
 
 // test clean-css semicolonAfterLastProperty option works as expected
 source = 'a{font-weight:bold;}';
-CleanCssOptions = {
+const CleanCssSemiOptions: CleanCSS.Options = {
     format: {
         semicolonAfterLastProperty: true
     }
 };
 
-new CleanCSS(CleanCssOptions).minify(source, (error: any, minified: CleanCSS.Output): void => {
+new CleanCSS(CleanCssSemiOptions).minify(source, (error: any, minified: CleanCSS.Output): void => {
     console.log(minified.styles);
 });

--- a/types/clean-css/clean-css-tests.ts
+++ b/types/clean-css/clean-css-tests.ts
@@ -99,12 +99,12 @@ new CleanCSS(CleanCssOptions).minify(source, (error: any, minified: CleanCSS.Out
 
 // test clean-css semicolonAfterLastProperty option works as expected
 source = 'a{font-weight:bold;}';
-const CleanCssSemiOptions: CleanCSS.Options = {
+CleanCssOptions = {
     format: {
         semicolonAfterLastProperty: true
     }
 };
 
-new CleanCSS(CleanCssSemiOptions).minify(source, (error: any, minified: CleanCSS.Output): void => {
+new CleanCSS(CleanCssOptions).minify(source, (error: any, minified: CleanCSS.Output): void => {
     console.log(minified.styles);
 });

--- a/types/clean-css/index.d.ts
+++ b/types/clean-css/index.d.ts
@@ -389,6 +389,11 @@ declare namespace CleanCSS {
          * Controls maximum line length; defaults to `false`
          */
         wrapAt?: false | number;
+
+        /**
+         * Controls removing trailing semicolons in rule; defaults to `false` - means remove
+         */
+        semicolonAfterLastProperty?: boolean;
     }
 
     /**
@@ -506,11 +511,6 @@ declare namespace CleanCSS {
              * Controls selectors optimizing; defaults to `true`
              */
             tidySelectors?: boolean;
-
-            /**
-             * Controls removing trailing semicolons in rule; defaults to `false` - means remove
-             */
-            semicolonAfterLastProperty?: boolean;
 
             /**
              * Defines a callback for fine-grained property optimization; defaults to no-op

--- a/types/clean-css/index.d.ts
+++ b/types/clean-css/index.d.ts
@@ -11,7 +11,7 @@ import { RequestOptions as HttpRequestOptions } from "http";
 /**
  * Shared options passed when initializing a new instance of CleanCSS that returns either a promise or output
  */
-interface OptionsBase {
+declare interface OptionsBase {
     /**
      * Controls compatibility mode used; defaults to ie10+ using `'*'`.
      *  Compatibility hash exposes the following properties: `colors`, `properties`, `selectors`, and `units`

--- a/types/clean-css/index.d.ts
+++ b/types/clean-css/index.d.ts
@@ -11,7 +11,7 @@ import { RequestOptions as HttpRequestOptions } from "http";
 /**
  * Shared options passed when initializing a new instance of CleanCSS that returns either a promise or output
  */
-declare interface OptionsBase {
+interface OptionsBase {
     /**
      * Controls compatibility mode used; defaults to ie10+ using `'*'`.
      *  Compatibility hash exposes the following properties: `colors`, `properties`, `selectors`, and `units`


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/jakubpawlowicz/clean-css#formatting-options>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

According to [documentation](https://github.com/jakubpawlowicz/clean-css#formatting-options) semicolonAfterLastProperty option is contained in `format` (FormatOption type)
