### PR TITLE
Fix bpmn-moddle typo

### DIFF
--- a/types/bpmn-moddle/index.d.ts
+++ b/types/bpmn-moddle/index.d.ts
@@ -19,7 +19,7 @@ declare namespace BPMNModdle {
         | "Diverging"
         | "Mixed";
     type ItemKind = "Physical" | "Information";
-    type MultiInstanceBehaviour = "None" | "One" | "All" | "Complex";
+    type MultiInstanceBehavior = "None" | "One" | "All" | "Complex";
     type ProcessType = "None" | "Public" | "Private";
     type RelationshipDirection = "None" | "Forward" | "Backward" | "Both";
 
@@ -599,7 +599,7 @@ declare namespace BPMNModdle {
     interface LoopCharacteristics extends BaseElement {}
     interface MultiInstanceLoopCharacteristics extends LoopCharacteristics {
         isSequential: boolean;
-        behavior: MultiInstanceBehaviour;
+        behavior: MultiInstanceBehavior;
         loopCardinality: Expression;
         loopDataInputRef: ItemAwareElement;
         loopDataOutputRef: ItemAwareElement;
@@ -644,7 +644,7 @@ declare namespace BPMNModdle {
         cancelRemainingInstances: boolean;
     }
     interface Transaction extends SubProcess {
-        protocal: string;
+        protocol: string;
         method: string;
     }
     interface GlobalScriptTask extends GlobalTask {


### PR DESCRIPTION
## Description

This PR corrects the typo about the type definition of bpmn-moddle.

### bpmn-moddle

* https://github.com/bpmn-io/bpmn-moddle/blob/9f6d389e19d94e4c5211a87cc14e6f9b9f455f5c/resources/bpmn/json/bpmn.json#L2390
* https://github.com/bpmn-io/bpmn-moddle/blob/9f6d389e19d94e4c5211a87cc14e6f9b9f455f5c/resources/bpmn/json/bpmn.json#L2616

## Check List

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.