### PR TITLE
[node]: Add missing "freeSockets" property to HTTP Agent

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -356,6 +356,7 @@ declare module "http" {
     class Agent {
         maxFreeSockets: number;
         maxSockets: number;
+        readonly freeSockets: NodeJS.ReadOnlyDict<Socket[]>;
         readonly sockets: NodeJS.ReadOnlyDict<Socket[]>;
         readonly requests: NodeJS.ReadOnlyDict<IncomingMessage[]>;
 

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3,6 +3,7 @@ import * as url from "url";
 import * as util from "util";
 import * as http from "http";
 import * as https from "https";
+import * as net from "net";
 import * as console2 from "console";
 import * as timers from "timers";
 import * as inspector from "inspector";
@@ -23,6 +24,9 @@ import * as trace_events from "trace_events";
     });
 
     agent = https.globalAgent;
+
+    let sockets: NodeJS.ReadOnlyDict<net.Socket[]> = agent.sockets;
+    sockets = agent.freeSockets;
 
     https.request({
         agent: false

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -144,6 +144,9 @@ import * as net from 'net';
 
     agent = http.globalAgent;
 
+    let sockets: NodeJS.ReadOnlyDict<net.Socket[]> = agent.sockets;
+    sockets = agent.freeSockets;
+
     http.request({ agent: false });
     http.request({ agent });
     http.request({ agent: undefined });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
  - _**My notes:** Checked that my changes passed Prettier, but these files in general do not pass Prettier. I did not include those unrelated changes here, as it would result in scope creep of this PR._
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/daa65fba7d413691d55051457993405457fa2f41/lib/_http_agent.js#L141-L148
  - Documentation can be found at http://nodejs.org/api/http.html#http_agent_freesockets
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
  - _**My notes:** This isn't about a new version of Node.js so this isn't applicable I think. This property has been in Node.js since version `0.11.4`, but was for some reason not included when the Agent class was added back in 2015 (see https://github.com/DefinitelyTyped/DefinitelyTyped/commit/369935805c1) and still after this PR there are many things missing in the Agent class. #27014 added the `maxFreeSockets` companion to the `maxSockets` property, this PR of mine does the same for the `sockets` property, but still more properties exists, as can be eg. seen in the documentation: http://nodejs.org/api/http.html#//apple_ref/cl/http%252EAgent_
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
  - _**My notes:** There was no original test for the `sockets` property, but I tried adding one for both the `sockets` and the `freeSockets` properties, though I'm pretty unsure whether I solved it in the correct way. **Feedback is very welcome!**_
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
  - _**My notes:** This is a very minor change, so this is not applicable._
